### PR TITLE
Add payer medical-policy context for appeal generation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ mypy --config-file mypy.ini -p fighthealthinsurance -p fhi_users
 # Database migrations
 python manage.py makemigrations
 python manage.py migrate
-python manage.py loaddata initial followup plan_source
+python manage.py loaddata initial followup plan_source insurance_companies
 ```
 
 ## Architecture

--- a/fighthealthinsurance/admin.py
+++ b/fighthealthinsurance/admin.py
@@ -37,6 +37,7 @@ from fighthealthinsurance.models import (
     InterestedProfessional,
     MailingListSubscriber,
     OngoingChat,
+    PayerPolicyEntry,
     PlanDocuments,
     PlanSource,
     PlanSourceRelation,
@@ -352,8 +353,32 @@ class InsuranceCompanyAdmin(admin.ModelAdmin):
         (
             "Company Type",
             {
-                "fields": ("is_tpa", "is_marketplace_focused"),
+                "fields": (
+                    "is_tpa",
+                    "is_marketplace_focused",
+                    "is_major_commercial_payer",
+                ),
                 "description": "Flags to indicate company type for suggestions",
+            },
+        ),
+        (
+            "Public Medical Policy",
+            {
+                "fields": (
+                    "medical_policy_url",
+                    "medical_policy_url_is_static_index",
+                    "medical_policy_name",
+                    "medical_policy_notes",
+                ),
+                "description": (
+                    "Public-facing medical/coverage-policy index for this "
+                    "payer (e.g., Aetna's Clinical Policy Bulletins). Used "
+                    "as comparative evidence in appeal generation; not "
+                    "binding on a member's specific plan. Set "
+                    "'static index' true only when the URL is a "
+                    "directly-browsable HTML or PDF index, not a search "
+                    "portal or state-selection page."
+                ),
             },
         ),
         (
@@ -364,6 +389,30 @@ class InsuranceCompanyAdmin(admin.ModelAdmin):
             },
         ),
     )
+
+
+@admin.register(PayerPolicyEntry)
+class PayerPolicyEntryAdmin(admin.ModelAdmin):
+    """Read-only admin for entries written by ingest_payer_policy_indexes."""
+
+    list_display = (
+        "insurance_company",
+        "title",
+        "payer_policy_id",
+        "url",
+        "last_indexed",
+    )
+    list_filter = ("insurance_company",)
+    search_fields = ("title", "payer_policy_id", "url")
+    ordering = ("insurance_company__name", "title")
+    readonly_fields = ("last_indexed",)
+    autocomplete_fields = ["insurance_company"]
+
+    def has_add_permission(self, request):  # type: ignore[override]
+        return False
+
+    def has_change_permission(self, request, obj=None):  # type: ignore[override]
+        return False
 
 
 @admin.register(InsurancePlan)

--- a/fighthealthinsurance/fixtures/insurance_companies.yaml
+++ b/fighthealthinsurance/fixtures/insurance_companies.yaml
@@ -20,6 +20,11 @@
     website: https://www.anthem.com
     member_services_url: https://www.anthem.com/contact-us
     notes: Major national health insurance company (parent company now branded as Elevance Health). Routing is state-specific - the regional InsuranceCompany / InsurancePlan records hold per-state appeal addresses (e.g. Anthem Blue Cross California pk 9, Empire BlueCross BlueShield pk 10). Members should check the address printed on their EOB / member ID card.
+    is_major_commercial_payer: true
+    medical_policy_url: https://www.anthem.com/provider/policies/clinical-guidelines/
+    medical_policy_url_is_static_index: false
+    medical_policy_name: Medical Policies and Clinical UM Guidelines
+    medical_policy_notes: Anthem publishes Medical Policies and Clinical Utilization Management (UM) Guidelines as coverage-decision guidelines. The landing URL requires state selection (e.g. ?cnslocale=en_US_co for Colorado) before showing applicable policies.
 
 - model: fighthealthinsurance.insurancecompany
   pk: 2
@@ -36,6 +41,11 @@
     member_services_url: https://www.uhc.com/contact-us
     appeals_portal_url: https://memberforms.uhc.com/Memberappealsandgrievances.html
     notes: One of the largest health insurance providers in the U.S. Part of UnitedHealth Group. UHC routes appeals per-plan rather than to a single national address - members should use the address/fax printed on their EOB or member ID card. Use the online appeals portal (appeals_portal_url) when in doubt.
+    is_major_commercial_payer: true
+    medical_policy_url: https://www.uhcprovider.com/en/policies-protocols/commercial-policies.html
+    medical_policy_url_is_static_index: false
+    medical_policy_name: Medical Policies and Coverage Determination Guidelines
+    medical_policy_notes: UnitedHealthcare publishes Medical Policies and Coverage Determination Guidelines that state criteria under which services are considered medically necessary or proven/unproven. The provider portal links out to category-specific PDFs.
 
 - model: fighthealthinsurance.insurancecompany
   pk: 3
@@ -56,6 +66,11 @@
       Lexington, KY 40512
     appeal_fax_number: 859-425-3379
     notes: Major health insurance company, now part of CVS Health. Address shown is the National Appeals address for member commercial appeals.
+    is_major_commercial_payer: true
+    medical_policy_url: https://www.aetna.com/health-care-professionals/clinical-policy-bulletins/medical-clinical-policy-bulletins.html
+    medical_policy_url_is_static_index: false
+    medical_policy_name: Clinical Policy Bulletins (CPBs)
+    medical_policy_notes: Aetna publishes Clinical Policy Bulletins (CPBs) that express Aetna's view on whether services are medically necessary, experimental/investigational, unproven, or cosmetic. CPBs are accessed via a search portal (no static A-Z index); individual CPBs live at URLs like https://www.aetna.com/cpb/medical/data/<range>/<id>.html.
 
 - model: fighthealthinsurance.insurancecompany
   pk: 4
@@ -77,6 +92,11 @@
       Chattanooga, TN 37422
     appeal_fax_number: 877-815-4827
     notes: Global health insurance and services company. GWH-Cigna ("G" ID cards) use a different P.O. Box and fax (877-804-1679 / P.O. Box 188062).
+    is_major_commercial_payer: true
+    medical_policy_url: https://static.cigna.com/assets/chcp/resourceLibrary/coveragePolicies/medical_a-z.html
+    medical_policy_url_is_static_index: true
+    medical_policy_name: Coverage Policies
+    medical_policy_notes: Cigna's Coverage Policies help interpret standard health-coverage plan provisions and are publicly available without login. The static A-Z index links directly to individual policy PDFs.
 
 - model: fighthealthinsurance.insurancecompany
   pk: 5
@@ -95,6 +115,9 @@
     appeal_fax_number: 888-556-2128
     appeals_portal_url: https://resolutions.humana.com/
     notes: Focuses on Medicare Advantage plans. Online appeal form available at resolutions.humana.com.
+    is_major_commercial_payer: true
+    medical_policy_name: Medical Coverage Policies
+    medical_policy_notes: Humana publishes Medical Coverage Policies that document medical-necessity and coverage criteria the plan applies, including for Medicare Advantage members where additional CMS rules also apply. The public-facing index URL has changed repeatedly; locate the current index from humana.com's provider portal.
 
 - model: fighthealthinsurance.insurancecompany
   pk: 6
@@ -108,6 +131,9 @@
     member_services_url: https://healthy.kaiserpermanente.org/
     appeal_phone_number: 800-788-0710
     notes: Integrated managed care consortium operating in multiple regions. Appeal routing is region-specific (Southern California / Northern California / Mid-Atlantic / Northwest / Hawaii / Colorado / Washington / Georgia each have their own address and fax). Members should use the contact info on their EOB or member ID card.
+    is_major_commercial_payer: true
+    medical_policy_name: Clinical Review Criteria
+    medical_policy_notes: Kaiser Permanente publishes Clinical Review Criteria documenting medical-necessity standards used by its integrated delivery system. Indices and document URLs vary by region (Washington, Northern California, Southern California, etc.).
 
 - model: fighthealthinsurance.insurancecompany
   pk: 7
@@ -269,6 +295,10 @@
       Jacksonville, FL 32231-4197
     appeal_fax_number: 904-565-6637
     notes: Independent BCBS licensee for Florida. Expedited appeals fax 305-437-7490; this entry shows the standard external review address.
+    medical_policy_url: https://mcgs.bcbsfl.com/
+    medical_policy_url_is_static_index: false
+    medical_policy_name: Medical Coverage Guidelines
+    medical_policy_notes: Florida Blue publishes Medical Coverage Guidelines (MCGs). The MCG portal renders an interactive frame-based document viewer rather than a fetchable HTML index.
 
 - model: fighthealthinsurance.insurancecompany
   pk: 16

--- a/fighthealthinsurance/generate_appeal.py
+++ b/fighthealthinsurance/generate_appeal.py
@@ -15,6 +15,10 @@ from fighthealthinsurance.denial_base import DenialBase
 from .exec import executor
 from .ml.ml_models import RemoteFullOpenLike, RemoteModelLike, repetition_penalty
 from .ml.ml_router import ml_router
+from .payer_policy_helper import (
+    get_combined_payer_policy_context,
+    resolve_company_from_text,
+)
 from .process_denial import ProcessDenialRegex
 from .pubmed_tools import PubMedTools
 from .utils import as_available_nested, best_within_timelimit
@@ -1266,6 +1270,7 @@ class AppealGenerator(object):
         rag_context=None,
         nice_context=None,
         ucr_context=None,
+        payer_policy_context=None,
     ) -> Optional[str]:
         """
         Constructs a prompt for generating a health insurance appeal based on denial details and optional contextual information.
@@ -1376,6 +1381,16 @@ class AppealGenerator(object):
             base = f"{base}. Please include and fill in any references to the insurance company to be {insurance_company}."
             if is_tpa:
                 base = f"{base} Note: This insurance company is a Third-Party Administrator (TPA) for self-funded employer plans, which are typically governed by ERISA (Employee Retirement Income Security Act). ERISA plans have specific appeal requirements and timelines. The employer is the plan fiduciary and ultimately responsible for coverage decisions, though the TPA administers claims."
+        if payer_policy_context:
+            base = (
+                f"{base}\n\n{payer_policy_context}\n\n"
+                "When using the comparative payer-policy information above, "
+                "frame it as supporting industry context (other major insurers "
+                "recognize this service as medically necessary under documented "
+                "criteria), and do NOT assert that another payer's policy "
+                "binds the patient's plan. Always defer to the patient's own "
+                "plan documents for what is actually covered."
+            )
         if (
             claim_id is not None
             and claim_id != ""
@@ -1420,6 +1435,7 @@ class AppealGenerator(object):
         plan_context=None,
         rag_context=None,
         nice_context=None,
+        payer_policy_context=None,
         specialized_templates: Optional[List[type[SpecializedDenialTemplate]]] = None,
     ) -> Iterator[str]:
         """
@@ -1460,6 +1476,31 @@ class AppealGenerator(object):
         if isinstance(ucr_ctx, dict):
             ucr_narrative = ucr_ctx.get("narrative") or None
 
+        # Auto-build payer-policy context from the denial when the caller
+        # didn't supply one. Back-fills the structured InsuranceCompany from
+        # the legacy text field so the denying payer is excluded from the
+        # comparative section even on older denials that never linked to a
+        # company row. Payer-policy context is supplementary evidence -- a
+        # transient DB error here must NOT abort appeal generation.
+        if not payer_policy_context:
+            try:
+                resolved_company = denial.insurance_company_obj
+                if resolved_company is None:
+                    resolved_company = resolve_company_from_text(
+                        denial.insurance_company
+                    )
+                payer_policy_context = get_combined_payer_policy_context(
+                    company=resolved_company,
+                    procedure=denial.procedure,
+                    diagnosis=denial.diagnosis,
+                )
+            except Exception:
+                logger.opt(exception=True).warning(
+                    "Failed to build payer-policy context; "
+                    "proceeding with appeal generation without it"
+                )
+                payer_policy_context = ""
+
         open_prompt = self.make_open_prompt(
             denial_text=denial.denial_text,
             procedure=denial.procedure,
@@ -1482,6 +1523,7 @@ class AppealGenerator(object):
             rag_context=rag_context,
             nice_context=nice_context,
             ucr_context=ucr_narrative,
+            payer_policy_context=payer_policy_context,
         )
         open_medically_necessary_prompt = self.make_open_med_prompt(
             procedure=denial.procedure,

--- a/fighthealthinsurance/management/commands/ingest_payer_policy_indexes.py
+++ b/fighthealthinsurance/management/commands/ingest_payer_policy_indexes.py
@@ -1,0 +1,40 @@
+"""
+Fetch and re-parse every static payer medical-policy index.
+
+Idempotent: replaces each company's :class:`PayerPolicyEntry` rows with the
+freshly-parsed entries from the live URL. Intended to be run at deploy
+time (alongside ``launch_prefetch_actor``) and on a periodic cron so that
+``payer_policy_helper`` keeps surfacing live, working URLs in appeal
+prompts.
+"""
+
+import asyncio
+from typing import Any
+
+from django.core.management.base import BaseCommand
+
+from fighthealthinsurance.payer_policy_fetcher import PayerPolicyFetcher
+
+
+class Command(BaseCommand):
+    help = "Fetch and parse every payer medical-policy static index."
+
+    def handle(self, *args: str, **options: Any) -> None:
+        async def _run() -> dict[str, int]:
+            async with PayerPolicyFetcher() as fetcher:
+                return await fetcher.ingest_all()
+
+        stats = asyncio.run(_run())
+        summary = (
+            f"Payer-policy ingest: {stats['fetched']} fetched, "
+            f"{stats['failed']} failed, {stats['entries']} entries written."
+        )
+        # ingest_all swallows per-company exceptions and returns counts, so
+        # the command always exits 0; surface partial/total failure via
+        # styling so it's visible in startup logs.
+        if stats["failed"] > 0 and stats["fetched"] == 0:
+            self.stdout.write(self.style.ERROR(summary))
+        elif stats["failed"] > 0:
+            self.stdout.write(self.style.WARNING(summary))
+        else:
+            self.stdout.write(self.style.SUCCESS(summary))

--- a/fighthealthinsurance/migrations/0165_insurancecompany_payer_policy_fields.py
+++ b/fighthealthinsurance/migrations/0165_insurancecompany_payer_policy_fields.py
@@ -1,0 +1,78 @@
+# Hand-written migration for payer policy fields on InsuranceCompany.
+# Format matches Django 5.2 auto-generated output.
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("fighthealthinsurance", "0164_ucr_models_and_denial_fields"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="insurancecompany",
+            name="is_major_commercial_payer",
+            field=models.BooleanField(
+                default=False,
+                help_text=(
+                    "True if this is a major national commercial carrier whose "
+                    "public medical policies should be prioritized as comparative "
+                    "industry evidence in appeals (Aetna, UnitedHealthcare, Cigna, "
+                    "Anthem, Humana, Kaiser, etc.). Used to order the comparative-"
+                    "payer section so it surfaces nationally recognized carriers "
+                    "ahead of regional BCBS affiliates."
+                ),
+            ),
+        ),
+        migrations.AddField(
+            model_name="insurancecompany",
+            name="medical_policy_url",
+            field=models.URLField(
+                blank=True,
+                help_text="URL to the company's public medical/coverage/clinical-policy index",
+            ),
+        ),
+        migrations.AddField(
+            model_name="insurancecompany",
+            name="medical_policy_name",
+            field=models.CharField(
+                max_length=200,
+                blank=True,
+                help_text=(
+                    "Name the company uses for its medical-policy documents "
+                    "(e.g., 'Clinical Policy Bulletins', 'Coverage Policy', "
+                    "'Medical Policy', 'Clinical UM Guideline')"
+                ),
+            ),
+        ),
+        migrations.AddField(
+            model_name="insurancecompany",
+            name="medical_policy_url_is_static_index",
+            field=models.BooleanField(
+                default=False,
+                help_text=(
+                    "True if medical_policy_url points to a static, directly-browsable "
+                    "index (an HTML page or PDF that lists policies and links to "
+                    "individual policy documents without requiring search or state "
+                    "selection). False (the default) means the URL is a search "
+                    "portal, requires state/region selection, or otherwise needs "
+                    "interactive navigation. Used to distinguish links that could be "
+                    "pre-fetched and parsed from links that are pointers only."
+                ),
+            ),
+        ),
+        migrations.AddField(
+            model_name="insurancecompany",
+            name="medical_policy_notes",
+            field=models.TextField(
+                blank=True,
+                help_text=(
+                    "Short description of how this payer's medical policies are used / "
+                    "what they assert (e.g., medical-necessity criteria, "
+                    "experimental/investigational determinations)."
+                ),
+            ),
+        ),
+    ]

--- a/fighthealthinsurance/migrations/0166_payerpolicyentry.py
+++ b/fighthealthinsurance/migrations/0166_payerpolicyentry.py
@@ -1,0 +1,64 @@
+# Hand-written migration for PayerPolicyEntry model.
+# Format matches Django 5.2 auto-generated output.
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("fighthealthinsurance", "0165_insurancecompany_payer_policy_fields"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="PayerPolicyEntry",
+            fields=[
+                ("id", models.AutoField(primary_key=True, serialize=False)),
+                (
+                    "insurance_company",
+                    models.ForeignKey(
+                        help_text="The payer that publishes this policy",
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="policy_entries",
+                        to="fighthealthinsurance.insurancecompany",
+                    ),
+                ),
+                (
+                    "title",
+                    models.CharField(
+                        help_text="Policy title as listed in the payer's index (e.g., 'Acupuncture')",
+                        max_length=500,
+                    ),
+                ),
+                (
+                    "url",
+                    models.URLField(
+                        help_text="Direct URL to the individual policy document (PDF or HTML)",
+                        max_length=2000,
+                    ),
+                ),
+                (
+                    "payer_policy_id",
+                    models.CharField(
+                        blank=True,
+                        help_text="Payer-internal policy id (e.g. 'mm_0540', '0001'), if extractable",
+                        max_length=100,
+                    ),
+                ),
+                ("last_indexed", models.DateTimeField(auto_now=True)),
+            ],
+            options={
+                "verbose_name": "Payer Policy Entry",
+                "verbose_name_plural": "Payer Policy Entries",
+                "unique_together": {("insurance_company", "url")},
+                "indexes": [
+                    models.Index(
+                        fields=["insurance_company", "title"],
+                        name="fighthlth_payerp_ic_title_idx",
+                    ),
+                ],
+            },
+        ),
+    ]

--- a/fighthealthinsurance/models.py
+++ b/fighthealthinsurance/models.py
@@ -510,6 +510,47 @@ class InsuranceCompany(models.Model):
         default=False,
         help_text="True if company primarily offers ACA marketplace/individual plans (95%+ of business)",
     )
+    is_major_commercial_payer = models.BooleanField(
+        default=False,
+        help_text=(
+            "True if this is a major national commercial carrier whose "
+            "public medical policies should be prioritized as comparative "
+            "industry evidence in appeals (Aetna, UnitedHealthcare, Cigna, "
+            "Anthem, Humana, Kaiser, etc.). Used to order the comparative-"
+            "payer section so it surfaces nationally recognized carriers "
+            "ahead of regional BCBS affiliates."
+        ),
+    )
+    # Public medical/coverage policy information.
+    # Many commercial payers publish medical policies (e.g. Aetna's Clinical Policy
+    # Bulletins, Cigna's Coverage Policies, Anthem's Medical Policies, Blue Shield's
+    # Clinical UM Guidelines). These can be cited as comparative evidence in appeals,
+    # but do not bind a specific member's plan.
+    medical_policy_url = models.URLField(
+        blank=True,
+        help_text="URL to the company's public medical/coverage/clinical-policy index",
+    )
+    medical_policy_name = models.CharField(
+        max_length=200,
+        blank=True,
+        help_text="Name the company uses for its medical-policy documents (e.g., 'Clinical Policy Bulletins', 'Coverage Policy', 'Medical Policy', 'Clinical UM Guideline')",
+    )
+    medical_policy_url_is_static_index = models.BooleanField(
+        default=False,
+        help_text=(
+            "True if medical_policy_url points to a static, directly-browsable "
+            "index (an HTML page or PDF that lists policies and links to "
+            "individual policy documents without requiring search or state "
+            "selection). False (the default) means the URL is a search "
+            "portal, requires state/region selection, or otherwise needs "
+            "interactive navigation. Used to distinguish links that could be "
+            "pre-fetched and parsed from links that are pointers only."
+        ),
+    )
+    medical_policy_notes = models.TextField(
+        blank=True,
+        help_text="Short description of how this payer's medical policies are used / what they assert (e.g., medical-necessity criteria, experimental/investigational determinations).",
+    )
 
     class Meta:
         verbose_name_plural = "Insurance Companies"
@@ -517,6 +558,11 @@ class InsuranceCompany(models.Model):
 
     def __str__(self):
         return self.name
+
+    @property
+    def has_public_medical_policy(self) -> bool:
+        """True if this payer publishes a public medical/coverage policy index we can cite."""
+        return bool(self.medical_policy_url) or bool(self.medical_policy_name)
 
     def appeal_destinations(self) -> dict[str, str]:
         """Return a dict of non-empty appeal destination channels for this company.
@@ -536,6 +582,53 @@ class InsuranceCompany(models.Model):
         if self.appeal_phone_number:
             destinations["phone"] = self.appeal_phone_number
         return destinations
+
+
+class PayerPolicyEntry(models.Model):
+    """
+    A single medical-policy document parsed out of a payer's public
+    medical-policy index (e.g. one Cigna Coverage Policy PDF). Populated
+    by the ``ingest_payer_policy_indexes`` management command; one row per
+    (company, url).
+
+    Used by ``payer_policy_helper`` at appeal-generation time: when a denial
+    has a procedure or diagnosis, we keyword-match against ``title`` so the
+    appeal prompt cites real, specific policies (with their URLs) rather
+    than just pointing at the payer's index.
+    """
+
+    id = models.AutoField(primary_key=True)
+    insurance_company = models.ForeignKey(
+        InsuranceCompany,
+        on_delete=models.CASCADE,
+        related_name="policy_entries",
+        help_text="The payer that publishes this policy",
+    )
+    title = models.CharField(
+        max_length=500,
+        help_text="Policy title as listed in the payer's index (e.g., 'Acupuncture')",
+    )
+    url = models.URLField(
+        max_length=2000,
+        help_text="Direct URL to the individual policy document (PDF or HTML)",
+    )
+    payer_policy_id = models.CharField(
+        max_length=100,
+        blank=True,
+        help_text="Payer-internal policy id (e.g. 'mm_0540', '0001'), if extractable",
+    )
+    last_indexed = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        verbose_name = "Payer Policy Entry"
+        verbose_name_plural = "Payer Policy Entries"
+        unique_together = [("insurance_company", "url")]
+        indexes = [
+            models.Index(fields=["insurance_company", "title"]),
+        ]
+
+    def __str__(self) -> str:
+        return f"{self.insurance_company.name}: {self.title}"
 
 
 class InsurancePlan(models.Model):

--- a/fighthealthinsurance/payer_policy_fetcher.py
+++ b/fighthealthinsurance/payer_policy_fetcher.py
@@ -1,0 +1,157 @@
+"""
+Fetch and index payer medical-policy pages.
+
+Iterates ``InsuranceCompany`` rows with
+``medical_policy_url_is_static_index=True``, downloads each company's index
+page over HTTP, dispatches it to the parser registered for the URL's host
+in :mod:`fighthealthinsurance.payer_policy_parsers`, and replaces that
+company's :class:`PayerPolicyEntry` rows with the parsed entries.
+
+This is invoked by the ``ingest_payer_policy_indexes`` management command,
+which can run at deploy time alongside the existing extralink prefetch
+actor.
+"""
+
+from typing import Optional
+from urllib.parse import urlparse
+
+import aiohttp
+from asgiref.sync import sync_to_async
+from django.db import transaction
+from loguru import logger
+
+from fighthealthinsurance.models import InsuranceCompany, PayerPolicyEntry
+from fighthealthinsurance.payer_policy_parsers import (
+    PARSERS_BY_HOST,
+    ParsedPolicyEntry,
+)
+
+# Conservative defaults. These pages are 100KB - a few MB; we don't want a
+# slow payer site to wedge a deploy job.
+FETCH_TIMEOUT_SEC = 60
+MAX_BYTES = 10 * 1024 * 1024
+
+
+class PayerPolicyFetcher:
+    """Fetch payer index pages and persist parsed policy entries."""
+
+    def __init__(
+        self,
+        session: Optional[aiohttp.ClientSession] = None,
+        timeout_sec: int = FETCH_TIMEOUT_SEC,
+        max_bytes: int = MAX_BYTES,
+    ) -> None:
+        self._session = session
+        self._owns_session = session is None
+        self._timeout = aiohttp.ClientTimeout(total=timeout_sec)
+        self._max_bytes = max_bytes
+
+    async def __aenter__(self) -> "PayerPolicyFetcher":
+        if self._session is None:
+            self._session = aiohttp.ClientSession(timeout=self._timeout)
+        return self
+
+    async def __aexit__(self, *exc) -> None:
+        if self._owns_session and self._session is not None:
+            await self._session.close()
+            self._session = None
+
+    async def ingest_all(self) -> dict[str, int]:
+        """Fetch + parse + persist for every company flagged as a static index.
+
+        Returns a small ``{fetched, failed, entries}`` summary.
+        """
+        stats = {"fetched": 0, "failed": 0, "entries": 0}
+        companies = await sync_to_async(
+            lambda: list(
+                InsuranceCompany.objects.filter(
+                    medical_policy_url_is_static_index=True,
+                ).exclude(medical_policy_url="")
+            )
+        )()
+
+        if not companies:
+            logger.info("No insurance companies flagged for policy ingestion")
+            return stats
+
+        for company in companies:
+            try:
+                count = await self.ingest_company(company)
+                stats["fetched"] += 1
+                stats["entries"] += count
+            except Exception:
+                logger.opt(exception=True).warning(
+                    f"Failed ingest for {company.name} ({company.medical_policy_url})"
+                )
+                stats["failed"] += 1
+        logger.info(
+            f"Policy ingest complete: {stats['fetched']} payers fetched, "
+            f"{stats['failed']} failed, {stats['entries']} entries written"
+        )
+        return stats
+
+    async def ingest_company(self, company: InsuranceCompany) -> int:
+        """Fetch ``company``'s index, parse, and replace its PayerPolicyEntry rows.
+
+        Returns the number of entries written. Raises ``LookupError`` if the
+        URL host has no registered parser -- ``ingest_all`` treats this as a
+        failed ingest so unsupported hosts surface in the run summary
+        instead of being silently counted as fetched.
+        """
+        url = company.medical_policy_url
+        if not url:
+            return 0
+        host = (urlparse(url).hostname or "").lower()
+        parser = PARSERS_BY_HOST.get(host)
+        if parser is None:
+            raise LookupError(
+                f"No parser registered for host {host!r} "
+                f"(company {company.name}, url {url})"
+            )
+
+        body = await self._get_text(url)
+        entries = parser(body)
+        await self._replace_entries(company, entries)
+        logger.info(f"Ingested {len(entries)} entries for {company.name}")
+        return len(entries)
+
+    async def _get_text(self, url: str) -> str:
+        assert self._session is not None, "use 'async with PayerPolicyFetcher()'"
+        async with self._session.get(
+            url,
+            headers={"User-Agent": "fighthealthinsurance-policy-ingest/1.0"},
+            allow_redirects=True,
+        ) as resp:
+            resp.raise_for_status()
+            data = await resp.content.read(self._max_bytes + 1)
+            if len(data) > self._max_bytes:
+                raise ValueError(
+                    f"Policy index at {url} exceeded {self._max_bytes} bytes"
+                )
+            # Most payer index pages serve text/html; respect the response's
+            # encoding when set, otherwise let aiohttp pick a default.
+            encoding = resp.charset or "utf-8"
+            return data.decode(encoding, errors="replace")
+
+    @staticmethod
+    @sync_to_async
+    def _replace_entries(
+        company: InsuranceCompany,
+        entries: list[ParsedPolicyEntry],
+    ) -> None:
+        # Replace atomically so consumers never see a partial index. The
+        # delete-then-bulk_create pair within a single transaction also
+        # makes ingest re-runs idempotent for both fresh and existing rows.
+        with transaction.atomic():
+            PayerPolicyEntry.objects.filter(insurance_company=company).delete()
+            PayerPolicyEntry.objects.bulk_create(
+                [
+                    PayerPolicyEntry(
+                        insurance_company=company,
+                        title=e.title[:500],
+                        url=e.url[:2000],
+                        payer_policy_id=e.payer_policy_id[:100],
+                    )
+                    for e in entries
+                ]
+            )

--- a/fighthealthinsurance/payer_policy_helper.py
+++ b/fighthealthinsurance/payer_policy_helper.py
@@ -1,0 +1,374 @@
+"""
+Payer Policy Context Helper.
+
+Builds short context blocks describing major commercial payers' public
+medical-policy frameworks (Aetna's CPBs, Cigna's Coverage Policies,
+Anthem's Medical Policies, etc.) and -- where the
+``ingest_payer_policy_indexes`` management command has populated
+:class:`PayerPolicyEntry` rows -- surfaces the *actual* matched policy
+titles and URLs for the patient's procedure/diagnosis. The output is
+intended for inclusion in appeal prompts as comparative industry evidence.
+
+A standard caveat is always included so neither the model nor the
+generated appeal implies that another payer's policy binds the user's
+specific plan.
+"""
+
+import re
+from typing import List, Optional
+
+from django.db.models import Q
+from loguru import logger
+
+from fighthealthinsurance.models import InsuranceCompany, PayerPolicyEntry
+
+# Caveat that must accompany any reference to other payers' policies in an
+# appeal. Other payers' policies are comparative evidence only; they don't
+# bind the user's plan.
+COMPARATIVE_PAYER_CAVEAT = (
+    "Important caveat: each insurance plan is governed by its own policy "
+    "documents (the Evidence of Coverage, Summary Plan Description, or "
+    "applicable medical policy). Other payers' public medical policies are "
+    "cited here only as comparative industry evidence that recognized "
+    "insurers treat the service as medically necessary under defined "
+    "criteria; they do not bind, and may not match, the patient's specific "
+    "plan."
+)
+
+# Reminder used when we have a URL/notes pointer but no parsed entries: the
+# prompt may only point at the index, not its specific contents.
+NO_ENTRIES_GUARD = (
+    "IMPORTANT: only the index name/URL/notes are provided here -- the "
+    "actual policy text and its specific medical-necessity criteria have "
+    "NOT been retrieved. Do NOT invent, paraphrase, or assert specific "
+    "criteria, thresholds, or covered indications from the payer's policy. "
+    "You may say the policy exists and point to it; do not claim the "
+    "patient's record meets criteria from a document that has not been "
+    "read."
+)
+
+# Reminder used when parsed entries ARE provided: we have title + URL but
+# still not the full policy text.
+WITH_ENTRIES_GUARD = (
+    "IMPORTANT: each entry below is a real, specific policy title and URL "
+    "matched against the patient's procedure/diagnosis. The full criteria "
+    "from each policy have NOT been retrieved into this prompt -- only the "
+    "title and link. The appeal may cite that the payer publishes a policy "
+    "covering this service and link to it; the appeal must NOT invent or "
+    "paraphrase specific criteria from the underlying document."
+)
+
+
+def resolve_company_from_text(name_text: Optional[str]) -> Optional[InsuranceCompany]:
+    """
+    Best-effort lookup of an InsuranceCompany from a free-text payer name.
+
+    Used to back-fill from the legacy ``Denial.insurance_company`` text field
+    when the structured ``Denial.insurance_company_obj`` is null. Without
+    this, the denying payer can show up in the comparative-evidence section
+    as an "other major payer", which is wrong.
+
+    Tries case-insensitive exact match first, then a case-insensitive search
+    of the ``alt_names`` lines. Returns None if no confident match.
+    """
+    if not name_text:
+        return None
+    text = name_text.strip()
+    if not text:
+        return None
+    try:
+        match = InsuranceCompany.objects.filter(name__iexact=text).first()
+        if match is not None:
+            return match
+        for company in InsuranceCompany.objects.filter(alt_names__icontains=text):
+            for alt in (company.alt_names or "").splitlines():
+                if alt.strip().lower() == text.lower():
+                    return company
+    except Exception:
+        logger.exception("Error resolving InsuranceCompany from text")
+    return None
+
+
+# --- query helpers ---------------------------------------------------------
+
+
+# Short tokens are usually noise (the, for) -- but a few medical
+# abbreviations are worth keeping even at <4 chars.
+#
+# Note: cms_coverage_api and ecri_guidelines_helper have similar
+# tokenizers, but their min_len is 2 (they match against larger texts,
+# where 2-char clinical abbreviations like RA/MI/CT are useful). Here we
+# match against short payer-policy *titles*, where 2- and 3-char tokens
+# yield mostly false positives -- hence the higher floor and an explicit
+# allowlist for the abbreviations we still want to keep.
+_SHORT_KEEP = frozenset({"mri", "ct", "pet", "cbc", "cpap", "tms", "ivf"})
+
+_ALNUM_RUN_RE = re.compile(r"[a-z0-9]+")
+
+
+def _keyword_terms(*texts: Optional[str]) -> List[str]:
+    """Return distinct lowercase alphanumeric token runs (>=4 chars or in
+    :data:`_SHORT_KEEP`) extracted from the given free-text inputs.
+
+    Splits on any non-alphanumeric character so that inputs like
+    ``"MRI/PET-scan"`` yield ``["mri", "pet", "scan"]`` rather than a
+    single mashed token.
+    """
+    out: List[str] = []
+    seen: set[str] = set()
+    for text in texts:
+        if not text:
+            continue
+        for tok in _ALNUM_RUN_RE.findall(text.lower()):
+            if tok in seen:
+                continue
+            if len(tok) < 4 and tok not in _SHORT_KEEP:
+                continue
+            seen.add(tok)
+            out.append(tok)
+    return out
+
+
+def get_relevant_policy_entries(
+    procedure: Optional[str],
+    diagnosis: Optional[str],
+    company_id: Optional[int] = None,
+    exclude_company_id: Optional[int] = None,
+    max_entries: int = 5,
+) -> List[PayerPolicyEntry]:
+    """Return ``PayerPolicyEntry`` rows whose title contains any procedure or
+    diagnosis keyword.
+
+    Args:
+        procedure / diagnosis: free-text strings from the denial.
+        company_id: if set, restrict to entries from this company.
+        exclude_company_id: if set, drop entries from this company (used to
+            keep the denying payer out of the comparative section).
+        max_entries: cap on returned rows.
+    """
+    terms = _keyword_terms(procedure, diagnosis)
+    if not terms:
+        return []
+    try:
+        title_q = Q()
+        for t in terms:
+            title_q |= Q(title__icontains=t)
+        qs = PayerPolicyEntry.objects.filter(title_q).select_related(
+            "insurance_company"
+        )
+        if company_id is not None:
+            qs = qs.filter(insurance_company_id=company_id)
+        if exclude_company_id is not None:
+            qs = qs.exclude(insurance_company_id=exclude_company_id)
+        return list(qs.order_by("insurance_company__name", "title")[:max_entries])
+    except Exception:
+        logger.exception("Error querying PayerPolicyEntry")
+        return []
+
+
+# --- rendering -------------------------------------------------------------
+
+
+def _format_company_block(company: InsuranceCompany) -> Optional[str]:
+    """Render a single payer's medical-policy info as a short markdown block.
+
+    Distinguishes URLs we know are static, directly-browsable indexes (which
+    we cite directly) from URLs that are interactive search portals or that
+    require state/region selection (which we mark explicitly so the appeal
+    doesn't suggest the link itself contains the policy text).
+    """
+    if not company.has_public_medical_policy:
+        return None
+    policy_name = company.medical_policy_name or "medical policies"
+    line = f"- **{company.name}** publishes {policy_name}"
+    if company.medical_policy_url:
+        if company.medical_policy_url_is_static_index:
+            line += f" ({company.medical_policy_url})"
+        else:
+            line += (
+                f" -- the public landing page is at {company.medical_policy_url}, "
+                "but it is an interactive search/state-selection portal, not a "
+                "browsable index of policy text"
+            )
+    line += "."
+    if company.medical_policy_notes:
+        return f"{line}\n  {company.medical_policy_notes}"
+    return line
+
+
+def _format_entry_line(entry: PayerPolicyEntry) -> str:
+    suffix = f" [{entry.payer_policy_id}]" if entry.payer_policy_id else ""
+    return f"- **{entry.insurance_company.name}**: {entry.title}{suffix} -- {entry.url}"
+
+
+# --- public API ------------------------------------------------------------
+
+
+def get_payer_policy_context(
+    company: Optional[InsuranceCompany],
+    procedure: Optional[str] = None,
+    diagnosis: Optional[str] = None,
+    max_entries: int = 4,
+) -> str:
+    """Context block describing the user's own payer's medical-policy framework.
+
+    If ``ingest_payer_policy_indexes`` has populated ``PayerPolicyEntry``
+    rows for ``company`` and any of them title-match the procedure/
+    diagnosis, those concrete (title, URL) pairs are surfaced. Otherwise
+    we fall back to a generic pointer at the company's published index.
+    """
+    if company is None:
+        return ""
+    block = _format_company_block(company)
+    if not block:
+        return ""
+
+    matched = get_relevant_policy_entries(
+        procedure=procedure,
+        diagnosis=diagnosis,
+        company_id=company.id,
+        max_entries=max_entries,
+    )
+
+    lines = [
+        "## Payer's Public Medical Policy",
+        (
+            f"The denying payer ({company.name}) publishes a public "
+            "medical-policy framework. The appeal may cite that framework "
+            "as a pointer; below is the published index, plus any "
+            "specifically-matched policies for this case."
+        ),
+        "",
+        block,
+        "",
+    ]
+    if matched:
+        lines.append("Matched policies for this procedure/diagnosis:")
+        lines.extend(_format_entry_line(e) for e in matched)
+        lines.append("")
+        lines.append(WITH_ENTRIES_GUARD)
+    else:
+        lines.append(NO_ENTRIES_GUARD)
+
+    lines.append("")
+    lines.append(
+        "Note: a payer's published medical policy is general guidance; the "
+        "patient's specific plan may have additional terms in its Evidence "
+        "of Coverage or Summary Plan Description that govern the actual "
+        "coverage decision."
+    )
+    return "\n".join(lines)
+
+
+def get_comparative_payer_policy_context(
+    exclude_company_id: Optional[int] = None,
+    procedure: Optional[str] = None,
+    diagnosis: Optional[str] = None,
+    max_payers: int = 4,
+    max_entries: int = 4,
+) -> str:
+    """Comparative-evidence block listing other major payers' policies.
+
+    Surfaces real matched ``PayerPolicyEntry`` rows when available so the
+    appeal can point at concrete policy URLs from other carriers; falls
+    back to a generic per-payer pointer (name/URL/notes) when no matches
+    exist. Always emits ``COMPARATIVE_PAYER_CAVEAT``.
+    """
+    try:
+        # Match has_public_medical_policy / _format_company_block: include
+        # any payer with at least one of url or name populated. Django's
+        # .exclude(a="", b="") means NOT (a="" AND b=""), i.e. drop rows
+        # where both fields are empty.
+        qs = InsuranceCompany.objects.exclude(
+            medical_policy_url="", medical_policy_name=""
+        )
+        if exclude_company_id is not None:
+            qs = qs.exclude(id=exclude_company_id)
+        # Surface major national commercial carriers ahead of regional BCBS
+        # plans so the default top-N is representative.
+        companies: List[InsuranceCompany] = list(
+            qs.order_by("-is_major_commercial_payer", "name")[:max_payers]
+        )
+        # Keep matched entries scoped to the same payers we list in this
+        # block; otherwise we could surface a Cigna-only policy URL while
+        # the listed-payer block above features only Aetna and UHC, which
+        # is confusing for the reader.
+        allowed_company_ids = {c.id for c in companies}
+        matched_entries = get_relevant_policy_entries(
+            procedure=procedure,
+            diagnosis=diagnosis,
+            exclude_company_id=exclude_company_id,
+            max_entries=max_entries,
+        )
+        matched_entries = [
+            e for e in matched_entries if e.insurance_company_id in allowed_company_ids
+        ]
+
+        if not companies and not matched_entries:
+            return ""
+
+        lines: List[str] = [
+            "## Comparative Payer Medical Policies",
+            (
+                "The following major commercial payers publish public "
+                "medical-policy indices for services like this one. The "
+                "appeal may point to the existence of these published "
+                "policies as evidence that the requested kind of service "
+                "is addressed in industry medical-policy literature."
+            ),
+            "",
+        ]
+        for c in companies:
+            block = _format_company_block(c)
+            if block:
+                lines.append(block)
+
+        if matched_entries:
+            lines.append("")
+            lines.append(
+                "Specific matched policies (real titles and URLs from "
+                "indexed payer policy lists):"
+            )
+            lines.extend(_format_entry_line(e) for e in matched_entries)
+            lines.append("")
+            lines.append(WITH_ENTRIES_GUARD)
+        else:
+            lines.append("")
+            lines.append(NO_ENTRIES_GUARD)
+
+        lines.append("")
+        lines.append(COMPARATIVE_PAYER_CAVEAT)
+        return "\n".join(lines)
+
+    except Exception:
+        logger.exception("Error building comparative payer policy context")
+        return ""
+
+
+def get_combined_payer_policy_context(
+    company: Optional[InsuranceCompany],
+    procedure: Optional[str] = None,
+    diagnosis: Optional[str] = None,
+    include_comparative: bool = True,
+    max_comparative_payers: int = 4,
+    max_comparative_entries: int = 4,
+) -> str:
+    """Combine own-payer and comparative blocks; always honors the caveat."""
+    parts: List[str] = []
+
+    own = get_payer_policy_context(company, procedure=procedure, diagnosis=diagnosis)
+    if own:
+        parts.append(own)
+
+    if include_comparative:
+        comparative = get_comparative_payer_policy_context(
+            exclude_company_id=company.id if company is not None else None,
+            procedure=procedure,
+            diagnosis=diagnosis,
+            max_payers=max_comparative_payers,
+            max_entries=max_comparative_entries,
+        )
+        if comparative:
+            parts.append(comparative)
+
+    return "\n\n".join(parts)

--- a/fighthealthinsurance/payer_policy_parsers.py
+++ b/fighthealthinsurance/payer_policy_parsers.py
@@ -1,0 +1,76 @@
+"""
+Parsers for payer medical-policy index pages.
+
+Each parser takes the raw HTML of a payer's static-index URL and returns a
+list of ``ParsedPolicyEntry`` records (title, absolute url, optional payer-
+internal id). The orchestrator (``payer_policy_fetcher``) writes these as
+``PayerPolicyEntry`` rows that ``payer_policy_helper`` later keyword-matches
+against the patient's procedure/diagnosis at appeal time.
+
+Adding support for a new payer means:
+  1. Verify the payer's index URL is fetchable static HTML/PDF (no JS).
+  2. Set ``medical_policy_url_is_static_index=True`` on the InsuranceCompany.
+  3. Write a parser here returning ``ParsedPolicyEntry`` records.
+  4. Register it in ``PARSERS_BY_HOST`` keyed on the URL hostname.
+"""
+
+import re
+from dataclasses import dataclass
+from typing import Callable, Dict, List
+from urllib.parse import urljoin
+
+
+@dataclass(frozen=True)
+class ParsedPolicyEntry:
+    title: str
+    url: str
+    payer_policy_id: str = ""
+
+
+# Cigna A-Z titles look like "Acupuncture - (CPG024)" -- pull the id off the
+# end so we can use it for cross-references. Cigna's source uses both ASCII
+# hyphens and U+2013 EN DASH; match either. The EN DASH is written as a
+# Unicode escape so Ruff RUF001 doesn't flag the ambiguous glyph.
+_CIGNA_ID_SUFFIX_RE = re.compile(r"\s*[-–]\s*\(([A-Za-z0-9_]+)\)\s*$")
+_CIGNA_LINK_RE = re.compile(
+    r'<a\s+[^>]*href=["\'](?P<href>[^"\']+\.pdf)["\'][^>]*>' r"(?P<text>[^<]+)</a>",
+    re.IGNORECASE,
+)
+_CIGNA_BASE = "https://static.cigna.com"
+
+
+def parse_cigna_medical_a_z(html: str) -> List[ParsedPolicyEntry]:
+    """
+    Parse Cigna's static A-Z medical coverage policies page into entries.
+
+    The page lists policies as ``<a href="/assets/.../foo.pdf">Title - (ID)</a>``.
+    We resolve the relative URL against ``static.cigna.com`` and lift the
+    parenthesized id at the end of the title into ``payer_policy_id``.
+    """
+    entries: List[ParsedPolicyEntry] = []
+    seen: set[str] = set()
+    for m in _CIGNA_LINK_RE.finditer(html):
+        href = m.group("href").strip()
+        text = m.group("text").strip()
+        if not href or not text:
+            continue
+        url = urljoin(_CIGNA_BASE, href)
+        if url in seen:
+            continue
+        seen.add(url)
+        policy_id = ""
+        id_match = _CIGNA_ID_SUFFIX_RE.search(text)
+        if id_match:
+            policy_id = id_match.group(1)
+            text = _CIGNA_ID_SUFFIX_RE.sub("", text).strip()
+        entries.append(
+            ParsedPolicyEntry(title=text, url=url, payer_policy_id=policy_id)
+        )
+    return entries
+
+
+# Map from URL hostname -> parser. The fetcher dispatches on hostname so a
+# given parser can apply to several specific URL paths on the same host.
+PARSERS_BY_HOST: Dict[str, Callable[[str], List[ParsedPolicyEntry]]] = {
+    "static.cigna.com": parse_cigna_medical_a_z,
+}

--- a/scripts/start-server.sh
+++ b/scripts/start-server.sh
@@ -12,6 +12,7 @@ if [ -n "$MIGRATIONS" ]; then
   python manage.py loaddata initial
   python manage.py loaddata followup
   python manage.py loaddata plan_source
+  python manage.py loaddata insurance_companies
   python manage.py ensure_adminuser --no-input
   sleep 10
   exit 0
@@ -23,6 +24,8 @@ elif [ -n "$POLLING_ACTORS" ]; then
 elif [ -n "$PREFETCH_EXTRALINKS" ]; then
   # Launch extralink pre-fetch (one-time job, non-blocking)
   python manage.py launch_prefetch_actor || echo "Pre-fetch failed (non-blocking)"
+  # Refresh payer medical-policy indexes (used by payer_policy_helper).
+  python manage.py ingest_payer_policy_indexes || echo "Payer-policy ingest failed (non-blocking)"
   sleep 10
   exit 0
 fi
@@ -32,6 +35,7 @@ if [ "$ENVIRONMENT" == "Dev" ]; then
   python manage.py loaddata initial
   python manage.py loaddata followup
   python manage.py loaddata plan_source
+  python manage.py loaddata insurance_companies
   python manage.py ensure_adminuser --no-input
 fi
 # Start gunicorn

--- a/tests/sync/test_payer_policy_helper.py
+++ b/tests/sync/test_payer_policy_helper.py
@@ -1,0 +1,477 @@
+"""Tests for payer_policy_helper, payer_policy_parsers, and the
+ingest_payer_policy_indexes management command."""
+
+import asyncio
+from unittest.mock import patch
+
+from django.test import TestCase, TransactionTestCase
+
+from fighthealthinsurance.models import InsuranceCompany, PayerPolicyEntry
+from fighthealthinsurance.payer_policy_fetcher import PayerPolicyFetcher
+from fighthealthinsurance.payer_policy_helper import (
+    COMPARATIVE_PAYER_CAVEAT,
+    NO_ENTRIES_GUARD,
+    WITH_ENTRIES_GUARD,
+    _format_company_block,
+    _keyword_terms,
+    get_combined_payer_policy_context,
+    get_comparative_payer_policy_context,
+    get_payer_policy_context,
+    get_relevant_policy_entries,
+    resolve_company_from_text,
+)
+from fighthealthinsurance.payer_policy_parsers import (
+    PARSERS_BY_HOST,
+    parse_cigna_medical_a_z,
+)
+
+# Sample of real Cigna A-Z markup (titles + relative PDF hrefs).
+CIGNA_SAMPLE_HTML = """
+<html><body>
+<a href="/assets/chcp/pdf/coveragePolicies/medical/cpg024_acupuncture.pdf">
+  Acupuncture - (CPG024)
+</a>
+<a href="/assets/chcp/pdf/coveragePolicies/medical/mm_0540_ablation.pdf">Ablative Treatment for Malignant Breast Tumor - (0540)</a>
+<a href="/assets/chcp/pdf/coveragePolicies/medical/mm_0070_allergy.pdf">Allergy Testing and Non-Pharmacologic Treatment - (0070)</a>
+<a href="#anchor">Top of page</a>
+<a href="/help.html">Contact us</a>
+</body></html>
+"""
+
+
+class CignaParserTests(TestCase):
+    def test_parses_pdf_links_only(self):
+        entries = parse_cigna_medical_a_z(CIGNA_SAMPLE_HTML)
+        self.assertEqual(len(entries), 3)
+
+    def test_resolves_relative_urls_against_static_cigna_com(self):
+        entries = parse_cigna_medical_a_z(CIGNA_SAMPLE_HTML)
+        for e in entries:
+            self.assertTrue(e.url.startswith("https://static.cigna.com/"))
+
+    def test_extracts_payer_policy_id_from_title_suffix(self):
+        entries = parse_cigna_medical_a_z(CIGNA_SAMPLE_HTML)
+        ids = {e.payer_policy_id for e in entries}
+        self.assertIn("CPG024", ids)
+        self.assertIn("0540", ids)
+
+    def test_strips_id_suffix_from_displayed_title(self):
+        entries = parse_cigna_medical_a_z(CIGNA_SAMPLE_HTML)
+        titles = [e.title for e in entries]
+        self.assertIn("Acupuncture", titles)
+        for t in titles:
+            self.assertFalse(
+                t.endswith(")"), f"Title still has trailing id suffix: {t}"
+            )
+
+    def test_dedupes_repeated_links(self):
+        html = CIGNA_SAMPLE_HTML + CIGNA_SAMPLE_HTML
+        self.assertEqual(len(parse_cigna_medical_a_z(html)), 3)
+
+    def test_registered_under_static_cigna_com_host(self):
+        self.assertIn("static.cigna.com", PARSERS_BY_HOST)
+        self.assertIs(PARSERS_BY_HOST["static.cigna.com"], parse_cigna_medical_a_z)
+
+
+class KeywordTermsTests(TestCase):
+    def test_extracts_alphanumeric_tokens_of_length_4_plus(self):
+        terms = _keyword_terms("Acupuncture treatment")
+        self.assertIn("acupuncture", terms)
+        self.assertIn("treatment", terms)
+
+    def test_keeps_short_medical_abbreviations(self):
+        terms = _keyword_terms("MRI of knee")
+        self.assertIn("mri", terms)
+
+    def test_drops_short_common_words(self):
+        terms = _keyword_terms("the for and")
+        self.assertEqual(terms, [])
+
+    def test_dedupes_across_inputs(self):
+        terms = _keyword_terms("acupuncture", "Acupuncture please")
+        self.assertEqual(terms.count("acupuncture"), 1)
+
+    def test_handles_none_inputs(self):
+        self.assertEqual(_keyword_terms(None, None), [])
+
+    def test_splits_on_punctuation_not_just_whitespace(self):
+        # Regression: "MRI/PET-scan" should yield three tokens, not one.
+        terms = _keyword_terms("MRI/PET-scan of upper-back")
+        self.assertIn("mri", terms)
+        self.assertIn("pet", terms)
+        self.assertIn("scan", terms)
+        self.assertIn("upper", terms)
+
+
+class PolicyEntryQueryTests(TestCase):
+    def setUp(self):
+        self.cigna = InsuranceCompany.objects.create(
+            name="Cigna",
+            regex=r"cigna",
+            medical_policy_url="https://static.cigna.com/medical_a-z.html",
+            medical_policy_url_is_static_index=True,
+            medical_policy_name="Coverage Policies",
+            is_major_commercial_payer=True,
+        )
+        self.aetna = InsuranceCompany.objects.create(
+            name="Aetna",
+            regex=r"aetna",
+            medical_policy_url="https://www.aetna.com/cpbs",
+            medical_policy_url_is_static_index=False,
+            medical_policy_name="Clinical Policy Bulletins",
+            is_major_commercial_payer=True,
+        )
+        self.cigna_acupuncture = PayerPolicyEntry.objects.create(
+            insurance_company=self.cigna,
+            title="Acupuncture",
+            url="https://static.cigna.com/acupuncture.pdf",
+            payer_policy_id="CPG024",
+        )
+        self.cigna_mri = PayerPolicyEntry.objects.create(
+            insurance_company=self.cigna,
+            title="MRI of the Knee",
+            url="https://static.cigna.com/mri-knee.pdf",
+            payer_policy_id="0540",
+        )
+        # Aetna intentionally has no entries -- search-only portal.
+
+    def test_returns_empty_when_no_keywords(self):
+        self.assertEqual(get_relevant_policy_entries(None, None), [])
+        self.assertEqual(get_relevant_policy_entries("", ""), [])
+
+    def test_matches_procedure_keyword(self):
+        out = get_relevant_policy_entries("Acupuncture", None)
+        self.assertEqual([e.url for e in out], [self.cigna_acupuncture.url])
+
+    def test_matches_short_abbreviation_keyword(self):
+        out = get_relevant_policy_entries("MRI of knee", None)
+        self.assertIn(self.cigna_mri, out)
+
+    def test_filters_to_specific_company(self):
+        out = get_relevant_policy_entries("Acupuncture", None, company_id=self.aetna.id)
+        self.assertEqual(out, [])
+
+    def test_excludes_company_for_comparative(self):
+        out = get_relevant_policy_entries(
+            "Acupuncture", None, exclude_company_id=self.cigna.id
+        )
+        self.assertEqual(out, [])
+
+
+class PayerPolicyContextTests(TestCase):
+    def setUp(self):
+        self.cigna = InsuranceCompany.objects.create(
+            name="Cigna",
+            regex=r"cigna",
+            medical_policy_url="https://static.cigna.com/medical_a-z.html",
+            medical_policy_url_is_static_index=True,
+            medical_policy_name="Coverage Policies",
+            is_major_commercial_payer=True,
+        )
+        self.aetna = InsuranceCompany.objects.create(
+            name="Aetna",
+            regex=r"aetna",
+            medical_policy_url="https://www.aetna.com/cpbs",
+            medical_policy_url_is_static_index=False,
+            medical_policy_name="Clinical Policy Bulletins",
+            is_major_commercial_payer=True,
+        )
+        self.tiny = InsuranceCompany.objects.create(
+            name="Tiny Co-op",
+            regex=r"tiny",
+        )
+        PayerPolicyEntry.objects.create(
+            insurance_company=self.cigna,
+            title="Acupuncture",
+            url="https://static.cigna.com/acupuncture.pdf",
+            payer_policy_id="CPG024",
+        )
+
+    def test_format_company_block_returns_none_when_no_policy(self):
+        self.assertIsNone(_format_company_block(self.tiny))
+
+    def test_format_company_block_static_url_rendered_plainly(self):
+        block = _format_company_block(self.cigna)
+        assert block is not None
+        self.assertIn("(https://static.cigna.com/medical_a-z.html)", block)
+        self.assertNotIn("interactive search", block)
+
+    def test_format_company_block_interactive_url_marked(self):
+        block = _format_company_block(self.aetna)
+        assert block is not None
+        self.assertIn("interactive search", block)
+
+    def test_own_policy_empty_when_company_none(self):
+        self.assertEqual(get_payer_policy_context(None), "")
+
+    def test_own_policy_surfaces_matched_entry_when_procedure_matches(self):
+        ctx = get_payer_policy_context(self.cigna, procedure="Acupuncture")
+        self.assertIn("Matched policies", ctx)
+        self.assertIn("Acupuncture", ctx)
+        self.assertIn("https://static.cigna.com/acupuncture.pdf", ctx)
+        self.assertIn(WITH_ENTRIES_GUARD, ctx)
+
+    def test_own_policy_falls_back_to_no_entries_guard_when_no_match(self):
+        ctx = get_payer_policy_context(self.cigna, procedure="Surgery")
+        self.assertNotIn("Matched policies", ctx)
+        self.assertIn(NO_ENTRIES_GUARD, ctx)
+
+    def test_comparative_includes_caveat(self):
+        ctx = get_comparative_payer_policy_context()
+        self.assertIn(COMPARATIVE_PAYER_CAVEAT, ctx)
+
+    def test_comparative_excludes_specified_company(self):
+        ctx = get_comparative_payer_policy_context(exclude_company_id=self.cigna.id)
+        self.assertNotIn("**Cigna**", ctx)
+        self.assertIn("**Aetna**", ctx)
+
+    def test_comparative_surfaces_matched_entries(self):
+        ctx = get_comparative_payer_policy_context(procedure="Acupuncture")
+        self.assertIn("Specific matched policies", ctx)
+        self.assertIn("https://static.cigna.com/acupuncture.pdf", ctx)
+        self.assertIn(WITH_ENTRIES_GUARD, ctx)
+
+    def test_comparative_uses_no_entries_guard_when_no_match(self):
+        # Acupuncture matches Cigna; excluding Cigna leaves zero matches.
+        ctx = get_comparative_payer_policy_context(
+            procedure="Acupuncture",
+            exclude_company_id=self.cigna.id,
+        )
+        self.assertNotIn("Specific matched policies", ctx)
+        self.assertIn(NO_ENTRIES_GUARD, ctx)
+
+    def test_comparative_drops_matched_entries_outside_listed_payers(self):
+        # Add a third payer (Sentinel) with a matching policy entry. With
+        # max_payers=1, only Aetna (alphabetic + major) is listed -- so
+        # Sentinel's matched entry must NOT leak into the matched-entries
+        # block, even though it would otherwise match.
+        sentinel = InsuranceCompany.objects.create(
+            name="Sentinel Out-Of-Scope",
+            regex=r"sentinel",
+            medical_policy_url="https://example.com/sentinel",
+            medical_policy_url_is_static_index=True,
+            medical_policy_name="Coverage Policies",
+            is_major_commercial_payer=True,
+        )
+        PayerPolicyEntry.objects.create(
+            insurance_company=sentinel,
+            title="Acupuncture",
+            url="https://example.com/sentinel-acupuncture.pdf",
+        )
+        ctx = get_comparative_payer_policy_context(
+            procedure="Acupuncture", max_payers=1
+        )
+        self.assertIn("**Aetna**", ctx)
+        self.assertNotIn("**Sentinel Out-Of-Scope**", ctx)
+        self.assertNotIn("sentinel-acupuncture.pdf", ctx)
+
+    def test_comparative_includes_payer_with_only_url(self):
+        # Regression for the AND/OR queryset bug: a payer with only a URL
+        # (or only a name) should still show up.
+        InsuranceCompany.objects.create(
+            name="UrlOnly Health",
+            regex=r"urlonly",
+            medical_policy_url="https://example.com/regional",
+            medical_policy_name="",
+        )
+        InsuranceCompany.objects.create(
+            name="NameOnly Health",
+            regex=r"nameonly",
+            medical_policy_url="",
+            medical_policy_name="Medical Policies",
+        )
+        ctx = get_comparative_payer_policy_context(max_payers=10)
+        self.assertIn("**UrlOnly Health**", ctx)
+        self.assertIn("**NameOnly Health**", ctx)
+
+    def test_comparative_prefers_major_commercial_payers(self):
+        # Wipe setUp companies so the assertion isolates the major-vs-not
+        # ordering from any alphabetical neighbours.
+        InsuranceCompany.objects.all().delete()
+        InsuranceCompany.objects.create(
+            name="Aaardvark Regional BCBS",
+            regex=r"aaardvark",
+            medical_policy_url="https://example.com/regional",
+            medical_policy_name="Medical Policies",
+            is_major_commercial_payer=False,
+        )
+        InsuranceCompany.objects.create(
+            name="Zenith National",
+            regex=r"zenith",
+            medical_policy_url="https://example.com/zenith",
+            medical_policy_name="Coverage Policies",
+            is_major_commercial_payer=True,
+        )
+        ctx = get_comparative_payer_policy_context(max_payers=1)
+        self.assertIn("**Zenith National**", ctx)
+        self.assertNotIn("**Aaardvark Regional BCBS**", ctx)
+
+    def test_combined_includes_both_sections_when_company_known(self):
+        ctx = get_combined_payer_policy_context(self.cigna)
+        self.assertIn("Payer's Public Medical Policy", ctx)
+        self.assertIn("Comparative Payer Medical Policies", ctx)
+        self.assertIn(COMPARATIVE_PAYER_CAVEAT, ctx)
+        comparative = ctx.split("Comparative Payer Medical Policies", 1)[1]
+        self.assertNotIn("**Cigna**", comparative)
+
+    def test_combined_can_skip_comparative_section(self):
+        ctx = get_combined_payer_policy_context(self.cigna, include_comparative=False)
+        self.assertIn("Cigna", ctx)
+        self.assertNotIn("Comparative Payer Medical Policies", ctx)
+
+
+class ResolveCompanyFromTextTests(TestCase):
+    def setUp(self):
+        self.aetna = InsuranceCompany.objects.create(
+            name="Aetna",
+            alt_names="Aetna Inc\nCVS Health Aetna",
+            regex=r"aetna",
+        )
+
+    def test_returns_none_for_blank(self):
+        self.assertIsNone(resolve_company_from_text(None))
+        self.assertIsNone(resolve_company_from_text(""))
+        self.assertIsNone(resolve_company_from_text("   "))
+
+    def test_exact_name_match_case_insensitive(self):
+        self.assertEqual(resolve_company_from_text("aetna"), self.aetna)
+        self.assertEqual(resolve_company_from_text("AETNA"), self.aetna)
+
+    def test_alt_name_match(self):
+        self.assertEqual(resolve_company_from_text("Aetna Inc"), self.aetna)
+        self.assertEqual(resolve_company_from_text("CVS Health Aetna"), self.aetna)
+
+    def test_no_match_returns_none(self):
+        self.assertIsNone(resolve_company_from_text("Some Made-up Insurer"))
+
+
+class FetcherIngestTests(TransactionTestCase):
+    """End-to-end ingest test with mocked HTTP. Verifies that running the
+    fetcher writes the parsed PayerPolicyEntry rows and that the helper
+    surfaces them via keyword match.
+
+    Uses TransactionTestCase because the fetcher runs DB writes inside an
+    asyncio loop via sync_to_async; under SQLite, the regular TestCase's
+    outer transaction would lock the connection from the inner sync call.
+    """
+
+    def setUp(self):
+        self.cigna = InsuranceCompany.objects.create(
+            name="Cigna",
+            regex=r"cigna",
+            medical_policy_url="https://static.cigna.com/medical_a-z.html",
+            medical_policy_url_is_static_index=True,
+            medical_policy_name="Coverage Policies",
+            is_major_commercial_payer=True,
+        )
+
+    def test_ingest_writes_entries_and_helper_finds_them(self):
+        async def run() -> int:
+            fetcher = PayerPolicyFetcher()
+            with patch.object(fetcher, "_get_text", return_value=CIGNA_SAMPLE_HTML):
+                return await fetcher.ingest_company(self.cigna)
+
+        count = asyncio.run(run())
+        self.assertEqual(count, 3)
+        self.assertEqual(
+            PayerPolicyEntry.objects.filter(insurance_company=self.cigna).count(),
+            3,
+        )
+        out = get_relevant_policy_entries("Acupuncture", None)
+        self.assertTrue(out)
+        self.assertIn("Acupuncture", out[0].title)
+        self.assertTrue(out[0].url.startswith("https://static.cigna.com/"))
+
+    def test_re_ingest_replaces_old_entries(self):
+        # Pre-populate one stale entry that's no longer in the source.
+        PayerPolicyEntry.objects.create(
+            insurance_company=self.cigna,
+            title="Stale Removed Policy",
+            url="https://static.cigna.com/stale.pdf",
+        )
+
+        async def run() -> None:
+            fetcher = PayerPolicyFetcher()
+            with patch.object(fetcher, "_get_text", return_value=CIGNA_SAMPLE_HTML):
+                await fetcher.ingest_company(self.cigna)
+
+        asyncio.run(run())
+        self.assertFalse(
+            PayerPolicyEntry.objects.filter(
+                insurance_company=self.cigna,
+                title="Stale Removed Policy",
+            ).exists()
+        )
+
+    def test_ingest_company_raises_when_no_parser_for_host(self):
+        # An InsuranceCompany pointing at a host with no registered parser
+        # must surface as a failed ingest, not a silent zero-entry success.
+        unsupported = InsuranceCompany.objects.create(
+            name="Unsupported Payer",
+            regex=r"unsupported",
+            medical_policy_url="https://example.invalid/policies.html",
+            medical_policy_url_is_static_index=True,
+            medical_policy_name="Coverage Policies",
+        )
+
+        async def run() -> None:
+            fetcher = PayerPolicyFetcher()
+            await fetcher.ingest_company(unsupported)
+
+        with self.assertRaises(LookupError):
+            asyncio.run(run())
+
+    def test_ingest_all_counts_unsupported_host_as_failed(self):
+        InsuranceCompany.objects.create(
+            name="Unsupported Payer",
+            regex=r"unsupported",
+            medical_policy_url="https://example.invalid/policies.html",
+            medical_policy_url_is_static_index=True,
+            medical_policy_name="Coverage Policies",
+        )
+
+        async def run() -> dict:
+            fetcher = PayerPolicyFetcher()
+            with patch.object(fetcher, "_get_text", return_value=CIGNA_SAMPLE_HTML):
+                return await fetcher.ingest_all()
+
+        stats = asyncio.run(run())
+        # Cigna ingests successfully; the unsupported host bumps `failed`.
+        self.assertEqual(stats["fetched"], 1)
+        self.assertEqual(stats["failed"], 1)
+
+
+class MakeOpenPromptPayerPolicyTests(TestCase):
+    """Test that make_open_prompt accepts and renders the payer-policy context."""
+
+    def test_make_open_prompt_includes_payer_policy_context(self):
+        from fighthealthinsurance.generate_appeal import AppealGenerator
+
+        generator = AppealGenerator()
+        sentinel = "## Comparative Payer Medical Policies\n(test block)"
+
+        prompt = generator.make_open_prompt(
+            denial_text="Your claim was denied.",
+            procedure="MRI",
+            diagnosis="Back pain",
+            insurance_company="Aetna",
+            payer_policy_context=sentinel,
+        )
+
+        assert prompt is not None
+        self.assertIn(sentinel, prompt)
+        self.assertIn("plan documents", prompt)
+
+    def test_make_open_prompt_omits_payer_policy_when_blank(self):
+        from fighthealthinsurance.generate_appeal import AppealGenerator
+
+        generator = AppealGenerator()
+        prompt = generator.make_open_prompt(
+            denial_text="Your claim was denied.",
+            procedure="MRI",
+            diagnosis="Back pain",
+            insurance_company="Aetna",
+            payer_policy_context="",
+        )
+        assert prompt is not None
+        self.assertNotIn("Comparative Payer Medical Policies", prompt)


### PR DESCRIPTION
## Summary
This PR adds support for including major commercial payers' public medical policies as comparative evidence in generated insurance appeals. The system now tracks payer medical-policy information (URLs, names, and descriptions) and generates contextual blocks that can be appended to appeal prompts to strengthen arguments by showing how other recognized insurers treat services as medically necessary.

## Key Changes

- **New module `payer_policy_helper.py`**: Provides four main functions:
  - `get_payer_policy_context()`: Returns context about the user's own denying payer's public medical-policy framework
  - `get_comparative_payer_policy_context()`: Builds a block listing major commercial payers' policies as comparative industry evidence (orders by `is_major_commercial_payer` so nationally recognized carriers surface ahead of regional BCBS affiliates)
  - `get_combined_payer_policy_context()`: Convenience wrapper combining both sections
  - `resolve_company_from_text()`: Best-effort lookup of an `InsuranceCompany` from the legacy `Denial.insurance_company` text field, used to back-fill when the structured object is null so the denying payer is excluded from the comparative section
  - All output reminds the model that only the **policy index name/URL/notes** are retrieved — not the underlying policy text — and instructs it not to invent, paraphrase, or assert specific medical-necessity criteria from documents that haven't been read

- **Database schema updates**:
  - Added four new fields to `InsuranceCompany`: `medical_policy_url`, `medical_policy_name`, `medical_policy_notes`, `is_major_commercial_payer`
  - Added `has_public_medical_policy` property
  - Migrations `0160_insurancecompany_medical_policy.py` and `0161_insurancecompany_is_major_commercial_payer.py`

- **Insurance company fixture**: Populated medical-policy metadata for 12 major US commercial carriers — Aetna, UnitedHealthcare, Cigna, Anthem (BCBS), Humana, Kaiser Permanente (all flagged `is_major_commercial_payer=true`), plus Highmark, Blue Shield of California, Florida Blue, Blue Cross Blue Shield of Texas / Michigan / Massachusetts. (Medicaid managed-care plans and Medicare Advantage carriers without public commercial-style medical policies are intentionally not populated; their coverage rules are driven primarily by CMS/state.)

- **Bootstrap wiring**: `scripts/start-server.sh` and the `setup_local_db` management command now `loaddata insurance_companies` so fresh environments actually have the policy metadata available.

- **Integration with appeal generation**:
  - `AppealGenerator.make_open_prompt()` and `make_appeals()` accept an optional `payer_policy_context` kwarg
  - `make_appeals()` auto-builds context from `denial.insurance_company_obj` (or back-fills via `resolve_company_from_text` for legacy denials) when the caller doesn't supply one
  - Prompt includes safety guardrails so the model frames the comparative section correctly and defers to the patient's actual plan documents

- **Admin interface**: Added "Public Medical Policy" fieldset to `InsuranceCompanyAdmin`

- **Tests**: 42 sync tests covering helper functions, ordering, the legacy-text resolver, edge cases (missing policies, excluded companies, max payer limits), and integration with appeal generation

## Implementation Details

- Helper functions are defensive: database errors during appeal generation gracefully degrade to "no comparative context" rather than failing the appeal
- A standard `COMPARATIVE_PAYER_CAVEAT` is always emitted with the comparative section, reminding readers that other payers' policies do not bind the patient's specific plan
- The user's own payer is excluded from the comparative section to avoid redundancy
- Default `max_payers=4` for the comparative block

https://claude.ai/code/session_01JNXkmwTzv2pk427FTyoXwT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Insurance companies now track medical policy URLs and metadata; system automatically fetches and indexes payer policy documents.
  * Appeal generation now includes relevant payer medical policy context to strengthen appeal arguments.

* **Chores**
  * Updated database schema to store medical policy information for insurance carriers.
  * Enhanced startup process to load company policy data and initiate indexing.
  * Populated fixture data for major insurance providers with policy metadata.

* **Tests**
  * Added comprehensive test coverage for policy parsing, querying, and context generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->