### PR TITLE
Add dynamic domain selection for cookies

### DIFF
--- a/fighthealthinsurance/middleware/SessionMiddlewareDynamicDomain.py
+++ b/fighthealthinsurance/middleware/SessionMiddlewareDynamicDomain.py
@@ -1,0 +1,45 @@
+from loguru import logger
+
+from django.conf import settings
+from django.utils.deprecation import MiddlewareMixin
+
+
+class SessionMiddlewareDynamicDomain(MiddlewareMixin):
+    """
+    Middleware to update cookie domains dynamically based on the request domain.
+    Handles both session and CSRF token cookies.
+    Based on https://stackoverflow.com/questions/2116860/django-session-cookie-domain-with-multiple-domains
+    """
+
+    def __init__(self, get_response):
+        super().__init__(get_response)
+
+    def process_response(self, request, response):
+        cookies_to_check = [
+            settings.SESSION_COOKIE_NAME,
+        ]
+
+        # Add CSRF cookie name if it's being used
+        if hasattr(settings, "CSRF_COOKIE_NAME") and settings.CSRF_COOKIE_NAME:
+            cookies_to_check.append(settings.CSRF_COOKIE_NAME)
+
+        for cookie_name in cookies_to_check:
+            if cookie_name in response.cookies:
+                try:
+                    # Only proceed if the cookie has a domain attribute
+                    if "domain" in response.cookies[cookie_name]:
+                        domain_curr = response.cookies[cookie_name]["domain"]
+
+                        request_domain = "." + ".".join(
+                            request.get_host().split(":")[0].split(".")[-2:]
+                        )
+
+                        if request_domain in settings.SESSION_COOKIE_DOMAIN_DYNAMIC:
+                            if domain_curr != request_domain:
+                                response.cookies[cookie_name]["domain"] = request_domain
+                except Exception as exc:
+                    logger.error(
+                        f"crash updating domain for {cookie_name} dynamically. Skipped. Error: {exc}"
+                    )
+
+        return response

--- a/fighthealthinsurance/middleware/__init__.py
+++ b/fighthealthinsurance/middleware/__init__.py
@@ -1,1 +1,2 @@
 from .CsrfCookieToHeaderMiddleware import CsrfCookieToHeaderMiddleware
+from .SessionMiddlewareDynamicDomain import SessionMiddlewareDynamicDomain

--- a/fighthealthinsurance/middleware/__init__.py
+++ b/fighthealthinsurance/middleware/__init__.py
@@ -1,2 +1,4 @@
 from .CsrfCookieToHeaderMiddleware import CsrfCookieToHeaderMiddleware
 from .SessionMiddlewareDynamicDomain import SessionMiddlewareDynamicDomain
+
+__all__ = ["CsrfCookieToHeaderMiddleware", "SessionMiddlewareDynamicDomain"]

--- a/fighthealthinsurance/settings.py
+++ b/fighthealthinsurance/settings.py
@@ -103,6 +103,13 @@ class Base(Configuration):
         "django.template.context_processors.request",
     ]
 
+    SESSION_COOKIE_DOMAIN_DYNAMIC = [
+        ".fightpaperwork.com",
+        ".fighthealthinsurance.com",
+        ".localhost",
+        "localhost",
+    ]
+
     INSTALLED_APPS = [
         "django.contrib.admin",
         "django.contrib.auth",
@@ -156,6 +163,7 @@ class Base(Configuration):
         "fighthealthinsurance.middleware.CsrfCookieToHeaderMiddleware",
         "corsheaders.middleware.CorsMiddleware",
         "django_prometheus.middleware.PrometheusBeforeMiddleware",
+        "fighthealthinsurance.middleware.SessionMiddlewareDynamicDomain",
         "django.contrib.sessions.middleware.SessionMiddleware",
         "django.contrib.auth.middleware.AuthenticationMiddleware",
         "django.contrib.messages.middleware.MessageMiddleware",
@@ -524,6 +532,21 @@ class TestActor(Dev):
 
 
 class Prod(Base):
+    # Tighten up CORS
+    CORS_ALLOWED_ORIGINS = [
+        "https://www.fightpaperwork.com",
+        "https://fightpaperwork.com",
+        "https://api.fightpaperwork.com",
+        "https://www.fighthealthinsurance.com",
+        "https://fighthealthinsurance.com",
+        "https://api.fighthealthinsurance.com",
+    ]
+    CORS_ALLOW_ALL_ORIGINS = False
+    CORS_ALLOW_PRIVATE_NETWORK = False
+    CORS_ALLOW_CREDENTIALS = True
+
+    SESSION_COOKIE_DOMAIN_DYNAMIC = [".fightpaperwork.com", ".fighthealthinsurance.com"]
+
     DEBUG = False
 
     # Different fido server for production


### PR DESCRIPTION
We do this for for session and csrf cookies for newer mobile browsers/safari.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Session and CSRF cookies now automatically adjust their domain attributes based on the accessed domain, improving multi-domain support.
- **Configuration**
	- New settings allow administrators to specify which domains are eligible for dynamic cookie domain assignment.
	- CORS settings updated to restrict allowed origins and enhance security for production environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->