### PR TITLE
Don't try to activate a venv if we're already in one

### DIFF
--- a/scripts/run_local.sh
+++ b/scripts/run_local.sh
@@ -9,12 +9,14 @@ if [ ! -f "cert.pem" ]; then
 fi
 
 # Activate the venv if present.
-if [ -f ./build_venv/bin/activate ]; then
-  source ./build_venv/bin/activate
-  echo "Using build_venv"
-elif [ -f ./.venv/bin/activate ]; then
-  source ./.venv/bin/activate
-  echo "Using .venv"
+if [[ -z $VIRTUAL_ENV ]]; then
+  if [ -f ./build_venv/bin/activate ]; then
+    source ./build_venv/bin/activate
+    echo "Using build_venv"
+  elif [ -f ./.venv/bin/activate ]; then
+    source ./.venv/bin/activate
+    echo "Using .venv"
+  fi
 fi
 
 # Check if requirements files have changed since last run


### PR DESCRIPTION
If **$VIRTUAL_ENV** is set then we're already in a venv, so skip trying to activate one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the local environment activation process to first check if a virtual environment is already active. This prevents conflicts from inadvertent overlapping activations, ensuring a smoother and more reliable local development experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->