### PR TITLE
Drop django nsoe

### DIFF
--- a/fighthealthinsurance/settings.py
+++ b/fighthealthinsurance/settings.py
@@ -129,7 +129,6 @@ class Base(Configuration):
         "compressor_toolkit",
         "django_extensions",
         "django_tables2",
-        "django_nose",
         "static_thumbnails",
         "memoize",
         "django_recaptcha",

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,6 @@ django_user_agents
 django-otp
 django-two-factor-auth
 django-mfa2
-django-nose
 coverage
 drf-spectacular
 easy_thumbnails


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the django-nose testing framework from the application settings and dependency list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->