### PR TITLE
Fix the test issue during websocket

### DIFF
--- a/fighthealthinsurance/websockets.py
+++ b/fighthealthinsurance/websockets.py
@@ -57,8 +57,14 @@ class StreamingAppealsBackend(AsyncWebsocketConsumer):
             logger.opt(exception=True).debug(f"Error sending back appeals: {e}")
             raise e
         finally:
-            await asyncio.sleep(1)
-            await self.close()
+            logger.debug("Yielding before closing connection")
+            await asyncio.sleep(0.1)
+            try:
+                logger.debug("Closing connection...")
+                await self.close()
+                logger.debug("Closed")
+            except Exception:
+                logger.debug("Error closing connection")
         logger.debug("All sent")
 
 
@@ -89,9 +95,14 @@ class StreamingEntityBackend(AsyncWebsocketConsumer):
             logger.opt(exception=True).debug(f"Error sending back entity: {e}")
             raise e
         finally:
-            await asyncio.sleep(1)
-            await self.close()
-            logger.debug("Closed connection")
+            logger.debug("Yielding before closing connection")
+            await asyncio.sleep(0.1)
+            try:
+                logger.debug("Prepairing to close connection")
+                await self.close()
+                logger.debug("Closed connection")
+            except Exception:
+                logger.debug("Error closing connection")
 
 
 class PriorAuthConsumer(AsyncWebsocketConsumer):

--- a/tests/sync/test_rest_api.py
+++ b/tests/sync/test_rest_api.py
@@ -244,8 +244,6 @@ class DenialEndToEnd(APITestCase):
                 response = await seb_communicator.receive_from()
         except:
             pass
-        finally:
-            await seb_communicator.disconnect()
         await asyncio.sleep(5)  # Give a second for the fire and forget pubmed to run
         # Set health history before next steps
         health_history_url = reverse("healthhistory-list")
@@ -325,8 +323,6 @@ class DenialEndToEnd(APITestCase):
         except Exception as e:
             print(f"Error {e}")
             pass
-        finally:
-            await a_communicator.disconnect()
         print(f"Received responses {responses}")
         responses = list(filter(lambda x: len(x) > 4, responses))
         # It's a streaming response with one per new line


### PR DESCRIPTION
Drop explicit disconnect because server side has already closed the channel and sending back the disconnect request then fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of WebSocket connections by enhancing error handling and logging during connection closure.

* **Tests**
  * Updated test cleanup procedures for WebSocket communicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->