### PR TITLE
Increase SQLite database timeout from 1s to 30s in test settings

### DIFF
--- a/fighthealthinsurance/settings.py
+++ b/fighthealthinsurance/settings.py
@@ -523,7 +523,7 @@ class Test(Dev):
     DATABASES = {
         "default": {
             "ENGINE": "django.db.backends.sqlite3",
-            "TIMEOUT": 1,
+            "TIMEOUT": 30,
             "CONN_MAX_AGE": 0,
             "NAME": "memory",
         },


### PR DESCRIPTION
## Summary
Increased the SQLite database connection timeout in the Test configuration from 1 second to 30 seconds to reduce timeout-related failures during test execution.

## Key Changes
- Updated `TIMEOUT` setting in Test database configuration from `1` to `30` seconds

## Details
The previous 1-second timeout was likely too aggressive for test scenarios, potentially causing intermittent connection timeout errors. Increasing it to 30 seconds provides a more reasonable grace period for database operations during testing while still maintaining a reasonable timeout threshold.

https://claude.ai/code/session_0155MLSJwJZZeFUmGC3VG1D5