### PR TITLE
Let's use the fight paperwork domain for our API for mobile.

### DIFF
--- a/fighthealthinsurance/settings.py
+++ b/fighthealthinsurance/settings.py
@@ -327,6 +327,7 @@ class Base(Configuration):
         "https://www.fighthealthinsurance.com",
         "https://api.fighthealthinsurance.com",
         "https://*.fightpaperwork.com",
+        "https://api.fightpaperwork.com",
         "https://*.fighthealthinsurance.com",
     ]
 

--- a/k8s/deploy.yaml
+++ b/k8s/deploy.yaml
@@ -226,6 +226,16 @@ spec:
                 name:  web-svc
                 port:
                   number: 80
+    - host: api.fightpaperwork.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name:  web-svc
+                port:
+                  number: 80
     - host: fighthealthinsurance.com
       http:
         paths:

--- a/k8s/deploy.yaml
+++ b/k8s/deploy.yaml
@@ -173,6 +173,7 @@ spec:
       - api.fighthealthinsurance.com
       - www.fuckhealthinsurance.com
       - www.appealhealthinsurance.com
+      - api.fightpaperwork.com
     secretName: combined-tls-secret
   rules:
     - host: www.fuckhealthinsurance.com


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added "https://api.fightpaperwork.com" as a trusted origin for enhanced security.
  - Updated configuration to support TLS for the "api.fightpaperwork.com" hostname.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->