### PR TITLE
Update to python 312

### DIFF
--- a/k8s/Dockerfile
+++ b/k8s/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:3.11.10-bullseye as base-arm64
+FROM python:3.12.11-bookworm as base-arm64
 
-FROM python:3.11.10-bullseye as base-amd64
+FROM python:3.12.11-bookworm as base-amd64
 
 FROM base-${TARGETARCH}
 

--- a/k8s/ray/RayDockerfile
+++ b/k8s/ray/RayDockerfile
@@ -1,7 +1,7 @@
 ARG RAY_VERSION
 
-FROM rayproject/ray:${RAY_VERSION}-aarch64 as base-arm64
+FROM rayproject/ray:${RAY_VERSION}-py312-aarch64 as base-arm64
 
-FROM rayproject/ray:${RAY_VERSION} as base-amd64
+FROM rayproject/ray:${RAY_VERSION}-py312 as base-amd64
 
 FROM base-${TARGETARCH}

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,9 +1,15 @@
 {
   "include": ["**/*.py"],
-  "exclude": ["**/migrations/**"],
+  "exclude": ["**/migrations/",
+  "**/.*",
+  "**/*.py[cod]",
+  "**/__pycache__/",
+  "**/node_modules/",
+  "**/*.sqlite3*",
+  ],
   "typeCheckingMode": "strict",
   "useLibraryCodeForTypes": true,
   "reportMissingTypeStubs": false,
-  "pythonVersion": "3.10",
+  "pythonVersion": "3.12",
   "pythonPlatform": "Linux"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ black
 bokeh
 numpy
 channels
+chardet
 django>=5.0.0
 django-cms
 djangocms-attributes-field

--- a/tox.ini
+++ b/tox.ini
@@ -2,11 +2,11 @@
 passenv = *
 requires = setuptools
 envlist =
-    py{310,311}-django{50}-async
-    py{310,311}-django{50}-sync
-    py{310,311}-django{50}-sync-actor
-    py310-black
-    py310-mypy
+    py{310,311,312}-django{50}-async
+    py{310,311,312}-django{50}-sync
+    py{310,311,312}-django{50}-sync-actor
+    py{310,312}-black
+    py{310,312}-mypy
 
 skip_missing_interpeters = true
 
@@ -14,6 +14,7 @@ skip_missing_interpeters = true
 python =
     3.10: py310, black
     3.11: py311
+    3.12: py312, black
 
 [gh-actions:env]
 DJANGO =
@@ -37,8 +38,7 @@ deps =
 commands =
     black: black --check setup.py fighthealthinsurance
 
-[testenv:mypy,py310-mypy]
-basepython = python3.10
+[testenv:mypy]
 setenv =
     DJANGO_SETTINGS_MODULE=fighthealthinsurance.settings
     PYTHONPATH={toxinidir}
@@ -72,11 +72,17 @@ commands =
     mypy: mypy --config-file mypy.ini -p fighthealthinsurance -p fhi_users
     pyright: pyright {posargs}
 
+[testenv:py310-mypy]
+basepython = python3.10
+
 [testenv:py311-mypy]
 basepython = python3.11
 
+[testenv:py312-mypy]
+basepython = python3.12
+
 # sync tests
-[testenv:{sync,py310-django50-sync,py311-django50-sync,pyright,py310-pyright,py3.10-django50-sync,py3.11-django50-sync,pyright,py3.10-pyright}]
+[testenv:{sync,py310-django50-sync,py311-django50-sync,py312-django50-sync,pyright,py310-pyright,py3.10-django50-sync,py3.11-django50-sync,pyright,py3.10-pyright,py3.12-pyright}]
 setenv =
     DJANGO_SETTINGS_MODULE=fighthealthinsurance.settings
     PYTHONPATH={toxinidir}
@@ -114,7 +120,7 @@ commands =
          {posargs}
 
 # actor sync tests
-[testenv:{sync-actor,py310-django50-sync-actor,py311-django50-sync-actor,pyright,py310-pyright,py3.10-django50-sync-actor,py3.11-django50-sync-actor,pyright,py3.10-pyright}]
+[testenv:{sync-actor,py310-django50-sync-actor,py311-django50-sync-actor,pyright,py310-pyright,py3.10-django50-sync-actor,py3.11-django50-sync-actor,py3.12-django50-sync-actor,pyright,py3.10-pyright}]
 setenv =
     DJANGO_SETTINGS_MODULE=fighthealthinsurance.settings
     PYTHONPATH={toxinidir}
@@ -153,7 +159,7 @@ commands =
 
 # async tests
 
-[testenv:{async,py310-django50-async,py311-django50-async,py3.10-django50-async,py3.11-django50-async}]
+[testenv:{async,py310-django50-async,py311-django50-async,py3.10-django50-async,py3.11-django50-async,py3.12-django50-async}]
 setenv =
     DJANGO_SETTINGS_MODULE=fighthealthinsurance.settings
     PYTHONPATH={toxinidir}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the base Docker image to Python 3.12 and Debian Bookworm for improved compatibility.
  * Expanded Pyright configuration to exclude additional files and directories from type checking and set Python version to 3.12.
  * Enhanced test and linting environments to support Python 3.12, including updates to tox and GitHub Actions configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->