### PR TITLE
fix weird screen layout on mobile

### DIFF
--- a/fighthealthinsurance/static/css/custom.css
+++ b/fighthealthinsurance/static/css/custom.css
@@ -207,7 +207,7 @@ a.link:hover::after {
 
 .row {
     display: flex;
-    flex-wrap: nowrap;
+    flex-wrap: wrap;
 }
 
 .row.no-gutters {


### PR DESCRIPTION
when opening the site on mobile, it'd render the page with half empty. (it would either show it correctly but allow users to scroll sideway to the empty page, or it would show the page zoomed-out with half the page being empty.) dug into the css a little and found out that `nowrap` might have messed with bootstrap's ability to wrap.