### PR TITLE
Revised age question in case being filled out by someone on behalf of  the claimant.

### DIFF
--- a/fighthealthinsurance/forms/questions.py
+++ b/fighthealthinsurance/forms/questions.py
@@ -76,7 +76,7 @@ class MedicalNeccessaryQuestions(InsuranceQuestions):
         label="Why is this medically necessary (if you know)?",
         required=False,
     )
-    age = forms.CharField(required=False, label="What is your age?")
+    age = forms.CharField(required=False, label="Age of the person with the denied claim?")
 
     def medical_context(self):
         response = ""


### PR DESCRIPTION
Revised age question in case being filled out by someone on behalf of  the claimant.

Signed-off-by: nyghtowl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the age question on the form to clearly indicate that the age input relates to the person with the denied claim.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->