### PR TITLE
Fixing tox and requirements sha

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -44,8 +44,8 @@ flake8-django
 geopy
 git+https://github.com/holdenk/static-thumbnails.git
 git+https://github.com/jazzband/django-cookie-consent.git#egg=django-cookie-consent
-git+https://github.com/fighthealthinsurance/django-encrypted-model-fields.git@87dfff140b3ad256404a913019e90f2c245e57f8
-git+https://github.com/fighthealthinsurance/llm-result-utils.git@c36b552eb93c5305a0262b52d0a13fab820eb7f7
+git+https://github.com/fighthealthinsurance/django-encrypted-model-fields.git@d96965e40e8b40da72fbc78cb968258a4d1bcdf1
+git+https://github.com/fighthealthinsurance/llm-result-utils.git@f24e0bf7fa485d682fe3e42df831623c55844462
 icd10-cm
 loguru
 markdown_strings

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ deps =
 commands =
     black: black --check setup.py fighthealthinsurance
 
-[testenv:{mypy,py310-mypy,py311-mypy}]
+[testenv:mypy,py310-mypy]
 basepython = python3.10
 setenv =
     DJANGO_SETTINGS_MODULE=fighthealthinsurance.settings
@@ -71,6 +71,9 @@ allowlist_externals = pytest, black, mypy
 commands =
     mypy: mypy --config-file mypy.ini -p fighthealthinsurance -p fhi_users
     pyright: pyright {posargs}
+
+[testenv:py311-mypy]
+basepython = python3.11
 
 # sync tests
 [testenv:{sync,py310-django50-sync,py311-django50-sync,pyright,py310-pyright,py3.10-django50-sync,py3.11-django50-sync,pyright,py3.10-pyright}]

--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,7 @@ commands =
     black: black --check setup.py fighthealthinsurance
 
 [testenv:{mypy,py310-mypy,py311-mypy}]
+basepython = python3.10
 setenv =
     DJANGO_SETTINGS_MODULE=fighthealthinsurance.settings
     PYTHONPATH={toxinidir}


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Adds explicit Python 3.10 requirement for mypy test environments in tox configuration to ensure consistent type checking.

- Added `basepython = python3.10` to the mypy test environment in `tox.ini` to ensure mypy always runs with the same Python version.
- Fixes potential issues with requirements SHA (mentioned in PR title but not visible in the patch).

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated dependency references for improved stability.
  - Separated test environments to explicitly use Python 3.10 and 3.11 interpreters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->