### PR TITLE
Fix template wording issues

### DIFF
--- a/fighthealthinsurance/templates/contact.html
+++ b/fighthealthinsurance/templates/contact.html
@@ -8,7 +8,7 @@ Contact
 <section id="contact">
     <div class="container">
       <div class="section-header text-align-center">
-	<h2>Fighthealthinsurance Contact</h2>
+	<h2>Fight Health Insurance Contact</h2>
       </div>
       Thank you for your interest! We'd love to hear from you, email is the easiest way to get in touch with us. If you're a software developer (hi!) you can also get in touch with us for <a href="https://github.com/orgs/fighthealthinsurance/repositories">non-security related bug reports or improvements on our GitHub.</a>
       <h5>Contact Information</h5>

--- a/fighthealthinsurance/templates/professional.html
+++ b/fighthealthinsurance/templates/professional.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% block title %}
-Fighthealthinsurance Professional Version
+Fight Health Insurance Professional Version
 {% endblock title %}
 {% load static %}
 {% load absolute %}

--- a/fighthealthinsurance/templates/remove_data.html
+++ b/fighthealthinsurance/templates/remove_data.html
@@ -10,7 +10,7 @@ Delete Your Data
         <div class="caption d-flex flex-column align-items-center justify-content-center">
             <div class="col-md-offset-1 col-md-10 text-align-center d-flex flex-column align-items-center justify-content-center">
                 <h1 class="delete-header">Delete your Data</h1>
-                <p>We do some things we think is cool-ish to try and improve your data privacy, you may wish to read the <a href="{% url 'privacy_policy' %}" target="_blank" rel="noopener noreferrer">privacy techniques in our privacy policy.</a></p>
+                <p>We take several steps to protect your data privacy. You can learn more about our <a href="{% url 'privacy_policy' %}" target="_blank" rel="noopener noreferrer">privacy practices in our privacy policy.</a></p>
                     <p>To help us delete your data, please provide the email address you used.</p>
                 <form action="{% url 'remove_data' %}" method="post" class="d-flex flex-column align-items-start">
                   {% csrf_token %}

--- a/fighthealthinsurance/templates/thankyou.html
+++ b/fighthealthinsurance/templates/thankyou.html
@@ -9,7 +9,6 @@ Thank you!
 
     <p>
       Thank you for using Fight Health Insurance :)
-	<br><br>.
     </p>
 
     {% include 'partials/share_buttons.html' %}

--- a/fighthealthinsurance/templates/warnings.html
+++ b/fighthealthinsurance/templates/warnings.html
@@ -19,11 +19,11 @@ Terms of Service
 	</p>
 
 	<p class="font-weight-bold">
-	  This tool is not a doctor, or lawyer and is not intended to provide an medical or legal advice. By using this tool you agree and understand that you will not use the output of fight health insurance to treat any medical condition. You also agree that you will review our <a href="{% url 'tos' %}">terms of service</a>
+	  This tool is not a doctor or lawyer and is not intended to provide any medical or legal advice. By using this tool you agree and understand that you will not use the output of fight health insurance to treat any medical condition. You also agree that you will review our <a href="{% url 'tos' %}">terms of service</a>
 	</p>
 	
         <p>
-	  We're really excited you're wiling to try out Fight Healht Insurance with your health insurance appeal. This software is still in <b>beta</b> and is only intended to be used to assist you in making your appeal, not replace your own (or others) judgement.
+	  We're really excited you're willing to try out Fight Health Insurance with your health insurance appeal. This software is still in <b>beta</b> and is only intended to be used to assist you in making your appeal, not replace your own (or others) judgement.
         </p>
 
 	<p>


### PR DESCRIPTION
- Fix "Fighthealthinsurance" -> "Fight Health Insurance" in contact.html and professional.html titles
- Fix typo "Fight Healht Insurance" -> "Fight Health Insurance" in warnings.html
- Fix "wiling" -> "willing" typo in warnings.html
- Fix "provide an medical" -> "provide any medical" grammar in warnings.html
- Remove stray period and extra line breaks in thankyou.html
- Improve remove_data.html wording from casual "cool-ish" to professional

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized product name formatting ("Fight Health Insurance") across all pages for brand consistency.
  * Corrected grammar and spelling errors in warning messages and instructional content.
  * Simplified and refined privacy-related descriptions for improved clarity.
  * Removed unnecessary formatting elements from templates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->