### PR TITLE
fix: Add cairo dependencies to style job in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
 
+      - name: Install system level packages
+        run: (sudo apt-get update || echo "sometimes this fails because of the azure cli repo which we do not use") && sudo apt-get install -y libcairo2-dev libgirepository1.0-dev pkg-config python3-dev && sudo apt-get clean
+
       - name: Install dependencies
         run: uv tool install tox --with tox-uv
 


### PR DESCRIPTION
The style job was failing with a pycairo build error because it was missing the required cairo system libraries. This adds libcairo2-dev, libgirepository1.0-dev, pkg-config, and python3-dev to match the other test jobs that already have these dependencies installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved continuous integration pipeline by adding system-level package installation to the build workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->