### PR TITLE
Add structured PubMed search with evidence categorization

### DIFF
--- a/fighthealthinsurance/pubmed_search.py
+++ b/fighthealthinsurance/pubmed_search.py
@@ -149,6 +149,24 @@ def _quote_phrase(term: str) -> str:
     return cleaned
 
 
+_YEAR_RE = re.compile(r"^\d{4}$")
+
+
+def _validated_year(value: Any) -> Optional[str]:
+    """Return ``value`` coerced to a 4-digit year string, or ``None``.
+
+    PubMed's ``[dp]`` filter silently low-recalls on garbage input ("recent",
+    "this year", "20-25"), so anything that isn't a literal four-digit year
+    is dropped. Accepts ``int`` (``2020``) as well as ``str``.
+    """
+    if value is None:
+        return None
+    s = str(value).strip()
+    if _YEAR_RE.match(s):
+        return s
+    return None
+
+
 @dataclass
 class StructuredQuery:
     """A composed PubMed query plus the components that produced it.
@@ -194,10 +212,12 @@ def build_structured_query(
         mesh_terms: MeSH terms to require (joined with ``AND``). Each is
             tagged ``[mh]`` so PubMed treats it as a controlled-vocabulary
             lookup rather than free-text.
-        since_year: Earliest publication year to include (inclusive). Renders
+        since_year: Earliest publication year to include (inclusive),
+            validated against ``^\\d{4}$``. Anything else (including blank
+            strings, words, or partial dates) is silently dropped. Renders
             as a PubMed date-range filter ``"YYYY"[dp] : "YYYY"[dp]``.
-        until_year: Latest publication year (defaults to current year when
-            ``since_year`` is set).
+        until_year: Latest publication year, same validation rule. Defaults
+            to the current year when only ``since_year`` is set.
         extra_terms: Free-text terms to append (e.g., microsite-specific
             keywords). Joined with ``AND``.
 
@@ -248,8 +268,10 @@ def build_structured_query(
 
     # PubMed's [dp] range needs both ends, so synthesize whichever bound the
     # caller didn't supply (1900 as a no-op lower bound, current year as upper).
-    since_clean = _sanitize_term(str(since_year)) if since_year else None
-    until_clean = _sanitize_term(str(until_year)) if until_year else None
+    # Non-year garbage is silently dropped so a typo doesn't quietly crater
+    # recall.
+    since_clean = _validated_year(since_year)
+    until_clean = _validated_year(until_year)
     if since_clean or until_clean:
         lower = since_clean or "1900"
         upper = until_clean or str(datetime.now().year)

--- a/fighthealthinsurance/pubmed_search.py
+++ b/fighthealthinsurance/pubmed_search.py
@@ -282,9 +282,16 @@ def extract_publication_types(article: Any) -> List[str]:
         if isinstance(value, dict):
             value = list(value.values())
         if isinstance(value, str):
-            return [value]
+            stripped = value.strip()
+            if stripped:
+                return [stripped]
+            continue
         if isinstance(value, (list, tuple, set)):
-            return [str(v) for v in value if v]
+            cleaned = [str(v) for v in value if v]
+            if cleaned:
+                return cleaned
+            # Fall through so an empty list on this attr doesn't shadow a
+            # populated fallback attr (providers vary in which field they fill).
     return []
 
 

--- a/fighthealthinsurance/pubmed_search.py
+++ b/fighthealthinsurance/pubmed_search.py
@@ -211,7 +211,6 @@ def build_structured_query(
     elif treatment_clean:
         parts.append(treatment_clean)
 
-    # MeSH terms are joined with AND so each one constrains results.
     mesh_clean: List[str] = []
     if mesh_terms:
         for term in mesh_terms:
@@ -220,14 +219,12 @@ def build_structured_query(
                 mesh_clean.append(sanitized)
                 parts.append(f'"{sanitized}"[mh]')
 
-    # Free-text "extra" terms (microsite keywords, etc.).
     if extra_terms:
         for term in extra_terms:
             quoted = _quote_phrase(term)
             if quoted:
                 parts.append(quoted)
 
-    # Combine pub-type preset + explicit filters into a single OR group.
     resolved_filters: List[str] = []
     if pub_type_preset:
         for key in PUB_TYPE_PRESETS.get(pub_type_preset, ()):
@@ -242,19 +239,14 @@ def build_structured_query(
         filter_tokens = [PUB_TYPE_FILTERS[k] for k in resolved_filters]
         parts.append("(" + " OR ".join(filter_tokens) + ")")
 
-    # Date-range filter. PubMed wants both ends, so synthesize an upper bound
-    # from the current year if only `since_year` is supplied.
-    since_clean: Optional[str] = None
-    until_clean: Optional[str] = None
-    if since_year:
-        since_clean = _sanitize_term(str(since_year))
-    if until_year:
-        until_clean = _sanitize_term(str(until_year))
-    if since_clean:
+    # PubMed's [dp] range needs both ends, so synthesize whichever bound the
+    # caller didn't supply (1900 as a no-op lower bound, current year as upper).
+    since_clean = _sanitize_term(str(since_year)) if since_year else None
+    until_clean = _sanitize_term(str(until_year)) if until_year else None
+    if since_clean or until_clean:
+        lower = since_clean or "1900"
         upper = until_clean or str(datetime.now().year)
-        parts.append(f'("{since_clean}"[dp] : "{upper}"[dp])')
-    elif until_clean:
-        parts.append(f'("1900"[dp] : "{until_clean}"[dp])')
+        parts.append(f'("{lower}"[dp] : "{upper}"[dp])')
 
     query_str = " AND ".join(parts)
 
@@ -357,8 +349,6 @@ def categorize_articles_by_strength(
     return buckets
 
 
-# How many sentences of the abstract to include in an appeal-friendly snippet.
-# Short enough to be quotable in a letter; long enough to convey the finding.
 SNIPPET_SENTENCE_COUNT = 3
 SNIPPET_MAX_CHARS = 600
 
@@ -369,6 +359,14 @@ def _split_sentences(text: str) -> List[str]:
         return []
     parts = re.split(r"(?<=[.!?])\s+", text.strip())
     return [p for p in parts if p]
+
+
+def _str_attr(obj: Any, name: str) -> str:
+    """Read an attribute and coerce ``None`` / non-strings to a stripped string."""
+    value = getattr(obj, name, "")
+    if value is None:
+        return ""
+    return str(value).strip()
 
 
 def format_appeal_snippet(
@@ -386,28 +384,17 @@ def format_appeal_snippet(
     Prefers ``basic_summary`` (already condensed) over the raw abstract.
     Truncates to ``max_chars`` so a snippet stays quotable in a letter.
     """
-    title = (getattr(article, "title", "") or "").strip()
-    journal = (getattr(article, "journal", "") or "").strip()
-    year = getattr(article, "year", "") or ""
-    if year is None:
-        year = ""
-    year = str(year).strip()
-    pmid = (getattr(article, "pmid", "") or "").strip()
-    url = (getattr(article, "article_url", "") or "").strip()
-    summary = (
-        getattr(article, "basic_summary", None)
-        or getattr(article, "abstract", None)
-        or ""
-    ).strip()
+    title = _str_attr(article, "title")
+    journal = _str_attr(article, "journal")
+    year = _str_attr(article, "year")
+    pmid = _str_attr(article, "pmid")
+    url = _str_attr(article, "article_url")
+    summary = _str_attr(article, "basic_summary") or _str_attr(article, "abstract")
 
     citation_parts: List[str] = []
     if title:
         citation_parts.append(title)
-    venue: List[str] = []
-    if journal:
-        venue.append(journal)
-    if year:
-        venue.append(year)
+    venue = [v for v in (journal, year) if v]
     if venue:
         citation_parts.append("(" + ", ".join(venue) + ")")
     if pmid:
@@ -419,10 +406,7 @@ def format_appeal_snippet(
     excerpt = ""
     if summary:
         sentences = _split_sentences(summary)
-        if sentences:
-            excerpt = " ".join(sentences[:sentence_count]).strip()
-        if not excerpt:
-            excerpt = summary
+        excerpt = " ".join(sentences[:sentence_count]).strip() if sentences else summary
         if len(excerpt) > max_chars:
             excerpt = excerpt[: max_chars - 1].rstrip() + "…"
 

--- a/fighthealthinsurance/pubmed_search.py
+++ b/fighthealthinsurance/pubmed_search.py
@@ -1,0 +1,471 @@
+"""Structured PubMed search helpers.
+
+Pure functions for building PubMed query strings with structured filters
+(publication type, date range, MeSH), classifying evidence strength from
+publication types, and formatting articles into appeal-friendly snippets.
+
+Kept separate from `pubmed_tools.py` (which holds the I/O-heavy ``PubMedTools``
+class) so these helpers can be unit tested without database or network access.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple
+
+
+class EvidenceStrength(str, Enum):
+    """Evidence strength tiers used to categorize PubMed articles.
+
+    The string values are stable identifiers safe to expose in JSON/API
+    responses and template strings.
+    """
+
+    STRONG = "strong"
+    MODERATE = "moderate"
+    WEAK = "weak"
+    UNKNOWN = "unknown"
+
+
+# Publication types that constitute the strongest tier of medical evidence.
+# These are typically what insurers and reviewers find most persuasive in an
+# appeal: meta-analyses, systematic reviews, RCTs, and formal guidelines.
+STRONG_PUB_TYPES: Set[str] = {
+    "meta-analysis",
+    "systematic review",
+    "randomized controlled trial",
+    "practice guideline",
+    "guideline",
+    "clinical trial, phase iii",
+    "clinical trial, phase iv",
+    "consensus development conference",
+    "consensus development conference, nih",
+}
+
+# Moderate-strength evidence: useful but less authoritative than the strong
+# tier. Still worth including in appeals, especially for newer therapies that
+# lack large RCTs.
+MODERATE_PUB_TYPES: Set[str] = {
+    "clinical trial",
+    "clinical trial, phase i",
+    "clinical trial, phase ii",
+    "controlled clinical trial",
+    "multicenter study",
+    "comparative study",
+    "observational study",
+    "validation study",
+    "review",
+    "pragmatic clinical trial",
+    "equivalence trial",
+}
+
+# Weaker-but-relevant evidence. Case reports and editorials still get
+# surfaced, but bucketed separately so the appeal letter can lead with
+# stronger sources.
+WEAK_PUB_TYPES: Set[str] = {
+    "case reports",
+    "editorial",
+    "comment",
+    "letter",
+    "news",
+    "historical article",
+    "personal narrative",
+}
+
+
+# PubMed publication-type filter tokens. These map to PubMed's ``[pt]`` field
+# search and are documented at
+# https://www.ncbi.nlm.nih.gov/books/NBK3827/#pubmedhelp.Publication_Types_PT
+PUB_TYPE_FILTERS: Dict[str, str] = {
+    "meta_analysis": "Meta-Analysis[pt]",
+    "systematic_review": "Systematic Review[pt]",
+    "rct": "Randomized Controlled Trial[pt]",
+    "guideline": "Guideline[pt] OR Practice Guideline[pt]",
+    "clinical_trial": "Clinical Trial[pt]",
+    "review": "Review[pt]",
+}
+
+
+# Preset bundles for common appeal-relevant filter combinations. Each preset
+# expands to a set of publication-type filter tokens joined with ``OR``.
+PUB_TYPE_PRESETS: Dict[str, Sequence[str]] = {
+    "guidelines_and_systematic_reviews": (
+        "guideline",
+        "systematic_review",
+        "meta_analysis",
+    ),
+    "high_quality_evidence": (
+        "guideline",
+        "systematic_review",
+        "meta_analysis",
+        "rct",
+    ),
+    "any_evidence": (
+        "guideline",
+        "systematic_review",
+        "meta_analysis",
+        "rct",
+        "clinical_trial",
+        "review",
+    ),
+}
+
+
+# Characters that have meaning inside a PubMed query string. We escape them
+# (or strip them) when interpolating user-provided text into a query.
+_PUBMED_QUERY_RESERVED_RE = re.compile(r'[\[\]\(\)"]')
+
+
+def _sanitize_term(term: str) -> str:
+    """Strip control chars and PubMed-reserved punctuation from a search term.
+
+    Preserves spaces and basic ASCII letters/digits/hyphens so that multi-word
+    medical phrases ("rheumatoid arthritis", "anti-tnf") survive unchanged.
+    """
+    if not term:
+        return ""
+    cleaned = _PUBMED_QUERY_RESERVED_RE.sub(" ", term)
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    return cleaned
+
+
+def _quote_phrase(term: str) -> str:
+    """Wrap a multi-word term in double quotes for exact-phrase matching."""
+    cleaned = _sanitize_term(term)
+    if not cleaned:
+        return ""
+    if " " in cleaned:
+        return f'"{cleaned}"'
+    return cleaned
+
+
+@dataclass
+class StructuredQuery:
+    """A composed PubMed query plus the components that produced it.
+
+    Carrying the components alongside the final string lets callers report
+    "we searched for X with filters Y" in UI/logs without re-parsing.
+    """
+
+    query: str
+    condition: str = ""
+    treatment: str = ""
+    pub_type_filters: List[str] = field(default_factory=list)
+    mesh_terms: List[str] = field(default_factory=list)
+    since_year: Optional[str] = None
+    until_year: Optional[str] = None
+
+    def __str__(self) -> str:
+        return self.query
+
+
+def build_structured_query(
+    condition: Optional[str] = None,
+    treatment: Optional[str] = None,
+    pub_type_preset: Optional[str] = None,
+    pub_type_filters: Optional[Sequence[str]] = None,
+    mesh_terms: Optional[Sequence[str]] = None,
+    since_year: Optional[str] = None,
+    until_year: Optional[str] = None,
+    extra_terms: Optional[Sequence[str]] = None,
+) -> StructuredQuery:
+    """Build a structured PubMed query from condition + treatment + filters.
+
+    Args:
+        condition: The disease/diagnosis (e.g., "rheumatoid arthritis").
+            Multi-word phrases are quoted automatically.
+        treatment: The procedure/medication being appealed (e.g., "physical
+            therapy", "infliximab").
+        pub_type_preset: Name of a preset from ``PUB_TYPE_PRESETS`` (e.g.,
+            ``"guidelines_and_systematic_reviews"``). Mutually inclusive with
+            ``pub_type_filters`` — both are combined with ``OR``.
+        pub_type_filters: Explicit list of filter keys from
+            ``PUB_TYPE_FILTERS`` (e.g., ``["rct", "meta_analysis"]``).
+        mesh_terms: MeSH terms to require (joined with ``AND``). Each is
+            tagged ``[mh]`` so PubMed treats it as a controlled-vocabulary
+            lookup rather than free-text.
+        since_year: Earliest publication year to include (inclusive). Renders
+            as a PubMed date-range filter ``"YYYY"[dp] : "YYYY"[dp]``.
+        until_year: Latest publication year (defaults to current year when
+            ``since_year`` is set).
+        extra_terms: Free-text terms to append (e.g., microsite-specific
+            keywords). Joined with ``AND``.
+
+    Returns:
+        A ``StructuredQuery`` whose ``.query`` is the assembled PubMed string
+        ready for ``pmids_for_query``. If no inputs produce any tokens, the
+        ``.query`` will be an empty string.
+    """
+    parts: List[str] = []
+
+    condition_clean = _quote_phrase(condition or "")
+    treatment_clean = _quote_phrase(treatment or "")
+
+    if condition_clean and treatment_clean:
+        parts.append(f"({condition_clean} AND {treatment_clean})")
+    elif condition_clean:
+        parts.append(condition_clean)
+    elif treatment_clean:
+        parts.append(treatment_clean)
+
+    # MeSH terms are joined with AND so each one constrains results.
+    mesh_clean: List[str] = []
+    if mesh_terms:
+        for term in mesh_terms:
+            sanitized = _sanitize_term(term)
+            if sanitized:
+                mesh_clean.append(sanitized)
+                parts.append(f'"{sanitized}"[mh]')
+
+    # Free-text "extra" terms (microsite keywords, etc.).
+    if extra_terms:
+        for term in extra_terms:
+            quoted = _quote_phrase(term)
+            if quoted:
+                parts.append(quoted)
+
+    # Combine pub-type preset + explicit filters into a single OR group.
+    resolved_filters: List[str] = []
+    if pub_type_preset:
+        for key in PUB_TYPE_PRESETS.get(pub_type_preset, ()):
+            if key in PUB_TYPE_FILTERS:
+                resolved_filters.append(key)
+    if pub_type_filters:
+        for key in pub_type_filters:
+            if key in PUB_TYPE_FILTERS and key not in resolved_filters:
+                resolved_filters.append(key)
+
+    if resolved_filters:
+        filter_tokens = [PUB_TYPE_FILTERS[k] for k in resolved_filters]
+        parts.append("(" + " OR ".join(filter_tokens) + ")")
+
+    # Date-range filter. PubMed wants both ends, so synthesize an upper bound
+    # from the current year if only `since_year` is supplied.
+    since_clean: Optional[str] = None
+    until_clean: Optional[str] = None
+    if since_year:
+        since_clean = _sanitize_term(str(since_year))
+    if until_year:
+        until_clean = _sanitize_term(str(until_year))
+    if since_clean:
+        upper = until_clean or str(datetime.now().year)
+        parts.append(f'("{since_clean}"[dp] : "{upper}"[dp])')
+    elif until_clean:
+        parts.append(f'("1900"[dp] : "{until_clean}"[dp])')
+
+    query_str = " AND ".join(parts)
+
+    return StructuredQuery(
+        query=query_str,
+        condition=condition_clean,
+        treatment=treatment_clean,
+        pub_type_filters=resolved_filters,
+        mesh_terms=mesh_clean,
+        since_year=since_clean,
+        until_year=until_clean,
+    )
+
+
+def normalize_pub_type(pub_type: Any) -> str:
+    """Lowercase and trim a publication-type label for set-based comparison."""
+    if pub_type is None:
+        return ""
+    return str(pub_type).strip().lower()
+
+
+def extract_publication_types(article: Any) -> List[str]:
+    """Pull a list of publication-type strings off a metapub-like article.
+
+    Tries the common attribute names in order: ``publication_types``,
+    ``pubtype``, ``pub_types``. Accepts a list, a dict (uses its values), a
+    single string, or ``None``. Returns ``[]`` if nothing usable is found.
+    """
+    for attr in ("publication_types", "pubtype", "pub_types"):
+        value = getattr(article, attr, None)
+        if value is None:
+            continue
+        if isinstance(value, dict):
+            value = list(value.values())
+        if isinstance(value, str):
+            return [value]
+        if isinstance(value, (list, tuple, set)):
+            return [str(v) for v in value if v]
+    return []
+
+
+def classify_evidence_strength(pub_types: Iterable[str]) -> EvidenceStrength:
+    """Classify a publication-type list into an ``EvidenceStrength`` tier.
+
+    The strongest tier present wins: an article tagged both "Review" (moderate)
+    and "Meta-Analysis" (strong) classifies as STRONG. Empty/unknown types
+    yield ``EvidenceStrength.UNKNOWN`` so callers can decide whether to
+    surface them.
+    """
+    if not pub_types:
+        return EvidenceStrength.UNKNOWN
+
+    normalized = {normalize_pub_type(p) for p in pub_types if p}
+    if not normalized:
+        return EvidenceStrength.UNKNOWN
+
+    if normalized & STRONG_PUB_TYPES:
+        return EvidenceStrength.STRONG
+    if normalized & MODERATE_PUB_TYPES:
+        return EvidenceStrength.MODERATE
+    if normalized & WEAK_PUB_TYPES:
+        return EvidenceStrength.WEAK
+    return EvidenceStrength.UNKNOWN
+
+
+def categorize_articles_by_strength(
+    articles: Iterable[Any],
+    pub_types_lookup: Optional[Dict[str, List[str]]] = None,
+) -> Dict[EvidenceStrength, List[Any]]:
+    """Bucket articles by evidence strength.
+
+    Args:
+        articles: Iterable of article-like objects with a ``pmid`` attribute.
+        pub_types_lookup: Optional ``{pmid: [pub_type, ...]}`` mapping. When
+            provided, takes precedence over publication types read directly
+            off the article object. Useful when types were fetched separately
+            (e.g., via ``efetch``) rather than stored on the article.
+
+    Returns:
+        A dict keyed by ``EvidenceStrength`` whose values are the article
+        objects in their original order. All four tiers are always present
+        (possibly with empty lists) so callers can render consistent
+        "strong / moderate / weak / unknown" sections.
+    """
+    buckets: Dict[EvidenceStrength, List[Any]] = {
+        EvidenceStrength.STRONG: [],
+        EvidenceStrength.MODERATE: [],
+        EvidenceStrength.WEAK: [],
+        EvidenceStrength.UNKNOWN: [],
+    }
+    for article in articles:
+        pmid = getattr(article, "pmid", None)
+        types: List[str] = []
+        if pub_types_lookup and pmid and pmid in pub_types_lookup:
+            types = pub_types_lookup[pmid]
+        else:
+            types = extract_publication_types(article)
+        strength = classify_evidence_strength(types)
+        buckets[strength].append(article)
+    return buckets
+
+
+# How many sentences of the abstract to include in an appeal-friendly snippet.
+# Short enough to be quotable in a letter; long enough to convey the finding.
+SNIPPET_SENTENCE_COUNT = 3
+SNIPPET_MAX_CHARS = 600
+
+
+def _split_sentences(text: str) -> List[str]:
+    """Split a paragraph into sentence-like chunks."""
+    if not text:
+        return []
+    parts = re.split(r"(?<=[.!?])\s+", text.strip())
+    return [p for p in parts if p]
+
+
+def format_appeal_snippet(
+    article: Any,
+    sentence_count: int = SNIPPET_SENTENCE_COUNT,
+    max_chars: int = SNIPPET_MAX_CHARS,
+) -> str:
+    """Format an article as a short, appeal-letter-ready snippet.
+
+    The output is a single line of the form::
+
+        Title (Journal, Year). PMID: 12345 [URL]
+        Excerpt: <first N sentences of summary or abstract>
+
+    Prefers ``basic_summary`` (already condensed) over the raw abstract.
+    Truncates to ``max_chars`` so a snippet stays quotable in a letter.
+    """
+    title = (getattr(article, "title", "") or "").strip()
+    journal = (getattr(article, "journal", "") or "").strip()
+    year = getattr(article, "year", "") or ""
+    if year is None:
+        year = ""
+    year = str(year).strip()
+    pmid = (getattr(article, "pmid", "") or "").strip()
+    url = (getattr(article, "article_url", "") or "").strip()
+    summary = (
+        getattr(article, "basic_summary", None)
+        or getattr(article, "abstract", None)
+        or ""
+    ).strip()
+
+    citation_parts: List[str] = []
+    if title:
+        citation_parts.append(title)
+    venue: List[str] = []
+    if journal:
+        venue.append(journal)
+    if year:
+        venue.append(year)
+    if venue:
+        citation_parts.append("(" + ", ".join(venue) + ")")
+    if pmid:
+        citation_parts.append(f"PMID: {pmid}")
+    if url:
+        citation_parts.append(f"[{url}]")
+    citation = " ".join(citation_parts).strip()
+
+    excerpt = ""
+    if summary:
+        sentences = _split_sentences(summary)
+        if sentences:
+            excerpt = " ".join(sentences[:sentence_count]).strip()
+        if not excerpt:
+            excerpt = summary
+        if len(excerpt) > max_chars:
+            excerpt = excerpt[: max_chars - 1].rstrip() + "…"
+
+    if citation and excerpt:
+        return f"{citation}\nExcerpt: {excerpt}"
+    return citation or excerpt
+
+
+def format_categorized_snippets(
+    buckets: Dict[EvidenceStrength, List[Any]],
+    include_empty: bool = False,
+) -> str:
+    """Render evidence buckets as a multi-section markdown-ish text block.
+
+    Output looks like::
+
+        ## Strong evidence
+        - <snippet 1>
+        - <snippet 2>
+
+        ## Moderate evidence
+        - ...
+
+    Sections with no articles are omitted unless ``include_empty=True``.
+    """
+    section_titles: List[Tuple[EvidenceStrength, str]] = [
+        (EvidenceStrength.STRONG, "Strong evidence"),
+        (EvidenceStrength.MODERATE, "Moderate evidence"),
+        (EvidenceStrength.WEAK, "Weak but relevant evidence"),
+        (EvidenceStrength.UNKNOWN, "Other evidence"),
+    ]
+    sections: List[str] = []
+    for strength, title in section_titles:
+        articles = buckets.get(strength, [])
+        if not articles and not include_empty:
+            continue
+        lines = [f"## {title}"]
+        if not articles:
+            lines.append("(no articles)")
+        else:
+            for article in articles:
+                snippet = format_appeal_snippet(article)
+                if snippet:
+                    lines.append("- " + snippet.replace("\n", "\n  "))
+        sections.append("\n".join(lines))
+    return "\n\n".join(sections)

--- a/fighthealthinsurance/pubmed_search.py
+++ b/fighthealthinsurance/pubmed_search.py
@@ -114,20 +114,27 @@ PUB_TYPE_PRESETS: Dict[str, Sequence[str]] = {
 }
 
 
-# Characters that have meaning inside a PubMed query string. We escape them
-# (or strip them) when interpolating user-provided text into a query.
-_PUBMED_QUERY_RESERVED_RE = re.compile(r'[\[\]\(\)"]')
+# Drop bracketed/parenthesized segments as a whole (so user-supplied
+# `asthma[ti]` doesn't leave "ti" behind as an injected free-text token).
+# Stray closing or stranded delimiter chars are then stripped, and any
+# remaining double quotes — also reserved by PubMed — are removed.
+_PUBMED_BRACKETED_RE = re.compile(r"\[[^\]]*\]|\([^\)]*\)")
+_PUBMED_STRAY_DELIM_RE = re.compile(r'[\[\]\(\)"]')
 
 
 def _sanitize_term(term: str) -> str:
-    """Strip control chars and PubMed-reserved punctuation from a search term.
+    """Strip PubMed field-tag injection vectors and reserved punctuation.
 
-    Preserves spaces and basic ASCII letters/digits/hyphens so that multi-word
-    medical phrases ("rheumatoid arthritis", "anti-tnf") survive unchanged.
+    Removes bracketed/parenthesized segments as a unit so attempted field
+    tags like ``[ti]`` or ``[mh]`` don't leak their contents back into the
+    query as free-text tokens. Preserves spaces and basic ASCII
+    letters/digits/hyphens so multi-word medical phrases ("rheumatoid
+    arthritis", "anti-tnf") survive unchanged.
     """
     if not term:
         return ""
-    cleaned = _PUBMED_QUERY_RESERVED_RE.sub(" ", term)
+    cleaned = _PUBMED_BRACKETED_RE.sub(" ", term)
+    cleaned = _PUBMED_STRAY_DELIM_RE.sub(" ", cleaned)
     cleaned = re.sub(r"\s+", " ", cleaned).strip()
     return cleaned
 
@@ -180,8 +187,8 @@ def build_structured_query(
         treatment: The procedure/medication being appealed (e.g., "physical
             therapy", "infliximab").
         pub_type_preset: Name of a preset from ``PUB_TYPE_PRESETS`` (e.g.,
-            ``"guidelines_and_systematic_reviews"``). Mutually inclusive with
-            ``pub_type_filters`` — both are combined with ``OR``.
+            ``"guidelines_and_systematic_reviews"``). Not mutually exclusive
+            with ``pub_type_filters``; both are combined with ``OR``.
         pub_type_filters: Explicit list of filter keys from
             ``PUB_TYPE_FILTERS`` (e.g., ``["rct", "meta_analysis"]``).
         mesh_terms: MeSH terms to require (joined with ``AND``). Each is

--- a/fighthealthinsurance/pubmed_tools.py
+++ b/fighthealthinsurance/pubmed_tools.py
@@ -11,6 +11,7 @@ from urllib.parse import quote, urljoin
 import aiohttp
 import eutils
 import PyPDF2
+import xml.etree.ElementTree as ET
 from asgiref.sync import async_to_sync, sync_to_async
 from loguru import logger
 from metapub import FindIt
@@ -21,6 +22,12 @@ from fighthealthinsurance.models import (
     PubMedArticleSummarized,
     PubMedMiniArticle,
     PubMedQueryData,
+)
+from fighthealthinsurance.pubmed_search import (
+    EvidenceStrength,
+    build_structured_query,
+    categorize_articles_by_strength,
+    format_categorized_snippets,
 )
 from fighthealthinsurance.utils import pubmed_fetcher
 
@@ -40,6 +47,15 @@ PER_QUERY = 2
 _FETCH_HEADERS = {
     "User-Agent": "FightHealthInsurance/1.0 (mailto:support@fighthealthinsurance.com)",
     "Accept": "application/pdf,text/html,application/xhtml+xml,*/*",
+}
+
+# NCBI E-utilities REST API base URL. Used for elink (related articles) and
+# efetch (MeSH terms / publication types). NCBI requests that ``tool`` and
+# ``email`` be supplied per their usage guidelines.
+_EUTILS_BASE = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils"
+_EUTILS_PARAMS = {
+    "tool": "fighthealthinsurance",
+    "email": "support@fighthealthinsurance.com",
 }
 
 
@@ -369,6 +385,307 @@ class PubMedTools(object):
             )
             pass
         return pmids
+
+    async def fetch_mesh_and_pub_types(
+        self,
+        pmids: List[str],
+        session: Optional[aiohttp.ClientSession] = None,
+        timeout: float = 15.0,
+    ) -> Dict[str, Dict[str, List[str]]]:
+        """Fetch MeSH terms and publication types for a list of PMIDs via efetch.
+
+        Returns ``{pmid: {"mesh": [...], "pub_types": [...]}}``. Missing PMIDs
+        are simply absent from the result rather than raising. A network error
+        or parse failure yields ``{}`` so callers can degrade gracefully.
+
+        We hit ``efetch?rettype=xml`` once for the whole batch (PubMed accepts
+        a comma-separated PMID list) to keep the request count low.
+        """
+        if not pmids:
+            return {}
+
+        owns_session = session is None
+        if owns_session:
+            session = aiohttp.ClientSession(headers=_FETCH_HEADERS)
+        assert session is not None
+
+        result: Dict[str, Dict[str, List[str]]] = {}
+        try:
+            params = {
+                **_EUTILS_PARAMS,
+                "db": "pubmed",
+                "id": ",".join(pmids),
+                "rettype": "xml",
+                "retmode": "xml",
+            }
+            url = f"{_EUTILS_BASE}/efetch.fcgi"
+            async with async_timeout(timeout):
+                async with session.get(url, params=params) as resp:
+                    if resp.status != 200:
+                        logger.debug(f"efetch returned {resp.status} for pmids {pmids}")
+                        return result
+                    body = await resp.text()
+            try:
+                root = ET.fromstring(body)
+            except ET.ParseError as e:
+                logger.debug(f"Failed to parse efetch XML: {e}")
+                return result
+
+            for art in root.findall(".//PubmedArticle"):
+                pmid_el = art.find(".//PMID")
+                if pmid_el is None or not pmid_el.text:
+                    continue
+                pmid = pmid_el.text.strip()
+                mesh_terms = [
+                    descriptor.text.strip()
+                    for descriptor in art.findall(".//MeshHeading/DescriptorName")
+                    if descriptor.text
+                ]
+                pub_types = [
+                    pt.text.strip()
+                    for pt in art.findall(".//PublicationTypeList/PublicationType")
+                    if pt.text
+                ]
+                result[pmid] = {"mesh": mesh_terms, "pub_types": pub_types}
+        except (asyncio.TimeoutError, asyncio.CancelledError) as e:
+            logger.debug(f"Timeout/cancel in fetch_mesh_and_pub_types: {e}")
+        except Exception as e:
+            logger.opt(exception=True).debug(f"Error in fetch_mesh_and_pub_types: {e}")
+        finally:
+            if owns_session and session:
+                await session.close()
+        return result
+
+    async def find_related_pmids(
+        self,
+        pmid: str,
+        session: Optional[aiohttp.ClientSession] = None,
+        timeout: float = 15.0,
+        max_results: int = 10,
+    ) -> List[str]:
+        """Return PMIDs related to ``pmid`` via NCBI's elink ``pubmed_pubmed`` set.
+
+        Useful for query expansion when a user's free-text terms are too
+        narrow or use lay vocabulary. Returns at most ``max_results`` PMIDs
+        and excludes the input PMID itself.
+        """
+        if not pmid:
+            return []
+
+        owns_session = session is None
+        if owns_session:
+            session = aiohttp.ClientSession(headers=_FETCH_HEADERS)
+        assert session is not None
+
+        related: List[str] = []
+        try:
+            params = {
+                **_EUTILS_PARAMS,
+                "dbfrom": "pubmed",
+                "db": "pubmed",
+                "id": pmid,
+                "linkname": "pubmed_pubmed",
+                "retmode": "json",
+            }
+            url = f"{_EUTILS_BASE}/elink.fcgi"
+            async with async_timeout(timeout):
+                async with session.get(url, params=params) as resp:
+                    if resp.status != 200:
+                        return []
+                    data = await resp.json()
+            for linkset in data.get("linksets", []):
+                for linksetdb in linkset.get("linksetdbs", []):
+                    if linksetdb.get("linkname") != "pubmed_pubmed":
+                        continue
+                    for related_id in linksetdb.get("links", []):
+                        related_id_str = str(related_id)
+                        if related_id_str != pmid and related_id_str not in related:
+                            related.append(related_id_str)
+                        if len(related) >= max_results:
+                            return related
+        except (asyncio.TimeoutError, asyncio.CancelledError) as e:
+            logger.debug(f"Timeout/cancel in find_related_pmids({pmid}): {e}")
+        except Exception as e:
+            logger.opt(exception=True).debug(
+                f"Error in find_related_pmids({pmid}): {e}"
+            )
+        finally:
+            if owns_session and session:
+                await session.close()
+        return related
+
+    async def structured_search(
+        self,
+        condition: Optional[str] = None,
+        treatment: Optional[str] = None,
+        pub_type_preset: Optional[str] = None,
+        pub_type_filters: Optional[List[str]] = None,
+        mesh_terms: Optional[List[str]] = None,
+        since_year: Optional[str] = None,
+        until_year: Optional[str] = None,
+        extra_terms: Optional[List[str]] = None,
+        max_results: int = 20,
+        expand_with_related: bool = False,
+        timeout: float = 60.0,
+    ) -> Dict[EvidenceStrength, List[PubMedMiniArticle]]:
+        """Run a structured PubMed search and return articles bucketed by strength.
+
+        Builds a query from ``condition``/``treatment`` plus optional
+        publication-type filters, MeSH constraints, and a date range; runs
+        the search; fetches publication types in a single batched ``efetch``;
+        and categorizes the result into strong / moderate / weak / unknown
+        evidence tiers.
+
+        Args:
+            condition: Diagnosis or condition (e.g., "rheumatoid arthritis").
+            treatment: Procedure or medication (e.g., "infliximab").
+            pub_type_preset: Preset key from ``PUB_TYPE_PRESETS``
+                (e.g., "guidelines_and_systematic_reviews").
+            pub_type_filters: Explicit filter keys from ``PUB_TYPE_FILTERS``.
+            mesh_terms: MeSH descriptors to require (joined with AND).
+            since_year: Earliest publication year (defaults to no lower bound).
+            until_year: Latest publication year (defaults to current year
+                if ``since_year`` is set).
+            extra_terms: Additional free-text terms (e.g., microsite
+                keywords).
+            max_results: Cap on total PMIDs to materialize.
+            expand_with_related: When true and the initial search returns at
+                least one PMID, fetch related PMIDs via elink and add them to
+                the result set (useful when user vocabulary is too narrow).
+            timeout: Wall-clock timeout for the whole operation.
+
+        Returns:
+            A dict keyed by ``EvidenceStrength`` with ``PubMedMiniArticle``
+            lists in each bucket. All four tiers are always present.
+        """
+        empty_buckets: Dict[EvidenceStrength, List[PubMedMiniArticle]] = {
+            s: [] for s in EvidenceStrength
+        }
+        structured = build_structured_query(
+            condition=condition,
+            treatment=treatment,
+            pub_type_preset=pub_type_preset,
+            pub_type_filters=pub_type_filters,
+            mesh_terms=mesh_terms,
+            since_year=since_year,
+            until_year=until_year,
+            extra_terms=extra_terms,
+        )
+        if not structured.query:
+            return empty_buckets
+
+        try:
+            async with async_timeout(timeout):
+                # since_year is already encoded into the date filter inside
+                # the query string, so pass since=None here to avoid
+                # double-filtering with metapub's own ``since`` keyword.
+                pmids = await self.find_pubmed_article_ids_for_query(
+                    structured.query,
+                    since=None,
+                    timeout=timeout / 2,
+                )
+                pmids = [p for p in pmids if p][:max_results]
+
+                if expand_with_related and pmids:
+                    seed = pmids[0]
+                    related = await self.find_related_pmids(
+                        seed,
+                        timeout=timeout / 4,
+                        max_results=max_results,
+                    )
+                    for related_pmid in related:
+                        if related_pmid not in pmids and len(pmids) < max_results:
+                            pmids.append(related_pmid)
+
+                if not pmids:
+                    return empty_buckets
+
+                articles = await self._materialize_mini_articles(
+                    pmids, per_source_timeout=timeout / 12
+                )
+                pub_types_by_pmid = await self.fetch_mesh_and_pub_types(
+                    [a.pmid for a in articles],
+                    timeout=timeout / 4,
+                )
+                pub_types_lookup = {
+                    pmid: data.get("pub_types", [])
+                    for pmid, data in pub_types_by_pmid.items()
+                }
+                buckets = categorize_articles_by_strength(
+                    articles, pub_types_lookup=pub_types_lookup
+                )
+                # Ensure all tiers are present in the return value.
+                for tier in EvidenceStrength:
+                    buckets.setdefault(tier, [])
+                return buckets
+        except asyncio.TimeoutError:
+            logger.debug(f"Timeout in structured_search: {structured.query}")
+        except asyncio.CancelledError:
+            logger.debug(f"Cancelled in structured_search: {structured.query}")
+        except Exception as e:
+            logger.opt(exception=True).debug(f"Error in structured_search: {e}")
+        return empty_buckets
+
+    async def _materialize_mini_articles(
+        self,
+        pmids: List[str],
+        per_source_timeout: float = 5.0,
+    ) -> List[PubMedMiniArticle]:
+        """Resolve a PMID list into ``PubMedMiniArticle`` rows, fetching as needed.
+
+        Reuses cached rows when present; otherwise fetches metadata via
+        metapub and creates a new row. Skips PMIDs that fail to fetch.
+        """
+        articles: List[PubMedMiniArticle] = []
+        async with aiohttp.ClientSession(headers=_FETCH_HEADERS) as session:
+            for pmid in pmids:
+                cached = await PubMedMiniArticle.objects.filter(pmid=pmid).afirst()
+                if cached:
+                    articles.append(cached)
+                    continue
+                try:
+                    fetched = await sync_to_async(pubmed_fetcher.article_by_pmid)(pmid)
+                    if not fetched:
+                        continue
+                    doi = getattr(fetched, "doi", None)
+                    url = None
+                    try:
+                        url = await asyncio.wait_for(
+                            self._find_article_url(
+                                pmid,
+                                doi=doi,
+                                session=session,
+                                per_source_timeout=per_source_timeout,
+                            ),
+                            timeout=per_source_timeout * 2,
+                        )
+                    except Exception as e:
+                        logger.debug(f"URL discovery failed for {pmid}: {e}")
+                    title = (fetched.title or "").replace("\x00", "")
+                    abstract = (fetched.abstract or "").replace("\x00", "")
+                    article = await PubMedMiniArticle.objects.acreate(
+                        pmid=pmid,
+                        title=title,
+                        abstract=abstract,
+                        article_url=url,
+                    )
+                    articles.append(article)
+                except Exception as e:
+                    logger.debug(f"Failed to materialize {pmid}: {e}")
+        return articles
+
+    @staticmethod
+    def format_structured_search_for_appeal(
+        buckets: Dict[EvidenceStrength, List[Any]],
+        include_empty: bool = False,
+    ) -> str:
+        """Render structured-search buckets as appeal-letter markdown.
+
+        Thin wrapper around ``pubmed_search.format_categorized_snippets`` so
+        callers can stay within ``PubMedTools`` without importing the helper
+        module directly.
+        """
+        return format_categorized_snippets(buckets, include_empty=include_empty)
 
     async def find_pubmed_articles_for_denial(
         self, denial: Denial, timeout=70.0

--- a/fighthealthinsurance/pubmed_tools.py
+++ b/fighthealthinsurance/pubmed_tools.py
@@ -58,6 +58,10 @@ _EUTILS_PARAMS = {
     "email": "support@fighthealthinsurance.com",
 }
 
+# NCBI documents 200 IDs as the practical limit for an efetch GET; chunk to
+# stay well under URL-length caps regardless of caller-supplied list size.
+_EFETCH_BATCH_SIZE = 200
+
 
 @asynccontextmanager
 async def _ensure_session(
@@ -407,65 +411,81 @@ class PubMedTools(object):
         pmids: List[str],
         session: Optional[aiohttp.ClientSession] = None,
         timeout: float = 15.0,
+        batch_size: int = _EFETCH_BATCH_SIZE,
     ) -> Dict[str, Dict[str, List[str]]]:
         """Fetch MeSH terms and publication types for a list of PMIDs via efetch.
 
         Returns ``{pmid: {"mesh": [...], "pub_types": [...]}}``. Missing PMIDs
-        are simply absent from the result rather than raising. A network error
-        or parse failure yields ``{}`` so callers can degrade gracefully.
+        are simply absent from the result rather than raising. Network errors
+        and XML parse failures degrade to a partial (or empty) result.
+        ``CancelledError`` is re-raised so request cancellation propagates;
+        ``TimeoutError`` returns whatever was collected so far.
 
-        Hits ``efetch?rettype=xml`` once for the whole batch (PubMed accepts a
-        comma-separated PMID list) to keep the request count low.
+        Splits ``pmids`` into ``batch_size`` chunks to avoid URL-length caps
+        and NCBI's recommended single-request limit. ``timeout`` applies to
+        the whole batched operation.
         """
         if not pmids:
             return {}
 
         result: Dict[str, Dict[str, List[str]]] = {}
-        params = {
-            **_EUTILS_PARAMS,
-            "db": "pubmed",
-            "id": ",".join(pmids),
-            "rettype": "xml",
-            "retmode": "xml",
-        }
         url = f"{_EUTILS_BASE}/efetch.fcgi"
         try:
             async with _ensure_session(session) as s:
                 async with async_timeout(timeout):
-                    async with s.get(url, params=params) as resp:
-                        if resp.status != 200:
-                            logger.debug(
-                                f"efetch returned {resp.status} for pmids {pmids}"
-                            )
-                            return result
-                        body = await resp.text()
-            try:
-                root = ET.fromstring(body)
-            except ET.ParseError as e:
-                logger.debug(f"Failed to parse efetch XML: {e}")
-                return result
-
-            for art in root.findall(".//PubmedArticle"):
-                pmid_el = art.find(".//PMID")
-                if pmid_el is None or not pmid_el.text:
-                    continue
-                pmid = pmid_el.text.strip()
-                mesh_terms = [
-                    descriptor.text.strip()
-                    for descriptor in art.findall(".//MeshHeading/DescriptorName")
-                    if descriptor.text
-                ]
-                pub_types = [
-                    pt.text.strip()
-                    for pt in art.findall(".//PublicationTypeList/PublicationType")
-                    if pt.text
-                ]
-                result[pmid] = {"mesh": mesh_terms, "pub_types": pub_types}
-        except (asyncio.TimeoutError, asyncio.CancelledError) as e:
-            logger.debug(f"Timeout/cancel in fetch_mesh_and_pub_types: {e}")
+                    for i in range(0, len(pmids), batch_size):
+                        batch = pmids[i : i + batch_size]
+                        params = {
+                            **_EUTILS_PARAMS,
+                            "db": "pubmed",
+                            "id": ",".join(batch),
+                            "rettype": "xml",
+                            "retmode": "xml",
+                        }
+                        async with s.get(url, params=params) as resp:
+                            if resp.status != 200:
+                                logger.debug(
+                                    f"efetch returned {resp.status} for batch starting at {i}"
+                                )
+                                continue
+                            body = await resp.text()
+                        self._merge_efetch_xml_into(body, result)
+        except asyncio.CancelledError:
+            raise
+        except asyncio.TimeoutError as e:
+            logger.debug(f"Timeout in fetch_mesh_and_pub_types: {e}")
         except Exception as e:
             logger.opt(exception=True).debug(f"Error in fetch_mesh_and_pub_types: {e}")
         return result
+
+    @staticmethod
+    def _merge_efetch_xml_into(
+        body: str, result: Dict[str, Dict[str, List[str]]]
+    ) -> None:
+        """Parse an efetch XML body and merge ``{pmid: {mesh, pub_types}}`` rows
+        into ``result``. Silently skips a malformed body so one bad batch
+        doesn't poison the rest."""
+        try:
+            root = ET.fromstring(body)
+        except ET.ParseError as e:
+            logger.debug(f"Failed to parse efetch XML: {e}")
+            return
+        for art in root.findall(".//PubmedArticle"):
+            pmid_el = art.find(".//PMID")
+            if pmid_el is None or not pmid_el.text:
+                continue
+            pmid = pmid_el.text.strip()
+            mesh_terms = [
+                descriptor.text.strip()
+                for descriptor in art.findall(".//MeshHeading/DescriptorName")
+                if descriptor.text
+            ]
+            pub_types = [
+                pt.text.strip()
+                for pt in art.findall(".//PublicationTypeList/PublicationType")
+                if pt.text
+            ]
+            result[pmid] = {"mesh": mesh_terms, "pub_types": pub_types}
 
     async def find_related_pmids(
         self,
@@ -510,8 +530,10 @@ class PubMedTools(object):
                             related.append(related_id_str)
                         if len(related) >= max_results:
                             return related
-        except (asyncio.TimeoutError, asyncio.CancelledError) as e:
-            logger.debug(f"Timeout/cancel in find_related_pmids({pmid}): {e}")
+        except asyncio.CancelledError:
+            raise
+        except asyncio.TimeoutError as e:
+            logger.debug(f"Timeout in find_related_pmids({pmid}): {e}")
         except Exception as e:
             logger.opt(exception=True).debug(
                 f"Error in find_related_pmids({pmid}): {e}"
@@ -618,10 +640,10 @@ class PubMedTools(object):
                 return categorize_articles_by_strength(
                     articles, pub_types_lookup=pub_types_lookup
                 )
+        except asyncio.CancelledError:
+            raise
         except asyncio.TimeoutError:
             logger.debug(f"Timeout in structured_search: {structured.query}")
-        except asyncio.CancelledError:
-            logger.debug(f"Cancelled in structured_search: {structured.query}")
         except Exception as e:
             logger.opt(exception=True).debug(f"Error in structured_search: {e}")
         return empty_buckets

--- a/fighthealthinsurance/pubmed_tools.py
+++ b/fighthealthinsurance/pubmed_tools.py
@@ -4,14 +4,15 @@ import json
 import re
 import sys
 import tempfile
+import xml.etree.ElementTree as ET
+from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, AsyncIterator, Dict, List, Optional, Set, Tuple
 from urllib.parse import quote, urljoin
 
 import aiohttp
 import eutils
 import PyPDF2
-import xml.etree.ElementTree as ET
 from asgiref.sync import async_to_sync, sync_to_async
 from loguru import logger
 from metapub import FindIt
@@ -27,7 +28,6 @@ from fighthealthinsurance.pubmed_search import (
     EvidenceStrength,
     build_structured_query,
     categorize_articles_by_strength,
-    format_categorized_snippets,
 )
 from fighthealthinsurance.utils import pubmed_fetcher
 
@@ -57,6 +57,22 @@ _EUTILS_PARAMS = {
     "tool": "fighthealthinsurance",
     "email": "support@fighthealthinsurance.com",
 }
+
+
+@asynccontextmanager
+async def _ensure_session(
+    session: Optional[aiohttp.ClientSession],
+) -> AsyncIterator[aiohttp.ClientSession]:
+    """Yield ``session`` if provided, else open and close one for the caller.
+
+    Lets methods accept an optional shared session for batching while still
+    working standalone.
+    """
+    if session is not None:
+        yield session
+        return
+    async with aiohttp.ClientSession(headers=_FETCH_HEADERS) as new_session:
+        yield new_session
 
 
 class PubMedTools(object):
@@ -398,33 +414,31 @@ class PubMedTools(object):
         are simply absent from the result rather than raising. A network error
         or parse failure yields ``{}`` so callers can degrade gracefully.
 
-        We hit ``efetch?rettype=xml`` once for the whole batch (PubMed accepts
-        a comma-separated PMID list) to keep the request count low.
+        Hits ``efetch?rettype=xml`` once for the whole batch (PubMed accepts a
+        comma-separated PMID list) to keep the request count low.
         """
         if not pmids:
             return {}
 
-        owns_session = session is None
-        if owns_session:
-            session = aiohttp.ClientSession(headers=_FETCH_HEADERS)
-        assert session is not None
-
         result: Dict[str, Dict[str, List[str]]] = {}
+        params = {
+            **_EUTILS_PARAMS,
+            "db": "pubmed",
+            "id": ",".join(pmids),
+            "rettype": "xml",
+            "retmode": "xml",
+        }
+        url = f"{_EUTILS_BASE}/efetch.fcgi"
         try:
-            params = {
-                **_EUTILS_PARAMS,
-                "db": "pubmed",
-                "id": ",".join(pmids),
-                "rettype": "xml",
-                "retmode": "xml",
-            }
-            url = f"{_EUTILS_BASE}/efetch.fcgi"
-            async with async_timeout(timeout):
-                async with session.get(url, params=params) as resp:
-                    if resp.status != 200:
-                        logger.debug(f"efetch returned {resp.status} for pmids {pmids}")
-                        return result
-                    body = await resp.text()
+            async with _ensure_session(session) as s:
+                async with async_timeout(timeout):
+                    async with s.get(url, params=params) as resp:
+                        if resp.status != 200:
+                            logger.debug(
+                                f"efetch returned {resp.status} for pmids {pmids}"
+                            )
+                            return result
+                        body = await resp.text()
             try:
                 root = ET.fromstring(body)
             except ET.ParseError as e:
@@ -451,9 +465,6 @@ class PubMedTools(object):
             logger.debug(f"Timeout/cancel in fetch_mesh_and_pub_types: {e}")
         except Exception as e:
             logger.opt(exception=True).debug(f"Error in fetch_mesh_and_pub_types: {e}")
-        finally:
-            if owns_session and session:
-                await session.close()
         return result
 
     async def find_related_pmids(
@@ -472,27 +483,23 @@ class PubMedTools(object):
         if not pmid:
             return []
 
-        owns_session = session is None
-        if owns_session:
-            session = aiohttp.ClientSession(headers=_FETCH_HEADERS)
-        assert session is not None
-
         related: List[str] = []
+        params = {
+            **_EUTILS_PARAMS,
+            "dbfrom": "pubmed",
+            "db": "pubmed",
+            "id": pmid,
+            "linkname": "pubmed_pubmed",
+            "retmode": "json",
+        }
+        url = f"{_EUTILS_BASE}/elink.fcgi"
         try:
-            params = {
-                **_EUTILS_PARAMS,
-                "dbfrom": "pubmed",
-                "db": "pubmed",
-                "id": pmid,
-                "linkname": "pubmed_pubmed",
-                "retmode": "json",
-            }
-            url = f"{_EUTILS_BASE}/elink.fcgi"
-            async with async_timeout(timeout):
-                async with session.get(url, params=params) as resp:
-                    if resp.status != 200:
-                        return []
-                    data = await resp.json()
+            async with _ensure_session(session) as s:
+                async with async_timeout(timeout):
+                    async with s.get(url, params=params) as resp:
+                        if resp.status != 200:
+                            return []
+                        data = await resp.json()
             for linkset in data.get("linksets", []):
                 for linksetdb in linkset.get("linksetdbs", []):
                     if linksetdb.get("linkname") != "pubmed_pubmed":
@@ -509,9 +516,6 @@ class PubMedTools(object):
             logger.opt(exception=True).debug(
                 f"Error in find_related_pmids({pmid}): {e}"
             )
-        finally:
-            if owns_session and session:
-                await session.close()
         return related
 
     async def structured_search(
@@ -611,13 +615,9 @@ class PubMedTools(object):
                     pmid: data.get("pub_types", [])
                     for pmid, data in pub_types_by_pmid.items()
                 }
-                buckets = categorize_articles_by_strength(
+                return categorize_articles_by_strength(
                     articles, pub_types_lookup=pub_types_lookup
                 )
-                # Ensure all tiers are present in the return value.
-                for tier in EvidenceStrength:
-                    buckets.setdefault(tier, [])
-                return buckets
         except asyncio.TimeoutError:
             logger.debug(f"Timeout in structured_search: {structured.query}")
         except asyncio.CancelledError:
@@ -673,19 +673,6 @@ class PubMedTools(object):
                 except Exception as e:
                     logger.debug(f"Failed to materialize {pmid}: {e}")
         return articles
-
-    @staticmethod
-    def format_structured_search_for_appeal(
-        buckets: Dict[EvidenceStrength, List[Any]],
-        include_empty: bool = False,
-    ) -> str:
-        """Render structured-search buckets as appeal-letter markdown.
-
-        Thin wrapper around ``pubmed_search.format_categorized_snippets`` so
-        callers can stay within ``PubMedTools`` without importing the helper
-        module directly.
-        """
-        return format_categorized_snippets(buckets, include_empty=include_empty)
 
     async def find_pubmed_articles_for_denial(
         self, denial: Denial, timeout=70.0

--- a/fighthealthinsurance/pubmed_tools.py
+++ b/fighthealthinsurance/pubmed_tools.py
@@ -8,7 +8,7 @@ import xml.etree.ElementTree as ET
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
 from typing import Any, AsyncIterator, Dict, List, Optional, Set, Tuple
-from urllib.parse import quote, urljoin
+from urllib.parse import quote, urlencode, urljoin
 
 import aiohttp
 import eutils
@@ -43,9 +43,16 @@ else:
 
 PER_QUERY = 2
 
+# Single source of truth for the contact identity NCBI / Unpaywall / etc.
+# expect alongside high-volume API requests. Used both in the fetch User-Agent
+# and the per-API `tool`/`email` query params so the value can't drift between
+# call sites.
+_TOOL_NAME = "fighthealthinsurance"
+_CONTACT_EMAIL = "support@fighthealthinsurance.com"
+
 # Common headers to avoid bot detection when fetching PDFs
 _FETCH_HEADERS = {
-    "User-Agent": "FightHealthInsurance/1.0 (mailto:support@fighthealthinsurance.com)",
+    "User-Agent": f"FightHealthInsurance/1.0 (mailto:{_CONTACT_EMAIL})",
     "Accept": "application/pdf,text/html,application/xhtml+xml,*/*",
 }
 
@@ -54,8 +61,8 @@ _FETCH_HEADERS = {
 # ``email`` be supplied per their usage guidelines.
 _EUTILS_BASE = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils"
 _EUTILS_PARAMS = {
-    "tool": "fighthealthinsurance",
-    "email": "support@fighthealthinsurance.com",
+    "tool": _TOOL_NAME,
+    "email": _CONTACT_EMAIL,
 }
 
 # NCBI documents 200 IDs as the practical limit for an efetch GET; chunk to
@@ -174,10 +181,8 @@ class PubMedTools(object):
         self, pmid: str, session: aiohttp.ClientSession, timeout_secs: float
     ) -> Optional[str]:
         """Check if article is in PubMed Central and get its PDF URL."""
-        url = (
-            f"https://www.ncbi.nlm.nih.gov/pmc/utils/idconv/v1.0/"
-            f"?ids={pmid}&format=json&tool=fighthealthinsurance&email=support@fighthealthinsurance.com"
-        )
+        params = urlencode({**_EUTILS_PARAMS, "ids": pmid, "format": "json"})
+        url = f"https://www.ncbi.nlm.nih.gov/pmc/utils/idconv/v1.0/?{params}"
         data = await self._fetch_json(session, url, timeout_secs, pmid)
         if data:
             records = data.get("records", [])
@@ -211,7 +216,9 @@ class PubMedTools(object):
         self, doi: str, session: aiohttp.ClientSession, timeout_secs: float
     ) -> Optional[str]:
         """Try Unpaywall API to find open access PDF."""
-        url = f"https://api.unpaywall.org/v2/{quote(doi, safe='')}?email=support@fighthealthinsurance.com"
+        url = (
+            f"https://api.unpaywall.org/v2/{quote(doi, safe='')}?email={_CONTACT_EMAIL}"
+        )
         data = await self._fetch_json(session, url, timeout_secs, f"DOI:{doi}")
         if not data:
             return None

--- a/tests/async-unit/test_pubmed_search.py
+++ b/tests/async-unit/test_pubmed_search.py
@@ -130,6 +130,25 @@ class TestBuildStructuredQuery:
         assert '"1900"[dp]' in sq.query
         assert '"2010"[dp]' in sq.query
 
+    def test_year_accepts_int(self):
+        sq = build_structured_query(condition="asthma", since_year=2020)
+        assert '"2020"[dp]' in sq.query
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        ["recent", "20-25", "2020-2024", "20", "20200", "two thousand", " ", ""],
+    )
+    def test_invalid_year_is_dropped(self, bad_value):
+        sq = build_structured_query(condition="asthma", since_year=bad_value)
+        # Garbage year input must not produce a [dp] filter at all.
+        assert "[dp]" not in sq.query
+        assert sq.since_year is None
+
+    def test_invalid_until_year_is_dropped(self):
+        sq = build_structured_query(condition="asthma", until_year="last year")
+        assert "[dp]" not in sq.query
+        assert sq.until_year is None
+
     def test_extra_terms_appended(self):
         sq = build_structured_query(
             condition="asthma", extra_terms=["pediatric", "severe asthma"]
@@ -187,11 +206,10 @@ class TestBuildStructuredQuery:
 
 class TestPubTypeExtraction:
     def test_extract_from_publication_types_attr(self):
-        article = MagicMock()
+        # spec= constrains the mock to just the primary attr so the fallback
+        # attrs raise AttributeError on access (which getattr catches).
+        article = MagicMock(spec=["publication_types"])
         article.publication_types = ["Journal Article", "Meta-Analysis"]
-        # Wipe other attrs so MagicMock auto-attrs don't shadow.
-        del article.pubtype
-        del article.pub_types
         types = extract_publication_types(article)
         assert "Meta-Analysis" in types
 

--- a/tests/async-unit/test_pubmed_search.py
+++ b/tests/async-unit/test_pubmed_search.py
@@ -193,6 +193,27 @@ class TestPubTypeExtraction:
         article = MagicMock(spec=[])
         assert extract_publication_types(article) == []
 
+    def test_empty_first_attr_falls_through_to_fallback(self):
+        # Regression: an empty list on the primary attr must not shadow a
+        # populated fallback attr. metapub-like providers sometimes fill
+        # `pubtype` but leave `publication_types` empty (or vice versa).
+        article = MagicMock(spec=["publication_types", "pubtype"])
+        article.publication_types = []
+        article.pubtype = ["Meta-Analysis"]
+        assert extract_publication_types(article) == ["Meta-Analysis"]
+
+    def test_empty_string_first_attr_falls_through(self):
+        article = MagicMock(spec=["publication_types", "pubtype"])
+        article.publication_types = ""
+        article.pubtype = ["Review"]
+        assert extract_publication_types(article) == ["Review"]
+
+    def test_empty_dict_first_attr_falls_through(self):
+        article = MagicMock(spec=["publication_types", "pub_types"])
+        article.publication_types = {}
+        article.pub_types = ["Guideline"]
+        assert extract_publication_types(article) == ["Guideline"]
+
     def test_normalize_pub_type(self):
         assert normalize_pub_type("Meta-Analysis") == "meta-analysis"
         assert normalize_pub_type(" Review  ") == "review"

--- a/tests/async-unit/test_pubmed_search.py
+++ b/tests/async-unit/test_pubmed_search.py
@@ -693,23 +693,3 @@ class StructuredSearchE2ETest(TransactionTestCase):
             # Both the seed and the related PMID should appear.
             assert "11111111" in all_pmids
             assert "22222222" in all_pmids
-
-
-# ---------------------------------------------------------------------------
-# PubMedTools.format_structured_search_for_appeal
-# ---------------------------------------------------------------------------
-
-
-def test_format_structured_search_for_appeal_delegates():
-    """Sanity: the static helper should produce the same output as
-    format_categorized_snippets."""
-    a = _make_article("1", title="X", basic_summary="finding")
-    buckets = {
-        EvidenceStrength.STRONG: [a],
-        EvidenceStrength.MODERATE: [],
-        EvidenceStrength.WEAK: [],
-        EvidenceStrength.UNKNOWN: [],
-    }
-    via_helper = format_categorized_snippets(buckets)
-    via_method = PubMedTools.format_structured_search_for_appeal(buckets)
-    assert via_helper == via_method

--- a/tests/async-unit/test_pubmed_search.py
+++ b/tests/async-unit/test_pubmed_search.py
@@ -12,6 +12,7 @@ The end-to-end ``structured_search`` test is wrapped with the Django
 ``TransactionTestCase`` so the article materialization step can use the ORM.
 """
 
+import asyncio
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -138,12 +139,28 @@ class TestBuildStructuredQuery:
 
     def test_reserved_chars_are_stripped(self):
         sq = build_structured_query(condition="asthma[ti] (pediatric)")
-        # Brackets and parentheses must be removed so the user can't inject
-        # arbitrary PubMed search field tags.
+        # Bracketed/parenthesized segments must be removed *as a unit* so the
+        # field tag ("ti") doesn't leak back as a free-text token. Otherwise
+        # the user can inject arbitrary PubMed search field semantics.
         assert "[" not in sq.condition
         assert "]" not in sq.condition
         assert "(" not in sq.condition
         assert ")" not in sq.condition
+        assert "ti" not in sq.condition.split()
+        assert "pediatric" not in sq.condition.split()
+        assert "asthma" in sq.condition
+
+    def test_nested_bracket_injection_is_stripped(self):
+        sq = build_structured_query(condition='diabetes "AND" cancer[mh]')
+        # The injected field-tag contents and the user-supplied stray quotes
+        # are gone; only the outer phrase quotes added by `_quote_phrase`
+        # remain. Otherwise a user could embed ``[mh]`` to coerce free-text
+        # into a MeSH lookup.
+        assert "mh" not in sq.condition.split()
+        # Strip the outer phrase quotes added by quoting; nothing else should
+        # remain.
+        inner = sq.condition.strip('"')
+        assert '"' not in inner
 
     def test_combination_of_all_filters(self):
         sq = build_structured_query(
@@ -527,6 +544,79 @@ async def test_fetch_mesh_and_pub_types_handles_malformed_xml():
     assert out == {}
 
 
+@pytest.mark.asyncio
+async def test_fetch_mesh_and_pub_types_chunks_large_input():
+    """Verify >batch_size PMIDs are split into multiple requests, not jammed
+    into one over-long URL."""
+    tools = PubMedTools()
+    # Two batches of 3 → two GET calls. Each batch returns its slice of XML.
+    pmids = [str(i) for i in range(1, 7)]
+
+    def fixture_for(batch_ids):
+        articles = "".join(
+            f"<PubmedArticle><MedlineCitation><PMID>{pid}</PMID>"
+            f"<Article><PublicationTypeList>"
+            f"<PublicationType>Review</PublicationType>"
+            f"</PublicationTypeList></Article></MedlineCitation></PubmedArticle>"
+            for pid in batch_ids
+        )
+        return f"<PubmedArticleSet>{articles}</PubmedArticleSet>"
+
+    responses = [
+        _make_aiohttp_response(text=fixture_for(pmids[0:3])),
+        _make_aiohttp_response(text=fixture_for(pmids[3:6])),
+    ]
+    session = AsyncMock()
+    session.get = MagicMock(side_effect=responses)
+
+    out = await tools.fetch_mesh_and_pub_types(
+        pmids, session=session, batch_size=3, timeout=5.0
+    )
+    assert session.get.call_count == 2
+    assert set(out.keys()) == set(pmids)
+    # Each GET call's `id` param should be the comma-joined batch.
+    first_params = session.get.call_args_list[0].kwargs["params"]
+    second_params = session.get.call_args_list[1].kwargs["params"]
+    assert first_params["id"] == "1,2,3"
+    assert second_params["id"] == "4,5,6"
+
+
+@pytest.mark.asyncio
+async def test_fetch_mesh_and_pub_types_reraises_cancelled():
+    """CancelledError must propagate so request cancellation works."""
+    tools = PubMedTools()
+    session = AsyncMock()
+    session.get = MagicMock(side_effect=asyncio.CancelledError())
+    with pytest.raises(asyncio.CancelledError):
+        await tools.fetch_mesh_and_pub_types(["1"], session=session, timeout=5.0)
+
+
+@pytest.mark.asyncio
+async def test_fetch_mesh_and_pub_types_partial_batch_failure_still_returns_rest():
+    """If one batch errors out mid-stream, prior batches' results survive."""
+    tools = PubMedTools()
+    good_xml = (
+        "<PubmedArticleSet>"
+        "<PubmedArticle><MedlineCitation><PMID>1</PMID>"
+        "<Article><PublicationTypeList>"
+        "<PublicationType>Review</PublicationType>"
+        "</PublicationTypeList></Article></MedlineCitation></PubmedArticle>"
+        "</PubmedArticleSet>"
+    )
+    responses = [
+        _make_aiohttp_response(text=good_xml),
+        _make_aiohttp_response(status=500, text=""),
+    ]
+    session = AsyncMock()
+    session.get = MagicMock(side_effect=responses)
+
+    out = await tools.fetch_mesh_and_pub_types(
+        ["1", "2"], session=session, batch_size=1, timeout=5.0
+    )
+    # Batch 1 succeeded; batch 2 failed → at least the first PMID is present.
+    assert "1" in out
+
+
 # ---------------------------------------------------------------------------
 # PubMedTools.find_related_pmids
 # ---------------------------------------------------------------------------
@@ -603,6 +693,15 @@ async def test_find_related_pmids_handles_http_error():
     assert related == []
 
 
+@pytest.mark.asyncio
+async def test_find_related_pmids_reraises_cancelled():
+    tools = PubMedTools()
+    session = AsyncMock()
+    session.get = MagicMock(side_effect=asyncio.CancelledError())
+    with pytest.raises(asyncio.CancelledError):
+        await tools.find_related_pmids("11111111", session=session, max_results=5)
+
+
 # ---------------------------------------------------------------------------
 # PubMedTools.structured_search end-to-end (DB + mocked PubMed API)
 # ---------------------------------------------------------------------------
@@ -675,6 +774,22 @@ class StructuredSearchE2ETest(TransactionTestCase):
         assert set(buckets.keys()) == set(EvidenceStrength)
         for tier in EvidenceStrength:
             assert buckets[tier] == []
+
+    def test_structured_search_reraises_cancelled(self):
+        tools = PubMedTools()
+
+        async def fake_find_ids(query, since=None, timeout=60.0):
+            raise asyncio.CancelledError()
+
+        with patch.object(
+            tools, "find_pubmed_article_ids_for_query", side_effect=fake_find_ids
+        ):
+
+            async def run():
+                await tools.structured_search(condition="asthma")
+
+            with pytest.raises(asyncio.CancelledError):
+                async_to_sync(run)()
 
     def test_structured_search_with_expand_with_related(self):
         tools = PubMedTools()

--- a/tests/async-unit/test_pubmed_search.py
+++ b/tests/async-unit/test_pubmed_search.py
@@ -1,0 +1,715 @@
+"""Unit tests for the structured PubMed search helpers.
+
+Covers:
+- ``pubmed_search`` pure helpers (query building, evidence classification,
+  snippet formatting, bucket categorization).
+- ``PubMedTools.fetch_mesh_and_pub_types`` and
+  ``PubMedTools.find_related_pmids`` (E-utilities calls, mocked).
+- ``PubMedTools.structured_search`` end-to-end (mocked PubMed + DB).
+
+These tests don't hit the real PubMed API or the database where avoidable.
+The end-to-end ``structured_search`` test is wrapped with the Django
+``TransactionTestCase`` so the article materialization step can use the ORM.
+"""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from asgiref.sync import async_to_sync
+from django.test import TransactionTestCase
+
+from fighthealthinsurance.models import PubMedMiniArticle
+from fighthealthinsurance.pubmed_search import (
+    EvidenceStrength,
+    MODERATE_PUB_TYPES,
+    PUB_TYPE_PRESETS,
+    STRONG_PUB_TYPES,
+    WEAK_PUB_TYPES,
+    build_structured_query,
+    categorize_articles_by_strength,
+    classify_evidence_strength,
+    extract_publication_types,
+    format_appeal_snippet,
+    format_categorized_snippets,
+    normalize_pub_type,
+)
+from fighthealthinsurance.pubmed_tools import PubMedTools
+
+# ---------------------------------------------------------------------------
+# build_structured_query
+# ---------------------------------------------------------------------------
+
+
+class TestBuildStructuredQuery:
+    def test_empty_inputs_returns_empty_query(self):
+        sq = build_structured_query()
+        assert sq.query == ""
+        assert sq.condition == ""
+        assert sq.treatment == ""
+
+    def test_condition_only(self):
+        sq = build_structured_query(condition="rheumatoid arthritis")
+        assert sq.query == '"rheumatoid arthritis"'
+        assert sq.condition == '"rheumatoid arthritis"'
+        assert sq.treatment == ""
+
+    def test_treatment_only(self):
+        sq = build_structured_query(treatment="infliximab")
+        # Single-word terms aren't quoted.
+        assert sq.query == "infliximab"
+
+    def test_condition_and_treatment(self):
+        sq = build_structured_query(
+            condition="rheumatoid arthritis", treatment="physical therapy"
+        )
+        assert "rheumatoid arthritis" in sq.query
+        assert "physical therapy" in sq.query
+        assert " AND " in sq.query
+
+    def test_pub_type_preset_guidelines(self):
+        sq = build_structured_query(
+            condition="asthma",
+            pub_type_preset="guidelines_and_systematic_reviews",
+        )
+        assert "Guideline[pt]" in sq.query
+        assert "Systematic Review[pt]" in sq.query
+        assert "Meta-Analysis[pt]" in sq.query
+        # Resolved filter list should match preset order.
+        assert sq.pub_type_filters == list(
+            PUB_TYPE_PRESETS["guidelines_and_systematic_reviews"]
+        )
+
+    def test_explicit_pub_type_filters(self):
+        sq = build_structured_query(
+            condition="asthma", pub_type_filters=["rct", "meta_analysis"]
+        )
+        assert "Randomized Controlled Trial[pt]" in sq.query
+        assert "Meta-Analysis[pt]" in sq.query
+
+    def test_unknown_pub_type_filter_is_dropped(self):
+        sq = build_structured_query(
+            condition="asthma", pub_type_filters=["bogus_filter", "rct"]
+        )
+        assert "Randomized Controlled Trial[pt]" in sq.query
+        assert "bogus_filter" not in sq.query
+        assert sq.pub_type_filters == ["rct"]
+
+    def test_preset_and_explicit_dedup(self):
+        sq = build_structured_query(
+            condition="asthma",
+            pub_type_preset="high_quality_evidence",
+            pub_type_filters=["rct"],  # already in preset
+        )
+        # rct should appear only once.
+        assert sq.pub_type_filters.count("rct") == 1
+
+    def test_mesh_terms_use_mh_tag(self):
+        sq = build_structured_query(
+            condition="arthritis", mesh_terms=["Arthritis, Rheumatoid"]
+        )
+        assert '"Arthritis, Rheumatoid"[mh]' in sq.query
+        assert sq.mesh_terms == ["Arthritis, Rheumatoid"]
+
+    def test_since_year_creates_date_filter(self):
+        sq = build_structured_query(condition="asthma", since_year="2020")
+        assert '"2020"[dp]' in sq.query
+        # Upper bound defaults to current year.
+        assert f'"{datetime.now().year}"[dp]' in sq.query
+
+    def test_since_and_until_year(self):
+        sq = build_structured_query(
+            condition="asthma", since_year="2018", until_year="2022"
+        )
+        assert '"2018"[dp]' in sq.query
+        assert '"2022"[dp]' in sq.query
+
+    def test_until_year_only(self):
+        sq = build_structured_query(condition="asthma", until_year="2010")
+        assert '"1900"[dp]' in sq.query
+        assert '"2010"[dp]' in sq.query
+
+    def test_extra_terms_appended(self):
+        sq = build_structured_query(
+            condition="asthma", extra_terms=["pediatric", "severe asthma"]
+        )
+        assert "pediatric" in sq.query
+        assert '"severe asthma"' in sq.query
+
+    def test_reserved_chars_are_stripped(self):
+        sq = build_structured_query(condition="asthma[ti] (pediatric)")
+        # Brackets and parentheses must be removed so the user can't inject
+        # arbitrary PubMed search field tags.
+        assert "[" not in sq.condition
+        assert "]" not in sq.condition
+        assert "(" not in sq.condition
+        assert ")" not in sq.condition
+
+    def test_combination_of_all_filters(self):
+        sq = build_structured_query(
+            condition="rheumatoid arthritis",
+            treatment="infliximab",
+            pub_type_preset="high_quality_evidence",
+            mesh_terms=["Arthritis, Rheumatoid"],
+            since_year="2020",
+            extra_terms=["adult"],
+        )
+        # All ingredients should be present in the final query.
+        assert "rheumatoid arthritis" in sq.query
+        assert "infliximab" in sq.query
+        assert "Meta-Analysis[pt]" in sq.query
+        assert "[mh]" in sq.query
+        assert '"2020"[dp]' in sq.query
+        assert "adult" in sq.query
+
+
+# ---------------------------------------------------------------------------
+# Publication type extraction & classification
+# ---------------------------------------------------------------------------
+
+
+class TestPubTypeExtraction:
+    def test_extract_from_publication_types_attr(self):
+        article = MagicMock()
+        article.publication_types = ["Journal Article", "Meta-Analysis"]
+        # Wipe other attrs so MagicMock auto-attrs don't shadow.
+        del article.pubtype
+        del article.pub_types
+        types = extract_publication_types(article)
+        assert "Meta-Analysis" in types
+
+    def test_extract_from_pubtype_dict(self):
+        article = MagicMock(spec=["pubtype"])
+        article.pubtype = {"D016428": "Journal Article", "D017418": "Meta-Analysis"}
+        types = extract_publication_types(article)
+        assert set(types) == {"Journal Article", "Meta-Analysis"}
+
+    def test_extract_from_string_value(self):
+        article = MagicMock(spec=["publication_types"])
+        article.publication_types = "Review"
+        assert extract_publication_types(article) == ["Review"]
+
+    def test_extract_returns_empty_when_no_attrs(self):
+        article = MagicMock(spec=[])
+        assert extract_publication_types(article) == []
+
+    def test_normalize_pub_type(self):
+        assert normalize_pub_type("Meta-Analysis") == "meta-analysis"
+        assert normalize_pub_type(" Review  ") == "review"
+        assert normalize_pub_type(None) == ""
+
+
+class TestClassifyEvidenceStrength:
+    @pytest.mark.parametrize("pub_type", sorted(STRONG_PUB_TYPES))
+    def test_strong_types_classify_as_strong(self, pub_type):
+        assert classify_evidence_strength([pub_type]) == EvidenceStrength.STRONG
+
+    @pytest.mark.parametrize("pub_type", sorted(MODERATE_PUB_TYPES))
+    def test_moderate_types_classify_as_moderate(self, pub_type):
+        assert classify_evidence_strength([pub_type]) == EvidenceStrength.MODERATE
+
+    @pytest.mark.parametrize("pub_type", sorted(WEAK_PUB_TYPES))
+    def test_weak_types_classify_as_weak(self, pub_type):
+        assert classify_evidence_strength([pub_type]) == EvidenceStrength.WEAK
+
+    def test_strongest_tier_wins_when_multiple_present(self):
+        # An article tagged Review (moderate) AND Meta-Analysis (strong)
+        # must classify as STRONG.
+        result = classify_evidence_strength(["Review", "Meta-Analysis"])
+        assert result == EvidenceStrength.STRONG
+
+    def test_unknown_types_classify_as_unknown(self):
+        result = classify_evidence_strength(["Journal Article"])
+        assert result == EvidenceStrength.UNKNOWN
+
+    def test_empty_list_classifies_as_unknown(self):
+        assert classify_evidence_strength([]) == EvidenceStrength.UNKNOWN
+
+    def test_case_insensitive_match(self):
+        # Authors of NCBI metadata use Title Case; our set uses lowercase.
+        # Classification must work either way.
+        assert classify_evidence_strength(["META-ANALYSIS"]) == EvidenceStrength.STRONG
+        assert (
+            classify_evidence_strength(["random ized controlled trial"])
+            == EvidenceStrength.UNKNOWN
+        )  # whitespace/typo doesn't accidentally match
+
+
+# ---------------------------------------------------------------------------
+# categorize_articles_by_strength
+# ---------------------------------------------------------------------------
+
+
+def _make_article(
+    pmid,
+    title="t",
+    abstract="a",
+    journal="J",
+    year="2024",
+    publication_types=None,
+    basic_summary=None,
+    article_url="",
+):
+    """Make a lightweight stand-in for a PubMedMiniArticle/-Summarized."""
+    art = MagicMock(
+        spec=[
+            "pmid",
+            "title",
+            "abstract",
+            "journal",
+            "year",
+            "publication_types",
+            "basic_summary",
+            "article_url",
+        ]
+    )
+    art.pmid = pmid
+    art.title = title
+    art.abstract = abstract
+    art.journal = journal
+    art.year = year
+    art.publication_types = publication_types
+    art.basic_summary = basic_summary
+    art.article_url = article_url
+    return art
+
+
+class TestCategorizeArticles:
+    def test_uses_lookup_when_provided(self):
+        # The lookup overrides whatever the article object reports.
+        a = _make_article("1", publication_types=["Editorial"])  # would be weak
+        buckets = categorize_articles_by_strength(
+            [a], pub_types_lookup={"1": ["Meta-Analysis"]}
+        )
+        assert a in buckets[EvidenceStrength.STRONG]
+        assert a not in buckets[EvidenceStrength.WEAK]
+
+    def test_falls_back_to_article_attrs(self):
+        a = _make_article("1", publication_types=["Meta-Analysis"])
+        buckets = categorize_articles_by_strength([a])
+        assert a in buckets[EvidenceStrength.STRONG]
+
+    def test_all_tiers_always_present(self):
+        buckets = categorize_articles_by_strength([])
+        assert set(buckets.keys()) == set(EvidenceStrength)
+        for tier in EvidenceStrength:
+            assert buckets[tier] == []
+
+    def test_mixed_set_distributes_correctly(self):
+        strong = _make_article("1", publication_types=["Meta-Analysis"])
+        moderate = _make_article("2", publication_types=["Review"])
+        weak = _make_article("3", publication_types=["Editorial"])
+        unknown = _make_article("4", publication_types=["Journal Article"])
+        buckets = categorize_articles_by_strength([strong, moderate, weak, unknown])
+        assert buckets[EvidenceStrength.STRONG] == [strong]
+        assert buckets[EvidenceStrength.MODERATE] == [moderate]
+        assert buckets[EvidenceStrength.WEAK] == [weak]
+        assert buckets[EvidenceStrength.UNKNOWN] == [unknown]
+
+    def test_preserves_input_order_within_bucket(self):
+        a1 = _make_article("1", publication_types=["Meta-Analysis"])
+        a2 = _make_article("2", publication_types=["Systematic Review"])
+        a3 = _make_article("3", publication_types=["Practice Guideline"])
+        buckets = categorize_articles_by_strength([a1, a2, a3])
+        assert buckets[EvidenceStrength.STRONG] == [a1, a2, a3]
+
+
+# ---------------------------------------------------------------------------
+# Appeal-friendly snippet formatting
+# ---------------------------------------------------------------------------
+
+
+class TestFormatAppealSnippet:
+    def test_basic_snippet_includes_citation_and_excerpt(self):
+        a = _make_article(
+            "12345",
+            title="Effective therapy for arthritis",
+            journal="JAMA",
+            year="2023",
+            article_url="https://pubmed.ncbi.nlm.nih.gov/12345/",
+            basic_summary="This trial showed strong improvement. Patients tolerated the drug well. Follow-up was 12 months.",
+        )
+        snippet = format_appeal_snippet(a)
+        assert "Effective therapy for arthritis" in snippet
+        assert "JAMA, 2023" in snippet
+        assert "PMID: 12345" in snippet
+        assert "https://pubmed.ncbi.nlm.nih.gov/12345/" in snippet
+        assert "Excerpt:" in snippet
+        # First three sentences should be present.
+        assert "strong improvement" in snippet
+        assert "tolerated the drug well" in snippet
+        assert "12 months" in snippet
+
+    def test_prefers_basic_summary_over_abstract(self):
+        a = _make_article(
+            "1",
+            basic_summary="Summary sentence one.",
+            abstract="Abstract sentence one. Abstract sentence two.",
+        )
+        snippet = format_appeal_snippet(a)
+        assert "Summary sentence one" in snippet
+        assert "Abstract sentence" not in snippet
+
+    def test_falls_back_to_abstract_when_no_summary(self):
+        a = _make_article("1", basic_summary=None, abstract="The abstract.")
+        snippet = format_appeal_snippet(a)
+        assert "The abstract" in snippet
+
+    def test_truncates_long_excerpt(self):
+        # Three long sentences so the first-3-sentence selection still
+        # exceeds max_chars and triggers truncation.
+        long_sentence = "x" * 300 + "."
+        long_text = " ".join([long_sentence] * 3)
+        a = _make_article("1", basic_summary=long_text)
+        snippet = format_appeal_snippet(a, max_chars=100)
+        assert "…" in snippet
+        excerpt_line = snippet.split("Excerpt: ", 1)[1]
+        assert len(excerpt_line) <= 101  # max_chars + ellipsis
+
+    def test_handles_missing_metadata(self):
+        a = _make_article("", title="", journal="", year="", basic_summary="")
+        # Should not crash; returns empty or just the citation line.
+        snippet = format_appeal_snippet(a)
+        assert isinstance(snippet, str)
+
+
+class TestFormatCategorizedSnippets:
+    def test_omits_empty_sections_by_default(self):
+        strong = _make_article(
+            "1", title="Strong study", basic_summary="Found benefit."
+        )
+        buckets = {
+            EvidenceStrength.STRONG: [strong],
+            EvidenceStrength.MODERATE: [],
+            EvidenceStrength.WEAK: [],
+            EvidenceStrength.UNKNOWN: [],
+        }
+        out = format_categorized_snippets(buckets)
+        assert "## Strong evidence" in out
+        assert "## Moderate evidence" not in out
+        assert "## Weak but relevant evidence" not in out
+
+    def test_include_empty_renders_all_sections(self):
+        out = format_categorized_snippets(
+            {tier: [] for tier in EvidenceStrength}, include_empty=True
+        )
+        assert "## Strong evidence" in out
+        assert "## Moderate evidence" in out
+        assert "## Weak but relevant evidence" in out
+        assert "## Other evidence" in out
+        assert out.count("(no articles)") == 4
+
+    def test_renders_articles_as_bulleted_list(self):
+        s1 = _make_article("1", title="A", basic_summary="findA")
+        s2 = _make_article("2", title="B", basic_summary="findB")
+        buckets = {
+            EvidenceStrength.STRONG: [s1, s2],
+            EvidenceStrength.MODERATE: [],
+            EvidenceStrength.WEAK: [],
+            EvidenceStrength.UNKNOWN: [],
+        }
+        out = format_categorized_snippets(buckets)
+        # Each article is bulleted.
+        assert out.count("- ") >= 2
+
+
+# ---------------------------------------------------------------------------
+# PubMedTools.fetch_mesh_and_pub_types
+# ---------------------------------------------------------------------------
+
+
+_EFETCH_XML_FIXTURE = """<?xml version="1.0"?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation>
+      <PMID>11111111</PMID>
+      <Article>
+        <PublicationTypeList>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+          <PublicationType UI="D017418">Meta-Analysis</PublicationType>
+        </PublicationTypeList>
+      </Article>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D001172">Arthritis, Rheumatoid</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D026741">Antirheumatic Agents</DescriptorName>
+        </MeshHeading>
+      </MeshHeadingList>
+    </MedlineCitation>
+  </PubmedArticle>
+  <PubmedArticle>
+    <MedlineCitation>
+      <PMID>22222222</PMID>
+      <Article>
+        <PublicationTypeList>
+          <PublicationType UI="D016454">Review</PublicationType>
+        </PublicationTypeList>
+      </Article>
+    </MedlineCitation>
+  </PubmedArticle>
+</PubmedArticleSet>
+"""
+
+
+def _make_aiohttp_response(text="", status=200, json_data=None):
+    resp = AsyncMock()
+    resp.status = status
+    resp.text = AsyncMock(return_value=text)
+    resp.json = AsyncMock(return_value=json_data or {})
+    resp.__aenter__ = AsyncMock(return_value=resp)
+    resp.__aexit__ = AsyncMock(return_value=False)
+    return resp
+
+
+def _make_aiohttp_session(response):
+    session = AsyncMock()
+    session.get = MagicMock(return_value=response)
+    return session
+
+
+@pytest.mark.asyncio
+async def test_fetch_mesh_and_pub_types_parses_xml():
+    tools = PubMedTools()
+    session = _make_aiohttp_session(_make_aiohttp_response(text=_EFETCH_XML_FIXTURE))
+    result = await tools.fetch_mesh_and_pub_types(
+        ["11111111", "22222222"], session=session, timeout=5.0
+    )
+    assert result["11111111"]["pub_types"] == ["Journal Article", "Meta-Analysis"]
+    assert "Arthritis, Rheumatoid" in result["11111111"]["mesh"]
+    assert "Antirheumatic Agents" in result["11111111"]["mesh"]
+    assert result["22222222"]["pub_types"] == ["Review"]
+    assert result["22222222"]["mesh"] == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_mesh_and_pub_types_handles_empty_input():
+    tools = PubMedTools()
+    out = await tools.fetch_mesh_and_pub_types([])
+    assert out == {}
+
+
+@pytest.mark.asyncio
+async def test_fetch_mesh_and_pub_types_handles_http_error():
+    tools = PubMedTools()
+    session = _make_aiohttp_session(_make_aiohttp_response(status=500, text=""))
+    out = await tools.fetch_mesh_and_pub_types(["1"], session=session, timeout=5.0)
+    assert out == {}
+
+
+@pytest.mark.asyncio
+async def test_fetch_mesh_and_pub_types_handles_malformed_xml():
+    tools = PubMedTools()
+    session = _make_aiohttp_session(_make_aiohttp_response(text="<not xml"))
+    out = await tools.fetch_mesh_and_pub_types(["1"], session=session, timeout=5.0)
+    assert out == {}
+
+
+# ---------------------------------------------------------------------------
+# PubMedTools.find_related_pmids
+# ---------------------------------------------------------------------------
+
+
+_ELINK_JSON_FIXTURE = {
+    "linksets": [
+        {
+            "linksetdbs": [
+                {
+                    "linkname": "pubmed_pubmed",
+                    "links": ["11111111", "33333333", "44444444", "55555555"],
+                },
+                {
+                    "linkname": "pubmed_pubmed_citedin",
+                    "links": ["99999999"],
+                },
+            ]
+        }
+    ]
+}
+
+
+@pytest.mark.asyncio
+async def test_find_related_pmids_excludes_seed():
+    tools = PubMedTools()
+    session = _make_aiohttp_session(
+        _make_aiohttp_response(json_data=_ELINK_JSON_FIXTURE)
+    )
+    related = await tools.find_related_pmids(
+        "11111111", session=session, max_results=10
+    )
+    assert "11111111" not in related
+    assert related == ["33333333", "44444444", "55555555"]
+
+
+@pytest.mark.asyncio
+async def test_find_related_pmids_respects_max_results():
+    tools = PubMedTools()
+    session = _make_aiohttp_session(
+        _make_aiohttp_response(json_data=_ELINK_JSON_FIXTURE)
+    )
+    related = await tools.find_related_pmids("11111111", session=session, max_results=2)
+    assert len(related) == 2
+
+
+@pytest.mark.asyncio
+async def test_find_related_pmids_only_uses_pubmed_pubmed_linkname():
+    tools = PubMedTools()
+    session = _make_aiohttp_session(
+        _make_aiohttp_response(json_data=_ELINK_JSON_FIXTURE)
+    )
+    related = await tools.find_related_pmids(
+        "11111111", session=session, max_results=10
+    )
+    # 99999999 is from `pubmed_pubmed_citedin`, must not be included.
+    assert "99999999" not in related
+
+
+@pytest.mark.asyncio
+async def test_find_related_pmids_handles_empty_pmid():
+    tools = PubMedTools()
+    related = await tools.find_related_pmids("")
+    assert related == []
+
+
+@pytest.mark.asyncio
+async def test_find_related_pmids_handles_http_error():
+    tools = PubMedTools()
+    session = _make_aiohttp_session(_make_aiohttp_response(status=503, json_data={}))
+    related = await tools.find_related_pmids(
+        "11111111", session=session, max_results=10
+    )
+    assert related == []
+
+
+# ---------------------------------------------------------------------------
+# PubMedTools.structured_search end-to-end (DB + mocked PubMed API)
+# ---------------------------------------------------------------------------
+
+
+class StructuredSearchE2ETest(TransactionTestCase):
+    """End-to-end: structured_search should run a query, fetch articles,
+    fetch publication types, and return categorized buckets."""
+
+    def setUp(self):
+        # Pre-seed mini articles so structured_search doesn't need to call
+        # metapub's article_by_pmid to materialize them.
+        for pmid, title in [
+            ("11111111", "Meta-analysis of biologic therapy for RA"),
+            ("22222222", "Review of TNF inhibitors"),
+            ("33333333", "Editorial commentary"),
+        ]:
+            PubMedMiniArticle.objects.create(
+                pmid=pmid,
+                title=title,
+                abstract=f"Abstract for {title}",
+                article_url=f"https://pubmed.ncbi.nlm.nih.gov/{pmid}/",
+            )
+
+    def test_structured_search_categorizes_results(self):
+        tools = PubMedTools()
+
+        async def fake_fetch_mesh_and_pub_types(pmids, **kwargs):
+            return {
+                "11111111": {"pub_types": ["Meta-Analysis"], "mesh": []},
+                "22222222": {"pub_types": ["Review"], "mesh": []},
+                "33333333": {"pub_types": ["Editorial"], "mesh": []},
+            }
+
+        async def fake_find_ids(query, since=None, timeout=60.0):
+            return ["11111111", "22222222", "33333333"]
+
+        with patch.object(
+            tools, "find_pubmed_article_ids_for_query", side_effect=fake_find_ids
+        ), patch.object(
+            tools,
+            "fetch_mesh_and_pub_types",
+            side_effect=fake_fetch_mesh_and_pub_types,
+        ):
+
+            async def run():
+                return await tools.structured_search(
+                    condition="rheumatoid arthritis",
+                    treatment="infliximab",
+                    pub_type_preset="high_quality_evidence",
+                )
+
+            buckets = async_to_sync(run)()
+
+            strong_pmids = [a.pmid for a in buckets[EvidenceStrength.STRONG]]
+            moderate_pmids = [a.pmid for a in buckets[EvidenceStrength.MODERATE]]
+            weak_pmids = [a.pmid for a in buckets[EvidenceStrength.WEAK]]
+
+            assert "11111111" in strong_pmids
+            assert "22222222" in moderate_pmids
+            assert "33333333" in weak_pmids
+
+    def test_structured_search_empty_query_returns_empty_buckets(self):
+        tools = PubMedTools()
+
+        async def run():
+            return await tools.structured_search()
+
+        buckets = async_to_sync(run)()
+        assert set(buckets.keys()) == set(EvidenceStrength)
+        for tier in EvidenceStrength:
+            assert buckets[tier] == []
+
+    def test_structured_search_with_expand_with_related(self):
+        tools = PubMedTools()
+
+        async def fake_find_ids(query, since=None, timeout=60.0):
+            return ["11111111"]
+
+        async def fake_related(seed, session=None, timeout=15.0, max_results=10):
+            assert seed == "11111111"
+            return ["22222222"]
+
+        async def fake_fetch_pub_types(pmids, **kwargs):
+            return {
+                "11111111": {"pub_types": ["Meta-Analysis"], "mesh": []},
+                "22222222": {"pub_types": ["Review"], "mesh": []},
+            }
+
+        with patch.object(
+            tools, "find_pubmed_article_ids_for_query", side_effect=fake_find_ids
+        ), patch.object(
+            tools, "find_related_pmids", side_effect=fake_related
+        ), patch.object(
+            tools,
+            "fetch_mesh_and_pub_types",
+            side_effect=fake_fetch_pub_types,
+        ):
+
+            async def run():
+                return await tools.structured_search(
+                    condition="rheumatoid arthritis",
+                    expand_with_related=True,
+                )
+
+            buckets = async_to_sync(run)()
+
+            all_pmids = [a.pmid for tier in EvidenceStrength for a in buckets[tier]]
+            # Both the seed and the related PMID should appear.
+            assert "11111111" in all_pmids
+            assert "22222222" in all_pmids
+
+
+# ---------------------------------------------------------------------------
+# PubMedTools.format_structured_search_for_appeal
+# ---------------------------------------------------------------------------
+
+
+def test_format_structured_search_for_appeal_delegates():
+    """Sanity: the static helper should produce the same output as
+    format_categorized_snippets."""
+    a = _make_article("1", title="X", basic_summary="finding")
+    buckets = {
+        EvidenceStrength.STRONG: [a],
+        EvidenceStrength.MODERATE: [],
+        EvidenceStrength.WEAK: [],
+        EvidenceStrength.UNKNOWN: [],
+    }
+    via_helper = format_categorized_snippets(buckets)
+    via_method = PubMedTools.format_structured_search_for_appeal(buckets)
+    assert via_helper == via_method


### PR DESCRIPTION
## Summary
This PR introduces a comprehensive structured PubMed search system that enables building complex queries with publication-type filters, MeSH terms, and date ranges, then categorizes results by evidence strength for use in insurance appeal letters.

## Key Changes

### New Module: `pubmed_search.py`
A pure-function module for PubMed query building and evidence classification:
- **Query Building**: `build_structured_query()` composes PubMed queries from condition, treatment, publication-type presets/filters, MeSH terms, date ranges, and extra terms
- **Evidence Classification**: `classify_evidence_strength()` categorizes articles into STRONG/MODERATE/WEAK/UNKNOWN tiers based on publication types (e.g., meta-analyses and RCTs are strong; editorials are weak)
- **Publication Type Handling**: `extract_publication_types()` and `normalize_pub_type()` normalize publication metadata from various article object formats
- **Article Categorization**: `categorize_articles_by_strength()` buckets articles by evidence tier with optional lookup override
- **Snippet Formatting**: `format_appeal_snippet()` and `format_categorized_snippets()` render articles as appeal-letter-ready text with citations and excerpts

### Enhanced `pubmed_tools.py`
Extended `PubMedTools` class with three new async methods:
- **`fetch_mesh_and_pub_types()`**: Batches PMID list into a single `efetch` call to retrieve MeSH terms and publication types from NCBI E-utilities, with graceful error handling
- **`find_related_pmids()`**: Uses NCBI's `elink` API to discover related articles for query expansion when user vocabulary is too narrow
- **`structured_search()`**: End-to-end orchestration that builds a query, runs the search, fetches publication metadata, and returns articles bucketed by evidence strength

### Configuration & Constants
- Defined publication-type tiers: `STRONG_PUB_TYPES` (meta-analyses, RCTs, guidelines), `MODERATE_PUB_TYPES` (reviews, clinical trials), `WEAK_PUB_TYPES` (editorials, case reports)
- Created `PUB_TYPE_FILTERS` mapping (e.g., `"rct"` → `"Randomized Controlled Trial[pt]"`)
- Added `PUB_TYPE_PRESETS` for common filter bundles (e.g., `"high_quality_evidence"`)
- Implemented `_ensure_session()` context manager for optional session reuse in async methods

## Notable Implementation Details

- **Query Sanitization**: User input is stripped of PubMed-reserved characters (`[]()`) to prevent injection attacks
- **Multi-word Phrase Handling**: Automatically quotes multi-word terms for exact-phrase matching
- **Graceful Degradation**: Network errors, timeouts, and XML parse failures return empty results rather than raising, allowing callers to degrade gracefully
- **Batching**: `fetch_mesh_and_pub_types()` accepts comma-separated PMIDs in a single request to minimize API calls
- **Evidence Tier Precedence**: When an article has multiple publication types, the strongest tier wins (e.g., an article tagged both "Review" and "Meta-Analysis" classifies as STRONG)
- **Comprehensive Test Coverage**: 695-line test suite covering query building, evidence classification, snippet formatting, and end-to-end search with mocked PubMed API and Django ORM

## Use Case
Enables the application to run sophisticated PubMed searches tailored to insurance appeals, automatically surfacing the highest-quality evidence (meta-analyses, RCTs, guidelines) while still capturing supporting evidence at lower tiers, all formatted for inclusion in appeal letters.

https://claude.ai/code/session_01EnWCVmgZFgPhtkxXpekCPp