### PR TITLE
Group follow-up emails by recipient to prevent duplicate sends

### DIFF
--- a/fighthealthinsurance/followup_emails.py
+++ b/fighthealthinsurance/followup_emails.py
@@ -280,7 +280,7 @@ class FollowUpEmailSender(AsyncEmailSenderMixin):
         """
         if candidates is None:
             candidates = await self.afind_candidates()
-        grouped = await sync_to_async(self._group_candidates_by_email)(candidates)
+        grouped = self._group_candidates_by_email(candidates)
         if count is not None:
             grouped = grouped[:count]
         sent = 0

--- a/fighthealthinsurance/followup_emails.py
+++ b/fighthealthinsurance/followup_emails.py
@@ -280,7 +280,7 @@ class FollowUpEmailSender(AsyncEmailSenderMixin):
         """
         if candidates is None:
             candidates = await self.afind_candidates()
-        grouped = self._group_candidates_by_email(candidates)
+        grouped = await sync_to_async(self._group_candidates_by_email)(candidates)
         if count is not None:
             grouped = grouped[:count]
         sent = 0

--- a/fighthealthinsurance/followup_emails.py
+++ b/fighthealthinsurance/followup_emails.py
@@ -108,30 +108,39 @@ class ThankyouEmailSender(AsyncEmailSenderMixin):
 
 
 class FollowUpEmailSender(AsyncEmailSenderMixin):
-    def _find_candidates(self):
+    def _find_due(self):
+        """Base query: all unsent follow-ups that are due and not too old."""
         six_months_ago = datetime.date.today() - datetime.timedelta(days=183)
-        base_qs = (
+        return (
             FollowUpSched.objects.filter(follow_up_sent=False)
             .filter(follow_up_date__lte=datetime.date.today())
             .filter(initial__gte=six_months_ago)
+            .select_related("follow_up_type")
             .order_by("follow_up_date")
         )
+
+    def _find_candidates(self):
+        base_qs = self._find_due()
         try:
-            # PostgreSQL DISTINCT ON requires ORDER BY to start with
-            # the DISTINCT ON columns.
             candidates = base_qs.order_by(
                 "email", "follow_up_type", "follow_up_date"
             ).distinct("email", "follow_up_type")
-            # Force partial evaluation to catch DISTINCT ON errors
-            # Used for SQLite in local dev/test mode.
             candidates.exists()
             return candidates
         except (NotSupportedError, ProgrammingError):
-            # Fallback for databases that don't support DISTINCT ON
             return base_qs
 
     def find_candidates(self):
         return list(self._find_candidates())
+
+    def find_all_due(self) -> list[FollowUpSched]:
+        """Return ALL due follow-ups without DISTINCT ON dedup.
+
+        send_all/asend_all need the complete set so that suppressed
+        rows across multiple denials for the same email/type are all
+        marked as sent.
+        """
+        return list(self._find_due())
 
     def _group_candidates_by_email(
         self, candidates: list[FollowUpSched]
@@ -201,7 +210,7 @@ class FollowUpEmailSender(AsyncEmailSenderMixin):
             if self._is_stale(candidate):
                 to_suppress.append(candidate)
                 continue
-            result = self.dosend(follow_up_sched=candidate)
+            result = self.dosend(follow_up_sched=candidate, _skip_stale_check=True)
             if result:
                 email_sent = True
             else:
@@ -221,7 +230,7 @@ class FollowUpEmailSender(AsyncEmailSenderMixin):
         candidates: Optional[list] = None,
     ) -> int:
         if candidates is None:
-            candidates = self.find_candidates()
+            candidates = self.find_all_due()
         grouped = self._group_candidates_by_email(candidates)
         if count is not None:
             grouped = grouped[:count]
@@ -235,31 +244,21 @@ class FollowUpEmailSender(AsyncEmailSenderMixin):
         self,
         follow_up_sched: Optional[FollowUpSched] = None,
         email: Optional[str] = None,
+        _skip_stale_check: bool = False,
     ) -> bool:
         if follow_up_sched is None and email is not None:
             follow_up_sched = FollowUpSched.objects.filter(email=email).filter(
                 follow_up_sent=False
             )[0]
         elif follow_up_sched is None and email is None:
-            # Both are None
             raise Exception("One of email and follow_up_sched must be set.")
-        # At this point follow_up_sched is guaranteed to be set by the logic above
         assert follow_up_sched is not None
 
-        # Suppress stale follow-ups: if a later follow-up for the same denial
-        # has already been sent, skip this one (e.g. don't send a 7-day email
-        # if the 30-day email was already sent).
-        if follow_up_sched.follow_up_type and follow_up_sched.follow_up_type.duration:
-            later_sent = FollowUpSched.objects.filter(
-                denial_id=follow_up_sched.denial_id,
-                follow_up_sent=True,
-                follow_up_type__duration__gt=follow_up_sched.follow_up_type.duration,
-            ).exists()
-            if later_sent:
-                follow_up_sched.follow_up_sent = True
-                follow_up_sched.follow_up_sent_date = timezone.now()
-                follow_up_sched.save()
-                return True
+        if not _skip_stale_check and self._is_stale(follow_up_sched):
+            follow_up_sched.follow_up_sent = True
+            follow_up_sched.follow_up_sent_date = timezone.now()
+            follow_up_sched.save()
+            return True
 
         # Use the email from follow_up_sched to ensure consistency
         email = follow_up_sched.email
@@ -317,7 +316,7 @@ class FollowUpEmailSender(AsyncEmailSenderMixin):
         skips stale ones, sends the first valid one, and marks the rest as sent.
         """
         if candidates is None:
-            candidates = await self.afind_candidates()
+            candidates = await sync_to_async(self.find_all_due)()
         grouped = await sync_to_async(self._group_candidates_by_email)(candidates)
         if count is not None:
             grouped = grouped[:count]

--- a/fighthealthinsurance/followup_emails.py
+++ b/fighthealthinsurance/followup_emails.py
@@ -227,7 +227,7 @@ class FollowUpEmailSender(AsyncEmailSenderMixin):
     def send_all(
         self,
         count: Optional[int] = None,
-        candidates: Optional[list] = None,
+        candidates: Optional[list[FollowUpSched]] = None,
     ) -> int:
         if candidates is None:
             candidates = self.find_all_due()
@@ -307,7 +307,9 @@ class FollowUpEmailSender(AsyncEmailSenderMixin):
             return False
 
     async def asend_all(
-        self, count: Optional[int] = None, candidates: Optional[list] = None
+        self,
+        count: Optional[int] = None,
+        candidates: Optional[list[FollowUpSched]] = None,
     ) -> int:
         """Async send_all with per-email grouping and rate limiting.
 

--- a/fighthealthinsurance/followup_emails.py
+++ b/fighthealthinsurance/followup_emails.py
@@ -224,6 +224,32 @@ class FollowUpEmailSender(AsyncEmailSenderMixin):
             self._mark_as_sent_without_sending(to_suppress)
         return email_sent
 
+    def group_due_followups(
+        self, candidates: Optional[list[FollowUpSched]] = None
+    ) -> list[tuple[FollowUpSched, list[FollowUpSched]]]:
+        """Group due follow-ups by email, sorted by priority (longest duration first).
+
+        Public API for both send_all and the management command.
+        """
+        if candidates is None:
+            candidates = self.find_all_due()
+        return self._group_candidates_by_email(candidates)
+
+    def preview_grouped_send(
+        self, all_candidates: list[FollowUpSched]
+    ) -> tuple[Optional[FollowUpSched], int]:
+        """Preview which candidate would be sent for a group.
+
+        Returns (candidate_to_send, suppressed_count).
+        candidate_to_send is None if all candidates are stale.
+        """
+        to_send = next(
+            (c for c in all_candidates if not self._is_stale(c)),
+            None,
+        )
+        suppressed = len(all_candidates) - (1 if to_send else 0)
+        return to_send, suppressed
+
     def send_all(
         self,
         count: Optional[int] = None,

--- a/fighthealthinsurance/followup_emails.py
+++ b/fighthealthinsurance/followup_emails.py
@@ -162,6 +162,16 @@ class FollowUpEmailSender(AsyncEmailSenderMixin):
             result.append((best, others))
         return result
 
+    def _is_stale(self, follow_up_sched: FollowUpSched) -> bool:
+        """Check if a follow-up is stale (a later type for same denial already sent)."""
+        if follow_up_sched.follow_up_type and follow_up_sched.follow_up_type.duration:
+            return FollowUpSched.objects.filter(
+                denial_id=follow_up_sched.denial_id,
+                follow_up_sent=True,
+                follow_up_type__duration__gt=follow_up_sched.follow_up_type.duration,
+            ).exists()
+        return False
+
     def _mark_as_sent_without_sending(
         self, follow_up_scheds: list[FollowUpSched]
     ) -> None:
@@ -175,6 +185,38 @@ class FollowUpEmailSender(AsyncEmailSenderMixin):
             follow_up_sent_date=now,
         )
 
+    def _send_grouped(
+        self, all_candidates: list[FollowUpSched]
+    ) -> bool:
+        """Send one email for a group of candidates sharing the same address.
+
+        Iterates candidates in priority order (longest duration first).
+        Skips stale candidates, sends the first non-stale one, and marks
+        the rest as sent without emailing. Returns True if an email was sent.
+        """
+        to_suppress: list[FollowUpSched] = []
+        email_sent = False
+        for candidate in all_candidates:
+            if email_sent:
+                to_suppress.append(candidate)
+                continue
+            if self._is_stale(candidate):
+                to_suppress.append(candidate)
+                continue
+            result = self.dosend(follow_up_sched=candidate)
+            if result:
+                email_sent = True
+            else:
+                break
+        if to_suppress:
+            if email_sent:
+                logger.info(
+                    f"Suppressed {len(to_suppress)} follow-up(s) for "
+                    f"{mask_email_for_logging(all_candidates[0].email)}"
+                )
+            self._mark_as_sent_without_sending(to_suppress)
+        return email_sent
+
     def send_all(self, count: Optional[int] = None) -> int:
         candidates = self.find_candidates()
         grouped = self._group_candidates_by_email(candidates)
@@ -182,14 +224,7 @@ class FollowUpEmailSender(AsyncEmailSenderMixin):
             grouped = grouped[:count]
         sent = 0
         for best, others in grouped:
-            result = self.dosend(follow_up_sched=best)
-            if result:
-                if others:
-                    logger.info(
-                        f"Suppressed {len(others)} duplicate follow-up(s) for "
-                        f"{mask_email_for_logging(best.email)}"
-                    )
-                self._mark_as_sent_without_sending(others)
+            if self._send_grouped([best] + others):
                 sent += 1
         return sent
 
@@ -275,8 +310,8 @@ class FollowUpEmailSender(AsyncEmailSenderMixin):
         """Async send_all with per-email grouping and rate limiting.
 
         Groups candidates by email address so each recipient gets at most
-        one follow-up email per batch. The best candidate (longest duration)
-        is sent; the rest are marked as sent without emailing.
+        one follow-up email per batch. Iterates candidates in priority order,
+        skips stale ones, sends the first valid one, and marks the rest as sent.
         """
         if candidates is None:
             candidates = await self.afind_candidates()
@@ -285,14 +320,8 @@ class FollowUpEmailSender(AsyncEmailSenderMixin):
             grouped = grouped[:count]
         sent = 0
         for best, others in grouped:
-            result = await self.adosend(follow_up_sched=best)
+            result = await sync_to_async(self._send_grouped)([best] + others)
             if result:
-                if others:
-                    await sync_to_async(self._mark_as_sent_without_sending)(others)
-                    logger.info(
-                        f"Suppressed {len(others)} duplicate follow-up(s) for "
-                        f"{mask_email_for_logging(best.email)}"
-                    )
                 sent += 1
                 await asyncio.sleep(random.uniform(1.0, 3.0))
         return sent

--- a/fighthealthinsurance/followup_emails.py
+++ b/fighthealthinsurance/followup_emails.py
@@ -1,6 +1,7 @@
 import asyncio
 import datetime
 import random
+from collections import defaultdict
 from typing import Any, Optional
 
 from asgiref.sync import sync_to_async
@@ -132,14 +133,65 @@ class FollowUpEmailSender(AsyncEmailSenderMixin):
     def find_candidates(self):
         return list(self._find_candidates())
 
+    def _group_candidates_by_email(
+        self, candidates: list[FollowUpSched]
+    ) -> list[tuple[FollowUpSched, list[FollowUpSched]]]:
+        """Group candidates by email, picking the best one to send per email.
+
+        Returns a list of (best_candidate, other_candidates) tuples.
+        The "best" candidate is the one with the longest follow_up_type.duration
+        (e.g., 90-day > 30-day > 7-day), since it represents the most
+        significant check-in milestone.
+        """
+        groups: dict[str, list[FollowUpSched]] = defaultdict(list)
+        for candidate in candidates:
+            groups[candidate.email].append(candidate)
+
+        result = []
+        for email, group in groups.items():
+            group.sort(
+                key=lambda s: (
+                    s.follow_up_type.duration
+                    if s.follow_up_type and s.follow_up_type.duration
+                    else datetime.timedelta(0)
+                ),
+                reverse=True,
+            )
+            best = group[0]
+            others = group[1:]
+            result.append((best, others))
+        return result
+
+    def _mark_as_sent_without_sending(
+        self, follow_up_scheds: list[FollowUpSched]
+    ) -> None:
+        """Mark follow-up schedules as sent without actually sending email."""
+        if not follow_up_scheds:
+            return
+        now = timezone.now()
+        pks = [s.pk for s in follow_up_scheds]
+        FollowUpSched.objects.filter(pk__in=pks).update(
+            follow_up_sent=True,
+            follow_up_sent_date=now,
+        )
+
     def send_all(self, count: Optional[int] = None) -> int:
         candidates = self.find_candidates()
-        selected_candidates = candidates
+        grouped = self._group_candidates_by_email(candidates)
         if count is not None:
-            selected_candidates = candidates[:count]
-        return len(
-            list(map(lambda f: self.dosend(follow_up_sched=f), selected_candidates))
-        )
+            grouped = grouped[:count]
+        sent = 0
+        for best, others in grouped:
+            result = self.dosend(follow_up_sched=best)
+            if result:
+                if others:
+                    logger.info(
+                        f"Suppressed {len(others)} duplicate follow-up(s) for "
+                        f"{mask_email_for_logging(best.email)}"
+                    )
+                self._mark_as_sent_without_sending(others)
+                sent += 1
+        return sent
 
     def dosend(
         self,
@@ -216,6 +268,34 @@ class FollowUpEmailSender(AsyncEmailSenderMixin):
                 f"Failed to send follow-up email to {mask_email_for_logging(email)}: {e}"
             )
             return False
+
+    async def asend_all(
+        self, count: Optional[int] = None, candidates: Optional[list] = None
+    ) -> int:
+        """Async send_all with per-email grouping and rate limiting.
+
+        Groups candidates by email address so each recipient gets at most
+        one follow-up email per batch. The best candidate (longest duration)
+        is sent; the rest are marked as sent without emailing.
+        """
+        if candidates is None:
+            candidates = await self.afind_candidates()
+        grouped = await sync_to_async(self._group_candidates_by_email)(candidates)
+        if count is not None:
+            grouped = grouped[:count]
+        sent = 0
+        for best, others in grouped:
+            result = await self.adosend(follow_up_sched=best)
+            if result:
+                if others:
+                    await sync_to_async(self._mark_as_sent_without_sending)(others)
+                    logger.info(
+                        f"Suppressed {len(others)} duplicate follow-up(s) for "
+                        f"{mask_email_for_logging(best.email)}"
+                    )
+                sent += 1
+                await asyncio.sleep(random.uniform(1.0, 3.0))
+        return sent
 
     async def _asend_one(self, candidate: Any) -> bool:
         return await self.adosend(follow_up_sched=candidate)

--- a/fighthealthinsurance/followup_emails.py
+++ b/fighthealthinsurance/followup_emails.py
@@ -148,7 +148,7 @@ class FollowUpEmailSender(AsyncEmailSenderMixin):
             groups[candidate.email].append(candidate)
 
         result = []
-        for email, group in groups.items():
+        for group in groups.values():
             group.sort(
                 key=lambda s: (
                     s.follow_up_type.duration
@@ -215,8 +215,13 @@ class FollowUpEmailSender(AsyncEmailSenderMixin):
             self._mark_as_sent_without_sending(to_suppress)
         return email_sent
 
-    def send_all(self, count: Optional[int] = None) -> int:
-        candidates = self.find_candidates()
+    def send_all(
+        self,
+        count: Optional[int] = None,
+        candidates: Optional[list] = None,
+    ) -> int:
+        if candidates is None:
+            candidates = self.find_candidates()
         grouped = self._group_candidates_by_email(candidates)
         if count is not None:
             grouped = grouped[:count]

--- a/fighthealthinsurance/followup_emails.py
+++ b/fighthealthinsurance/followup_emails.py
@@ -185,9 +185,7 @@ class FollowUpEmailSender(AsyncEmailSenderMixin):
             follow_up_sent_date=now,
         )
 
-    def _send_grouped(
-        self, all_candidates: list[FollowUpSched]
-    ) -> bool:
+    def _send_grouped(self, all_candidates: list[FollowUpSched]) -> bool:
         """Send one email for a group of candidates sharing the same address.
 
         Iterates candidates in priority order (longest duration first).

--- a/fighthealthinsurance/management/commands/send_followup_emails.py
+++ b/fighthealthinsurance/management/commands/send_followup_emails.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
         count = options.get("count")
         dry_run = options.get("dry_run", False)
 
-        candidates = sender.find_candidates()
+        candidates = sender.find_all_due()
         candidate_count = len(candidates)
 
         if candidate_count == 0:

--- a/fighthealthinsurance/management/commands/send_followup_emails.py
+++ b/fighthealthinsurance/management/commands/send_followup_emails.py
@@ -37,7 +37,7 @@ class Command(BaseCommand):
             )
             return
 
-        grouped = sender._group_candidates_by_email(candidates)
+        grouped = sender.group_due_followups(candidates)
         self.stdout.write(
             f"Found {candidate_count} pending follow-up records "
             f"for {len(grouped)} unique email(s)."
@@ -47,20 +47,13 @@ class Command(BaseCommand):
             self.stdout.write(self.style.WARNING("Dry run mode - not sending emails."))
             selected = grouped[:count] if count else grouped
             for best, others in selected:
-                # Mirror _send_grouped: skip stale candidates and pick the
-                # first non-stale one as the actual recipient.
-                all_in_group = [best] + others
-                to_send = next(
-                    (c for c in all_in_group if not sender._is_stale(c)),
-                    None,
-                )
+                to_send, suppressed = sender.preview_grouped_send([best] + others)
                 if to_send is None:
                     self.stdout.write(
-                        f"  Would suppress all {len(all_in_group)} follow-up(s) "
+                        f"  Would suppress all {len(others) + 1} follow-up(s) "
                         f"for {best.email} (all stale)"
                     )
                     continue
-                suppressed = len(all_in_group) - 1
                 suffix = f" (+{suppressed} suppressed)" if suppressed else ""
                 self.stdout.write(f"  Would send to: {to_send.email}{suffix}")
             return

--- a/fighthealthinsurance/management/commands/send_followup_emails.py
+++ b/fighthealthinsurance/management/commands/send_followup_emails.py
@@ -47,11 +47,25 @@ class Command(BaseCommand):
             self.stdout.write(self.style.WARNING("Dry run mode - not sending emails."))
             selected = grouped[:count] if count else grouped
             for best, others in selected:
-                suppressed = f" (+{len(others)} suppressed)" if others else ""
-                self.stdout.write(f"  Would send to: {best.email}{suppressed}")
+                # Mirror _send_grouped: skip stale candidates and pick the
+                # first non-stale one as the actual recipient.
+                all_in_group = [best] + others
+                to_send = next(
+                    (c for c in all_in_group if not sender._is_stale(c)),
+                    None,
+                )
+                if to_send is None:
+                    self.stdout.write(
+                        f"  Would suppress all {len(all_in_group)} follow-up(s) "
+                        f"for {best.email} (all stale)"
+                    )
+                    continue
+                suppressed = len(all_in_group) - 1
+                suffix = f" (+{suppressed} suppressed)" if suppressed else ""
+                self.stdout.write(f"  Would send to: {to_send.email}{suffix}")
             return
 
-        sent_count = sender.send_all(count=count)
+        sent_count = sender.send_all(count=count, candidates=candidates)
         self.stdout.write(
             self.style.SUCCESS(f"Successfully sent {sent_count} follow-up emails.")
         )

--- a/fighthealthinsurance/management/commands/send_followup_emails.py
+++ b/fighthealthinsurance/management/commands/send_followup_emails.py
@@ -28,8 +28,8 @@ class Command(BaseCommand):
         count = options.get("count")
         dry_run = options.get("dry_run", False)
 
-        candidates = sender._find_candidates()
-        candidate_count = candidates.count()
+        candidates = sender.find_candidates()
+        candidate_count = len(candidates)
 
         if candidate_count == 0:
             self.stdout.write(
@@ -37,12 +37,18 @@ class Command(BaseCommand):
             )
             return
 
-        self.stdout.write(f"Found {candidate_count} pending follow-up emails.")
+        grouped = sender._group_candidates_by_email(candidates)
+        self.stdout.write(
+            f"Found {candidate_count} pending follow-up records "
+            f"for {len(grouped)} unique email(s)."
+        )
 
         if dry_run:
             self.stdout.write(self.style.WARNING("Dry run mode - not sending emails."))
-            for candidate in candidates[:count] if count else candidates:
-                self.stdout.write(f"  Would send to: {candidate.email}")
+            selected = grouped[:count] if count else grouped
+            for best, others in selected:
+                suppressed = f" (+{len(others)} suppressed)" if others else ""
+                self.stdout.write(f"  Would send to: {best.email}{suppressed}")
             return
 
         sent_count = sender.send_all(count=count)

--- a/tests/async-unit/test_followup_emails.py
+++ b/tests/async-unit/test_followup_emails.py
@@ -645,6 +645,31 @@ class TestFollowUpEmailGrouping:
         )
 
     @patch("fighthealthinsurance.followup_emails.send_fallback_email")
+    def test_send_all_single_followup_passes_through(
+        self, mock_send_email, followup_types
+    ):
+        """Single denial with one follow-up works through the grouping path."""
+        email = "patient@gmail.com"
+        denial = self._create_denial(email)
+        fut_7, _, _ = followup_types
+
+        sched = FollowUpSched.objects.create(
+            email=email,
+            denial_id=denial,
+            follow_up_type=fut_7,
+            follow_up_date=datetime.date.today() - datetime.timedelta(days=1),
+            follow_up_sent=False,
+        )
+
+        sender = FollowUpEmailSender()
+        count = sender.send_all()
+
+        assert count == 1
+        assert mock_send_email.call_count == 1
+        sched.refresh_from_db()
+        assert sched.follow_up_sent is True
+
+    @patch("fighthealthinsurance.followup_emails.send_fallback_email")
     def test_send_all_groups_same_email_sends_once(
         self, mock_send_email, followup_types
     ):

--- a/tests/async-unit/test_followup_emails.py
+++ b/tests/async-unit/test_followup_emails.py
@@ -906,6 +906,227 @@ class TestFollowUpEmailGrouping:
         assert best == s90
         assert set(o.pk for o in others) == {s7.pk, s30.pk}
 
+    def test_is_stale_returns_true_when_later_type_sent(self, followup_types):
+        """_is_stale returns True when a longer-duration follow-up was already sent."""
+        email = "patient@gmail.com"
+        denial = self._create_denial(email)
+        fut_7, fut_30, _ = followup_types
+
+        FollowUpSched.objects.create(
+            email=email,
+            denial_id=denial,
+            follow_up_type=fut_30,
+            follow_up_date=datetime.date.today() - datetime.timedelta(days=10),
+            follow_up_sent=True,
+            follow_up_sent_date=timezone.now() - datetime.timedelta(days=10),
+        )
+        sched_7 = FollowUpSched.objects.create(
+            email=email,
+            denial_id=denial,
+            follow_up_type=fut_7,
+            follow_up_date=datetime.date.today() - datetime.timedelta(days=1),
+            follow_up_sent=False,
+        )
+
+        sender = FollowUpEmailSender()
+        assert sender._is_stale(sched_7) is True
+
+    def test_is_stale_returns_false_when_no_later_type_sent(self, followup_types):
+        """_is_stale returns False when no longer-duration follow-up was sent."""
+        email = "patient@gmail.com"
+        denial = self._create_denial(email)
+        fut_7, _, _ = followup_types
+
+        sched_7 = FollowUpSched.objects.create(
+            email=email,
+            denial_id=denial,
+            follow_up_type=fut_7,
+            follow_up_date=datetime.date.today() - datetime.timedelta(days=1),
+            follow_up_sent=False,
+        )
+
+        sender = FollowUpEmailSender()
+        assert sender._is_stale(sched_7) is False
+
+    def test_is_stale_returns_false_when_only_shorter_type_sent(self, followup_types):
+        """_is_stale returns False when only a shorter-duration follow-up was sent."""
+        email = "patient@gmail.com"
+        denial = self._create_denial(email)
+        fut_7, fut_30, _ = followup_types
+
+        FollowUpSched.objects.create(
+            email=email,
+            denial_id=denial,
+            follow_up_type=fut_7,
+            follow_up_date=datetime.date.today() - datetime.timedelta(days=24),
+            follow_up_sent=True,
+            follow_up_sent_date=timezone.now() - datetime.timedelta(days=24),
+        )
+        sched_30 = FollowUpSched.objects.create(
+            email=email,
+            denial_id=denial,
+            follow_up_type=fut_30,
+            follow_up_date=datetime.date.today() - datetime.timedelta(days=1),
+            follow_up_sent=False,
+        )
+
+        sender = FollowUpEmailSender()
+        assert sender._is_stale(sched_30) is False
+
+    def test_is_stale_returns_false_for_null_type(self, test_followup_sched):
+        """_is_stale returns False when follow_up_type is None."""
+        sender = FollowUpEmailSender()
+        assert sender._is_stale(test_followup_sched) is False
+
+    @patch("fighthealthinsurance.followup_emails.send_fallback_email")
+    def test_send_all_all_stale_sends_no_email(self, mock_send_email, followup_types):
+        """If every candidate in a group is stale, no email is sent but all are marked."""
+        email = "patient@gmail.com"
+        denial1 = self._create_denial(email)
+        denial2 = self._create_denial(email)
+        fut_7, fut_30, _ = followup_types
+
+        # Both denials have 30-day already sent, making their 7-day stale
+        for denial in (denial1, denial2):
+            FollowUpSched.objects.create(
+                email=email,
+                denial_id=denial,
+                follow_up_type=fut_30,
+                follow_up_date=datetime.date.today() - datetime.timedelta(days=10),
+                follow_up_sent=True,
+                follow_up_sent_date=timezone.now() - datetime.timedelta(days=10),
+            )
+        sched1_7 = FollowUpSched.objects.create(
+            email=email,
+            denial_id=denial1,
+            follow_up_type=fut_7,
+            follow_up_date=datetime.date.today() - datetime.timedelta(days=1),
+            follow_up_sent=False,
+        )
+        sched2_7 = FollowUpSched.objects.create(
+            email=email,
+            denial_id=denial2,
+            follow_up_type=fut_7,
+            follow_up_date=datetime.date.today() - datetime.timedelta(days=1),
+            follow_up_sent=False,
+        )
+
+        sender = FollowUpEmailSender()
+        count = sender.send_all()
+
+        # No email should be sent, but both stale candidates should be marked
+        assert count == 0
+        assert mock_send_email.call_count == 0
+        sched1_7.refresh_from_db()
+        sched2_7.refresh_from_db()
+        assert sched1_7.follow_up_sent is True
+        assert sched2_7.follow_up_sent is True
+
+    @patch("fighthealthinsurance.followup_emails.send_fallback_email")
+    def test_send_all_mixed_stale_and_valid_with_three_denials(
+        self, mock_send_email, followup_types
+    ):
+        """Three denials: longest-duration is stale, middle is valid, shortest is valid.
+
+        The valid middle candidate should be sent, the stale and the remaining
+        valid candidate should be marked as suppressed.
+        """
+        email = "patient@gmail.com"
+        denial1 = self._create_denial(email)
+        denial2 = self._create_denial(email)
+        denial3 = self._create_denial(email)
+        fut_7, fut_30, fut_90 = followup_types
+
+        # Denial 1: 90-day is stale because... wait, can't be stale (nothing longer).
+        # Make denial1's 30-day stale by having its 90-day already sent.
+        FollowUpSched.objects.create(
+            email=email,
+            denial_id=denial1,
+            follow_up_type=fut_90,
+            follow_up_date=datetime.date.today() - datetime.timedelta(days=5),
+            follow_up_sent=True,
+            follow_up_sent_date=timezone.now() - datetime.timedelta(days=5),
+        )
+        sched1_30 = FollowUpSched.objects.create(
+            email=email,
+            denial_id=denial1,
+            follow_up_type=fut_30,
+            follow_up_date=datetime.date.today() - datetime.timedelta(days=1),
+            follow_up_sent=False,
+        )
+
+        # Denial 2: valid 30-day
+        sched2_30 = FollowUpSched.objects.create(
+            email=email,
+            denial_id=denial2,
+            follow_up_type=fut_30,
+            follow_up_date=datetime.date.today() - datetime.timedelta(days=1),
+            follow_up_sent=False,
+        )
+
+        # Denial 3: valid 7-day
+        sched3_7 = FollowUpSched.objects.create(
+            email=email,
+            denial_id=denial3,
+            follow_up_type=fut_7,
+            follow_up_date=datetime.date.today() - datetime.timedelta(days=1),
+            follow_up_sent=False,
+        )
+
+        sender = FollowUpEmailSender()
+        count = sender.send_all()
+
+        # Exactly one email should be sent (a valid 30-day)
+        assert count == 1
+        assert mock_send_email.call_count == 1
+        # The sent email should be a 30-day template
+        call_kwargs = mock_send_email.call_args[1]
+        assert call_kwargs["template_name"] == "followup_30day"
+
+        # All three should be marked as sent
+        sched1_30.refresh_from_db()
+        sched2_30.refresh_from_db()
+        sched3_7.refresh_from_db()
+        assert sched1_30.follow_up_sent is True
+        assert sched2_30.follow_up_sent is True
+        assert sched3_7.follow_up_sent is True
+
+    @patch("fighthealthinsurance.followup_emails.send_fallback_email")
+    def test_send_all_preserves_unsent_after_send_failure(
+        self, mock_send_email, followup_types
+    ):
+        """If the valid candidate fails to send, later unsent candidates stay unsent."""
+        mock_send_email.side_effect = Exception("SMTP down")
+        email = "patient@gmail.com"
+        denial1 = self._create_denial(email)
+        denial2 = self._create_denial(email)
+        _, fut_30, _ = followup_types
+
+        sched1 = FollowUpSched.objects.create(
+            email=email,
+            denial_id=denial1,
+            follow_up_type=fut_30,
+            follow_up_date=datetime.date.today() - datetime.timedelta(days=1),
+            follow_up_sent=False,
+        )
+        sched2 = FollowUpSched.objects.create(
+            email=email,
+            denial_id=denial2,
+            follow_up_type=fut_30,
+            follow_up_date=datetime.date.today() - datetime.timedelta(days=1),
+            follow_up_sent=False,
+        )
+
+        sender = FollowUpEmailSender()
+        count = sender.send_all()
+
+        assert count == 0
+        sched1.refresh_from_db()
+        sched2.refresh_from_db()
+        # Neither should be marked as sent when the actual send failed
+        assert sched1.follow_up_sent is False
+        assert sched2.follow_up_sent is False
+
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
@@ -959,6 +1180,65 @@ class TestFollowUpEmailGroupingAsync:
         await sync_to_async(sched2.refresh_from_db)()
         assert sched1.follow_up_sent is True
         assert sched2.follow_up_sent is True
+
+    @patch("fighthealthinsurance.followup_emails.send_fallback_email")
+    @patch("fighthealthinsurance.followup_emails.asyncio.sleep", return_value=None)
+    async def test_asend_all_skips_stale_and_sends_valid(
+        self, mock_sleep, mock_send_email, followup_types
+    ):
+        """Async: stale best candidate is skipped, next valid one is sent."""
+        email = "patient@gmail.com"
+        hashed = Denial.get_hashed_email(email)
+        denial1 = await sync_to_async(Denial.objects.create)(
+            denial_text="Denial 1",
+            hashed_email=hashed,
+            raw_email=email,
+            health_history="",
+        )
+        denial2 = await sync_to_async(Denial.objects.create)(
+            denial_text="Denial 2",
+            hashed_email=hashed,
+            raw_email=email,
+            health_history="",
+        )
+        fut_7, fut_30, _ = followup_types
+
+        # Denial 1: 30-day already sent → its 7-day is stale
+        await sync_to_async(FollowUpSched.objects.create)(
+            email=email,
+            denial_id=denial1,
+            follow_up_type=fut_30,
+            follow_up_date=datetime.date.today() - datetime.timedelta(days=10),
+            follow_up_sent=True,
+            follow_up_sent_date=timezone.now() - datetime.timedelta(days=10),
+        )
+        sched1_7 = await sync_to_async(FollowUpSched.objects.create)(
+            email=email,
+            denial_id=denial1,
+            follow_up_type=fut_7,
+            follow_up_date=datetime.date.today() - datetime.timedelta(days=1),
+            follow_up_sent=False,
+        )
+
+        # Denial 2: valid 7-day
+        sched2_7 = await sync_to_async(FollowUpSched.objects.create)(
+            email=email,
+            denial_id=denial2,
+            follow_up_type=fut_7,
+            follow_up_date=datetime.date.today() - datetime.timedelta(days=1),
+            follow_up_sent=False,
+        )
+
+        sender = FollowUpEmailSender()
+        count = await sender.asend_all()
+
+        assert count == 1
+        assert mock_send_email.call_count == 1
+
+        await sync_to_async(sched1_7.refresh_from_db)()
+        await sync_to_async(sched2_7.refresh_from_db)()
+        assert sched1_7.follow_up_sent is True
+        assert sched2_7.follow_up_sent is True
 
 
 @pytest.fixture

--- a/tests/async-unit/test_followup_emails.py
+++ b/tests/async-unit/test_followup_emails.py
@@ -821,6 +821,55 @@ class TestFollowUpEmailGrouping:
         assert count == 1
         assert mock_send_email.call_count == 1
 
+    @patch("fighthealthinsurance.followup_emails.send_fallback_email")
+    def test_send_all_skips_stale_best_sends_next(
+        self, mock_send_email, followup_types
+    ):
+        """If best candidate is stale, skip it and send the next non-stale one."""
+        email = "patient@gmail.com"
+        denial1 = self._create_denial(email)
+        denial2 = self._create_denial(email)
+        fut_7, fut_30, _ = followup_types
+
+        # Denial 1: 30-day already sent, making its 7-day stale
+        FollowUpSched.objects.create(
+            email=email,
+            denial_id=denial1,
+            follow_up_type=fut_30,
+            follow_up_date=datetime.date.today() - datetime.timedelta(days=10),
+            follow_up_sent=True,
+            follow_up_sent_date=timezone.now() - datetime.timedelta(days=10),
+        )
+        sched1_7 = FollowUpSched.objects.create(
+            email=email,
+            denial_id=denial1,
+            follow_up_type=fut_7,
+            follow_up_date=datetime.date.today() - datetime.timedelta(days=1),
+            follow_up_sent=False,
+        )
+
+        # Denial 2: 7-day is NOT stale (no later type sent)
+        sched2_7 = FollowUpSched.objects.create(
+            email=email,
+            denial_id=denial2,
+            follow_up_type=fut_7,
+            follow_up_date=datetime.date.today() - datetime.timedelta(days=1),
+            follow_up_sent=False,
+        )
+
+        sender = FollowUpEmailSender()
+        count = sender.send_all()
+
+        # Should send exactly 1 email (for denial2's non-stale follow-up)
+        assert count == 1
+        assert mock_send_email.call_count == 1
+
+        sched1_7.refresh_from_db()
+        sched2_7.refresh_from_db()
+        # Both should be marked as sent
+        assert sched1_7.follow_up_sent is True
+        assert sched2_7.follow_up_sent is True
+
     def test_group_candidates_picks_longest_duration(self, followup_types):
         """_group_candidates_by_email picks 90-day over 30-day over 7-day."""
         email = "patient@gmail.com"

--- a/tests/async-unit/test_followup_emails.py
+++ b/tests/async-unit/test_followup_emails.py
@@ -9,7 +9,10 @@ from django.template.loader import render_to_string
 from django.utils import timezone
 
 from fighthealthinsurance.models import Denial, FollowUpSched, FollowUpType
-from fighthealthinsurance.followup_emails import FollowUpEmailSender, ThankyouEmailSender
+from fighthealthinsurance.followup_emails import (
+    FollowUpEmailSender,
+    ThankyouEmailSender,
+)
 from fighthealthinsurance.common_view_logic import schedule_follow_ups
 
 
@@ -626,6 +629,263 @@ class TestFollowUpEmailTemplates:
         html = render_to_string("emails/followup_90day.html", context)
 
         assert "here for you" in html
+
+
+@pytest.mark.django_db
+class TestFollowUpEmailGrouping:
+    """Test that follow-up emails are grouped by email address."""
+
+    def _create_denial(self, email="patient@gmail.com"):
+        hashed_email = Denial.get_hashed_email(email)
+        return Denial.objects.create(
+            denial_text="Test denial text",
+            hashed_email=hashed_email,
+            raw_email=email,
+            health_history="",
+        )
+
+    @patch("fighthealthinsurance.followup_emails.send_fallback_email")
+    def test_send_all_groups_same_email_sends_once(
+        self, mock_send_email, followup_types
+    ):
+        """Two denials for the same email with due follow-ups → only 1 email sent."""
+        email = "patient@gmail.com"
+        denial1 = self._create_denial(email)
+        denial2 = self._create_denial(email)
+        fut_7, _, _ = followup_types
+
+        sched1 = FollowUpSched.objects.create(
+            email=email,
+            denial_id=denial1,
+            follow_up_type=fut_7,
+            follow_up_date=datetime.date.today() - datetime.timedelta(days=1),
+            follow_up_sent=False,
+        )
+        sched2 = FollowUpSched.objects.create(
+            email=email,
+            denial_id=denial2,
+            follow_up_type=fut_7,
+            follow_up_date=datetime.date.today() - datetime.timedelta(days=1),
+            follow_up_sent=False,
+        )
+
+        sender = FollowUpEmailSender()
+        count = sender.send_all()
+
+        assert count == 1
+        assert mock_send_email.call_count == 1
+
+        sched1.refresh_from_db()
+        sched2.refresh_from_db()
+        assert sched1.follow_up_sent is True
+        assert sched2.follow_up_sent is True
+
+    @patch("fighthealthinsurance.followup_emails.send_fallback_email")
+    def test_send_all_picks_longest_duration(self, mock_send_email, followup_types):
+        """When 7-day and 30-day are both due for same email, sends the 30-day."""
+        email = "patient@gmail.com"
+        denial1 = self._create_denial(email)
+        denial2 = self._create_denial(email)
+        fut_7, fut_30, _ = followup_types
+
+        FollowUpSched.objects.create(
+            email=email,
+            denial_id=denial1,
+            follow_up_type=fut_7,
+            follow_up_date=datetime.date.today() - datetime.timedelta(days=1),
+            follow_up_sent=False,
+        )
+        FollowUpSched.objects.create(
+            email=email,
+            denial_id=denial2,
+            follow_up_type=fut_30,
+            follow_up_date=datetime.date.today() - datetime.timedelta(days=1),
+            follow_up_sent=False,
+        )
+
+        sender = FollowUpEmailSender()
+        sender.send_all()
+
+        assert mock_send_email.call_count == 1
+        call_kwargs = mock_send_email.call_args[1]
+        assert call_kwargs["template_name"] == "followup_30day"
+
+    @patch("fighthealthinsurance.followup_emails.send_fallback_email")
+    def test_send_all_different_emails_sent_separately(
+        self, mock_send_email, followup_types
+    ):
+        """Different email addresses each get their own email."""
+        fut_7, _, _ = followup_types
+        denial1 = self._create_denial("alice@gmail.com")
+        denial2 = self._create_denial("bob@gmail.com")
+
+        FollowUpSched.objects.create(
+            email="alice@gmail.com",
+            denial_id=denial1,
+            follow_up_type=fut_7,
+            follow_up_date=datetime.date.today() - datetime.timedelta(days=1),
+            follow_up_sent=False,
+        )
+        FollowUpSched.objects.create(
+            email="bob@gmail.com",
+            denial_id=denial2,
+            follow_up_type=fut_7,
+            follow_up_date=datetime.date.today() - datetime.timedelta(days=1),
+            follow_up_sent=False,
+        )
+
+        sender = FollowUpEmailSender()
+        count = sender.send_all()
+
+        assert count == 2
+        assert mock_send_email.call_count == 2
+
+    @patch("fighthealthinsurance.followup_emails.send_fallback_email")
+    def test_send_all_does_not_mark_others_on_failure(
+        self, mock_send_email, followup_types
+    ):
+        """If sending fails, the grouped others are NOT marked as sent."""
+        mock_send_email.side_effect = Exception("Email sending failed")
+        email = "patient@gmail.com"
+        denial1 = self._create_denial(email)
+        denial2 = self._create_denial(email)
+        fut_7, _, _ = followup_types
+
+        sched1 = FollowUpSched.objects.create(
+            email=email,
+            denial_id=denial1,
+            follow_up_type=fut_7,
+            follow_up_date=datetime.date.today() - datetime.timedelta(days=1),
+            follow_up_sent=False,
+        )
+        sched2 = FollowUpSched.objects.create(
+            email=email,
+            denial_id=denial2,
+            follow_up_type=fut_7,
+            follow_up_date=datetime.date.today() - datetime.timedelta(days=1),
+            follow_up_sent=False,
+        )
+
+        sender = FollowUpEmailSender()
+        count = sender.send_all()
+
+        assert count == 0
+        sched1.refresh_from_db()
+        sched2.refresh_from_db()
+        assert sched1.follow_up_sent is False
+        assert sched2.follow_up_sent is False
+
+    @patch("fighthealthinsurance.followup_emails.send_fallback_email")
+    def test_send_all_count_limits_unique_emails(self, mock_send_email, followup_types):
+        """Count parameter limits the number of unique email groups processed."""
+        fut_7, _, _ = followup_types
+        for i in range(3):
+            email = f"patient{i}@gmail.com"
+            denial = self._create_denial(email)
+            FollowUpSched.objects.create(
+                email=email,
+                denial_id=denial,
+                follow_up_type=fut_7,
+                follow_up_date=datetime.date.today() - datetime.timedelta(days=1),
+                follow_up_sent=False,
+            )
+
+        sender = FollowUpEmailSender()
+        count = sender.send_all(count=1)
+
+        assert count == 1
+        assert mock_send_email.call_count == 1
+
+    def test_group_candidates_picks_longest_duration(self, followup_types):
+        """_group_candidates_by_email picks 90-day over 30-day over 7-day."""
+        email = "patient@gmail.com"
+        denial = self._create_denial(email)
+        fut_7, fut_30, fut_90 = followup_types
+
+        s7 = FollowUpSched.objects.create(
+            email=email,
+            denial_id=denial,
+            follow_up_type=fut_7,
+            follow_up_date=datetime.date.today() - datetime.timedelta(days=1),
+            follow_up_sent=False,
+        )
+        s30 = FollowUpSched.objects.create(
+            email=email,
+            denial_id=denial,
+            follow_up_type=fut_30,
+            follow_up_date=datetime.date.today() - datetime.timedelta(days=1),
+            follow_up_sent=False,
+        )
+        s90 = FollowUpSched.objects.create(
+            email=email,
+            denial_id=denial,
+            follow_up_type=fut_90,
+            follow_up_date=datetime.date.today() - datetime.timedelta(days=1),
+            follow_up_sent=False,
+        )
+
+        sender = FollowUpEmailSender()
+        grouped = sender._group_candidates_by_email([s7, s30, s90])
+
+        assert len(grouped) == 1
+        best, others = grouped[0]
+        assert best == s90
+        assert set(o.pk for o in others) == {s7.pk, s30.pk}
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+class TestFollowUpEmailGroupingAsync:
+    """Test async grouping of follow-up emails."""
+
+    @patch("fighthealthinsurance.followup_emails.send_fallback_email")
+    @patch("fighthealthinsurance.followup_emails.asyncio.sleep", return_value=None)
+    async def test_asend_all_groups_same_email(
+        self, mock_sleep, mock_send_email, followup_types
+    ):
+        """Async: two denials for the same email → only 1 email sent."""
+        email = "patient@gmail.com"
+        hashed = Denial.get_hashed_email(email)
+        denial1 = await sync_to_async(Denial.objects.create)(
+            denial_text="Denial 1",
+            hashed_email=hashed,
+            raw_email=email,
+            health_history="",
+        )
+        denial2 = await sync_to_async(Denial.objects.create)(
+            denial_text="Denial 2",
+            hashed_email=hashed,
+            raw_email=email,
+            health_history="",
+        )
+        fut_7 = followup_types[0]
+
+        sched1 = await sync_to_async(FollowUpSched.objects.create)(
+            email=email,
+            denial_id=denial1,
+            follow_up_type=fut_7,
+            follow_up_date=datetime.date.today() - datetime.timedelta(days=1),
+            follow_up_sent=False,
+        )
+        sched2 = await sync_to_async(FollowUpSched.objects.create)(
+            email=email,
+            denial_id=denial2,
+            follow_up_type=fut_7,
+            follow_up_date=datetime.date.today() - datetime.timedelta(days=1),
+            follow_up_sent=False,
+        )
+
+        sender = FollowUpEmailSender()
+        count = await sender.asend_all()
+
+        assert count == 1
+        assert mock_send_email.call_count == 1
+
+        await sync_to_async(sched1.refresh_from_db)()
+        await sync_to_async(sched2.refresh_from_db)()
+        assert sched1.follow_up_sent is True
+        assert sched2.follow_up_sent is True
+
 
 @pytest.fixture
 def valid_email_denial(db):


### PR DESCRIPTION
## Summary
Implement email grouping logic in the follow-up email sender to ensure each recipient receives at most one follow-up email per batch, even if multiple denials are pending for the same email address. When multiple follow-ups are due for the same recipient, the most significant one (longest duration: 90-day > 30-day > 7-day) is sent, and the others are marked as sent without actually emailing.

## Key Changes

- **Email grouping in `FollowUpEmailSender`**:
  - Added `_group_candidates_by_email()` method that groups pending follow-ups by email address and selects the best candidate (longest duration) per email
  - Added `_mark_as_sent_without_sending()` helper to mark suppressed follow-ups as sent in the database without sending emails

- **Updated `send_all()` method**:
  - Now groups candidates by email before processing
  - Sends only the best candidate per email address
  - Marks other grouped candidates as sent without emailing
  - Logs suppressed follow-ups for visibility

- **Added async support**:
  - Implemented `asend_all()` method with the same grouping logic
  - Includes rate limiting with random delays between sends
  - Uses `sync_to_async` for database operations

- **Management command improvements**:
  - Updated `send_followup_emails` command to display both total pending records and unique email count
  - Dry-run mode now shows suppressed follow-up counts per recipient
  - Uses new `find_candidates()` method instead of `_find_candidates()`

## Implementation Details

- Grouping uses `defaultdict` to organize candidates by email address
- Best candidate selection sorts by `follow_up_type.duration` in descending order
- Suppressed follow-ups are marked with current timestamp to maintain audit trail
- Both sync and async paths support the `count` parameter to limit unique emails processed
- Comprehensive test coverage including edge cases (failures, different emails, duration selection)

https://claude.ai/code/session_01QsSDRMusP22NR7F9eqhptd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Follow-up emails are now sent in intelligent batches—one email per unique email address, with the system automatically selecting the longest-duration follow-up type when multiple follow-ups are pending for the same recipient.

* **Improvements**
  * Status reporting in follow-up email commands now displays unique recipient counts and suppression counts for better visibility into pending emails.

* **Tests**
  * Added comprehensive test coverage for follow-up email grouping and batch processing logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->