### PR TITLE
Add billing backend

### DIFF
--- a/fhi_users/auth/rest_auth_views.py
+++ b/fhi_users/auth/rest_auth_views.py
@@ -1060,7 +1060,9 @@ class ProfessionalUserViewSet(viewsets.ViewSet, CreateMixin):
         if not new_domain:
             return Response(
                 serializers.ProfessionalSignupResponseSerializer(
-                    {"next_url": f"https://{settings.FIGHT_PAPERWORK_DOMAIN}/auth/login"}
+                    {
+                        "next_url": f"https://{settings.FIGHT_PAPERWORK_DOMAIN}/auth/login"
+                    }
                 ).data,
                 status=status.HTTP_201_CREATED,
             )
@@ -1096,7 +1098,9 @@ class ProfessionalUserViewSet(viewsets.ViewSet, CreateMixin):
         else:
             return Response(
                 serializers.ProfessionalSignupResponseSerializer(
-                    {"next_url": f"https://{settings.FIGHT_PAPERWORK_DOMAIN}/?q=testmode"}
+                    {
+                        "next_url": f"https://{settings.FIGHT_PAPERWORK_DOMAIN}/?q=testmode"
+                    }
                 ).data,
                 status=status.HTTP_201_CREATED,
             )
@@ -1240,7 +1244,9 @@ class ProfessionalUserViewSet(viewsets.ViewSet, CreateMixin):
                 status=status.HTTP_200_OK,
             )
         except Exception as e:
-            logger.opt(exception=True).error(f"Error creating Stripe billing portal session: {str(e)}")
+            logger.opt(exception=True).error(
+                f"Error creating Stripe billing portal session: {str(e)}"
+            )
             return Response(
                 common_serializers.ErrorSerializer(
                     {"error": f"Could not create billing portal session: {str(e)}"}

--- a/fhi_users/auth/rest_auth_views.py
+++ b/fhi_users/auth/rest_auth_views.py
@@ -1193,7 +1193,7 @@ class ProfessionalUserViewSet(viewsets.ViewSet, CreateMixin):
 
     @extend_schema(
         responses={
-            200: serializers.StatusResponseSerializer,
+            200: serializers.ProfessionalBillingResponseSerializer,
             403: common_serializers.ErrorSerializer,
         }
     )
@@ -1231,11 +1231,11 @@ class ProfessionalUserViewSet(viewsets.ViewSet, CreateMixin):
         try:
             session = stripe.billing_portal.Session.create(
                 customer=user_domain.stripe_customer_id,
-                return_url=f"https://{settings.FIGHT_PAPERWORK_DOMAIN}/dashboard",
+                return_url=f"https://{settings.FIGHT_PAPERWORK_DOMAIN}/dashboard/billing",
             )
             return Response(
-                serializers.StatusResponseSerializer(
-                    {"status": "success", "next_url": session.url}
+                serializers.ProfessionalBillingResponseSerializer(
+                    {"next_url": session.url}
                 ).data,
                 status=status.HTTP_200_OK,
             )

--- a/fhi_users/auth/rest_auth_views.py
+++ b/fhi_users/auth/rest_auth_views.py
@@ -1231,7 +1231,7 @@ class ProfessionalUserViewSet(viewsets.ViewSet, CreateMixin):
         try:
             session = stripe.billing_portal.Session.create(
                 customer=user_domain.stripe_customer_id,
-                return_url=f"https://{settings.FIGHT_PAPERWORK_DOMAIN}/dashboard/billing",
+                return_url=f"https://{settings.FIGHT_PAPERWORK_DOMAIN}/dashboard",
             )
             return Response(
                 serializers.StatusResponseSerializer(

--- a/fhi_users/auth/rest_serializers.py
+++ b/fhi_users/auth/rest_serializers.py
@@ -239,12 +239,23 @@ class FullProfessionalSerializer(serializers.ModelSerializer):
         return f"{user.first_name} {user.last_name}"
 
 
-class ProfessionalSignupResponseSerializer(serializers.Serializer):
+class NextUrlResponseSerializer(serializers.Serializer):
+    """
+    Generic serializer for returning a next_url field.
+    """
+    next_url = serializers.URLField()
+
+class ProfessionalSignupResponseSerializer(NextUrlResponseSerializer):
     """
     Returns a 'next_url' guiding the user to checkout or follow-up steps.
     """
+    pass
 
-    next_url = serializers.URLField()
+class FinishPaymentResponseSerializer(NextUrlResponseSerializer):
+    pass
+
+class ProfessionalBillingResponseSerializer(NextUrlResponseSerializer):
+    pass
 
 
 class AcceptProfessionalUserSerializer(serializers.Serializer):
@@ -407,10 +418,6 @@ class FinishPaymentSerializer(serializers.Serializer):
     cancel_url = serializers.URLField(
         required=False, default="https://www.fightpaperwork.com/?q=ohno"
     )
-
-
-class FinishPaymentResponseSerializer(serializers.Serializer):
-    next_url = serializers.URLField()
 
 
 class DomainExistsSerializer(serializers.Serializer):

--- a/fhi_users/auth/rest_serializers.py
+++ b/fhi_users/auth/rest_serializers.py
@@ -243,16 +243,21 @@ class NextUrlResponseSerializer(serializers.Serializer):
     """
     Generic serializer for returning a next_url field.
     """
+
     next_url = serializers.URLField()
+
 
 class ProfessionalSignupResponseSerializer(NextUrlResponseSerializer):
     """
     Returns a 'next_url' guiding the user to checkout or follow-up steps.
     """
+
     pass
+
 
 class FinishPaymentResponseSerializer(NextUrlResponseSerializer):
     pass
+
 
 class ProfessionalBillingResponseSerializer(NextUrlResponseSerializer):
     pass


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Adds a new endpoint to generate Stripe billing portal URLs for domain administrators to manage their subscription and payment methods.

- Added `get_billing_url` method to `ProfessionalUserViewSet` in `rest_auth_views.py` that creates a Stripe billing portal session for domain admins.
- Refactored serializers in `rest_serializers.py` to create a common `NextUrlResponseSerializer` parent class for all serializers that return a URL.
- Created comprehensive tests in `test_rest_auth_views.py` to verify the billing URL functionality works for admins and is restricted for non-admins.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an endpoint for admin users to retrieve a Stripe billing portal URL for their domain.

- **Refactor**
  - Centralized response serializers for actions returning a next URL, improving consistency and maintainability.

- **Tests**
  - Introduced tests to verify that only admin users can access the billing portal URL and non-admins are correctly denied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->