### PR TITLE
Add RxNorm drug name normalization with caching and chat integration

### DIFF
--- a/API_KEYS_SETUP.md
+++ b/API_KEYS_SETUP.md
@@ -10,6 +10,7 @@ and in CI.
 | ------------------------------------ | ---------------- | ---------------- | --------------- |
 | `NICE_API_KEY`                       | NICE syndication | Optional         | UK clinical guidance as international evidence in appeals |
 | `NCBI_API_KEY`                       | NCBI / PubMed    | Semi-optional    | Higher PubMed rate limits (3 → 10 req/sec) |
+| _none_                               | RxNav / RxNorm   | Not required     | Drug-name normalization (brand ↔ generic, misspelling correction) |
 | `OCTOAI_TOKEN`                       | OctoAI           | One ML backend required | Cloud ML inference for appeal generation |
 | `HEALTH_BACKEND_HOST` / `_PORT`      | Local LLM        | One ML backend required | Self-hosted ML inference |
 | `PERPLEXITY_API`                     | Perplexity       | Optional         | Sonar models for citation discovery |
@@ -111,6 +112,53 @@ export NCBI_TOOL="fighthealthinsurance"        # optional
 ```
 
 Same GitHub Secrets pattern as above.
+
+---
+
+## RxNav / RxNorm (no key required)
+
+RxNorm is a standardized drug vocabulary published by the U.S. National
+Library of Medicine; RxNav is the public REST front-end at
+`https://rxnav.nlm.nih.gov/REST/`. We use it to normalize whatever the user
+typed (e.g., `"Glucophage"`, `"metformen"`, `"METFORMIN HCL 500mg"`) into a
+canonical drug name, RxCUI, plus brand / ingredient synonyms before searching
+PubMed, DailyMed, or insurer policies.
+
+**No API key, no registration, no headers required.** From the
+[RxNav API documentation](https://lhncbc.nlm.nih.gov/RxNav/APIs/RxNormAPIs.html):
+
+> With one exception, no license is needed to use the RxNorm API. This is
+> because the data returned from the API is from the RxNorm vocabulary, a
+> non-proprietary vocabulary developed by the National Library of Medicine.
+
+You only need an API key for the [RxClass / DrugBank-licensed endpoints](https://lhncbc.nlm.nih.gov/RxNav/APIs/RxClassAPIs.html#license),
+which we do not use.
+
+### Configure
+
+Nothing to configure. The integration runs automatically as long as the
+process can reach `https://rxnav.nlm.nih.gov`.
+
+The client sends a courtesy `User-Agent` with a contact email
+(`FightHealthInsurance/1.0 (mailto:support@fighthealthinsurance.com)`) so
+NIH can reach us if our traffic looks abnormal. No key is associated with
+this — it's just identification.
+
+### Behavior
+
+- Normalized lookups are cached for 30 days in the `RxNormConcept` table per
+  query string, so repeat requests don't hit the API.
+- Cold lookups make 1–3 HTTP calls (`/rxcui.json`, `/rxcui/{id}/properties.json`,
+  optionally `/rxcui/{id}/related.json`); the per-call timeout is 5s.
+- Failures are caught and logged at `debug` level — appeal / chat / prior-auth
+  generation falls back to the original drug name and proceeds.
+
+### Rate limits
+
+RxNav doesn't publish a hard rate limit and doesn't enforce per-key quotas.
+Their terms of service ask clients to be reasonable; the 30-day cache plus
+single-drug-only normalization heuristic keeps our traffic to a few requests
+per appeal.
 
 ---
 

--- a/fighthealthinsurance/chat/tools/__init__.py
+++ b/fighthealthinsurance/chat/tools/__init__.py
@@ -23,10 +23,12 @@ from .patterns import (
     MEDICAID_ELIGIBILITY_REGEX,
     MEDICAID_INFO_REGEX,
     PUBMED_QUERY_REGEX,
+    RXNORM_LOOKUP_REGEX,
     USPSTF_LOOKUP_REGEX,
 )
 from .prior_auth_tool import PriorAuthTool
 from .pubmed_tool import PubMedTool
+from .rxnorm_tool import RxNormLookupTool
 from .uspstf_tool import USPSTFLookupTool
 
 __all__ = [
@@ -37,6 +39,7 @@ __all__ = [
     "CREATE_OR_UPDATE_APPEAL_REGEX",
     "CREATE_OR_UPDATE_PRIOR_AUTH_REGEX",
     "FETCH_DOC_REGEX",
+    "RXNORM_LOOKUP_REGEX",
     "USPSTF_LOOKUP_REGEX",
     "LOOKUP_PA_REQUIREMENT_REGEX",
     "ALL_TOOL_PATTERNS",
@@ -49,6 +52,7 @@ __all__ = [
     "AppealTool",
     "PriorAuthTool",
     "DocFetcherTool",
+    "RxNormLookupTool",
     "USPSTFLookupTool",
     "PaRequirementLookupTool",
 ]

--- a/fighthealthinsurance/chat/tools/patterns.py
+++ b/fighthealthinsurance/chat/tools/patterns.py
@@ -46,6 +46,10 @@ LOOKUP_PA_REQUIREMENT_REGEX = (
     r"(?:\*\*)?lookup_pa_requirement\s*(\{[^}]*\})\s*(?:\*\*)?"
 )
 
+# RxNorm drug normalization tool - captures the drug name (free-text)
+# Matches: [rxnorm_lookup: drug name], **rxnorm_lookup: drug name**, etc.
+RXNORM_LOOKUP_REGEX = r"[\[\*]{0,4}rxnorm[ _]?lookup:?\s*([^*\[\]\n]+)"
+
 # List of all tool patterns for scoring/detection
 ALL_TOOL_PATTERNS = [
     PUBMED_QUERY_REGEX,
@@ -56,4 +60,5 @@ ALL_TOOL_PATTERNS = [
     FETCH_DOC_REGEX,
     USPSTF_LOOKUP_REGEX,
     LOOKUP_PA_REQUIREMENT_REGEX,
+    RXNORM_LOOKUP_REGEX,
 ]

--- a/fighthealthinsurance/chat/tools/patterns.py
+++ b/fighthealthinsurance/chat/tools/patterns.py
@@ -46,9 +46,17 @@ LOOKUP_PA_REQUIREMENT_REGEX = (
     r"(?:\*\*)?lookup_pa_requirement\s*(\{[^}]*\})\s*(?:\*\*)?"
 )
 
-# RxNorm drug normalization tool - captures the drug name (free-text)
+# RxNorm drug normalization tool - captures the drug name (free-text).
 # Matches: [rxnorm_lookup: drug name], **rxnorm_lookup: drug name**, etc.
-RXNORM_LOOKUP_REGEX = r"[\[\*]{0,4}rxnorm[ _]?lookup:?\s*([^*\[\]\n]+)"
+# The colon is mandatory and we require either a leading `[`/`*` marker
+# or a word boundary, so prose like "RxNorm lookup for Lipitor" doesn't
+# trip it. The capture is non-greedy and terminates at the closing
+# `]`/`**` wrapper, end of line, or end of string, so cleanup doesn't
+# leave stray delimiters in the response.
+RXNORM_LOOKUP_REGEX = (
+    r"(?:[\[\*]{1,4}|\b)rxnorm[ _]?lookup\s*:\s*"
+    r"([^*\[\]\n]+?)\s*(?:[\]\*]{1,4}|$|(?=\n))"
+)
 
 # List of all tool patterns for scoring/detection
 ALL_TOOL_PATTERNS = [

--- a/fighthealthinsurance/chat/tools/pubmed_tool.py
+++ b/fighthealthinsurance/chat/tools/pubmed_tool.py
@@ -12,6 +12,7 @@ from typing import Any, Awaitable, Callable, Optional, Tuple, Union
 from loguru import logger
 
 from fighthealthinsurance.pubmed_tools import PubMedTools
+from fighthealthinsurance.rxnorm_tools import RxNormTools
 
 from .base_tool import BaseTool
 from .patterns import PUBMED_QUERY_REGEX
@@ -38,6 +39,7 @@ class PubMedTool(BaseTool):
         call_llm_callback: Optional[
             Callable[..., Awaitable[Tuple[Optional[str], Optional[str]]]]
         ] = None,
+        rxnorm_tools: Optional[RxNormTools] = None,
     ):
         """
         Initialize the PubMed tool.
@@ -46,10 +48,12 @@ class PubMedTool(BaseTool):
             send_status_message: Async function to send status updates
             pubmed_tools: PubMedTools instance (created if not provided)
             call_llm_callback: Callback to call LLM with additional context
+            rxnorm_tools: RxNormTools for normalizing drug-name queries
         """
         super().__init__(send_status_message)
         self.pubmed_tools = pubmed_tools or PubMedTools()
         self.call_llm_callback = call_llm_callback
+        self.rxnorm_tools = rxnorm_tools or RxNormTools()
 
     async def execute(
         self,
@@ -92,10 +96,20 @@ class PubMedTool(BaseTool):
         if len(pubmed_query_terms.strip()) == 0:
             return cleaned_response, context
 
-        await self.send_status_message(f"Searching PubMed for: {pubmed_query_terms}...")
+        # If the query is a single drug-like phrase, normalize it through
+        # RxNorm so we search for the canonical name rather than a brand
+        # variant or misspelling. The original query is preserved as a
+        # fallback inside _search_articles.
+        normalized_query = await self._normalize_drug_terms(pubmed_query_terms)
+        if normalized_query != pubmed_query_terms:
+            await self.send_status_message(
+                f"Normalized {pubmed_query_terms!r} to {normalized_query!r} via RxNorm."
+            )
+
+        await self.send_status_message(f"Searching PubMed for: {normalized_query}...")
 
         # Search for both recent and all-time articles in parallel
-        article_ids = await self._search_articles(pubmed_query_terms)
+        article_ids = await self._search_articles(normalized_query)
 
         if not article_ids:
             await self.send_status_message(
@@ -135,6 +149,29 @@ class PubMedTool(BaseTool):
         updated_context = context + pubmed_context if context else pubmed_context
 
         return cleaned_response, updated_context
+
+    async def _normalize_drug_terms(self, query: str) -> str:
+        """Best-effort drug-name normalization for a PubMed query.
+
+        We only rewrite the query when RxNorm returns a high-confidence
+        match — otherwise we leave it alone, since the LLM may be searching
+        for procedures, diagnoses, or general topics that have nothing to
+        do with medications.
+        """
+        try:
+            normalized = await self.rxnorm_tools.normalize(query)
+        except Exception as e:
+            logger.opt(exception=True).debug(f"RxNorm normalization failed: {e}")
+            return query
+        if not normalized.matched:
+            return query
+        # Only rewrite for high-confidence matches. Approximate scores below
+        # ~75 often introduce more noise than signal.
+        if normalized.score is not None and normalized.score < 75:
+            return query
+        if normalized.canonical_name.lower() == query.strip().lower():
+            return query
+        return normalized.canonical_name
 
     async def _search_articles(self, query: str) -> list[str]:
         """

--- a/fighthealthinsurance/chat/tools/pubmed_tool.py
+++ b/fighthealthinsurance/chat/tools/pubmed_tool.py
@@ -12,7 +12,7 @@ from typing import Any, Awaitable, Callable, Optional, Tuple, Union
 from loguru import logger
 
 from fighthealthinsurance.pubmed_tools import PubMedTools
-from fighthealthinsurance.rxnorm_tools import RxNormTools
+from fighthealthinsurance.rxnorm_tools import RxNormTools, looks_like_single_drug_query
 
 from .base_tool import BaseTool
 from .patterns import PUBMED_QUERY_REGEX
@@ -165,48 +165,16 @@ class PubMedTool(BaseTool):
 
         return cleaned_response, updated_context
 
-    # Conjunctions/operators that signal a multi-concept query like
-    # "metformin AND kidney disease" — never rewrite the whole thing.
-    _MULTI_CONCEPT_TOKENS = (
-        " and ",
-        " or ",
-        " vs ",
-        " versus ",
-        ",",
-        ";",
-        " AND ",
-        " OR ",
-    )
-
-    @classmethod
-    def _looks_like_single_drug_query(cls, query: str) -> bool:
-        """Heuristic: is this short enough and unitary enough that it might
-        be a single drug name?
-
-        We cap at 2 tokens because anything longer is ambiguous between
-        "drug + dose" (e.g., ``"metformin 500mg"``) and "drug + condition"
-        (e.g., ``"metformin kidney"``). Rewriting the latter would silently
-        drop the condition, so we err on the side of leaving multi-token
-        queries alone — PubMed still finds drug results from the user's
-        original spelling, we just skip the canonical-name optimization.
-        """
-        q = (query or "").strip()
-        if not q:
-            return False
-        if any(tok in q for tok in cls._MULTI_CONCEPT_TOKENS):
-            return False
-        return len(q.split()) <= 2
-
     async def _normalize_drug_terms(self, query: str) -> str:
         """Best-effort drug-name normalization for a PubMed query.
 
         Only runs for queries that look like a single drug name (see
-        :py:meth:`_looks_like_single_drug_query`) and only rewrites when
-        RxNorm returns a high-confidence match. Multi-concept queries like
-        "metformin kidney disease" fall through unchanged, since rewriting
-        them would drop the non-drug terms.
+        :py:func:`~fighthealthinsurance.rxnorm_tools.looks_like_single_drug_query`)
+        and only rewrites when RxNorm returns a high-confidence match.
+        Multi-concept queries like "metformin kidney disease" fall through
+        unchanged, since rewriting them would drop the non-drug terms.
         """
-        if not self._looks_like_single_drug_query(query):
+        if not looks_like_single_drug_query(query):
             return query
         try:
             normalized = await self.rxnorm_tools.normalize(query)

--- a/fighthealthinsurance/chat/tools/pubmed_tool.py
+++ b/fighthealthinsurance/chat/tools/pubmed_tool.py
@@ -98,18 +98,33 @@ class PubMedTool(BaseTool):
 
         # If the query is a single drug-like phrase, normalize it through
         # RxNorm so we search for the canonical name rather than a brand
-        # variant or misspelling. The original query is preserved as a
-        # fallback inside _search_articles.
+        # variant or misspelling. When normalization rewrites the query we
+        # search for BOTH the canonical name AND the original term and
+        # merge the results, so brand-only searches don't lose evidence
+        # indexed under the brand name.
         normalized_query = await self._normalize_drug_terms(pubmed_query_terms)
         if normalized_query != pubmed_query_terms:
             await self.send_status_message(
                 f"Normalized {pubmed_query_terms!r} to {normalized_query!r} via RxNorm."
             )
-
-        await self.send_status_message(f"Searching PubMed for: {normalized_query}...")
-
-        # Search for both recent and all-time articles in parallel
-        article_ids = await self._search_articles(normalized_query)
+            await self.send_status_message(
+                f"Searching PubMed for: {normalized_query} and {pubmed_query_terms}..."
+            )
+            canonical_ids = await self._search_articles(normalized_query)
+            original_ids = await self._search_articles(pubmed_query_terms)
+            # Preserve canonical-name results first, then add brand-name
+            # ids that weren't already returned.
+            seen: set[str] = set()
+            article_ids: list[str] = []
+            for pmid in canonical_ids + original_ids:
+                if pmid not in seen:
+                    seen.add(pmid)
+                    article_ids.append(pmid)
+        else:
+            await self.send_status_message(
+                f"Searching PubMed for: {normalized_query}..."
+            )
+            article_ids = await self._search_articles(normalized_query)
 
         if not article_ids:
             await self.send_status_message(
@@ -150,14 +165,49 @@ class PubMedTool(BaseTool):
 
         return cleaned_response, updated_context
 
+    # Conjunctions/operators that signal a multi-concept query like
+    # "metformin AND kidney disease" — never rewrite the whole thing.
+    _MULTI_CONCEPT_TOKENS = (
+        " and ",
+        " or ",
+        " vs ",
+        " versus ",
+        ",",
+        ";",
+        " AND ",
+        " OR ",
+    )
+
+    @classmethod
+    def _looks_like_single_drug_query(cls, query: str) -> bool:
+        """Heuristic: is this short enough and unitary enough that it might
+        be a single drug name?
+
+        We cap at 2 tokens because anything longer is ambiguous between
+        "drug + dose" (e.g., ``"metformin 500mg"``) and "drug + condition"
+        (e.g., ``"metformin kidney"``). Rewriting the latter would silently
+        drop the condition, so we err on the side of leaving multi-token
+        queries alone — PubMed still finds drug results from the user's
+        original spelling, we just skip the canonical-name optimization.
+        """
+        q = (query or "").strip()
+        if not q:
+            return False
+        if any(tok in q for tok in cls._MULTI_CONCEPT_TOKENS):
+            return False
+        return len(q.split()) <= 2
+
     async def _normalize_drug_terms(self, query: str) -> str:
         """Best-effort drug-name normalization for a PubMed query.
 
-        We only rewrite the query when RxNorm returns a high-confidence
-        match — otherwise we leave it alone, since the LLM may be searching
-        for procedures, diagnoses, or general topics that have nothing to
-        do with medications.
+        Only runs for queries that look like a single drug name (see
+        :py:meth:`_looks_like_single_drug_query`) and only rewrites when
+        RxNorm returns a high-confidence match. Multi-concept queries like
+        "metformin kidney disease" fall through unchanged, since rewriting
+        them would drop the non-drug terms.
         """
+        if not self._looks_like_single_drug_query(query):
+            return query
         try:
             normalized = await self.rxnorm_tools.normalize(query)
         except Exception as e:

--- a/fighthealthinsurance/chat/tools/rxnorm_tool.py
+++ b/fighthealthinsurance/chat/tools/rxnorm_tool.py
@@ -1,0 +1,106 @@
+"""
+RxNorm drug-name lookup tool for the chat interface.
+
+Lets the LLM ask the system "what is this drug, really?" before searching
+PubMed or insurer policy docs. Given a brand or misspelled drug name, it
+returns the canonical name, the active ingredient(s), and known brand
+names. The LLM can then plug those into a follow-up query.
+"""
+
+import re
+from typing import Any, Awaitable, Callable, Optional, Tuple
+
+from loguru import logger
+
+from fighthealthinsurance.rxnorm_tools import RxNormTools
+
+from .base_tool import BaseTool
+from .patterns import RXNORM_LOOKUP_REGEX
+
+
+class RxNormLookupTool(BaseTool):
+    """Handle ``rxnorm_lookup: <drug name>`` calls from the LLM."""
+
+    pattern = RXNORM_LOOKUP_REGEX
+    name = "RxNorm"
+
+    def __init__(
+        self,
+        send_status_message: Callable[[str], Awaitable[None]],
+        rxnorm_tools: Optional[RxNormTools] = None,
+        call_llm_callback: Optional[
+            Callable[..., Awaitable[Tuple[Optional[str], Optional[str]]]]
+        ] = None,
+    ):
+        super().__init__(send_status_message)
+        self.rxnorm_tools = rxnorm_tools or RxNormTools()
+        self.call_llm_callback = call_llm_callback
+
+    async def execute(
+        self,
+        match: re.Match[str],
+        response_text: str,
+        context: str,
+        model_backends: Any = None,
+        previous_context_summary: str = "",
+        history_for_llm: Any = None,
+        depth: int = 0,
+        is_logged_in: bool = False,
+        is_professional: bool = False,
+        **kwargs: Any,
+    ) -> Tuple[str, str]:
+        drug_name = match.group(1).strip()
+        cleaned_response = self.clean_response(response_text, match)
+
+        if not drug_name or "drug name" in drug_name.lower():
+            logger.debug(f"Ignoring empty/placeholder rxnorm_lookup: {drug_name!r}")
+            return cleaned_response, context
+
+        await self.send_status_message(f"Normalizing drug name: {drug_name}...")
+
+        info = await self.rxnorm_tools.get_brands_and_generics(drug_name)
+        rx_context = self._format_context(drug_name, info)
+
+        if self.call_llm_callback and model_backends and rx_context:
+            additional_response, additional_context = await self.call_llm_callback(
+                model_backends,
+                rx_context,
+                previous_context_summary,
+                history_for_llm,
+                depth=depth + 1,
+                is_logged_in=is_logged_in,
+                is_professional=is_professional,
+            )
+
+            if cleaned_response and additional_response:
+                cleaned_response += additional_response
+            elif additional_response:
+                cleaned_response = additional_response
+
+            if context and additional_context:
+                context = context + additional_context
+            elif additional_context:
+                context = additional_context
+
+        updated_context = (context + rx_context) if context else rx_context
+        return cleaned_response, updated_context
+
+    @staticmethod
+    def _format_context(query: str, info: dict[str, Any]) -> str:
+        if not info.get("matched"):
+            return (
+                f"\n\nRxNorm lookup for {query!r}: no canonical RxNorm record "
+                f"found. Use the user's spelling as-is and consider asking the "
+                f"user to confirm.\n"
+            )
+        ingredients = ", ".join(info.get("ingredients") or []) or "(unknown)"
+        brand_names = ", ".join(info.get("brand_names") or []) or "(none listed)"
+        return (
+            f"\n\nRxNorm lookup for {query!r}:\n"
+            f"  canonical name: {info['canonical_name']}\n"
+            f"  RxCUI: {info['rxcui']}\n"
+            f"  term type: {info.get('tty') or '(unknown)'}\n"
+            f"  active ingredient(s): {ingredients}\n"
+            f"  known brand names: {brand_names}\n"
+            f"Use the canonical name for any follow-up search.\n"
+        )

--- a/fighthealthinsurance/chat/tools/rxnorm_tool.py
+++ b/fighthealthinsurance/chat/tools/rxnorm_tool.py
@@ -24,6 +24,12 @@ class RxNormLookupTool(BaseTool):
     pattern = RXNORM_LOOKUP_REGEX
     name = "RxNorm"
 
+    # Minimum approximate-match score we'll surface to the LLM. Anything
+    # below this is treated as "no confident match" so we don't put a
+    # plausibly-wrong canonical name in front of the model. Aligned with
+    # the threshold PubMedTool uses for query rewriting.
+    MIN_MATCH_SCORE = 75
+
     def __init__(
         self,
         send_status_message: Callable[[str], Awaitable[None]],
@@ -72,31 +78,46 @@ class RxNormLookupTool(BaseTool):
                 is_professional=is_professional,
             )
 
-            if cleaned_response and additional_response:
-                cleaned_response += additional_response
-            elif additional_response:
-                cleaned_response = additional_response
+            cleaned_response = self._merge(cleaned_response, additional_response)
+            context = self._merge(context, additional_context)
 
-            if context and additional_context:
-                context = context + additional_context
-            elif additional_context:
-                context = additional_context
-
-        updated_context = (context + rx_context) if context else rx_context
+        updated_context = self._merge(context, rx_context)
         return cleaned_response, updated_context
 
     @staticmethod
-    def _format_context(query: str, info: dict[str, Any]) -> str:
-        if not info.get("matched"):
+    def _merge(existing: Optional[str], addition: Optional[str]) -> str:
+        """Concatenate two strings with a blank-line separator.
+
+        Returns ``""`` if both are empty/None. Avoids running text
+        together when the recursive callback returns plain prose.
+        """
+        if not existing:
+            return (addition or "").lstrip()
+        if not addition:
+            return existing
+        return f"{existing.rstrip()}\n\n{addition.lstrip()}"
+
+    @classmethod
+    def _format_context(cls, query: str, info: dict[str, Any]) -> str:
+        # Treat low-score fuzzy matches the same as a miss — we'd rather
+        # tell the LLM to fall back on the user's spelling than hand it a
+        # plausibly-wrong canonical name from approximate matching.
+        score = info.get("score")
+        below_threshold = (
+            info.get("matched") and score is not None and score < cls.MIN_MATCH_SCORE
+        )
+        # NB: deliberately avoid emitting the literal phrase "rxnorm lookup:"
+        # so an LLM that echoes the context can't re-trigger this tool.
+        if not info.get("matched") or below_threshold:
             return (
-                f"\n\nRxNorm lookup for {query!r}: no canonical RxNorm record "
+                f"\n\nRxNorm result for {query!r}: no canonical RxNorm record "
                 f"found. Use the user's spelling as-is and consider asking the "
                 f"user to confirm.\n"
             )
         ingredients = ", ".join(info.get("ingredients") or []) or "(unknown)"
         brand_names = ", ".join(info.get("brand_names") or []) or "(none listed)"
         return (
-            f"\n\nRxNorm lookup for {query!r}:\n"
+            f"\n\nRxNorm result for {query!r}\n"
             f"  canonical name: {info['canonical_name']}\n"
             f"  RxCUI: {info['rxcui']}\n"
             f"  term type: {info.get('tty') or '(unknown)'}\n"

--- a/fighthealthinsurance/chat_interface.py
+++ b/fighthealthinsurance/chat_interface.py
@@ -56,6 +56,7 @@ from fighthealthinsurance.models import (
 from fighthealthinsurance.microsites import get_microsite
 from fighthealthinsurance.prompt_templates import get_intro_template
 from fighthealthinsurance.pubmed_tools import PubMedTools
+from fighthealthinsurance.rxnorm_tools import RxNormTools
 from fighthealthinsurance.utils import (
     best_within_timelimit,
     fire_and_forget_in_new_threadpool,
@@ -92,6 +93,9 @@ class ChatInterface:
 
         self.send_json_message_func = wrap_send_json_message_func
         self.pubmed_tools = PubMedTools()
+        # Single RxNormTools shared across RxNormLookupTool and PubMedTool
+        # so they reuse the same client / cache view per chat session.
+        self.rxnorm_tools = RxNormTools()
         self.chat: OngoingChat = chat
         self.user: User = user
         self.use_external_models: bool = use_external_models
@@ -375,6 +379,7 @@ class ChatInterface:
         # plug a canonical drug name into a follow-up pubmed_query.
         rxnorm_tool = RxNormLookupTool(
             self.send_status_message,
+            rxnorm_tools=self.rxnorm_tools,
             call_llm_callback=self._call_llm_with_actions,
         )
         response_text, context, _ = await rxnorm_tool.handle(
@@ -384,6 +389,7 @@ class ChatInterface:
         pubmed_tool = PubMedTool(
             self.send_status_message,
             pubmed_tools=self.pubmed_tools,
+            rxnorm_tools=self.rxnorm_tools,
             call_llm_callback=self._call_llm_with_actions,
         )
         response_text, context, _ = await pubmed_tool.handle(

--- a/fighthealthinsurance/chat_interface.py
+++ b/fighthealthinsurance/chat_interface.py
@@ -35,6 +35,7 @@ from fighthealthinsurance.chat.tools import (
     PaRequirementLookupTool,
     PriorAuthTool,
     PubMedTool,
+    RxNormLookupTool,
     USPSTFLookupTool,
 )
 from fighthealthinsurance.extralink_context_helper import ExtraLinkContextHelper
@@ -367,6 +368,16 @@ class ChatInterface:
             self.send_status_message, self._call_llm_with_actions
         )
         response_text, context, _ = await medicaid_info_tool.handle(
+            response_text, context, **tool_kwargs
+        )
+
+        # Run drug name normalization before PubMed so the LLM can
+        # plug a canonical drug name into a follow-up pubmed_query.
+        rxnorm_tool = RxNormLookupTool(
+            self.send_status_message,
+            call_llm_callback=self._call_llm_with_actions,
+        )
+        response_text, context, _ = await rxnorm_tool.handle(
             response_text, context, **tool_kwargs
         )
 

--- a/fighthealthinsurance/extralink_prefetch_actor.py
+++ b/fighthealthinsurance/extralink_prefetch_actor.py
@@ -8,6 +8,7 @@ from microsites and PubMed articles from microsite search terms.
 import asyncio
 import os
 import time
+from typing import List, Set
 
 import ray
 from loguru import logger
@@ -158,7 +159,23 @@ class ExtraLinkPrefetchActor:
                 if not microsite.pubmed_search_terms:
                     continue
 
+                # Expand drug-like microsite search terms so the prefetch
+                # warms the cache for canonical / brand variants too.
+                expanded_terms: List[str] = []
+                seen_terms: Set[str] = set()
                 for search_term in microsite.pubmed_search_terms:
+                    stripped = search_term.strip()
+                    if stripped and stripped.lower() not in seen_terms:
+                        expanded_terms.append(stripped)
+                        seen_terms.add(stripped.lower())
+                    for synonym in await pubmed_tools._expand_drug_term_for_search(
+                        stripped
+                    ):
+                        if synonym.lower() not in seen_terms:
+                            expanded_terms.append(synonym)
+                            seen_terms.add(synonym.lower())
+
+                for search_term in expanded_terms:
                     try:
                         # Find article IDs
                         pmids = await pubmed_tools.find_pubmed_article_ids_for_query(

--- a/fighthealthinsurance/generate_prior_auth.py
+++ b/fighthealthinsurance/generate_prior_auth.py
@@ -3,7 +3,7 @@ import datetime
 import random
 import uuid
 from concurrent.futures import Future
-from typing import Any, AsyncIterator, Dict, List
+from typing import Any, AsyncIterator, Dict, List, Optional
 
 from asgiref.sync import async_to_sync, sync_to_async
 from loguru import logger
@@ -13,7 +13,49 @@ from fighthealthinsurance.ml.ml_models import RemoteModelLike
 from fighthealthinsurance.ml.ml_router import ml_router
 from fighthealthinsurance.models import PriorAuthRequest, ProposedPriorAuth
 from fighthealthinsurance.prior_auth_utils import PriorAuthTextSubstituter
+from fighthealthinsurance.rxnorm_tools import RxNormTools
 from fighthealthinsurance.utils import as_available
+
+
+def _build_rxnorm_context(treatment: str, normalized: Any) -> str:
+    """Format an RxNorm hint to attach to the prior-auth prompt.
+
+    Returns ``""`` when the treatment didn't match a drug — e.g., for a
+    procedure like "MRI" or "physical therapy". The prompt is enriched
+    only when normalization yields a high-confidence drug record.
+    """
+    if not normalized or not normalized.matched:
+        return ""
+    if normalized.score is not None and normalized.score < 75:
+        return ""
+    canonical = (normalized.canonical_name or "").strip()
+    if not canonical or canonical.lower() == treatment.strip().lower():
+        # Already canonical — nothing to add.
+        return ""
+    ingredients = [
+        c.get("name", "").strip()
+        for c in normalized.related.get("IN", [])
+        if c.get("name")
+    ]
+    brand_names = [
+        c.get("name", "").strip()
+        for c in normalized.related.get("BN", [])
+        if c.get("name")
+    ]
+    parts = [
+        f"For reference, RxNorm normalizes {treatment!r} to canonical "
+        f"name {canonical!r} (RxCUI {normalized.rxcui})."
+    ]
+    if ingredients:
+        parts.append(f"Active ingredient(s): {', '.join(ingredients[:3])}.")
+    if brand_names:
+        parts.append(f"Known brand names: {', '.join(brand_names[:3])}.")
+    parts.append(
+        f"Use {treatment!r} consistently in the letter (matching the "
+        f"patient's prescription), but feel free to reference the canonical "
+        f"name and ingredients in clinical justification."
+    )
+    return " ".join(parts)
 
 
 class PriorAuthGenerator:
@@ -21,9 +63,19 @@ class PriorAuthGenerator:
     Generator for prior authorization proposals using ML models.
     """
 
-    def __init__(self):
-        """Initialize the prior auth generator."""
-        pass
+    def __init__(self, rxnorm_tools: Optional[RxNormTools] = None):
+        """Initialize the prior auth generator.
+
+        ``rxnorm_tools`` is optional: when omitted we lazy-create one the
+        first time we need to normalize a drug name. Inject one in tests
+        or in long-running consumers that want to share a session.
+        """
+        self._rxnorm_tools = rxnorm_tools
+
+    def _get_rxnorm_tools(self) -> RxNormTools:
+        if self._rxnorm_tools is None:
+            self._rxnorm_tools = RxNormTools()
+        return self._rxnorm_tools
 
     async def generate_prior_auth_proposals(
         self, prior_auth: PriorAuthRequest
@@ -141,7 +193,7 @@ class PriorAuthGenerator:
             letter = True
             if prior_auth.proposal_type and prior_auth.proposal_type != "letter":
                 letter = False
-            prompt = self._create_prompt(context, letter=letter)
+            prompt = await self._create_prompt(context, letter=letter)
 
             proposal_text = None
             try:
@@ -186,7 +238,7 @@ class PriorAuthGenerator:
                 "error": f"Error generating proposal with model {index+1}: {str(e)}"
             }
 
-    def _create_prompt(self, context: Dict[str, Any], letter: bool) -> str:
+    async def _create_prompt(self, context: Dict[str, Any], letter: bool) -> str:
         """
         Create a prompt for the language model based on the context.
 
@@ -218,6 +270,22 @@ class PriorAuthGenerator:
         Generate a {what_to_gen} for {treatment} to treat {diagnosis}.
         Insurance Company: {insurance_company}
         """
+
+        # If the treatment is a drug name, attach the RxNorm canonical form
+        # as a hint. We deliberately don't rewrite the user-supplied
+        # ``treatment`` value so the letter still uses whatever wording
+        # the patient/provider used in the prescription.
+        if treatment and treatment.strip():
+            try:
+                normalized = await self._get_rxnorm_tools().normalize(treatment)
+            except Exception as e:
+                logger.opt(exception=True).debug(
+                    f"RxNorm normalization failed for treatment {treatment!r}: {e}"
+                )
+                normalized = None
+            rx_hint = _build_rxnorm_context(treatment, normalized)
+            if rx_hint:
+                prompt += f"\n\n{rx_hint}\n"
 
         # Add Q&A information if available
         if qa_pairs:

--- a/fighthealthinsurance/generate_prior_auth.py
+++ b/fighthealthinsurance/generate_prior_auth.py
@@ -115,6 +115,20 @@ class PriorAuthGenerator:
             proposal_type = prior_auth.proposal_type
         logger.debug(f"Creating proposal type {proposal_type} from {prior_auth}")
 
+        # Resolve the RxNorm hint once up front. Each concurrent proposal
+        # path used to call .normalize() independently in _create_prompt,
+        # which fanned out to N identical RxNav requests per request.
+        rx_hint = ""
+        if treatment and treatment.strip():
+            try:
+                normalized = await self._get_rxnorm_tools().normalize(treatment)
+            except Exception as e:
+                logger.opt(exception=True).debug(
+                    f"RxNorm normalization failed for treatment {treatment!r}: {e}"
+                )
+                normalized = None
+            rx_hint = _build_rxnorm_context(treatment, normalized)
+
         # Prepare prompt context
         context = {
             "diagnosis": diagnosis,
@@ -126,6 +140,7 @@ class PriorAuthGenerator:
             "urgent": prior_auth.urgent,
             "patient_info": patient_info,
             "proposal_type": proposal_type,
+            "rxnorm_hint": rx_hint,
         }  # type: Dict[str, Any]
 
         # Get available models
@@ -271,21 +286,12 @@ class PriorAuthGenerator:
         Insurance Company: {insurance_company}
         """
 
-        # If the treatment is a drug name, attach the RxNorm canonical form
-        # as a hint. We deliberately don't rewrite the user-supplied
-        # ``treatment`` value so the letter still uses whatever wording
-        # the patient/provider used in the prescription.
-        if treatment and treatment.strip():
-            try:
-                normalized = await self._get_rxnorm_tools().normalize(treatment)
-            except Exception as e:
-                logger.opt(exception=True).debug(
-                    f"RxNorm normalization failed for treatment {treatment!r}: {e}"
-                )
-                normalized = None
-            rx_hint = _build_rxnorm_context(treatment, normalized)
-            if rx_hint:
-                prompt += f"\n\n{rx_hint}\n"
+        # The RxNorm hint is resolved once in ``generate_prior_auth_proposals``
+        # and passed through ``context`` so concurrent proposal paths share
+        # the same lookup result instead of each calling RxNav.
+        rx_hint = context.get("rxnorm_hint", "")
+        if rx_hint:
+            prompt += f"\n\n{rx_hint}\n"
 
         # Add Q&A information if available
         if qa_pairs:

--- a/fighthealthinsurance/migrations/0173_rxnormconcept.py
+++ b/fighthealthinsurance/migrations/0173_rxnormconcept.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
             name="RxNormConcept",
             fields=[
                 ("id", models.AutoField(primary_key=True, serialize=False)),
-                ("query", models.CharField(db_index=True, max_length=300)),
+                ("query", models.CharField(max_length=300, unique=True)),
                 ("rxcui", models.CharField(blank=True, default="", max_length=32)),
                 (
                     "canonical_name",
@@ -31,7 +31,6 @@ class Migration(migrations.Migration):
             ],
             options={
                 "indexes": [
-                    models.Index(fields=["query"], name="rxnorm_query_idx"),
                     models.Index(fields=["rxcui"], name="rxnorm_rxcui_idx"),
                 ],
             },

--- a/fighthealthinsurance/migrations/0173_rxnormconcept.py
+++ b/fighthealthinsurance/migrations/0173_rxnormconcept.py
@@ -1,0 +1,39 @@
+# Generated migration for RxNorm concept cache.
+
+from django.db import migrations, models
+from django.db.models.functions import Now
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("fighthealthinsurance", "0172_payerpriorauthrequirement"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="RxNormConcept",
+            fields=[
+                ("id", models.AutoField(primary_key=True, serialize=False)),
+                ("query", models.CharField(db_index=True, max_length=300)),
+                ("rxcui", models.CharField(blank=True, default="", max_length=32)),
+                (
+                    "canonical_name",
+                    models.CharField(blank=True, default="", max_length=300),
+                ),
+                ("tty", models.CharField(blank=True, default="", max_length=16)),
+                ("score", models.IntegerField(blank=True, null=True)),
+                ("related_json", models.JSONField(blank=True, default=dict)),
+                (
+                    "created",
+                    models.DateTimeField(db_default=Now(), null=True),
+                ),
+                ("last_used", models.DateTimeField(auto_now=True)),
+            ],
+            options={
+                "indexes": [
+                    models.Index(fields=["query"], name="rxnorm_query_idx"),
+                    models.Index(fields=["rxcui"], name="rxnorm_rxcui_idx"),
+                ],
+            },
+        ),
+    ]

--- a/fighthealthinsurance/models.py
+++ b/fighthealthinsurance/models.py
@@ -1244,8 +1244,9 @@ class RxNormConcept(models.Model):
 
     id = models.AutoField(primary_key=True)
     # The user-supplied query string, lowercased + whitespace-collapsed.
-    # Indexed because we look up by it on every normalization call.
-    query = models.CharField(max_length=300, db_index=True)
+    # Unique so concurrent misses can't write duplicate rows; the unique
+    # constraint also gives us the equivalent of an index for free.
+    query = models.CharField(max_length=300, unique=True)
     # Canonical RxCUI from RxNorm. Empty string when no match was found —
     # we still cache the miss to avoid hammering the API for unknown terms.
     rxcui = models.CharField(max_length=32, blank=True, default="")
@@ -1264,7 +1265,6 @@ class RxNormConcept(models.Model):
 
     class Meta:
         indexes = [
-            models.Index(fields=["query"], name="rxnorm_query_idx"),
             models.Index(fields=["rxcui"], name="rxnorm_rxcui_idx"),
         ]
 

--- a/fighthealthinsurance/models.py
+++ b/fighthealthinsurance/models.py
@@ -1232,6 +1232,48 @@ class USPSTFRecommendation(models.Model):
         return f"USPSTF {self.grade} - {self.title}"
 
 
+class RxNormConcept(models.Model):
+    """
+    Caches RxNorm/RxNav lookups for medication name normalization.
+
+    A "concept" is the canonical record returned for a given input drug name:
+    a canonical RxCUI plus the canonical name and term type (e.g., "IN" for
+    ingredient, "BN" for brand). Related synonyms, brand names, ingredients,
+    and dose forms are cached as JSON to avoid repeated round trips.
+    """
+
+    id = models.AutoField(primary_key=True)
+    # The user-supplied query string, lowercased + whitespace-collapsed.
+    # Indexed because we look up by it on every normalization call.
+    query = models.CharField(max_length=300, db_index=True)
+    # Canonical RxCUI from RxNorm. Empty string when no match was found —
+    # we still cache the miss to avoid hammering the API for unknown terms.
+    rxcui = models.CharField(max_length=32, blank=True, default="")
+    # Canonical preferred name from RxNorm (e.g., "atorvastatin").
+    canonical_name = models.CharField(max_length=300, blank=True, default="")
+    # Term type abbreviation: IN (ingredient), BN (brand), SCD, SBD, etc.
+    tty = models.CharField(max_length=16, blank=True, default="")
+    # Match score from RxNorm approximateTerm (100 = exact). Null when not
+    # produced by an approximate match (e.g., exact rxcui lookup).
+    score = models.IntegerField(null=True, blank=True)
+    # JSON of related concepts grouped by tty:
+    # {"IN": [{"rxcui": "...", "name": "..."}, ...], "BN": [...], ...}
+    related_json = models.JSONField(blank=True, default=dict)
+    created = models.DateTimeField(db_default=Now(), null=True)
+    last_used = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        indexes = [
+            models.Index(fields=["query"], name="rxnorm_query_idx"),
+            models.Index(fields=["rxcui"], name="rxnorm_rxcui_idx"),
+        ]
+
+    def __str__(self) -> str:
+        return (
+            f"RxNormConcept({self.query!r} -> {self.canonical_name!r} [{self.rxcui}])"
+        )
+
+
 class ExtraLinkDocument(
     ExportModelOperationsMixin("ExtraLinkDocument"), models.Model  # type: ignore
 ):

--- a/fighthealthinsurance/pubmed_tools.py
+++ b/fighthealthinsurance/pubmed_tools.py
@@ -29,7 +29,7 @@ from fighthealthinsurance.pubmed_search import (
     build_structured_query,
     categorize_articles_by_strength,
 )
-from fighthealthinsurance.rxnorm_tools import RxNormTools
+from fighthealthinsurance.rxnorm_tools import RxNormTools, looks_like_single_drug_query
 from fighthealthinsurance.utils import pubmed_fetcher
 
 from .exec import pubmed_executor
@@ -91,18 +91,6 @@ class PubMedTools(object):
     # Rough bias to "recent" articles
     since_list = ["2024", None]
 
-    # Tokens that mark a query as multi-concept and disqualify it from
-    # drug-expansion (mirrors the chat-tool heuristic).
-    _MULTI_CONCEPT_TOKENS = (
-        " and ",
-        " or ",
-        " vs ",
-        " versus ",
-        ",",
-        ";",
-        " AND ",
-        " OR ",
-    )
     # Maximum extra search terms we'll add per drug-like query. Each extra
     # term costs one PubMed search round-trip, so we cap this aggressively.
     _MAX_DRUG_EXPANSIONS = 2
@@ -112,17 +100,6 @@ class PubMedTools(object):
         # across PubMedTools and chat handlers; lazy-create on first use
         # otherwise so existing call sites keep working unchanged.
         self._rxnorm_tools = rxnorm_tools
-
-    @classmethod
-    def _looks_like_single_drug_term(cls, term: str) -> bool:
-        """Mirror of PubMedTool._looks_like_single_drug_query for inline
-        procedure terms. Caps at 2 tokens, no connectors, non-empty."""
-        t = (term or "").strip()
-        if not t:
-            return False
-        if any(tok in t for tok in cls._MULTI_CONCEPT_TOKENS):
-            return False
-        return len(t.split()) <= 2
 
     def _get_rxnorm_tools(self) -> RxNormTools:
         if self._rxnorm_tools is None:
@@ -143,7 +120,7 @@ class PubMedTools(object):
         insensitive) and from each other; callers can append them to an
         existing query list without further deduplication of these.
         """
-        if not self._looks_like_single_drug_term(term):
+        if not looks_like_single_drug_query(term):
             return []
         try:
             normalized = await self._get_rxnorm_tools().normalize(term)

--- a/fighthealthinsurance/pubmed_tools.py
+++ b/fighthealthinsurance/pubmed_tools.py
@@ -29,6 +29,7 @@ from fighthealthinsurance.pubmed_search import (
     build_structured_query,
     categorize_articles_by_strength,
 )
+from fighthealthinsurance.rxnorm_tools import RxNormTools
 from fighthealthinsurance.utils import pubmed_fetcher
 
 from .exec import pubmed_executor
@@ -89,6 +90,97 @@ async def _ensure_session(
 class PubMedTools(object):
     # Rough bias to "recent" articles
     since_list = ["2024", None]
+
+    # Tokens that mark a query as multi-concept and disqualify it from
+    # drug-expansion (mirrors the chat-tool heuristic).
+    _MULTI_CONCEPT_TOKENS = (
+        " and ",
+        " or ",
+        " vs ",
+        " versus ",
+        ",",
+        ";",
+        " AND ",
+        " OR ",
+    )
+    # Maximum extra search terms we'll add per drug-like query. Each extra
+    # term costs one PubMed search round-trip, so we cap this aggressively.
+    _MAX_DRUG_EXPANSIONS = 2
+
+    def __init__(self, rxnorm_tools: Optional[RxNormTools] = None) -> None:
+        # Accept an injected RxNormTools so callers can share one instance
+        # across PubMedTools and chat handlers; lazy-create on first use
+        # otherwise so existing call sites keep working unchanged.
+        self._rxnorm_tools = rxnorm_tools
+
+    @classmethod
+    def _looks_like_single_drug_term(cls, term: str) -> bool:
+        """Mirror of PubMedTool._looks_like_single_drug_query for inline
+        procedure terms. Caps at 2 tokens, no connectors, non-empty."""
+        t = (term or "").strip()
+        if not t:
+            return False
+        if any(tok in t for tok in cls._MULTI_CONCEPT_TOKENS):
+            return False
+        return len(t.split()) <= 2
+
+    def _get_rxnorm_tools(self) -> RxNormTools:
+        if self._rxnorm_tools is None:
+            self._rxnorm_tools = RxNormTools()
+        return self._rxnorm_tools
+
+    async def _expand_drug_term_for_search(
+        self, term: str, max_extra: int = _MAX_DRUG_EXPANSIONS
+    ) -> List[str]:
+        """Return up to ``max_extra`` RxNorm-derived synonyms for ``term``.
+
+        Used to broaden PubMed/policy searches when the procedure or a
+        microsite search term is a drug name. Returns ``[]`` when the term
+        doesn't look like a single drug, when RxNorm has no match, or when
+        the match is below the confidence threshold the chat tools use.
+
+        The returned terms are guaranteed to differ from ``term`` (case-
+        insensitive) and from each other; callers can append them to an
+        existing query list without further deduplication of these.
+        """
+        if not self._looks_like_single_drug_term(term):
+            return []
+        try:
+            normalized = await self._get_rxnorm_tools().normalize(term)
+        except Exception as e:
+            logger.opt(exception=True).debug(
+                f"RxNorm expansion failed for {term!r}: {e}"
+            )
+            return []
+        if not normalized.matched:
+            return []
+        # Same threshold as PubMedTool / RxNormLookupTool: low scores from
+        # approximate matching are too noisy to bias a real search on.
+        if normalized.score is not None and normalized.score < 75:
+            return []
+        out: List[str] = []
+        seen: set[str] = {term.strip().lower()}
+
+        def add(name: str) -> None:
+            cleaned = (name or "").strip()
+            if not cleaned:
+                return
+            key = cleaned.lower()
+            if key in seen or len(out) >= max_extra:
+                return
+            seen.add(key)
+            out.append(cleaned)
+
+        # Canonical name first — this is the highest-signal synonym.
+        add(normalized.canonical_name)
+        # Then plain ingredients (most useful for drug-evidence queries).
+        for ingredient in normalized.related.get("IN", []):
+            add(ingredient.get("name", ""))
+        # Then a couple of brand names, in case PubMed indexes evidence
+        # under the brand name rather than the generic.
+        for brand in normalized.related.get("BN", []):
+            add(brand.get("name", ""))
+        return out
 
     def _url_sources(
         self,
@@ -725,13 +817,27 @@ class PubMedTools(object):
         diagnosis_opt = denial.diagnosis if denial.diagnosis else ""
         query = f"{procedure_opt} {diagnosis_opt}".strip()
         # Build an ordered, deduplicated list of queries: base query first,
-        # then microsite search terms. Order matters for deterministic PER_QUERY
-        # truncation when queries share overlapping PubMed results.
+        # then RxNorm-derived synonyms when the procedure looks like a
+        # drug name, then microsite search terms (also RxNorm-expanded).
+        # Order matters for deterministic PER_QUERY truncation when queries
+        # share overlapping PubMed results.
         queries: List[str] = []
         seen_queries: Set[str] = set()
         if query:
             queries.append(query)
             seen_queries.add(query)
+
+        # If the procedure is a single drug-like term, add searches that
+        # use the canonical name plus a couple of synonyms (e.g. brand
+        # name → generic ingredient). Brand-only or misspelled procedures
+        # would otherwise miss evidence indexed under the canonical name.
+        if procedure_opt:
+            for synonym in await self._expand_drug_term_for_search(procedure_opt):
+                expanded = f"{synonym} {diagnosis_opt}".strip()
+                if expanded and expanded not in seen_queries:
+                    queries.append(expanded)
+                    seen_queries.add(expanded)
+
         if denial.microsite_slug:
             try:
                 microsite = get_microsite(denial.microsite_slug)
@@ -741,6 +847,15 @@ class PubMedTools(object):
                         if stripped and stripped not in seen_queries:
                             queries.append(stripped)
                             seen_queries.add(stripped)
+                        # Microsite search terms are often single drug
+                        # names; expand them too so brand/generic variants
+                        # don't slip past the search.
+                        for synonym in await self._expand_drug_term_for_search(
+                            stripped
+                        ):
+                            if synonym not in seen_queries:
+                                queries.append(synonym)
+                                seen_queries.add(synonym)
                     if microsite.pubmed_search_terms:
                         logger.debug(
                             f"Adding {len(microsite.pubmed_search_terms)} microsite search terms for {denial.microsite_slug}"

--- a/fighthealthinsurance/pubmed_tools.py
+++ b/fighthealthinsurance/pubmed_tools.py
@@ -799,10 +799,13 @@ class PubMedTools(object):
         # Order matters for deterministic PER_QUERY truncation when queries
         # share overlapping PubMed results.
         queries: List[str] = []
+        # Dedup is case-insensitive — PubMed treats "Lipitor" and "lipitor"
+        # as the same query, and we don't want a brand expansion to fire a
+        # second identical search just because the casing differs.
         seen_queries: Set[str] = set()
         if query:
             queries.append(query)
-            seen_queries.add(query)
+            seen_queries.add(query.casefold())
 
         # If the procedure is a single drug-like term, add searches that
         # use the canonical name plus a couple of synonyms (e.g. brand
@@ -811,9 +814,10 @@ class PubMedTools(object):
         if procedure_opt:
             for synonym in await self._expand_drug_term_for_search(procedure_opt):
                 expanded = f"{synonym} {diagnosis_opt}".strip()
-                if expanded and expanded not in seen_queries:
+                key = expanded.casefold()
+                if expanded and key not in seen_queries:
                     queries.append(expanded)
-                    seen_queries.add(expanded)
+                    seen_queries.add(key)
 
         if denial.microsite_slug:
             try:
@@ -821,18 +825,20 @@ class PubMedTools(object):
                 if microsite and microsite.pubmed_search_terms:
                     for term in microsite.pubmed_search_terms:
                         stripped = term.strip()
-                        if stripped and stripped not in seen_queries:
+                        key = stripped.casefold()
+                        if stripped and key not in seen_queries:
                             queries.append(stripped)
-                            seen_queries.add(stripped)
+                            seen_queries.add(key)
                         # Microsite search terms are often single drug
                         # names; expand them too so brand/generic variants
                         # don't slip past the search.
                         for synonym in await self._expand_drug_term_for_search(
                             stripped
                         ):
-                            if synonym not in seen_queries:
+                            syn_key = synonym.casefold()
+                            if syn_key not in seen_queries:
                                 queries.append(synonym)
-                                seen_queries.add(synonym)
+                                seen_queries.add(syn_key)
                     if microsite.pubmed_search_terms:
                         logger.debug(
                             f"Adding {len(microsite.pubmed_search_terms)} microsite search terms for {denial.microsite_slug}"

--- a/fighthealthinsurance/rxnorm_tools.py
+++ b/fighthealthinsurance/rxnorm_tools.py
@@ -1,0 +1,469 @@
+"""
+RxNorm / RxNav API integration for medication name normalization.
+
+RxNorm is a standardized vocabulary published by the U.S. National Library
+of Medicine that links drug names across vocabularies (brand names, generic
+ingredient names, dose forms, clinical drug forms, etc.). RxNav exposes a
+free public REST API at https://rxnav.nlm.nih.gov/REST/.
+
+This module wraps a small subset of the RxNav API and caches results in the
+``RxNormConcept`` model. The goal is "data plumbing" rather than appeal
+evidence: before searching PubMed, DailyMed, or insurer policy documents,
+normalize whatever the user typed (e.g., "Glucophage", "metformen",
+"METFORMIN HCL 500mg") into a canonical drug name plus a pool of related
+synonyms (brand names, ingredients, etc.).
+
+Public entry points:
+
+* :py:meth:`RxNormTools.normalize` -- normalize one input string to a
+  :py:class:`NormalizedDrug` (canonical name + RxCUI + score). Cached.
+* :py:meth:`RxNormTools.expand_query_terms` -- given a free-text drug name,
+  return an ordered, deduplicated list of search-friendly terms (canonical
+  name first, then brand names and ingredients) suitable for feeding into
+  PubMed / policy search queries.
+* :py:meth:`RxNormTools.get_brands_and_generics` -- structured view of a
+  drug: its canonical name, generic ingredients, and known brand names.
+"""
+
+import asyncio
+import re
+import sys
+from dataclasses import dataclass, field
+from datetime import timedelta
+from typing import Any, Dict, List, Optional
+from urllib.parse import quote
+
+import aiohttp
+from asgiref.sync import async_to_sync
+from django.utils import timezone
+from loguru import logger
+
+from fighthealthinsurance.models import RxNormConcept
+
+if sys.version_info >= (3, 11):
+    from asyncio import timeout as async_timeout
+else:
+    from async_timeout import timeout as async_timeout
+
+
+# Base URL for the public RxNav REST API.
+RXNAV_BASE_URL = "https://rxnav.nlm.nih.gov/REST"
+
+# How long a cache entry stays fresh. RxNorm is updated weekly; a 30-day
+# cache is plenty for our normalization use case and keeps API traffic low.
+CACHE_TTL = timedelta(days=30)
+
+# Per-request timeout (seconds). The RxNav API is usually fast (<500ms) so
+# a short ceiling keeps us from blocking appeal generation when it's down.
+DEFAULT_TIMEOUT = 5.0
+
+# Term types we care about when expanding a drug name. See
+# https://www.nlm.nih.gov/research/umls/rxnorm/docs/appendix5.html
+TTY_INGREDIENT = "IN"
+TTY_PRECISE_INGREDIENT = "PIN"
+TTY_BRAND_NAME = "BN"
+TTY_SEMANTIC_CLINICAL_DRUG = "SCD"
+TTY_SEMANTIC_BRANDED_DRUG = "SBD"
+
+EXPAND_TTYS = [
+    TTY_INGREDIENT,
+    TTY_PRECISE_INGREDIENT,
+    TTY_BRAND_NAME,
+    TTY_SEMANTIC_CLINICAL_DRUG,
+    TTY_SEMANTIC_BRANDED_DRUG,
+]
+
+# HTTP headers for RxNav. Including a contact email is a courtesy expected
+# by NIH services and helps them reach us if our traffic looks abusive.
+_FETCH_HEADERS = {
+    "User-Agent": "FightHealthInsurance/1.0 (mailto:support@fighthealthinsurance.com)",
+    "Accept": "application/json",
+}
+
+
+@dataclass
+class NormalizedDrug:
+    """Canonical drug record returned from a normalization call.
+
+    ``rxcui`` is empty when no RxNorm match was found; callers should fall
+    back to the original input in that case.
+    """
+
+    query: str
+    rxcui: str
+    canonical_name: str
+    tty: str = ""
+    score: Optional[int] = None
+    related: Dict[str, List[Dict[str, str]]] = field(default_factory=dict)
+
+    @property
+    def matched(self) -> bool:
+        return bool(self.rxcui) and bool(self.canonical_name)
+
+
+def _clean_query(name: str) -> str:
+    """Lowercase, trim, collapse whitespace.
+
+    We deliberately keep punctuation (e.g., dashes in "co-trimoxazole") so
+    we don't mangle real drug names.
+    """
+    s = (name or "").strip().lower()
+    s = re.sub(r"\s+", " ", s)
+    return s
+
+
+class RxNormTools:
+    """Async client for RxNav with database-backed caching.
+
+    Instances are cheap to create and stateless aside from an optional
+    shared :py:class:`aiohttp.ClientSession`. In long-running consumers
+    (chat workers, prefetch actors) reuse a single instance per request to
+    benefit from connection pooling.
+    """
+
+    def __init__(
+        self,
+        session: Optional[aiohttp.ClientSession] = None,
+        timeout: float = DEFAULT_TIMEOUT,
+        base_url: str = RXNAV_BASE_URL,
+    ) -> None:
+        self._external_session = session
+        self._timeout = timeout
+        self._base_url = base_url.rstrip("/")
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        if self._external_session is not None:
+            return self._external_session
+        # Lazy create a per-call session if the caller didn't provide one.
+        return aiohttp.ClientSession(headers=_FETCH_HEADERS)
+
+    async def _fetch_json(self, url: str) -> Optional[Dict[str, Any]]:
+        """GET ``url`` and parse the response as JSON, returning ``None`` on
+        any error or non-200 response. Honors :py:attr:`_timeout`."""
+        session = await self._get_session()
+        owns_session = self._external_session is None
+        try:
+            async with async_timeout(self._timeout):
+                async with session.get(url) as resp:
+                    if resp.status != 200:
+                        logger.debug(f"RxNav GET {url} -> HTTP {resp.status}")
+                        return None
+                    data: Dict[str, Any] = await resp.json()
+                    return data
+        except asyncio.TimeoutError:
+            logger.debug(f"RxNav GET {url} timed out")
+            return None
+        except Exception as e:
+            logger.opt(exception=True).debug(f"RxNav GET {url} failed: {e}")
+            return None
+        finally:
+            if owns_session:
+                await session.close()
+
+    # ---- cache helpers ---------------------------------------------------
+
+    async def _cache_get(self, query: str) -> Optional[RxNormConcept]:
+        cutoff = timezone.now() - CACHE_TTL
+        return await RxNormConcept.objects.filter(
+            query=query, created__gte=cutoff
+        ).afirst()
+
+    async def _cache_put(
+        self,
+        query: str,
+        rxcui: str,
+        canonical_name: str,
+        tty: str,
+        score: Optional[int],
+        related: Dict[str, List[Dict[str, str]]],
+    ) -> RxNormConcept:
+        # Replace any stale entry for this query so we never accumulate
+        # multiple rows per input. This keeps the cache table small.
+        await RxNormConcept.objects.filter(query=query).adelete()
+        return await RxNormConcept.objects.acreate(
+            query=query,
+            rxcui=rxcui,
+            canonical_name=canonical_name,
+            tty=tty,
+            score=score,
+            related_json=related,
+        )
+
+    # ---- RxNav HTTP wrappers --------------------------------------------
+
+    async def _exact_rxcui(self, name: str) -> Optional[Dict[str, str]]:
+        """Try an exact name match. Returns ``{"rxcui": ..., "name": ...}``
+        if RxNorm has a record with this exact name, else ``None``."""
+        url = f"{self._base_url}/rxcui.json?name={quote(name, safe='')}&search=2"
+        data = await self._fetch_json(url)
+        if not data:
+            return None
+        ids = (data.get("idGroup") or {}).get("rxnormId") or []
+        if not ids:
+            return None
+        rxcui = str(ids[0])
+        # RxNav's rxcui.json doesn't return the canonical name; fetch it.
+        props = await self._properties(rxcui)
+        if not props:
+            return {"rxcui": rxcui, "name": name, "tty": ""}
+        return {
+            "rxcui": rxcui,
+            "name": props.get("name", name),
+            "tty": props.get("tty", ""),
+        }
+
+    async def _approximate(
+        self, name: str, max_entries: int = 4
+    ) -> Optional[Dict[str, Any]]:
+        """Approximate match — handles misspellings and partial names."""
+        url = (
+            f"{self._base_url}/approximateTerm.json"
+            f"?term={quote(name, safe='')}&maxEntries={max_entries}"
+        )
+        data = await self._fetch_json(url)
+        if not data:
+            return None
+        candidates = (data.get("approximateGroup") or {}).get("candidate") or []
+        if not candidates:
+            return None
+        best = candidates[0]
+        rxcui = str(best.get("rxcui") or "")
+        if not rxcui:
+            return None
+        try:
+            score: Optional[int] = int(best.get("score"))
+        except (TypeError, ValueError):
+            score = None
+        props = await self._properties(rxcui)
+        return {
+            "rxcui": rxcui,
+            "name": (props or {}).get("name") or best.get("name") or name,
+            "tty": (props or {}).get("tty") or "",
+            "score": score,
+        }
+
+    async def _properties(self, rxcui: str) -> Optional[Dict[str, str]]:
+        """Fetch canonical name + tty for a known RxCUI."""
+        url = f"{self._base_url}/rxcui/{quote(rxcui, safe='')}/properties.json"
+        data = await self._fetch_json(url)
+        if not data:
+            return None
+        props = data.get("properties") or {}
+        if not props:
+            return None
+        return {
+            "name": str(props.get("name") or ""),
+            "tty": str(props.get("tty") or ""),
+            "synonym": str(props.get("synonym") or ""),
+        }
+
+    async def _related(
+        self, rxcui: str, ttys: List[str]
+    ) -> Dict[str, List[Dict[str, str]]]:
+        """Fetch related concepts (brands, ingredients, etc.) for an RxCUI.
+
+        Returns a dict keyed by tty (e.g., "IN", "BN") whose values are
+        lists of ``{"rxcui": str, "name": str}`` dicts. Empty dict on
+        failure.
+        """
+        if not rxcui or not ttys:
+            return {}
+        url = (
+            f"{self._base_url}/rxcui/{quote(rxcui, safe='')}/related.json"
+            f"?tty={'+'.join(ttys)}"
+        )
+        data = await self._fetch_json(url)
+        if not data:
+            return {}
+        groups = (data.get("relatedGroup") or {}).get("conceptGroup") or []
+        out: Dict[str, List[Dict[str, str]]] = {}
+        for group in groups:
+            tty = str(group.get("tty") or "")
+            props = group.get("conceptProperties") or []
+            if not tty or not props:
+                continue
+            out[tty] = [
+                {"rxcui": str(p.get("rxcui") or ""), "name": str(p.get("name") or "")}
+                for p in props
+                if p.get("name")
+            ]
+        return out
+
+    # ---- public API ------------------------------------------------------
+
+    async def normalize(self, name: str) -> NormalizedDrug:
+        """Normalize a free-text drug name to a canonical RxNorm concept.
+
+        Tries an exact name lookup first, then an approximate (fuzzy) match.
+        Always returns a :py:class:`NormalizedDrug`; callers should check
+        :py:attr:`NormalizedDrug.matched` before trusting the result.
+
+        Results — including misses — are cached in :py:class:`RxNormConcept`
+        for :py:data:`CACHE_TTL` so repeated lookups don't hit the API.
+        """
+        query = _clean_query(name)
+        if not query:
+            return NormalizedDrug(query="", rxcui="", canonical_name="")
+
+        cached = await self._cache_get(query)
+        if cached is not None:
+            # Touching last_used helps an LRU-style eviction job later.
+            await RxNormConcept.objects.filter(pk=cached.pk).aupdate(
+                last_used=timezone.now()
+            )
+            return NormalizedDrug(
+                query=query,
+                rxcui=cached.rxcui,
+                canonical_name=cached.canonical_name,
+                tty=cached.tty,
+                score=cached.score,
+                related=cached.related_json or {},
+            )
+
+        # Not cached — query RxNav. Try exact match first, then approximate.
+        match = await self._exact_rxcui(query)
+        score: Optional[int] = 100 if match else None
+        if not match:
+            approx = await self._approximate(query)
+            if approx:
+                match = {
+                    "rxcui": approx["rxcui"],
+                    "name": approx["name"],
+                    "tty": approx.get("tty", ""),
+                }
+                score = approx.get("score")
+
+        if not match:
+            # Cache the miss so we don't keep retrying unknown junk strings.
+            await self._cache_put(query, "", "", "", None, {})
+            return NormalizedDrug(query=query, rxcui="", canonical_name="")
+
+        rxcui = match["rxcui"]
+        canonical_name = match["name"]
+        tty = match.get("tty", "")
+        related = await self._related(rxcui, EXPAND_TTYS)
+
+        await self._cache_put(query, rxcui, canonical_name, tty, score, related)
+
+        return NormalizedDrug(
+            query=query,
+            rxcui=rxcui,
+            canonical_name=canonical_name,
+            tty=tty,
+            score=score,
+            related=related,
+        )
+
+    async def expand_query_terms(
+        self, name: str, include_brands: bool = True, max_terms: int = 8
+    ) -> List[str]:
+        """Return search-friendly terms for ``name`` ordered by relevance.
+
+        Use this to broaden a PubMed / policy search beyond what the user
+        typed. The canonical name comes first, then ingredient names, then
+        brand names. The original input is appended last when no RxNorm
+        match exists, so callers can always feed the result back into a
+        search engine without losing the user's intent.
+        """
+        normalized = await self.normalize(name)
+        terms: List[str] = []
+        seen: set[str] = set()
+
+        def add(term: str) -> None:
+            cleaned = (term or "").strip()
+            if not cleaned:
+                return
+            key = cleaned.lower()
+            if key in seen:
+                return
+            seen.add(key)
+            terms.append(cleaned)
+
+        if normalized.matched:
+            add(normalized.canonical_name)
+            for tty in (TTY_INGREDIENT, TTY_PRECISE_INGREDIENT):
+                for concept in normalized.related.get(tty, []):
+                    add(concept.get("name", ""))
+            if include_brands:
+                for concept in normalized.related.get(TTY_BRAND_NAME, []):
+                    add(concept.get("name", ""))
+
+        # Always include the original cleaned query so callers don't lose
+        # the user's input (and so a miss still returns something useful).
+        add(_clean_query(name))
+
+        return terms[:max_terms]
+
+    async def get_brands_and_generics(self, name: str) -> Dict[str, Any]:
+        """Structured view of a drug for display / chat answers.
+
+        Returns a dict with::
+
+            {
+                "matched": bool,
+                "rxcui": str,
+                "canonical_name": str,
+                "tty": str,             # "IN", "BN", ...
+                "ingredients": [name, ...],
+                "brand_names": [name, ...],
+            }
+        """
+        normalized = await self.normalize(name)
+        ingredients = [
+            c["name"]
+            for c in normalized.related.get(TTY_INGREDIENT, [])
+            if c.get("name")
+        ]
+        # Fall back to PIN if no plain IN entries were returned.
+        if not ingredients:
+            ingredients = [
+                c["name"]
+                for c in normalized.related.get(TTY_PRECISE_INGREDIENT, [])
+                if c.get("name")
+            ]
+        brand_names = [
+            c["name"]
+            for c in normalized.related.get(TTY_BRAND_NAME, [])
+            if c.get("name")
+        ]
+        return {
+            "matched": normalized.matched,
+            "rxcui": normalized.rxcui,
+            "canonical_name": normalized.canonical_name,
+            "tty": normalized.tty,
+            "ingredients": ingredients,
+            "brand_names": brand_names,
+        }
+
+
+_default_tools: Optional[RxNormTools] = None
+
+
+def get_default_rxnorm_tools() -> RxNormTools:
+    """Process-wide singleton for callers that don't manage their own."""
+    global _default_tools
+    if _default_tools is None:
+        _default_tools = RxNormTools()
+    return _default_tools
+
+
+async def normalize_drug_name(name: str) -> NormalizedDrug:
+    """Convenience wrapper around the default :py:class:`RxNormTools`."""
+    return await get_default_rxnorm_tools().normalize(name)
+
+
+async def expand_drug_query_terms(name: str, max_terms: int = 8) -> List[str]:
+    """Convenience wrapper around :py:meth:`RxNormTools.expand_query_terms`."""
+    return await get_default_rxnorm_tools().expand_query_terms(
+        name, max_terms=max_terms
+    )
+
+
+def normalize_drug_name_sync(name: str) -> NormalizedDrug:
+    """Sync wrapper for callers that aren't async-aware (e.g., admin views).
+
+    Internally runs :py:func:`normalize_drug_name` on a private event loop
+    via ``asgiref``. Avoid in tight loops.
+    """
+    result: NormalizedDrug = async_to_sync(normalize_drug_name)(name)
+    return result

--- a/fighthealthinsurance/rxnorm_tools.py
+++ b/fighthealthinsurance/rxnorm_tools.py
@@ -113,6 +113,38 @@ def _clean_query(name: str) -> str:
     return s
 
 
+# Conjunctions/operators that mark a query as multi-concept.
+# Queries containing these tokens should NOT be treated as a single drug name
+# and should not be rewritten via RxNorm normalization.
+_MULTI_CONCEPT_TOKENS = (
+    " and ",
+    " or ",
+    " vs ",
+    " versus ",
+    ",",
+    ";",
+    " AND ",
+    " OR ",
+)
+
+
+def looks_like_single_drug_query(query: str) -> bool:
+    """Heuristic: is *query* short/unitary enough to be a single drug name?
+
+    Caps at 2 tokens because anything longer could be "drug + condition"
+    (e.g., ``"metformin kidney"``). Multi-concept queries like
+    ``"metformin AND kidney disease"`` are identified by the presence of
+    boolean connectors. Both cases should fall through unchanged — we err on
+    the side of leaving the query alone rather than silently dropping parts.
+    """
+    q = (query or "").strip()
+    if not q:
+        return False
+    if any(tok in q for tok in _MULTI_CONCEPT_TOKENS):
+        return False
+    return len(q.split()) <= 2
+
+
 class RxNormTools:
     """Async client for RxNav with database-backed caching.
 

--- a/fighthealthinsurance/rxnorm_tools.py
+++ b/fighthealthinsurance/rxnorm_tools.py
@@ -28,9 +28,10 @@ Public entry points:
 import asyncio
 import re
 import sys
+from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from datetime import timedelta
-from typing import Any, Dict, List, Optional
+from typing import Any, AsyncIterator, Dict, List, Optional
 from urllib.parse import quote
 
 import aiohttp
@@ -115,10 +116,13 @@ def _clean_query(name: str) -> str:
 class RxNormTools:
     """Async client for RxNav with database-backed caching.
 
-    Instances are cheap to create and stateless aside from an optional
-    shared :py:class:`aiohttp.ClientSession`. In long-running consumers
-    (chat workers, prefetch actors) reuse a single instance per request to
-    benefit from connection pooling.
+    Sessions are owned at the level of a single :py:meth:`normalize` (or
+    :py:meth:`expand_query_terms` / :py:meth:`get_brands_and_generics`)
+    call: we open one :py:class:`aiohttp.ClientSession` at the start of
+    each call and reuse it for the 1-3 HTTP requests that follow, then
+    close it. Callers can also pass in an external session via the
+    constructor, in which case all calls share that session and we never
+    close it.
     """
 
     def __init__(
@@ -131,17 +135,29 @@ class RxNormTools:
         self._timeout = timeout
         self._base_url = base_url.rstrip("/")
 
-    async def _get_session(self) -> aiohttp.ClientSession:
-        if self._external_session is not None:
-            return self._external_session
-        # Lazy create a per-call session if the caller didn't provide one.
-        return aiohttp.ClientSession(headers=_FETCH_HEADERS)
+    @asynccontextmanager
+    async def _session_scope(self) -> AsyncIterator[aiohttp.ClientSession]:
+        """Yield a session for use by HTTP helpers within one logical call.
 
-    async def _fetch_json(self, url: str) -> Optional[Dict[str, Any]]:
+        Reuses the externally-supplied session when one was provided, or
+        opens a fresh session and closes it on exit otherwise. All HTTP
+        helpers below take an explicit ``session`` argument so we don't
+        accidentally open one session per request.
+        """
+        if self._external_session is not None:
+            yield self._external_session
+            return
+        session = aiohttp.ClientSession(headers=_FETCH_HEADERS)
+        try:
+            yield session
+        finally:
+            await session.close()
+
+    async def _fetch_json(
+        self, url: str, session: aiohttp.ClientSession
+    ) -> Optional[Dict[str, Any]]:
         """GET ``url`` and parse the response as JSON, returning ``None`` on
         any error or non-200 response. Honors :py:attr:`_timeout`."""
-        session = await self._get_session()
-        owns_session = self._external_session is None
         try:
             async with async_timeout(self._timeout):
                 async with session.get(url) as resp:
@@ -156,9 +172,6 @@ class RxNormTools:
         except Exception as e:
             logger.opt(exception=True).debug(f"RxNav GET {url} failed: {e}")
             return None
-        finally:
-            if owns_session:
-                await session.close()
 
     # ---- cache helpers ---------------------------------------------------
 
@@ -177,25 +190,31 @@ class RxNormTools:
         score: Optional[int],
         related: Dict[str, List[Dict[str, str]]],
     ) -> RxNormConcept:
-        # Replace any stale entry for this query so we never accumulate
-        # multiple rows per input. This keeps the cache table small.
-        await RxNormConcept.objects.filter(query=query).adelete()
-        return await RxNormConcept.objects.acreate(
+        # Atomic upsert keyed on the (unique) ``query`` field. This avoids
+        # the delete+create race where two concurrent misses would both
+        # try to insert a row, leaving duplicates plus a constraint
+        # violation depending on order.
+        obj, _ = await RxNormConcept.objects.aupdate_or_create(
             query=query,
-            rxcui=rxcui,
-            canonical_name=canonical_name,
-            tty=tty,
-            score=score,
-            related_json=related,
+            defaults={
+                "rxcui": rxcui,
+                "canonical_name": canonical_name,
+                "tty": tty,
+                "score": score,
+                "related_json": related,
+            },
         )
+        return obj
 
     # ---- RxNav HTTP wrappers --------------------------------------------
 
-    async def _exact_rxcui(self, name: str) -> Optional[Dict[str, str]]:
+    async def _exact_rxcui(
+        self, name: str, session: aiohttp.ClientSession
+    ) -> Optional[Dict[str, str]]:
         """Try an exact name match. Returns ``{"rxcui": ..., "name": ...}``
         if RxNorm has a record with this exact name, else ``None``."""
         url = f"{self._base_url}/rxcui.json?name={quote(name, safe='')}&search=2"
-        data = await self._fetch_json(url)
+        data = await self._fetch_json(url, session)
         if not data:
             return None
         ids = (data.get("idGroup") or {}).get("rxnormId") or []
@@ -203,7 +222,7 @@ class RxNormTools:
             return None
         rxcui = str(ids[0])
         # RxNav's rxcui.json doesn't return the canonical name; fetch it.
-        props = await self._properties(rxcui)
+        props = await self._properties(rxcui, session)
         if not props:
             return {"rxcui": rxcui, "name": name, "tty": ""}
         return {
@@ -213,14 +232,17 @@ class RxNormTools:
         }
 
     async def _approximate(
-        self, name: str, max_entries: int = 4
+        self,
+        name: str,
+        session: aiohttp.ClientSession,
+        max_entries: int = 4,
     ) -> Optional[Dict[str, Any]]:
         """Approximate match — handles misspellings and partial names."""
         url = (
             f"{self._base_url}/approximateTerm.json"
             f"?term={quote(name, safe='')}&maxEntries={max_entries}"
         )
-        data = await self._fetch_json(url)
+        data = await self._fetch_json(url, session)
         if not data:
             return None
         candidates = (data.get("approximateGroup") or {}).get("candidate") or []
@@ -234,7 +256,7 @@ class RxNormTools:
             score: Optional[int] = int(best.get("score"))
         except (TypeError, ValueError):
             score = None
-        props = await self._properties(rxcui)
+        props = await self._properties(rxcui, session)
         return {
             "rxcui": rxcui,
             "name": (props or {}).get("name") or best.get("name") or name,
@@ -242,10 +264,12 @@ class RxNormTools:
             "score": score,
         }
 
-    async def _properties(self, rxcui: str) -> Optional[Dict[str, str]]:
+    async def _properties(
+        self, rxcui: str, session: aiohttp.ClientSession
+    ) -> Optional[Dict[str, str]]:
         """Fetch canonical name + tty for a known RxCUI."""
         url = f"{self._base_url}/rxcui/{quote(rxcui, safe='')}/properties.json"
-        data = await self._fetch_json(url)
+        data = await self._fetch_json(url, session)
         if not data:
             return None
         props = data.get("properties") or {}
@@ -258,7 +282,10 @@ class RxNormTools:
         }
 
     async def _related(
-        self, rxcui: str, ttys: List[str]
+        self,
+        rxcui: str,
+        ttys: List[str],
+        session: aiohttp.ClientSession,
     ) -> Dict[str, List[Dict[str, str]]]:
         """Fetch related concepts (brands, ingredients, etc.) for an RxCUI.
 
@@ -272,7 +299,7 @@ class RxNormTools:
             f"{self._base_url}/rxcui/{quote(rxcui, safe='')}/related.json"
             f"?tty={'+'.join(ttys)}"
         )
-        data = await self._fetch_json(url)
+        data = await self._fetch_json(url, session)
         if not data:
             return {}
         groups = (data.get("relatedGroup") or {}).get("conceptGroup") or []
@@ -320,28 +347,30 @@ class RxNormTools:
                 related=cached.related_json or {},
             )
 
-        # Not cached — query RxNav. Try exact match first, then approximate.
-        match = await self._exact_rxcui(query)
-        score: Optional[int] = 100 if match else None
-        if not match:
-            approx = await self._approximate(query)
-            if approx:
-                match = {
-                    "rxcui": approx["rxcui"],
-                    "name": approx["name"],
-                    "tty": approx.get("tty", ""),
-                }
-                score = approx.get("score")
+        # Not cached — query RxNav. Open one session for the 1-3 HTTP
+        # requests below so we don't pay TCP/TLS setup per request.
+        async with self._session_scope() as session:
+            match = await self._exact_rxcui(query, session)
+            score: Optional[int] = 100 if match else None
+            if not match:
+                approx = await self._approximate(query, session)
+                if approx:
+                    match = {
+                        "rxcui": approx["rxcui"],
+                        "name": approx["name"],
+                        "tty": approx.get("tty", ""),
+                    }
+                    score = approx.get("score")
 
-        if not match:
-            # Cache the miss so we don't keep retrying unknown junk strings.
-            await self._cache_put(query, "", "", "", None, {})
-            return NormalizedDrug(query=query, rxcui="", canonical_name="")
+            if not match:
+                # Cache the miss so we don't keep retrying unknown junk strings.
+                await self._cache_put(query, "", "", "", None, {})
+                return NormalizedDrug(query=query, rxcui="", canonical_name="")
 
-        rxcui = match["rxcui"]
-        canonical_name = match["name"]
-        tty = match.get("tty", "")
-        related = await self._related(rxcui, EXPAND_TTYS)
+            rxcui = match["rxcui"]
+            canonical_name = match["name"]
+            tty = match.get("tty", "")
+            related = await self._related(rxcui, EXPAND_TTYS, session)
 
         await self._cache_put(query, rxcui, canonical_name, tty, score, related)
 
@@ -403,7 +432,8 @@ class RxNormTools:
                 "matched": bool,
                 "rxcui": str,
                 "canonical_name": str,
-                "tty": str,             # "IN", "BN", ...
+                "tty": str,                 # "IN", "BN", ...
+                "score": Optional[int],     # 100 for exact, lower for fuzzy
                 "ingredients": [name, ...],
                 "brand_names": [name, ...],
             }
@@ -431,6 +461,7 @@ class RxNormTools:
             "rxcui": normalized.rxcui,
             "canonical_name": normalized.canonical_name,
             "tty": normalized.tty,
+            "score": normalized.score,
             "ingredients": ingredients,
             "brand_names": brand_names,
         }

--- a/fighthealthinsurance/rxnorm_tools.py
+++ b/fighthealthinsurance/rxnorm_tools.py
@@ -209,8 +209,13 @@ class RxNormTools:
 
     async def _cache_get(self, query: str) -> Optional[RxNormConcept]:
         cutoff = timezone.now() - CACHE_TTL
+        # Use ``last_used`` (auto_now) rather than ``created`` so we measure
+        # "time since last refresh" — which is what TTL really means here.
+        # ``aupdate_or_create`` doesn't reset ``created``, so a row that
+        # ages past TTL would otherwise stay stale forever, even if every
+        # subsequent miss re-populated it from the API.
         return await RxNormConcept.objects.filter(
-            query=query, created__gte=cutoff
+            query=query, last_used__gte=cutoff
         ).afirst()
 
     async def _cache_put(

--- a/tests/async-unit/test_rxnorm_tools.py
+++ b/tests/async-unit/test_rxnorm_tools.py
@@ -11,6 +11,7 @@ from fighthealthinsurance.rxnorm_tools import (
     RxNormTools,
     _clean_query,
     expand_drug_query_terms,
+    looks_like_single_drug_query,
     normalize_drug_name,
 )
 
@@ -329,35 +330,27 @@ class TestModuleHelpers:
 
 
 class TestPubMedSingleDrugHeuristic:
-    """Cover PubMedTool._looks_like_single_drug_query / _normalize_drug_terms."""
+    """Cover looks_like_single_drug_query / PubMedTool._normalize_drug_terms."""
 
     def test_looks_like_drug_for_short_unitary_query(self):
-        from fighthealthinsurance.chat.tools.pubmed_tool import PubMedTool
-
-        assert PubMedTool._looks_like_single_drug_query("Lipitor")
-        assert PubMedTool._looks_like_single_drug_query("metformin 500mg")
-        assert PubMedTool._looks_like_single_drug_query("co-trimoxazole")
+        assert looks_like_single_drug_query("Lipitor")
+        assert looks_like_single_drug_query("metformin 500mg")
+        assert looks_like_single_drug_query("co-trimoxazole")
 
     def test_rejects_multi_concept_query(self):
-        from fighthealthinsurance.chat.tools.pubmed_tool import PubMedTool
-
         # Multi-concept queries that would lose information if collapsed
         # to a canonical drug name.
-        assert not PubMedTool._looks_like_single_drug_query(
-            "metformin and kidney disease"
-        )
-        assert not PubMedTool._looks_like_single_drug_query("Lipitor vs simvastatin")
-        assert not PubMedTool._looks_like_single_drug_query("metformin, atorvastatin")
+        assert not looks_like_single_drug_query("metformin and kidney disease")
+        assert not looks_like_single_drug_query("Lipitor vs simvastatin")
+        assert not looks_like_single_drug_query("metformin, atorvastatin")
         # Three-or-more-token query — even without a connector, refuse to
         # rewrite, since "metformin kidney disease" looks lexically like a
         # drug+dose pair but means drug+condition.
-        assert not PubMedTool._looks_like_single_drug_query("metformin kidney disease")
+        assert not looks_like_single_drug_query("metformin kidney disease")
 
     def test_rejects_empty(self):
-        from fighthealthinsurance.chat.tools.pubmed_tool import PubMedTool
-
-        assert not PubMedTool._looks_like_single_drug_query("")
-        assert not PubMedTool._looks_like_single_drug_query("   ")
+        assert not looks_like_single_drug_query("")
+        assert not looks_like_single_drug_query("   ")
 
     @pytest.mark.asyncio
     async def test_normalize_drug_terms_skips_multi_concept(self):
@@ -563,25 +556,18 @@ class TestRxNormLookupToolHandle:
 
 
 class TestPubMedToolsDrugExpansion:
-    """Cover PubMedTools._looks_like_single_drug_term and
-    ._expand_drug_term_for_search — used in find_pubmed_articles_for_denial
-    and the extralink prefetch actor."""
+    """Cover looks_like_single_drug_query and PubMedTools._expand_drug_term_for_search
+    — used in find_pubmed_articles_for_denial and the extralink prefetch actor."""
 
     def test_looks_like_single_drug_short(self):
-        from fighthealthinsurance.pubmed_tools import PubMedTools
-
-        assert PubMedTools._looks_like_single_drug_term("Lipitor")
-        assert PubMedTools._looks_like_single_drug_term("metformin 500mg")
+        assert looks_like_single_drug_query("Lipitor")
+        assert looks_like_single_drug_query("metformin 500mg")
 
     def test_rejects_multi_concept(self):
-        from fighthealthinsurance.pubmed_tools import PubMedTools
-
         # Connector words and 3+ tokens are out.
-        assert not PubMedTools._looks_like_single_drug_term("Lipitor and atorvastatin")
-        assert not PubMedTools._looks_like_single_drug_term(
-            "physical therapy arthritis"
-        )
-        assert not PubMedTools._looks_like_single_drug_term("")
+        assert not looks_like_single_drug_query("Lipitor and atorvastatin")
+        assert not looks_like_single_drug_query("physical therapy arthritis")
+        assert not looks_like_single_drug_query("")
 
     @pytest.mark.asyncio
     async def test_expand_drug_term_returns_canonical_and_synonyms(self):

--- a/tests/async-unit/test_rxnorm_tools.py
+++ b/tests/async-unit/test_rxnorm_tools.py
@@ -55,9 +55,14 @@ APPROX_MISS: Dict[str, Any] = {"approximateGroup": {"candidate": []}}
 
 
 def _make_fetch_json_mock(routes: Dict[str, Optional[Dict[str, Any]]]):
-    """Build a side-effect that returns canned JSON keyed by URL substring."""
+    """Build a side-effect that returns canned JSON keyed by URL substring.
 
-    async def _fetch(url: str) -> Optional[Dict[str, Any]]:
+    Accepts ``(url, session)`` because ``RxNormTools._fetch_json`` now
+    threads a shared session through every HTTP helper. The session arg
+    is ignored — the mock just keys on the URL.
+    """
+
+    async def _fetch(url: str, session: Any = None) -> Optional[Dict[str, Any]]:
         for needle, payload in routes.items():
             if needle in url:
                 return payload
@@ -269,6 +274,9 @@ class TestGetBrandsAndGenerics:
         assert info["canonical_name"] == "atorvastatin"
         assert info["ingredients"] == ["atorvastatin"]
         assert "Lipitor" in info["brand_names"]
+        # Exact matches surface a score of 100 so callers can distinguish
+        # them from approximate hits.
+        assert info["score"] == 100
 
     async def test_unmatched_returns_empty_lists(self):
         tools = RxNormTools()
@@ -318,3 +326,237 @@ class TestModuleHelpers:
         # max_terms is forwarded to the underlying tool.
         kwargs = mock_expand.await_args.kwargs
         assert kwargs.get("max_terms") == 3
+
+
+class TestPubMedSingleDrugHeuristic:
+    """Cover PubMedTool._looks_like_single_drug_query / _normalize_drug_terms."""
+
+    def test_looks_like_drug_for_short_unitary_query(self):
+        from fighthealthinsurance.chat.tools.pubmed_tool import PubMedTool
+
+        assert PubMedTool._looks_like_single_drug_query("Lipitor")
+        assert PubMedTool._looks_like_single_drug_query("metformin 500mg")
+        assert PubMedTool._looks_like_single_drug_query("co-trimoxazole")
+
+    def test_rejects_multi_concept_query(self):
+        from fighthealthinsurance.chat.tools.pubmed_tool import PubMedTool
+
+        # Multi-concept queries that would lose information if collapsed
+        # to a canonical drug name.
+        assert not PubMedTool._looks_like_single_drug_query(
+            "metformin and kidney disease"
+        )
+        assert not PubMedTool._looks_like_single_drug_query("Lipitor vs simvastatin")
+        assert not PubMedTool._looks_like_single_drug_query("metformin, atorvastatin")
+        # Three-or-more-token query — even without a connector, refuse to
+        # rewrite, since "metformin kidney disease" looks lexically like a
+        # drug+dose pair but means drug+condition.
+        assert not PubMedTool._looks_like_single_drug_query("metformin kidney disease")
+
+    def test_rejects_empty(self):
+        from fighthealthinsurance.chat.tools.pubmed_tool import PubMedTool
+
+        assert not PubMedTool._looks_like_single_drug_query("")
+        assert not PubMedTool._looks_like_single_drug_query("   ")
+
+    @pytest.mark.asyncio
+    async def test_normalize_drug_terms_skips_multi_concept(self):
+        from fighthealthinsurance.chat.tools.pubmed_tool import PubMedTool
+
+        send_status = AsyncMock()
+        rxnorm = RxNormTools()
+        # If the heuristic were bypassed and normalize() ran, we'd see a call.
+        with patch.object(
+            rxnorm, "normalize", new_callable=AsyncMock
+        ) as mock_normalize:
+            tool = PubMedTool(send_status, rxnorm_tools=rxnorm)
+            result = await tool._normalize_drug_terms("metformin kidney disease")
+
+        assert result == "metformin kidney disease"
+        mock_normalize.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_normalize_drug_terms_rewrites_single_drug(self):
+        from fighthealthinsurance.chat.tools.pubmed_tool import PubMedTool
+
+        send_status = AsyncMock()
+        rxnorm = RxNormTools()
+        with patch.object(
+            rxnorm, "normalize", new_callable=AsyncMock
+        ) as mock_normalize:
+            mock_normalize.return_value = NormalizedDrug(
+                query="lipitor",
+                rxcui="153165",
+                canonical_name="atorvastatin",
+                tty="IN",
+                score=100,
+            )
+            tool = PubMedTool(send_status, rxnorm_tools=rxnorm)
+            result = await tool._normalize_drug_terms("Lipitor")
+
+        assert result == "atorvastatin"
+        mock_normalize.assert_awaited_once_with("Lipitor")
+
+
+class TestRxNormLookupToolFormatting:
+    """Cover RxNormLookupTool._format_context (score gating, _merge)."""
+
+    def test_low_score_treated_as_miss(self):
+        from fighthealthinsurance.chat.tools.rxnorm_tool import RxNormLookupTool
+
+        info = {
+            "matched": True,
+            "rxcui": "83367",
+            "canonical_name": "atorvastatin",
+            "tty": "IN",
+            "score": 50,
+            "ingredients": ["atorvastatin"],
+            "brand_names": ["Lipitor"],
+        }
+        out = RxNormLookupTool._format_context("atrovstatn", info)
+        # Below threshold — should not include the canonical name; should
+        # advise falling back to the user's spelling.
+        assert "atorvastatin" not in out
+        assert "no canonical RxNorm record" in out
+
+    def test_exact_match_includes_canonical(self):
+        from fighthealthinsurance.chat.tools.rxnorm_tool import RxNormLookupTool
+
+        info = {
+            "matched": True,
+            "rxcui": "83367",
+            "canonical_name": "atorvastatin",
+            "tty": "IN",
+            "score": 100,
+            "ingredients": ["atorvastatin"],
+            "brand_names": ["Lipitor"],
+        }
+        out = RxNormLookupTool._format_context("Atorvastatin", info)
+        assert "canonical name: atorvastatin" in out
+        assert "Lipitor" in out
+
+    def test_merge_inserts_separator(self):
+        from fighthealthinsurance.chat.tools.rxnorm_tool import RxNormLookupTool
+
+        merged = RxNormLookupTool._merge("first sentence.", "second sentence.")
+        assert merged == "first sentence.\n\nsecond sentence."
+
+    def test_merge_handles_empties(self):
+        from fighthealthinsurance.chat.tools.rxnorm_tool import RxNormLookupTool
+
+        assert RxNormLookupTool._merge("", "") == ""
+        assert RxNormLookupTool._merge(None, None) == ""
+        assert RxNormLookupTool._merge("only", "") == "only"
+        assert RxNormLookupTool._merge("", "only") == "only"
+
+
+class TestRxNormLookupToolHandle:
+    """End-to-end coverage of RxNormLookupTool.handle()/execute().
+
+    Mocks the underlying ``RxNormTools`` so we don't hit the network.
+    Specifically guards against regressions in: wrapper cleanup
+    (``[...]`` / ``**...**``), score-based gating, and self-recursion
+    safety on the resulting context.
+    """
+
+    @pytest.mark.asyncio
+    async def test_handle_strips_bracket_wrapper(self):
+        from fighthealthinsurance.chat.tools.rxnorm_tool import RxNormLookupTool
+
+        send_status = AsyncMock()
+        rxnorm = RxNormTools()
+        with patch.object(
+            rxnorm, "get_brands_and_generics", new_callable=AsyncMock
+        ) as mock_info:
+            mock_info.return_value = {
+                "matched": True,
+                "rxcui": "153165",
+                "canonical_name": "atorvastatin",
+                "tty": "IN",
+                "score": 100,
+                "ingredients": ["atorvastatin"],
+                "brand_names": ["Lipitor"],
+            }
+            tool = RxNormLookupTool(send_status, rxnorm_tools=rxnorm)
+            response_text = "Some response. [rxnorm_lookup: Lipitor] Trailing text."
+            cleaned, ctx, handled = await tool.handle(response_text, "")
+
+        assert handled
+        # Trailing `]` from the tool call should be consumed entirely;
+        # the surrounding response text should remain readable.
+        assert "[rxnorm_lookup" not in cleaned
+        assert "]" not in cleaned.split(".")[1]  # nothing dangling on second sentence
+        assert "atorvastatin" in ctx
+        mock_info.assert_awaited_once_with("Lipitor")
+
+    @pytest.mark.asyncio
+    async def test_handle_strips_asterisk_wrapper(self):
+        from fighthealthinsurance.chat.tools.rxnorm_tool import RxNormLookupTool
+
+        send_status = AsyncMock()
+        rxnorm = RxNormTools()
+        with patch.object(
+            rxnorm, "get_brands_and_generics", new_callable=AsyncMock
+        ) as mock_info:
+            mock_info.return_value = {
+                "matched": True,
+                "rxcui": "6809",
+                "canonical_name": "metformin",
+                "tty": "IN",
+                "score": 100,
+                "ingredients": ["metformin"],
+                "brand_names": ["Glucophage"],
+            }
+            tool = RxNormLookupTool(send_status, rxnorm_tools=rxnorm)
+            cleaned, ctx, handled = await tool.handle(
+                "**rxnorm_lookup: glucophage** continuing.", ""
+            )
+
+        assert handled
+        # Both leading and trailing ** should be consumed.
+        assert "**rxnorm_lookup" not in cleaned
+        assert "**" not in cleaned.split("continuing")[0]
+        assert "metformin" in ctx
+
+    @pytest.mark.asyncio
+    async def test_handle_does_not_match_prose(self):
+        """Plain prose without an explicit tool call should be ignored."""
+        from fighthealthinsurance.chat.tools.rxnorm_tool import RxNormLookupTool
+
+        send_status = AsyncMock()
+        rxnorm = RxNormTools()
+        with patch.object(
+            rxnorm, "get_brands_and_generics", new_callable=AsyncMock
+        ) as mock_info:
+            tool = RxNormLookupTool(send_status, rxnorm_tools=rxnorm)
+            cleaned, ctx, handled = await tool.handle(
+                "I might do an RxNorm lookup for the medication.", ""
+            )
+
+        assert not handled
+        assert "RxNorm lookup for the medication" in cleaned
+        mock_info.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_emitted_context_is_not_self_triggering(self):
+        """The formatted context must not contain a phrase that re-triggers
+        the tool when the LLM echoes it back."""
+        from fighthealthinsurance.chat.tools.rxnorm_tool import RxNormLookupTool
+
+        info = {
+            "matched": True,
+            "rxcui": "153165",
+            "canonical_name": "atorvastatin",
+            "tty": "IN",
+            "score": 100,
+            "ingredients": ["atorvastatin"],
+            "brand_names": ["Lipitor"],
+        }
+        formatted = RxNormLookupTool._format_context("Lipitor", info)
+
+        # Run the formatted output back through the tool's pattern; if a
+        # match is found, the tool would recurse on itself.
+        send_status = AsyncMock()
+        rxnorm = RxNormTools()
+        tool = RxNormLookupTool(send_status, rxnorm_tools=rxnorm)
+        assert tool.detect(formatted) is None

--- a/tests/async-unit/test_rxnorm_tools.py
+++ b/tests/async-unit/test_rxnorm_tools.py
@@ -560,3 +560,172 @@ class TestRxNormLookupToolHandle:
         rxnorm = RxNormTools()
         tool = RxNormLookupTool(send_status, rxnorm_tools=rxnorm)
         assert tool.detect(formatted) is None
+
+
+class TestPubMedToolsDrugExpansion:
+    """Cover PubMedTools._looks_like_single_drug_term and
+    ._expand_drug_term_for_search — used in find_pubmed_articles_for_denial
+    and the extralink prefetch actor."""
+
+    def test_looks_like_single_drug_short(self):
+        from fighthealthinsurance.pubmed_tools import PubMedTools
+
+        assert PubMedTools._looks_like_single_drug_term("Lipitor")
+        assert PubMedTools._looks_like_single_drug_term("metformin 500mg")
+
+    def test_rejects_multi_concept(self):
+        from fighthealthinsurance.pubmed_tools import PubMedTools
+
+        # Connector words and 3+ tokens are out.
+        assert not PubMedTools._looks_like_single_drug_term("Lipitor and atorvastatin")
+        assert not PubMedTools._looks_like_single_drug_term(
+            "physical therapy arthritis"
+        )
+        assert not PubMedTools._looks_like_single_drug_term("")
+
+    @pytest.mark.asyncio
+    async def test_expand_drug_term_returns_canonical_and_synonyms(self):
+        from fighthealthinsurance.pubmed_tools import PubMedTools
+
+        rxnorm = RxNormTools()
+        tools = PubMedTools(rxnorm_tools=rxnorm)
+        with patch.object(
+            rxnorm, "normalize", new_callable=AsyncMock
+        ) as mock_normalize:
+            mock_normalize.return_value = NormalizedDrug(
+                query="lipitor",
+                rxcui="153165",
+                canonical_name="atorvastatin",
+                tty="BN",
+                score=100,
+                related={
+                    "IN": [{"rxcui": "83367", "name": "atorvastatin"}],
+                    "BN": [
+                        {"rxcui": "153165", "name": "Lipitor"},
+                        {"rxcui": "1000048", "name": "Atorvaliq"},
+                    ],
+                },
+            )
+            terms = await tools._expand_drug_term_for_search("Lipitor")
+
+        # Canonical first, then ingredients, then brand names. Capped at
+        # _MAX_DRUG_EXPANSIONS (2). The original input is excluded.
+        assert "Lipitor" not in terms
+        assert "atorvastatin" in terms
+        assert len(terms) <= PubMedTools._MAX_DRUG_EXPANSIONS
+
+    @pytest.mark.asyncio
+    async def test_expand_skips_multi_concept_query(self):
+        from fighthealthinsurance.pubmed_tools import PubMedTools
+
+        rxnorm = RxNormTools()
+        tools = PubMedTools(rxnorm_tools=rxnorm)
+        with patch.object(
+            rxnorm, "normalize", new_callable=AsyncMock
+        ) as mock_normalize:
+            terms = await tools._expand_drug_term_for_search(
+                "physical therapy arthritis"
+            )
+
+        assert terms == []
+        mock_normalize.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_expand_skips_low_score_match(self):
+        from fighthealthinsurance.pubmed_tools import PubMedTools
+
+        rxnorm = RxNormTools()
+        tools = PubMedTools(rxnorm_tools=rxnorm)
+        with patch.object(
+            rxnorm, "normalize", new_callable=AsyncMock
+        ) as mock_normalize:
+            mock_normalize.return_value = NormalizedDrug(
+                query="atrovstatn",
+                rxcui="83367",
+                canonical_name="atorvastatin",
+                tty="IN",
+                score=55,
+            )
+            terms = await tools._expand_drug_term_for_search("atrovstatn")
+
+        # Below the 75 confidence threshold — leave it alone.
+        assert terms == []
+
+    @pytest.mark.asyncio
+    async def test_expand_no_match(self):
+        from fighthealthinsurance.pubmed_tools import PubMedTools
+
+        rxnorm = RxNormTools()
+        tools = PubMedTools(rxnorm_tools=rxnorm)
+        with patch.object(
+            rxnorm, "normalize", new_callable=AsyncMock
+        ) as mock_normalize:
+            mock_normalize.return_value = NormalizedDrug(
+                query="nonexistent",
+                rxcui="",
+                canonical_name="",
+            )
+            terms = await tools._expand_drug_term_for_search("nonexistent")
+
+        assert terms == []
+
+
+class TestPriorAuthRxNormContext:
+    """Cover the RxNorm hint that gets added to the prior-auth prompt."""
+
+    def test_drug_match_adds_canonical_hint(self):
+        from fighthealthinsurance.generate_prior_auth import _build_rxnorm_context
+
+        normalized = NormalizedDrug(
+            query="lipitor",
+            rxcui="153165",
+            canonical_name="atorvastatin",
+            tty="BN",
+            score=100,
+            related={
+                "IN": [{"rxcui": "83367", "name": "atorvastatin"}],
+                "BN": [{"rxcui": "153165", "name": "Lipitor"}],
+            },
+        )
+        hint = _build_rxnorm_context("Lipitor", normalized)
+
+        assert "atorvastatin" in hint
+        # The prompt should explicitly tell the LLM to keep the user's
+        # wording in the rendered letter.
+        assert "use" in hint.lower()
+        assert "Lipitor" in hint
+
+    def test_no_match_returns_empty_hint(self):
+        from fighthealthinsurance.generate_prior_auth import _build_rxnorm_context
+
+        normalized = NormalizedDrug(
+            query="mri",
+            rxcui="",
+            canonical_name="",
+        )
+        assert _build_rxnorm_context("MRI", normalized) == ""
+
+    def test_low_score_returns_empty_hint(self):
+        from fighthealthinsurance.generate_prior_auth import _build_rxnorm_context
+
+        normalized = NormalizedDrug(
+            query="atrovstatn",
+            rxcui="83367",
+            canonical_name="atorvastatin",
+            tty="IN",
+            score=55,
+        )
+        assert _build_rxnorm_context("atrovstatn", normalized) == ""
+
+    def test_already_canonical_returns_empty_hint(self):
+        from fighthealthinsurance.generate_prior_auth import _build_rxnorm_context
+
+        # Treatment is already the canonical name — no rewriting needed.
+        normalized = NormalizedDrug(
+            query="atorvastatin",
+            rxcui="83367",
+            canonical_name="atorvastatin",
+            tty="IN",
+            score=100,
+        )
+        assert _build_rxnorm_context("atorvastatin", normalized) == ""

--- a/tests/async-unit/test_rxnorm_tools.py
+++ b/tests/async-unit/test_rxnorm_tools.py
@@ -1,0 +1,320 @@
+"""Unit tests for RxNorm/RxNav integration."""
+
+from typing import Any, Dict, Optional
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from fighthealthinsurance.models import RxNormConcept
+from fighthealthinsurance.rxnorm_tools import (
+    NormalizedDrug,
+    RxNormTools,
+    _clean_query,
+    expand_drug_query_terms,
+    normalize_drug_name,
+)
+
+# ---- Sample RxNav-shaped JSON responses --------------------------------
+
+# Exact-match response for "atorvastatin".
+EXACT_ATORVASTATIN = {"idGroup": {"name": "atorvastatin", "rxnormId": ["83367"]}}
+# Properties for atorvastatin (RxCUI 83367).
+PROPS_ATORVASTATIN = {
+    "properties": {"rxcui": "83367", "name": "atorvastatin", "tty": "IN"}
+}
+# Approximate-match response for misspelling "atrovastatn".
+APPROX_ATORVASTATIN = {
+    "approximateGroup": {
+        "candidate": [
+            {"rxcui": "83367", "score": "85", "rank": "1", "name": "atorvastatin"}
+        ]
+    }
+}
+# Related concepts for atorvastatin: ingredient + brand names.
+RELATED_ATORVASTATIN = {
+    "relatedGroup": {
+        "conceptGroup": [
+            {
+                "tty": "IN",
+                "conceptProperties": [{"rxcui": "83367", "name": "atorvastatin"}],
+            },
+            {
+                "tty": "BN",
+                "conceptProperties": [
+                    {"rxcui": "153165", "name": "Lipitor"},
+                    {"rxcui": "1000048", "name": "Atorvaliq"},
+                ],
+            },
+        ]
+    }
+}
+
+# Empty response — no idGroup match.
+EXACT_MISS: Dict[str, Any] = {"idGroup": {"name": "asdfqwerty"}}
+APPROX_MISS: Dict[str, Any] = {"approximateGroup": {"candidate": []}}
+
+
+def _make_fetch_json_mock(routes: Dict[str, Optional[Dict[str, Any]]]):
+    """Build a side-effect that returns canned JSON keyed by URL substring."""
+
+    async def _fetch(url: str) -> Optional[Dict[str, Any]]:
+        for needle, payload in routes.items():
+            if needle in url:
+                return payload
+        return None
+
+    return _fetch
+
+
+class TestCleanQuery:
+    def test_lowercases_and_trims(self):
+        assert _clean_query("  Lipitor  ") == "lipitor"
+
+    def test_collapses_whitespace(self):
+        assert _clean_query("metformin\t  500  mg") == "metformin 500 mg"
+
+    def test_handles_empty(self):
+        assert _clean_query("") == ""
+        assert _clean_query(None) == ""  # type: ignore[arg-type]
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+class TestRxNormToolsNormalize:
+    async def test_exact_match_returns_canonical_name(self):
+        tools = RxNormTools()
+        routes = {
+            "/rxcui.json?name=atorvastatin": EXACT_ATORVASTATIN,
+            "/rxcui/83367/properties.json": PROPS_ATORVASTATIN,
+            "/rxcui/83367/related.json": RELATED_ATORVASTATIN,
+        }
+        with patch.object(
+            tools, "_fetch_json", side_effect=_make_fetch_json_mock(routes)
+        ):
+            result = await tools.normalize("Atorvastatin")
+
+        assert result.matched
+        assert result.canonical_name == "atorvastatin"
+        assert result.rxcui == "83367"
+        assert result.tty == "IN"
+        assert "BN" in result.related
+        brand_names = [c["name"] for c in result.related["BN"]]
+        assert "Lipitor" in brand_names
+
+    async def test_approximate_match_for_misspelling(self):
+        tools = RxNormTools()
+        routes = {
+            # Exact match miss
+            "/rxcui.json?name=atrovastatn": EXACT_MISS,
+            "/approximateTerm.json": APPROX_ATORVASTATIN,
+            "/rxcui/83367/properties.json": PROPS_ATORVASTATIN,
+            "/rxcui/83367/related.json": RELATED_ATORVASTATIN,
+        }
+        with patch.object(
+            tools, "_fetch_json", side_effect=_make_fetch_json_mock(routes)
+        ):
+            result = await tools.normalize("atrovastatn")
+
+        assert result.matched
+        assert result.canonical_name == "atorvastatin"
+        assert result.rxcui == "83367"
+        assert result.score == 85
+
+    async def test_total_miss_is_cached_and_returns_unmatched(self):
+        tools = RxNormTools()
+        routes = {
+            "/rxcui.json": EXACT_MISS,
+            "/approximateTerm.json": APPROX_MISS,
+        }
+        with patch.object(
+            tools, "_fetch_json", side_effect=_make_fetch_json_mock(routes)
+        ) as mock_fetch:
+            first = await tools.normalize("zzzzzzzzz")
+            assert not first.matched
+            assert first.rxcui == ""
+            calls_after_first = mock_fetch.call_count
+
+            # Second call should be served from cache (no extra HTTP calls).
+            second = await tools.normalize("zzzzzzzzz")
+            assert not second.matched
+            assert mock_fetch.call_count == calls_after_first
+
+    async def test_cache_hit_avoids_http(self):
+        tools = RxNormTools()
+        # Pre-populate the cache.
+        await RxNormConcept.objects.acreate(
+            query="lipitor",
+            rxcui="153165",
+            canonical_name="Lipitor",
+            tty="BN",
+            score=100,
+            related_json={
+                "IN": [{"rxcui": "83367", "name": "atorvastatin"}],
+            },
+        )
+        with patch.object(tools, "_fetch_json", new_callable=AsyncMock) as mock_fetch:
+            result = await tools.normalize("Lipitor")
+
+        assert mock_fetch.call_count == 0
+        assert result.matched
+        assert result.canonical_name == "Lipitor"
+        assert result.related["IN"][0]["name"] == "atorvastatin"
+
+    async def test_empty_input_returns_unmatched(self):
+        tools = RxNormTools()
+        result = await tools.normalize("")
+        assert not result.matched
+        assert result.rxcui == ""
+
+    async def test_low_score_approximate_still_returned(self):
+        # The normalize() call returns whatever RxNorm gave us; downstream
+        # callers (e.g., PubMedTool._normalize_drug_terms) decide whether
+        # to trust it. Confirm the score is preserved verbatim.
+        tools = RxNormTools()
+        low_approx = {
+            "approximateGroup": {
+                "candidate": [{"rxcui": "83367", "score": "55", "name": "atorvastatin"}]
+            }
+        }
+        routes = {
+            "/rxcui.json": EXACT_MISS,
+            "/approximateTerm.json": low_approx,
+            "/rxcui/83367/properties.json": PROPS_ATORVASTATIN,
+            "/rxcui/83367/related.json": RELATED_ATORVASTATIN,
+        }
+        with patch.object(
+            tools, "_fetch_json", side_effect=_make_fetch_json_mock(routes)
+        ):
+            result = await tools.normalize("atrovstatn")
+
+        assert result.matched
+        assert result.score == 55
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+class TestExpandQueryTerms:
+    async def test_expands_brand_to_canonical_plus_synonyms(self):
+        tools = RxNormTools()
+        routes = {
+            "/rxcui.json?name=lipitor": {
+                "idGroup": {"name": "Lipitor", "rxnormId": ["153165"]}
+            },
+            "/rxcui/153165/properties.json": {
+                "properties": {"rxcui": "153165", "name": "Lipitor", "tty": "BN"}
+            },
+            "/rxcui/153165/related.json": {
+                "relatedGroup": {
+                    "conceptGroup": [
+                        {
+                            "tty": "IN",
+                            "conceptProperties": [
+                                {"rxcui": "83367", "name": "atorvastatin"}
+                            ],
+                        },
+                        {
+                            "tty": "BN",
+                            "conceptProperties": [
+                                {"rxcui": "153165", "name": "Lipitor"},
+                                {"rxcui": "1000048", "name": "Atorvaliq"},
+                            ],
+                        },
+                    ]
+                }
+            },
+        }
+        with patch.object(
+            tools, "_fetch_json", side_effect=_make_fetch_json_mock(routes)
+        ):
+            terms = await tools.expand_query_terms("Lipitor")
+
+        # Canonical name first, then ingredients, then brand names. We
+        # also de-duplicate (Lipitor would otherwise appear twice).
+        assert terms[0] == "Lipitor"
+        assert "atorvastatin" in terms
+        assert "Atorvaliq" in terms
+        # No duplicates.
+        assert len(terms) == len(set(t.lower() for t in terms))
+
+    async def test_falls_back_to_user_input_on_miss(self):
+        tools = RxNormTools()
+        routes = {
+            "/rxcui.json": EXACT_MISS,
+            "/approximateTerm.json": APPROX_MISS,
+        }
+        with patch.object(
+            tools, "_fetch_json", side_effect=_make_fetch_json_mock(routes)
+        ):
+            terms = await tools.expand_query_terms("xyz123 tablet")
+
+        assert terms == ["xyz123 tablet"]
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+class TestGetBrandsAndGenerics:
+    async def test_returns_structured_view(self):
+        tools = RxNormTools()
+        routes = {
+            "/rxcui.json?name=atorvastatin": EXACT_ATORVASTATIN,
+            "/rxcui/83367/properties.json": PROPS_ATORVASTATIN,
+            "/rxcui/83367/related.json": RELATED_ATORVASTATIN,
+        }
+        with patch.object(
+            tools, "_fetch_json", side_effect=_make_fetch_json_mock(routes)
+        ):
+            info = await tools.get_brands_and_generics("atorvastatin")
+
+        assert info["matched"] is True
+        assert info["canonical_name"] == "atorvastatin"
+        assert info["ingredients"] == ["atorvastatin"]
+        assert "Lipitor" in info["brand_names"]
+
+    async def test_unmatched_returns_empty_lists(self):
+        tools = RxNormTools()
+        routes = {
+            "/rxcui.json": EXACT_MISS,
+            "/approximateTerm.json": APPROX_MISS,
+        }
+        with patch.object(
+            tools, "_fetch_json", side_effect=_make_fetch_json_mock(routes)
+        ):
+            info = await tools.get_brands_and_generics("nonexistentdrug")
+
+        assert info["matched"] is False
+        assert info["ingredients"] == []
+        assert info["brand_names"] == []
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+class TestModuleHelpers:
+    async def test_normalize_drug_name_uses_default_singleton(self):
+        with patch(
+            "fighthealthinsurance.rxnorm_tools.RxNormTools.normalize",
+            new_callable=AsyncMock,
+        ) as mock_normalize:
+            mock_normalize.return_value = NormalizedDrug(
+                query="lipitor",
+                rxcui="153165",
+                canonical_name="Lipitor",
+                tty="BN",
+            )
+            result = await normalize_drug_name("Lipitor")
+
+        assert result.matched
+        assert result.canonical_name == "Lipitor"
+
+    async def test_expand_drug_query_terms_caps_at_max_terms(self):
+        with patch(
+            "fighthealthinsurance.rxnorm_tools.RxNormTools.expand_query_terms",
+            new_callable=AsyncMock,
+        ) as mock_expand:
+            mock_expand.return_value = ["a", "b", "c"]
+            terms = await expand_drug_query_terms("anything", max_terms=3)
+
+        assert terms == ["a", "b", "c"]
+        mock_expand.assert_awaited_once()
+        # max_terms is forwarded to the underlying tool.
+        kwargs = mock_expand.await_args.kwargs
+        assert kwargs.get("max_terms") == 3

--- a/tests/async-unit/test_rxnorm_tools.py
+++ b/tests/async-unit/test_rxnorm_tools.py
@@ -522,7 +522,7 @@ class TestRxNormLookupToolHandle:
             rxnorm, "get_brands_and_generics", new_callable=AsyncMock
         ) as mock_info:
             tool = RxNormLookupTool(send_status, rxnorm_tools=rxnorm)
-            cleaned, ctx, handled = await tool.handle(
+            cleaned, _ctx, handled = await tool.handle(
                 "I might do an RxNorm lookup for the medication.", ""
             )
 

--- a/tests/async/test_non_professional_abandoned_cart.py
+++ b/tests/async/test_non_professional_abandoned_cart.py
@@ -86,15 +86,19 @@ def test_non_professional_abandoned_cart():
 
     # Legacy support: rows created before secure token rollout were emailed
     # with ?session_id=<row_id>; honor those old links.
-    legacy_session = LostStripeSession(
+    legacy_session = LostStripeSession.objects.create(
         pk=42,
         session_id="legacy_stripe_session",
-        created_at=datetime.datetime(2026, 5, 3, tzinfo=datetime.UTC),
         payment_type="non_professional_item",
         email=email,
         metadata=metadata,
     )
-    legacy_session.save()
+    # Bypass auto_now_add to backdate created_at into the pre-rollout window.
+    # `auto_now_add` ignores values passed to the constructor, so a plain
+    # save() always stamps "now"; an UPDATE goes through unmolested.
+    LostStripeSession.objects.filter(pk=legacy_session.pk).update(
+        created_at=datetime.datetime(2026, 5, 3, tzinfo=datetime.UTC)
+    )
     with patch("stripe.checkout.Session.create") as mock_create:
         mock_create.return_value.url = "https://checkout.stripe.com/legacy"
         response = client.get(

--- a/tests/sync/test_chat_tools.py
+++ b/tests/sync/test_chat_tools.py
@@ -90,6 +90,26 @@ class TestToolPatterns(TestCase):
             self.assertIsNotNone(match, f"Failed to match: {text}")
             self.assertEqual(match.group(1).strip(), expected)
 
+    def test_rxnorm_lookup_pattern_rejects_prose(self):
+        """Pattern should not match natural-language mentions without an
+        explicit ``rxnorm_lookup:`` directive."""
+        # No colon — should not match.
+        self.assertIsNone(
+            re.search(
+                RXNORM_LOOKUP_REGEX,
+                "RxNorm lookup for Lipitor",
+                re.IGNORECASE,
+            )
+        )
+        # Random sentence containing the words but not in tool form.
+        self.assertIsNone(
+            re.search(
+                RXNORM_LOOKUP_REGEX,
+                "I will check rxnorm lookup later",
+                re.IGNORECASE,
+            )
+        )
+
 
 class TestBaseTool(TestCase):
     """Test BaseTool abstract class functionality."""

--- a/tests/sync/test_chat_tools.py
+++ b/tests/sync/test_chat_tools.py
@@ -12,12 +12,14 @@ from fighthealthinsurance.chat.tools import (
     CREATE_OR_UPDATE_APPEAL_REGEX,
     CREATE_OR_UPDATE_PRIOR_AUTH_REGEX,
     FETCH_DOC_REGEX,
+    RXNORM_LOOKUP_REGEX,
     USPSTF_LOOKUP_REGEX,
     BaseTool,
     PubMedTool,
     MedicaidInfoTool,
     MedicaidEligibilityTool,
     DocFetcherTool,
+    RxNormLookupTool,
     USPSTFLookupTool,
 )
 from fighthealthinsurance.chat.tools.doc_fetcher_tool import (
@@ -74,6 +76,19 @@ class TestToolPatterns(TestCase):
         )
         self.assertIsNotNone(match)
         self.assertIn("MRI", match.group(1))
+
+    def test_rxnorm_lookup_pattern(self):
+        """Test rxnorm_lookup pattern matches drug-name forms."""
+        test_cases = [
+            ("rxnorm_lookup: Lipitor", "Lipitor"),
+            ("rxnorm lookup: metformin 500mg", "metformin 500mg"),
+            ("**rxnorm_lookup: glucophage**", "glucophage"),
+            ("[rxnorm lookup: omeprazole]", "omeprazole"),
+        ]
+        for text, expected in test_cases:
+            match = re.search(RXNORM_LOOKUP_REGEX, text, re.IGNORECASE)
+            self.assertIsNotNone(match, f"Failed to match: {text}")
+            self.assertEqual(match.group(1).strip(), expected)
 
 
 class TestBaseTool(TestCase):


### PR DESCRIPTION
## Summary

This PR adds comprehensive RxNorm/RxNav API integration for medication name normalization. It enables the system to resolve brand names, misspellings, and generic names to canonical drug records, with database-backed caching and LLM-aware chat tool integration.

## Key Changes

- **New `rxnorm_tools.py` module**: Async client for RxNav REST API with:
  - `RxNormTools` class providing exact and approximate drug name matching
  - `NormalizedDrug` dataclass for canonical name + RxCUI + match score
  - `expand_query_terms()` for generating search-friendly synonyms (canonical name, ingredients, brand names)
  - `get_brands_and_generics()` for structured drug information display
  - 30-day TTL caching via new `RxNormConcept` Django model to minimize API calls
  - Sync wrapper `normalize_drug_name_sync()` for non-async contexts (e.g., admin views)

- **New `RxNormConcept` model**: Database cache for RxNorm lookups storing:
  - Query string, RxCUI, canonical name, term type (IN/BN/SCD/SBD)
  - Match score from approximate matching
  - Related concepts (ingredients, brand names) as JSON
  - Indexes on `query` and `rxcui` for fast lookups

- **New `RxNormLookupTool` chat tool**: LLM-callable tool that:
  - Intercepts `rxnorm_lookup: <drug name>` directives from the LLM
  - Returns structured drug information (canonical name, RxCUI, ingredients, brand names)
  - Feeds results back to LLM for context-aware follow-up queries
  - Gracefully handles unmatched drugs with user-friendly fallback messaging

- **PubMed tool enhancement**: Integrates RxNorm normalization to:
  - Normalize single drug-name queries before searching PubMed
  - Preserve original query as fallback for robustness
  - Improve search relevance by using canonical names instead of brand variants

- **Chat interface integration**: Registers `RxNormLookupTool` in the action dispatcher

- **Comprehensive test coverage**: 320 lines of async unit tests covering:
  - Exact and approximate matching
  - Cache hits/misses
  - Query expansion and deduplication
  - Structured output formatting
  - Edge cases (empty input, low scores, unmatched drugs)

## Implementation Details

- Uses `aiohttp` for async HTTP with configurable timeout (5s default) and connection pooling
- Respects RxNav API conventions (User-Agent header with contact email, JSON responses)
- Handles multiple term types (IN, PIN, BN, SCD, SBD) for comprehensive synonym expansion
- Cache entries are replaced (not accumulated) per query to keep the table lean
- Supports both async-first and sync-wrapper calling patterns for flexibility
- Includes detailed docstrings and module-level documentation for maintainability

https://claude.ai/code/session_017z19kjctcKSBtjzV9H7tsT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic medication name normalization using industry-standard RxNorm database to improve search accuracy and consistency without requiring additional API keys
  * Enhanced PubMed article search with automatic drug-term expansion, including synonyms and brand names, to discover more relevant medical research
  * Improved prior authorization prompt generation with canonical medication names, active ingredients, and brand name information for clearer submissions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->