### PR TITLE
Nyghtowl/tox fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -44,8 +44,8 @@ flake8-django
 geopy
 git+https://github.com/holdenk/static-thumbnails.git
 git+https://github.com/jazzband/django-cookie-consent.git#egg=django-cookie-consent
-git+https://github.com/totallylegitco/django-encrypted-model-fields.git@87dfff140b3ad256404a913019e90f2c245e57f8
-git+https://github.com/totallylegitco/llm-result-utils.git@c36b552eb93c5305a0262b52d0a13fab820eb7f7
+git+https://github.com/fighthealthinsurance/django-encrypted-model-fields.git@87dfff140b3ad256404a913019e90f2c245e57f8
+git+https://github.com/fighthealthinsurance/llm-result-utils.git@c36b552eb93c5305a0262b52d0a13fab820eb7f7
 icd10-cm
 loguru
 markdown_strings

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,8 +44,8 @@ flake8-django
 geopy
 git+https://github.com/holdenk/static-thumbnails.git
 git+https://github.com/jazzband/django-cookie-consent.git#egg=django-cookie-consent
-git+https://github.com/fighthealthinsurance/django-encrypted-model-fields.git@87dfff140b3ad256404a913019e90f2c245e57f8
-git+https://github.com/fighthealthinsurance/llm-result-utils.git@c36b552eb93c5305a0262b52d0a13fab820eb7f7
+git+https://github.com/fighthealthinsurance/django-encrypted-model-fields.git@d96965e40e8b40da72fbc78cb968258a4d1bcdf1
+git+https://github.com/fighthealthinsurance/llm-result-utils.git@f24e0bf7fa485d682fe3e42df831623c55844462
 icd10-cm
 loguru
 markdown_strings

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,7 +8,7 @@ BUILDX_CMD=${BUILDX_CMD:-push}
 source "${SCRIPT_DIR}/setup_templates.sh"
 
 # BUILDKIT_NO_CLIENT_TOKEN=true
-FHI_VERSION=v0.11.21b
+FHI_VERSION=v0.11.21c
 
 MYORG=${MYORG:-totallylegitco}
 RAY_BASE=${RAY_BASE:-${MYORG}/fhi-ray}

--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,7 @@ commands =
     black: black --check setup.py fighthealthinsurance
 
 [testenv:{mypy,py310-mypy,py311-mypy}]
+basepython = python3.10
 setenv =
     DJANGO_SETTINGS_MODULE=fighthealthinsurance.settings
     PYTHONPATH={toxinidir}


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Fixes tox configuration by specifying Python 3.10 for mypy tests and bumps application version to v0.11.21c.

- Added `basepython = python3.10` to the mypy test environment in `tox.ini` to ensure consistent type checking with a specific Python version.
- Updated `FHI_VERSION` in `scripts/build.sh` from v0.11.21b to v0.11.21c for a minor version increment.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated package source URLs for dependencies to a new repository owner.
	- Bumped internal version identifier to v0.11.21c.
	- Set Python 3.10 as the interpreter for certain test environments to ensure consistency during type checking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->