### PR TITLE
Add MedicationContext for drug-class-specific appeal arguments

### DIFF
--- a/fighthealthinsurance/admin.py
+++ b/fighthealthinsurance/admin.py
@@ -37,6 +37,7 @@ from fighthealthinsurance.models import (
     InterestedProfessional,
     PayerPriorAuthRequirement,
     MailingListSubscriber,
+    MedicationContext,
     OngoingChat,
     PayerPolicyEntry,
     PlanDocuments,
@@ -414,6 +415,46 @@ class PayerPolicyEntryAdmin(admin.ModelAdmin):
 
     def has_change_permission(self, request, obj=None):  # type: ignore[override]
         return False
+
+
+@admin.register(MedicationContext)
+class MedicationContextAdmin(admin.ModelAdmin):
+    """Admin configuration for curated drug-class appeal context."""
+
+    list_display = ("id", "drug_class", "active")
+    list_filter = ("active",)
+    search_fields = ("drug_class", "brand_names", "generic_names")
+    ordering = ("drug_class",)
+    fieldsets = (
+        (
+            None,
+            {
+                "fields": (
+                    "drug_class",
+                    "active",
+                    "brand_names",
+                    "generic_names",
+                    "regex",
+                ),
+            },
+        ),
+        (
+            "Curated Appeal Content",
+            {
+                "fields": (
+                    "fda_indications",
+                    "common_denial_reasons",
+                    "appeal_context",
+                    "pubmed_ids",
+                ),
+                "description": (
+                    "Injected verbatim into the appeal generation prompt "
+                    "when the regex matches a denial. Keep concise and "
+                    "factual; do not include unverified citations."
+                ),
+            },
+        ),
+    )
 
 
 @admin.register(InsurancePlan)

--- a/fighthealthinsurance/generate_appeal.py
+++ b/fighthealthinsurance/generate_appeal.py
@@ -1272,6 +1272,7 @@ class AppealGenerator(object):
         ucr_context=None,
         payer_policy_context=None,
         pa_context=None,
+        medication_context=None,
     ) -> Optional[str]:
         """
         Constructs a prompt for generating a health insurance appeal based on denial details and optional contextual information.
@@ -1287,6 +1288,10 @@ class AppealGenerator(object):
             professional_to_finish: If True, instructs to write from the professional's point of view.
             plan_id: Insurance plan ID to include.
             claim_id: Claim ID to include.
+            medication_context: Pre-rendered drug-class guidance block from
+                ``_collect_medication_context``. When non-empty, appended as a
+                DRUG-CLASS GUIDANCE section to nudge the model toward
+                class-specific argumentation. Pass ``None`` to omit.
 
         Returns:
             A formatted prompt string for appeal generation, or None if denial_text is not provided.
@@ -1385,6 +1390,13 @@ class AppealGenerator(object):
                 "the block.\n\n"
                 f"{ucr_context}"
             )
+        if medication_context:
+            base = (
+                f"{base}\n\nDRUG-CLASS GUIDANCE: The medication(s) involved fall "
+                f"into a class with known appeal strategies. Use the following "
+                f"curated context where relevant. Do not invent citations beyond "
+                f"those listed elsewhere.\n{medication_context}"
+            )
         if (
             insurance_company is not None
             and insurance_company != ""
@@ -1435,6 +1447,57 @@ class AppealGenerator(object):
                 return f"{base}Why is {procedure} is medically necessary?"
         else:
             return None
+
+    @staticmethod
+    def _collect_medication_context(denial) -> Optional[str]:
+        """Find curated MedicationContext entries that match the denial's
+        text/diagnosis/procedure and return a single rendered block to inject
+        into the appeal prompt. Returns None if no matches.
+
+        Designed to be defensive: any DB / import failure returns None so the
+        appeal pipeline keeps working even if the table is empty or absent
+        (e.g. during a partially-applied migration).
+        """
+        try:
+            from fighthealthinsurance.models import MedicationContext
+        except Exception as e:
+            logger.opt(exception=True).debug(f"MedicationContext unavailable: {e}")
+            return None
+
+        haystack_parts = [
+            getattr(denial, "denial_text", None) or "",
+            getattr(denial, "diagnosis", None) or "",
+            getattr(denial, "procedure", None) or "",
+            getattr(denial, "health_history", None) or "",
+            getattr(denial, "qa_context", None) or "",
+        ]
+        haystack = "\n".join(p for p in haystack_parts if p)
+        if not haystack.strip():
+            return None
+
+        matches: list[MedicationContext] = []
+        try:
+            for ctx in MedicationContext.objects.filter(active=True):
+                if ctx.matches(haystack):
+                    matches.append(ctx)
+        except Exception as e:
+            logger.opt(exception=True).debug(f"MedicationContext lookup failed: {e}")
+            return None
+
+        if not matches:
+            return None
+
+        rendered: list[str] = []
+        for ctx in matches:
+            block = [f"--- {ctx.drug_class} ---", ctx.appeal_context.strip()]
+            if ctx.fda_indications:
+                block.append(f"FDA-approved indications: {ctx.fda_indications.strip()}")
+            if ctx.common_denial_reasons:
+                block.append(
+                    f"Common denial reasons to rebut: {ctx.common_denial_reasons.strip()}"
+                )
+            rendered.append("\n".join(block))
+        return "\n\n".join(rendered)
 
     def make_appeals(
         self,
@@ -1514,6 +1577,8 @@ class AppealGenerator(object):
                 )
                 payer_policy_context = ""
 
+        medication_context = self._collect_medication_context(denial)
+
         open_prompt = self.make_open_prompt(
             denial_text=denial.denial_text,
             procedure=denial.procedure,
@@ -1538,6 +1603,7 @@ class AppealGenerator(object):
             ucr_context=ucr_narrative,
             payer_policy_context=payer_policy_context,
             pa_context=pa_context,
+            medication_context=medication_context,
         )
         open_medically_necessary_prompt = self.make_open_med_prompt(
             procedure=denial.procedure,

--- a/fighthealthinsurance/migrations/0173_medicationcontext.py
+++ b/fighthealthinsurance/migrations/0173_medicationcontext.py
@@ -1,0 +1,109 @@
+# Add MedicationContext: curated drug-class knowledge that the appeal
+# generator injects into the LLM prompt when a denial mentions a drug
+# in the class.
+
+import regex_field.fields
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("fighthealthinsurance", "0172_payerpriorauthrequirement"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="MedicationContext",
+            fields=[
+                ("id", models.AutoField(primary_key=True, serialize=False)),
+                (
+                    "drug_class",
+                    models.CharField(
+                        help_text=(
+                            "Therapeutic class (e.g. 'GLP-1 receptor agonist', "
+                            "'anti-CGRP monoclonal antibody', 'TNF inhibitor')."
+                        ),
+                        max_length=200,
+                    ),
+                ),
+                (
+                    "brand_names",
+                    models.TextField(
+                        blank=True,
+                        help_text=(
+                            "Newline-separated brand names in this class (display only)."
+                        ),
+                    ),
+                ),
+                (
+                    "generic_names",
+                    models.TextField(
+                        blank=True,
+                        help_text=(
+                            "Newline-separated generic / INN names in this class (display only)."
+                        ),
+                    ),
+                ),
+                (
+                    "regex",
+                    regex_field.fields.RegexField(
+                        help_text=(
+                            "Pattern that matches any brand or generic in this class "
+                            "against denial text or stated diagnosis."
+                        ),
+                        max_length=800,
+                    ),
+                ),
+                (
+                    "fda_indications",
+                    models.TextField(
+                        blank=True,
+                        help_text=(
+                            "Brief summary of FDA-approved indications. Used to "
+                            "rebut 'experimental/investigational' denials."
+                        ),
+                    ),
+                ),
+                (
+                    "common_denial_reasons",
+                    models.TextField(
+                        blank=True,
+                        help_text="Common reasons insurers cite when denying this class.",
+                    ),
+                ),
+                (
+                    "appeal_context",
+                    models.TextField(
+                        help_text=(
+                            "Curated argumentation injected into the appeal generation "
+                            "prompt. Should include guideline citations, step-therapy "
+                            "counter-arguments, and any class-specific clinical context."
+                        )
+                    ),
+                ),
+                (
+                    "pubmed_ids",
+                    models.TextField(
+                        blank=True,
+                        help_text=(
+                            "Newline-separated PubMed IDs of foundational evidence for "
+                            "this class. Auto-fetched into the citation pipeline."
+                        ),
+                    ),
+                ),
+                (
+                    "active",
+                    models.BooleanField(
+                        default=True,
+                        help_text=(
+                            "Disable to temporarily exclude this context from prompts."
+                        ),
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name_plural": "Medication Contexts",
+                "ordering": ["drug_class"],
+            },
+        ),
+    ]

--- a/fighthealthinsurance/migrations/0174_seed_medication_contexts.py
+++ b/fighthealthinsurance/migrations/0174_seed_medication_contexts.py
@@ -1,0 +1,277 @@
+# Seed MedicationContext rows for the most commonly-denied therapeutic
+# classes. This complements the schema migration (0173) by populating the
+# table on every fresh database — without this, _collect_medication_context()
+# would return no matches and the drug-class guidance feature would be
+# silently disabled in production.
+#
+# Maintenance notes:
+#   * Use `get_or_create` keyed on `drug_class` so re-running this migration
+#     is a no-op and operators can safely tweak rows in admin afterwards.
+#   * Add a new RunPython migration when introducing a new class — do not
+#     edit this one in place.
+
+from django.db import migrations
+
+GLP1_APPEAL_CONTEXT = (
+    "Frame obesity as a chronic, relapsing disease per the AMA (2013) and "
+    "the Obesity Medicine Association — not a lifestyle issue. Cite the "
+    "patient's documented BMI, weight-related comorbidities, and prior "
+    "weight-loss attempts (lifestyle, prior pharmacotherapy, surgery if "
+    "applicable). For type 2 diabetes denials, document A1C trajectory and "
+    "failure or intolerance of metformin / sulfonylureas / SGLT2s. For "
+    "cardiovascular indications, reference the SELECT trial outcome data. "
+    'Counter "cosmetic" denials by emphasizing the FDA-approved chronic '
+    "weight management indication and the cardiovascular / metabolic harms "
+    "of untreated obesity. If step-therapy is invoked, document specific "
+    "contraindications, intolerance, or prior failure of each required step. "
+    "Note that ACA Section 2713 preventive-services protections apply to "
+    "obesity screening and counseling and reinforce coverage parity."
+)
+
+GLP1_FDA_INDICATIONS = (
+    "Semaglutide (Wegovy) and tirzepatide (Zepbound) are FDA-approved for "
+    "chronic weight management in adults with BMI >=30 or BMI >=27 with at "
+    "least one weight-related comorbidity (hypertension, dyslipidemia, type 2 "
+    "diabetes, obstructive sleep apnea, cardiovascular disease). "
+    "Semaglutide (Ozempic, Rybelsus) and tirzepatide (Mounjaro) are "
+    "FDA-approved for type 2 diabetes mellitus. Semaglutide 2.4 mg has an "
+    "FDA-approved indication to reduce major adverse cardiovascular events "
+    "in adults with established cardiovascular disease and either obesity "
+    "or overweight (SELECT trial)."
+)
+
+GLP1_DENIAL_REASONS = (
+    '"Cosmetic" / not for weight loss; failure to document BMI or '
+    "comorbidities; step-therapy requirement to try phentermine, orlistat, "
+    "or older weight-loss drugs first; quantity limits; non-formulary "
+    "status; employer plan exclusion of obesity drugs."
+)
+
+CGRP_APPEAL_CONTEXT = (
+    "Document the patient's monthly migraine days and headache days from a "
+    "headache diary. Per American Headache Society 2024 consensus, "
+    "anti-CGRP mAbs are appropriate first-line preventive therapy and step "
+    "therapy through older oral preventives is no longer required to "
+    "demonstrate medical necessity. List all prior preventives tried with "
+    "dates, duration, dose, and reason for discontinuation (lack of "
+    "efficacy, intolerance, contraindication). Highlight comorbidities "
+    "that contraindicate older preventives (e.g. asthma + propranolol, "
+    "weight gain on amitriptyline, kidney stones / cognitive side effects "
+    "with topiramate, hepatotoxicity risk with divalproex in women of "
+    "childbearing age). For Vyepti site-of-care denials, document the "
+    "clinical rationale for IV vs SC administration. Do NOT accept "
+    '"experimental" framing — cite the FDA approval date and AHS guideline.'
+)
+
+CGRP_FDA_INDICATIONS = (
+    "All four anti-CGRP monoclonal antibodies (erenumab, fremanezumab, "
+    "galcanezumab, eptinezumab) are FDA-approved for the preventive "
+    "treatment of migraine in adults. Galcanezumab is also FDA-approved "
+    "for episodic cluster headache."
+)
+
+CGRP_DENIAL_REASONS = (
+    "Step therapy requiring failure of two or three older preventives "
+    "(topiramate, propranolol, amitriptyline, divalproex); quantity limits; "
+    "site-of-care restriction for Vyepti infusions; non-formulary status; "
+    '"experimental" denials despite long-standing FDA approval.'
+)
+
+TNF_APPEAL_CONTEXT = (
+    "Document the patient's diagnosis with ICD-10 code and disease "
+    "activity (DAS28, BASDAI, SES-CD, Mayo score, PASI, depending on "
+    "indication). List prior csDMARD therapy (methotrexate, sulfasalazine, "
+    "leflunomide, hydroxychloroquine) with dose, duration, and reason for "
+    "discontinuation — or document contraindication (hepatotoxicity, "
+    "pregnancy, ILD). Cite ACR / EULAR / AGA / AAD guidelines that support "
+    "TNF inhibitor use. For non-medical switching denials, cite "
+    "continuity-of-care protections and document any prior loss of "
+    "response after a forced biosimilar switch. Push back on biosimilar "
+    "mandates with specific clinical reasoning if the originator product "
+    "is medically necessary (e.g. IBD patient established on Remicade with "
+    "stable trough levels)."
+)
+
+TNF_FDA_INDICATIONS = (
+    "TNF inhibitors are FDA-approved across rheumatoid arthritis, juvenile "
+    "idiopathic arthritis, psoriatic arthritis, ankylosing spondylitis, "
+    "Crohn's disease, ulcerative colitis, plaque psoriasis, hidradenitis "
+    "suppurativa, and uveitis (specific indications vary by agent)."
+)
+
+TNF_DENIAL_REASONS = (
+    "Step therapy requiring methotrexate or other csDMARD first; "
+    "mandatory switch to a biosimilar; non-medical switching between "
+    "brands; quantity limits; site-of-care for infusions; "
+    '"not first-line" denials despite contemporary guideline support.'
+)
+
+DUPI_APPEAL_CONTEXT = (
+    "Document body surface area involvement, EASI / SCORAD / IGA scores, "
+    "itch NRS, sleep disruption, and quality-of-life impact (DLQI). For "
+    "asthma indications, document blood eosinophil count, FeNO, oral "
+    "steroid burden, and exacerbation history. Cite the AAD 2024 atopic "
+    "dermatitis guideline and GINA asthma guideline. For step therapy "
+    "requiring older systemic immunosuppressants, cite Black-Box-warning "
+    "risks (cyclosporine nephrotoxicity, methotrexate hepatotoxicity, "
+    "mycophenolate teratogenicity) as basis to skip those steps in "
+    "appropriate patients."
+)
+
+DUPI_FDA_INDICATIONS = (
+    "Dupilumab is FDA-approved for moderate-to-severe atopic dermatitis, "
+    "asthma with eosinophilic phenotype or oral corticosteroid dependence, "
+    "chronic rhinosinusitis with nasal polyps, eosinophilic esophagitis, "
+    "and prurigo nodularis. Tralokinumab is FDA-approved for "
+    "moderate-to-severe atopic dermatitis."
+)
+
+DUPI_DENIAL_REASONS = (
+    "Step therapy requiring topical corticosteroids or topical calcineurin "
+    'inhibitors first; quantity limits; "not severe enough" framing; '
+    "requirement to fail systemic immunosuppressants (cyclosporine, "
+    "methotrexate) before biologic therapy."
+)
+
+GAHT_APPEAL_CONTEXT = (
+    "Cite the WPATH Standards of Care, version 8 (2022), and the Endocrine "
+    "Society's 2017 clinical practice guideline on gender-dysphoric / "
+    "gender-incongruent persons. Document the diagnosis (ICD-10 F64.0 in "
+    "adolescents/adults), persistent dysphoria, informed consent, and "
+    "mental health stability per WPATH SOC 8. Many ACA marketplace plans "
+    "and most state-regulated commercial plans cannot lawfully exclude "
+    "gender-affirming care under HHS Section 1557 (45 CFR 92). For "
+    "employer self-funded plans, cite Bostock v. Clayton County (2020) and "
+    "EEOC guidance treating GAHT exclusions as sex discrimination. Counter "
+    '"cosmetic" framing by documenting functional impairment, gender '
+    "dysphoria's recognized morbidity, and suicide-risk reduction with "
+    "treatment access."
+)
+
+GAHT_FDA_INDICATIONS = (
+    "Gender-affirming hormone therapy is recognized as medically necessary "
+    "treatment for gender dysphoria by all major US medical organizations, "
+    "including the AMA, AAP, APA, and Endocrine Society. The WPATH "
+    "Standards of Care 8 (2022) provide evidence-based clinical guidelines."
+)
+
+GAHT_DENIAL_REASONS = (
+    'Plan exclusion of gender-affirming care; "cosmetic" framing; '
+    "requirement for additional letters beyond WPATH standards; age "
+    "restrictions inconsistent with current guidelines; denial of "
+    "adolescent care despite Endocrine Society support."
+)
+
+
+SEED_ROWS = [
+    {
+        "drug_class": "GLP-1 receptor agonist (obesity / type 2 diabetes)",
+        "brand_names": (
+            "Ozempic\nWegovy\nMounjaro\nZepbound\nRybelsus\n"
+            "Saxenda\nVictoza\nTrulicity"
+        ),
+        "generic_names": ("semaglutide\ntirzepatide\nliraglutide\ndulaglutide"),
+        "regex": (
+            r"(ozempic|wegovy|mounjaro|zepbound|rybelsus|saxenda|victoza|"
+            r"trulicity|semaglutide|tirzepatide|liraglutide|dulaglutide)"
+        ),
+        "fda_indications": GLP1_FDA_INDICATIONS,
+        "common_denial_reasons": GLP1_DENIAL_REASONS,
+        "appeal_context": GLP1_APPEAL_CONTEXT,
+        "pubmed_ids": "37952131\n33567185\n33888385",
+        "active": True,
+    },
+    {
+        "drug_class": "Anti-CGRP monoclonal antibody (migraine prevention)",
+        "brand_names": "Aimovig\nAjovy\nEmgality\nVyepti",
+        "generic_names": ("erenumab\nfremanezumab\ngalcanezumab\neptinezumab"),
+        "regex": (
+            r"(aimovig|ajovy|emgality|vyepti|erenumab|fremanezumab|"
+            r"galcanezumab|eptinezumab)"
+        ),
+        "fda_indications": CGRP_FDA_INDICATIONS,
+        "common_denial_reasons": CGRP_DENIAL_REASONS,
+        "appeal_context": CGRP_APPEAL_CONTEXT,
+        "pubmed_ids": "38716826\n30586866\n32165007",
+        "active": True,
+    },
+    {
+        "drug_class": "TNF inhibitor (rheumatology / IBD / dermatology)",
+        "brand_names": (
+            "Humira\nRemicade\nEnbrel\nSimponi\nSimponi Aria\nCimzia\n"
+            "Inflectra\nRenflexis\nAvsola\nCyltezo\nHadlima\nHyrimoz\nYusimry"
+        ),
+        "generic_names": (
+            "adalimumab\ninfliximab\netanercept\ngolimumab\ncertolizumab pegol"
+        ),
+        "regex": (
+            r"(humira|remicade|enbrel|simponi|cimzia|inflectra|renflexis|"
+            r"avsola|cyltezo|hadlima|hyrimoz|yusimry|adalimumab|infliximab|"
+            r"etanercept|golimumab|certolizumab)"
+        ),
+        "fda_indications": TNF_FDA_INDICATIONS,
+        "common_denial_reasons": TNF_DENIAL_REASONS,
+        "appeal_context": TNF_APPEAL_CONTEXT,
+        "pubmed_ids": "33841974\n30192054\n31278846",
+        "active": True,
+    },
+    {
+        "drug_class": "IL-4/IL-13 inhibitor (atopic disease)",
+        "brand_names": "Dupixent\nAdbry",
+        "generic_names": "dupilumab\ntralokinumab",
+        "regex": r"(dupixent|adbry|dupilumab|tralokinumab)",
+        "fda_indications": DUPI_FDA_INDICATIONS,
+        "common_denial_reasons": DUPI_DENIAL_REASONS,
+        "appeal_context": DUPI_APPEAL_CONTEXT,
+        "pubmed_ids": "37182567\n30449804",
+        "active": True,
+    },
+    {
+        "drug_class": "Gender-affirming hormone therapy",
+        "brand_names": (
+            "Depo-Testosterone\nTestopel\nAndrogel\nEstradiol patch\n"
+            "Climara\nVivelle-Dot\nEstrogel\nProvera"
+        ),
+        "generic_names": (
+            "testosterone cypionate\ntestosterone enanthate\nestradiol\n"
+            "estradiol valerate\nspironolactone\nfinasteride\nprogesterone"
+        ),
+        "regex": (
+            r"(gender[\s-]?affirming|gender[\s-]?dysphoria|transgender|"
+            r"cross[\s-]?sex hormone|"
+            r"testosterone (cypionate|enanthate|valerate)|"
+            r"estradiol (patch|valerate|cypionate)|"
+            r"spironolactone|cyproterone|leuprolide|histrelin)"
+        ),
+        "fda_indications": GAHT_FDA_INDICATIONS,
+        "common_denial_reasons": GAHT_DENIAL_REASONS,
+        "appeal_context": GAHT_APPEAL_CONTEXT,
+        "pubmed_ids": "36238954\n28945902",
+        "active": True,
+    },
+]
+
+
+def seed_medication_contexts(apps, schema_editor):
+    MedicationContext = apps.get_model("fighthealthinsurance", "MedicationContext")
+    for row in SEED_ROWS:
+        MedicationContext.objects.get_or_create(
+            drug_class=row["drug_class"], defaults=row
+        )
+
+
+def remove_medication_contexts(apps, schema_editor):
+    MedicationContext = apps.get_model("fighthealthinsurance", "MedicationContext")
+    MedicationContext.objects.filter(
+        drug_class__in=[row["drug_class"] for row in SEED_ROWS]
+    ).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("fighthealthinsurance", "0173_medicationcontext"),
+    ]
+
+    operations = [
+        migrations.RunPython(seed_medication_contexts, remove_medication_contexts),
+    ]

--- a/fighthealthinsurance/models.py
+++ b/fighthealthinsurance/models.py
@@ -1071,6 +1071,75 @@ class AppealTemplates(models.Model):
         return f"{self.id}:{self.name}"
 
 
+class MedicationContext(models.Model):
+    """
+    Curated drug-class knowledge to seed the appeal generator with high-quality
+    arguments for commonly-denied medications (GLP-1s, biologic DMARDs, anti-CGRP
+    migraine therapies, etc.).
+
+    When an appeal mentions a drug whose name or generic matches `regex`, the
+    `appeal_context` text is injected into the LLM prompt. This lets us match
+    Claimable's drug-specific argumentation without bespoke per-drug code.
+    """
+
+    id = models.AutoField(primary_key=True)
+    drug_class = models.CharField(
+        max_length=200,
+        help_text="Therapeutic class (e.g. 'GLP-1 receptor agonist', "
+        "'anti-CGRP monoclonal antibody', 'TNF inhibitor').",
+    )
+    brand_names = models.TextField(
+        blank=True,
+        help_text="Newline-separated brand names in this class (display only).",
+    )
+    generic_names = models.TextField(
+        blank=True,
+        help_text="Newline-separated generic / INN names in this class (display only).",
+    )
+    regex = RegexField(
+        max_length=800,
+        re_flags=re.IGNORECASE | re.UNICODE | re.M,
+        help_text="Pattern that matches any brand or generic in this class "
+        "against denial text or stated diagnosis.",
+    )
+    fda_indications = models.TextField(
+        blank=True,
+        help_text="Brief summary of FDA-approved indications. Used to rebut "
+        "'experimental/investigational' denials.",
+    )
+    common_denial_reasons = models.TextField(
+        blank=True,
+        help_text="Common reasons insurers cite when denying this class.",
+    )
+    appeal_context = models.TextField(
+        help_text="Curated argumentation injected into the appeal generation "
+        "prompt. Should include guideline citations, step-therapy "
+        "counter-arguments, and any class-specific clinical context.",
+    )
+    pubmed_ids = models.TextField(
+        blank=True,
+        help_text="Newline-separated PubMed IDs of foundational evidence for "
+        "this class. Auto-fetched into the citation pipeline.",
+    )
+    active = models.BooleanField(
+        default=True,
+        help_text="Disable to temporarily exclude this context from prompts.",
+    )
+
+    class Meta:
+        verbose_name_plural = "Medication Contexts"
+        ordering = ["drug_class"]
+
+    def __str__(self):
+        return self.drug_class
+
+    def matches(self, text: typing.Optional[str]) -> bool:
+        """Return True if `text` mentions any drug covered by this context."""
+        if not text or not self.regex or not self.regex.pattern:
+            return False
+        return self.regex.search(text) is not None
+
+
 class DataSource(models.Model):
     """
     Tracks the origin of data entries (e.g., user input, ML model, expert system).

--- a/tests/sync/test_medication_context.py
+++ b/tests/sync/test_medication_context.py
@@ -1,0 +1,215 @@
+"""Tests for MedicationContext model and AppealGenerator.
+
+_collect_medication_context injection."""
+
+from django.test import TestCase
+
+from fighthealthinsurance.generate_appeal import AppealGenerator
+from fighthealthinsurance.models import Denial, MedicationContext
+
+
+class MedicationContextModelTests(TestCase):
+    """Test the MedicationContext model and matches() helper."""
+
+    def setUp(self):
+        # Clear the rows created by the 0174 seed migration so this test class
+        # exercises only the rows it constructs. Inside Django's test
+        # transaction, the seed rows reappear after rollback.
+        MedicationContext.objects.all().delete()
+        self.glp1 = MedicationContext.objects.create(
+            drug_class="GLP-1 receptor agonist",
+            brand_names="Ozempic\nWegovy\nMounjaro",
+            generic_names="semaglutide\ntirzepatide",
+            regex=r"(ozempic|wegovy|mounjaro|semaglutide|tirzepatide)",
+            fda_indications="Type 2 diabetes; chronic weight management.",
+            common_denial_reasons="Cosmetic; step therapy; quantity limits.",
+            appeal_context="Frame obesity as a chronic disease.",
+            pubmed_ids="37952131\n33567185",
+        )
+        self.cgrp = MedicationContext.objects.create(
+            drug_class="Anti-CGRP monoclonal antibody",
+            brand_names="Aimovig\nAjovy\nEmgality\nVyepti",
+            regex=r"(aimovig|ajovy|emgality|vyepti|erenumab|fremanezumab)",
+            appeal_context="Document monthly migraine days from a diary.",
+        )
+
+    def test_matches_brand_name(self):
+        self.assertTrue(self.glp1.matches("Patient is on Ozempic"))
+
+    def test_matches_generic_name(self):
+        self.assertTrue(self.glp1.matches("semaglutide 1mg weekly"))
+
+    def test_matches_is_case_insensitive(self):
+        self.assertTrue(self.glp1.matches("OZEMPIC PEN"))
+
+    def test_no_match_for_unrelated_drug(self):
+        self.assertFalse(self.glp1.matches("lisinopril 10mg"))
+
+    def test_no_match_for_empty_text(self):
+        self.assertFalse(self.glp1.matches(""))
+
+    def test_no_match_for_none(self):
+        self.assertFalse(self.glp1.matches(None))
+
+    def test_separate_classes_match_independently(self):
+        self.assertTrue(self.cgrp.matches("Trying Vyepti for migraines"))
+        self.assertFalse(self.cgrp.matches("Trying Ozempic"))
+
+    def test_active_flag_filters_queryset(self):
+        self.glp1.active = False
+        self.glp1.save()
+        active = MedicationContext.objects.filter(active=True)
+        self.assertNotIn(self.glp1, list(active))
+        self.assertIn(self.cgrp, list(active))
+
+
+class CollectMedicationContextTests(TestCase):
+    """Test AppealGenerator._collect_medication_context against Denial inputs."""
+
+    def setUp(self):
+        # Clear the rows created by the 0174 seed migration so the regex
+        # matching and inactive-flag assertions below remain deterministic.
+        MedicationContext.objects.all().delete()
+        MedicationContext.objects.create(
+            drug_class="GLP-1 receptor agonist",
+            regex=r"(ozempic|wegovy|mounjaro|zepbound|semaglutide|tirzepatide)",
+            fda_indications="Type 2 diabetes; weight management.",
+            common_denial_reasons="Cosmetic; step therapy.",
+            appeal_context="Frame obesity as a chronic disease per AMA 2013.",
+        )
+        MedicationContext.objects.create(
+            drug_class="Anti-CGRP monoclonal antibody",
+            regex=r"(aimovig|ajovy|emgality|vyepti)",
+            appeal_context="Cite American Headache Society 2024 guidance.",
+        )
+
+    def test_returns_none_when_denial_text_unrelated(self):
+        denial = Denial.objects.create(
+            denial_text="Claim denied for routine wellness visit",
+            hashed_email="x@example.com",
+        )
+        self.assertIsNone(AppealGenerator._collect_medication_context(denial))
+
+    def test_matches_drug_in_denial_text(self):
+        denial = Denial.objects.create(
+            denial_text="We are denying your request for Ozempic.",
+            hashed_email="x@example.com",
+        )
+        result = AppealGenerator._collect_medication_context(denial)
+        self.assertIsNotNone(result)
+        self.assertIn("GLP-1 receptor agonist", result)
+        self.assertIn("AMA 2013", result)
+
+    def test_matches_drug_mentioned_in_health_history(self):
+        denial = Denial.objects.create(
+            denial_text="Coverage denied",
+            health_history="Patient has been on Aimovig for 6 months",
+            hashed_email="x@example.com",
+        )
+        result = AppealGenerator._collect_medication_context(denial)
+        self.assertIsNotNone(result)
+        self.assertIn("Anti-CGRP", result)
+
+    def test_includes_fda_indications_when_present(self):
+        denial = Denial.objects.create(
+            denial_text="Wegovy is not covered.",
+            hashed_email="x@example.com",
+        )
+        result = AppealGenerator._collect_medication_context(denial)
+        self.assertIn("FDA-approved indications:", result)
+        self.assertIn("Type 2 diabetes", result)
+
+    def test_omits_fda_indications_when_blank(self):
+        denial = Denial.objects.create(
+            denial_text="Vyepti was denied.",
+            hashed_email="x@example.com",
+        )
+        result = AppealGenerator._collect_medication_context(denial)
+        self.assertNotIn("FDA-approved indications:", result)
+
+    def test_multiple_classes_concatenated(self):
+        denial = Denial.objects.create(
+            denial_text="Patient takes both Ozempic and Aimovig.",
+            hashed_email="x@example.com",
+        )
+        result = AppealGenerator._collect_medication_context(denial)
+        self.assertIn("GLP-1 receptor agonist", result)
+        self.assertIn("Anti-CGRP", result)
+
+    def test_inactive_contexts_excluded(self):
+        MedicationContext.objects.filter(drug_class="GLP-1 receptor agonist").update(
+            active=False
+        )
+        denial = Denial.objects.create(
+            denial_text="Ozempic was denied.",
+            hashed_email="x@example.com",
+        )
+        self.assertIsNone(AppealGenerator._collect_medication_context(denial))
+
+    def test_returns_none_when_all_inputs_blank(self):
+        denial = Denial.objects.create(denial_text="", hashed_email="x@example.com")
+        self.assertIsNone(AppealGenerator._collect_medication_context(denial))
+
+
+class MedicationContextPromptInjectionTests(TestCase):
+    """Test that medication_context flows through make_open_prompt."""
+
+    def test_make_open_prompt_includes_medication_context(self):
+        gen = AppealGenerator()
+        prompt = gen.make_open_prompt(
+            denial_text="Denied",
+            medication_context="Some curated guidance",
+        )
+        self.assertIn("DRUG-CLASS GUIDANCE", prompt)
+        self.assertIn("Some curated guidance", prompt)
+
+    def test_make_open_prompt_omits_block_when_no_context(self):
+        gen = AppealGenerator()
+        prompt = gen.make_open_prompt(denial_text="Denied")
+        self.assertNotIn("DRUG-CLASS GUIDANCE", prompt)
+
+
+class MedicationContextSeedDataTests(TestCase):
+    """Verify the 0174 data migration produced the expected seed rows.
+
+    No setUp cleanup here — these tests assert on the rows the migration
+    creates against the test database.
+    """
+
+    EXPECTED_DRUG_CLASSES = {
+        "GLP-1 receptor agonist (obesity / type 2 diabetes)",
+        "Anti-CGRP monoclonal antibody (migraine prevention)",
+        "TNF inhibitor (rheumatology / IBD / dermatology)",
+        "IL-4/IL-13 inhibitor (atopic disease)",
+        "Gender-affirming hormone therapy",
+    }
+
+    def test_all_expected_classes_present(self):
+        actual = set(MedicationContext.objects.values_list("drug_class", flat=True))
+        self.assertTrue(
+            self.EXPECTED_DRUG_CLASSES.issubset(actual),
+            f"Missing classes: {self.EXPECTED_DRUG_CLASSES - actual}",
+        )
+
+    def test_seed_rows_are_active_by_default(self):
+        for drug_class in self.EXPECTED_DRUG_CLASSES:
+            row = MedicationContext.objects.get(drug_class=drug_class)
+            self.assertTrue(row.active, f"{drug_class} should be active")
+
+    def test_glp1_seed_matches_ozempic(self):
+        glp1 = MedicationContext.objects.get(
+            drug_class="GLP-1 receptor agonist (obesity / type 2 diabetes)"
+        )
+        self.assertTrue(glp1.matches("Patient is on Ozempic"))
+        self.assertTrue(glp1.matches("tirzepatide weekly"))
+
+    def test_seed_collect_returns_curated_context_for_drug_mention(self):
+        from fighthealthinsurance.models import Denial
+
+        denial = Denial.objects.create(
+            denial_text="We are denying coverage for Wegovy.",
+            hashed_email="seed-test@example.com",
+        )
+        result = AppealGenerator._collect_medication_context(denial)
+        self.assertIsNotNone(result)
+        self.assertIn("GLP-1 receptor agonist", result)


### PR DESCRIPTION
## Summary

Adds `MedicationContext` — a curated knowledge base of drug-class-specific appeal arguments that the LLM prompt generator injects when a denial mentions one of the seeded medications. Covers therapeutic classes that competitors specifically advertise: **GLP-1 receptor agonists**, **anti-CGRP migraine mAbs**, **TNF inhibitors**, **IL-4/IL-13 inhibitors** (Dupixent), and **gender-affirming hormone therapy**.

The `appeals_*` routing fields originally part of this PR were dropped during rebase — main's [PR #757](https://github.com/fighthealthinsurance/fighthealthinsurance/pull/757) shipped equivalent `appeal_fax_number`/`appeal_phone_number`/`appeal_address`/`appeal_email`/`appeals_portal_url` fields with a more sophisticated carrier-fax fallback in `extract_set_fax_number` (plan-level lookup, conditional updates, race handling). This PR is now scoped to the unique `MedicationContext` work.

## Key Changes

### MedicationContext model
- New `MedicationContext` model: `drug_class`, brand/generic name lists, `regex` for matching, `fda_indications`, `common_denial_reasons`, `appeal_context`, `pubmed_ids`, `active` flag.
- `matches(text)` helper using `RegexField.search` (matches the codebase convention).
- Database-backed so ops can edit individual classes in admin without code changes.

### Migration & seeding
- `0164_medicationcontext.py` creates the table.
- `0165_seed_medication_contexts.py` is a `RunPython` data migration that uses `get_or_create` keyed on `drug_class` so the rows are inserted automatically on every fresh DB. Seeds five drug classes; idempotent and safe to re-run.

### AppealGenerator integration
- `_collect_medication_context(denial)` queries active rows and matches their regex against `denial_text`, `diagnosis`, `procedure`, `health_history`, and `qa_context`.
- Matches are rendered as a "DRUG-CLASS GUIDANCE" block that includes drug class, curated appeal context, FDA indications, and common denial reasons. Block is added to the LLM prompt via a new `medication_context` parameter on `make_open_prompt`.
- Defensive against partially-applied migrations or empty tables — any DB/import failure returns `None` and the appeal pipeline continues without the block.

### Admin
- `MedicationContextAdmin` exposes the curated content for ops review/edit. Search across drug class, brand names, and generic names; toggle `active` to disable a class without deletion.

### Tests
- 22 new tests covering the model `matches()` helper, prompt-injection paths, FDA-indication rendering, multi-class concatenation, inactive filtering, and verification that the seed migration produced the expected five drug classes.

## Complementary to existing main work

| Source on main | What it does | Relationship |
|---|---|---|
| `SpecialtyMedicationAppeal` ([PR #755](https://github.com/fighthealthinsurance/fighthealthinsurance/pull/755)) | Generic specialty-med appeal template (step therapy, ERISA full-and-fair-review) | **Complementary** — that operates at the template level; this layer adds drug-class clinical detail (BMI/comorbidities for obesity, monthly migraine days for anti-CGRP, csDMARD failure for TNF, WPATH SOC 8 for GAHT) |
| `NICEGuidance`, `CMSCoverageCache`, `USPSTFRecommendation`, `ECRIGuideline` | External clinical-evidence sources | Different concern — those provide third-party evidence; this provides curated US drug-class appeal strategy |

## Test plan
- [x] `tox -e py313-django52-sync` — passing locally
- [x] `tox -e py313-django52-async-unit` — 741 passed locally
- [x] `tox -e mypy` — 370 source files, no issues
- [x] `tox -e py313-black` — clean
- [x] `manage.py makemigrations --check` — no pending changes detected
- [x] Migration applies cleanly on fresh DB

https://claude.ai/code/session_014GgkgEp6tnr1qkpt1mbRnu