### PR TITLE
Insurance Company and appeal fax (for entity extractor)

### DIFF
--- a/charts/views.py
+++ b/charts/views.py
@@ -121,6 +121,8 @@ def de_identified_export(request):
         "generated_questions",
         "procedure",
         "diagnosis",
+        "insurance_company",
+        "appeal_fax_number",
     )
     if limit:
         safe_denials = safe_denials[0:int(limit)]


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Added insurance company and appeal fax number fields to the de-identified export function to support entity extraction capabilities.

- Added `insurance_company` field to the de-identified export in `charts/views.py` to capture insurance provider information.
- Added `appeal_fax_number` field to the de-identified export in `charts/views.py` to capture fax numbers for appeals.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->