### PR TITLE
Fix broken GH links for FHI part two

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Currently this has both the frontend (HTML & javascript) along with a bunch of "
 
 In the future this may be seperated out into different projects.
 
-The [ML model is generated using this repo](https://github.com/totallylegitco/healthinsurance-llm).
+The [ML model is generated using this repo](https://github.com/fighthealthinsurance/healthinsurance-llm).
 
 ## Running Locally
 
@@ -18,7 +18,7 @@ If you get `django.core.exceptions.AppRegistryNotReady: The translation infrastr
 
 The `./scripts/run_local.sh` can be used to launch django to run locally.
 
-To really test changes you'll likely want access to a model, one [option is using this repo](https://github.com/totallylegitco/healthinsurance-llm) and setting `HEALTH_BACKEND_PORT` to `8000` and `HEALTH_BACKEND_HOST` to `localhost`. Deploying locally requires ~ GPU equivalent to a 3090.
+To really test changes you'll likely want access to a model, one [option is using this repo](https://github.com/fighthealthinsurance/healthinsurance-llm) and setting `HEALTH_BACKEND_PORT` to `8000` and `HEALTH_BACKEND_HOST` to `localhost`. Deploying locally requires ~ GPU equivalent to a 3090.
 
 If you don't have a GPU handy the other option is to use an external model. The current one setup by default is [octoai](https://octoai.cloud/) & you can get a free API key with enough credits to run locally. You'll want to set the enviornment variable `OCTOAI_TOKEN` to the value of your API key.
 

--- a/fighthealthinsurance/templates/base.html
+++ b/fighthealthinsurance/templates/base.html
@@ -99,7 +99,7 @@
 </head>
 
 <body id="top" data-spy="scroll" data-target=".navbar-collapse" data-offset="50">
-  <a class="github-fork-ribbon" href="https://github.com/orgs/totallylegitco/repositories" data-ribbon="Alpha -- Fork me on GH" title="Alpha -- Fork me on GH">Contribute on GitHub</a>
+  <a class="github-fork-ribbon" href="https://github.com/orgs/fighthealthinsurance/repositories" data-ribbon="Alpha -- Fork me on GH" title="Alpha -- Fork me on GH">Contribute on GitHub</a>
 <!--  <div class="betaribbon"><a href="https://inc42.com/glossary/alpha-release-beta-release/#:~:text=An%20alpha%20release%20is%20an,caught%20during%20the%20previous%20tests.">Alpha</a> <a href="{% url 'contact' %}">Feedback welcome</a></div>-->
     <!-- PRE LOADER -->
     <section class="preloader">

--- a/fighthealthinsurance/templates/contact.html
+++ b/fighthealthinsurance/templates/contact.html
@@ -10,7 +10,7 @@ Contact
       <div class="section-header text-align-center">
 	<h2>Fighthealthinsurance Contact</h2>
       </div>
-      Thank you for your interest! We'd love to hear from you, email is the easiest way to get in touch with us. If you're a software developer (hi!) you can also get in touch with us for <a href="https://github.com/orgs/totallylegitco/repositories">non-security related bug reports or improvements on our GitHub.</a>
+      Thank you for your interest! We'd love to hear from you, email is the easiest way to get in touch with us. If you're a software developer (hi!) you can also get in touch with us for <a href="https://github.com/orgs/fighthealthinsurance/repositories">non-security related bug reports or improvements on our GitHub.</a>
       <h5>Contact Information</h5>
       <p>
         Holden Karau <br>

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,8 +44,8 @@ flake8-django
 geopy
 git+https://github.com/holdenk/static-thumbnails.git
 git+https://github.com/jazzband/django-cookie-consent.git#egg=django-cookie-consent
-git+https://github.com/totallylegitco/django-encrypted-model-fields.git@87dfff140b3ad256404a913019e90f2c245e57f8
-git+https://github.com/totallylegitco/llm-result-utils.git@c36b552eb93c5305a0262b52d0a13fab820eb7f7
+git+https://github.com/fighthealthinsurance/django-encrypted-model-fields.git@87dfff140b3ad256404a913019e90f2c245e57f8
+git+https://github.com/fighthealthinsurance/llm-result-utils.git@c36b552eb93c5305a0262b52d0a13fab820eb7f7
 icd10-cm
 loguru
 markdown_strings


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Updates GitHub repository links from "totallylegitco" to "fighthealthinsurance" organization across documentation and templates.

- Updated repository links in `README.md` to point to the correct organization for the ML model repository.
- Fixed GitHub ribbon link in `base.html` to direct users to the proper organization repositories.
- Corrected the developer contact link in `contact.html` to ensure bug reports go to the right GitHub organization.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated repository URLs in the README and contact page to reference the new GitHub organization.
- **Chores**
  - Changed dependency source URLs in requirements to the new GitHub organization.
  - Updated the GitHub fork ribbon link to point to the new organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->