### PR TITLE
Fix appeal id based on first

### DIFF
--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -1500,7 +1500,11 @@ class DenialCreatorHelper:
     def format_denial_response_info(cls, denial):
         appeal_id = None
         if Appeal.objects.filter(for_denial=denial).exists():
-            appeal_id = Appeal.objects.filter(for_denial=denial).first().id
+            appeal_obj = Appeal.objects.filter(for_denial=denial).first()
+            if appeal_obj is None:
+                raise Exception(f"Could not find appeal for denial {denial.denial_id}")
+            else:
+                appeal_id = appeal_obj.id
         else:
             logger.debug(
                 f"Could not find appeal for {denial} -- expected for consumer version"

--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -1500,7 +1500,7 @@ class DenialCreatorHelper:
     def format_denial_response_info(cls, denial):
         appeal_id = None
         if Appeal.objects.filter(for_denial=denial).exists():
-            appeal_id = Appeal.objects.get(for_denial=denial).id
+            appeal_id = Appeal.objects.filter(for_denial=denial).first().id
         else:
             logger.debug(
                 f"Could not find appeal for {denial} -- expected for consumer version"


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Fixed a potential bug in appeal ID retrieval by using filter().first() instead of get() to handle cases where multiple appeals exist for a single denial.

- Modified `format_denial_response_info` method in `fighthealthinsurance/common_view_logic.py` to safely retrieve the first appeal ID when multiple appeals might exist for a denial.
- Prevents potential errors that would occur if multiple appeals were associated with a single denial, as the previous implementation assumed only one appeal existed.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of situations where multiple or no appeals are linked to a denial, reducing the likelihood of errors when viewing denial response information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->