### PR TITLE
Refactor PDF URL resolution into modular async methods

### DIFF
--- a/fighthealthinsurance/pubmed_tools.py
+++ b/fighthealthinsurance/pubmed_tools.py
@@ -11,7 +11,6 @@ from urllib.parse import quote, urljoin
 import aiohttp
 import eutils
 import PyPDF2
-import requests
 from asgiref.sync import async_to_sync, sync_to_async
 from loguru import logger
 from metapub import FindIt
@@ -454,18 +453,25 @@ class PubMedTools(object):
                                 if fetched:
                                     doi = getattr(fetched, "doi", None)
                                     t = timeout / 5.0
-                                    logger.debug(
-                                        f"Looking for {pmid} with timeout of {t}"
-                                    )
-                                    url = await asyncio.wait_for(
-                                        self._find_article_url(
-                                            pmid,
-                                            doi=doi,
-                                            session=session,
-                                            per_source_timeout=t / 6,
-                                        ),
-                                        timeout=t,
-                                    )
+                                    url = None
+                                    try:
+                                        logger.debug(
+                                            f"Looking for {pmid} with timeout of {t}"
+                                        )
+                                        url = await asyncio.wait_for(
+                                            self._find_article_url(
+                                                pmid,
+                                                doi=doi,
+                                                session=session,
+                                                per_source_timeout=t / 6,
+                                            ),
+                                            timeout=t,
+                                        )
+                                    except Exception as e:
+                                        logger.debug(
+                                            f"URL discovery failed for {pmid}: {e}"
+                                        )
+                                    # Always create the article, even without a URL
                                     mini_article = (
                                         await PubMedMiniArticle.objects.acreate(
                                             pmid=pmid,
@@ -846,18 +852,17 @@ class PubMedTools(object):
                             f"Stored URL {article.article_url} didn't yield PDF, trying other sources"
                         )
 
-                    url = await self._find_article_url(
-                        article_id,
-                        doi=article.doi,
-                        session=session,
-                        per_source_timeout=5.0,
-                    )
-                    if url:
+                    # Iterate sources individually so non-PDF results don't block fallbacks
+                    for name, make_coro in self._url_sources(
+                        article_id, article.doi, session, 5.0
+                    ):
+                        url = await make_coro()
+                        if not url:
+                            continue
                         result = await self._try_fetch_pdf_to_file(
                             url, prefix=f"{article_id}", session=session
                         )
                         if result:
-                            # Update the stored URL for next time
                             if url != article.article_url:
                                 try:
                                     await PubMedArticleSummarized.objects.filter(
@@ -866,6 +871,9 @@ class PubMedTools(object):
                                 except Exception:
                                     pass
                             return result
+                        logger.debug(
+                            f"[{article_id}] {name} URL {url} didn't yield PDF, continuing"
+                        )
         except Exception as e:
             logger.debug(f"Error {e} fetching article PDF for {article}")
 

--- a/fighthealthinsurance/pubmed_tools.py
+++ b/fighthealthinsurance/pubmed_tools.py
@@ -161,17 +161,15 @@ class PubMedTools(object):
         if not results:
             return None
         ft_urls = results[0].get("fullTextUrlList", {}).get("fullTextUrl", [])
+        fallback = None
         for ft in ft_urls:
-            if (
-                ft.get("documentStyle") == "pdf"
-                and ft.get("availabilityCode") in ("OA", "F")
-                and ft.get("url")
-            ):
+            if ft.get("availabilityCode") not in ("OA", "F") or not ft.get("url"):
+                continue
+            if ft.get("documentStyle") == "pdf":
                 return str(ft["url"])
-        for ft in ft_urls:
-            if ft.get("availabilityCode") in ("OA", "F") and ft.get("url"):
-                return str(ft["url"])
-        return None
+            if fallback is None:
+                fallback = str(ft["url"])
+        return fallback
 
     async def _try_unpaywall(
         self, doi: str, session: aiohttp.ClientSession, timeout_secs: float
@@ -441,6 +439,8 @@ class PubMedTools(object):
                                     break
 
                 # Check if articles already exist in database
+                url_timeout = timeout / 5.0
+                per_source = url_timeout / 6
                 async with aiohttp.ClientSession(headers=_FETCH_HEADERS) as session:
                     for pmid in pmids:
                         mini_article = await PubMedMiniArticle.objects.filter(
@@ -449,15 +449,14 @@ class PubMedTools(object):
                         if mini_article:
                             if not mini_article.article_url:
                                 try:
-                                    t = timeout / 5.0
                                     url = await asyncio.wait_for(
                                         self._find_article_url(
                                             pmid,
                                             doi=getattr(mini_article, "doi", None),
                                             session=session,
-                                            per_source_timeout=t / 6,
+                                            per_source_timeout=per_source,
                                         ),
-                                        timeout=t,
+                                        timeout=url_timeout,
                                     )
                                     if url:
                                         await PubMedMiniArticle.objects.filter(
@@ -477,20 +476,16 @@ class PubMedTools(object):
                                 )(pmid)
                                 if fetched:
                                     doi = getattr(fetched, "doi", None)
-                                    t = timeout / 5.0
                                     url = None
                                     try:
-                                        logger.debug(
-                                            f"Looking for {pmid} with timeout of {t}"
-                                        )
                                         url = await asyncio.wait_for(
                                             self._find_article_url(
                                                 pmid,
                                                 doi=doi,
                                                 session=session,
-                                                per_source_timeout=t / 6,
+                                                per_source_timeout=per_source,
                                             ),
-                                            timeout=t,
+                                            timeout=url_timeout,
                                         )
                                     except Exception as e:
                                         logger.debug(
@@ -784,39 +779,23 @@ class PubMedTools(object):
                 ):
                     article_text = fetched.content.text
 
-                title = (fetched.title if hasattr(fetched, "title") else "").strip()
-                abstract = (
-                    fetched.abstract if hasattr(fetched, "abstract") else ""
-                ).strip()
+                title = (getattr(fetched, "title", "") or "").strip()
+                abstract = (getattr(fetched, "abstract", "") or "").strip()
                 if article_text:
                     article_text = article_text.strip()
-
-                # Extract authors, journal, and year from metapub
-                authors_str = ""
-                if hasattr(fetched, "authors") and fetched.authors:
-                    authors_str = ", ".join(fetched.authors)
-                journal_str = (
-                    fetched.journal
-                    if hasattr(fetched, "journal") and fetched.journal
-                    else ""
-                )
-                year_str = (
-                    str(fetched.year)
-                    if hasattr(fetched, "year") and fetched.year
-                    else ""
-                )
+                authors = getattr(fetched, "authors", None)
+                authors_str = ", ".join(authors) if authors else ""
+                journal_str = getattr(fetched, "journal", "") or ""
+                year_val = getattr(fetched, "year", None)
+                year_str = str(year_val) if year_val else ""
 
                 if fetched is not None and (
-                    (
-                        hasattr(fetched, "abstract")
-                        and fetched.abstract
-                        and len(fetched.abstract) > 40
-                    )
+                    (abstract and len(abstract) > 40)
                     or (article_text and len(article_text) > 40)
                 ):
                     article = await PubMedArticleSummarized.objects.acreate(
                         pmid=article_id,
-                        doi=fetched.doi if hasattr(fetched, "doi") else "",
+                        doi=getattr(fetched, "doi", "") or "",
                         title=title,
                         authors=authors_str,
                         journal=journal_str,

--- a/fighthealthinsurance/pubmed_tools.py
+++ b/fighthealthinsurance/pubmed_tools.py
@@ -449,10 +449,18 @@ class PubMedTools(object):
                         if mini_article:
                             if not mini_article.article_url:
                                 try:
+                                    fetched = await sync_to_async(
+                                        pubmed_fetcher.article_by_pmid
+                                    )(pmid)
+                                    doi = (
+                                        getattr(fetched, "doi", None)
+                                        if fetched
+                                        else None
+                                    )
                                     url = await asyncio.wait_for(
                                         self._find_article_url(
                                             pmid,
-                                            doi=getattr(mini_article, "doi", None),
+                                            doi=doi,
                                             session=session,
                                             per_source_timeout=per_source,
                                         ),

--- a/fighthealthinsurance/pubmed_tools.py
+++ b/fighthealthinsurance/pubmed_tools.py
@@ -149,13 +149,7 @@ class PubMedTools(object):
                         records = data.get("records", [])
                         if records and records[0].get("pmcid"):
                             pmcid = records[0]["pmcid"]
-                            pdf_url = f"https://www.ncbi.nlm.nih.gov/pmc/articles/{pmcid}/pdf/"
-                            # Verify it's accessible
-                            async with session.head(
-                                pdf_url, allow_redirects=True
-                            ) as head_resp:
-                                if head_resp.status == 200:
-                                    return pdf_url
+                            return f"https://www.ncbi.nlm.nih.gov/pmc/articles/{pmcid}/pdf/"
         except Exception as e:
             logger.debug(f"[{pmid}] PMC lookup failed: {e}")
         return None
@@ -228,6 +222,32 @@ class PubMedTools(object):
             logger.debug(f"[DOI:{doi}] Unpaywall lookup failed: {e}")
         return None
 
+    async def _query_biorxiv_api(
+        self,
+        server: str,
+        doi: str,
+        session: aiohttp.ClientSession,
+        timeout_secs: float,
+    ) -> Optional[str]:
+        """Query biorxiv/medrxiv API for a single server+DOI and return PDF URL if found."""
+        try:
+            api_url = f"https://api.biorxiv.org/details/{server}/{doi}"
+            async with async_timeout(timeout_secs):
+                async with session.get(api_url) as resp:
+                    if resp.status == 200:
+                        data = await resp.json()
+                        results = data.get("collection", [])
+                        if results:
+                            jatsxml = results[-1].get("jatsxml")
+                            if jatsxml:
+                                return str(jatsxml).replace(".source.xml", ".full.pdf")
+                            biorxiv_doi = str(results[-1].get("doi", ""))
+                            if biorxiv_doi:
+                                return f"https://www.{server}.org/content/{biorxiv_doi}.full.pdf"
+        except Exception as e:
+            logger.debug(f"[DOI:{doi}] {server} lookup failed: {e}")
+        return None
+
     async def _try_preprint_servers(
         self,
         doi: str,
@@ -236,48 +256,16 @@ class PubMedTools(object):
     ) -> Optional[str]:
         """Try medRxiv and bioRxiv for preprint PDFs."""
         doi_lower = doi.lower()
-
-        # Direct medRxiv/bioRxiv DOI pattern
+        if (
+            "10.1101/" not in doi
+            and "medrxiv" not in doi_lower
+            and "biorxiv" not in doi_lower
+        ):
+            return None
         for server in ("medrxiv", "biorxiv"):
-            if server in doi_lower or "10.1101/" in doi:
-                try:
-                    # medRxiv/bioRxiv API
-                    api_url = f"https://api.biorxiv.org/details/{server}/{doi}"
-                    async with async_timeout(timeout_secs):
-                        async with session.get(api_url) as resp:
-                            if resp.status == 200:
-                                data = await resp.json()
-                                results = data.get("collection", [])
-                                if results:
-                                    jatsxml = results[-1].get("jatsxml")
-                                    if jatsxml:
-                                        # Convert JATSXML URL to PDF URL
-                                        pdf_url: str = str(jatsxml).replace(
-                                            ".source.xml", ".full.pdf"
-                                        )
-                                        return pdf_url
-                                    # Try constructing PDF URL from DOI
-                                    biorxiv_doi = str(results[-1].get("doi", doi))
-                                    return f"https://www.{server}.org/content/{biorxiv_doi}.full.pdf"
-                except Exception as e:
-                    logger.debug(f"[DOI:{doi}] {server} lookup failed: {e}")
-
-        # Even if the DOI doesn't look like medRxiv/bioRxiv, search for the DOI
-        # on these servers as they may host preprints of published papers
-        for server in ("medrxiv", "biorxiv"):
-            try:
-                api_url = f"https://api.biorxiv.org/details/{server}/{doi}"
-                async with async_timeout(timeout_secs / 2):
-                    async with session.get(api_url) as resp:
-                        if resp.status == 200:
-                            data = await resp.json()
-                            results = data.get("collection", [])
-                            if results:
-                                biorxiv_doi = str(results[-1].get("doi", ""))
-                                if biorxiv_doi:
-                                    return f"https://www.{server}.org/content/{biorxiv_doi}.full.pdf"
-            except Exception as e:
-                logger.debug(f"[DOI:{doi}] {server} search failed: {e}")
+            result = await self._query_biorxiv_api(server, doi, session, timeout_secs)
+            if result:
+                return result
         return None
 
     async def _try_doi_resolution(
@@ -310,6 +298,11 @@ class PubMedTools(object):
         except Exception as e:
             logger.debug(f"[DOI:{doi}] DOI resolution failed: {e}")
         return None
+
+    @staticmethod
+    def _is_pdf_response(url: str, content_type: str) -> bool:
+        """Check if a URL or content-type indicates a PDF response."""
+        return ".pdf" in url or "application/pdf" in content_type
 
     @staticmethod
     def _extract_pdf_url_from_html(html: str, base_url: str) -> Optional[str]:
@@ -741,7 +734,7 @@ class PubMedTools(object):
             async with session.get(url, headers=_FETCH_HEADERS) as response:
                 response.raise_for_status()
                 content_type = response.headers.get("Content-Type", "")
-                if ".pdf" in url or "application/pdf" in content_type:
+                if self._is_pdf_response(url, content_type):
                     with tempfile.NamedTemporaryFile(
                         suffix=".pdf", delete=False
                     ) as my_data:
@@ -857,7 +850,7 @@ class PubMedTools(object):
             async with session.get(url, headers=_FETCH_HEADERS) as response:
                 if response.status == 200:
                     content_type = response.headers.get("Content-Type", "")
-                    if ".pdf" in url or "application/pdf" in content_type:
+                    if self._is_pdf_response(url, content_type):
                         content = await response.read()
                         if len(content) > 20:
                             with tempfile.NamedTemporaryFile(

--- a/fighthealthinsurance/pubmed_tools.py
+++ b/fighthealthinsurance/pubmed_tools.py
@@ -93,7 +93,7 @@ class PubMedTools(object):
             for name, make_coro in self._url_sources(
                 pmid, doi, session, per_source_timeout
             ):
-                url = await make_coro()
+                url: Optional[str] = await make_coro()
                 if url:
                     logger.debug(f"[{pmid}] Found URL via {name}: {url}")
                     return url
@@ -128,7 +128,8 @@ class PubMedTools(object):
             async with async_timeout(timeout_secs):
                 async with session.get(url) as resp:
                     if resp.status == 200:
-                        return await resp.json()
+                        result: Dict = await resp.json()
+                        return result
         except Exception as e:
             logger.debug(f"[{label}] JSON fetch failed: {e}")
         return None
@@ -868,8 +869,10 @@ class PubMedTools(object):
                                     await PubMedArticleSummarized.objects.filter(
                                         pmid=article_id
                                     ).aupdate(article_url=url)
-                                except Exception:
-                                    pass
+                                except Exception as e:
+                                    logger.debug(
+                                        f"[{article_id}] Failed to update article_url to {url}: {e}"
+                                    )
                             return result
                         logger.debug(
                             f"[{article_id}] {name} URL {url} didn't yield PDF, continuing"

--- a/fighthealthinsurance/pubmed_tools.py
+++ b/fighthealthinsurance/pubmed_tools.py
@@ -182,13 +182,13 @@ class PubMedTools(object):
         if not data:
             return None
         best_oa = data.get("best_oa_location")
-        if best_oa:
-            for key in ("url_for_pdf", "url_for_landing_page"):
-                if best_oa.get(key):
-                    return str(best_oa[key])
+        if best_oa and best_oa.get("url_for_pdf"):
+            return str(best_oa["url_for_pdf"])
         for oa_loc in data.get("oa_locations", []):
             if oa_loc.get("url_for_pdf"):
                 return str(oa_loc["url_for_pdf"])
+        if best_oa and best_oa.get("url_for_landing_page"):
+            return str(best_oa["url_for_landing_page"])
         return None
 
     async def _query_biorxiv(
@@ -275,7 +275,9 @@ class PubMedTools(object):
     @staticmethod
     def _is_pdf_response(url: str, content_type: str) -> bool:
         """Check if a URL or content-type indicates a PDF response."""
-        return ".pdf" in url or "application/pdf" in content_type
+        if "application/pdf" in content_type.lower():
+            return True
+        return url.lower().split("?", 1)[0].endswith(".pdf")
 
     @staticmethod
     def _extract_pdf_url_from_html(html: str, base_url: str) -> Optional[str]:
@@ -445,6 +447,27 @@ class PubMedTools(object):
                             pmid=pmid
                         ).afirst()
                         if mini_article:
+                            if not mini_article.article_url:
+                                try:
+                                    t = timeout / 5.0
+                                    url = await asyncio.wait_for(
+                                        self._find_article_url(
+                                            pmid,
+                                            doi=getattr(mini_article, "doi", None),
+                                            session=session,
+                                            per_source_timeout=t / 6,
+                                        ),
+                                        timeout=t,
+                                    )
+                                    if url:
+                                        await PubMedMiniArticle.objects.filter(
+                                            pmid=pmid
+                                        ).aupdate(article_url=url)
+                                        mini_article.article_url = url
+                                except Exception as e:
+                                    logger.debug(
+                                        f"URL re-resolution failed for cached {pmid}: {e}"
+                                    )
                             articles.append(mini_article)
                         else:
                             # Create a new mini article
@@ -706,24 +729,26 @@ class PubMedTools(object):
         self,
         url: str,
         session: aiohttp.ClientSession,
+        timeout_secs: float = 15.0,
     ) -> str:
         """Fetch article text from a URL, handling both PDF and HTML content."""
         article_text = ""
         try:
-            async with session.get(url, headers=_FETCH_HEADERS) as response:
-                response.raise_for_status()
-                content_type = response.headers.get("Content-Type", "")
-                if self._is_pdf_response(url, content_type):
-                    pdf_bytes = await response.read()
-                    read_pdf = PyPDF2.PdfReader(io.BytesIO(pdf_bytes))
-                    if read_pdf.is_encrypted:
-                        read_pdf.decrypt("")
-                    for page in read_pdf.pages:
-                        article_text += page.extract_text()
-                else:
-                    text = (await response.text()).strip()
-                    if " " in text and len(text) > 50:
-                        article_text = text
+            async with async_timeout(timeout_secs):
+                async with session.get(url, headers=_FETCH_HEADERS) as response:
+                    response.raise_for_status()
+                    content_type = response.headers.get("Content-Type", "")
+                    if self._is_pdf_response(url, content_type):
+                        pdf_bytes = await response.read()
+                        read_pdf = PyPDF2.PdfReader(io.BytesIO(pdf_bytes))
+                        if read_pdf.is_encrypted:
+                            read_pdf.decrypt("")
+                        for page in read_pdf.pages:
+                            article_text += page.extract_text()
+                    else:
+                        text = (await response.text()).strip()
+                        if " " in text and len(text) > 50:
+                            article_text = text
         except Exception as e:
             logger.debug(f"Error fetching text from {url}: {e}")
         return article_text
@@ -825,7 +850,7 @@ class PubMedTools(object):
                     content_type = response.headers.get("Content-Type", "")
                     if self._is_pdf_response(url, content_type):
                         content = await response.read()
-                        if len(content) > 20:
+                        if len(content) > 512 and content.lstrip().startswith(b"%PDF"):
                             with tempfile.NamedTemporaryFile(
                                 prefix=prefix, suffix=".pdf", delete=False
                             ) as my_data:

--- a/fighthealthinsurance/pubmed_tools.py
+++ b/fighthealthinsurance/pubmed_tools.py
@@ -162,14 +162,15 @@ class PubMedTools(object):
             return None
         ft_urls = results[0].get("fullTextUrlList", {}).get("fullTextUrl", [])
         for ft in ft_urls:
-            if ft.get("documentStyle") == "pdf" and ft.get("availabilityCode") in (
-                "OA",
-                "F",
+            if (
+                ft.get("documentStyle") == "pdf"
+                and ft.get("availabilityCode") in ("OA", "F")
+                and ft.get("url")
             ):
-                return str(ft.get("url"))
+                return str(ft["url"])
         for ft in ft_urls:
             if ft.get("availabilityCode") in ("OA", "F") and ft.get("url"):
-                return str(ft.get("url"))
+                return str(ft["url"])
         return None
 
     async def _try_unpaywall(
@@ -211,9 +212,9 @@ class PubMedTools(object):
             jatsxml = last.get("jatsxml")
             if jatsxml:
                 return str(jatsxml).replace(".source.xml", ".full.pdf")
-            doi_val = str(last.get("doi", ""))
+            doi_val = last.get("doi") or ""
         else:
-            doi_val = str(last.get("preprint_doi", ""))
+            doi_val = last.get("preprint_doi") or ""
         if doi_val:
             return f"https://www.{server}.org/content/{doi_val}.full.pdf"
         return None

--- a/fighthealthinsurance/pubmed_tools.py
+++ b/fighthealthinsurance/pubmed_tools.py
@@ -248,6 +248,29 @@ class PubMedTools(object):
             logger.debug(f"[DOI:{doi}] {server} lookup failed: {e}")
         return None
 
+    async def _query_biorxiv_pubs_api(
+        self,
+        server: str,
+        doi: str,
+        session: aiohttp.ClientSession,
+        timeout_secs: float,
+    ) -> Optional[str]:
+        """Look up a published DOI on biorxiv/medrxiv to find its preprint PDF."""
+        try:
+            api_url = f"https://api.biorxiv.org/pubs/{server}/{doi}"
+            async with async_timeout(timeout_secs):
+                async with session.get(api_url) as resp:
+                    if resp.status == 200:
+                        data = await resp.json()
+                        results = data.get("collection", [])
+                        if results:
+                            preprint_doi = str(results[-1].get("preprint_doi", ""))
+                            if preprint_doi:
+                                return f"https://www.{server}.org/content/{preprint_doi}.full.pdf"
+        except Exception as e:
+            logger.debug(f"[DOI:{doi}] {server} pubs lookup failed: {e}")
+        return None
+
     async def _try_preprint_servers(
         self,
         doi: str,
@@ -256,14 +279,23 @@ class PubMedTools(object):
     ) -> Optional[str]:
         """Try medRxiv and bioRxiv for preprint PDFs."""
         doi_lower = doi.lower()
-        if (
-            "10.1101/" not in doi
-            and "medrxiv" not in doi_lower
-            and "biorxiv" not in doi_lower
-        ):
-            return None
-        for server in ("medrxiv", "biorxiv"):
-            result = await self._query_biorxiv_api(server, doi, session, timeout_secs)
+        is_preprint = (
+            "10.1101/" in doi or "medrxiv" in doi_lower or "biorxiv" in doi_lower
+        )
+        if is_preprint:
+            # Direct lookup via /details/ endpoint
+            for server in ("medrxiv", "biorxiv"):
+                result = await self._query_biorxiv_api(
+                    server, doi, session, timeout_secs
+                )
+                if result:
+                    return result
+        else:
+            # Published DOI — check if a preprint exists via /pubs/ endpoint
+            # Only try medrxiv to limit HTTP calls (most relevant for health appeals)
+            result = await self._query_biorxiv_pubs_api(
+                "medrxiv", doi, session, timeout_secs
+            )
             if result:
                 return result
         return None

--- a/fighthealthinsurance/pubmed_tools.py
+++ b/fighthealthinsurance/pubmed_tools.py
@@ -1,9 +1,11 @@
 import asyncio
 import json
+import re
 import sys
 import tempfile
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Set, Tuple
+from urllib.parse import quote, urljoin
 
 import aiohttp
 import eutils
@@ -34,10 +36,296 @@ else:
 
 PER_QUERY = 2
 
+# Common headers to avoid bot detection when fetching PDFs
+_FETCH_HEADERS = {
+    "User-Agent": "FightHealthInsurance/1.0 (mailto:support@fighthealthinsurance.com)",
+    "Accept": "application/pdf,text/html,application/xhtml+xml,*/*",
+}
+
 
 class PubMedTools(object):
     # Rough bias to "recent" articles
     since_list = ["2024", None]
+
+    async def _find_article_url(
+        self,
+        pmid: str,
+        doi: Optional[str] = None,
+        session: Optional[aiohttp.ClientSession] = None,
+        per_source_timeout: float = 10.0,
+    ) -> Optional[str]:
+        """Aggressively try multiple sources to find a PDF/full-text URL for an article.
+
+        Tries in order:
+        1. metapub FindIt (existing approach)
+        2. PubMed Central (PMC) direct PDF link
+        3. Europe PMC full text
+        4. Unpaywall API (open access finder)
+        5. medRxiv/bioRxiv preprint PDF
+        6. DOI resolution to publisher with PDF link detection
+        """
+        url: Optional[str] = None
+        owns_session = session is None
+        if owns_session:
+            session = aiohttp.ClientSession(headers=_FETCH_HEADERS)
+
+        try:
+            # 1. metapub FindIt
+            url = await self._try_findit(pmid, per_source_timeout)
+            if url:
+                logger.debug(f"[{pmid}] Found URL via FindIt: {url}")
+                return url
+
+            # 2. PMC direct PDF
+            url = await self._try_pmc(pmid, session, per_source_timeout)
+            if url:
+                logger.debug(f"[{pmid}] Found URL via PMC: {url}")
+                return url
+
+            # 3. Europe PMC
+            url = await self._try_europe_pmc(pmid, session, per_source_timeout)
+            if url:
+                logger.debug(f"[{pmid}] Found URL via Europe PMC: {url}")
+                return url
+
+            # 4. Unpaywall (needs DOI)
+            if doi:
+                url = await self._try_unpaywall(doi, session, per_source_timeout)
+                if url:
+                    logger.debug(f"[{pmid}] Found URL via Unpaywall: {url}")
+                    return url
+
+            # 5. medRxiv/bioRxiv (needs DOI)
+            if doi:
+                url = await self._try_preprint_servers(doi, session, per_source_timeout)
+                if url:
+                    logger.debug(f"[{pmid}] Found URL via preprint server: {url}")
+                    return url
+
+            # 6. DOI resolution
+            if doi:
+                url = await self._try_doi_resolution(doi, session, per_source_timeout)
+                if url:
+                    logger.debug(f"[{pmid}] Found URL via DOI resolution: {url}")
+                    return url
+
+            logger.debug(f"[{pmid}] No PDF URL found from any source")
+            return None
+        finally:
+            if owns_session and session:
+                await session.close()
+
+    async def _try_findit(self, pmid: str, timeout_secs: float) -> Optional[str]:
+        """Try metapub's FindIt to locate article URL."""
+        try:
+            src = await asyncio.wait_for(
+                sync_to_async(FindIt)(pmid),
+                timeout=timeout_secs,
+            )
+            return src.url
+        except Exception:
+            logger.debug(f"[{pmid}] FindIt failed")
+            return None
+
+    async def _try_pmc(
+        self,
+        pmid: str,
+        session: aiohttp.ClientSession,
+        timeout_secs: float,
+    ) -> Optional[str]:
+        """Check if article is in PubMed Central and get its PDF URL."""
+        try:
+            # Use NCBI ID converter to find PMC ID
+            converter_url = (
+                f"https://www.ncbi.nlm.nih.gov/pmc/utils/idconv/v1.0/"
+                f"?ids={pmid}&format=json&tool=fighthealthinsurance&email=support@fighthealthinsurance.com"
+            )
+            async with async_timeout(timeout_secs):
+                async with session.get(converter_url) as resp:
+                    if resp.status == 200:
+                        data = await resp.json()
+                        records = data.get("records", [])
+                        if records and records[0].get("pmcid"):
+                            pmcid = records[0]["pmcid"]
+                            pdf_url = f"https://www.ncbi.nlm.nih.gov/pmc/articles/{pmcid}/pdf/"
+                            # Verify it's accessible
+                            async with session.head(
+                                pdf_url, allow_redirects=True
+                            ) as head_resp:
+                                if head_resp.status == 200:
+                                    return pdf_url
+        except Exception as e:
+            logger.debug(f"[{pmid}] PMC lookup failed: {e}")
+        return None
+
+    async def _try_europe_pmc(
+        self,
+        pmid: str,
+        session: aiohttp.ClientSession,
+        timeout_secs: float,
+    ) -> Optional[str]:
+        """Try Europe PMC for full text PDF."""
+        try:
+            api_url = f"https://www.ebi.ac.uk/europepmc/webservices/rest/search?query=EXT_ID:{pmid}%20AND%20SRC:MED&resultType=core&format=json"
+            async with async_timeout(timeout_secs):
+                async with session.get(api_url) as resp:
+                    if resp.status == 200:
+                        data = await resp.json()
+                        results = data.get("resultList", {}).get("result", [])
+                        if results:
+                            result = results[0]
+                            # Check for full text URLs
+                            full_text_urls = result.get("fullTextUrlList", {}).get(
+                                "fullTextUrl", []
+                            )
+                            # Prefer PDF, then HTML
+                            for ft_url in full_text_urls:
+                                if ft_url.get("documentStyle") == "pdf" and ft_url.get(
+                                    "availabilityCode"
+                                ) in ("OA", "F"):
+                                    return ft_url.get("url")
+                            for ft_url in full_text_urls:
+                                if ft_url.get("availabilityCode") in (
+                                    "OA",
+                                    "F",
+                                ) and ft_url.get("url"):
+                                    return ft_url.get("url")
+        except Exception as e:
+            logger.debug(f"[{pmid}] Europe PMC lookup failed: {e}")
+        return None
+
+    async def _try_unpaywall(
+        self,
+        doi: str,
+        session: aiohttp.ClientSession,
+        timeout_secs: float,
+    ) -> Optional[str]:
+        """Try Unpaywall API to find open access PDF."""
+        try:
+            encoded_doi = quote(doi, safe="")
+            api_url = f"https://api.unpaywall.org/v2/{encoded_doi}?email=support@fighthealthinsurance.com"
+            async with async_timeout(timeout_secs):
+                async with session.get(api_url) as resp:
+                    if resp.status == 200:
+                        data = await resp.json()
+                        best_oa = data.get("best_oa_location")
+                        if best_oa:
+                            # Prefer PDF URL, fall back to landing page
+                            pdf_url = best_oa.get("url_for_pdf")
+                            if pdf_url:
+                                return pdf_url
+                            landing_url = best_oa.get("url_for_landing_page")
+                            if landing_url:
+                                return landing_url
+                        # Try all OA locations
+                        for oa_loc in data.get("oa_locations", []):
+                            pdf_url = oa_loc.get("url_for_pdf")
+                            if pdf_url:
+                                return pdf_url
+        except Exception as e:
+            logger.debug(f"[DOI:{doi}] Unpaywall lookup failed: {e}")
+        return None
+
+    async def _try_preprint_servers(
+        self,
+        doi: str,
+        session: aiohttp.ClientSession,
+        timeout_secs: float,
+    ) -> Optional[str]:
+        """Try medRxiv and bioRxiv for preprint PDFs."""
+        doi_lower = doi.lower()
+
+        # Direct medRxiv/bioRxiv DOI pattern
+        for server in ("medrxiv", "biorxiv"):
+            if server in doi_lower or "10.1101/" in doi:
+                try:
+                    # medRxiv/bioRxiv API
+                    api_url = f"https://api.biorxiv.org/details/{server}/{doi}"
+                    async with async_timeout(timeout_secs):
+                        async with session.get(api_url) as resp:
+                            if resp.status == 200:
+                                data = await resp.json()
+                                results = data.get("collection", [])
+                                if results:
+                                    jatsxml = results[-1].get("jatsxml")
+                                    if jatsxml:
+                                        # Convert JATSXML URL to PDF URL
+                                        pdf_url = jatsxml.replace(
+                                            ".source.xml", ".full.pdf"
+                                        )
+                                        return pdf_url
+                                    # Try constructing PDF URL from DOI
+                                    biorxiv_doi = results[-1].get("doi", doi)
+                                    return f"https://www.{server}.org/content/{biorxiv_doi}.full.pdf"
+                except Exception as e:
+                    logger.debug(f"[DOI:{doi}] {server} lookup failed: {e}")
+
+        # Even if the DOI doesn't look like medRxiv/bioRxiv, search for the DOI
+        # on these servers as they may host preprints of published papers
+        for server in ("medrxiv", "biorxiv"):
+            try:
+                api_url = f"https://api.biorxiv.org/details/{server}/{doi}"
+                async with async_timeout(timeout_secs / 2):
+                    async with session.get(api_url) as resp:
+                        if resp.status == 200:
+                            data = await resp.json()
+                            results = data.get("collection", [])
+                            if results:
+                                biorxiv_doi = results[-1].get("doi", "")
+                                if biorxiv_doi:
+                                    return f"https://www.{server}.org/content/{biorxiv_doi}.full.pdf"
+            except Exception as e:
+                logger.debug(f"[DOI:{doi}] {server} search failed: {e}")
+        return None
+
+    async def _try_doi_resolution(
+        self,
+        doi: str,
+        session: aiohttp.ClientSession,
+        timeout_secs: float,
+    ) -> Optional[str]:
+        """Resolve DOI and look for PDF links on the landing page."""
+        try:
+            doi_url = f"https://doi.org/{quote(doi, safe='')}"
+            async with async_timeout(timeout_secs):
+                async with session.get(
+                    doi_url, allow_redirects=True, headers=_FETCH_HEADERS
+                ) as resp:
+                    if resp.status == 200:
+                        final_url = str(resp.url)
+                        content_type = resp.headers.get("Content-Type", "")
+
+                        # If the DOI resolved directly to a PDF
+                        if "application/pdf" in content_type:
+                            return final_url
+
+                        # Check for common publisher PDF URL patterns
+                        if "text/html" in content_type:
+                            html = await resp.text()
+                            pdf_url = self._extract_pdf_url_from_html(html, final_url)
+                            if pdf_url:
+                                return pdf_url
+        except Exception as e:
+            logger.debug(f"[DOI:{doi}] DOI resolution failed: {e}")
+        return None
+
+    @staticmethod
+    def _extract_pdf_url_from_html(html: str, base_url: str) -> Optional[str]:
+        """Extract PDF URL from publisher HTML page using common patterns."""
+        # Common meta tag patterns for PDF links
+        patterns = [
+            r'<meta[^>]*name=["\']citation_pdf_url["\'][^>]*content=["\'](.*?)["\']',
+            r'<meta[^>]*content=["\'](.*?)["\'][^>]*name=["\']citation_pdf_url["\']',
+            r'<a[^>]*href=["\'](.*?\.pdf(?:\?[^"\']*)?)["\'][^>]*>(?:[^<]*(?:pdf|full.text|download))',
+        ]
+        for pattern in patterns:
+            match = re.search(pattern, html, re.IGNORECASE)
+            if match:
+                pdf_url = match.group(1)
+                if not pdf_url.startswith("http"):
+                    pdf_url = urljoin(base_url, pdf_url)
+                return pdf_url
+        return None
 
     async def find_pubmed_article_ids_for_query(
         self,
@@ -184,52 +472,55 @@ class PubMedTools(object):
                                     break
 
                 # Check if articles already exist in database
-                for pmid in pmids:
-                    mini_article = await PubMedMiniArticle.objects.filter(
-                        pmid=pmid
-                    ).afirst()
-                    if mini_article:
-                        articles.append(mini_article)
-                    else:
-                        # Create a new mini article
-                        try:
-                            fetched = await sync_to_async(
-                                pubmed_fetcher.article_by_pmid
-                            )(pmid)
-                            if fetched:
-                                url = None
-                                try:
+                async with aiohttp.ClientSession(headers=_FETCH_HEADERS) as session:
+                    for pmid in pmids:
+                        mini_article = await PubMedMiniArticle.objects.filter(
+                            pmid=pmid
+                        ).afirst()
+                        if mini_article:
+                            articles.append(mini_article)
+                        else:
+                            # Create a new mini article
+                            try:
+                                fetched = await sync_to_async(
+                                    pubmed_fetcher.article_by_pmid
+                                )(pmid)
+                                if fetched:
+                                    doi = getattr(fetched, "doi", None)
                                     t = timeout / 5.0
                                     logger.debug(
-                                        f"Looking for {pmid} with  with timeout of {t}"
+                                        f"Looking for {pmid} with timeout of {t}"
                                     )
-                                    src = await asyncio.wait_for(
-                                        sync_to_async(FindIt)(pmid),
+                                    url = await asyncio.wait_for(
+                                        self._find_article_url(
+                                            pmid,
+                                            doi=doi,
+                                            session=session,
+                                            per_source_timeout=t / 6,
+                                        ),
                                         timeout=t,
                                     )
-                                    logger.debug(f"Found it {src}")
-                                    url = src.url
-                                except Exception:
-                                    logger.debug("Findit failed.")
-                                mini_article = await PubMedMiniArticle.objects.acreate(
-                                    pmid=pmid,
-                                    title=(
-                                        fetched.title.replace("\x00", "")
-                                        if fetched.title
-                                        else ""
-                                    ),
-                                    abstract=(
-                                        fetched.abstract.replace("\x00", "")
-                                        if fetched.abstract
-                                        else ""
-                                    ),
-                                    article_url=url,
+                                    mini_article = (
+                                        await PubMedMiniArticle.objects.acreate(
+                                            pmid=pmid,
+                                            title=(
+                                                fetched.title.replace("\x00", "")
+                                                if fetched.title
+                                                else ""
+                                            ),
+                                            abstract=(
+                                                fetched.abstract.replace("\x00", "")
+                                                if fetched.abstract
+                                                else ""
+                                            ),
+                                            article_url=url,
+                                        )
+                                    )
+                                    articles.append(mini_article)
+                            except Exception as e:
+                                logger.opt(exception=True).debug(
+                                    f"Error fetching article {pmid}: {e}"
                                 )
-                                articles.append(mini_article)
-                        except Exception as e:
-                            logger.opt(exception=True).debug(
-                                f"Error fetching article {pmid}: {e}"
-                            )
         except asyncio.TimeoutError as e:
             logger.debug(
                 f"Timeout in find_pubmed_articles_for_denial: {e} so far got {articles}"
@@ -437,6 +728,37 @@ class PubMedTools(object):
 
         return pubmed_docs
 
+    async def _fetch_text_from_url(
+        self,
+        url: str,
+        session: aiohttp.ClientSession,
+    ) -> str:
+        """Fetch article text from a URL, handling both PDF and HTML content."""
+        article_text = ""
+        try:
+            async with session.get(url, headers=_FETCH_HEADERS) as response:
+                response.raise_for_status()
+                content_type = response.headers.get("Content-Type", "")
+                if ".pdf" in url or "application/pdf" in content_type:
+                    with tempfile.NamedTemporaryFile(
+                        suffix=".pdf", delete=False
+                    ) as my_data:
+                        my_data.write(await response.read())
+                        with open(my_data.name, "rb") as open_pdf_file:
+                            read_pdf = PyPDF2.PdfReader(open_pdf_file)
+                            if read_pdf.is_encrypted:
+                                read_pdf.decrypt("")
+                            for page in read_pdf.pages:
+                                article_text += page.extract_text()
+                else:
+                    # Assume maybe text-ish
+                    text = (await response.text()).strip()
+                    if " " in text and len(text) > 50:
+                        article_text = text
+        except Exception as e:
+            logger.debug(f"Error fetching text from {url}: {e}")
+        return article_text
+
     async def do_article_summary(self, article_id) -> Optional[PubMedArticleSummarized]:
         article: Optional[PubMedArticleSummarized] = (
             await PubMedArticleSummarized.objects.filter(
@@ -449,37 +771,18 @@ class PubMedTools(object):
             try:
                 fetched = pubmed_fetcher.article_by_pmid(article_id)
                 article_text = ""
-                try:
-                    src = FindIt(article_id)
-                    url = src.url
+                url = None
+                doi = getattr(fetched, "doi", None) if fetched else None
+
+                # Use aggressive multi-source URL finder
+                async with aiohttp.ClientSession(headers=_FETCH_HEADERS) as session:
+                    url = await self._find_article_url(
+                        article_id, doi=doi, session=session
+                    )
 
                     if url is not None:
-                        async with aiohttp.ClientSession() as session:
-                            async with session.get(url) as response:
-                                response.raise_for_status()
-                                if (
-                                    ".pdf" in url
-                                    or response.headers.get("Content-Type")
-                                    == "application/pdf"
-                                ):
-                                    with tempfile.NamedTemporaryFile(
-                                        suffix=".pdf", delete=False
-                                    ) as my_data:
-                                        my_data.write(await response.read())
+                        article_text = await self._fetch_text_from_url(url, session)
 
-                                        open_pdf_file = open(my_data.name, "rb")
-                                        read_pdf = PyPDF2.PdfReader(open_pdf_file)
-                                        if read_pdf.is_encrypted:
-                                            read_pdf.decrypt("")
-                                        for page in read_pdf.pages:
-                                            article_text += page.extract_text()
-                                else:
-                                    # Assume maybe text-ish
-                                    text = (await response.text()).strip()
-                                    if " " in text and len(text) > 50:
-                                        article_text = text
-                except Exception as e:
-                    logger.debug("Error trying to get full text")
                 if (
                     (article_text is None or article_text == "")
                     and fetched
@@ -541,34 +844,73 @@ class PubMedTools(object):
 
         return article
 
-    async def article_as_pdf(self, article: PubMedArticleSummarized) -> Optional[str]:
-        """Return the best PDF we can find of the article."""
-        # First we try and fetch the article
+    async def _try_fetch_pdf_to_file(
+        self,
+        url: str,
+        prefix: str,
+        session: aiohttp.ClientSession,
+    ) -> Optional[str]:
+        """Try to fetch a PDF from a URL and save to a temp file. Returns path or None."""
         try:
-            async with async_timeout(20.0):
-                article_id = article.pmid
-                url = article.article_url
-                if url is not None:
-                    # TODO: Update to AIO http
-                    response = requests.get(url)
-                    if response.ok and (
-                        ".pdf" in url
-                        or response.headers.get("Content-Type") == "application/pdf"
-                    ):
-                        with tempfile.NamedTemporaryFile(
-                            prefix=f"{article_id}", suffix=".pdf", delete=False
-                        ) as my_data:
-                            if len(response.content) > 20:
-                                my_data.write(response.content)
+            async with session.get(url, headers=_FETCH_HEADERS) as response:
+                if response.status == 200:
+                    content_type = response.headers.get("Content-Type", "")
+                    if ".pdf" in url or "application/pdf" in content_type:
+                        content = await response.read()
+                        if len(content) > 20:
+                            with tempfile.NamedTemporaryFile(
+                                prefix=prefix, suffix=".pdf", delete=False
+                            ) as my_data:
+                                my_data.write(content)
                                 my_data.flush()
                                 return my_data.name
-                            else:
-                                logger.debug(f"No content from fetching {url}")
         except Exception as e:
-            logger.debug(f"Error {e} fetching article for {article}")
-            pass
+            logger.debug(f"Error fetching PDF from {url}: {e}")
+        return None
 
-        # Backup us markdown & pandoc -- but only if we have something to write
+    async def article_as_pdf(self, article: PubMedArticleSummarized) -> Optional[str]:
+        """Return the best PDF we can find of the article."""
+        article_id = article.pmid
+
+        try:
+            async with async_timeout(30.0):
+                async with aiohttp.ClientSession(headers=_FETCH_HEADERS) as session:
+                    # Try the stored URL first
+                    if article.article_url:
+                        result = await self._try_fetch_pdf_to_file(
+                            article.article_url, prefix=f"{article_id}", session=session
+                        )
+                        if result:
+                            return result
+                        logger.debug(
+                            f"Stored URL {article.article_url} didn't yield PDF, trying other sources"
+                        )
+
+                    # Aggressively search for a PDF URL using all sources
+                    url = await self._find_article_url(
+                        article_id,
+                        doi=article.doi,
+                        session=session,
+                        per_source_timeout=5.0,
+                    )
+                    if url:
+                        result = await self._try_fetch_pdf_to_file(
+                            url, prefix=f"{article_id}", session=session
+                        )
+                        if result:
+                            # Update the stored URL for next time
+                            if url != article.article_url:
+                                try:
+                                    await PubMedArticleSummarized.objects.filter(
+                                        pmid=article_id
+                                    ).aupdate(article_url=url)
+                                except Exception:
+                                    pass
+                            return result
+        except Exception as e:
+            logger.debug(f"Error {e} fetching article PDF for {article}")
+
+        # Backup: markdown & pandoc -- but only if we have something to write
         if article.abstract is None and article.text is None:
             return None
 

--- a/fighthealthinsurance/pubmed_tools.py
+++ b/fighthealthinsurance/pubmed_tools.py
@@ -117,149 +117,109 @@ class PubMedTools(object):
             logger.debug(f"[{pmid}] FindIt failed")
             return None
 
-    async def _try_pmc(
+    async def _fetch_json(
         self,
-        pmid: str,
         session: aiohttp.ClientSession,
+        url: str,
         timeout_secs: float,
+        label: str = "",
+    ) -> Optional[Dict]:
+        """Fetch JSON from url with timeout. Returns None on any failure."""
+        try:
+            async with async_timeout(timeout_secs):
+                async with session.get(url) as resp:
+                    if resp.status == 200:
+                        return await resp.json()
+        except Exception as e:
+            logger.debug(f"[{label}] JSON fetch failed: {e}")
+        return None
+
+    async def _try_pmc(
+        self, pmid: str, session: aiohttp.ClientSession, timeout_secs: float
     ) -> Optional[str]:
         """Check if article is in PubMed Central and get its PDF URL."""
-        try:
-            converter_url = (
-                f"https://www.ncbi.nlm.nih.gov/pmc/utils/idconv/v1.0/"
-                f"?ids={pmid}&format=json&tool=fighthealthinsurance&email=support@fighthealthinsurance.com"
-            )
-            async with async_timeout(timeout_secs):
-                async with session.get(converter_url) as resp:
-                    if resp.status == 200:
-                        data = await resp.json()
-                        records = data.get("records", [])
-                        if records and records[0].get("pmcid"):
-                            pmcid = records[0]["pmcid"]
-                            return f"https://www.ncbi.nlm.nih.gov/pmc/articles/{pmcid}/pdf/"
-        except Exception as e:
-            logger.debug(f"[{pmid}] PMC lookup failed: {e}")
+        url = (
+            f"https://www.ncbi.nlm.nih.gov/pmc/utils/idconv/v1.0/"
+            f"?ids={pmid}&format=json&tool=fighthealthinsurance&email=support@fighthealthinsurance.com"
+        )
+        data = await self._fetch_json(session, url, timeout_secs, pmid)
+        if data:
+            records = data.get("records", [])
+            if records and records[0].get("pmcid"):
+                return f"https://www.ncbi.nlm.nih.gov/pmc/articles/{records[0]['pmcid']}/pdf/"
         return None
 
     async def _try_europe_pmc(
-        self,
-        pmid: str,
-        session: aiohttp.ClientSession,
-        timeout_secs: float,
+        self, pmid: str, session: aiohttp.ClientSession, timeout_secs: float
     ) -> Optional[str]:
         """Try Europe PMC for full text PDF."""
-        try:
-            api_url = f"https://www.ebi.ac.uk/europepmc/webservices/rest/search?query=EXT_ID:{pmid}%20AND%20SRC:MED&resultType=core&format=json"
-            async with async_timeout(timeout_secs):
-                async with session.get(api_url) as resp:
-                    if resp.status == 200:
-                        data = await resp.json()
-                        results = data.get("resultList", {}).get("result", [])
-                        if results:
-                            result = results[0]
-                            full_text_urls = result.get("fullTextUrlList", {}).get(
-                                "fullTextUrl", []
-                            )
-                            for ft_url in full_text_urls:
-                                if ft_url.get("documentStyle") == "pdf" and ft_url.get(
-                                    "availabilityCode"
-                                ) in ("OA", "F"):
-                                    return str(ft_url.get("url"))
-                            for ft_url in full_text_urls:
-                                if ft_url.get("availabilityCode") in (
-                                    "OA",
-                                    "F",
-                                ) and ft_url.get("url"):
-                                    return str(ft_url.get("url"))
-        except Exception as e:
-            logger.debug(f"[{pmid}] Europe PMC lookup failed: {e}")
+        url = f"https://www.ebi.ac.uk/europepmc/webservices/rest/search?query=EXT_ID:{pmid}%20AND%20SRC:MED&resultType=core&format=json"
+        data = await self._fetch_json(session, url, timeout_secs, pmid)
+        if not data:
+            return None
+        results = data.get("resultList", {}).get("result", [])
+        if not results:
+            return None
+        ft_urls = results[0].get("fullTextUrlList", {}).get("fullTextUrl", [])
+        for ft in ft_urls:
+            if ft.get("documentStyle") == "pdf" and ft.get("availabilityCode") in (
+                "OA",
+                "F",
+            ):
+                return str(ft.get("url"))
+        for ft in ft_urls:
+            if ft.get("availabilityCode") in ("OA", "F") and ft.get("url"):
+                return str(ft.get("url"))
         return None
 
     async def _try_unpaywall(
-        self,
-        doi: str,
-        session: aiohttp.ClientSession,
-        timeout_secs: float,
+        self, doi: str, session: aiohttp.ClientSession, timeout_secs: float
     ) -> Optional[str]:
         """Try Unpaywall API to find open access PDF."""
-        try:
-            encoded_doi = quote(doi, safe="")
-            api_url = f"https://api.unpaywall.org/v2/{encoded_doi}?email=support@fighthealthinsurance.com"
-            async with async_timeout(timeout_secs):
-                async with session.get(api_url) as resp:
-                    if resp.status == 200:
-                        data = await resp.json()
-                        best_oa = data.get("best_oa_location")
-                        if best_oa:
-                            pdf_url = best_oa.get("url_for_pdf")
-                            if pdf_url:
-                                return str(pdf_url)
-                            landing_url = best_oa.get("url_for_landing_page")
-                            if landing_url:
-                                return str(landing_url)
-                        # Try all OA locations
-                        for oa_loc in data.get("oa_locations", []):
-                            pdf_url = oa_loc.get("url_for_pdf")
-                            if pdf_url:
-                                return str(pdf_url)
-        except Exception as e:
-            logger.debug(f"[DOI:{doi}] Unpaywall lookup failed: {e}")
+        url = f"https://api.unpaywall.org/v2/{quote(doi, safe='')}?email=support@fighthealthinsurance.com"
+        data = await self._fetch_json(session, url, timeout_secs, f"DOI:{doi}")
+        if not data:
+            return None
+        best_oa = data.get("best_oa_location")
+        if best_oa:
+            for key in ("url_for_pdf", "url_for_landing_page"):
+                if best_oa.get(key):
+                    return str(best_oa[key])
+        for oa_loc in data.get("oa_locations", []):
+            if oa_loc.get("url_for_pdf"):
+                return str(oa_loc["url_for_pdf"])
         return None
 
-    async def _query_biorxiv_api(
+    async def _query_biorxiv(
         self,
         server: str,
         doi: str,
+        endpoint: str,
         session: aiohttp.ClientSession,
         timeout_secs: float,
     ) -> Optional[str]:
-        """Query biorxiv/medrxiv API for a single server+DOI and return PDF URL if found."""
-        try:
-            api_url = f"https://api.biorxiv.org/details/{server}/{doi}"
-            async with async_timeout(timeout_secs):
-                async with session.get(api_url) as resp:
-                    if resp.status == 200:
-                        data = await resp.json()
-                        results = data.get("collection", [])
-                        if results:
-                            jatsxml = results[-1].get("jatsxml")
-                            if jatsxml:
-                                return str(jatsxml).replace(".source.xml", ".full.pdf")
-                            biorxiv_doi = str(results[-1].get("doi", ""))
-                            if biorxiv_doi:
-                                return f"https://www.{server}.org/content/{biorxiv_doi}.full.pdf"
-        except Exception as e:
-            logger.debug(f"[DOI:{doi}] {server} lookup failed: {e}")
-        return None
-
-    async def _query_biorxiv_pubs_api(
-        self,
-        server: str,
-        doi: str,
-        session: aiohttp.ClientSession,
-        timeout_secs: float,
-    ) -> Optional[str]:
-        """Look up a published DOI on biorxiv/medrxiv to find its preprint PDF."""
-        try:
-            api_url = f"https://api.biorxiv.org/pubs/{server}/{doi}"
-            async with async_timeout(timeout_secs):
-                async with session.get(api_url) as resp:
-                    if resp.status == 200:
-                        data = await resp.json()
-                        results = data.get("collection", [])
-                        if results:
-                            preprint_doi = str(results[-1].get("preprint_doi", ""))
-                            if preprint_doi:
-                                return f"https://www.{server}.org/content/{preprint_doi}.full.pdf"
-        except Exception as e:
-            logger.debug(f"[DOI:{doi}] {server} pubs lookup failed: {e}")
+        """Query biorxiv/medrxiv API. endpoint is 'details' or 'pubs'."""
+        url = f"https://api.biorxiv.org/{endpoint}/{server}/{doi}"
+        data = await self._fetch_json(session, url, timeout_secs, f"DOI:{doi}")
+        if not data:
+            return None
+        results = data.get("collection", [])
+        if not results:
+            return None
+        last = results[-1]
+        if endpoint == "details":
+            jatsxml = last.get("jatsxml")
+            if jatsxml:
+                return str(jatsxml).replace(".source.xml", ".full.pdf")
+            doi_val = str(last.get("doi", ""))
+        else:
+            doi_val = str(last.get("preprint_doi", ""))
+        if doi_val:
+            return f"https://www.{server}.org/content/{doi_val}.full.pdf"
         return None
 
     async def _try_preprint_servers(
-        self,
-        doi: str,
-        session: aiohttp.ClientSession,
-        timeout_secs: float,
+        self, doi: str, session: aiohttp.ClientSession, timeout_secs: float
     ) -> Optional[str]:
         """Try medRxiv and bioRxiv for preprint PDFs."""
         doi_lower = doi.lower()
@@ -267,18 +227,16 @@ class PubMedTools(object):
             "10.1101/" in doi or "medrxiv" in doi_lower or "biorxiv" in doi_lower
         )
         if is_preprint:
-            # Direct lookup via /details/ endpoint
             for server in ("medrxiv", "biorxiv"):
-                result = await self._query_biorxiv_api(
-                    server, doi, session, timeout_secs
+                result = await self._query_biorxiv(
+                    server, doi, "details", session, timeout_secs
                 )
                 if result:
                     return result
         else:
-            # Published DOI — check if a preprint exists via /pubs/ endpoint
             # Only try medrxiv to limit HTTP calls (most relevant for health appeals)
-            result = await self._query_biorxiv_pubs_api(
-                "medrxiv", doi, session, timeout_secs
+            result = await self._query_biorxiv(
+                "medrxiv", doi, "pubs", session, timeout_secs
             )
             if result:
                 return result

--- a/fighthealthinsurance/pubmed_tools.py
+++ b/fighthealthinsurance/pubmed_tools.py
@@ -1,4 +1,5 @@
 import asyncio
+import io
 import json
 import re
 import sys
@@ -47,6 +48,35 @@ class PubMedTools(object):
     # Rough bias to "recent" articles
     since_list = ["2024", None]
 
+    def _url_sources(
+        self,
+        pmid: str,
+        doi: Optional[str],
+        session: aiohttp.ClientSession,
+        per_source_timeout: float,
+    ) -> List[Tuple[str, Any]]:
+        """Build the ordered list of (name, coroutine-factory) pairs for URL resolution.
+
+        Returns callables (not live coroutines) so the caller can create them lazily,
+        avoiding "coroutine was never awaited" warnings on early return.
+        """
+        t = per_source_timeout
+        sources: List[Tuple[str, Any]] = [
+            ("FindIt", lambda: self._try_findit(pmid, t)),
+            ("PMC", lambda: self._try_pmc(pmid, session, t)),
+            ("Europe PMC", lambda: self._try_europe_pmc(pmid, session, t)),
+        ]
+        if doi:
+            sources += [
+                ("Unpaywall", lambda: self._try_unpaywall(doi, session, t)),
+                (
+                    "preprint server",
+                    lambda: self._try_preprint_servers(doi, session, t),
+                ),
+                ("DOI resolution", lambda: self._try_doi_resolution(doi, session, t)),
+            ]
+        return sources
+
     async def _find_article_url(
         self,
         pmid: str,
@@ -54,62 +84,20 @@ class PubMedTools(object):
         session: Optional[aiohttp.ClientSession] = None,
         per_source_timeout: float = 10.0,
     ) -> Optional[str]:
-        """Aggressively try multiple sources to find a PDF/full-text URL for an article.
-
-        Tries in order:
-        1. metapub FindIt (existing approach)
-        2. PubMed Central (PMC) direct PDF link
-        3. Europe PMC full text
-        4. Unpaywall API (open access finder)
-        5. medRxiv/bioRxiv preprint PDF
-        6. DOI resolution to publisher with PDF link detection
-        """
-        url: Optional[str] = None
+        """Try multiple sources in order to find a PDF/full-text URL for an article."""
         owns_session = session is None
         if owns_session:
             session = aiohttp.ClientSession(headers=_FETCH_HEADERS)
         assert session is not None
 
         try:
-            # 1. metapub FindIt
-            url = await self._try_findit(pmid, per_source_timeout)
-            if url:
-                logger.debug(f"[{pmid}] Found URL via FindIt: {url}")
-                return url
-
-            # 2. PMC direct PDF
-            url = await self._try_pmc(pmid, session, per_source_timeout)
-            if url:
-                logger.debug(f"[{pmid}] Found URL via PMC: {url}")
-                return url
-
-            # 3. Europe PMC
-            url = await self._try_europe_pmc(pmid, session, per_source_timeout)
-            if url:
-                logger.debug(f"[{pmid}] Found URL via Europe PMC: {url}")
-                return url
-
-            # 4. Unpaywall (needs DOI)
-            if doi:
-                url = await self._try_unpaywall(doi, session, per_source_timeout)
+            for name, make_coro in self._url_sources(
+                pmid, doi, session, per_source_timeout
+            ):
+                url = await make_coro()
                 if url:
-                    logger.debug(f"[{pmid}] Found URL via Unpaywall: {url}")
+                    logger.debug(f"[{pmid}] Found URL via {name}: {url}")
                     return url
-
-            # 5. medRxiv/bioRxiv (needs DOI)
-            if doi:
-                url = await self._try_preprint_servers(doi, session, per_source_timeout)
-                if url:
-                    logger.debug(f"[{pmid}] Found URL via preprint server: {url}")
-                    return url
-
-            # 6. DOI resolution
-            if doi:
-                url = await self._try_doi_resolution(doi, session, per_source_timeout)
-                if url:
-                    logger.debug(f"[{pmid}] Found URL via DOI resolution: {url}")
-                    return url
-
             logger.debug(f"[{pmid}] No PDF URL found from any source")
             return None
         finally:
@@ -137,7 +125,6 @@ class PubMedTools(object):
     ) -> Optional[str]:
         """Check if article is in PubMed Central and get its PDF URL."""
         try:
-            # Use NCBI ID converter to find PMC ID
             converter_url = (
                 f"https://www.ncbi.nlm.nih.gov/pmc/utils/idconv/v1.0/"
                 f"?ids={pmid}&format=json&tool=fighthealthinsurance&email=support@fighthealthinsurance.com"
@@ -170,11 +157,9 @@ class PubMedTools(object):
                         results = data.get("resultList", {}).get("result", [])
                         if results:
                             result = results[0]
-                            # Check for full text URLs
                             full_text_urls = result.get("fullTextUrlList", {}).get(
                                 "fullTextUrl", []
                             )
-                            # Prefer PDF, then HTML
                             for ft_url in full_text_urls:
                                 if ft_url.get("documentStyle") == "pdf" and ft_url.get(
                                     "availabilityCode"
@@ -206,7 +191,6 @@ class PubMedTools(object):
                         data = await resp.json()
                         best_oa = data.get("best_oa_location")
                         if best_oa:
-                            # Prefer PDF URL, fall back to landing page
                             pdf_url = best_oa.get("url_for_pdf")
                             if pdf_url:
                                 return str(pdf_url)
@@ -317,11 +301,9 @@ class PubMedTools(object):
                         final_url = str(resp.url)
                         content_type = resp.headers.get("Content-Type", "")
 
-                        # If the DOI resolved directly to a PDF
                         if "application/pdf" in content_type:
                             return final_url
 
-                        # Check for common publisher PDF URL patterns
                         if "text/html" in content_type:
                             html = await resp.text()
                             pdf_url = self._extract_pdf_url_from_html(html, final_url)
@@ -339,7 +321,6 @@ class PubMedTools(object):
     @staticmethod
     def _extract_pdf_url_from_html(html: str, base_url: str) -> Optional[str]:
         """Extract PDF URL from publisher HTML page using common patterns."""
-        # Common meta tag patterns for PDF links
         patterns = [
             r'<meta[^>]*name=["\']citation_pdf_url["\'][^>]*content=["\'](.*?)["\']',
             r'<meta[^>]*content=["\'](.*?)["\'][^>]*name=["\']citation_pdf_url["\']',
@@ -767,18 +748,13 @@ class PubMedTools(object):
                 response.raise_for_status()
                 content_type = response.headers.get("Content-Type", "")
                 if self._is_pdf_response(url, content_type):
-                    with tempfile.NamedTemporaryFile(
-                        suffix=".pdf", delete=False
-                    ) as my_data:
-                        my_data.write(await response.read())
-                        with open(my_data.name, "rb") as open_pdf_file:
-                            read_pdf = PyPDF2.PdfReader(open_pdf_file)
-                            if read_pdf.is_encrypted:
-                                read_pdf.decrypt("")
-                            for page in read_pdf.pages:
-                                article_text += page.extract_text()
+                    pdf_bytes = await response.read()
+                    read_pdf = PyPDF2.PdfReader(io.BytesIO(pdf_bytes))
+                    if read_pdf.is_encrypted:
+                        read_pdf.decrypt("")
+                    for page in read_pdf.pages:
+                        article_text += page.extract_text()
                 else:
-                    # Assume maybe text-ish
                     text = (await response.text()).strip()
                     if " " in text and len(text) > 50:
                         article_text = text
@@ -801,7 +777,6 @@ class PubMedTools(object):
                 url = None
                 doi = getattr(fetched, "doi", None) if fetched else None
 
-                # Use aggressive multi-source URL finder
                 async with aiohttp.ClientSession(headers=_FETCH_HEADERS) as session:
                     url = await self._find_article_url(
                         article_id, doi=doi, session=session
@@ -913,7 +888,6 @@ class PubMedTools(object):
                             f"Stored URL {article.article_url} didn't yield PDF, trying other sources"
                         )
 
-                    # Aggressively search for a PDF URL using all sources
                     url = await self._find_article_url(
                         article_id,
                         doi=article.doi,

--- a/fighthealthinsurance/pubmed_tools.py
+++ b/fighthealthinsurance/pubmed_tools.py
@@ -68,6 +68,7 @@ class PubMedTools(object):
         owns_session = session is None
         if owns_session:
             session = aiohttp.ClientSession(headers=_FETCH_HEADERS)
+        assert session is not None
 
         try:
             # 1. metapub FindIt
@@ -122,7 +123,8 @@ class PubMedTools(object):
                 sync_to_async(FindIt)(pmid),
                 timeout=timeout_secs,
             )
-            return src.url
+            url: Optional[str] = src.url
+            return url
         except Exception:
             logger.debug(f"[{pmid}] FindIt failed")
             return None
@@ -183,13 +185,13 @@ class PubMedTools(object):
                                 if ft_url.get("documentStyle") == "pdf" and ft_url.get(
                                     "availabilityCode"
                                 ) in ("OA", "F"):
-                                    return ft_url.get("url")
+                                    return str(ft_url.get("url"))
                             for ft_url in full_text_urls:
                                 if ft_url.get("availabilityCode") in (
                                     "OA",
                                     "F",
                                 ) and ft_url.get("url"):
-                                    return ft_url.get("url")
+                                    return str(ft_url.get("url"))
         except Exception as e:
             logger.debug(f"[{pmid}] Europe PMC lookup failed: {e}")
         return None
@@ -213,15 +215,15 @@ class PubMedTools(object):
                             # Prefer PDF URL, fall back to landing page
                             pdf_url = best_oa.get("url_for_pdf")
                             if pdf_url:
-                                return pdf_url
+                                return str(pdf_url)
                             landing_url = best_oa.get("url_for_landing_page")
                             if landing_url:
-                                return landing_url
+                                return str(landing_url)
                         # Try all OA locations
                         for oa_loc in data.get("oa_locations", []):
                             pdf_url = oa_loc.get("url_for_pdf")
                             if pdf_url:
-                                return pdf_url
+                                return str(pdf_url)
         except Exception as e:
             logger.debug(f"[DOI:{doi}] Unpaywall lookup failed: {e}")
         return None
@@ -250,12 +252,12 @@ class PubMedTools(object):
                                     jatsxml = results[-1].get("jatsxml")
                                     if jatsxml:
                                         # Convert JATSXML URL to PDF URL
-                                        pdf_url = jatsxml.replace(
+                                        pdf_url: str = str(jatsxml).replace(
                                             ".source.xml", ".full.pdf"
                                         )
                                         return pdf_url
                                     # Try constructing PDF URL from DOI
-                                    biorxiv_doi = results[-1].get("doi", doi)
+                                    biorxiv_doi = str(results[-1].get("doi", doi))
                                     return f"https://www.{server}.org/content/{biorxiv_doi}.full.pdf"
                 except Exception as e:
                     logger.debug(f"[DOI:{doi}] {server} lookup failed: {e}")
@@ -271,7 +273,7 @@ class PubMedTools(object):
                             data = await resp.json()
                             results = data.get("collection", [])
                             if results:
-                                biorxiv_doi = results[-1].get("doi", "")
+                                biorxiv_doi = str(results[-1].get("doi", ""))
                                 if biorxiv_doi:
                                     return f"https://www.{server}.org/content/{biorxiv_doi}.full.pdf"
             except Exception as e:

--- a/tests/async-unit/test_pubmed_pdf_resolution.py
+++ b/tests/async-unit/test_pubmed_pdf_resolution.py
@@ -38,34 +38,22 @@ def _make_mock_response(
     return resp
 
 
-def _make_mock_session(responses=None):
+def _make_mock_session(responses=None, error=False):
     """Create a mock aiohttp.ClientSession."""
     session = AsyncMock()
+    if error:
+        session.get = MagicMock(side_effect=Exception("Connection refused"))
+        return session
     if responses is None:
         responses = [_make_mock_response()]
-
-    if isinstance(responses, list):
-        call_count = {"get": 0}
-
-        def make_get(*args, **kwargs):
-            idx = min(call_count["get"], len(responses) - 1)
-            call_count["get"] += 1
-            return responses[idx]
-
-        session.get = MagicMock(side_effect=make_get)
-    else:
-        session.get = MagicMock(return_value=responses)
-
+    session.get = MagicMock(side_effect=list(responses))
     session.__aenter__ = AsyncMock(return_value=session)
     session.__aexit__ = AsyncMock(return_value=False)
     return session
 
 
 def _make_error_session():
-    """Create a mock session that raises on get()."""
-    session = AsyncMock()
-    session.get = MagicMock(side_effect=Exception("Connection refused"))
-    return session
+    return _make_mock_session(error=True)
 
 
 class TestExtractPdfUrlFromHtml:
@@ -169,11 +157,10 @@ class TestTryPmc:
         session = _make_mock_session(responses=[resp])
         assert await tools._try_pmc("12345", session, timeout_secs=5.0) is None
 
-    async def test_returns_none_on_network_error(self, tools):
-        assert (
-            await tools._try_pmc("12345", _make_error_session(), timeout_secs=5.0)
-            is None
-        )
+
+def _epmc_response(ft_urls):
+    """Build an Europe PMC API response wrapping fullTextUrl entries."""
+    return {"resultList": {"result": [{"fullTextUrlList": {"fullTextUrl": ft_urls}}]}}
 
 
 @pytest.mark.asyncio
@@ -182,23 +169,15 @@ class TestTryEuropePmc:
 
     async def test_returns_pdf_url_when_oa_pdf_found(self, tools):
         resp = _make_mock_response(
-            json_data={
-                "resultList": {
-                    "result": [
-                        {
-                            "fullTextUrlList": {
-                                "fullTextUrl": [
-                                    {
-                                        "documentStyle": "pdf",
-                                        "availabilityCode": "OA",
-                                        "url": "https://europepmc.org/article/pdf/12345",
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
+            json_data=_epmc_response(
+                [
+                    {
+                        "documentStyle": "pdf",
+                        "availabilityCode": "OA",
+                        "url": "https://europepmc.org/article/pdf/12345",
+                    }
+                ]
+            )
         )
         session = _make_mock_session(responses=[resp])
         result = await tools._try_europe_pmc("12345", session, timeout_secs=5.0)
@@ -206,23 +185,15 @@ class TestTryEuropePmc:
 
     async def test_falls_back_to_non_pdf_oa_url(self, tools):
         resp = _make_mock_response(
-            json_data={
-                "resultList": {
-                    "result": [
-                        {
-                            "fullTextUrlList": {
-                                "fullTextUrl": [
-                                    {
-                                        "documentStyle": "html",
-                                        "availabilityCode": "OA",
-                                        "url": "https://europepmc.org/article/12345",
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
+            json_data=_epmc_response(
+                [
+                    {
+                        "documentStyle": "html",
+                        "availabilityCode": "OA",
+                        "url": "https://europepmc.org/article/12345",
+                    }
+                ]
+            )
         )
         session = _make_mock_session(responses=[resp])
         result = await tools._try_europe_pmc("12345", session, timeout_secs=5.0)
@@ -232,23 +203,15 @@ class TestTryEuropePmc:
         "json_data",
         [
             {"resultList": {"result": []}},
-            {
-                "resultList": {
-                    "result": [
-                        {
-                            "fullTextUrlList": {
-                                "fullTextUrl": [
-                                    {
-                                        "documentStyle": "pdf",
-                                        "availabilityCode": "S",
-                                        "url": "https://publisher.com/paywalled.pdf",
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
+            _epmc_response(
+                [
+                    {
+                        "documentStyle": "pdf",
+                        "availabilityCode": "S",
+                        "url": "https://publisher.com/paywalled.pdf",
+                    }
+                ]
+            ),
         ],
     )
     async def test_returns_none_when_no_accessible_urls(self, tools, json_data):
@@ -257,29 +220,17 @@ class TestTryEuropePmc:
         assert await tools._try_europe_pmc("12345", session, timeout_secs=5.0) is None
 
     async def test_skips_entry_with_missing_url(self, tools):
-        # Regression: first-pass scan must not return "None" string when url key is absent
         resp = _make_mock_response(
-            json_data={
-                "resultList": {
-                    "result": [
-                        {
-                            "fullTextUrlList": {
-                                "fullTextUrl": [
-                                    {
-                                        "documentStyle": "pdf",
-                                        "availabilityCode": "OA",
-                                    },
-                                    {
-                                        "documentStyle": "html",
-                                        "availabilityCode": "OA",
-                                        "url": "https://europepmc.org/article/12345",
-                                    },
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
+            json_data=_epmc_response(
+                [
+                    {"documentStyle": "pdf", "availabilityCode": "OA"},
+                    {
+                        "documentStyle": "html",
+                        "availabilityCode": "OA",
+                        "url": "https://europepmc.org/article/12345",
+                    },
+                ]
+            )
         )
         session = _make_mock_session(responses=[resp])
         result = await tools._try_europe_pmc("12345", session, timeout_secs=5.0)
@@ -362,77 +313,6 @@ class TestTryUnpaywall:
 
 
 @pytest.mark.asyncio
-class TestTryPreprintServers:
-    """Tests for _try_preprint_servers method."""
-
-    async def test_returns_pdf_for_medrxiv_doi_with_jatsxml(self, tools):
-        resp = _make_mock_response(
-            json_data={
-                "collection": [
-                    {
-                        "doi": "10.1101/2024.01.01.123456",
-                        "jatsxml": "https://www.medrxiv.org/content/10.1101/2024.01.01.123456v1.source.xml",
-                    }
-                ]
-            }
-        )
-        session = _make_mock_session(responses=[resp])
-        result = await tools._try_preprint_servers(
-            "10.1101/2024.01.01.123456", session, timeout_secs=5.0
-        )
-        assert (
-            result
-            == "https://www.medrxiv.org/content/10.1101/2024.01.01.123456v1.full.pdf"
-        )
-
-    async def test_constructs_url_from_doi_when_no_jatsxml(self, tools):
-        resp = _make_mock_response(
-            json_data={"collection": [{"doi": "10.1101/2024.01.01.123456"}]}
-        )
-        session = _make_mock_session(responses=[resp])
-        result = await tools._try_preprint_servers(
-            "10.1101/2024.01.01.123456", session, timeout_secs=5.0
-        )
-        assert (
-            result
-            == "https://www.medrxiv.org/content/10.1101/2024.01.01.123456.full.pdf"
-        )
-
-    async def test_non_preprint_doi_uses_pubs_endpoint(self, tools):
-        resp = _make_mock_response(json_data={"collection": []})
-        session = _make_mock_session(responses=[resp])
-        result = await tools._try_preprint_servers(
-            "10.1016/j.cell.2024.01.001", session, timeout_secs=5.0
-        )
-        assert result is None
-        assert session.get.call_count == 1
-
-    async def test_non_preprint_doi_finds_preprint(self, tools):
-        resp = _make_mock_response(
-            json_data={"collection": [{"preprint_doi": "10.1101/2023.06.15.545100"}]}
-        )
-        session = _make_mock_session(responses=[resp])
-        result = await tools._try_preprint_servers(
-            "10.1016/j.cell.2024.01.001", session, timeout_secs=5.0
-        )
-        assert (
-            result
-            == "https://www.medrxiv.org/content/10.1101/2023.06.15.545100.full.pdf"
-        )
-
-    async def test_biorxiv_doi_pattern(self, tools):
-        resp = _make_mock_response(
-            json_data={"collection": [{"doi": "10.1101/2024.05.15.789012"}]}
-        )
-        session = _make_mock_session(responses=[resp])
-        result = await tools._try_preprint_servers(
-            "10.1101/2024.05.15.789012", session, timeout_secs=5.0
-        )
-        assert result is not None
-        assert "10.1101/2024.05.15.789012.full.pdf" in result
-
-
-@pytest.mark.asyncio
 class TestQueryBiorxiv:
     """Tests for the unified _query_biorxiv method."""
 
@@ -503,11 +383,27 @@ class TestQueryBiorxiv:
         )
         assert result is None
 
-    async def test_returns_none_on_error(self, tools):
-        result = await tools._query_biorxiv(
-            "medrxiv", "10.1101/err", "details", _make_error_session(), timeout_secs=5.0
+    async def test_preprint_server_routing_preprint_doi(self, tools):
+        """_try_preprint_servers uses details endpoint for 10.1101/ DOIs."""
+        resp = _make_mock_response(
+            json_data={"collection": [{"doi": "10.1101/2024.01.01.123"}]}
+        )
+        session = _make_mock_session(responses=[resp])
+        result = await tools._try_preprint_servers(
+            "10.1101/2024.01.01.123", session, timeout_secs=5.0
+        )
+        assert result is not None
+        assert "10.1101/2024.01.01.123.full.pdf" in result
+
+    async def test_preprint_server_routing_published_doi(self, tools):
+        """_try_preprint_servers uses pubs endpoint for non-preprint DOIs."""
+        resp = _make_mock_response(json_data={"collection": []})
+        session = _make_mock_session(responses=[resp])
+        result = await tools._try_preprint_servers(
+            "10.1016/j.cell.2024.01.001", session, timeout_secs=5.0
         )
         assert result is None
+        assert session.get.call_count == 1
 
 
 @pytest.mark.asyncio
@@ -567,64 +463,38 @@ class TestTryDoiResolution:
 class TestFindArticleUrl:
     """Tests for the _find_article_url fallback chain."""
 
-    async def test_returns_findit_url_first(self, tools):
-        session = _make_mock_session()
-        with patch.object(tools, "_try_findit", new_callable=AsyncMock) as mock_findit:
-            mock_findit.return_value = "https://findit.com/article.pdf"
-            result = await tools._find_article_url(
-                "12345", doi="10.1000/test", session=session
-            )
-        assert result == "https://findit.com/article.pdf"
+    def _patch_all_sources(self, tools, return_values=None):
+        """Patch all source methods. return_values maps method name to return value."""
+        rv = return_values or {}
+        sources = [
+            "_try_findit",
+            "_try_pmc",
+            "_try_europe_pmc",
+            "_try_unpaywall",
+            "_try_preprint_servers",
+            "_try_doi_resolution",
+        ]
+        patches = [
+            patch.object(tools, name, new_callable=AsyncMock, return_value=rv.get(name))
+            for name in sources
+        ]
+        return patches
 
-    async def test_falls_through_to_pmc_when_findit_fails(self, tools):
+    async def test_returns_first_successful_source(self, tools):
         session = _make_mock_session()
-        with patch.object(
-            tools, "_try_findit", new_callable=AsyncMock, return_value=None
-        ), patch.object(tools, "_try_pmc", new_callable=AsyncMock) as mock_pmc:
-            mock_pmc.return_value = "https://pmc.ncbi.nlm.nih.gov/article.pdf"
+        patches = self._patch_all_sources(
+            tools, {"_try_pmc": "https://pmc.ncbi.nlm.nih.gov/article.pdf"}
+        )
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
             result = await tools._find_article_url(
                 "12345", doi="10.1000/test", session=session
             )
         assert result == "https://pmc.ncbi.nlm.nih.gov/article.pdf"
 
-    async def test_falls_through_entire_chain(self, tools):
-        session = _make_mock_session()
-        with patch.object(
-            tools, "_try_findit", new_callable=AsyncMock, return_value=None
-        ), patch.object(
-            tools, "_try_pmc", new_callable=AsyncMock, return_value=None
-        ), patch.object(
-            tools, "_try_europe_pmc", new_callable=AsyncMock, return_value=None
-        ), patch.object(
-            tools, "_try_unpaywall", new_callable=AsyncMock, return_value=None
-        ), patch.object(
-            tools, "_try_preprint_servers", new_callable=AsyncMock, return_value=None
-        ), patch.object(
-            tools,
-            "_try_doi_resolution",
-            new_callable=AsyncMock,
-        ) as mock_doi:
-            mock_doi.return_value = "https://publisher.com/pdf/article.pdf"
-            result = await tools._find_article_url(
-                "12345", doi="10.1000/test", session=session
-            )
-        assert result == "https://publisher.com/pdf/article.pdf"
-
     async def test_returns_none_when_all_fail(self, tools):
         session = _make_mock_session()
-        with patch.object(
-            tools, "_try_findit", new_callable=AsyncMock, return_value=None
-        ), patch.object(
-            tools, "_try_pmc", new_callable=AsyncMock, return_value=None
-        ), patch.object(
-            tools, "_try_europe_pmc", new_callable=AsyncMock, return_value=None
-        ), patch.object(
-            tools, "_try_unpaywall", new_callable=AsyncMock, return_value=None
-        ), patch.object(
-            tools, "_try_preprint_servers", new_callable=AsyncMock, return_value=None
-        ), patch.object(
-            tools, "_try_doi_resolution", new_callable=AsyncMock, return_value=None
-        ):
+        patches = self._patch_all_sources(tools)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
             result = await tools._find_article_url(
                 "12345", doi="10.1000/test", session=session
             )
@@ -632,39 +502,15 @@ class TestFindArticleUrl:
 
     async def test_skips_doi_sources_when_no_doi(self, tools):
         session = _make_mock_session()
-        with patch.object(
-            tools, "_try_findit", new_callable=AsyncMock, return_value=None
-        ), patch.object(
-            tools, "_try_pmc", new_callable=AsyncMock, return_value=None
-        ), patch.object(
-            tools, "_try_europe_pmc", new_callable=AsyncMock, return_value=None
-        ), patch.object(
-            tools, "_try_unpaywall", new_callable=AsyncMock
-        ) as mock_unpaywall, patch.object(
-            tools, "_try_preprint_servers", new_callable=AsyncMock
-        ) as mock_preprint, patch.object(
-            tools, "_try_doi_resolution", new_callable=AsyncMock
-        ) as mock_doi:
+        patches = self._patch_all_sources(tools)
+        with patches[0], patches[1], patches[2], patches[3] as mu, patches[
+            4
+        ] as mp, patches[5] as md:
             result = await tools._find_article_url("12345", doi=None, session=session)
-        mock_unpaywall.assert_not_called()
-        mock_preprint.assert_not_called()
-        mock_doi.assert_not_called()
+        mu.assert_not_called()
+        mp.assert_not_called()
+        md.assert_not_called()
         assert result is None
-
-    async def test_creates_own_session_when_none_provided(self, tools):
-        with patch.object(
-            tools, "_try_findit", new_callable=AsyncMock
-        ) as mock_findit, patch(
-            "fighthealthinsurance.pubmed_tools.aiohttp.ClientSession"
-        ) as mock_session_cls:
-            mock_findit.return_value = "https://example.com/article.pdf"
-            mock_session = AsyncMock()
-            mock_session.close = AsyncMock()
-            mock_session_cls.return_value = mock_session
-            result = await tools._find_article_url("12345")
-        assert result == "https://example.com/article.pdf"
-        mock_session_cls.assert_called_once()
-        mock_session.close.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -688,15 +534,6 @@ class TestFetchTextFromUrl:
         result = await tools._fetch_text_from_url(
             "https://example.com/article.html", session
         )
-        assert result == ""
-
-    async def test_returns_empty_string_on_error(self, tools):
-        session = AsyncMock()
-        error_resp = AsyncMock()
-        error_resp.__aenter__ = AsyncMock(side_effect=Exception("Connection error"))
-        error_resp.__aexit__ = AsyncMock(return_value=False)
-        session.get = MagicMock(return_value=error_resp)
-        result = await tools._fetch_text_from_url("https://example.com/broken", session)
         assert result == ""
 
 
@@ -748,13 +585,23 @@ class TestTryFetchPdfToFile:
         result = await tools._try_fetch_pdf_to_file(url, "test_", session)
         assert result is None
 
-    async def test_returns_none_on_network_error(self, tools):
-        session = AsyncMock()
-        error_resp = AsyncMock()
-        error_resp.__aenter__ = AsyncMock(side_effect=Exception("Network error"))
-        error_resp.__aexit__ = AsyncMock(return_value=False)
-        session.get = MagicMock(return_value=error_resp)
-        result = await tools._try_fetch_pdf_to_file(
-            "https://example.com/paper.pdf", "test_", session
-        )
-        assert result is None
+
+@pytest.mark.asyncio
+class TestNetworkErrorHandling:
+    """All URL-fetching methods gracefully handle connection errors."""
+
+    @pytest.mark.parametrize(
+        "method,args,kwargs,expected",
+        [
+            ("_try_pmc", ("12345",), {"timeout_secs": 5.0}, None),
+            ("_try_europe_pmc", ("12345",), {"timeout_secs": 5.0}, None),
+            ("_fetch_text_from_url", ("https://example.com/broken",), {}, ""),
+            ("_try_fetch_pdf_to_file", ("https://example.com/a.pdf", "t_"), {}, None),
+        ],
+    )
+    async def test_returns_gracefully_on_connection_error(
+        self, tools, method, args, kwargs, expected
+    ):
+        session = _make_error_session()
+        result = await getattr(tools, method)(*args, session, **kwargs)
+        assert result == expected

--- a/tests/async-unit/test_pubmed_pdf_resolution.py
+++ b/tests/async-unit/test_pubmed_pdf_resolution.py
@@ -179,8 +179,7 @@ class TestTryPmc:
         converter_resp = _make_mock_response(
             json_data={"records": [{"pmcid": "PMC1234567"}]}
         )
-        head_resp = _make_mock_response(status=200)
-        session = _make_mock_session(responses=[converter_resp, head_resp])
+        session = _make_mock_session(responses=[converter_resp])
 
         result = await tools._try_pmc("12345", session, timeout_secs=5.0)
         assert result == "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1234567/pdf/"
@@ -190,20 +189,6 @@ class TestTryPmc:
 
         converter_resp = _make_mock_response(json_data={"records": [{"pmid": "12345"}]})
         session = _make_mock_session(responses=[converter_resp])
-
-        result = await tools._try_pmc("12345", session, timeout_secs=5.0)
-        assert result is None
-
-    async def test_returns_none_when_head_fails(self):
-        tools = PubMedTools()
-
-        converter_resp = _make_mock_response(
-            json_data={"records": [{"pmcid": "PMC1234567"}]}
-        )
-        head_resp = _make_mock_response(status=404)
-        session = _make_mock_session(responses=[converter_resp])
-        # Override head to return 404
-        session.head = MagicMock(return_value=head_resp)
 
         result = await tools._try_pmc("12345", session, timeout_secs=5.0)
         assert result is None
@@ -449,16 +434,17 @@ class TestTryPreprintServers:
             == "https://www.medrxiv.org/content/10.1101/2024.01.01.123456.full.pdf"
         )
 
-    async def test_returns_none_for_non_preprint_doi_no_results(self):
+    async def test_returns_none_for_non_preprint_doi_without_api_call(self):
         tools = PubMedTools()
 
-        resp = _make_mock_response(json_data={"collection": []})
-        session = _make_mock_session(responses=[resp])
+        session = _make_mock_session()
 
         result = await tools._try_preprint_servers(
             "10.1016/j.cell.2024.01.001", session, timeout_secs=5.0
         )
         assert result is None
+        # Should not have made any API calls for a non-preprint DOI
+        session.get.assert_not_called()
 
     async def test_biorxiv_doi_pattern(self):
         tools = PubMedTools()
@@ -480,6 +466,94 @@ class TestTryPreprintServers:
         # Should match medrxiv first due to 10.1101/ pattern
         assert result is not None
         assert "10.1101/2024.05.15.789012.full.pdf" in result
+
+
+@pytest.mark.asyncio
+class TestQueryBiorxivApi:
+    """Tests for _query_biorxiv_api helper method."""
+
+    async def test_returns_pdf_url_from_jatsxml(self):
+        tools = PubMedTools()
+
+        resp = _make_mock_response(
+            json_data={
+                "collection": [
+                    {
+                        "doi": "10.1101/2024.01.01.123456",
+                        "jatsxml": "https://www.medrxiv.org/content/10.1101/2024.01.01.123456v1.source.xml",
+                    }
+                ]
+            }
+        )
+        session = _make_mock_session(responses=[resp])
+
+        result = await tools._query_biorxiv_api(
+            "medrxiv", "10.1101/2024.01.01.123456", session, timeout_secs=5.0
+        )
+        assert (
+            result
+            == "https://www.medrxiv.org/content/10.1101/2024.01.01.123456v1.full.pdf"
+        )
+
+    async def test_returns_pdf_url_from_doi_when_no_jatsxml(self):
+        tools = PubMedTools()
+
+        resp = _make_mock_response(
+            json_data={"collection": [{"doi": "10.1101/2024.01.01.123456"}]}
+        )
+        session = _make_mock_session(responses=[resp])
+
+        result = await tools._query_biorxiv_api(
+            "biorxiv", "10.1101/2024.01.01.123456", session, timeout_secs=5.0
+        )
+        assert (
+            result
+            == "https://www.biorxiv.org/content/10.1101/2024.01.01.123456.full.pdf"
+        )
+
+    async def test_returns_none_on_empty_collection(self):
+        tools = PubMedTools()
+
+        resp = _make_mock_response(json_data={"collection": []})
+        session = _make_mock_session(responses=[resp])
+
+        result = await tools._query_biorxiv_api(
+            "medrxiv", "10.1101/nothing", session, timeout_secs=5.0
+        )
+        assert result is None
+
+    async def test_returns_none_on_error(self):
+        tools = PubMedTools()
+
+        session = AsyncMock()
+        session.get = MagicMock(side_effect=Exception("timeout"))
+
+        result = await tools._query_biorxiv_api(
+            "medrxiv", "10.1101/err", session, timeout_secs=5.0
+        )
+        assert result is None
+
+
+class TestIsPdfResponse:
+    """Tests for _is_pdf_response static method."""
+
+    def test_pdf_in_url(self):
+        assert PubMedTools._is_pdf_response(
+            "https://example.com/paper.pdf", "text/html"
+        )
+
+    def test_pdf_content_type(self):
+        assert PubMedTools._is_pdf_response(
+            "https://example.com/download", "application/pdf"
+        )
+
+    def test_neither(self):
+        assert not PubMedTools._is_pdf_response("https://example.com/page", "text/html")
+
+    def test_pdf_url_with_query(self):
+        assert PubMedTools._is_pdf_response(
+            "https://example.com/paper.pdf?token=abc", "text/html"
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/async-unit/test_pubmed_pdf_resolution.py
+++ b/tests/async-unit/test_pubmed_pdf_resolution.py
@@ -434,17 +434,41 @@ class TestTryPreprintServers:
             == "https://www.medrxiv.org/content/10.1101/2024.01.01.123456.full.pdf"
         )
 
-    async def test_returns_none_for_non_preprint_doi_without_api_call(self):
+    async def test_non_preprint_doi_uses_pubs_endpoint(self):
         tools = PubMedTools()
 
-        session = _make_mock_session()
+        # /pubs/ endpoint returns no results for this DOI
+        resp = _make_mock_response(json_data={"collection": []})
+        session = _make_mock_session(responses=[resp])
 
         result = await tools._try_preprint_servers(
             "10.1016/j.cell.2024.01.001", session, timeout_secs=5.0
         )
         assert result is None
-        # Should not have made any API calls for a non-preprint DOI
-        session.get.assert_not_called()
+        # Should have made exactly 1 call (medrxiv pubs endpoint only)
+        assert session.get.call_count == 1
+
+    async def test_non_preprint_doi_finds_preprint(self):
+        tools = PubMedTools()
+
+        resp = _make_mock_response(
+            json_data={
+                "collection": [
+                    {
+                        "preprint_doi": "10.1101/2023.06.15.545100",
+                    }
+                ]
+            }
+        )
+        session = _make_mock_session(responses=[resp])
+
+        result = await tools._try_preprint_servers(
+            "10.1016/j.cell.2024.01.001", session, timeout_secs=5.0
+        )
+        assert (
+            result
+            == "https://www.medrxiv.org/content/10.1101/2023.06.15.545100.full.pdf"
+        )
 
     async def test_biorxiv_doi_pattern(self):
         tools = PubMedTools()
@@ -530,6 +554,62 @@ class TestQueryBiorxivApi:
 
         result = await tools._query_biorxiv_api(
             "medrxiv", "10.1101/err", session, timeout_secs=5.0
+        )
+        assert result is None
+
+
+@pytest.mark.asyncio
+class TestQueryBiorxivPubsApi:
+    """Tests for _query_biorxiv_pubs_api helper method."""
+
+    async def test_returns_pdf_url_when_preprint_found(self):
+        tools = PubMedTools()
+
+        resp = _make_mock_response(
+            json_data={"collection": [{"preprint_doi": "10.1101/2023.06.15.545100"}]}
+        )
+        session = _make_mock_session(responses=[resp])
+
+        result = await tools._query_biorxiv_pubs_api(
+            "medrxiv", "10.1016/j.cell.2024.01.001", session, timeout_secs=5.0
+        )
+        assert (
+            result
+            == "https://www.medrxiv.org/content/10.1101/2023.06.15.545100.full.pdf"
+        )
+
+    async def test_returns_none_on_empty_collection(self):
+        tools = PubMedTools()
+
+        resp = _make_mock_response(json_data={"collection": []})
+        session = _make_mock_session(responses=[resp])
+
+        result = await tools._query_biorxiv_pubs_api(
+            "medrxiv", "10.1016/j.cell.2024.01.001", session, timeout_secs=5.0
+        )
+        assert result is None
+
+    async def test_returns_none_on_error(self):
+        tools = PubMedTools()
+
+        session = AsyncMock()
+        session.get = MagicMock(side_effect=Exception("timeout"))
+
+        result = await tools._query_biorxiv_pubs_api(
+            "medrxiv", "10.1016/j.cell.2024.01.001", session, timeout_secs=5.0
+        )
+        assert result is None
+
+    async def test_returns_none_when_no_preprint_doi(self):
+        tools = PubMedTools()
+
+        resp = _make_mock_response(
+            json_data={"collection": [{"some_other_field": "value"}]}
+        )
+        session = _make_mock_session(responses=[resp])
+
+        result = await tools._query_biorxiv_pubs_api(
+            "medrxiv", "10.1016/j.cell.2024.01.001", session, timeout_secs=5.0
         )
         assert result is None
 

--- a/tests/async-unit/test_pubmed_pdf_resolution.py
+++ b/tests/async-unit/test_pubmed_pdf_resolution.py
@@ -329,6 +329,22 @@ class TestTryUnpaywall:
         result = await tools._try_unpaywall("10.1000/test", session, timeout_secs=5.0)
         assert result == "https://repo.org/pdf/article.pdf"
 
+    async def test_prefers_oa_locations_pdf_over_landing_page(self, tools):
+        resp = _make_mock_response(
+            json_data={
+                "best_oa_location": {
+                    "url_for_pdf": None,
+                    "url_for_landing_page": "https://publisher.com/article",
+                },
+                "oa_locations": [
+                    {"url_for_pdf": "https://repo.org/pdf/article.pdf"},
+                ],
+            }
+        )
+        session = _make_mock_session(responses=[resp])
+        result = await tools._try_unpaywall("10.1000/test", session, timeout_secs=5.0)
+        assert result == "https://repo.org/pdf/article.pdf"
+
     @pytest.mark.parametrize(
         "json_data,status",
         [
@@ -689,7 +705,7 @@ class TestTryFetchPdfToFile:
     """Tests for _try_fetch_pdf_to_file method."""
 
     async def test_saves_pdf_to_temp_file(self, tools):
-        pdf_content = b"%PDF-1.4 " + b"x" * 100
+        pdf_content = b"%PDF-1.4 " + b"x" * 600
         resp = _make_mock_response(content=pdf_content, content_type="application/pdf")
         session = _make_mock_session(responses=[resp])
         result = await tools._try_fetch_pdf_to_file(
@@ -714,6 +730,12 @@ class TestTryFetchPdfToFile:
             ),
             ("https://example.com/paper.pdf", b"tiny", "application/pdf", 200),
             ("https://example.com/paper.pdf", b"", "application/pdf", 403),
+            (
+                "https://example.com/paper.pdf",
+                b"<html>Error 404</html>" + b"x" * 600,
+                "application/pdf",
+                200,
+            ),
         ],
     )
     async def test_returns_none_on_invalid(

--- a/tests/async-unit/test_pubmed_pdf_resolution.py
+++ b/tests/async-unit/test_pubmed_pdf_resolution.py
@@ -1,6 +1,4 @@
-"""
-Unit tests for the aggressive PDF URL resolution methods in PubMedTools.
-"""
+"""Unit tests for the PDF URL resolution methods in PubMedTools."""
 
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -9,9 +7,11 @@ import pytest
 
 from fighthealthinsurance.pubmed_tools import PubMedTools
 
+
 @pytest.fixture
 def tools():
     return PubMedTools()
+
 
 def _make_mock_response(
     status=200,
@@ -32,185 +32,154 @@ def _make_mock_response(
     resp.raise_for_status = MagicMock()
     if status >= 400:
         resp.raise_for_status.side_effect = Exception(f"HTTP {status}")
-    # Support async context manager (async with session.get(...) as resp)
     resp.__aenter__ = AsyncMock(return_value=resp)
     resp.__aexit__ = AsyncMock(return_value=False)
     return resp
 
-def _make_mock_session(responses=None):
-    """Create a mock aiohttp.ClientSession.
 
-    Args:
-        responses: list of mock responses to return in order from get/head calls,
-                   or a single response for all calls.
-    """
+def _make_mock_session(responses=None):
+    """Create a mock aiohttp.ClientSession."""
     session = AsyncMock()
     if responses is None:
         responses = [_make_mock_response()]
 
     if isinstance(responses, list):
-        # Return responses in order; if we run out, use the last one
-        call_count = {"get": 0, "head": 0}
+        call_count = {"get": 0}
 
         def make_get(*args, **kwargs):
             idx = min(call_count["get"], len(responses) - 1)
             call_count["get"] += 1
             return responses[idx]
 
-        def make_head(*args, **kwargs):
-            idx = min(call_count["head"], len(responses) - 1)
-            call_count["head"] += 1
-            return responses[idx]
-
         session.get = MagicMock(side_effect=make_get)
-        session.head = MagicMock(side_effect=make_head)
     else:
         session.get = MagicMock(return_value=responses)
-        session.head = MagicMock(return_value=responses)
 
     session.__aenter__ = AsyncMock(return_value=session)
     session.__aexit__ = AsyncMock(return_value=False)
     return session
 
+
+def _make_error_session():
+    """Create a mock session that raises on get()."""
+    session = AsyncMock()
+    session.get = MagicMock(side_effect=Exception("Connection refused"))
+    return session
+
+
 class TestExtractPdfUrlFromHtml:
     """Tests for _extract_pdf_url_from_html static method."""
 
-    def test_citation_pdf_url_name_first(self):
-        html = '<meta name="citation_pdf_url" content="https://example.com/paper.pdf">'
-        result = PubMedTools._extract_pdf_url_from_html(
-            html, "https://example.com/article"
-        )
-        assert result == "https://example.com/paper.pdf"
+    @pytest.mark.parametrize(
+        "html,base_url,expected",
+        [
+            (
+                '<meta name="citation_pdf_url" content="https://example.com/paper.pdf">',
+                "https://example.com/article",
+                "https://example.com/paper.pdf",
+            ),
+            (
+                '<meta content="https://example.com/paper.pdf" name="citation_pdf_url">',
+                "https://example.com/article",
+                "https://example.com/paper.pdf",
+            ),
+            (
+                '<META NAME="Citation_PDF_URL" CONTENT="https://example.com/paper.pdf">',
+                "https://example.com/article",
+                "https://example.com/paper.pdf",
+            ),
+            (
+                '<a href="/downloads/paper.pdf" class="btn">Download PDF</a>',
+                "https://publisher.com/article/123",
+                "https://publisher.com/downloads/paper.pdf",
+            ),
+            (
+                '<meta name="citation_pdf_url" content="/pdf/12345.pdf">',
+                "https://journals.example.com/article/view/1",
+                "https://journals.example.com/pdf/12345.pdf",
+            ),
+            (
+                '<meta name="citation_pdf_url" content="https://cdn.example.com/paper.pdf">',
+                "https://different-domain.com/article",
+                "https://cdn.example.com/paper.pdf",
+            ),
+            (
+                '<a href="/paper.pdf?token=abc123" class="link">Full Text PDF</a>',
+                "https://example.com/article",
+                "https://example.com/paper.pdf?token=abc123",
+            ),
+            (
+                "<html><body><p>No PDF here</p></body></html>",
+                "https://example.com/article",
+                None,
+            ),
+        ],
+    )
+    def test_extracts_pdf_url(self, html, base_url, expected):
+        assert PubMedTools._extract_pdf_url_from_html(html, base_url) == expected
 
-    def test_citation_pdf_url_content_first(self):
-        html = '<meta content="https://example.com/paper.pdf" name="citation_pdf_url">'
-        result = PubMedTools._extract_pdf_url_from_html(
-            html, "https://example.com/article"
-        )
-        assert result == "https://example.com/paper.pdf"
-
-    def test_pdf_anchor_tag(self):
-        html = '<a href="/downloads/paper.pdf" class="btn">Download PDF</a>'
-        result = PubMedTools._extract_pdf_url_from_html(
-            html, "https://publisher.com/article/123"
-        )
-        assert result == "https://publisher.com/downloads/paper.pdf"
-
-    def test_relative_url_resolved(self):
-        html = '<meta name="citation_pdf_url" content="/pdf/12345.pdf">'
-        result = PubMedTools._extract_pdf_url_from_html(
-            html, "https://journals.example.com/article/view/1"
-        )
-        assert result == "https://journals.example.com/pdf/12345.pdf"
-
-    def test_absolute_url_unchanged(self):
-        html = (
-            '<meta name="citation_pdf_url" content="https://cdn.example.com/paper.pdf">'
-        )
-        result = PubMedTools._extract_pdf_url_from_html(
-            html, "https://different-domain.com/article"
-        )
-        assert result == "https://cdn.example.com/paper.pdf"
-
-    def test_no_pdf_link_returns_none(self):
-        html = "<html><body><p>No PDF here</p></body></html>"
-        result = PubMedTools._extract_pdf_url_from_html(
-            html, "https://example.com/article"
-        )
-        assert result is None
-
-    def test_case_insensitive(self):
-        html = '<META NAME="Citation_PDF_URL" CONTENT="https://example.com/paper.pdf">'
-        result = PubMedTools._extract_pdf_url_from_html(
-            html, "https://example.com/article"
-        )
-        assert result == "https://example.com/paper.pdf"
-
-    def test_pdf_url_with_query_params(self):
-        html = '<a href="/paper.pdf?token=abc123" class="link">Full Text PDF</a>'
-        result = PubMedTools._extract_pdf_url_from_html(
-            html, "https://example.com/article"
-        )
-        assert result == "https://example.com/paper.pdf?token=abc123"
 
 @pytest.mark.asyncio
 class TestTryFindit:
     """Tests for _try_findit method."""
 
     async def test_returns_url_on_success(self, tools):
-
         mock_src = MagicMock()
         mock_src.url = "https://example.com/article.pdf"
-
         with patch("fighthealthinsurance.pubmed_tools.sync_to_async") as mock_s2a:
             mock_s2a.return_value = AsyncMock(return_value=mock_src)
             result = await tools._try_findit("12345", timeout_secs=5.0)
-
         assert result == "https://example.com/article.pdf"
 
     async def test_returns_none_on_exception(self, tools):
-
         with patch("fighthealthinsurance.pubmed_tools.sync_to_async") as mock_s2a:
             mock_s2a.return_value = AsyncMock(side_effect=Exception("FindIt error"))
             result = await tools._try_findit("12345", timeout_secs=5.0)
-
         assert result is None
 
     async def test_returns_none_when_url_is_none(self, tools):
-
         mock_src = MagicMock()
         mock_src.url = None
-
         with patch("fighthealthinsurance.pubmed_tools.sync_to_async") as mock_s2a:
             mock_s2a.return_value = AsyncMock(return_value=mock_src)
             result = await tools._try_findit("12345", timeout_secs=5.0)
-
         assert result is None
+
 
 @pytest.mark.asyncio
 class TestTryPmc:
     """Tests for _try_pmc method."""
 
     async def test_returns_pdf_url_when_pmcid_found(self, tools):
-
-        converter_resp = _make_mock_response(
-            json_data={"records": [{"pmcid": "PMC1234567"}]}
-        )
-        session = _make_mock_session(responses=[converter_resp])
-
+        resp = _make_mock_response(json_data={"records": [{"pmcid": "PMC1234567"}]})
+        session = _make_mock_session(responses=[resp])
         result = await tools._try_pmc("12345", session, timeout_secs=5.0)
         assert result == "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1234567/pdf/"
 
-    async def test_returns_none_when_no_pmcid(self, tools):
-
-        converter_resp = _make_mock_response(json_data={"records": [{"pmid": "12345"}]})
-        session = _make_mock_session(responses=[converter_resp])
-
-        result = await tools._try_pmc("12345", session, timeout_secs=5.0)
-        assert result is None
-
-    async def test_returns_none_when_empty_records(self, tools):
-
-        converter_resp = _make_mock_response(json_data={"records": []})
-        session = _make_mock_session(responses=[converter_resp])
-
-        result = await tools._try_pmc("12345", session, timeout_secs=5.0)
-        assert result is None
+    @pytest.mark.parametrize(
+        "json_data",
+        [
+            {"records": [{"pmid": "12345"}]},
+            {"records": []},
+        ],
+    )
+    async def test_returns_none_when_no_pmcid(self, tools, json_data):
+        resp = _make_mock_response(json_data=json_data)
+        session = _make_mock_session(responses=[resp])
+        assert await tools._try_pmc("12345", session, timeout_secs=5.0) is None
 
     async def test_returns_none_on_network_error(self, tools):
+        assert (
+            await tools._try_pmc("12345", _make_error_session(), timeout_secs=5.0)
+            is None
+        )
 
-        session = AsyncMock()
-        session.get = MagicMock(side_effect=Exception("Connection refused"))
-
-        result = await tools._try_pmc("12345", session, timeout_secs=5.0)
-        assert result is None
 
 @pytest.mark.asyncio
 class TestTryEuropePmc:
     """Tests for _try_europe_pmc method."""
 
     async def test_returns_pdf_url_when_oa_pdf_found(self, tools):
-
         resp = _make_mock_response(
             json_data={
                 "resultList": {
@@ -231,12 +200,10 @@ class TestTryEuropePmc:
             }
         )
         session = _make_mock_session(responses=[resp])
-
         result = await tools._try_europe_pmc("12345", session, timeout_secs=5.0)
         assert result == "https://europepmc.org/article/pdf/12345"
 
     async def test_falls_back_to_non_pdf_oa_url(self, tools):
-
         resp = _make_mock_response(
             json_data={
                 "resultList": {
@@ -257,22 +224,14 @@ class TestTryEuropePmc:
             }
         )
         session = _make_mock_session(responses=[resp])
-
         result = await tools._try_europe_pmc("12345", session, timeout_secs=5.0)
         assert result == "https://europepmc.org/article/12345"
 
-    async def test_returns_none_when_no_results(self, tools):
-
-        resp = _make_mock_response(json_data={"resultList": {"result": []}})
-        session = _make_mock_session(responses=[resp])
-
-        result = await tools._try_europe_pmc("12345", session, timeout_secs=5.0)
-        assert result is None
-
-    async def test_returns_none_when_no_oa_urls(self, tools):
-
-        resp = _make_mock_response(
-            json_data={
+    @pytest.mark.parametrize(
+        "json_data",
+        [
+            {"resultList": {"result": []}},
+            {
                 "resultList": {
                     "result": [
                         {
@@ -288,19 +247,20 @@ class TestTryEuropePmc:
                         }
                     ]
                 }
-            }
-        )
+            },
+        ],
+    )
+    async def test_returns_none_when_no_accessible_urls(self, tools, json_data):
+        resp = _make_mock_response(json_data=json_data)
         session = _make_mock_session(responses=[resp])
+        assert await tools._try_europe_pmc("12345", session, timeout_secs=5.0) is None
 
-        result = await tools._try_europe_pmc("12345", session, timeout_secs=5.0)
-        assert result is None
 
 @pytest.mark.asyncio
 class TestTryUnpaywall:
     """Tests for _try_unpaywall method."""
 
     async def test_returns_best_oa_pdf_url(self, tools):
-
         resp = _make_mock_response(
             json_data={
                 "best_oa_location": {
@@ -311,12 +271,10 @@ class TestTryUnpaywall:
             }
         )
         session = _make_mock_session(responses=[resp])
-
         result = await tools._try_unpaywall("10.1000/test", session, timeout_secs=5.0)
         assert result == "https://unpaywall.org/pdf/10.1000/test"
 
     async def test_falls_back_to_landing_page(self, tools):
-
         resp = _make_mock_response(
             json_data={
                 "best_oa_location": {
@@ -327,52 +285,41 @@ class TestTryUnpaywall:
             }
         )
         session = _make_mock_session(responses=[resp])
-
         result = await tools._try_unpaywall("10.1000/test", session, timeout_secs=5.0)
         assert result == "https://publisher.com/article"
 
     async def test_falls_back_to_oa_locations(self, tools):
-
         resp = _make_mock_response(
             json_data={
                 "best_oa_location": None,
-                "oa_locations": [
-                    {"url_for_pdf": "https://repo.org/pdf/article.pdf"},
-                ],
+                "oa_locations": [{"url_for_pdf": "https://repo.org/pdf/article.pdf"}],
             }
         )
         session = _make_mock_session(responses=[resp])
-
         result = await tools._try_unpaywall("10.1000/test", session, timeout_secs=5.0)
         assert result == "https://repo.org/pdf/article.pdf"
 
-    async def test_returns_none_on_404(self, tools):
-
-        resp = _make_mock_response(status=404)
+    @pytest.mark.parametrize(
+        "json_data,status",
+        [
+            (None, 404),
+            ({"best_oa_location": None, "oa_locations": []}, 200),
+        ],
+    )
+    async def test_returns_none_when_unavailable(self, tools, json_data, status):
+        resp = _make_mock_response(status=status, json_data=json_data)
         session = _make_mock_session(responses=[resp])
-
-        result = await tools._try_unpaywall("10.1000/test", session, timeout_secs=5.0)
-        assert result is None
-
-    async def test_returns_none_when_no_oa(self, tools):
-
-        resp = _make_mock_response(
-            json_data={
-                "best_oa_location": None,
-                "oa_locations": [],
-            }
+        assert (
+            await tools._try_unpaywall("10.1000/test", session, timeout_secs=5.0)
+            is None
         )
-        session = _make_mock_session(responses=[resp])
 
-        result = await tools._try_unpaywall("10.1000/test", session, timeout_secs=5.0)
-        assert result is None
 
 @pytest.mark.asyncio
 class TestTryPreprintServers:
     """Tests for _try_preprint_servers method."""
 
     async def test_returns_pdf_for_medrxiv_doi_with_jatsxml(self, tools):
-
         resp = _make_mock_response(
             json_data={
                 "collection": [
@@ -384,7 +331,6 @@ class TestTryPreprintServers:
             }
         )
         session = _make_mock_session(responses=[resp])
-
         result = await tools._try_preprint_servers(
             "10.1101/2024.01.01.123456", session, timeout_secs=5.0
         )
@@ -394,18 +340,10 @@ class TestTryPreprintServers:
         )
 
     async def test_constructs_url_from_doi_when_no_jatsxml(self, tools):
-
         resp = _make_mock_response(
-            json_data={
-                "collection": [
-                    {
-                        "doi": "10.1101/2024.01.01.123456",
-                    }
-                ]
-            }
+            json_data={"collection": [{"doi": "10.1101/2024.01.01.123456"}]}
         )
         session = _make_mock_session(responses=[resp])
-
         result = await tools._try_preprint_servers(
             "10.1101/2024.01.01.123456", session, timeout_secs=5.0
         )
@@ -415,31 +353,19 @@ class TestTryPreprintServers:
         )
 
     async def test_non_preprint_doi_uses_pubs_endpoint(self, tools):
-
-        # /pubs/ endpoint returns no results for this DOI
         resp = _make_mock_response(json_data={"collection": []})
         session = _make_mock_session(responses=[resp])
-
         result = await tools._try_preprint_servers(
             "10.1016/j.cell.2024.01.001", session, timeout_secs=5.0
         )
         assert result is None
-        # Should have made exactly 1 call (medrxiv pubs endpoint only)
         assert session.get.call_count == 1
 
     async def test_non_preprint_doi_finds_preprint(self, tools):
-
         resp = _make_mock_response(
-            json_data={
-                "collection": [
-                    {
-                        "preprint_doi": "10.1101/2023.06.15.545100",
-                    }
-                ]
-            }
+            json_data={"collection": [{"preprint_doi": "10.1101/2023.06.15.545100"}]}
         )
         session = _make_mock_session(responses=[resp])
-
         result = await tools._try_preprint_servers(
             "10.1016/j.cell.2024.01.001", session, timeout_secs=5.0
         )
@@ -449,31 +375,22 @@ class TestTryPreprintServers:
         )
 
     async def test_biorxiv_doi_pattern(self, tools):
-
         resp = _make_mock_response(
-            json_data={
-                "collection": [
-                    {
-                        "doi": "10.1101/2024.05.15.789012",
-                    }
-                ]
-            }
+            json_data={"collection": [{"doi": "10.1101/2024.05.15.789012"}]}
         )
         session = _make_mock_session(responses=[resp])
-
         result = await tools._try_preprint_servers(
             "10.1101/2024.05.15.789012", session, timeout_secs=5.0
         )
-        # Should match medrxiv first due to 10.1101/ pattern
         assert result is not None
         assert "10.1101/2024.05.15.789012.full.pdf" in result
 
+
 @pytest.mark.asyncio
-class TestQueryBiorxivApi:
-    """Tests for _query_biorxiv_api helper method."""
+class TestQueryBiorxiv:
+    """Tests for the unified _query_biorxiv method."""
 
-    async def test_returns_pdf_url_from_jatsxml(self, tools):
-
+    async def test_details_returns_pdf_url_from_jatsxml(self, tools):
         resp = _make_mock_response(
             json_data={
                 "collection": [
@@ -485,142 +402,82 @@ class TestQueryBiorxivApi:
             }
         )
         session = _make_mock_session(responses=[resp])
-
-        result = await tools._query_biorxiv_api(
-            "medrxiv", "10.1101/2024.01.01.123456", session, timeout_secs=5.0
+        result = await tools._query_biorxiv(
+            "medrxiv", "10.1101/2024.01.01.123456", "details", session, timeout_secs=5.0
         )
         assert (
             result
             == "https://www.medrxiv.org/content/10.1101/2024.01.01.123456v1.full.pdf"
         )
 
-    async def test_returns_pdf_url_from_doi_when_no_jatsxml(self, tools):
-
+    async def test_details_falls_back_to_doi(self, tools):
         resp = _make_mock_response(
             json_data={"collection": [{"doi": "10.1101/2024.01.01.123456"}]}
         )
         session = _make_mock_session(responses=[resp])
-
-        result = await tools._query_biorxiv_api(
-            "biorxiv", "10.1101/2024.01.01.123456", session, timeout_secs=5.0
+        result = await tools._query_biorxiv(
+            "biorxiv", "10.1101/2024.01.01.123456", "details", session, timeout_secs=5.0
         )
         assert (
             result
             == "https://www.biorxiv.org/content/10.1101/2024.01.01.123456.full.pdf"
         )
 
-    async def test_returns_none_on_empty_collection(self, tools):
-
-        resp = _make_mock_response(json_data={"collection": []})
-        session = _make_mock_session(responses=[resp])
-
-        result = await tools._query_biorxiv_api(
-            "medrxiv", "10.1101/nothing", session, timeout_secs=5.0
-        )
-        assert result is None
-
-    async def test_returns_none_on_error(self, tools):
-
-        session = AsyncMock()
-        session.get = MagicMock(side_effect=Exception("timeout"))
-
-        result = await tools._query_biorxiv_api(
-            "medrxiv", "10.1101/err", session, timeout_secs=5.0
-        )
-        assert result is None
-
-@pytest.mark.asyncio
-class TestQueryBiorxivPubsApi:
-    """Tests for _query_biorxiv_pubs_api helper method."""
-
-    async def test_returns_pdf_url_when_preprint_found(self, tools):
-
+    async def test_pubs_returns_preprint_pdf(self, tools):
         resp = _make_mock_response(
             json_data={"collection": [{"preprint_doi": "10.1101/2023.06.15.545100"}]}
         )
         session = _make_mock_session(responses=[resp])
-
-        result = await tools._query_biorxiv_pubs_api(
-            "medrxiv", "10.1016/j.cell.2024.01.001", session, timeout_secs=5.0
+        result = await tools._query_biorxiv(
+            "medrxiv", "10.1016/j.cell.2024.01.001", "pubs", session, timeout_secs=5.0
         )
         assert (
             result
             == "https://www.medrxiv.org/content/10.1101/2023.06.15.545100.full.pdf"
         )
 
-    async def test_returns_none_on_empty_collection(self, tools):
-
-        resp = _make_mock_response(json_data={"collection": []})
+    @pytest.mark.parametrize(
+        "endpoint,json_data",
+        [
+            ("details", {"collection": []}),
+            ("pubs", {"collection": []}),
+            ("pubs", {"collection": [{"some_other_field": "value"}]}),
+        ],
+    )
+    async def test_returns_none_on_empty_or_missing_data(
+        self, tools, endpoint, json_data
+    ):
+        resp = _make_mock_response(json_data=json_data)
         session = _make_mock_session(responses=[resp])
-
-        result = await tools._query_biorxiv_pubs_api(
-            "medrxiv", "10.1016/j.cell.2024.01.001", session, timeout_secs=5.0
+        result = await tools._query_biorxiv(
+            "medrxiv", "10.1101/nothing", endpoint, session, timeout_secs=5.0
         )
         assert result is None
 
     async def test_returns_none_on_error(self, tools):
-
-        session = AsyncMock()
-        session.get = MagicMock(side_effect=Exception("timeout"))
-
-        result = await tools._query_biorxiv_pubs_api(
-            "medrxiv", "10.1016/j.cell.2024.01.001", session, timeout_secs=5.0
+        result = await tools._query_biorxiv(
+            "medrxiv", "10.1101/err", "details", _make_error_session(), timeout_secs=5.0
         )
         assert result is None
 
-    async def test_returns_none_when_no_preprint_doi(self, tools):
-
-        resp = _make_mock_response(
-            json_data={"collection": [{"some_other_field": "value"}]}
-        )
-        session = _make_mock_session(responses=[resp])
-
-        result = await tools._query_biorxiv_pubs_api(
-            "medrxiv", "10.1016/j.cell.2024.01.001", session, timeout_secs=5.0
-        )
-        assert result is None
-
-class TestIsPdfResponse:
-    """Tests for _is_pdf_response static method."""
-
-    def test_pdf_in_url(self):
-        assert PubMedTools._is_pdf_response(
-            "https://example.com/paper.pdf", "text/html"
-        )
-
-    def test_pdf_content_type(self):
-        assert PubMedTools._is_pdf_response(
-            "https://example.com/download", "application/pdf"
-        )
-
-    def test_neither(self):
-        assert not PubMedTools._is_pdf_response("https://example.com/page", "text/html")
-
-    def test_pdf_url_with_query(self):
-        assert PubMedTools._is_pdf_response(
-            "https://example.com/paper.pdf?token=abc", "text/html"
-        )
 
 @pytest.mark.asyncio
 class TestTryDoiResolution:
     """Tests for _try_doi_resolution method."""
 
     async def test_returns_url_when_doi_resolves_to_pdf(self, tools):
-
         resp = _make_mock_response(
             status=200,
             content_type="application/pdf",
             url="https://publisher.com/article/12345.pdf",
         )
         session = _make_mock_session(responses=[resp])
-
         result = await tools._try_doi_resolution(
             "10.1000/test", session, timeout_secs=5.0
         )
         assert result == "https://publisher.com/article/12345.pdf"
 
     async def test_extracts_pdf_from_html_landing_page(self, tools):
-
         html = '<html><head><meta name="citation_pdf_url" content="https://publisher.com/pdf/12345.pdf"></head></html>'
         resp = _make_mock_response(
             status=200,
@@ -629,73 +486,60 @@ class TestTryDoiResolution:
             url="https://publisher.com/article/12345",
         )
         session = _make_mock_session(responses=[resp])
-
         result = await tools._try_doi_resolution(
             "10.1000/test", session, timeout_secs=5.0
         )
         assert result == "https://publisher.com/pdf/12345.pdf"
 
-    async def test_returns_none_when_no_pdf_on_page(self, tools):
-
+    @pytest.mark.parametrize(
+        "status,content_type,text_data",
+        [
+            (200, "text/html", "<html><body>No PDF link here</body></html>"),
+            (404, "text/html", ""),
+        ],
+    )
+    async def test_returns_none_when_no_pdf(
+        self, tools, status, content_type, text_data
+    ):
         resp = _make_mock_response(
-            status=200,
-            content_type="text/html",
-            text_data="<html><body>No PDF link here</body></html>",
+            status=status,
+            content_type=content_type,
+            text_data=text_data,
             url="https://publisher.com/article/12345",
         )
         session = _make_mock_session(responses=[resp])
-
-        result = await tools._try_doi_resolution(
-            "10.1000/test", session, timeout_secs=5.0
+        assert (
+            await tools._try_doi_resolution("10.1000/test", session, timeout_secs=5.0)
+            is None
         )
-        assert result is None
 
-    async def test_returns_none_on_404(self, tools):
-
-        resp = _make_mock_response(status=404)
-        session = _make_mock_session(responses=[resp])
-
-        result = await tools._try_doi_resolution(
-            "10.1000/nonexistent", session, timeout_secs=5.0
-        )
-        assert result is None
 
 @pytest.mark.asyncio
 class TestFindArticleUrl:
     """Tests for the _find_article_url fallback chain."""
 
     async def test_returns_findit_url_first(self, tools):
-
         session = _make_mock_session()
-
         with patch.object(tools, "_try_findit", new_callable=AsyncMock) as mock_findit:
             mock_findit.return_value = "https://findit.com/article.pdf"
-
             result = await tools._find_article_url(
                 "12345", doi="10.1000/test", session=session
             )
-
         assert result == "https://findit.com/article.pdf"
 
     async def test_falls_through_to_pmc_when_findit_fails(self, tools):
-
         session = _make_mock_session()
-
         with patch.object(
             tools, "_try_findit", new_callable=AsyncMock, return_value=None
         ), patch.object(tools, "_try_pmc", new_callable=AsyncMock) as mock_pmc:
             mock_pmc.return_value = "https://pmc.ncbi.nlm.nih.gov/article.pdf"
-
             result = await tools._find_article_url(
                 "12345", doi="10.1000/test", session=session
             )
-
         assert result == "https://pmc.ncbi.nlm.nih.gov/article.pdf"
 
     async def test_falls_through_entire_chain(self, tools):
-
         session = _make_mock_session()
-
         with patch.object(
             tools, "_try_findit", new_callable=AsyncMock, return_value=None
         ), patch.object(
@@ -712,17 +556,13 @@ class TestFindArticleUrl:
             new_callable=AsyncMock,
         ) as mock_doi:
             mock_doi.return_value = "https://publisher.com/pdf/article.pdf"
-
             result = await tools._find_article_url(
                 "12345", doi="10.1000/test", session=session
             )
-
         assert result == "https://publisher.com/pdf/article.pdf"
 
     async def test_returns_none_when_all_fail(self, tools):
-
         session = _make_mock_session()
-
         with patch.object(
             tools, "_try_findit", new_callable=AsyncMock, return_value=None
         ), patch.object(
@@ -739,13 +579,10 @@ class TestFindArticleUrl:
             result = await tools._find_article_url(
                 "12345", doi="10.1000/test", session=session
             )
-
         assert result is None
 
     async def test_skips_doi_sources_when_no_doi(self, tools):
-
         session = _make_mock_session()
-
         with patch.object(
             tools, "_try_findit", new_callable=AsyncMock, return_value=None
         ), patch.object(
@@ -760,15 +597,12 @@ class TestFindArticleUrl:
             tools, "_try_doi_resolution", new_callable=AsyncMock
         ) as mock_doi:
             result = await tools._find_article_url("12345", doi=None, session=session)
-
-        # DOI-dependent methods should not be called
         mock_unpaywall.assert_not_called()
         mock_preprint.assert_not_called()
         mock_doi.assert_not_called()
         assert result is None
 
     async def test_creates_own_session_when_none_provided(self, tools):
-
         with patch.object(
             tools, "_try_findit", new_callable=AsyncMock
         ) as mock_findit, patch(
@@ -778,121 +612,85 @@ class TestFindArticleUrl:
             mock_session = AsyncMock()
             mock_session.close = AsyncMock()
             mock_session_cls.return_value = mock_session
-
             result = await tools._find_article_url("12345")
-
         assert result == "https://example.com/article.pdf"
         mock_session_cls.assert_called_once()
         mock_session.close.assert_called_once()
+
 
 @pytest.mark.asyncio
 class TestFetchTextFromUrl:
     """Tests for _fetch_text_from_url method."""
 
     async def test_extracts_text_from_html_response(self, tools):
-
         resp = _make_mock_response(
             text_data="This is a long enough article text that should be returned as content for the test",
             content_type="text/html",
         )
         session = _make_mock_session(responses=[resp])
-
         result = await tools._fetch_text_from_url(
             "https://example.com/article.html", session
         )
         assert "long enough article text" in result
 
     async def test_returns_empty_string_on_short_text(self, tools):
-
-        resp = _make_mock_response(
-            text_data="short",
-            content_type="text/html",
-        )
+        resp = _make_mock_response(text_data="short", content_type="text/html")
         session = _make_mock_session(responses=[resp])
-
         result = await tools._fetch_text_from_url(
             "https://example.com/article.html", session
         )
         assert result == ""
 
     async def test_returns_empty_string_on_error(self, tools):
-
         session = AsyncMock()
         error_resp = AsyncMock()
         error_resp.__aenter__ = AsyncMock(side_effect=Exception("Connection error"))
         error_resp.__aexit__ = AsyncMock(return_value=False)
         session.get = MagicMock(return_value=error_resp)
-
         result = await tools._fetch_text_from_url("https://example.com/broken", session)
         assert result == ""
+
 
 @pytest.mark.asyncio
 class TestTryFetchPdfToFile:
     """Tests for _try_fetch_pdf_to_file method."""
 
     async def test_saves_pdf_to_temp_file(self, tools):
-
-        pdf_content = b"%PDF-1.4 " + b"x" * 100  # >20 bytes
-        resp = _make_mock_response(
-            content=pdf_content,
-            content_type="application/pdf",
-        )
+        pdf_content = b"%PDF-1.4 " + b"x" * 100
+        resp = _make_mock_response(content=pdf_content, content_type="application/pdf")
         session = _make_mock_session(responses=[resp])
-
         result = await tools._try_fetch_pdf_to_file(
             "https://example.com/paper.pdf", "test_", session
         )
         assert result is not None
         assert result.endswith(".pdf")
-
-        # Verify content was written
         with open(result, "rb") as f:
             assert f.read() == pdf_content
 
-    async def test_returns_none_for_non_pdf_content(self, tools):
-
+    @pytest.mark.parametrize(
+        "url,content,content_type,status",
+        [
+            ("https://example.com/article", b"<html>not a pdf</html>", "text/html", 200),
+            ("https://example.com/paper.pdf", b"tiny", "application/pdf", 200),
+            ("https://example.com/paper.pdf", b"", "application/pdf", 403),
+        ],
+    )
+    async def test_returns_none_on_invalid(
+        self, tools, url, content, content_type, status
+    ):
         resp = _make_mock_response(
-            content=b"<html>not a pdf</html>",
-            content_type="text/html",
+            content=content, content_type=content_type, status=status
         )
         session = _make_mock_session(responses=[resp])
-
-        result = await tools._try_fetch_pdf_to_file(
-            "https://example.com/article.html", "test_", session
-        )
-        assert result is None
-
-    async def test_returns_none_for_tiny_content(self, tools):
-
-        resp = _make_mock_response(
-            content=b"tiny",  # <=20 bytes
-            content_type="application/pdf",
-        )
-        session = _make_mock_session(responses=[resp])
-
-        result = await tools._try_fetch_pdf_to_file(
-            "https://example.com/paper.pdf", "test_", session
-        )
-        assert result is None
-
-    async def test_returns_none_on_non_200(self, tools):
-
-        resp = _make_mock_response(status=403)
-        session = _make_mock_session(responses=[resp])
-
-        result = await tools._try_fetch_pdf_to_file(
-            "https://example.com/paper.pdf", "test_", session
-        )
+        result = await tools._try_fetch_pdf_to_file(url, "test_", session)
         assert result is None
 
     async def test_returns_none_on_network_error(self, tools):
-
         session = AsyncMock()
         error_resp = AsyncMock()
         error_resp.__aenter__ = AsyncMock(side_effect=Exception("Network error"))
         error_resp.__aexit__ = AsyncMock(return_value=False)
         session.get = MagicMock(return_value=error_resp)
-
         result = await tools._try_fetch_pdf_to_file(
             "https://example.com/paper.pdf", "test_", session
         )

--- a/tests/async-unit/test_pubmed_pdf_resolution.py
+++ b/tests/async-unit/test_pubmed_pdf_resolution.py
@@ -256,6 +256,35 @@ class TestTryEuropePmc:
         session = _make_mock_session(responses=[resp])
         assert await tools._try_europe_pmc("12345", session, timeout_secs=5.0) is None
 
+    async def test_skips_entry_with_missing_url(self, tools):
+        # Regression: first-pass scan must not return "None" string when url key is absent
+        resp = _make_mock_response(
+            json_data={
+                "resultList": {
+                    "result": [
+                        {
+                            "fullTextUrlList": {
+                                "fullTextUrl": [
+                                    {
+                                        "documentStyle": "pdf",
+                                        "availabilityCode": "OA",
+                                    },
+                                    {
+                                        "documentStyle": "html",
+                                        "availabilityCode": "OA",
+                                        "url": "https://europepmc.org/article/12345",
+                                    },
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        )
+        session = _make_mock_session(responses=[resp])
+        result = await tools._try_europe_pmc("12345", session, timeout_secs=5.0)
+        assert result == "https://europepmc.org/article/12345"
+
 
 @pytest.mark.asyncio
 class TestTryUnpaywall:
@@ -443,6 +472,9 @@ class TestQueryBiorxiv:
             ("details", {"collection": []}),
             ("pubs", {"collection": []}),
             ("pubs", {"collection": [{"some_other_field": "value"}]}),
+            # Regression: explicit null doi must not build "None" URL
+            ("details", {"collection": [{"doi": None}]}),
+            ("pubs", {"collection": [{"preprint_doi": None}]}),
         ],
     )
     async def test_returns_none_on_empty_or_missing_data(

--- a/tests/async-unit/test_pubmed_pdf_resolution.py
+++ b/tests/async-unit/test_pubmed_pdf_resolution.py
@@ -9,6 +9,9 @@ import pytest
 
 from fighthealthinsurance.pubmed_tools import PubMedTools
 
+@pytest.fixture
+def tools():
+    return PubMedTools()
 
 def _make_mock_response(
     status=200,
@@ -33,7 +36,6 @@ def _make_mock_response(
     resp.__aenter__ = AsyncMock(return_value=resp)
     resp.__aexit__ = AsyncMock(return_value=False)
     return resp
-
 
 def _make_mock_session(responses=None):
     """Create a mock aiohttp.ClientSession.
@@ -69,7 +71,6 @@ def _make_mock_session(responses=None):
     session.__aenter__ = AsyncMock(return_value=session)
     session.__aexit__ = AsyncMock(return_value=False)
     return session
-
 
 class TestExtractPdfUrlFromHtml:
     """Tests for _extract_pdf_url_from_html static method."""
@@ -132,13 +133,12 @@ class TestExtractPdfUrlFromHtml:
         )
         assert result == "https://example.com/paper.pdf?token=abc123"
 
-
 @pytest.mark.asyncio
 class TestTryFindit:
     """Tests for _try_findit method."""
 
-    async def test_returns_url_on_success(self):
-        tools = PubMedTools()
+    async def test_returns_url_on_success(self, tools):
+
         mock_src = MagicMock()
         mock_src.url = "https://example.com/article.pdf"
 
@@ -148,8 +148,7 @@ class TestTryFindit:
 
         assert result == "https://example.com/article.pdf"
 
-    async def test_returns_none_on_exception(self):
-        tools = PubMedTools()
+    async def test_returns_none_on_exception(self, tools):
 
         with patch("fighthealthinsurance.pubmed_tools.sync_to_async") as mock_s2a:
             mock_s2a.return_value = AsyncMock(side_effect=Exception("FindIt error"))
@@ -157,8 +156,8 @@ class TestTryFindit:
 
         assert result is None
 
-    async def test_returns_none_when_url_is_none(self):
-        tools = PubMedTools()
+    async def test_returns_none_when_url_is_none(self, tools):
+
         mock_src = MagicMock()
         mock_src.url = None
 
@@ -168,13 +167,11 @@ class TestTryFindit:
 
         assert result is None
 
-
 @pytest.mark.asyncio
 class TestTryPmc:
     """Tests for _try_pmc method."""
 
-    async def test_returns_pdf_url_when_pmcid_found(self):
-        tools = PubMedTools()
+    async def test_returns_pdf_url_when_pmcid_found(self, tools):
 
         converter_resp = _make_mock_response(
             json_data={"records": [{"pmcid": "PMC1234567"}]}
@@ -184,8 +181,7 @@ class TestTryPmc:
         result = await tools._try_pmc("12345", session, timeout_secs=5.0)
         assert result == "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1234567/pdf/"
 
-    async def test_returns_none_when_no_pmcid(self):
-        tools = PubMedTools()
+    async def test_returns_none_when_no_pmcid(self, tools):
 
         converter_resp = _make_mock_response(json_data={"records": [{"pmid": "12345"}]})
         session = _make_mock_session(responses=[converter_resp])
@@ -193,8 +189,7 @@ class TestTryPmc:
         result = await tools._try_pmc("12345", session, timeout_secs=5.0)
         assert result is None
 
-    async def test_returns_none_when_empty_records(self):
-        tools = PubMedTools()
+    async def test_returns_none_when_empty_records(self, tools):
 
         converter_resp = _make_mock_response(json_data={"records": []})
         session = _make_mock_session(responses=[converter_resp])
@@ -202,8 +197,7 @@ class TestTryPmc:
         result = await tools._try_pmc("12345", session, timeout_secs=5.0)
         assert result is None
 
-    async def test_returns_none_on_network_error(self):
-        tools = PubMedTools()
+    async def test_returns_none_on_network_error(self, tools):
 
         session = AsyncMock()
         session.get = MagicMock(side_effect=Exception("Connection refused"))
@@ -211,13 +205,11 @@ class TestTryPmc:
         result = await tools._try_pmc("12345", session, timeout_secs=5.0)
         assert result is None
 
-
 @pytest.mark.asyncio
 class TestTryEuropePmc:
     """Tests for _try_europe_pmc method."""
 
-    async def test_returns_pdf_url_when_oa_pdf_found(self):
-        tools = PubMedTools()
+    async def test_returns_pdf_url_when_oa_pdf_found(self, tools):
 
         resp = _make_mock_response(
             json_data={
@@ -243,8 +235,7 @@ class TestTryEuropePmc:
         result = await tools._try_europe_pmc("12345", session, timeout_secs=5.0)
         assert result == "https://europepmc.org/article/pdf/12345"
 
-    async def test_falls_back_to_non_pdf_oa_url(self):
-        tools = PubMedTools()
+    async def test_falls_back_to_non_pdf_oa_url(self, tools):
 
         resp = _make_mock_response(
             json_data={
@@ -270,8 +261,7 @@ class TestTryEuropePmc:
         result = await tools._try_europe_pmc("12345", session, timeout_secs=5.0)
         assert result == "https://europepmc.org/article/12345"
 
-    async def test_returns_none_when_no_results(self):
-        tools = PubMedTools()
+    async def test_returns_none_when_no_results(self, tools):
 
         resp = _make_mock_response(json_data={"resultList": {"result": []}})
         session = _make_mock_session(responses=[resp])
@@ -279,8 +269,7 @@ class TestTryEuropePmc:
         result = await tools._try_europe_pmc("12345", session, timeout_secs=5.0)
         assert result is None
 
-    async def test_returns_none_when_no_oa_urls(self):
-        tools = PubMedTools()
+    async def test_returns_none_when_no_oa_urls(self, tools):
 
         resp = _make_mock_response(
             json_data={
@@ -306,13 +295,11 @@ class TestTryEuropePmc:
         result = await tools._try_europe_pmc("12345", session, timeout_secs=5.0)
         assert result is None
 
-
 @pytest.mark.asyncio
 class TestTryUnpaywall:
     """Tests for _try_unpaywall method."""
 
-    async def test_returns_best_oa_pdf_url(self):
-        tools = PubMedTools()
+    async def test_returns_best_oa_pdf_url(self, tools):
 
         resp = _make_mock_response(
             json_data={
@@ -328,8 +315,7 @@ class TestTryUnpaywall:
         result = await tools._try_unpaywall("10.1000/test", session, timeout_secs=5.0)
         assert result == "https://unpaywall.org/pdf/10.1000/test"
 
-    async def test_falls_back_to_landing_page(self):
-        tools = PubMedTools()
+    async def test_falls_back_to_landing_page(self, tools):
 
         resp = _make_mock_response(
             json_data={
@@ -345,8 +331,7 @@ class TestTryUnpaywall:
         result = await tools._try_unpaywall("10.1000/test", session, timeout_secs=5.0)
         assert result == "https://publisher.com/article"
 
-    async def test_falls_back_to_oa_locations(self):
-        tools = PubMedTools()
+    async def test_falls_back_to_oa_locations(self, tools):
 
         resp = _make_mock_response(
             json_data={
@@ -361,8 +346,7 @@ class TestTryUnpaywall:
         result = await tools._try_unpaywall("10.1000/test", session, timeout_secs=5.0)
         assert result == "https://repo.org/pdf/article.pdf"
 
-    async def test_returns_none_on_404(self):
-        tools = PubMedTools()
+    async def test_returns_none_on_404(self, tools):
 
         resp = _make_mock_response(status=404)
         session = _make_mock_session(responses=[resp])
@@ -370,8 +354,7 @@ class TestTryUnpaywall:
         result = await tools._try_unpaywall("10.1000/test", session, timeout_secs=5.0)
         assert result is None
 
-    async def test_returns_none_when_no_oa(self):
-        tools = PubMedTools()
+    async def test_returns_none_when_no_oa(self, tools):
 
         resp = _make_mock_response(
             json_data={
@@ -384,13 +367,11 @@ class TestTryUnpaywall:
         result = await tools._try_unpaywall("10.1000/test", session, timeout_secs=5.0)
         assert result is None
 
-
 @pytest.mark.asyncio
 class TestTryPreprintServers:
     """Tests for _try_preprint_servers method."""
 
-    async def test_returns_pdf_for_medrxiv_doi_with_jatsxml(self):
-        tools = PubMedTools()
+    async def test_returns_pdf_for_medrxiv_doi_with_jatsxml(self, tools):
 
         resp = _make_mock_response(
             json_data={
@@ -412,8 +393,7 @@ class TestTryPreprintServers:
             == "https://www.medrxiv.org/content/10.1101/2024.01.01.123456v1.full.pdf"
         )
 
-    async def test_constructs_url_from_doi_when_no_jatsxml(self):
-        tools = PubMedTools()
+    async def test_constructs_url_from_doi_when_no_jatsxml(self, tools):
 
         resp = _make_mock_response(
             json_data={
@@ -434,8 +414,7 @@ class TestTryPreprintServers:
             == "https://www.medrxiv.org/content/10.1101/2024.01.01.123456.full.pdf"
         )
 
-    async def test_non_preprint_doi_uses_pubs_endpoint(self):
-        tools = PubMedTools()
+    async def test_non_preprint_doi_uses_pubs_endpoint(self, tools):
 
         # /pubs/ endpoint returns no results for this DOI
         resp = _make_mock_response(json_data={"collection": []})
@@ -448,8 +427,7 @@ class TestTryPreprintServers:
         # Should have made exactly 1 call (medrxiv pubs endpoint only)
         assert session.get.call_count == 1
 
-    async def test_non_preprint_doi_finds_preprint(self):
-        tools = PubMedTools()
+    async def test_non_preprint_doi_finds_preprint(self, tools):
 
         resp = _make_mock_response(
             json_data={
@@ -470,8 +448,7 @@ class TestTryPreprintServers:
             == "https://www.medrxiv.org/content/10.1101/2023.06.15.545100.full.pdf"
         )
 
-    async def test_biorxiv_doi_pattern(self):
-        tools = PubMedTools()
+    async def test_biorxiv_doi_pattern(self, tools):
 
         resp = _make_mock_response(
             json_data={
@@ -491,13 +468,11 @@ class TestTryPreprintServers:
         assert result is not None
         assert "10.1101/2024.05.15.789012.full.pdf" in result
 
-
 @pytest.mark.asyncio
 class TestQueryBiorxivApi:
     """Tests for _query_biorxiv_api helper method."""
 
-    async def test_returns_pdf_url_from_jatsxml(self):
-        tools = PubMedTools()
+    async def test_returns_pdf_url_from_jatsxml(self, tools):
 
         resp = _make_mock_response(
             json_data={
@@ -519,8 +494,7 @@ class TestQueryBiorxivApi:
             == "https://www.medrxiv.org/content/10.1101/2024.01.01.123456v1.full.pdf"
         )
 
-    async def test_returns_pdf_url_from_doi_when_no_jatsxml(self):
-        tools = PubMedTools()
+    async def test_returns_pdf_url_from_doi_when_no_jatsxml(self, tools):
 
         resp = _make_mock_response(
             json_data={"collection": [{"doi": "10.1101/2024.01.01.123456"}]}
@@ -535,8 +509,7 @@ class TestQueryBiorxivApi:
             == "https://www.biorxiv.org/content/10.1101/2024.01.01.123456.full.pdf"
         )
 
-    async def test_returns_none_on_empty_collection(self):
-        tools = PubMedTools()
+    async def test_returns_none_on_empty_collection(self, tools):
 
         resp = _make_mock_response(json_data={"collection": []})
         session = _make_mock_session(responses=[resp])
@@ -546,8 +519,7 @@ class TestQueryBiorxivApi:
         )
         assert result is None
 
-    async def test_returns_none_on_error(self):
-        tools = PubMedTools()
+    async def test_returns_none_on_error(self, tools):
 
         session = AsyncMock()
         session.get = MagicMock(side_effect=Exception("timeout"))
@@ -557,13 +529,11 @@ class TestQueryBiorxivApi:
         )
         assert result is None
 
-
 @pytest.mark.asyncio
 class TestQueryBiorxivPubsApi:
     """Tests for _query_biorxiv_pubs_api helper method."""
 
-    async def test_returns_pdf_url_when_preprint_found(self):
-        tools = PubMedTools()
+    async def test_returns_pdf_url_when_preprint_found(self, tools):
 
         resp = _make_mock_response(
             json_data={"collection": [{"preprint_doi": "10.1101/2023.06.15.545100"}]}
@@ -578,8 +548,7 @@ class TestQueryBiorxivPubsApi:
             == "https://www.medrxiv.org/content/10.1101/2023.06.15.545100.full.pdf"
         )
 
-    async def test_returns_none_on_empty_collection(self):
-        tools = PubMedTools()
+    async def test_returns_none_on_empty_collection(self, tools):
 
         resp = _make_mock_response(json_data={"collection": []})
         session = _make_mock_session(responses=[resp])
@@ -589,8 +558,7 @@ class TestQueryBiorxivPubsApi:
         )
         assert result is None
 
-    async def test_returns_none_on_error(self):
-        tools = PubMedTools()
+    async def test_returns_none_on_error(self, tools):
 
         session = AsyncMock()
         session.get = MagicMock(side_effect=Exception("timeout"))
@@ -600,8 +568,7 @@ class TestQueryBiorxivPubsApi:
         )
         assert result is None
 
-    async def test_returns_none_when_no_preprint_doi(self):
-        tools = PubMedTools()
+    async def test_returns_none_when_no_preprint_doi(self, tools):
 
         resp = _make_mock_response(
             json_data={"collection": [{"some_other_field": "value"}]}
@@ -612,7 +579,6 @@ class TestQueryBiorxivPubsApi:
             "medrxiv", "10.1016/j.cell.2024.01.001", session, timeout_secs=5.0
         )
         assert result is None
-
 
 class TestIsPdfResponse:
     """Tests for _is_pdf_response static method."""
@@ -635,13 +601,11 @@ class TestIsPdfResponse:
             "https://example.com/paper.pdf?token=abc", "text/html"
         )
 
-
 @pytest.mark.asyncio
 class TestTryDoiResolution:
     """Tests for _try_doi_resolution method."""
 
-    async def test_returns_url_when_doi_resolves_to_pdf(self):
-        tools = PubMedTools()
+    async def test_returns_url_when_doi_resolves_to_pdf(self, tools):
 
         resp = _make_mock_response(
             status=200,
@@ -655,8 +619,7 @@ class TestTryDoiResolution:
         )
         assert result == "https://publisher.com/article/12345.pdf"
 
-    async def test_extracts_pdf_from_html_landing_page(self):
-        tools = PubMedTools()
+    async def test_extracts_pdf_from_html_landing_page(self, tools):
 
         html = '<html><head><meta name="citation_pdf_url" content="https://publisher.com/pdf/12345.pdf"></head></html>'
         resp = _make_mock_response(
@@ -672,8 +635,7 @@ class TestTryDoiResolution:
         )
         assert result == "https://publisher.com/pdf/12345.pdf"
 
-    async def test_returns_none_when_no_pdf_on_page(self):
-        tools = PubMedTools()
+    async def test_returns_none_when_no_pdf_on_page(self, tools):
 
         resp = _make_mock_response(
             status=200,
@@ -688,8 +650,7 @@ class TestTryDoiResolution:
         )
         assert result is None
 
-    async def test_returns_none_on_404(self):
-        tools = PubMedTools()
+    async def test_returns_none_on_404(self, tools):
 
         resp = _make_mock_response(status=404)
         session = _make_mock_session(responses=[resp])
@@ -699,13 +660,12 @@ class TestTryDoiResolution:
         )
         assert result is None
 
-
 @pytest.mark.asyncio
 class TestFindArticleUrl:
     """Tests for the _find_article_url fallback chain."""
 
-    async def test_returns_findit_url_first(self):
-        tools = PubMedTools()
+    async def test_returns_findit_url_first(self, tools):
+
         session = _make_mock_session()
 
         with patch.object(tools, "_try_findit", new_callable=AsyncMock) as mock_findit:
@@ -717,8 +677,8 @@ class TestFindArticleUrl:
 
         assert result == "https://findit.com/article.pdf"
 
-    async def test_falls_through_to_pmc_when_findit_fails(self):
-        tools = PubMedTools()
+    async def test_falls_through_to_pmc_when_findit_fails(self, tools):
+
         session = _make_mock_session()
 
         with patch.object(
@@ -732,8 +692,8 @@ class TestFindArticleUrl:
 
         assert result == "https://pmc.ncbi.nlm.nih.gov/article.pdf"
 
-    async def test_falls_through_entire_chain(self):
-        tools = PubMedTools()
+    async def test_falls_through_entire_chain(self, tools):
+
         session = _make_mock_session()
 
         with patch.object(
@@ -759,8 +719,8 @@ class TestFindArticleUrl:
 
         assert result == "https://publisher.com/pdf/article.pdf"
 
-    async def test_returns_none_when_all_fail(self):
-        tools = PubMedTools()
+    async def test_returns_none_when_all_fail(self, tools):
+
         session = _make_mock_session()
 
         with patch.object(
@@ -782,8 +742,8 @@ class TestFindArticleUrl:
 
         assert result is None
 
-    async def test_skips_doi_sources_when_no_doi(self):
-        tools = PubMedTools()
+    async def test_skips_doi_sources_when_no_doi(self, tools):
+
         session = _make_mock_session()
 
         with patch.object(
@@ -807,8 +767,7 @@ class TestFindArticleUrl:
         mock_doi.assert_not_called()
         assert result is None
 
-    async def test_creates_own_session_when_none_provided(self):
-        tools = PubMedTools()
+    async def test_creates_own_session_when_none_provided(self, tools):
 
         with patch.object(
             tools, "_try_findit", new_callable=AsyncMock
@@ -826,13 +785,11 @@ class TestFindArticleUrl:
         mock_session_cls.assert_called_once()
         mock_session.close.assert_called_once()
 
-
 @pytest.mark.asyncio
 class TestFetchTextFromUrl:
     """Tests for _fetch_text_from_url method."""
 
-    async def test_extracts_text_from_html_response(self):
-        tools = PubMedTools()
+    async def test_extracts_text_from_html_response(self, tools):
 
         resp = _make_mock_response(
             text_data="This is a long enough article text that should be returned as content for the test",
@@ -845,8 +802,7 @@ class TestFetchTextFromUrl:
         )
         assert "long enough article text" in result
 
-    async def test_returns_empty_string_on_short_text(self):
-        tools = PubMedTools()
+    async def test_returns_empty_string_on_short_text(self, tools):
 
         resp = _make_mock_response(
             text_data="short",
@@ -859,8 +815,7 @@ class TestFetchTextFromUrl:
         )
         assert result == ""
 
-    async def test_returns_empty_string_on_error(self):
-        tools = PubMedTools()
+    async def test_returns_empty_string_on_error(self, tools):
 
         session = AsyncMock()
         error_resp = AsyncMock()
@@ -871,13 +826,11 @@ class TestFetchTextFromUrl:
         result = await tools._fetch_text_from_url("https://example.com/broken", session)
         assert result == ""
 
-
 @pytest.mark.asyncio
 class TestTryFetchPdfToFile:
     """Tests for _try_fetch_pdf_to_file method."""
 
-    async def test_saves_pdf_to_temp_file(self):
-        tools = PubMedTools()
+    async def test_saves_pdf_to_temp_file(self, tools):
 
         pdf_content = b"%PDF-1.4 " + b"x" * 100  # >20 bytes
         resp = _make_mock_response(
@@ -896,8 +849,7 @@ class TestTryFetchPdfToFile:
         with open(result, "rb") as f:
             assert f.read() == pdf_content
 
-    async def test_returns_none_for_non_pdf_content(self):
-        tools = PubMedTools()
+    async def test_returns_none_for_non_pdf_content(self, tools):
 
         resp = _make_mock_response(
             content=b"<html>not a pdf</html>",
@@ -910,8 +862,7 @@ class TestTryFetchPdfToFile:
         )
         assert result is None
 
-    async def test_returns_none_for_tiny_content(self):
-        tools = PubMedTools()
+    async def test_returns_none_for_tiny_content(self, tools):
 
         resp = _make_mock_response(
             content=b"tiny",  # <=20 bytes
@@ -924,8 +875,7 @@ class TestTryFetchPdfToFile:
         )
         assert result is None
 
-    async def test_returns_none_on_non_200(self):
-        tools = PubMedTools()
+    async def test_returns_none_on_non_200(self, tools):
 
         resp = _make_mock_response(status=403)
         session = _make_mock_session(responses=[resp])
@@ -935,8 +885,7 @@ class TestTryFetchPdfToFile:
         )
         assert result is None
 
-    async def test_returns_none_on_network_error(self):
-        tools = PubMedTools()
+    async def test_returns_none_on_network_error(self, tools):
 
         session = AsyncMock()
         error_resp = AsyncMock()

--- a/tests/async-unit/test_pubmed_pdf_resolution.py
+++ b/tests/async-unit/test_pubmed_pdf_resolution.py
@@ -1,0 +1,796 @@
+"""
+Unit tests for the aggressive PDF URL resolution methods in PubMedTools.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from fighthealthinsurance.pubmed_tools import PubMedTools
+
+
+def _make_mock_response(
+    status=200,
+    json_data=None,
+    text_data="",
+    content=b"",
+    content_type="text/html",
+    url="https://example.com",
+):
+    """Create a mock aiohttp response with async context manager support."""
+    resp = AsyncMock()
+    resp.status = status
+    resp.headers = {"Content-Type": content_type}
+    resp.json = AsyncMock(return_value=json_data or {})
+    resp.text = AsyncMock(return_value=text_data)
+    resp.read = AsyncMock(return_value=content)
+    resp.url = url
+    resp.raise_for_status = MagicMock()
+    if status >= 400:
+        resp.raise_for_status.side_effect = Exception(f"HTTP {status}")
+    # Support async context manager (async with session.get(...) as resp)
+    resp.__aenter__ = AsyncMock(return_value=resp)
+    resp.__aexit__ = AsyncMock(return_value=False)
+    return resp
+
+
+def _make_mock_session(responses=None):
+    """Create a mock aiohttp.ClientSession.
+
+    Args:
+        responses: list of mock responses to return in order from get/head calls,
+                   or a single response for all calls.
+    """
+    session = AsyncMock()
+    if responses is None:
+        responses = [_make_mock_response()]
+
+    if isinstance(responses, list):
+        # Return responses in order; if we run out, use the last one
+        call_count = {"get": 0, "head": 0}
+
+        def make_get(*args, **kwargs):
+            idx = min(call_count["get"], len(responses) - 1)
+            call_count["get"] += 1
+            return responses[idx]
+
+        def make_head(*args, **kwargs):
+            idx = min(call_count["head"], len(responses) - 1)
+            call_count["head"] += 1
+            return responses[idx]
+
+        session.get = MagicMock(side_effect=make_get)
+        session.head = MagicMock(side_effect=make_head)
+    else:
+        session.get = MagicMock(return_value=responses)
+        session.head = MagicMock(return_value=responses)
+
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    return session
+
+
+class TestExtractPdfUrlFromHtml:
+    """Tests for _extract_pdf_url_from_html static method."""
+
+    def test_citation_pdf_url_name_first(self):
+        html = '<meta name="citation_pdf_url" content="https://example.com/paper.pdf">'
+        result = PubMedTools._extract_pdf_url_from_html(
+            html, "https://example.com/article"
+        )
+        assert result == "https://example.com/paper.pdf"
+
+    def test_citation_pdf_url_content_first(self):
+        html = '<meta content="https://example.com/paper.pdf" name="citation_pdf_url">'
+        result = PubMedTools._extract_pdf_url_from_html(
+            html, "https://example.com/article"
+        )
+        assert result == "https://example.com/paper.pdf"
+
+    def test_pdf_anchor_tag(self):
+        html = '<a href="/downloads/paper.pdf" class="btn">Download PDF</a>'
+        result = PubMedTools._extract_pdf_url_from_html(
+            html, "https://publisher.com/article/123"
+        )
+        assert result == "https://publisher.com/downloads/paper.pdf"
+
+    def test_relative_url_resolved(self):
+        html = '<meta name="citation_pdf_url" content="/pdf/12345.pdf">'
+        result = PubMedTools._extract_pdf_url_from_html(
+            html, "https://journals.example.com/article/view/1"
+        )
+        assert result == "https://journals.example.com/pdf/12345.pdf"
+
+    def test_absolute_url_unchanged(self):
+        html = (
+            '<meta name="citation_pdf_url" content="https://cdn.example.com/paper.pdf">'
+        )
+        result = PubMedTools._extract_pdf_url_from_html(
+            html, "https://different-domain.com/article"
+        )
+        assert result == "https://cdn.example.com/paper.pdf"
+
+    def test_no_pdf_link_returns_none(self):
+        html = "<html><body><p>No PDF here</p></body></html>"
+        result = PubMedTools._extract_pdf_url_from_html(
+            html, "https://example.com/article"
+        )
+        assert result is None
+
+    def test_case_insensitive(self):
+        html = '<META NAME="Citation_PDF_URL" CONTENT="https://example.com/paper.pdf">'
+        result = PubMedTools._extract_pdf_url_from_html(
+            html, "https://example.com/article"
+        )
+        assert result == "https://example.com/paper.pdf"
+
+    def test_pdf_url_with_query_params(self):
+        html = '<a href="/paper.pdf?token=abc123" class="link">Full Text PDF</a>'
+        result = PubMedTools._extract_pdf_url_from_html(
+            html, "https://example.com/article"
+        )
+        assert result == "https://example.com/paper.pdf?token=abc123"
+
+
+@pytest.mark.asyncio
+class TestTryFindit:
+    """Tests for _try_findit method."""
+
+    async def test_returns_url_on_success(self):
+        tools = PubMedTools()
+        mock_src = MagicMock()
+        mock_src.url = "https://example.com/article.pdf"
+
+        with patch("fighthealthinsurance.pubmed_tools.sync_to_async") as mock_s2a:
+            mock_s2a.return_value = AsyncMock(return_value=mock_src)
+            result = await tools._try_findit("12345", timeout_secs=5.0)
+
+        assert result == "https://example.com/article.pdf"
+
+    async def test_returns_none_on_exception(self):
+        tools = PubMedTools()
+
+        with patch("fighthealthinsurance.pubmed_tools.sync_to_async") as mock_s2a:
+            mock_s2a.return_value = AsyncMock(side_effect=Exception("FindIt error"))
+            result = await tools._try_findit("12345", timeout_secs=5.0)
+
+        assert result is None
+
+    async def test_returns_none_when_url_is_none(self):
+        tools = PubMedTools()
+        mock_src = MagicMock()
+        mock_src.url = None
+
+        with patch("fighthealthinsurance.pubmed_tools.sync_to_async") as mock_s2a:
+            mock_s2a.return_value = AsyncMock(return_value=mock_src)
+            result = await tools._try_findit("12345", timeout_secs=5.0)
+
+        assert result is None
+
+
+@pytest.mark.asyncio
+class TestTryPmc:
+    """Tests for _try_pmc method."""
+
+    async def test_returns_pdf_url_when_pmcid_found(self):
+        tools = PubMedTools()
+
+        converter_resp = _make_mock_response(
+            json_data={"records": [{"pmcid": "PMC1234567"}]}
+        )
+        head_resp = _make_mock_response(status=200)
+        session = _make_mock_session(responses=[converter_resp, head_resp])
+
+        result = await tools._try_pmc("12345", session, timeout_secs=5.0)
+        assert result == "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1234567/pdf/"
+
+    async def test_returns_none_when_no_pmcid(self):
+        tools = PubMedTools()
+
+        converter_resp = _make_mock_response(json_data={"records": [{"pmid": "12345"}]})
+        session = _make_mock_session(responses=[converter_resp])
+
+        result = await tools._try_pmc("12345", session, timeout_secs=5.0)
+        assert result is None
+
+    async def test_returns_none_when_head_fails(self):
+        tools = PubMedTools()
+
+        converter_resp = _make_mock_response(
+            json_data={"records": [{"pmcid": "PMC1234567"}]}
+        )
+        head_resp = _make_mock_response(status=404)
+        session = _make_mock_session(responses=[converter_resp])
+        # Override head to return 404
+        session.head = MagicMock(return_value=head_resp)
+
+        result = await tools._try_pmc("12345", session, timeout_secs=5.0)
+        assert result is None
+
+    async def test_returns_none_when_empty_records(self):
+        tools = PubMedTools()
+
+        converter_resp = _make_mock_response(json_data={"records": []})
+        session = _make_mock_session(responses=[converter_resp])
+
+        result = await tools._try_pmc("12345", session, timeout_secs=5.0)
+        assert result is None
+
+    async def test_returns_none_on_network_error(self):
+        tools = PubMedTools()
+
+        session = AsyncMock()
+        session.get = MagicMock(side_effect=Exception("Connection refused"))
+
+        result = await tools._try_pmc("12345", session, timeout_secs=5.0)
+        assert result is None
+
+
+@pytest.mark.asyncio
+class TestTryEuropePmc:
+    """Tests for _try_europe_pmc method."""
+
+    async def test_returns_pdf_url_when_oa_pdf_found(self):
+        tools = PubMedTools()
+
+        resp = _make_mock_response(
+            json_data={
+                "resultList": {
+                    "result": [
+                        {
+                            "fullTextUrlList": {
+                                "fullTextUrl": [
+                                    {
+                                        "documentStyle": "pdf",
+                                        "availabilityCode": "OA",
+                                        "url": "https://europepmc.org/article/pdf/12345",
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        )
+        session = _make_mock_session(responses=[resp])
+
+        result = await tools._try_europe_pmc("12345", session, timeout_secs=5.0)
+        assert result == "https://europepmc.org/article/pdf/12345"
+
+    async def test_falls_back_to_non_pdf_oa_url(self):
+        tools = PubMedTools()
+
+        resp = _make_mock_response(
+            json_data={
+                "resultList": {
+                    "result": [
+                        {
+                            "fullTextUrlList": {
+                                "fullTextUrl": [
+                                    {
+                                        "documentStyle": "html",
+                                        "availabilityCode": "OA",
+                                        "url": "https://europepmc.org/article/12345",
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        )
+        session = _make_mock_session(responses=[resp])
+
+        result = await tools._try_europe_pmc("12345", session, timeout_secs=5.0)
+        assert result == "https://europepmc.org/article/12345"
+
+    async def test_returns_none_when_no_results(self):
+        tools = PubMedTools()
+
+        resp = _make_mock_response(json_data={"resultList": {"result": []}})
+        session = _make_mock_session(responses=[resp])
+
+        result = await tools._try_europe_pmc("12345", session, timeout_secs=5.0)
+        assert result is None
+
+    async def test_returns_none_when_no_oa_urls(self):
+        tools = PubMedTools()
+
+        resp = _make_mock_response(
+            json_data={
+                "resultList": {
+                    "result": [
+                        {
+                            "fullTextUrlList": {
+                                "fullTextUrl": [
+                                    {
+                                        "documentStyle": "pdf",
+                                        "availabilityCode": "S",
+                                        "url": "https://publisher.com/paywalled.pdf",
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        )
+        session = _make_mock_session(responses=[resp])
+
+        result = await tools._try_europe_pmc("12345", session, timeout_secs=5.0)
+        assert result is None
+
+
+@pytest.mark.asyncio
+class TestTryUnpaywall:
+    """Tests for _try_unpaywall method."""
+
+    async def test_returns_best_oa_pdf_url(self):
+        tools = PubMedTools()
+
+        resp = _make_mock_response(
+            json_data={
+                "best_oa_location": {
+                    "url_for_pdf": "https://unpaywall.org/pdf/10.1000/test",
+                    "url_for_landing_page": "https://publisher.com/article",
+                },
+                "oa_locations": [],
+            }
+        )
+        session = _make_mock_session(responses=[resp])
+
+        result = await tools._try_unpaywall("10.1000/test", session, timeout_secs=5.0)
+        assert result == "https://unpaywall.org/pdf/10.1000/test"
+
+    async def test_falls_back_to_landing_page(self):
+        tools = PubMedTools()
+
+        resp = _make_mock_response(
+            json_data={
+                "best_oa_location": {
+                    "url_for_pdf": None,
+                    "url_for_landing_page": "https://publisher.com/article",
+                },
+                "oa_locations": [],
+            }
+        )
+        session = _make_mock_session(responses=[resp])
+
+        result = await tools._try_unpaywall("10.1000/test", session, timeout_secs=5.0)
+        assert result == "https://publisher.com/article"
+
+    async def test_falls_back_to_oa_locations(self):
+        tools = PubMedTools()
+
+        resp = _make_mock_response(
+            json_data={
+                "best_oa_location": None,
+                "oa_locations": [
+                    {"url_for_pdf": "https://repo.org/pdf/article.pdf"},
+                ],
+            }
+        )
+        session = _make_mock_session(responses=[resp])
+
+        result = await tools._try_unpaywall("10.1000/test", session, timeout_secs=5.0)
+        assert result == "https://repo.org/pdf/article.pdf"
+
+    async def test_returns_none_on_404(self):
+        tools = PubMedTools()
+
+        resp = _make_mock_response(status=404)
+        session = _make_mock_session(responses=[resp])
+
+        result = await tools._try_unpaywall("10.1000/test", session, timeout_secs=5.0)
+        assert result is None
+
+    async def test_returns_none_when_no_oa(self):
+        tools = PubMedTools()
+
+        resp = _make_mock_response(
+            json_data={
+                "best_oa_location": None,
+                "oa_locations": [],
+            }
+        )
+        session = _make_mock_session(responses=[resp])
+
+        result = await tools._try_unpaywall("10.1000/test", session, timeout_secs=5.0)
+        assert result is None
+
+
+@pytest.mark.asyncio
+class TestTryPreprintServers:
+    """Tests for _try_preprint_servers method."""
+
+    async def test_returns_pdf_for_medrxiv_doi_with_jatsxml(self):
+        tools = PubMedTools()
+
+        resp = _make_mock_response(
+            json_data={
+                "collection": [
+                    {
+                        "doi": "10.1101/2024.01.01.123456",
+                        "jatsxml": "https://www.medrxiv.org/content/10.1101/2024.01.01.123456v1.source.xml",
+                    }
+                ]
+            }
+        )
+        session = _make_mock_session(responses=[resp])
+
+        result = await tools._try_preprint_servers(
+            "10.1101/2024.01.01.123456", session, timeout_secs=5.0
+        )
+        assert (
+            result
+            == "https://www.medrxiv.org/content/10.1101/2024.01.01.123456v1.full.pdf"
+        )
+
+    async def test_constructs_url_from_doi_when_no_jatsxml(self):
+        tools = PubMedTools()
+
+        resp = _make_mock_response(
+            json_data={
+                "collection": [
+                    {
+                        "doi": "10.1101/2024.01.01.123456",
+                    }
+                ]
+            }
+        )
+        session = _make_mock_session(responses=[resp])
+
+        result = await tools._try_preprint_servers(
+            "10.1101/2024.01.01.123456", session, timeout_secs=5.0
+        )
+        assert (
+            result
+            == "https://www.medrxiv.org/content/10.1101/2024.01.01.123456.full.pdf"
+        )
+
+    async def test_returns_none_for_non_preprint_doi_no_results(self):
+        tools = PubMedTools()
+
+        resp = _make_mock_response(json_data={"collection": []})
+        session = _make_mock_session(responses=[resp])
+
+        result = await tools._try_preprint_servers(
+            "10.1016/j.cell.2024.01.001", session, timeout_secs=5.0
+        )
+        assert result is None
+
+    async def test_biorxiv_doi_pattern(self):
+        tools = PubMedTools()
+
+        resp = _make_mock_response(
+            json_data={
+                "collection": [
+                    {
+                        "doi": "10.1101/2024.05.15.789012",
+                    }
+                ]
+            }
+        )
+        session = _make_mock_session(responses=[resp])
+
+        result = await tools._try_preprint_servers(
+            "10.1101/2024.05.15.789012", session, timeout_secs=5.0
+        )
+        # Should match medrxiv first due to 10.1101/ pattern
+        assert result is not None
+        assert "10.1101/2024.05.15.789012.full.pdf" in result
+
+
+@pytest.mark.asyncio
+class TestTryDoiResolution:
+    """Tests for _try_doi_resolution method."""
+
+    async def test_returns_url_when_doi_resolves_to_pdf(self):
+        tools = PubMedTools()
+
+        resp = _make_mock_response(
+            status=200,
+            content_type="application/pdf",
+            url="https://publisher.com/article/12345.pdf",
+        )
+        session = _make_mock_session(responses=[resp])
+
+        result = await tools._try_doi_resolution(
+            "10.1000/test", session, timeout_secs=5.0
+        )
+        assert result == "https://publisher.com/article/12345.pdf"
+
+    async def test_extracts_pdf_from_html_landing_page(self):
+        tools = PubMedTools()
+
+        html = '<html><head><meta name="citation_pdf_url" content="https://publisher.com/pdf/12345.pdf"></head></html>'
+        resp = _make_mock_response(
+            status=200,
+            content_type="text/html; charset=utf-8",
+            text_data=html,
+            url="https://publisher.com/article/12345",
+        )
+        session = _make_mock_session(responses=[resp])
+
+        result = await tools._try_doi_resolution(
+            "10.1000/test", session, timeout_secs=5.0
+        )
+        assert result == "https://publisher.com/pdf/12345.pdf"
+
+    async def test_returns_none_when_no_pdf_on_page(self):
+        tools = PubMedTools()
+
+        resp = _make_mock_response(
+            status=200,
+            content_type="text/html",
+            text_data="<html><body>No PDF link here</body></html>",
+            url="https://publisher.com/article/12345",
+        )
+        session = _make_mock_session(responses=[resp])
+
+        result = await tools._try_doi_resolution(
+            "10.1000/test", session, timeout_secs=5.0
+        )
+        assert result is None
+
+    async def test_returns_none_on_404(self):
+        tools = PubMedTools()
+
+        resp = _make_mock_response(status=404)
+        session = _make_mock_session(responses=[resp])
+
+        result = await tools._try_doi_resolution(
+            "10.1000/nonexistent", session, timeout_secs=5.0
+        )
+        assert result is None
+
+
+@pytest.mark.asyncio
+class TestFindArticleUrl:
+    """Tests for the _find_article_url fallback chain."""
+
+    async def test_returns_findit_url_first(self):
+        tools = PubMedTools()
+        session = _make_mock_session()
+
+        with patch.object(tools, "_try_findit", new_callable=AsyncMock) as mock_findit:
+            mock_findit.return_value = "https://findit.com/article.pdf"
+
+            result = await tools._find_article_url(
+                "12345", doi="10.1000/test", session=session
+            )
+
+        assert result == "https://findit.com/article.pdf"
+
+    async def test_falls_through_to_pmc_when_findit_fails(self):
+        tools = PubMedTools()
+        session = _make_mock_session()
+
+        with patch.object(
+            tools, "_try_findit", new_callable=AsyncMock, return_value=None
+        ), patch.object(tools, "_try_pmc", new_callable=AsyncMock) as mock_pmc:
+            mock_pmc.return_value = "https://pmc.ncbi.nlm.nih.gov/article.pdf"
+
+            result = await tools._find_article_url(
+                "12345", doi="10.1000/test", session=session
+            )
+
+        assert result == "https://pmc.ncbi.nlm.nih.gov/article.pdf"
+
+    async def test_falls_through_entire_chain(self):
+        tools = PubMedTools()
+        session = _make_mock_session()
+
+        with patch.object(
+            tools, "_try_findit", new_callable=AsyncMock, return_value=None
+        ), patch.object(
+            tools, "_try_pmc", new_callable=AsyncMock, return_value=None
+        ), patch.object(
+            tools, "_try_europe_pmc", new_callable=AsyncMock, return_value=None
+        ), patch.object(
+            tools, "_try_unpaywall", new_callable=AsyncMock, return_value=None
+        ), patch.object(
+            tools, "_try_preprint_servers", new_callable=AsyncMock, return_value=None
+        ), patch.object(
+            tools,
+            "_try_doi_resolution",
+            new_callable=AsyncMock,
+        ) as mock_doi:
+            mock_doi.return_value = "https://publisher.com/pdf/article.pdf"
+
+            result = await tools._find_article_url(
+                "12345", doi="10.1000/test", session=session
+            )
+
+        assert result == "https://publisher.com/pdf/article.pdf"
+
+    async def test_returns_none_when_all_fail(self):
+        tools = PubMedTools()
+        session = _make_mock_session()
+
+        with patch.object(
+            tools, "_try_findit", new_callable=AsyncMock, return_value=None
+        ), patch.object(
+            tools, "_try_pmc", new_callable=AsyncMock, return_value=None
+        ), patch.object(
+            tools, "_try_europe_pmc", new_callable=AsyncMock, return_value=None
+        ), patch.object(
+            tools, "_try_unpaywall", new_callable=AsyncMock, return_value=None
+        ), patch.object(
+            tools, "_try_preprint_servers", new_callable=AsyncMock, return_value=None
+        ), patch.object(
+            tools, "_try_doi_resolution", new_callable=AsyncMock, return_value=None
+        ):
+            result = await tools._find_article_url(
+                "12345", doi="10.1000/test", session=session
+            )
+
+        assert result is None
+
+    async def test_skips_doi_sources_when_no_doi(self):
+        tools = PubMedTools()
+        session = _make_mock_session()
+
+        with patch.object(
+            tools, "_try_findit", new_callable=AsyncMock, return_value=None
+        ), patch.object(
+            tools, "_try_pmc", new_callable=AsyncMock, return_value=None
+        ), patch.object(
+            tools, "_try_europe_pmc", new_callable=AsyncMock, return_value=None
+        ), patch.object(
+            tools, "_try_unpaywall", new_callable=AsyncMock
+        ) as mock_unpaywall, patch.object(
+            tools, "_try_preprint_servers", new_callable=AsyncMock
+        ) as mock_preprint, patch.object(
+            tools, "_try_doi_resolution", new_callable=AsyncMock
+        ) as mock_doi:
+            result = await tools._find_article_url("12345", doi=None, session=session)
+
+        # DOI-dependent methods should not be called
+        mock_unpaywall.assert_not_called()
+        mock_preprint.assert_not_called()
+        mock_doi.assert_not_called()
+        assert result is None
+
+    async def test_creates_own_session_when_none_provided(self):
+        tools = PubMedTools()
+
+        with patch.object(
+            tools, "_try_findit", new_callable=AsyncMock
+        ) as mock_findit, patch(
+            "fighthealthinsurance.pubmed_tools.aiohttp.ClientSession"
+        ) as mock_session_cls:
+            mock_findit.return_value = "https://example.com/article.pdf"
+            mock_session = AsyncMock()
+            mock_session.close = AsyncMock()
+            mock_session_cls.return_value = mock_session
+
+            result = await tools._find_article_url("12345")
+
+        assert result == "https://example.com/article.pdf"
+        mock_session_cls.assert_called_once()
+        mock_session.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+class TestFetchTextFromUrl:
+    """Tests for _fetch_text_from_url method."""
+
+    async def test_extracts_text_from_html_response(self):
+        tools = PubMedTools()
+
+        resp = _make_mock_response(
+            text_data="This is a long enough article text that should be returned as content for the test",
+            content_type="text/html",
+        )
+        session = _make_mock_session(responses=[resp])
+
+        result = await tools._fetch_text_from_url(
+            "https://example.com/article.html", session
+        )
+        assert "long enough article text" in result
+
+    async def test_returns_empty_string_on_short_text(self):
+        tools = PubMedTools()
+
+        resp = _make_mock_response(
+            text_data="short",
+            content_type="text/html",
+        )
+        session = _make_mock_session(responses=[resp])
+
+        result = await tools._fetch_text_from_url(
+            "https://example.com/article.html", session
+        )
+        assert result == ""
+
+    async def test_returns_empty_string_on_error(self):
+        tools = PubMedTools()
+
+        session = AsyncMock()
+        error_resp = AsyncMock()
+        error_resp.__aenter__ = AsyncMock(side_effect=Exception("Connection error"))
+        error_resp.__aexit__ = AsyncMock(return_value=False)
+        session.get = MagicMock(return_value=error_resp)
+
+        result = await tools._fetch_text_from_url("https://example.com/broken", session)
+        assert result == ""
+
+
+@pytest.mark.asyncio
+class TestTryFetchPdfToFile:
+    """Tests for _try_fetch_pdf_to_file method."""
+
+    async def test_saves_pdf_to_temp_file(self):
+        tools = PubMedTools()
+
+        pdf_content = b"%PDF-1.4 " + b"x" * 100  # >20 bytes
+        resp = _make_mock_response(
+            content=pdf_content,
+            content_type="application/pdf",
+        )
+        session = _make_mock_session(responses=[resp])
+
+        result = await tools._try_fetch_pdf_to_file(
+            "https://example.com/paper.pdf", "test_", session
+        )
+        assert result is not None
+        assert result.endswith(".pdf")
+
+        # Verify content was written
+        with open(result, "rb") as f:
+            assert f.read() == pdf_content
+
+    async def test_returns_none_for_non_pdf_content(self):
+        tools = PubMedTools()
+
+        resp = _make_mock_response(
+            content=b"<html>not a pdf</html>",
+            content_type="text/html",
+        )
+        session = _make_mock_session(responses=[resp])
+
+        result = await tools._try_fetch_pdf_to_file(
+            "https://example.com/article.html", "test_", session
+        )
+        assert result is None
+
+    async def test_returns_none_for_tiny_content(self):
+        tools = PubMedTools()
+
+        resp = _make_mock_response(
+            content=b"tiny",  # <=20 bytes
+            content_type="application/pdf",
+        )
+        session = _make_mock_session(responses=[resp])
+
+        result = await tools._try_fetch_pdf_to_file(
+            "https://example.com/paper.pdf", "test_", session
+        )
+        assert result is None
+
+    async def test_returns_none_on_non_200(self):
+        tools = PubMedTools()
+
+        resp = _make_mock_response(status=403)
+        session = _make_mock_session(responses=[resp])
+
+        result = await tools._try_fetch_pdf_to_file(
+            "https://example.com/paper.pdf", "test_", session
+        )
+        assert result is None
+
+    async def test_returns_none_on_network_error(self):
+        tools = PubMedTools()
+
+        session = AsyncMock()
+        error_resp = AsyncMock()
+        error_resp.__aenter__ = AsyncMock(side_effect=Exception("Network error"))
+        error_resp.__aexit__ = AsyncMock(return_value=False)
+        session.get = MagicMock(return_value=error_resp)
+
+        result = await tools._try_fetch_pdf_to_file(
+            "https://example.com/paper.pdf", "test_", session
+        )
+        assert result is None

--- a/tests/async-unit/test_pubmed_pdf_resolution.py
+++ b/tests/async-unit/test_pubmed_pdf_resolution.py
@@ -1,6 +1,7 @@
 """Unit tests for the PDF URL resolution methods in PubMedTools."""
 
 import asyncio
+import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -664,13 +665,21 @@ class TestTryFetchPdfToFile:
         )
         assert result is not None
         assert result.endswith(".pdf")
-        with open(result, "rb") as f:
-            assert f.read() == pdf_content
+        try:
+            with open(result, "rb") as f:
+                assert f.read() == pdf_content
+        finally:
+            os.unlink(result)
 
     @pytest.mark.parametrize(
         "url,content,content_type,status",
         [
-            ("https://example.com/article", b"<html>not a pdf</html>", "text/html", 200),
+            (
+                "https://example.com/article",
+                b"<html>not a pdf</html>",
+                "text/html",
+                200,
+            ),
             ("https://example.com/paper.pdf", b"tiny", "application/pdf", 200),
             ("https://example.com/paper.pdf", b"", "application/pdf", 403),
         ],


### PR DESCRIPTION
## Summary
Refactored the PubMed article PDF/full-text URL resolution logic into a comprehensive set of modular async methods, replacing the previous single-source FindIt approach with a fallback chain that tries multiple sources in order.

## Key Changes

- **New `_find_article_url()` method**: Implements a fallback chain that tries multiple sources in order (FindIt → PMC → Europe PMC → Unpaywall → Preprint servers → DOI resolution), returning the first successful URL found
- **Individual source methods**: Created dedicated async methods for each resolution source:
  - `_try_findit()`: Wraps metapub's FindIt in async/timeout handling
  - `_try_pmc()`: Queries NCBI PMC ID converter API
  - `_try_europe_pmc()`: Queries Europe PMC API for open access content
  - `_try_unpaywall()`: Queries Unpaywall API for open access PDFs
  - `_try_preprint_servers()`: Checks medRxiv/bioRxiv for preprints via `_query_biorxiv()`
  - `_try_doi_resolution()`: Resolves DOI and extracts PDF links from landing pages
- **HTML PDF extraction**: Added `_extract_pdf_url_from_html()` static method to parse common citation metadata patterns and PDF links from publisher pages
- **Text fetching**: Extracted `_fetch_text_from_url()` method to handle both PDF and HTML content fetching with proper error handling
- **PDF file download**: Added `_try_fetch_pdf_to_file()` method to download and validate PDFs to temporary files
- **Helper methods**: Added `_fetch_json()` for consistent JSON API calls with timeout handling and `_is_pdf_response()` for content-type detection
- **Session management**: Updated `find_pubmed_articles_for_denial()` and `do_article_summary()` to use the new `_find_article_url()` method with shared session for efficiency
- **Common headers**: Added `_FETCH_HEADERS` constant with User-Agent to avoid bot detection

## Implementation Details

- All new methods follow async/await patterns with proper timeout handling via `async_timeout`
- The fallback chain is built dynamically via `_url_sources()` to avoid creating unnecessary coroutines
- DOI-based sources are only attempted when a DOI is available
- Session is created once and reused across multiple source attempts for efficiency
- Comprehensive unit test suite added with 697 lines of async tests covering all new methods

https://claude.ai/code/session_01FUaNeoVBCGXbCbTtw86LLP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded asynchronous article discovery that probes multiple scholarly sources, preprint servers, and DOI pathways with prioritized fallbacks to locate PDFs and full text.
  * In-memory PDF/text extraction and unified async fetching with shared headers and per-source timeouts.

* **Bug Fixes**
  * More robust URL handling, validation of PDF responses, and improved retry/fallback behavior to increase successful retrievals.

* **Tests**
  * Added comprehensive async unit tests covering URL resolution, HTML-to-PDF extraction, PDF fetching, and error/connection handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->