### PR TITLE
In prod we've got two different domains

### DIFF
--- a/fighthealthinsurance/middleware/CsrfCookieToHeaderMiddleware.py
+++ b/fighthealthinsurance/middleware/CsrfCookieToHeaderMiddleware.py
@@ -1,0 +1,8 @@
+from django.utils.deprecation import MiddlewareMixin
+
+
+class CsrfCookieToHeaderMiddleware(MiddlewareMixin):
+    def process_request(self, request):
+        csrf_token = request.COOKIES.get("csrftoken")
+        if csrf_token and "HTTP_X_CSRFTOKEN" not in request.META:
+            request.META["HTTP_X_CSRFTOKEN"] = csrf_token

--- a/fighthealthinsurance/middleware/__init__.py
+++ b/fighthealthinsurance/middleware/__init__.py
@@ -1,0 +1,1 @@
+from .CsrfCookieToHeaderMiddleware import CsrfCookieToHeaderMiddleware

--- a/fighthealthinsurance/settings.py
+++ b/fighthealthinsurance/settings.py
@@ -38,12 +38,6 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 from rest_framework.authentication import SessionAuthentication
 
 
-class CsrfExemptSessionAuthentication(SessionAuthentication):
-
-    def enforce_csrf(self, request):
-        return  # To not perform the csrf check previously happening
-
-
 class Base(Configuration):
     SENTRY_ENDPOINT = os.getenv("SENTRY_ENDPOINT")
     COOKIE_CONSENT_ENABLED = False
@@ -155,6 +149,7 @@ class Base(Configuration):
     )
 
     MIDDLEWARE = [
+        "fighthealthinsurance.middleware.CsrfCookieToHeaderMiddleware",
         "corsheaders.middleware.CorsMiddleware",
         "django_prometheus.middleware.PrometheusBeforeMiddleware",
         "django.contrib.sessions.middleware.SessionMiddleware",
@@ -393,16 +388,6 @@ class Base(Configuration):
 
 
 class Dev(Base):
-    # Relax for http in dev even though we mostly want https
-    # Session cookie configs
-    SESSION_COOKIE_SECURE = False  # sometimes dev http
-    SESSION_COOKIE_HTTPONLY = False  # allow js access
-    SESSION_COOKIE_SAMESITE = "Lax"  # cross site happytimes.
-    # Same for CSRF
-    CSRF_COOKIE_SECURE = False  # sometimes dev http
-    CSRF_COOKIE_HTTPONLY = False
-    CSRF_COOKIE_SAMESITE = "Lax"
-
     CSRF_TRUSTED_ORIGINS = [
         "https://fightpaperwork.com",
         "https://localhost:3000",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,7 +8,7 @@ BUILDX_CMD=${BUILDX_CMD:-push}
 source "${SCRIPT_DIR}/setup_templates.sh"
 
 # BUILDKIT_NO_CLIENT_TOKEN=true
-FHI_VERSION=v0.11.8b
+FHI_VERSION=v0.11.8c
 
 MYORG=${MYORG:-holdenk}
 RAY_BASE=${RAY_BASE:-${MYORG}/fhi-ray}


### PR DESCRIPTION
And we can't read cookies in JS from a different domain, but they come back as a cookie so lets grab the cookie and set the header as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced security token handling ensures anti-forgery tokens from cookies are automatically available in request headers.
- **Refactor**
	- Deprecated previous custom session authentication and removed outdated development cookie settings.
- **Chores**
	- Updated the application version to v0.11.8c.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->