### PR TITLE
Add Anthropic Claude API backend support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,3 +105,7 @@ PERPLEXITY_API=your-perplexity-api-key
 # Groq API for ultra-fast inference (optional)
 # Used for chat and letter generation when use_external=True
 GROQ_API_KEY=your-groq-api-key
+
+# Anthropic Claude API (optional)
+# Used for high-quality chat and letter generation when use_external=True
+ANTHROPIC_API_KEY=your-anthropic-api-key

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -2974,6 +2974,213 @@ class RemoteGroq(RemoteFullOpenLike):
         return self.rate_limiter.can_request()
 
 
+class RemoteAnthropic(RemoteFullOpenLike):
+    """
+    Anthropic Claude API backend.
+
+    Uses Anthropic's OpenAI-compatible endpoint at /v1/chat/completions, which
+    accepts standard OpenAI-format requests and Bearer-token authentication.
+    See: https://docs.anthropic.com/en/api/openai-sdk
+
+    Features:
+    - Per-model backoff when rate limited (429 responses with Retry-After)
+    - Three tiers: Haiku (speed), Sonnet (quality), Opus (premium)
+    - All Claude models support 200K input context
+
+    Environment variables:
+    - ANTHROPIC_API_KEY: API key for Anthropic (required)
+    """
+
+    # Model specifications - all Claude models support 200K input context
+    MODEL_SPECS: ClassVar[dict[str, dict[str, str]]] = {
+        "claude-haiku-4-5-20251001": {
+            "tier": "speed",
+            "description": "Claude Haiku 4.5 - fast, cost-effective",
+        },
+        "claude-sonnet-4-6": {
+            "tier": "quality",
+            "description": "Claude Sonnet 4.6 - balanced quality and speed",
+        },
+        "claude-opus-4-7": {
+            "tier": "premium",
+            "description": "Claude Opus 4.7 - highest quality, most capable",
+        },
+    }
+
+    # Shared rate limiters per model (class-level, initialized lazily)
+    _rate_limiters: ClassVar[dict[str, RateLimiter]] = {}
+    _rate_limiter_lock: ClassVar[threading.Lock] = threading.Lock()
+
+    def __init__(self, model: str, dual_mode: bool = False):
+        """
+        Initialize an Anthropic Claude model backend.
+
+        Args:
+            model: The Anthropic model identifier (e.g., 'claude-sonnet-4-6')
+            dual_mode: Whether to run primary and backup concurrently
+        """
+        api_base = "https://api.anthropic.com/v1"
+        token = os.getenv("ANTHROPIC_API_KEY")
+        if token is None or len(token) < 1:
+            raise EnvironmentError(
+                "No API key found for Anthropic. Please set the ANTHROPIC_API_KEY environment variable "
+                "in your environment or .env file."
+            )
+
+        # All Claude models support 200K input context
+        super().__init__(
+            api_base, token, model=model, dual_mode=dual_mode, max_len=200000
+        )
+
+        self._ensure_rate_limiter(model)
+
+        model_spec = self.MODEL_SPECS.get(model, {})
+        logger.debug(
+            f"RemoteAnthropic initialized: model={model}, "
+            f"tier={model_spec.get('tier', 'unknown')}"
+        )
+
+    @classmethod
+    def _ensure_rate_limiter(cls, model: str) -> None:
+        """
+        Ensure a rate limiter exists for the given model.
+        Creates one if it doesn't exist (thread-safe).
+        """
+        if model not in cls._rate_limiters:
+            with cls._rate_limiter_lock:
+                if model not in cls._rate_limiters:
+                    cls._rate_limiters[model] = RateLimiter(
+                        name=f"anthropic-{model}",
+                    )
+                    logger.info(f"Created rate limiter for anthropic-{model}")
+
+    @property
+    def rate_limiter(self) -> RateLimiter:
+        """Get the rate limiter for this model instance."""
+        return self._rate_limiters[self.model]
+
+    @property
+    def supports_system(self):
+        return True
+
+    @property
+    def external(self):
+        return True
+
+    def get_tier(self) -> str:
+        """Get the tier (speed/quality/premium) for this model."""
+        return self.MODEL_SPECS.get(self.model, {}).get("tier", "unknown")
+
+    async def _infer(
+        self,
+        system_prompts: list[str],
+        prompt: str,
+        patient_context: Optional[str] = None,
+        plan_context: Optional[str] = None,
+        pubmed_context: Optional[str] = None,
+        ml_citations_context: Optional[List[str]] = None,
+        history: Optional[List[dict[str, str]]] = None,
+        temperature: float = 0.7,
+    ) -> Optional[Tuple[Optional[str], Optional[List[str]]]]:
+        """
+        Perform inference with rate limit checking and 429 handling.
+
+        Checks the rate limiter before making the API call. If rate limited,
+        returns None immediately to allow fallback to other backends.
+        On 429 response, marks the limiter as exhausted and returns None.
+        """
+        if not self.rate_limiter.can_request():
+            logger.debug(f"RemoteAnthropic._infer: Skipping {self.model} - backing off")
+            return None
+
+        try:
+            return await super()._infer(
+                system_prompts=system_prompts,
+                prompt=prompt,
+                patient_context=patient_context,
+                plan_context=plan_context,
+                pubmed_context=pubmed_context,
+                ml_citations_context=ml_citations_context,
+                history=history,
+                temperature=temperature,
+            )
+        except aiohttp.ClientResponseError as e:
+            if e.status == 429:
+                retry_after = 60.0
+                if hasattr(e, "headers") and e.headers:
+                    retry_header = e.headers.get("Retry-After", "")
+                    if retry_header:
+                        try:
+                            retry_after = float(retry_header)
+                        except ValueError:
+                            logger.debug(
+                                f"RemoteAnthropic._infer: Non-numeric Retry-After header "
+                                f"'{retry_header}' for {self.model}; using default {retry_after}s"
+                            )
+
+                retry_after = max(1.0, min(retry_after, 600.0))
+
+                self.rate_limiter.mark_exhausted(retry_after)
+                logger.warning(
+                    f"RemoteAnthropic._infer: 429 from Anthropic for {self.model}, "
+                    f"backing off for {retry_after}s"
+                )
+                return None
+            else:
+                raise
+        except Exception as e:
+            logger.warning(f"RemoteAnthropic._infer error for {self.model}: {e}")
+            return None
+
+    @classmethod
+    def models(cls) -> List[ModelDescription]:
+        """
+        Return available Anthropic Claude models with cost tiers.
+
+        Costs are set to reflect Anthropic's pricing tiers relative to other
+        external backends. Haiku is positioned as a mid-cost speed option,
+        Sonnet as a quality option comparable to Llama-4-Maverick, and Opus
+        as a premium option for the highest-quality output.
+        """
+        if not os.getenv("ANTHROPIC_API_KEY"):
+            logger.debug("RemoteAnthropic.models: ANTHROPIC_API_KEY not set, skipping")
+            return []
+
+        return [
+            # Speed tier - cheapest Claude option
+            ModelDescription(
+                cost=25,
+                name="anthropic/claude-haiku-4-5",
+                internal_name="claude-haiku-4-5-20251001",
+            ),
+            # Quality tier - mid-priced, similar to DeepInfra's largest llama
+            ModelDescription(
+                cost=90,
+                name="anthropic/claude-sonnet-4-6",
+                internal_name="claude-sonnet-4-6",
+            ),
+            # Premium tier - highest cost, only used when other backends fail
+            # or are explicitly preferred for quality.
+            ModelDescription(
+                cost=250,
+                name="anthropic/claude-opus-4-7",
+                internal_name="claude-opus-4-7",
+            ),
+        ]
+
+    def model_is_ok(self) -> bool:
+        """
+        Check if the model is available (API key set and not rate limited).
+
+        Note: We don't query the /models endpoint because Anthropic's
+        OpenAI-compatibility layer historically has limited support for it,
+        and we'd rather fail fast on actual inference than block startup.
+        """
+        if not os.getenv("ANTHROPIC_API_KEY"):
+            return False
+        return self.rate_limiter.can_request()
+
+
 class TailscaleModelBackend(RemoteFullOpenLike):
     """
     Backend that auto-discovers model servers via Tailscale DNS.

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -1134,6 +1134,13 @@ class RemoteModel(RemoteModelLike):
 class RemoteOpenLike(RemoteModel):
     _expensive = False
 
+    # If True, aiohttp.ClientResponseError is re-raised from _infer so that
+    # subclasses can react to specific status codes (e.g. 429 backoff in
+    # RemoteGroq / RemoteAnthropic). Default is False to preserve the
+    # historical contract that _infer returns None on transport errors and
+    # callers that don't catch exceptions keep working.
+    _propagate_http_errors: ClassVar[bool] = False
+
     def __init__(
         self,
         api_base,
@@ -1853,9 +1860,13 @@ class RemoteOpenLike(RemoteModel):
                     return backup_response
 
         except aiohttp.ClientResponseError:
-            # Let subclasses handle status-specific HTTP errors (e.g., 429
-            # rate limiting in RemoteGroq / RemoteAnthropic).
-            raise
+            # Subclasses that opt in (via _propagate_http_errors) handle
+            # status-specific HTTP errors themselves (e.g. 429 backoff in
+            # RemoteGroq / RemoteAnthropic). Otherwise preserve the original
+            # contract of returning None on transport errors.
+            if self._propagate_http_errors:
+                raise
+            logger.opt(exception=True).error(f"HTTP error calling {self.api_base}")
         except Exception as e:
             logger.opt(exception=True).error(f"Error {e} calling {self.api_base}")
 
@@ -2743,6 +2754,9 @@ class RemoteGroq(RemoteFullOpenLike):
     _rate_limiters: ClassVar[dict[str, RateLimiter]] = {}
     _rate_limiter_lock: ClassVar[threading.Lock] = threading.Lock()
 
+    # Re-raise ClientResponseError from the parent _infer so we can detect 429.
+    _propagate_http_errors: ClassVar[bool] = True
+
     def __init__(self, model: str, dual_mode: bool = False):
         """
         Initialize a Groq model backend.
@@ -3014,6 +3028,9 @@ class RemoteAnthropic(RemoteFullOpenLike):
     # Shared rate limiters per model (class-level, initialized lazily)
     _rate_limiters: ClassVar[dict[str, RateLimiter]] = {}
     _rate_limiter_lock: ClassVar[threading.Lock] = threading.Lock()
+
+    # Re-raise ClientResponseError from the parent _infer so we can detect 429.
+    _propagate_http_errors: ClassVar[bool] = True
 
     def __init__(self, model: str, dual_mode: bool = False):
         """

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -1852,6 +1852,10 @@ class RemoteOpenLike(RemoteModel):
                     )
                     return backup_response
 
+        except aiohttp.ClientResponseError:
+            # Let subclasses handle status-specific HTTP errors (e.g., 429
+            # rate limiting in RemoteGroq / RemoteAnthropic).
+            raise
         except Exception as e:
             logger.opt(exception=True).error(f"Error {e} calling {self.api_base}")
 

--- a/tests/async-unit/test_anthropic_models.py
+++ b/tests/async-unit/test_anthropic_models.py
@@ -1,0 +1,325 @@
+"""
+Tests for the RemoteAnthropic class in fighthealthinsurance.ml.ml_models.
+
+Tests cover:
+- Model initialization and configuration
+- Rate limit checking before inference
+- 429 response handling
+- Model registration and cost tiers
+"""
+
+import asyncio
+import os
+import time
+import unittest
+from unittest.mock import patch, MagicMock, AsyncMock
+
+import aiohttp
+
+# Set up environment before importing RemoteAnthropic
+os.environ.setdefault("ANTHROPIC_API_KEY", "test-api-key")
+
+from fighthealthinsurance.ml.ml_models import RemoteAnthropic
+from fighthealthinsurance.utils import RateLimiter
+
+
+class TestRemoteAnthropicInit(unittest.TestCase):
+    """Tests for RemoteAnthropic initialization."""
+
+    def setUp(self):
+        """Reset class-level state before each test."""
+        RemoteAnthropic._rate_limiters.clear()
+
+    @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"})
+    def test_init_with_valid_api_key(self):
+        """Test RemoteAnthropic initializes with valid API key."""
+        model = RemoteAnthropic(model="claude-sonnet-4-6")
+
+        self.assertEqual(model.model, "claude-sonnet-4-6")
+        self.assertTrue(model.supports_system)
+        self.assertTrue(model.external)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_init_without_api_key_raises(self):
+        """Test RemoteAnthropic raises EnvironmentError without API key."""
+        if "ANTHROPIC_API_KEY" in os.environ:
+            del os.environ["ANTHROPIC_API_KEY"]
+
+        with self.assertRaises(EnvironmentError) as context:
+            RemoteAnthropic(model="claude-sonnet-4-6")
+
+        self.assertIn("ANTHROPIC_API_KEY", str(context.exception))
+
+    @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"})
+    def test_init_creates_rate_limiter(self):
+        """Test RemoteAnthropic creates a rate limiter for the model."""
+        model = RemoteAnthropic(model="claude-sonnet-4-6")
+
+        self.assertIn("claude-sonnet-4-6", RemoteAnthropic._rate_limiters)
+        self.assertIsInstance(model.rate_limiter, RateLimiter)
+
+    @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"})
+    def test_all_models_use_200k_context(self):
+        """Test all Claude models use 200K context length."""
+        for model_name in RemoteAnthropic.MODEL_SPECS.keys():
+            model = RemoteAnthropic(model=model_name)
+            self.assertEqual(model.get_max_context(), 200000)
+
+    @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"})
+    def test_uses_anthropic_api_base(self):
+        """Test that the api_base points at Anthropic's API."""
+        model = RemoteAnthropic(model="claude-sonnet-4-6")
+
+        self.assertEqual(model.api_base, "https://api.anthropic.com/v1")
+
+
+class TestRemoteAnthropicModels(unittest.TestCase):
+    """Tests for RemoteAnthropic.models() class method."""
+
+    @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"})
+    def test_models_returns_three_models(self):
+        """Test models() returns three Claude models (Haiku, Sonnet, Opus)."""
+        models = RemoteAnthropic.models()
+
+        self.assertEqual(len(models), 3)
+
+    @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"})
+    def test_models_have_anthropic_prefix(self):
+        """Test models have anthropic/ prefix in their friendly name."""
+        models = RemoteAnthropic.models()
+        model_names = [m.name for m in models]
+
+        for name in model_names:
+            self.assertTrue(
+                name.startswith("anthropic/"),
+                f"{name} should start with 'anthropic/'",
+            )
+
+    @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"})
+    def test_models_cost_ordering(self):
+        """Haiku < Sonnet < Opus in cost."""
+        models = RemoteAnthropic.models()
+        models_by_name = {m.name: m for m in models}
+
+        haiku_cost = models_by_name["anthropic/claude-haiku-4-5"].cost
+        sonnet_cost = models_by_name["anthropic/claude-sonnet-4-6"].cost
+        opus_cost = models_by_name["anthropic/claude-opus-4-7"].cost
+
+        self.assertLess(haiku_cost, sonnet_cost)
+        self.assertLess(sonnet_cost, opus_cost)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_models_returns_empty_without_api_key(self):
+        """Test models() returns empty list without API key."""
+        if "ANTHROPIC_API_KEY" in os.environ:
+            del os.environ["ANTHROPIC_API_KEY"]
+
+        models = RemoteAnthropic.models()
+
+        self.assertEqual(len(models), 0)
+
+
+class TestRemoteAnthropicTiers(unittest.TestCase):
+    """Tests for model tier classification."""
+
+    def setUp(self):
+        """Reset class-level state before each test."""
+        RemoteAnthropic._rate_limiters.clear()
+
+    @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"})
+    def test_haiku_is_speed_tier(self):
+        """Test Haiku is in speed tier."""
+        model = RemoteAnthropic(model="claude-haiku-4-5-20251001")
+
+        self.assertEqual(model.get_tier(), "speed")
+
+    @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"})
+    def test_sonnet_is_quality_tier(self):
+        """Test Sonnet is in quality tier."""
+        model = RemoteAnthropic(model="claude-sonnet-4-6")
+
+        self.assertEqual(model.get_tier(), "quality")
+
+    @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"})
+    def test_opus_is_premium_tier(self):
+        """Test Opus is in premium tier."""
+        model = RemoteAnthropic(model="claude-opus-4-7")
+
+        self.assertEqual(model.get_tier(), "premium")
+
+
+class TestRemoteAnthropicInfer(unittest.TestCase):
+    """Tests for RemoteAnthropic._infer method."""
+
+    def setUp(self):
+        """Reset class-level state before each test."""
+        RemoteAnthropic._rate_limiters.clear()
+
+    @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"})
+    async def async_test_infer_checks_rate_limit(self):
+        """Test that _infer returns None without calling API when rate limited."""
+        model = RemoteAnthropic(model="claude-sonnet-4-6")
+
+        model.rate_limiter.mark_exhausted(60.0)
+
+        result = await model._infer(
+            system_prompts=["You are helpful."], prompt="Test prompt"
+        )
+
+        self.assertIsNone(result)
+
+    def test_infer_checks_rate_limit(self):
+        """Run the async test."""
+        asyncio.run(self.async_test_infer_checks_rate_limit())
+
+    @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"})
+    async def async_test_infer_handles_429(self):
+        """Test that _infer handles 429 response and marks exhausted."""
+        model = RemoteAnthropic(model="claude-sonnet-4-6")
+
+        error = aiohttp.ClientResponseError(
+            request_info=MagicMock(),
+            history=(),
+            status=429,
+            message="Rate limited",
+            headers={"Retry-After": "120"},
+        )
+
+        with patch.object(
+            RemoteAnthropic.__bases__[0],
+            "_infer",
+            new_callable=AsyncMock,
+            side_effect=error,
+        ):
+            result = await model._infer(
+                system_prompts=["You are helpful."], prompt="Test prompt"
+            )
+
+        self.assertIsNone(result)
+
+        status = model.rate_limiter.get_status()
+        self.assertTrue(status["exhausted"])
+
+    def test_infer_handles_429(self):
+        """Run the async test."""
+        asyncio.run(self.async_test_infer_handles_429())
+
+    @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"})
+    async def async_test_infer_429_with_invalid_retry_after_uses_default(self):
+        """Test 429 with non-numeric Retry-After falls back to default 60s."""
+        model = RemoteAnthropic(model="claude-sonnet-4-6")
+
+        error = aiohttp.ClientResponseError(
+            request_info=MagicMock(),
+            history=(),
+            status=429,
+            message="Rate limited",
+            headers={"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"},
+        )
+
+        with patch.object(
+            RemoteAnthropic.__bases__[0],
+            "_infer",
+            new_callable=AsyncMock,
+            side_effect=error,
+        ):
+            result = await model._infer(
+                system_prompts=["You are helpful."], prompt="Test prompt"
+            )
+
+        self.assertIsNone(result)
+
+        status = model.rate_limiter.get_status()
+        self.assertTrue(status["exhausted"])
+        self.assertGreater(status["exhausted_until"], time.time() + 50)
+        self.assertLess(status["exhausted_until"], time.time() + 70)
+
+    def test_infer_429_with_invalid_retry_after_uses_default(self):
+        """Run the async test for invalid Retry-After."""
+        asyncio.run(self.async_test_infer_429_with_invalid_retry_after_uses_default())
+
+    @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"})
+    async def async_test_infer_other_http_errors_propagate(self):
+        """Test that non-429 HTTP errors are re-raised, not swallowed."""
+        model = RemoteAnthropic(model="claude-sonnet-4-6")
+
+        error = aiohttp.ClientResponseError(
+            request_info=MagicMock(),
+            history=(),
+            status=500,
+            message="Server error",
+            headers={},
+        )
+
+        with patch.object(
+            RemoteAnthropic.__bases__[0],
+            "_infer",
+            new_callable=AsyncMock,
+            side_effect=error,
+        ):
+            with self.assertRaises(aiohttp.ClientResponseError):
+                await model._infer(
+                    system_prompts=["You are helpful."], prompt="Test prompt"
+                )
+
+    def test_infer_other_http_errors_propagate(self):
+        """Run the async test."""
+        asyncio.run(self.async_test_infer_other_http_errors_propagate())
+
+
+class TestRemoteAnthropicModelIsOk(unittest.TestCase):
+    """Tests for RemoteAnthropic.model_is_ok method."""
+
+    def setUp(self):
+        """Reset class-level state before each test."""
+        RemoteAnthropic._rate_limiters.clear()
+
+    @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"})
+    def test_model_is_ok_when_available(self):
+        """Test model_is_ok returns True when not rate limited."""
+        model = RemoteAnthropic(model="claude-sonnet-4-6")
+
+        self.assertTrue(model.model_is_ok())
+
+    @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"})
+    def test_model_is_ok_false_when_rate_limited(self):
+        """Test model_is_ok returns False when rate limited."""
+        model = RemoteAnthropic(model="claude-sonnet-4-6")
+
+        model.rate_limiter.mark_exhausted(60.0)
+
+        self.assertFalse(model.model_is_ok())
+
+    def test_model_is_ok_false_without_api_key(self):
+        """Test model_is_ok returns False without API key."""
+        os.environ["ANTHROPIC_API_KEY"] = "test-key"
+        model = RemoteAnthropic(model="claude-sonnet-4-6")
+
+        del os.environ["ANTHROPIC_API_KEY"]
+        try:
+            self.assertFalse(model.model_is_ok())
+        finally:
+            os.environ["ANTHROPIC_API_KEY"] = "test-api-key"
+
+
+class TestRemoteAnthropicIntegration(unittest.TestCase):
+    """Integration tests for RemoteAnthropic with MLRouter."""
+
+    def setUp(self):
+        """Reset class-level state before each test."""
+        RemoteAnthropic._rate_limiters.clear()
+
+    @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"})
+    def test_anthropic_models_are_external(self):
+        """Test that all Anthropic models are marked as external."""
+        models = RemoteAnthropic.models()
+
+        for model_desc in models:
+            if model_desc.model is None:
+                model_desc.model = RemoteAnthropic(model=model_desc.internal_name)
+
+            self.assertTrue(model_desc.model.external)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/async-unit/test_anthropic_models.py
+++ b/tests/async-unit/test_anthropic_models.py
@@ -266,6 +266,44 @@ class TestRemoteAnthropicInfer(unittest.TestCase):
         """Run the async test."""
         asyncio.run(self.async_test_infer_other_http_errors_propagate())
 
+    @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"})
+    async def async_test_infer_429_through_real_infer_marks_exhausted(self):
+        """End-to-end: a 429 from the underlying HTTP call must reach the
+        subclass handler and trigger backoff, not be swallowed by the parent's
+        catch-all exception handler.
+
+        Mocks the inner `__infer` (the actual HTTP request) rather than the
+        subclass's `_infer`, so the real `RemoteOpenLike._infer` runs in
+        between and any regression in its exception handling will surface.
+        """
+        model = RemoteAnthropic(model="claude-sonnet-4-6")
+
+        error = aiohttp.ClientResponseError(
+            request_info=MagicMock(),
+            history=(),
+            status=429,
+            message="Rate limited",
+            headers={"Retry-After": "120"},
+        )
+
+        # Name-mangled private method on RemoteOpenLike
+        with patch.object(
+            model,
+            "_RemoteOpenLike__infer",
+            new_callable=AsyncMock,
+            side_effect=error,
+        ):
+            result = await model._infer(
+                system_prompts=["You are helpful."], prompt="Test prompt"
+            )
+
+        self.assertIsNone(result)
+        self.assertTrue(model.rate_limiter.get_status()["exhausted"])
+
+    def test_infer_429_through_real_infer_marks_exhausted(self):
+        """Run the async test."""
+        asyncio.run(self.async_test_infer_429_through_real_infer_marks_exhausted())
+
 
 class TestRemoteAnthropicModelIsOk(unittest.TestCase):
     """Tests for RemoteAnthropic.model_is_ok method."""


### PR DESCRIPTION
## Summary
This PR adds support for Anthropic's Claude models as an external inference backend, enabling the system to use Claude Haiku, Sonnet, and Opus models for chat and letter generation.

## Key Changes
- **New `RemoteAnthropic` class**: Implements Anthropic Claude API integration using their OpenAI-compatible endpoint at `/v1/chat/completions`
  - Supports three Claude models across three cost/capability tiers:
    - Claude Haiku 4.5 (speed tier) - fastest, most cost-effective
    - Claude Sonnet 4.6 (quality tier) - balanced performance
    - Claude Opus 4.7 (premium tier) - highest quality
  - All models configured with 200K input context window
  
- **Rate limiting and backoff handling**:
  - Per-model rate limiters with thread-safe initialization
  - Automatic handling of 429 (rate limit) responses with Retry-After header parsing
  - Graceful fallback to other backends when rate limited
  - Configurable backoff duration (1-600 seconds, default 60s)

- **Model registration**: Added `models()` class method returning available Claude models with relative cost tiers for the MLRouter to select from

- **Configuration**: Added `ANTHROPIC_API_KEY` environment variable support with validation at initialization

- **Comprehensive test suite**: Added 325 lines of async unit tests covering:
  - Initialization and API key validation
  - Rate limit checking before inference
  - 429 response handling with various Retry-After formats
  - Model tier classification
  - Integration with MLRouter

## Implementation Details
- Inherits from `RemoteFullOpenLike` to leverage existing OpenAI-compatible request handling
- Uses class-level `_rate_limiters` dictionary to share rate limit state across instances of the same model
- Thread-safe rate limiter creation with lock-based synchronization
- Non-numeric Retry-After headers (HTTP date format) fall back to 60-second default
- Returns `None` on rate limit or error to allow MLRouter to try alternative backends
- Non-429 HTTP errors are re-raised to surface actual API failures

https://claude.ai/code/session_017nJvPykREsybqTGVr5PVae