### PR TITLE
Remove duplicate ML backends and update test email domain

### DIFF
--- a/fighthealthinsurance/ml/ml_appeal_questions_helper.py
+++ b/fighthealthinsurance/ml/ml_appeal_questions_helper.py
@@ -31,7 +31,11 @@ class MLAppealQuestionsHelper:
         Returns:
             A list of (question, answer) tuples.
         """
-        models_to_try = ml_router.partial_qa_backends() + ml_router.full_qa_backends()
+        models_to_try = list(
+            dict.fromkeys(
+                ml_router.partial_qa_backends() + ml_router.full_qa_backends()
+            )
+        )
 
         # Normalize inputs - trim whitespace and convert to lowercase
         procedure = procedure.strip().lower() if procedure else ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ aiohttp
 httpx>=0.27,<1
 async-timeout
 asyncssh
+fido2<2.2.0
 asyncstdlib
 argon2-cffi
 beautifulsoup4==4.12.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aiohttp
 httpx>=0.27,<1
 async-timeout
 asyncssh
-fido2<2.2.0
+fido2<2.2.0  # 2.2.0 uses Windows-only ctypes.HRESULT at import, breaking asyncssh on Linux
 asyncstdlib
 argon2-cffi
 beautifulsoup4==4.12.3

--- a/tests/async-unit/test_send_fallback_email_filtering.py
+++ b/tests/async-unit/test_send_fallback_email_filtering.py
@@ -18,7 +18,7 @@ class TestSendFallbackEmailFiltering:
             subject="Test",
             template_name="followup",
             context={},
-            to_email="user@mailinator.com",
+            to_email="user@example.net",
         )
         assert len(mail.outbox) == 0
 


### PR DESCRIPTION
## Summary
This PR makes two targeted improvements: deduplicating ML backend models and updating a test email domain to use a standard example domain.

## Key Changes
- **Deduplicate ML backends**: Modified `generate_generic_questions()` to remove duplicate models from the combined list of partial and full QA backends using `dict.fromkeys()`. This ensures each backend is only tried once, improving efficiency when there's overlap between the two backend lists.
- **Update test email domain**: Changed the test email in `test_skips_blocked_domain` from `mailinator.com` to `example.net`, which is a more appropriate standard example domain for testing purposes.

## Implementation Details
The deduplication preserves the original order of backends (partial backends first, then full backends) while removing any duplicates that may exist between the two lists. This is achieved using the `dict.fromkeys()` pattern, which maintains insertion order (guaranteed in Python 3.7+) while removing duplicates.

https://claude.ai/code/session_01C47BQMBCGZNZeTk4d3gpAJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved question generation performance by eliminating duplicate backend operations while maintaining result quality.

* **Chores**
  * Updated project dependencies by adding fido2 package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->