### PR TITLE
Add IMR/external-appeal decision retrieval for appeal generation

### DIFF
--- a/fighthealthinsurance/actor_health_status.py
+++ b/fighthealthinsurance/actor_health_status.py
@@ -37,6 +37,7 @@ def check_actor_health() -> Dict[str, Any]:
         ("email_polling_actor", "fhi"),
         ("fax_polling_actor", "fhi"),
         ("chooser_refill_actor", "fhi"),
+        ("imr_refresh_actor", "fhi"),
     ]
 
     details: List[ActorHealthDetail] = []
@@ -119,17 +120,20 @@ def relaunch_actors(force: bool = False) -> Dict[str, Any]:
     from fighthealthinsurance.chooser_refill_actor_ref import chooser_refill_actor_ref
     from fighthealthinsurance.email_polling_actor_ref import email_polling_actor_ref
     from fighthealthinsurance.fax_polling_actor_ref import fax_polling_actor_ref
+    from fighthealthinsurance.imr_refresh_actor_ref import imr_refresh_actor_ref
 
     results: Dict[str, Dict[str, Any]] = {
         "email_polling_actor": {"status": "pending"},
         "fax_polling_actor": {"status": "pending"},
         "chooser_refill_actor": {"status": "pending"},
+        "imr_refresh_actor": {"status": "pending"},
     }
 
     actors = [
         ("email_polling_actor", email_polling_actor_ref),
         ("fax_polling_actor", fax_polling_actor_ref),
         ("chooser_refill_actor", chooser_refill_actor_ref),
+        ("imr_refresh_actor", imr_refresh_actor_ref),
     ]
 
     for actor_name, actor_ref in actors:
@@ -155,6 +159,8 @@ def relaunch_actors(force: bool = False) -> Dict[str, Any]:
                     actor_ref.fax_polling_actor = None  # type: ignore
                 elif actor_name == "chooser_refill_actor":
                     actor_ref.chooser_refill_actor = None  # type: ignore
+                elif actor_name == "imr_refresh_actor":
+                    actor_ref.imr_refresh_actor = None  # type: ignore
 
                 # Clear the cached property by deleting it from the instance
                 try:

--- a/fighthealthinsurance/actor_health_status.py
+++ b/fighthealthinsurance/actor_health_status.py
@@ -1,10 +1,11 @@
 """
 Actor health check module for Ray polling actors.
 
-This module provides health checks for the three polling actors:
+This module provides health checks for the polling actors:
 - EmailPollingActor
 - FaxPollingActor
 - ChooserRefillActor
+- IMRRefreshActor
 
 It checks if actors are alive and returns their status.
 """
@@ -152,17 +153,11 @@ def relaunch_actors(force: bool = False) -> Dict[str, Any]:
                     logger.warning(f"Error killing actor {actor_name}: {e}")
                     results[actor_name]["kill_error"] = str(e)
 
-                # Reset the actor reference to force recreation
-                if actor_name == "email_polling_actor":
-                    actor_ref.email_polling_actor = None  # type: ignore
-                elif actor_name == "fax_polling_actor":
-                    actor_ref.fax_polling_actor = None  # type: ignore
-                elif actor_name == "chooser_refill_actor":
-                    actor_ref.chooser_refill_actor = None  # type: ignore
-                elif actor_name == "imr_refresh_actor":
-                    actor_ref.imr_refresh_actor = None  # type: ignore
-
-                # Clear the cached property by deleting it from the instance
+                # Reset the actor reference so the next .get builds a fresh
+                # handle. BaseActorRef caches the live handle in
+                # _actor_instance and the cached_property in __dict__["get"];
+                # both must be cleared or .get returns the dead handle.
+                actor_ref._actor_instance = None  # type: ignore
                 try:
                     if hasattr(actor_ref, "get"):
                         delattr(actor_ref, "get")

--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -51,6 +51,7 @@ from fighthealthinsurance.form_utils import *
 from fighthealthinsurance.generate_appeal import *
 from fighthealthinsurance.ml.ml_appeal_questions_helper import MLAppealQuestionsHelper
 from fighthealthinsurance.ml.ml_citations_helper import MLCitationsHelper
+from fighthealthinsurance.ml.imr_decision_retriever import IMRDecisionRetriever
 from fighthealthinsurance.ml.ml_plan_doc_helper import MLPlanDocHelper
 from fighthealthinsurance.models import *
 from fighthealthinsurance.process_denial import ProcessDenialCodes
@@ -2466,6 +2467,7 @@ class AppealsBackendHelper:
         ml_citation_context: Optional[Any] = None
         rag_context: Optional[str] = None
         nice_context: Optional[str] = None
+        imr_context: Optional[str] = None
 
         # Get PubMed context
         logger.debug("Looking up the pubmed context")
@@ -2573,6 +2575,16 @@ class AppealsBackendHelper:
                 done_msg="Guidelines lookup complete",
             )
 
+            # Get prior IMR / external-appeal decisions similar to this denial
+            imr_context_awaitable = tracked_awaitable(
+                asyncio.wait_for(
+                    IMRDecisionRetriever.get_context_for_denial(denial),
+                    timeout=10,
+                ),
+                substep="imr_decisions",
+                done_msg="Prior IMR decisions lookup complete",
+            )
+
             # Skip the NICE task entirely when no key is configured: avoids a
             # misleading "NICE guidance lookup complete" status and the wait_for
             # overhead in environments without syndication access.
@@ -2580,6 +2592,7 @@ class AppealsBackendHelper:
                 pubmed_context_awaitable,
                 ml_citation_context_awaitable,
                 rag_context_awaitable,
+                imr_context_awaitable,
             ]
             if cls.nice.api_key:
                 gather_awaitables.append(
@@ -2627,8 +2640,11 @@ class AppealsBackendHelper:
                     rag_context = None
                     if results[2] is not None:
                         logger.debug(f"RAG context not available: {results[2]}")
-                if len(results) > 3 and isinstance(results[3], str):
-                    nice_context = results[3]
+                if isinstance(results[3], str) and results[3]:
+                    imr_context = results[3]
+                    logger.info("IMR decisions context retrieved")
+                if len(results) > 4 and isinstance(results[4], str):
+                    nice_context = results[4]
                 else:
                     # No fresh NICE result (skipped task or non-string error). Fall
                     # back to whatever is already persisted on the denial so cached
@@ -2698,6 +2714,18 @@ class AppealsBackendHelper:
                     else:
                         # Use microsite context as standalone context
                         ml_citation_context = microsite_context
+
+        if imr_context:
+            if ml_citation_context:
+                if isinstance(ml_citation_context, list):
+                    ml_citation_context = "\n".join(
+                        str(c) for c in ml_citation_context if c
+                    )
+                ml_citation_context = f"{ml_citation_context}\n\n{imr_context}"
+            elif pubmed_context:
+                pubmed_context = f"{pubmed_context}\n\n{imr_context}"
+            else:
+                ml_citation_context = imr_context
 
         async def save_appeal(appeal_text: str) -> dict[str, str]:
             # Save all of the proposed appeals, so we can use RL later.

--- a/fighthealthinsurance/imr_ingest.py
+++ b/fighthealthinsurance/imr_ingest.py
@@ -1,0 +1,281 @@
+"""Parsers and ingestion helpers for public IMR / external-appeal datasets.
+
+The CA DMHC IMR dataset is published on the California CHHS open data portal as
+a CSV with a stable column schema (Reference ID, Report Year, Diagnosis
+Category/Sub-Category, Treatment Category/Sub-Category, Determination, Type,
+Age Range, Patient Gender, Findings). The NY DFS External Appeals database is
+served as a search UI; we accept the same kind of normalized CSV export so the
+loader can be reused.
+
+The loader is idempotent: each source row maps to a single ``IMRDecision`` row
+keyed by ``(source, case_id)``.
+"""
+
+import csv
+import io
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Dict, Iterable, Iterator, List, Optional, Tuple
+
+from loguru import logger
+
+from fighthealthinsurance.models import IMRDecision
+
+
+@dataclass
+class ParsedIMRRow:
+    """Normalized representation of a single IMR / external-appeal record."""
+
+    source: str
+    case_id: str
+    state: str
+    decision_year: Optional[int] = None
+    decision_date: Optional[date] = None
+    diagnosis: str = ""
+    diagnosis_category: str = ""
+    treatment: str = ""
+    treatment_category: str = ""
+    treatment_subcategory: str = ""
+    determination: str = IMRDecision.DETERMINATION_OTHER
+    decision_type: str = ""
+    insurance_type: str = ""
+    age_range: str = ""
+    gender: str = ""
+    findings: str = ""
+    summary: str = ""
+    source_url: str = ""
+    raw_data: Optional[Dict] = None
+
+
+# --- Header normalization ----------------------------------------------------
+
+
+def _norm_header(h: str) -> str:
+    return "".join(ch for ch in h.lower() if ch.isalnum())
+
+
+def _normalize_row(row: Dict[str, str]) -> Dict[str, str]:
+    """Return a copy of the row keyed by normalized (alnum-lowercase) headers."""
+    return {_norm_header(k): v for k, v in row.items() if k}
+
+
+def _lookup(normalized: Dict[str, str], *candidates: str) -> str:
+    """First non-empty value among ``candidates`` in a pre-normalized row."""
+    for c in candidates:
+        v = normalized.get(_norm_header(c))
+        if v:
+            return v.strip()
+    return ""
+
+
+# --- Determination normalization --------------------------------------------
+
+_DETERMINATION_MAP = {
+    "overturned": IMRDecision.DETERMINATION_OVERTURNED,
+    "overturneddecision": IMRDecision.DETERMINATION_OVERTURNED,
+    "overturnedinpart": IMRDecision.DETERMINATION_OVERTURNED_IN_PART,
+    "overturnedmodified": IMRDecision.DETERMINATION_OVERTURNED_IN_PART,
+    "overturnedpartial": IMRDecision.DETERMINATION_OVERTURNED_IN_PART,
+    "upheld": IMRDecision.DETERMINATION_UPHELD,
+    "upholddecision": IMRDecision.DETERMINATION_UPHELD,
+    "upheldfinaldetermination": IMRDecision.DETERMINATION_UPHELD,
+}
+
+
+def _normalize_determination(raw: str) -> str:
+    if not raw:
+        return IMRDecision.DETERMINATION_OTHER
+    key = "".join(ch for ch in raw.lower() if ch.isalnum())
+    return _DETERMINATION_MAP.get(key, IMRDecision.DETERMINATION_OTHER)
+
+
+def _parse_year(raw: str) -> Optional[int]:
+    if not raw:
+        return None
+    digits = "".join(ch for ch in raw if ch.isdigit())[:4]
+    if len(digits) == 4:
+        try:
+            return int(digits)
+        except ValueError:
+            return None
+    return None
+
+
+def _parse_date(raw: str) -> Optional[date]:
+    if not raw:
+        return None
+    for fmt in ("%Y-%m-%d", "%m/%d/%Y", "%m/%d/%y", "%Y/%m/%d"):
+        try:
+            return datetime.strptime(raw.strip(), fmt).date()
+        except ValueError:
+            continue
+    return None
+
+
+# --- Source-specific parsers -------------------------------------------------
+
+
+def parse_ca_dmhc_row(row: Dict[str, str]) -> Optional[ParsedIMRRow]:
+    """Parse a single row from the CA DMHC IMR CSV.
+
+    Returns None when the row lacks a usable case identifier.
+    """
+    n = _normalize_row(row)
+    case_id = _lookup(n, "Reference ID", "ReferenceID", "Case Number", "Case Id")
+    if not case_id:
+        return None
+    treatment_subcategory = _lookup(
+        n, "Treatment Sub Category", "TreatmentSubCategory", "Treatment SubCategory"
+    )
+    treatment_category = _lookup(n, "Treatment Category", "TreatmentCategory")
+    return ParsedIMRRow(
+        source=IMRDecision.SOURCE_CA_DMHC,
+        case_id=case_id,
+        state="CA",
+        decision_year=_parse_year(_lookup(n, "Report Year", "ReportYear", "Year")),
+        decision_date=_parse_date(
+            _lookup(n, "Decision Date", "DecisionDate", "Determination Date")
+        ),
+        diagnosis_category=_lookup(n, "Diagnosis Category", "DiagnosisCategory"),
+        diagnosis=_lookup(
+            n,
+            "Diagnosis Sub Category",
+            "DiagnosisSubCategory",
+            "Diagnosis SubCategory",
+            "Diagnosis",
+        ),
+        treatment_category=treatment_category,
+        treatment_subcategory=treatment_subcategory,
+        # CA dataset has no top-level "Treatment" column; fall back from
+        # subcategory to category so the searchable treatment field is set.
+        treatment=treatment_subcategory or treatment_category,
+        determination=_normalize_determination(
+            _lookup(n, "Determination", "Outcome", "Decision")
+        ),
+        decision_type=_lookup(n, "Type", "IMR Type", "IMRType", "Decision Type"),
+        age_range=_lookup(n, "Age Range", "AgeRange"),
+        gender=_lookup(n, "Patient Gender", "PatientGender", "Gender"),
+        findings=_lookup(n, "Findings", "Determination Rationale", "Rationale"),
+        raw_data=dict(row),
+    )
+
+
+def parse_ny_dfs_row(row: Dict[str, str]) -> Optional[ParsedIMRRow]:
+    """Parse a single row from a NY DFS external-appeals CSV export."""
+    n = _normalize_row(row)
+    case_id = _lookup(n, "Appeal Number", "AppealNumber", "Case ID", "Reference ID")
+    if not case_id:
+        return None
+    return ParsedIMRRow(
+        source=IMRDecision.SOURCE_NY_DFS,
+        case_id=case_id,
+        state="NY",
+        decision_year=_parse_year(_lookup(n, "Year", "Decision Year", "DecisionYear")),
+        decision_date=_parse_date(_lookup(n, "Decision Date", "DecisionDate", "Date")),
+        diagnosis=_lookup(n, "Diagnosis", "Patient Diagnosis"),
+        diagnosis_category=_lookup(n, "Diagnosis Category", "DiagnosisCategory"),
+        treatment=_lookup(n, "Treatment", "Service", "Procedure"),
+        treatment_category=_lookup(
+            n, "Treatment Category", "TreatmentCategory", "Service Category"
+        ),
+        treatment_subcategory=_lookup(
+            n, "Treatment Sub Category", "TreatmentSubCategory"
+        ),
+        determination=_normalize_determination(
+            _lookup(n, "Determination", "Decision", "Outcome")
+        ),
+        decision_type=_lookup(
+            n, "Appeal Type", "AppealType", "Reason", "Decision Reason"
+        ),
+        insurance_type=_lookup(n, "Plan Type", "PlanType", "Insurer Type"),
+        age_range=_lookup(n, "Age Range", "AgeRange", "Age Group", "Age"),
+        gender=_lookup(n, "Gender", "Patient Gender"),
+        findings=_lookup(n, "Description", "Summary", "Findings", "Decision Detail"),
+        raw_data=dict(row),
+    )
+
+
+# --- Loader ------------------------------------------------------------------
+
+
+def iter_csv_rows(text: str) -> Iterator[Dict[str, str]]:
+    reader = csv.DictReader(io.StringIO(text))
+    for row in reader:
+        yield {(k or ""): (v or "") for k, v in row.items()}
+
+
+def load_parsed_rows(rows: Iterable[ParsedIMRRow]) -> Tuple[int, int]:
+    """Upsert parsed rows. Returns ``(created, updated)`` counts."""
+    created = 0
+    updated = 0
+    for row in rows:
+        defaults = {
+            "state": row.state,
+            "decision_year": row.decision_year,
+            "decision_date": row.decision_date,
+            "diagnosis": row.diagnosis,
+            "diagnosis_category": row.diagnosis_category,
+            "treatment": row.treatment,
+            "treatment_category": row.treatment_category,
+            "treatment_subcategory": row.treatment_subcategory,
+            "determination": row.determination,
+            "decision_type": row.decision_type,
+            "insurance_type": row.insurance_type,
+            "age_range": row.age_range,
+            "gender": row.gender,
+            "findings": row.findings,
+            "summary": row.summary,
+            "source_url": row.source_url,
+            "raw_data": row.raw_data,
+        }
+        try:
+            _, was_created = IMRDecision.objects.update_or_create(
+                source=row.source,
+                case_id=row.case_id,
+                defaults=defaults,
+            )
+            if was_created:
+                created += 1
+            else:
+                updated += 1
+        except Exception as e:
+            logger.opt(exception=True).warning(
+                f"Failed to upsert IMR decision {row.source}/{row.case_id}: {e}"
+            )
+    return created, updated
+
+
+def fetch_csv(source_url: str, timeout: int = 120) -> str:
+    """Download a CSV from ``source_url``. Imported lazily to keep import cost low."""
+    import requests
+
+    response = requests.get(source_url, timeout=timeout)
+    response.raise_for_status()
+    return response.text
+
+
+def load_csv_text(
+    csv_text: str,
+    source: str,
+    source_url: str = "",
+) -> Tuple[int, int, int]:
+    """Parse and load a CSV body. Returns ``(created, updated, skipped)``."""
+    if source == IMRDecision.SOURCE_CA_DMHC:
+        parser = parse_ca_dmhc_row
+    elif source == IMRDecision.SOURCE_NY_DFS:
+        parser = parse_ny_dfs_row
+    else:
+        raise ValueError(f"Unknown IMR source: {source}")
+
+    parsed: List[ParsedIMRRow] = []
+    skipped = 0
+    for row in iter_csv_rows(csv_text):
+        result = parser(row)
+        if result is None:
+            skipped += 1
+            continue
+        if source_url:
+            result.source_url = source_url
+        parsed.append(result)
+    created, updated = load_parsed_rows(parsed)
+    return created, updated, skipped

--- a/fighthealthinsurance/imr_ingest.py
+++ b/fighthealthinsurance/imr_ingest.py
@@ -205,10 +205,15 @@ def iter_csv_rows(text: str) -> Iterator[Dict[str, str]]:
         yield {(k or ""): (v or "") for k, v in row.items()}
 
 
-def load_parsed_rows(rows: Iterable[ParsedIMRRow]) -> Tuple[int, int]:
-    """Upsert parsed rows. Returns ``(created, updated)`` counts."""
+def load_parsed_rows(rows: Iterable[ParsedIMRRow]) -> Tuple[int, int, int]:
+    """Upsert parsed rows. Returns ``(created, updated, failed)`` counts.
+
+    ``failed`` counts rows that raised during upsert; callers should surface
+    a non-zero value rather than reporting a clean ingest.
+    """
     created = 0
     updated = 0
+    failed = 0
     for row in rows:
         defaults = {
             "state": row.state,
@@ -240,10 +245,11 @@ def load_parsed_rows(rows: Iterable[ParsedIMRRow]) -> Tuple[int, int]:
             else:
                 updated += 1
         except Exception as e:
+            failed += 1
             logger.opt(exception=True).warning(
                 f"Failed to upsert IMR decision {row.source}/{row.case_id}: {e}"
             )
-    return created, updated
+    return created, updated, failed
 
 
 def fetch_csv(source_url: str, timeout: int = 120) -> str:
@@ -259,8 +265,8 @@ def load_csv_text(
     csv_text: str,
     source: str,
     source_url: str = "",
-) -> Tuple[int, int, int]:
-    """Parse and load a CSV body. Returns ``(created, updated, skipped)``."""
+) -> Tuple[int, int, int, int]:
+    """Parse and load a CSV body. Returns ``(created, updated, skipped, failed)``."""
     if source == IMRDecision.SOURCE_CA_DMHC:
         parser = parse_ca_dmhc_row
     elif source == IMRDecision.SOURCE_NY_DFS:
@@ -278,5 +284,5 @@ def load_csv_text(
         if source_url:
             result.source_url = source_url
         parsed.append(result)
-    created, updated = load_parsed_rows(parsed)
-    return created, updated, skipped
+    created, updated, failed = load_parsed_rows(parsed)
+    return created, updated, skipped, failed

--- a/fighthealthinsurance/imr_ingest.py
+++ b/fighthealthinsurance/imr_ingest.py
@@ -77,6 +77,7 @@ _DETERMINATION_MAP = {
     "overturnedmodified": IMRDecision.DETERMINATION_OVERTURNED_IN_PART,
     "overturnedpartial": IMRDecision.DETERMINATION_OVERTURNED_IN_PART,
     "upheld": IMRDecision.DETERMINATION_UPHELD,
+    "uphelddecision": IMRDecision.DETERMINATION_UPHELD,
     "upholddecision": IMRDecision.DETERMINATION_UPHELD,
     "upheldfinaldetermination": IMRDecision.DETERMINATION_UPHELD,
 }

--- a/fighthealthinsurance/imr_refresh_actor.py
+++ b/fighthealthinsurance/imr_refresh_actor.py
@@ -1,0 +1,120 @@
+"""Ray actor that periodically refreshes the IMR / external-appeal corpus.
+
+Pulls the CA DMHC and (optionally) NY DFS CSV exports on the
+``IMR_REFRESH_INTERVAL_HOURS`` cadence and upserts rows via the shared
+``load_csv_text`` loader. Sources whose URL setting is unset are skipped.
+"""
+
+import asyncio
+import datetime
+import os
+import time
+from typing import Optional, Tuple
+
+import ray
+from asgiref.sync import sync_to_async
+
+from fighthealthinsurance.utils import get_env_variable
+
+name = "IMRRefreshActor"
+
+
+# Backoff between attempts after an unexpected error.
+ERROR_BACKOFF_SECONDS = 600
+
+
+@ray.remote(max_restarts=-1, max_task_retries=-1)
+class IMRRefreshActor:
+    def __init__(self) -> None:
+        time.sleep(1)
+        os.environ.setdefault(
+            "DJANGO_SETTINGS_MODULE",
+            get_env_variable("DJANGO_SETTINGS_MODULE", "fighthealthinsurance.settings"),
+        )
+        from configurations.wsgi import get_wsgi_application
+
+        _application = get_wsgi_application()
+        from loguru import logger
+
+        self._logger = logger
+        self.running = False
+        self.last_refresh: Optional[datetime.datetime] = None
+        self._logger.info("IMRRefreshActor initialized")
+
+    async def health_check(self) -> bool:
+        return self.running
+
+    async def run(self) -> None:
+        self._logger.info("Starting IMRRefreshActor run")
+        self.running = True
+
+        while self.running:
+            try:
+                interval_hours = self._interval_hours()
+                await self._refresh_due_sources(interval_hours)
+                # Re-check hourly so config changes are picked up without restart.
+                await asyncio.sleep(3600)
+            except Exception:
+                self._logger.opt(exception=True).error(
+                    "Error in IMRRefreshActor refresh cycle"
+                )
+                await asyncio.sleep(ERROR_BACKOFF_SECONDS)
+
+        self._logger.warning("IMRRefreshActor stopped running")
+
+    def stop(self) -> None:
+        self.running = False
+
+    # --- Implementation -----------------------------------------------------
+
+    @staticmethod
+    def _interval_hours() -> int:
+        from django.conf import settings
+
+        return getattr(settings, "IMR_REFRESH_INTERVAL_HOURS", 168)
+
+    @staticmethod
+    def _configured_sources() -> list[Tuple[str, str]]:
+        from django.conf import settings
+
+        from fighthealthinsurance.models import IMRDecision
+
+        candidates = [
+            (IMRDecision.SOURCE_CA_DMHC, getattr(settings, "IMR_DMHC_CSV_URL", "")),
+            (IMRDecision.SOURCE_NY_DFS, getattr(settings, "IMR_DFS_CSV_URL", "")),
+        ]
+        return [(src, url) for src, url in candidates if url]
+
+    async def _refresh_due_sources(self, interval_hours: int) -> None:
+        sources = self._configured_sources()
+        if not sources:
+            self._logger.debug("No IMR_*_CSV_URL settings configured; skipping refresh")
+            return
+
+        if self.last_refresh is not None:
+            elapsed = datetime.datetime.utcnow() - self.last_refresh
+            if elapsed < datetime.timedelta(hours=interval_hours):
+                return
+
+        for source, url in sources:
+            try:
+                created, updated, skipped = await sync_to_async(
+                    self._refresh_source, thread_sensitive=False
+                )(source, url)
+                self._logger.info(
+                    f"IMR refresh ({source}): {created} created, "
+                    f"{updated} updated, {skipped} skipped"
+                )
+            except Exception as e:
+                self._logger.opt(exception=True).warning(
+                    f"IMR refresh failed for source {source}: {e}"
+                )
+
+        self.last_refresh = datetime.datetime.utcnow()
+
+    @staticmethod
+    def _refresh_source(source: str, url: str) -> Tuple[int, int, int]:
+        from fighthealthinsurance.imr_ingest import fetch_csv, load_csv_text
+
+        csv_text = fetch_csv(url)
+        return load_csv_text(csv_text, source=source, source_url=url)

--- a/fighthealthinsurance/imr_refresh_actor.py
+++ b/fighthealthinsurance/imr_refresh_actor.py
@@ -99,13 +99,14 @@ class IMRRefreshActor:
         any_success = False
         for source, url in sources:
             try:
-                created, updated, skipped = await sync_to_async(
+                created, updated, skipped, failed = await sync_to_async(
                     self._refresh_source, thread_sensitive=False
                 )(source, url)
                 any_success = True
-                self._logger.info(
+                log = self._logger.warning if failed else self._logger.info
+                log(
                     f"IMR refresh ({source}): {created} created, "
-                    f"{updated} updated, {skipped} skipped"
+                    f"{updated} updated, {skipped} skipped, {failed} failed"
                 )
             except Exception as e:
                 self._logger.opt(exception=True).warning(
@@ -119,7 +120,7 @@ class IMRRefreshActor:
             self.last_refresh = datetime.datetime.utcnow()
 
     @staticmethod
-    def _refresh_source(source: str, url: str) -> Tuple[int, int, int]:
+    def _refresh_source(source: str, url: str) -> Tuple[int, int, int, int]:
         from fighthealthinsurance.imr_ingest import fetch_csv, load_csv_text
 
         csv_text = fetch_csv(url)

--- a/fighthealthinsurance/imr_refresh_actor.py
+++ b/fighthealthinsurance/imr_refresh_actor.py
@@ -96,11 +96,13 @@ class IMRRefreshActor:
             if elapsed < datetime.timedelta(hours=interval_hours):
                 return
 
+        any_success = False
         for source, url in sources:
             try:
                 created, updated, skipped = await sync_to_async(
                     self._refresh_source, thread_sensitive=False
                 )(source, url)
+                any_success = True
                 self._logger.info(
                     f"IMR refresh ({source}): {created} created, "
                     f"{updated} updated, {skipped} skipped"
@@ -110,7 +112,11 @@ class IMRRefreshActor:
                     f"IMR refresh failed for source {source}: {e}"
                 )
 
-        self.last_refresh = datetime.datetime.utcnow()
+        # Only mark the cycle as complete if at least one source actually
+        # refreshed; otherwise the next loop iteration will retry instead of
+        # waiting another full IMR_REFRESH_INTERVAL_HOURS window.
+        if any_success:
+            self.last_refresh = datetime.datetime.utcnow()
 
     @staticmethod
     def _refresh_source(source: str, url: str) -> Tuple[int, int, int]:

--- a/fighthealthinsurance/imr_refresh_actor_ref.py
+++ b/fighthealthinsurance/imr_refresh_actor_ref.py
@@ -1,0 +1,13 @@
+from fighthealthinsurance.base_actor_ref import BaseActorRef
+from fighthealthinsurance.imr_refresh_actor import IMRRefreshActor
+
+
+class IMRRefreshActorRef(BaseActorRef):
+    """A reference to the IMR refresh actor."""
+
+    actor_class = IMRRefreshActor
+    actor_name = "imr_refresh_actor"
+    has_run_method = True
+
+
+imr_refresh_actor_ref = IMRRefreshActorRef()

--- a/fighthealthinsurance/management/commands/_imr_ingest_base.py
+++ b/fighthealthinsurance/management/commands/_imr_ingest_base.py
@@ -50,12 +50,14 @@ class IMRIngestCommand(BaseCommand):
                 csv_text = fh.read()
             source_url = ""
 
-        created, updated, skipped = load_csv_text(
+        created, updated, skipped, failed = load_csv_text(
             csv_text, source=self.source, source_url=source_url
         )
+        style = self.style.WARNING if failed else self.style.SUCCESS
         self.stdout.write(
-            self.style.SUCCESS(
+            style(
                 f"{self.label} ingest complete: "
-                f"{created} created, {updated} updated, {skipped} skipped"
+                f"{created} created, {updated} updated, "
+                f"{skipped} skipped, {failed} failed"
             )
         )

--- a/fighthealthinsurance/management/commands/_imr_ingest_base.py
+++ b/fighthealthinsurance/management/commands/_imr_ingest_base.py
@@ -1,0 +1,60 @@
+"""Shared base command for IMR / external-appeal CSV ingestion."""
+
+from typing import Any
+
+from django.core.management.base import BaseCommand, CommandError
+
+from fighthealthinsurance.imr_ingest import fetch_csv, load_csv_text
+
+
+class IMRIngestCommand(BaseCommand):
+    """Base management command: fetch a CSV (URL or file) and upsert IMR rows.
+
+    Subclasses set ``source`` to one of ``IMRDecision.SOURCE_*`` and
+    ``label`` to a short human-readable name used in status messages.
+    """
+
+    source: str = ""
+    label: str = ""
+
+    def add_arguments(self, parser: Any) -> None:
+        parser.add_argument(
+            "--url",
+            type=str,
+            help="URL to the CSV (mutually exclusive with --file).",
+        )
+        parser.add_argument(
+            "--file",
+            type=str,
+            help="Local path to a previously-downloaded CSV.",
+        )
+
+    def handle(self, *args: str, **options: Any) -> None:
+        if not self.source:
+            raise CommandError("Subclass must set `source`")
+        url = options.get("url")
+        path = options.get("file")
+        if not url and not path:
+            raise CommandError("Provide --url or --file")
+        if url and path:
+            raise CommandError("Provide --url or --file, not both")
+
+        if url:
+            self.stdout.write(f"Fetching {self.label} CSV from {url}")
+            csv_text = fetch_csv(url)
+            source_url = url
+        else:
+            self.stdout.write(f"Loading {self.label} CSV from {path}")
+            with open(path, "r", encoding="utf-8-sig") as fh:
+                csv_text = fh.read()
+            source_url = ""
+
+        created, updated, skipped = load_csv_text(
+            csv_text, source=self.source, source_url=source_url
+        )
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"{self.label} ingest complete: "
+                f"{created} created, {updated} updated, {skipped} skipped"
+            )
+        )

--- a/fighthealthinsurance/management/commands/_imr_ingest_base.py
+++ b/fighthealthinsurance/management/commands/_imr_ingest_base.py
@@ -1,6 +1,6 @@
 """Shared base command for IMR / external-appeal CSV ingestion."""
 
-from typing import Any
+from typing import Any, Optional
 
 from django.core.management.base import BaseCommand, CommandError
 
@@ -32,8 +32,8 @@ class IMRIngestCommand(BaseCommand):
     def handle(self, *args: str, **options: Any) -> None:
         if not self.source:
             raise CommandError("Subclass must set `source`")
-        url = options.get("url")
-        path = options.get("file")
+        url: Optional[str] = options.get("url")
+        path: Optional[str] = options.get("file")
         if not url and not path:
             raise CommandError("Provide --url or --file")
         if url and path:
@@ -44,6 +44,7 @@ class IMRIngestCommand(BaseCommand):
             csv_text = fetch_csv(url)
             source_url = url
         else:
+            assert path is not None  # narrowed by the checks above
             self.stdout.write(f"Loading {self.label} CSV from {path}")
             with open(path, "r", encoding="utf-8-sig") as fh:
                 csv_text = fh.read()

--- a/fighthealthinsurance/management/commands/ingest_dfs_appeals.py
+++ b/fighthealthinsurance/management/commands/ingest_dfs_appeals.py
@@ -1,0 +1,15 @@
+"""Ingest NY DFS External Appeals decisions from a CSV export.
+
+The NY DFS exposes external appeals through a search UI; ingest a CSV that has
+been exported (or scraped into CSV form) using the same loader as the CA DMHC
+dataset. Pass ``--url`` or ``--file``; idempotent on ``(source, case_id)``.
+"""
+
+from fighthealthinsurance.management.commands._imr_ingest_base import IMRIngestCommand
+from fighthealthinsurance.models import IMRDecision
+
+
+class Command(IMRIngestCommand):
+    help = "Ingest New York DFS External Appeals decisions from a CSV."
+    source = IMRDecision.SOURCE_NY_DFS
+    label = "NY DFS appeals"

--- a/fighthealthinsurance/management/commands/ingest_dmhc_imr.py
+++ b/fighthealthinsurance/management/commands/ingest_dmhc_imr.py
@@ -1,0 +1,16 @@
+"""Ingest CA DMHC Independent Medical Review decisions from the CHHS CSV export.
+
+The CHHS open data portal hosts the IMR Determinations Trend dataset as a CSV.
+Pass ``--url`` to download from a URL or ``--file`` to load a local CSV. The
+loader is idempotent on ``(source, case_id)`` so re-running it refreshes the
+existing rows.
+"""
+
+from fighthealthinsurance.management.commands._imr_ingest_base import IMRIngestCommand
+from fighthealthinsurance.models import IMRDecision
+
+
+class Command(IMRIngestCommand):
+    help = "Ingest California DMHC Independent Medical Review decisions from a CSV."
+    source = IMRDecision.SOURCE_CA_DMHC
+    label = "CA DMHC IMR"

--- a/fighthealthinsurance/management/commands/launch_polling_actors.py
+++ b/fighthealthinsurance/management/commands/launch_polling_actors.py
@@ -34,7 +34,7 @@ class Command(BaseCommand):
                         )
                     )
         else:
-            from fighthealthinsurance.polling_actor_setup import cpar, epar, fpar
+            from fighthealthinsurance.polling_actor_setup import cpar, epar, fpar, ipar
 
-            self.stdout.write(f"Loaded actors: {epar} {fpar} {cpar}")
+            self.stdout.write(f"Loaded actors: {epar} {fpar} {cpar} {ipar}")
             self.stdout.write(self.style.SUCCESS("Polling actors loaded successfully"))

--- a/fighthealthinsurance/migrations/0161_imrdecision.py
+++ b/fighthealthinsurance/migrations/0161_imrdecision.py
@@ -1,0 +1,101 @@
+# Generated for IMRDecision model
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("fighthealthinsurance", "0160_niceguidance_denial_nice_context_and_more"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="IMRDecision",
+            fields=[
+                ("id", models.AutoField(primary_key=True, serialize=False)),
+                (
+                    "source",
+                    models.CharField(
+                        choices=[
+                            ("ca_dmhc", "California DMHC"),
+                            ("ny_dfs", "New York DFS"),
+                        ],
+                        max_length=20,
+                    ),
+                ),
+                ("case_id", models.CharField(max_length=100)),
+                ("state", models.CharField(max_length=2)),
+                ("decision_year", models.IntegerField(blank=True, null=True)),
+                ("decision_date", models.DateField(blank=True, null=True)),
+                ("diagnosis", models.CharField(blank=True, default="", max_length=500)),
+                (
+                    "diagnosis_category",
+                    models.CharField(blank=True, default="", max_length=300),
+                ),
+                ("treatment", models.CharField(blank=True, default="", max_length=500)),
+                (
+                    "treatment_category",
+                    models.CharField(blank=True, default="", max_length=300),
+                ),
+                (
+                    "treatment_subcategory",
+                    models.CharField(blank=True, default="", max_length=300),
+                ),
+                (
+                    "determination",
+                    models.CharField(
+                        choices=[
+                            ("overturned", "Overturned"),
+                            ("upheld", "Upheld"),
+                            ("overturned_in_part", "Overturned in part"),
+                            ("other", "Other"),
+                        ],
+                        default="other",
+                        max_length=30,
+                    ),
+                ),
+                (
+                    "decision_type",
+                    models.CharField(blank=True, default="", max_length=100),
+                ),
+                (
+                    "insurance_type",
+                    models.CharField(blank=True, default="", max_length=200),
+                ),
+                ("age_range", models.CharField(blank=True, default="", max_length=50)),
+                ("gender", models.CharField(blank=True, default="", max_length=30)),
+                ("findings", models.TextField(blank=True, default="")),
+                ("summary", models.TextField(blank=True, default="")),
+                ("source_url", models.URLField(blank=True, default="", max_length=500)),
+                ("raw_data", models.JSONField(blank=True, null=True)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+            ],
+            options={
+                "indexes": [
+                    models.Index(
+                        fields=["diagnosis", "treatment"],
+                        name="imrdec_diag_treat_idx",
+                    ),
+                    models.Index(
+                        fields=["treatment_category", "determination"],
+                        name="imrdec_tcat_det_idx",
+                    ),
+                    models.Index(
+                        fields=["state", "determination"],
+                        name="imrdec_state_det_idx",
+                    ),
+                    models.Index(
+                        fields=["source", "determination"],
+                        name="imrdec_source_det_idx",
+                    ),
+                ],
+                "constraints": [
+                    models.UniqueConstraint(
+                        fields=["source", "case_id"],
+                        name="imrdecision_unique_source_case",
+                    ),
+                ],
+            },
+        ),
+    ]

--- a/fighthealthinsurance/migrations/0162_imrdecision_search_text.py
+++ b/fighthealthinsurance/migrations/0162_imrdecision_search_text.py
@@ -1,0 +1,45 @@
+"""Add denormalized search_text field to IMRDecision."""
+
+from django.db import migrations, models
+
+
+def backfill_search_text(apps, schema_editor):
+    IMRDecision = apps.get_model("fighthealthinsurance", "IMRDecision")
+    db_alias = schema_editor.connection.alias
+    rows = (
+        IMRDecision.objects.using(db_alias)
+        .all()
+        .only(
+            "id",
+            "treatment",
+            "treatment_category",
+            "treatment_subcategory",
+            "diagnosis",
+            "diagnosis_category",
+        )
+    )
+    for row in rows.iterator():
+        parts = [
+            row.treatment,
+            row.treatment_category,
+            row.treatment_subcategory,
+            row.diagnosis,
+            row.diagnosis_category,
+        ]
+        row.search_text = " ".join(p.lower() for p in parts if p).strip()
+        row.save(update_fields=["search_text"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("fighthealthinsurance", "0161_imrdecision"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="imrdecision",
+            name="search_text",
+            field=models.TextField(blank=True, default=""),
+        ),
+        migrations.RunPython(backfill_search_text, migrations.RunPython.noop),
+    ]

--- a/fighthealthinsurance/migrations/0163_imrdecision_pg_trgm_index.py
+++ b/fighthealthinsurance/migrations/0163_imrdecision_pg_trgm_index.py
@@ -1,0 +1,36 @@
+"""Add a Postgres trigram GIN index on IMRDecision.search_text.
+
+Postgres-only. On other backends (SQLite for dev/tests) the migration is a
+no-op so it can run unchanged everywhere.
+"""
+
+from django.db import migrations
+
+PG_INDEX_NAME = "imrdec_search_trgm_idx"
+
+
+def add_pg_trgm_index(apps, schema_editor):
+    if schema_editor.connection.vendor != "postgresql":
+        return
+    schema_editor.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+    schema_editor.execute(
+        f"CREATE INDEX IF NOT EXISTS {PG_INDEX_NAME} "
+        f"ON fighthealthinsurance_imrdecision "
+        f"USING gin (search_text gin_trgm_ops)"
+    )
+
+
+def drop_pg_trgm_index(apps, schema_editor):
+    if schema_editor.connection.vendor != "postgresql":
+        return
+    schema_editor.execute(f"DROP INDEX IF EXISTS {PG_INDEX_NAME}")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("fighthealthinsurance", "0162_imrdecision_search_text"),
+    ]
+
+    operations = [
+        migrations.RunPython(add_pg_trgm_index, drop_pg_trgm_index),
+    ]

--- a/fighthealthinsurance/ml/imr_decision_retriever.py
+++ b/fighthealthinsurance/ml/imr_decision_retriever.py
@@ -79,34 +79,17 @@ class IMRDecisionRetriever:
         diagnosis: str,
         state: Optional[str],
     ) -> QuerySet:
-        proc_tokens = _tokens(procedure)
-        diag_tokens = _tokens(diagnosis)
-
-        # Need at least one signal to retrieve anything meaningful
-        if not proc_tokens and not diag_tokens:
+        # Query against the denormalized `search_text` column populated at
+        # save() time. Postgres has a GIN trigram index on it (migration 0162);
+        # SQLite falls back to a sequential icontains scan.
+        all_tokens = _tokens(procedure) + _tokens(diagnosis)
+        if not all_tokens:
             return IMRDecision.objects.none()
 
-        qs = IMRDecision.objects.all()
-
-        # Build a match filter: any token from procedure or diagnosis matches
-        # any of treatment / treatment_category / treatment_subcategory /
-        # diagnosis / diagnosis_category.
-        match_q: Optional[Q] = None
-        for field in (
-            "treatment",
-            "treatment_category",
-            "treatment_subcategory",
-            "diagnosis",
-            "diagnosis_category",
-        ):
-            for tokens in (proc_tokens, diag_tokens):
-                clause = _build_text_q(field, tokens)
-                if clause is not None:
-                    match_q = clause if match_q is None else match_q | clause
-
+        match_q = _build_text_q("search_text", all_tokens)
         if match_q is None:
             return IMRDecision.objects.none()
-        qs = qs.filter(match_q)
+        qs = IMRDecision.objects.filter(match_q)
 
         # Score: overturned > overturned_in_part > other > upheld; same-state bonus.
         determination_score = Case(
@@ -128,10 +111,9 @@ class IMRDecisionRetriever:
         else:
             state_score = Value(0, output_field=IntegerField())
 
-        qs = qs.annotate(
+        return qs.annotate(
             _det_score=determination_score, _state_score=state_score
         ).order_by("-_det_score", "-_state_score", "-decision_year", "-id")
-        return qs
 
     @classmethod
     async def retrieve_for_denial(

--- a/fighthealthinsurance/ml/imr_decision_retriever.py
+++ b/fighthealthinsurance/ml/imr_decision_retriever.py
@@ -9,7 +9,7 @@ and intentionally framed as illustrative rather than legally binding.
 import re
 from typing import List, Optional
 
-from django.db.models import Case, IntegerField, Q, QuerySet, Value, When
+from django.db.models import Case, F, IntegerField, Q, QuerySet, Value, When
 from django.db.models.expressions import Combinable
 from loguru import logger
 
@@ -81,7 +81,7 @@ class IMRDecisionRetriever:
         state: Optional[str],
     ) -> QuerySet:
         # Query against the denormalized `search_text` column populated at
-        # save() time. Postgres has a GIN trigram index on it (migration 0162);
+        # save() time. Postgres has a GIN trigram index on it (migration 0163);
         # SQLite falls back to a sequential icontains scan.
         all_tokens = _tokens(procedure) + _tokens(diagnosis)
         if not all_tokens:
@@ -112,9 +112,16 @@ class IMRDecisionRetriever:
         else:
             state_score = Value(0, output_field=IntegerField())
 
+        # nulls_last keeps undated/parse-failed rows from outranking dated
+        # decisions on Postgres (where NULL sorts first by default on DESC).
         return qs.annotate(
             _det_score=determination_score, _state_score=state_score
-        ).order_by("-_det_score", "-_state_score", "-decision_year", "-id")
+        ).order_by(
+            "-_det_score",
+            "-_state_score",
+            F("decision_year").desc(nulls_last=True),
+            "-id",
+        )
 
     @classmethod
     async def retrieve_for_denial(

--- a/fighthealthinsurance/ml/imr_decision_retriever.py
+++ b/fighthealthinsurance/ml/imr_decision_retriever.py
@@ -1,0 +1,199 @@
+"""Retrieval helper for prior independent medical review / external appeal decisions.
+
+Surfaces public CA DMHC IMR and NY DFS external appeal decisions that look
+similar to a denial so the appeal-generation prompt can reference precedent-like
+outcomes ("similar prior decisions"). These are jurisdiction- and fact-specific
+and intentionally framed as illustrative rather than legally binding.
+"""
+
+import re
+from typing import List, Optional
+
+from django.db.models import Case, IntegerField, Q, QuerySet, Value, When
+from loguru import logger
+
+from fighthealthinsurance.models import Denial, IMRDecision
+
+_TOKEN_RE = re.compile(r"[A-Za-z0-9]{3,}")
+_STOPWORDS = {
+    "the",
+    "and",
+    "for",
+    "with",
+    "from",
+    "that",
+    "this",
+    "into",
+    "treatment",
+    "therapy",
+    "procedure",
+    "service",
+    "services",
+    "care",
+    "medical",
+    "patient",
+    "patients",
+    "disease",
+    "disorder",
+    "condition",
+    "syndrome",
+    "system",
+    "non",
+    "use",
+    "used",
+    "type",
+}
+
+
+def _tokens(text: Optional[str]) -> List[str]:
+    if not text:
+        return []
+    return [
+        t.lower()
+        for t in _TOKEN_RE.findall(text)
+        if t.lower() not in _STOPWORDS and len(t) >= 3
+    ]
+
+
+def _build_text_q(field: str, tokens: List[str]) -> Optional[Q]:
+    """Build an OR'd icontains Q across the supplied tokens for a field."""
+    if not tokens:
+        return None
+    q: Optional[Q] = None
+    for t in tokens:
+        clause = Q(**{f"{field}__icontains": t})
+        q = clause if q is None else q | clause
+    return q
+
+
+class IMRDecisionRetriever:
+    """Retrieves similar prior IMR / external appeal decisions for a denial."""
+
+    DEFAULT_LIMIT = 5
+    PER_DECISION_FINDINGS_CHARS = 600
+
+    @classmethod
+    def _build_queryset(
+        cls,
+        procedure: str,
+        diagnosis: str,
+        state: Optional[str],
+    ) -> QuerySet:
+        proc_tokens = _tokens(procedure)
+        diag_tokens = _tokens(diagnosis)
+
+        # Need at least one signal to retrieve anything meaningful
+        if not proc_tokens and not diag_tokens:
+            return IMRDecision.objects.none()
+
+        qs = IMRDecision.objects.all()
+
+        # Build a match filter: any token from procedure or diagnosis matches
+        # any of treatment / treatment_category / treatment_subcategory /
+        # diagnosis / diagnosis_category.
+        match_q: Optional[Q] = None
+        for field in (
+            "treatment",
+            "treatment_category",
+            "treatment_subcategory",
+            "diagnosis",
+            "diagnosis_category",
+        ):
+            for tokens in (proc_tokens, diag_tokens):
+                clause = _build_text_q(field, tokens)
+                if clause is not None:
+                    match_q = clause if match_q is None else match_q | clause
+
+        if match_q is None:
+            return IMRDecision.objects.none()
+        qs = qs.filter(match_q)
+
+        # Score: overturned > overturned_in_part > other > upheld; same-state bonus.
+        determination_score = Case(
+            When(determination=IMRDecision.DETERMINATION_OVERTURNED, then=Value(3)),
+            When(
+                determination=IMRDecision.DETERMINATION_OVERTURNED_IN_PART,
+                then=Value(2),
+            ),
+            When(determination=IMRDecision.DETERMINATION_OTHER, then=Value(1)),
+            default=Value(0),
+            output_field=IntegerField(),
+        )
+        if state:
+            state_score = Case(
+                When(state=state.upper(), then=Value(2)),
+                default=Value(0),
+                output_field=IntegerField(),
+            )
+        else:
+            state_score = Value(0, output_field=IntegerField())
+
+        qs = qs.annotate(
+            _det_score=determination_score, _state_score=state_score
+        ).order_by("-_det_score", "-_state_score", "-decision_year", "-id")
+        return qs
+
+    @classmethod
+    async def retrieve_for_denial(
+        cls, denial: Denial, limit: int = DEFAULT_LIMIT
+    ) -> List[IMRDecision]:
+        """Return up to ``limit`` IMRDecision rows similar to the denial."""
+        try:
+            procedure = (denial.procedure or "").strip()
+            diagnosis = (denial.diagnosis or "").strip()
+            state = (getattr(denial, "state", None) or "").strip() or None
+            if not procedure and not diagnosis:
+                return []
+            qs = cls._build_queryset(procedure, diagnosis, state)
+            results: List[IMRDecision] = [decision async for decision in qs[:limit]]
+            logger.debug(
+                f"IMR retrieval returned {len(results)} decisions for "
+                f"procedure={procedure!r} diagnosis={diagnosis!r} state={state}"
+            )
+            return results
+        except Exception as e:
+            logger.opt(exception=True).warning(
+                f"IMR retrieval failed for denial {getattr(denial, 'denial_id', '?')}: {e}"
+            )
+            return []
+
+    @classmethod
+    def format_for_appeal(cls, decisions: List[IMRDecision]) -> Optional[str]:
+        """Render decisions as a prompt-friendly bullet list, or None if empty.
+
+        Phrased as "similar public appeal decisions", not legal precedent.
+        """
+        if not decisions:
+            return None
+        lines = [
+            "Similar public independent medical review / external appeal "
+            "decisions (illustrative, not legal precedent):",
+        ]
+        for d in decisions:
+            label = {
+                IMRDecision.SOURCE_CA_DMHC: "CA DMHC IMR",
+                IMRDecision.SOURCE_NY_DFS: "NY DFS External Appeal",
+            }.get(d.source, d.source)
+            year = f" {d.decision_year}" if d.decision_year else ""
+            determination = d.get_determination_display()
+            treatment = d.treatment or d.treatment_category or "(unspecified)"
+            diagnosis = d.diagnosis or d.diagnosis_category or "(unspecified)"
+            findings = (d.findings or "").strip().replace("\n", " ")
+            if len(findings) > cls.PER_DECISION_FINDINGS_CHARS:
+                findings = findings[: cls.PER_DECISION_FINDINGS_CHARS].rstrip() + "..."
+            line = (
+                f"- {label}{year} (case {d.case_id}): {determination} - "
+                f"treatment {treatment} for {diagnosis}."
+            )
+            if findings:
+                line += f" Reviewer findings: {findings}"
+            lines.append(line)
+        return "\n".join(lines)
+
+    @classmethod
+    async def get_context_for_denial(
+        cls, denial: Denial, limit: int = DEFAULT_LIMIT
+    ) -> Optional[str]:
+        """Convenience wrapper: retrieve + format. Returns None when nothing matched."""
+        decisions = await cls.retrieve_for_denial(denial, limit=limit)
+        return cls.format_for_appeal(decisions)

--- a/fighthealthinsurance/ml/imr_decision_retriever.py
+++ b/fighthealthinsurance/ml/imr_decision_retriever.py
@@ -10,6 +10,7 @@ import re
 from typing import List, Optional
 
 from django.db.models import Case, IntegerField, Q, QuerySet, Value, When
+from django.db.models.expressions import Combinable
 from loguru import logger
 
 from fighthealthinsurance.models import Denial, IMRDecision
@@ -103,7 +104,7 @@ class IMRDecisionRetriever:
             output_field=IntegerField(),
         )
         if state:
-            state_score = Case(
+            state_score: Combinable = Case(
                 When(state=state.upper(), then=Value(2)),
                 default=Value(0),
                 output_field=IntegerField(),
@@ -121,9 +122,9 @@ class IMRDecisionRetriever:
     ) -> List[IMRDecision]:
         """Return up to ``limit`` IMRDecision rows similar to the denial."""
         try:
-            procedure = (denial.procedure or "").strip()
-            diagnosis = (denial.diagnosis or "").strip()
-            state = (getattr(denial, "state", None) or "").strip() or None
+            procedure = str(denial.procedure or "").strip()
+            diagnosis = str(denial.diagnosis or "").strip()
+            state = str(getattr(denial, "state", None) or "").strip() or None
             if not procedure and not diagnosis:
                 return []
             qs = cls._build_queryset(procedure, diagnosis, state)
@@ -152,15 +153,16 @@ class IMRDecisionRetriever:
             "decisions (illustrative, not legal precedent):",
         ]
         for d in decisions:
+            source = str(d.source)
             label = {
                 IMRDecision.SOURCE_CA_DMHC: "CA DMHC IMR",
                 IMRDecision.SOURCE_NY_DFS: "NY DFS External Appeal",
-            }.get(d.source, d.source)
+            }.get(source, source)
             year = f" {d.decision_year}" if d.decision_year else ""
             determination = d.get_determination_display()
             treatment = d.treatment or d.treatment_category or "(unspecified)"
             diagnosis = d.diagnosis or d.diagnosis_category or "(unspecified)"
-            findings = (d.findings or "").strip().replace("\n", " ")
+            findings = str(d.findings or "").strip().replace("\n", " ")
             if len(findings) > cls.PER_DECISION_FINDINGS_CHARS:
                 findings = findings[: cls.PER_DECISION_FINDINGS_CHARS].rstrip() + "..."
             line = (

--- a/fighthealthinsurance/models.py
+++ b/fighthealthinsurance/models.py
@@ -117,6 +117,80 @@ class CMSCoverageCache(ExportModelOperationsMixin("CMSCoverageCache"), models.Mo
         return f"CMS Coverage: {self.procedure} / {self.diagnosis}"
 
 
+class IMRDecision(ExportModelOperationsMixin("IMRDecision"), models.Model):  # type: ignore
+    """
+    Public independent medical review / external appeal decisions used as a
+    "similar prior decisions" retrieval corpus when generating appeals.
+
+    Sources include the California DMHC IMR dataset (CHHS open data) and the
+    New York DFS External Appeals database. These are jurisdiction- and
+    fact-specific and are surfaced to the model as illustrative prior decisions,
+    not legal precedent.
+    """
+
+    SOURCE_CA_DMHC = "ca_dmhc"
+    SOURCE_NY_DFS = "ny_dfs"
+    SOURCE_CHOICES = [
+        (SOURCE_CA_DMHC, "California DMHC"),
+        (SOURCE_NY_DFS, "New York DFS"),
+    ]
+
+    DETERMINATION_OVERTURNED = "overturned"
+    DETERMINATION_UPHELD = "upheld"
+    DETERMINATION_OVERTURNED_IN_PART = "overturned_in_part"
+    DETERMINATION_OTHER = "other"
+    DETERMINATION_CHOICES = [
+        (DETERMINATION_OVERTURNED, "Overturned"),
+        (DETERMINATION_UPHELD, "Upheld"),
+        (DETERMINATION_OVERTURNED_IN_PART, "Overturned in part"),
+        (DETERMINATION_OTHER, "Other"),
+    ]
+
+    id = models.AutoField(primary_key=True)
+    source = models.CharField(max_length=20, choices=SOURCE_CHOICES)
+    # Original case identifier from the source (combined with source for uniqueness)
+    case_id = models.CharField(max_length=100)
+    state = models.CharField(max_length=2)
+    decision_year = models.IntegerField(null=True, blank=True)
+    decision_date = models.DateField(null=True, blank=True)
+    # Normalized lowercase searchable fields
+    diagnosis = models.CharField(max_length=500, default="", blank=True)
+    diagnosis_category = models.CharField(max_length=300, default="", blank=True)
+    treatment = models.CharField(max_length=500, default="", blank=True)
+    treatment_category = models.CharField(max_length=300, default="", blank=True)
+    treatment_subcategory = models.CharField(max_length=300, default="", blank=True)
+    determination = models.CharField(
+        max_length=30, choices=DETERMINATION_CHOICES, default=DETERMINATION_OTHER
+    )
+    decision_type = models.CharField(max_length=100, default="", blank=True)
+    insurance_type = models.CharField(max_length=200, default="", blank=True)
+    age_range = models.CharField(max_length=50, default="", blank=True)
+    gender = models.CharField(max_length=30, default="", blank=True)
+    findings = models.TextField(default="", blank=True)
+    summary = models.TextField(default="", blank=True)
+    source_url = models.URLField(max_length=500, default="", blank=True)
+    raw_data = models.JSONField(null=True, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        indexes = [
+            models.Index(fields=["diagnosis", "treatment"]),
+            models.Index(fields=["treatment_category", "determination"]),
+            models.Index(fields=["state", "determination"]),
+            models.Index(fields=["source", "determination"]),
+        ]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["source", "case_id"],
+                name="imrdecision_unique_source_case",
+            ),
+        ]
+
+    def __str__(self):
+        return f"IMR {self.source}/{self.case_id}: {self.determination} {self.treatment} for {self.diagnosis}"
+
+
 # Money related :p
 class InterestedProfessional(ExportModelOperationsMixin("InterestedProfessional"), models.Model):  # type: ignore
     """

--- a/fighthealthinsurance/models.py
+++ b/fighthealthinsurance/models.py
@@ -179,10 +179,19 @@ class IMRDecision(ExportModelOperationsMixin("IMRDecision"), models.Model):  # t
 
     class Meta:
         indexes = [
-            models.Index(fields=["diagnosis", "treatment"]),
-            models.Index(fields=["treatment_category", "determination"]),
-            models.Index(fields=["state", "determination"]),
-            models.Index(fields=["source", "determination"]),
+            models.Index(
+                fields=["diagnosis", "treatment"], name="imrdec_diag_treat_idx"
+            ),
+            models.Index(
+                fields=["treatment_category", "determination"],
+                name="imrdec_tcat_det_idx",
+            ),
+            models.Index(
+                fields=["state", "determination"], name="imrdec_state_det_idx"
+            ),
+            models.Index(
+                fields=["source", "determination"], name="imrdec_source_det_idx"
+            ),
         ]
         constraints = [
             models.UniqueConstraint(

--- a/fighthealthinsurance/models.py
+++ b/fighthealthinsurance/models.py
@@ -170,6 +170,10 @@ class IMRDecision(ExportModelOperationsMixin("IMRDecision"), models.Model):  # t
     summary = models.TextField(default="", blank=True)
     source_url = models.URLField(max_length=500, default="", blank=True)
     raw_data = models.JSONField(null=True, blank=True)
+    # Lowercased concatenation of treatment + diagnosis fields. Lets the
+    # retriever filter on a single column instead of OR-ing icontains across
+    # five, and is the column the Postgres trigram GIN index targets.
+    search_text = models.TextField(default="", blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
@@ -186,6 +190,20 @@ class IMRDecision(ExportModelOperationsMixin("IMRDecision"), models.Model):  # t
                 name="imrdecision_unique_source_case",
             ),
         ]
+
+    def compute_search_text(self) -> str:
+        parts = [
+            self.treatment,
+            self.treatment_category,
+            self.treatment_subcategory,
+            self.diagnosis,
+            self.diagnosis_category,
+        ]
+        return " ".join(p.lower() for p in parts if p).strip()
+
+    def save(self, *args, **kwargs):
+        self.search_text = self.compute_search_text()
+        super().save(*args, **kwargs)
 
     def __str__(self):
         return f"IMR {self.source}/{self.case_id}: {self.determination} {self.treatment} for {self.diagnosis}"

--- a/fighthealthinsurance/polling_actor_setup.py
+++ b/fighthealthinsurance/polling_actor_setup.py
@@ -6,6 +6,7 @@ from loguru import logger
 from fighthealthinsurance.chooser_refill_actor_ref import chooser_refill_actor_ref
 from fighthealthinsurance.email_polling_actor_ref import email_polling_actor_ref
 from fighthealthinsurance.fax_polling_actor_ref import fax_polling_actor_ref
+from fighthealthinsurance.imr_refresh_actor_ref import imr_refresh_actor_ref
 
 logger.info("Waiting for ray to (probably) launch.")
 time.sleep(60)
@@ -16,6 +17,7 @@ attempt = 0
 epar = None
 fpar = None
 cpar = None
+ipar = None
 while not success and attempt < 10:
     logger.info("Attempting to launch actors.")
     attempt = attempt + 1
@@ -23,18 +25,20 @@ while not success and attempt < 10:
         epar, etask = email_polling_actor_ref.get
         fpar, ftask = fax_polling_actor_ref.get
         cpar, ctask = chooser_refill_actor_ref.get
+        ipar, itask = imr_refresh_actor_ref.get
         logger.info(f"Launched email polling actor {epar}")
         logger.info(f"Launched fax polling actor {fpar}")
         logger.info(f"Launched chooser refill actor {cpar}")
+        logger.info(f"Launched IMR refresh actor {ipar}")
         logger.info("Checking that polling tasks are still running")
         time.sleep(10)
-        ready, wait = ray.wait([etask, ftask, ctask], timeout=10)
+        ready, wait = ray.wait([etask, ftask, ctask, itask], timeout=10)
         logger.info(f"Finished {ready}")
         result = ray.get(ready)
         logger.info(f"Results: {result}")
         if len(result) > 0:
             raise Exception("We should not have any polling actors finished!")
-        for actor in [epar, fpar, cpar]:
+        for actor in [epar, fpar, cpar, ipar]:
             logger.info(f"Checking health of {actor}")
             result = ray.get(actor.health_check.remote())
             logger.info(f"Health check result: {result}")
@@ -48,4 +52,4 @@ while not success and attempt < 10:
 if not success:
     logger.error("Failed to launch polling actors after all attempts")
 
-__all__ = ["epar", "fpar", "cpar"]
+__all__ = ["epar", "fpar", "cpar", "ipar"]

--- a/fighthealthinsurance/settings.py
+++ b/fighthealthinsurance/settings.py
@@ -55,7 +55,11 @@ class Base(Configuration):
     # any source whose URL is unset. Interval defaults to weekly (168 hours).
     IMR_DMHC_CSV_URL = os.getenv("IMR_DMHC_CSV_URL", "")
     IMR_DFS_CSV_URL = os.getenv("IMR_DFS_CSV_URL", "")
-    IMR_REFRESH_INTERVAL_HOURS = int(os.getenv("IMR_REFRESH_INTERVAL_HOURS", "168"))
+    try:
+        IMR_REFRESH_INTERVAL_HOURS = int(os.getenv("IMR_REFRESH_INTERVAL_HOURS") or 168)
+    except ValueError:
+        # Misconfigured env var should not block app startup.
+        IMR_REFRESH_INTERVAL_HOURS = 168
     LOGIN_URL = "login"
     LOGIN_REDIRECT_URL = "/"
     THUMBNAIL_DEBUG = True

--- a/fighthealthinsurance/settings.py
+++ b/fighthealthinsurance/settings.py
@@ -50,6 +50,12 @@ class Base(Configuration):
 
     # Audit logging - disabled by default, enable via environment variable
     ENABLE_AUDIT_LOGGING = os.getenv("ENABLE_AUDIT_LOGGING", "false").lower() == "true"
+
+    # IMR / external-appeal corpus refresh. URLs are optional; the actor skips
+    # any source whose URL is unset. Interval defaults to weekly (168 hours).
+    IMR_DMHC_CSV_URL = os.getenv("IMR_DMHC_CSV_URL", "")
+    IMR_DFS_CSV_URL = os.getenv("IMR_DFS_CSV_URL", "")
+    IMR_REFRESH_INTERVAL_HOURS = int(os.getenv("IMR_REFRESH_INTERVAL_HOURS", "168"))
     LOGIN_URL = "login"
     LOGIN_REDIRECT_URL = "/"
     THUMBNAIL_DEBUG = True

--- a/tests/async-unit/test_imr_decision_retriever.py
+++ b/tests/async-unit/test_imr_decision_retriever.py
@@ -1,0 +1,98 @@
+"""Unit tests for IMRDecisionRetriever's pure-Python helpers (no DB)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from fighthealthinsurance.ml.imr_decision_retriever import (
+    IMRDecisionRetriever,
+    _build_text_q,
+    _tokens,
+)
+from fighthealthinsurance.models import IMRDecision
+
+
+class TestTokens:
+    def test_lowercases_and_filters_short_tokens(self):
+        assert _tokens("Trastuzumab Therapy") == ["trastuzumab"]
+
+    def test_drops_stopwords(self):
+        # 'patient' / 'condition' / 'medical' are stopwords
+        assert "patient" not in _tokens("Patient with the condition")
+
+    def test_handles_none_and_empty(self):
+        assert _tokens(None) == []
+        assert _tokens("") == []
+
+    def test_keeps_alphanumeric_codes(self):
+        assert "j9355" in _tokens("HCPCS J9355 administration")
+
+
+class TestBuildTextQ:
+    def test_returns_none_for_empty_tokens(self):
+        assert _build_text_q("treatment", []) is None
+
+    def test_returns_q_for_tokens(self):
+        q = _build_text_q("treatment", ["foo", "bar"])
+        assert q is not None
+        # The Q should be an OR over icontains lookups
+        assert "treatment__icontains" in str(q.children) or len(q.children) == 2
+
+
+class TestFormatForAppeal:
+    def _make_decision(self, **overrides):
+        d = MagicMock(spec=IMRDecision)
+        d.source = IMRDecision.SOURCE_CA_DMHC
+        d.case_id = "EI-1"
+        d.decision_year = 2020
+        d.diagnosis = "breast cancer"
+        d.diagnosis_category = "cancer"
+        d.treatment = "trastuzumab"
+        d.treatment_category = "pharmacy"
+        d.findings = "Reviewer found treatment medically necessary."
+        d.determination = IMRDecision.DETERMINATION_OVERTURNED
+        d.get_determination_display = lambda: "Overturned"
+        for k, v in overrides.items():
+            setattr(d, k, v)
+        return d
+
+    def test_returns_none_for_empty_list(self):
+        assert IMRDecisionRetriever.format_for_appeal([]) is None
+
+    def test_includes_disclaimer(self):
+        out = IMRDecisionRetriever.format_for_appeal([self._make_decision()])
+        assert "illustrative, not legal precedent" in out
+
+    def test_includes_source_label(self):
+        ca = self._make_decision()
+        ny = self._make_decision(source=IMRDecision.SOURCE_NY_DFS, case_id="NY-1")
+        out = IMRDecisionRetriever.format_for_appeal([ca, ny])
+        assert "CA DMHC IMR" in out
+        assert "NY DFS External Appeal" in out
+
+    def test_truncates_long_findings(self):
+        long_findings = "x" * 5000
+        d = self._make_decision(findings=long_findings)
+        out = IMRDecisionRetriever.format_for_appeal([d])
+        assert out.endswith("...")
+        # Ensure it didn't dump the whole 5000 chars
+        assert len(out) < 5000
+
+    def test_falls_back_to_categories_when_treatment_missing(self):
+        d = self._make_decision(
+            treatment="", treatment_category="Mental Health", diagnosis=""
+        )
+        out = IMRDecisionRetriever.format_for_appeal([d])
+        assert "Mental Health" in out
+
+
+class TestRetrieveForDenialEarlyReturn:
+    @pytest.mark.asyncio
+    async def test_no_procedure_or_diagnosis_returns_empty(self):
+        denial = MagicMock()
+        denial.procedure = ""
+        denial.diagnosis = ""
+        denial.state = "CA"
+        denial.denial_id = 1
+        results = await IMRDecisionRetriever.retrieve_for_denial(denial)
+        assert results == []

--- a/tests/async-unit/test_imr_refresh_actor.py
+++ b/tests/async-unit/test_imr_refresh_actor.py
@@ -1,0 +1,60 @@
+"""Unit tests for IMRRefreshActor's testable helpers (without Ray)."""
+
+from unittest.mock import patch
+
+from fighthealthinsurance.imr_refresh_actor import IMRRefreshActor
+from fighthealthinsurance.models import IMRDecision
+
+# Access the underlying class through the Ray decorator's __ray_metadata__.
+# When @ray.remote wraps a class, the original class is accessible at this
+# attribute; falling back to the decorated object if Ray isn't loaded.
+_Klass = getattr(IMRRefreshActor, "__ray_metadata__", None)
+_Underlying = _Klass.modified_class if _Klass else IMRRefreshActor
+
+
+class TestConfiguredSources:
+    @patch("django.conf.settings.IMR_DMHC_CSV_URL", "https://example.gov/dmhc.csv")
+    @patch("django.conf.settings.IMR_DFS_CSV_URL", "https://example.gov/dfs.csv")
+    def test_returns_both_when_both_set(self):
+        sources = _Underlying._configured_sources()
+        assert (IMRDecision.SOURCE_CA_DMHC, "https://example.gov/dmhc.csv") in sources
+        assert (IMRDecision.SOURCE_NY_DFS, "https://example.gov/dfs.csv") in sources
+
+    @patch("django.conf.settings.IMR_DMHC_CSV_URL", "https://example.gov/dmhc.csv")
+    @patch("django.conf.settings.IMR_DFS_CSV_URL", "")
+    def test_skips_empty_urls(self):
+        sources = _Underlying._configured_sources()
+        sources_dict = dict(sources)
+        assert IMRDecision.SOURCE_CA_DMHC in sources_dict
+        assert IMRDecision.SOURCE_NY_DFS not in sources_dict
+
+    @patch("django.conf.settings.IMR_DMHC_CSV_URL", "")
+    @patch("django.conf.settings.IMR_DFS_CSV_URL", "")
+    def test_returns_empty_when_none_set(self):
+        assert _Underlying._configured_sources() == []
+
+
+class TestRefreshSource:
+    @patch("fighthealthinsurance.imr_ingest.load_csv_text")
+    @patch("fighthealthinsurance.imr_ingest.fetch_csv")
+    def test_refresh_source_fetches_and_loads(self, mock_fetch, mock_load):
+        mock_fetch.return_value = "csv,body"
+        mock_load.return_value = (3, 1, 0)
+
+        result = _Underlying._refresh_source(
+            IMRDecision.SOURCE_CA_DMHC, "https://example.gov/dmhc.csv"
+        )
+
+        assert result == (3, 1, 0)
+        mock_fetch.assert_called_once_with("https://example.gov/dmhc.csv")
+        mock_load.assert_called_once_with(
+            "csv,body",
+            source=IMRDecision.SOURCE_CA_DMHC,
+            source_url="https://example.gov/dmhc.csv",
+        )
+
+
+class TestIntervalHours:
+    @patch("django.conf.settings.IMR_REFRESH_INTERVAL_HOURS", 24, create=True)
+    def test_returns_configured_value(self):
+        assert _Underlying._interval_hours() == 24

--- a/tests/async-unit/test_imr_refresh_actor.py
+++ b/tests/async-unit/test_imr_refresh_actor.py
@@ -39,13 +39,13 @@ class TestRefreshSource:
     @patch("fighthealthinsurance.imr_ingest.fetch_csv")
     def test_refresh_source_fetches_and_loads(self, mock_fetch, mock_load):
         mock_fetch.return_value = "csv,body"
-        mock_load.return_value = (3, 1, 0)
+        mock_load.return_value = (3, 1, 0, 0)
 
         result = _Underlying._refresh_source(
             IMRDecision.SOURCE_CA_DMHC, "https://example.gov/dmhc.csv"
         )
 
-        assert result == (3, 1, 0)
+        assert result == (3, 1, 0, 0)
         mock_fetch.assert_called_once_with("https://example.gov/dmhc.csv")
         mock_load.assert_called_once_with(
             "csv,body",

--- a/tests/async/test_actor_health_status.py
+++ b/tests/async/test_actor_health_status.py
@@ -20,8 +20,8 @@ class TestActorHealthStatus(TestCase):
         assert "alive_actors" in data
         assert "total_actors" in data
         assert "details" in data
-        # Total actors should always be 3
-        assert data["total_actors"] == 3
+        # Total actors: email, fax, chooser, IMR refresh
+        assert data["total_actors"] == 4
 
     @mock.patch("fighthealthinsurance.actor_health_status.ray")
     def test_actor_health_all_down(self, mock_ray):
@@ -33,8 +33,8 @@ class TestActorHealthStatus(TestCase):
 
         result = check_actor_health()
         assert result["alive_actors"] == 0
-        assert result["total_actors"] == 3
-        assert len(result["details"]) == 3
+        assert result["total_actors"] == 4
+        assert len(result["details"]) == 4
         # All should have error messages
         for detail in result["details"]:
             assert detail["alive"] is False
@@ -54,9 +54,9 @@ class TestActorHealthStatus(TestCase):
         from fighthealthinsurance.actor_health_status import check_actor_health
 
         result = check_actor_health()
-        assert result["alive_actors"] == 3
-        assert result["total_actors"] == 3
-        assert len(result["details"]) == 3
+        assert result["alive_actors"] == 4
+        assert result["total_actors"] == 4
+        assert len(result["details"]) == 4
         # All should be alive
         for detail in result["details"]:
             assert detail["alive"] is True
@@ -84,8 +84,8 @@ class TestActorHealthStatus(TestCase):
 
         result = check_actor_health()
         assert result["alive_actors"] == 1
-        assert result["total_actors"] == 3
-        assert len(result["details"]) == 3
+        assert result["total_actors"] == 4
+        assert len(result["details"]) == 4
 
     def test_actor_health_endpoint_caching(self):
         """Test that the actor health endpoint has appropriate cache headers."""

--- a/tests/async/test_imr_decision_retriever.py
+++ b/tests/async/test_imr_decision_retriever.py
@@ -1,0 +1,134 @@
+"""DB-backed tests for the IMR / external-appeal decision retriever."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from fighthealthinsurance.ml.imr_decision_retriever import IMRDecisionRetriever
+from fighthealthinsurance.models import Denial, IMRDecision
+
+
+def _make_denial(procedure="", diagnosis="", state=None):
+    """Create a MagicMock Denial — retriever only reads procedure/diagnosis/state."""
+    denial = MagicMock(spec=Denial)
+    denial.denial_id = 1
+    denial.procedure = procedure
+    denial.diagnosis = diagnosis
+    denial.state = state
+    return denial
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+class TestIMRDecisionRetrieverDB:
+    async def _seed(self):
+        await IMRDecision.objects.acreate(
+            source=IMRDecision.SOURCE_CA_DMHC,
+            case_id="CA-1",
+            state="CA",
+            decision_year=2020,
+            diagnosis="breast cancer",
+            diagnosis_category="cancer",
+            treatment="trastuzumab",
+            treatment_category="pharmacy/prescription drugs",
+            determination=IMRDecision.DETERMINATION_OVERTURNED,
+            findings="Reviewer found trastuzumab medically necessary for HER2+ disease.",
+        )
+        await IMRDecision.objects.acreate(
+            source=IMRDecision.SOURCE_CA_DMHC,
+            case_id="CA-2",
+            state="CA",
+            decision_year=2018,
+            diagnosis="breast cancer",
+            treatment="trastuzumab",
+            determination=IMRDecision.DETERMINATION_UPHELD,
+            findings="Insurer denial upheld; insufficient documentation.",
+        )
+        await IMRDecision.objects.acreate(
+            source=IMRDecision.SOURCE_NY_DFS,
+            case_id="NY-1",
+            state="NY",
+            decision_year=2022,
+            diagnosis="breast cancer",
+            treatment="trastuzumab",
+            determination=IMRDecision.DETERMINATION_OVERTURNED,
+            findings="External reviewer overturned denial of trastuzumab.",
+        )
+        await IMRDecision.objects.acreate(
+            source=IMRDecision.SOURCE_CA_DMHC,
+            case_id="CA-3",
+            state="CA",
+            decision_year=2021,
+            diagnosis="diabetes",
+            treatment="insulin pump",
+            determination=IMRDecision.DETERMINATION_OVERTURNED,
+            findings="Unrelated case.",
+        )
+
+    async def test_returns_empty_when_no_query_signals(self):
+        await self._seed()
+        denial = _make_denial(procedure="", diagnosis="")
+        results = await IMRDecisionRetriever.retrieve_for_denial(denial)
+        assert results == []
+
+    async def test_matches_by_treatment_token(self):
+        await self._seed()
+        denial = _make_denial(procedure="trastuzumab", diagnosis="")
+        results = await IMRDecisionRetriever.retrieve_for_denial(denial)
+        case_ids = {r.case_id for r in results}
+        assert {"CA-1", "CA-2", "NY-1"}.issubset(case_ids)
+        assert "CA-3" not in case_ids
+
+    async def test_overturned_outranks_upheld(self):
+        await self._seed()
+        denial = _make_denial(procedure="trastuzumab", diagnosis="breast cancer")
+        results = await IMRDecisionRetriever.retrieve_for_denial(denial)
+        # First result must be an overturned decision (CA-1 or NY-1)
+        assert results[0].determination == IMRDecision.DETERMINATION_OVERTURNED
+        # CA-2 (upheld) should appear after the overturned ones
+        ranks = {r.case_id: i for i, r in enumerate(results)}
+        assert ranks["CA-2"] > ranks["CA-1"]
+        assert ranks["CA-2"] > ranks["NY-1"]
+
+    async def test_same_state_bonus_breaks_tie(self):
+        await self._seed()
+        # Both CA-1 and NY-1 are overturned; CA query should put CA-1 first
+        denial_ca = _make_denial(
+            procedure="trastuzumab", diagnosis="breast cancer", state="CA"
+        )
+        results = await IMRDecisionRetriever.retrieve_for_denial(denial_ca)
+        assert results[0].case_id == "CA-1"
+
+        denial_ny = _make_denial(
+            procedure="trastuzumab", diagnosis="breast cancer", state="NY"
+        )
+        results_ny = await IMRDecisionRetriever.retrieve_for_denial(denial_ny)
+        assert results_ny[0].case_id == "NY-1"
+
+    async def test_limit_respected(self):
+        await self._seed()
+        denial = _make_denial(procedure="trastuzumab", diagnosis="breast cancer")
+        results = await IMRDecisionRetriever.retrieve_for_denial(denial, limit=1)
+        assert len(results) == 1
+
+    async def test_get_context_for_denial_formats_or_returns_none(self):
+        await self._seed()
+        # No matches -> None
+        denial_none = _make_denial(procedure="aspirin", diagnosis="headache")
+        assert await IMRDecisionRetriever.get_context_for_denial(denial_none) is None
+
+        # Matches -> formatted string with disclaimer
+        denial = _make_denial(procedure="trastuzumab", diagnosis="breast cancer")
+        ctx = await IMRDecisionRetriever.get_context_for_denial(denial, limit=2)
+        assert ctx is not None
+        assert "illustrative, not legal precedent" in ctx
+        assert "Overturned" in ctx
+        assert "trastuzumab" in ctx.lower()
+
+    async def test_diagnosis_only_query_matches(self):
+        await self._seed()
+        denial = _make_denial(procedure="", diagnosis="breast cancer")
+        results = await IMRDecisionRetriever.retrieve_for_denial(denial)
+        case_ids = {r.case_id for r in results}
+        # All breast-cancer rows should match
+        assert {"CA-1", "CA-2", "NY-1"}.issubset(case_ids)

--- a/tests/sync/test_imr_ingest.py
+++ b/tests/sync/test_imr_ingest.py
@@ -1,0 +1,235 @@
+"""Tests for the IMR / external-appeal ingestion parsers and loader."""
+
+import pytest
+
+from fighthealthinsurance.imr_ingest import (
+    iter_csv_rows,
+    load_csv_text,
+    load_parsed_rows,
+    parse_ca_dmhc_row,
+    parse_ny_dfs_row,
+    _normalize_determination,
+    _parse_year,
+    _parse_date,
+)
+from fighthealthinsurance.models import IMRDecision
+
+
+class TestNormalizationHelpers:
+    def test_normalize_determination_overturned_variants(self):
+        assert (
+            _normalize_determination("Overturned")
+            == IMRDecision.DETERMINATION_OVERTURNED
+        )
+        assert (
+            _normalize_determination("OVERTURNED DECISION")
+            == IMRDecision.DETERMINATION_OVERTURNED
+        )
+
+    def test_normalize_determination_in_part(self):
+        assert (
+            _normalize_determination("Overturned in Part")
+            == IMRDecision.DETERMINATION_OVERTURNED_IN_PART
+        )
+        assert (
+            _normalize_determination("Overturned (Modified)")
+            == IMRDecision.DETERMINATION_OVERTURNED_IN_PART
+        )
+
+    def test_normalize_determination_upheld(self):
+        assert _normalize_determination("Upheld") == IMRDecision.DETERMINATION_UPHELD
+        assert (
+            _normalize_determination("Uphold Decision")
+            == IMRDecision.DETERMINATION_UPHELD
+        )
+
+    def test_normalize_determination_unknown_falls_back_to_other(self):
+        assert _normalize_determination("") == IMRDecision.DETERMINATION_OTHER
+        assert _normalize_determination("Pending") == IMRDecision.DETERMINATION_OTHER
+
+    def test_parse_year_handles_iso_and_partials(self):
+        assert _parse_year("2019") == 2019
+        assert _parse_year("2019-04-01") == 2019
+        assert _parse_year("19") is None
+        assert _parse_year("") is None
+
+    def test_parse_date_supports_common_formats(self):
+        assert _parse_date("2019-04-01").isoformat() == "2019-04-01"
+        assert _parse_date("4/1/2019").isoformat() == "2019-04-01"
+        assert _parse_date("not a date") is None
+        assert _parse_date("") is None
+
+
+class TestCAParser:
+    def test_parse_ca_row_basic(self):
+        row = {
+            "Reference ID": "EI-12345",
+            "Report Year": "2020",
+            "Diagnosis Category": "Cancer",
+            "Diagnosis Sub Category": "Breast Cancer",
+            "Treatment Category": "Pharmacy/Prescription Drugs",
+            "Treatment Sub Category": "Trastuzumab",
+            "Determination": "Overturned",
+            "Type": "Medical Necessity",
+            "Age Range": "41-50",
+            "Patient Gender": "Female",
+            "Findings": "Reviewer found treatment medically necessary based on records.",
+        }
+        parsed = parse_ca_dmhc_row(row)
+        assert parsed is not None
+        assert parsed.source == IMRDecision.SOURCE_CA_DMHC
+        assert parsed.case_id == "EI-12345"
+        assert parsed.state == "CA"
+        assert parsed.decision_year == 2020
+        assert parsed.diagnosis_category == "Cancer"
+        assert parsed.diagnosis == "Breast Cancer"
+        assert parsed.treatment_category == "Pharmacy/Prescription Drugs"
+        assert parsed.treatment_subcategory == "Trastuzumab"
+        assert parsed.treatment == "Trastuzumab"
+        assert parsed.determination == IMRDecision.DETERMINATION_OVERTURNED
+        assert parsed.decision_type == "Medical Necessity"
+        assert parsed.age_range == "41-50"
+        assert parsed.gender == "Female"
+        assert "medically necessary" in parsed.findings
+        assert parsed.raw_data == row
+
+    def test_parse_ca_row_missing_case_id_returns_none(self):
+        assert parse_ca_dmhc_row({"Report Year": "2020"}) is None
+
+    def test_parse_ca_row_treatment_falls_back_to_category(self):
+        # CA dataset has no "Treatment" column; if Sub Category is missing,
+        # treatment should fall back to Treatment Category.
+        row = {
+            "Reference ID": "EI-2",
+            "Treatment Category": "Mental Health",
+            "Determination": "Overturned",
+        }
+        parsed = parse_ca_dmhc_row(row)
+        assert parsed is not None
+        assert parsed.treatment_subcategory == ""
+        assert parsed.treatment_category == "Mental Health"
+        assert parsed.treatment == "Mental Health"
+
+    def test_parse_ca_row_is_header_case_insensitive(self):
+        row = {
+            "REFERENCE ID": "EI-99",
+            "diagnosiscategory": "Mental Health",
+            "TREATMENT CATEGORY": "Mental Health",
+            "DETERMINATION": "Upheld",
+        }
+        parsed = parse_ca_dmhc_row(row)
+        assert parsed is not None
+        assert parsed.case_id == "EI-99"
+        assert parsed.diagnosis_category == "Mental Health"
+        assert parsed.treatment_category == "Mental Health"
+        assert parsed.determination == IMRDecision.DETERMINATION_UPHELD
+
+
+class TestNYParser:
+    def test_parse_ny_row_basic(self):
+        row = {
+            "Appeal Number": "NY-2021-001",
+            "Year": "2021",
+            "Diagnosis": "Type 1 Diabetes",
+            "Treatment": "Continuous Glucose Monitor",
+            "Treatment Category": "Durable Medical Equipment",
+            "Determination": "Overturned",
+            "Plan Type": "Commercial",
+            "Age Range": "18-29",
+            "Gender": "Male",
+            "Description": "Insurer denial overturned; CGM medically necessary.",
+        }
+        parsed = parse_ny_dfs_row(row)
+        assert parsed is not None
+        assert parsed.source == IMRDecision.SOURCE_NY_DFS
+        assert parsed.case_id == "NY-2021-001"
+        assert parsed.state == "NY"
+        assert parsed.decision_year == 2021
+        assert parsed.diagnosis == "Type 1 Diabetes"
+        assert parsed.treatment == "Continuous Glucose Monitor"
+        assert parsed.treatment_category == "Durable Medical Equipment"
+        assert parsed.determination == IMRDecision.DETERMINATION_OVERTURNED
+        assert parsed.insurance_type == "Commercial"
+        assert parsed.age_range == "18-29"
+        assert parsed.gender == "Male"
+        assert "CGM medically necessary" in parsed.findings
+
+    def test_parse_ny_row_missing_id_returns_none(self):
+        assert parse_ny_dfs_row({"Year": "2021"}) is None
+
+
+class TestIterCsvRows:
+    def test_iter_csv_rows_handles_empty_cells(self):
+        text = "A,B,C\n1,,3\n,,\n"
+        rows = list(iter_csv_rows(text))
+        assert rows[0] == {"A": "1", "B": "", "C": "3"}
+        assert rows[1] == {"A": "", "B": "", "C": ""}
+
+
+@pytest.mark.django_db
+class TestLoadParsedRows:
+    @staticmethod
+    def _sample_row():
+        return parse_ca_dmhc_row(
+            {
+                "Reference ID": "EI-1",
+                "Report Year": "2020",
+                "Diagnosis Sub Category": "Asthma",
+                "Treatment Sub Category": "Inhaler",
+                "Determination": "Overturned",
+            }
+        )
+
+    def test_load_creates_new_row(self):
+        parsed = self._sample_row()
+        assert parsed is not None
+        created, updated = load_parsed_rows([parsed])
+        assert (created, updated) == (1, 0)
+
+    def test_load_is_idempotent_on_repeat(self):
+        parsed = self._sample_row()
+        load_parsed_rows([parsed])
+        parsed.findings = "Updated findings."
+        created, updated = load_parsed_rows([parsed])
+        assert (created, updated) == (0, 1)
+        stored = IMRDecision.objects.get(
+            source=IMRDecision.SOURCE_CA_DMHC, case_id="EI-1"
+        )
+        assert stored.findings == "Updated findings."
+
+
+@pytest.mark.django_db
+class TestLoadCsvText:
+    def test_ca_csv_end_to_end(self):
+        csv_text = (
+            "Reference ID,Report Year,Diagnosis Category,Treatment Category,Determination\n"
+            "EI-101,2020,Cancer,Chemotherapy,Overturned\n"
+            "EI-102,2021,Cancer,Radiation,Upheld\n"
+            ",2021,Cancer,X,Upheld\n"  # missing Reference ID — skipped
+        )
+        created, updated, skipped = load_csv_text(
+            csv_text, source=IMRDecision.SOURCE_CA_DMHC
+        )
+        assert (created, updated, skipped) == (2, 0, 1)
+        assert (
+            IMRDecision.objects.filter(source=IMRDecision.SOURCE_CA_DMHC).count() == 2
+        )
+
+    def test_ny_csv_end_to_end(self):
+        csv_text = (
+            "Appeal Number,Year,Diagnosis,Treatment,Determination\n"
+            "NY-1,2022,Crohn's Disease,Infliximab,Overturned\n"
+        )
+        created, updated, skipped = load_csv_text(
+            csv_text,
+            source=IMRDecision.SOURCE_NY_DFS,
+            source_url="https://example.gov/ny.csv",
+        )
+        assert (created, updated, skipped) == (1, 0, 0)
+        d = IMRDecision.objects.get(case_id="NY-1")
+        assert d.source_url == "https://example.gov/ny.csv"
+        assert d.state == "NY"
+
+    def test_unknown_source_raises(self):
+        with pytest.raises(ValueError):
+            load_csv_text("a,b\n1,2\n", source="unknown")

--- a/tests/sync/test_imr_ingest.py
+++ b/tests/sync/test_imr_ingest.py
@@ -42,6 +42,12 @@ class TestNormalizationHelpers:
             _normalize_determination("Uphold Decision")
             == IMRDecision.DETERMINATION_UPHELD
         )
+        # The CHHS dataset emits "Upheld Decision" (past tense). Make sure we
+        # map it to upheld rather than silently downgrading to other.
+        assert (
+            _normalize_determination("Upheld Decision")
+            == IMRDecision.DETERMINATION_UPHELD
+        )
 
     def test_normalize_determination_unknown_falls_back_to_other(self):
         assert _normalize_determination("") == IMRDecision.DETERMINATION_OTHER

--- a/tests/sync/test_imr_ingest.py
+++ b/tests/sync/test_imr_ingest.py
@@ -167,6 +167,53 @@ class TestIterCsvRows:
 
 
 @pytest.mark.django_db
+class TestSearchText:
+    def test_compute_search_text_lowercases_and_concatenates(self):
+        d = IMRDecision(
+            source=IMRDecision.SOURCE_CA_DMHC,
+            case_id="X",
+            state="CA",
+            treatment="Trastuzumab",
+            treatment_category="Pharmacy",
+            diagnosis="Breast Cancer",
+            diagnosis_category="Cancer",
+        )
+        assert d.compute_search_text() == "trastuzumab pharmacy breast cancer cancer"
+
+    def test_compute_search_text_skips_blank_fields(self):
+        d = IMRDecision(
+            source=IMRDecision.SOURCE_CA_DMHC,
+            case_id="X",
+            state="CA",
+            treatment="Inhaler",
+        )
+        assert d.compute_search_text() == "inhaler"
+
+    def test_save_populates_search_text(self):
+        d = IMRDecision.objects.create(
+            source=IMRDecision.SOURCE_NY_DFS,
+            case_id="NY-S1",
+            state="NY",
+            treatment="CGM",
+            diagnosis="Type 1 Diabetes",
+        )
+        d.refresh_from_db()
+        assert d.search_text == "cgm type 1 diabetes"
+
+    def test_save_recomputes_on_field_change(self):
+        d = IMRDecision.objects.create(
+            source=IMRDecision.SOURCE_NY_DFS,
+            case_id="NY-S2",
+            state="NY",
+            treatment="Old",
+        )
+        d.treatment = "New"
+        d.save()
+        d.refresh_from_db()
+        assert d.search_text == "new"
+
+
+@pytest.mark.django_db
 class TestLoadParsedRows:
     @staticmethod
     def _sample_row():

--- a/tests/sync/test_imr_ingest.py
+++ b/tests/sync/test_imr_ingest.py
@@ -236,19 +236,29 @@ class TestLoadParsedRows:
     def test_load_creates_new_row(self):
         parsed = self._sample_row()
         assert parsed is not None
-        created, updated = load_parsed_rows([parsed])
-        assert (created, updated) == (1, 0)
+        assert load_parsed_rows([parsed]) == (1, 0, 0)
 
     def test_load_is_idempotent_on_repeat(self):
         parsed = self._sample_row()
         load_parsed_rows([parsed])
         parsed.findings = "Updated findings."
-        created, updated = load_parsed_rows([parsed])
-        assert (created, updated) == (0, 1)
+        assert load_parsed_rows([parsed]) == (0, 1, 0)
         stored = IMRDecision.objects.get(
             source=IMRDecision.SOURCE_CA_DMHC, case_id="EI-1"
         )
         assert stored.findings == "Updated findings."
+
+    def test_load_counts_failures(self):
+        # Force update_or_create to raise so we can verify the failed counter.
+        from unittest.mock import patch
+
+        parsed = self._sample_row()
+        with patch.object(
+            IMRDecision.objects,
+            "update_or_create",
+            side_effect=RuntimeError("boom"),
+        ):
+            assert load_parsed_rows([parsed]) == (0, 0, 1)
 
 
 @pytest.mark.django_db
@@ -260,10 +270,8 @@ class TestLoadCsvText:
             "EI-102,2021,Cancer,Radiation,Upheld\n"
             ",2021,Cancer,X,Upheld\n"  # missing Reference ID — skipped
         )
-        created, updated, skipped = load_csv_text(
-            csv_text, source=IMRDecision.SOURCE_CA_DMHC
-        )
-        assert (created, updated, skipped) == (2, 0, 1)
+        result = load_csv_text(csv_text, source=IMRDecision.SOURCE_CA_DMHC)
+        assert result == (2, 0, 1, 0)
         assert (
             IMRDecision.objects.filter(source=IMRDecision.SOURCE_CA_DMHC).count() == 2
         )
@@ -273,12 +281,12 @@ class TestLoadCsvText:
             "Appeal Number,Year,Diagnosis,Treatment,Determination\n"
             "NY-1,2022,Crohn's Disease,Infliximab,Overturned\n"
         )
-        created, updated, skipped = load_csv_text(
+        result = load_csv_text(
             csv_text,
             source=IMRDecision.SOURCE_NY_DFS,
             source_url="https://example.gov/ny.csv",
         )
-        assert (created, updated, skipped) == (1, 0, 0)
+        assert result == (1, 0, 0, 0)
         d = IMRDecision.objects.get(case_id="NY-1")
         assert d.source_url == "https://example.gov/ny.csv"
         assert d.state == "NY"


### PR DESCRIPTION
## Summary
This PR adds a complete system for ingesting, storing, and retrieving public independent medical review (IMR) and external appeal decisions from California DMHC and New York DFS sources. These decisions are surfaced as "similar prior decisions" context when generating insurance appeals, providing illustrative precedent without legal binding.

## Key Changes

### Data Model & Migrations
- **IMRDecision model** (`models.py`): New model to store normalized IMR/external-appeal decisions with fields for diagnosis, treatment, determination outcome, findings, and metadata. Includes a denormalized `search_text` field for efficient retrieval.
- **Migrations 0160-0162**: Create IMRDecision table, add search_text field with backfill, and add Postgres trigram GIN index for fast full-text search.

### Ingestion Pipeline
- **imr_ingest.py**: Core parsing and loading module with:
  - `parse_ca_dmhc_row()` and `parse_ny_dfs_row()`: Source-specific CSV parsers with flexible header matching (case-insensitive, normalized)
  - `_normalize_determination()`: Maps various determination text variants to standard enum values
  - `_parse_year()` and `_parse_date()`: Robust date/year parsing supporting multiple formats
  - `load_parsed_rows()`: Idempotent upsert keyed on `(source, case_id)`
  - `iter_csv_rows()`: CSV reader with empty-cell handling

- **Management commands** (`ingest_dmhc_imr.py`, `ingest_dfs_appeals.py`): CLI tools to ingest from URL or local file
- **_imr_ingest_base.py**: Shared base command class for both sources

### Retrieval & Integration
- **imr_decision_retriever.py**: `IMRDecisionRetriever` class that:
  - Tokenizes procedure/diagnosis text, filters stopwords, and builds OR'd search queries
  - Scores results by determination type (overturned > overturned_in_part > other > upheld) with same-state bonus
  - Formats decisions as prompt-friendly bullet list with source labels and truncated findings
  - Async-compatible for integration with appeal generation

- **common_view_logic.py**: Integrated IMR context retrieval into appeal generation pipeline via `IMRDecisionRetriever.retrieve_for_denial()`

### Background Refresh
- **imr_refresh_actor.py**: Ray actor that periodically fetches and upserts IMR data from configured URLs on a configurable interval (default 168 hours)
- **imr_refresh_actor_ref.py**: Actor reference for polling setup
- **settings.py**: New settings for `IMR_DMHC_CSV_URL`, `IMR_DFS_CSV_URL`, and `IMR_REFRESH_INTERVAL_HOURS`
- **polling_actor_setup.py** & **actor_health_status.py**: Integrated IMR refresh actor into polling infrastructure

### Testing
- **test_imr_ingest.py**: Comprehensive unit tests for parsers, normalization helpers, CSV iteration, and database loading
- **test_imr_decision_retriever.py**: Async DB tests for retrieval scoring, state bonuses, and ranking
- **test_imr_refresh_actor.py**: Unit tests for actor configuration and refresh logic

## Notable Implementation Details

1. **Header normalization**: Parsers use case-insensitive, alphanumeric-only header matching to handle schema variations across sources
2. **Idempotent loading**: Uses `update_or_create()` on `(source, case_id)` to safely re-run ingestion without duplicates
3. **Search optimization**: Denormalized `search_text` field with Postgres trigram index for fast retrieval; SQLite falls back to sequential scan
4. **Flexible date parsing**: Supports ISO, US, and other common date formats with graceful fallback to None
5. **Determination mapping**: Normalizes various text representations (e.g., "Overturned Decision", "OVERTURNED") to standard enum values
6. **Async-ready**:

https://claude.ai/code/session_01KZYYb9p5J1oHjz9JCS1jP1