### PR TITLE
Add regulator escalation packet feature for parallel appeals

### DIFF
--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -2783,13 +2783,13 @@ class EscalationPacketHelper:
             return None
         try:
             escalation = RegulatorEscalation.objects.get(
-                uuid=str(escalation_uuid), for_denial=denial
+                uuid=escalation_uuid, for_denial=denial
             )
         except RegulatorEscalation.DoesNotExist:
             return None
         was_edited = letter_text.strip() != (escalation.letter_text or "").strip()
         escalation.letter_text = letter_text
         escalation.chosen = True
-        escalation.editted = escalation.editted or was_edited
+        escalation.edited = escalation.edited or was_edited
         escalation.save()
         return escalation

--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -2646,14 +2646,19 @@ class EscalationPacketHelper:
             generate_regulator_letter,
         )
 
-        denial_id = parameters.get("denial_id")
-        email = parameters.get("email")
-        semi_sekret = parameters.get("semi_sekret")
+        denial_id_raw = parameters.get("denial_id")
+        email = parameters.get("email") or ""
+        semi_sekret = parameters.get("semi_sekret") or ""
 
-        if denial_id is None or email is None or semi_sekret is None:
+        if not denial_id_raw or not email or not semi_sekret:
             yield json.dumps(
                 {"type": "error", "message": "Missing denial id, email, or semi_sekret"}
             ) + "\n"
+            return
+        try:
+            denial_id = int(denial_id_raw)
+        except (TypeError, ValueError):
+            yield json.dumps({"type": "error", "message": "Invalid denial id"}) + "\n"
             return
 
         hashed_email = Denial.get_hashed_email(email)
@@ -2778,7 +2783,7 @@ class EscalationPacketHelper:
             return None
         try:
             escalation = RegulatorEscalation.objects.get(
-                uuid=escalation_uuid, for_denial=denial
+                uuid=str(escalation_uuid), for_denial=denial
             )
         except RegulatorEscalation.DoesNotExist:
             return None

--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -2605,3 +2605,162 @@ class AppealsBackendHelper:
                 "total_appeals": new + old,
             }
         ) + "\n"
+
+
+class EscalationPacketHelper:
+    """Streaming generator for the regulator/executive escalation packet.
+
+    Produces one cover letter per recipient (state DOI, plan medical
+    director, DOL EBSA for ERISA plans) and persists each draft as a
+    `RegulatorEscalation` row keyed to the originating denial.
+    """
+
+    @classmethod
+    async def generate_escalation_letters(cls, parameters: dict) -> AsyncIterator[str]:
+        """Async generator yielding JSON payloads, mirroring AppealsBackendHelper."""
+        from fighthealthinsurance.escalation_addresses import get_recipients_for_denial
+        from fighthealthinsurance.generate_regulator_letter import (
+            generate_regulator_letter,
+        )
+
+        denial_id = parameters.get("denial_id")
+        email = parameters.get("email")
+        semi_sekret = parameters.get("semi_sekret")
+
+        if denial_id is None or email is None or semi_sekret is None:
+            yield json.dumps(
+                {"type": "error", "message": "Missing denial id, email, or semi_sekret"}
+            ) + "\n"
+            return
+
+        hashed_email = Denial.get_hashed_email(email)
+
+        yield json.dumps(
+            {
+                "type": "status",
+                "phase": "init",
+                "message": "Starting escalation letter generation...",
+            }
+        ) + "\n"
+
+        try:
+            denial = await Denial.objects.select_related(
+                "regulator", "insurance_company_obj"
+            ).aget(
+                denial_id=denial_id,
+                semi_sekret=semi_sekret,
+                hashed_email=hashed_email,
+            )
+        except Denial.DoesNotExist:
+            yield json.dumps({"type": "error", "message": "Denial not found"}) + "\n"
+            return
+
+        recipients = await sync_to_async(get_recipients_for_denial)(denial)
+        if not recipients:
+            yield json.dumps(
+                {"type": "error", "message": "No regulator recipients available"}
+            ) + "\n"
+            return
+
+        yield json.dumps(
+            {
+                "type": "status",
+                "phase": "generating",
+                "message": f"Generating {len(recipients)} regulator letter(s)...",
+                "total": len(recipients),
+            }
+        ) + "\n"
+
+        use_external = bool(getattr(denial, "use_external", False))
+        for recipient in recipients:
+            yield json.dumps(
+                {
+                    "type": "status",
+                    "phase": "generating",
+                    "substep": recipient.recipient_type,
+                    "message": f"Drafting letter to {recipient.name}...",
+                }
+            ) + "\n"
+
+            letter_text: Optional[str] = await generate_regulator_letter(
+                denial, recipient, use_external=use_external
+            )
+            if not letter_text:
+                yield json.dumps(
+                    {
+                        "type": "status",
+                        "phase": "generating",
+                        "substep": recipient.recipient_type,
+                        "state": "error",
+                        "message": (
+                            f"Could not generate a letter for {recipient.name}; "
+                            "skipping."
+                        ),
+                    }
+                ) + "\n"
+                continue
+
+            escalation = await RegulatorEscalation.objects.acreate(
+                for_denial=denial,
+                hashed_email=hashed_email,
+                recipient_type=recipient.recipient_type,
+                recipient_name=recipient.name,
+                recipient_address=recipient.address,
+                recipient_phone=recipient.phone,
+                recipient_url=recipient.url,
+                letter_text=letter_text,
+            )
+
+            yield json.dumps(
+                {
+                    "type": "letter",
+                    "escalation_id": str(escalation.uuid),
+                    "recipient_type": recipient.recipient_type,
+                    "recipient_name": recipient.name,
+                    "recipient_address": recipient.address,
+                    "recipient_phone": recipient.phone,
+                    "recipient_url": recipient.url,
+                    "rationale": recipient.rationale,
+                    "content": letter_text,
+                }
+            ) + "\n"
+
+        yield json.dumps(
+            {
+                "type": "status",
+                "phase": "done",
+                "message": "All regulator letters generated.",
+            }
+        ) + "\n"
+
+    @classmethod
+    def save_chosen_letter(
+        cls,
+        escalation_uuid: str,
+        denial_id: int,
+        email: str,
+        semi_sekret: str,
+        letter_text: str,
+    ) -> Optional["RegulatorEscalation"]:
+        """Persist the user's edited regulator letter as the chosen draft."""
+        hashed_email = Denial.get_hashed_email(email)
+        try:
+            denial = Denial.objects.get(
+                denial_id=denial_id,
+                semi_sekret=semi_sekret,
+                hashed_email=hashed_email,
+            )
+        except Denial.DoesNotExist:
+            return None
+        try:
+            escalation = RegulatorEscalation.objects.get(
+                uuid=escalation_uuid, for_denial=denial
+            )
+        except RegulatorEscalation.DoesNotExist:
+            return None
+        was_edited = letter_text.strip() != (escalation.letter_text or "").strip()
+        escalation.letter_text = letter_text
+        escalation.chosen = True
+        escalation.editted = escalation.editted or was_edited
+        escalation.save()
+        return escalation

--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -2607,6 +2607,29 @@ class AppealsBackendHelper:
         ) + "\n"
 
 
+def get_denial_for_action(
+    denial_id: Any, email: str, semi_sekret: str
+) -> Optional[Denial]:
+    """Look up the denial keyed by id + hashed email + semi_sekret.
+
+    Returns None if any field is missing/invalid or the denial doesn't
+    exist. The (denial_id, hashed_email, semi_sekret) triple is the
+    canonical "is this the right user touching this denial" check used
+    throughout the appeal flow.
+    """
+    if denial_id is None or not email or not semi_sekret:
+        return None
+    try:
+        denial_id_int = int(denial_id)
+    except (TypeError, ValueError):
+        return None
+    return Denial.objects.filter(
+        denial_id=denial_id_int,
+        hashed_email=Denial.get_hashed_email(email),
+        semi_sekret=semi_sekret,
+    ).first()
+
+
 class EscalationPacketHelper:
     """Streaming generator for the regulator/executive escalation packet.
 
@@ -2644,12 +2667,14 @@ class EscalationPacketHelper:
         ) + "\n"
 
         try:
-            denial = await Denial.objects.select_related(
-                "regulator", "insurance_company_obj"
-            ).aget(
-                denial_id=denial_id,
-                semi_sekret=semi_sekret,
-                hashed_email=hashed_email,
+            denial = await (
+                Denial.objects.select_related("regulator", "insurance_company_obj")
+                .prefetch_related("plan_source")
+                .aget(
+                    denial_id=denial_id,
+                    semi_sekret=semi_sekret,
+                    hashed_email=hashed_email,
+                )
             )
         except Denial.DoesNotExist:
             yield json.dumps({"type": "error", "message": "Denial not found"}) + "\n"
@@ -2672,58 +2697,63 @@ class EscalationPacketHelper:
         ) + "\n"
 
         use_external = bool(getattr(denial, "use_external", False))
-        for recipient in recipients:
-            yield json.dumps(
-                {
-                    "type": "status",
-                    "phase": "generating",
-                    "substep": recipient.recipient_type,
-                    "message": f"Drafting letter to {recipient.name}...",
-                }
-            ) + "\n"
 
-            letter_text: Optional[str] = await generate_regulator_letter(
+        async def _draft(recipient):
+            text = await generate_regulator_letter(
                 denial, recipient, use_external=use_external
             )
-            if not letter_text:
+            return recipient, text
+
+        tasks = [asyncio.create_task(_draft(r)) for r in recipients]
+        try:
+            for fut in asyncio.as_completed(tasks):
+                recipient, letter_text = await fut
+                if not letter_text:
+                    yield json.dumps(
+                        {
+                            "type": "status",
+                            "phase": "generating",
+                            "substep": recipient.recipient_type,
+                            "state": "error",
+                            "message": (
+                                f"Could not generate a letter for "
+                                f"{recipient.name}; skipping."
+                            ),
+                        }
+                    ) + "\n"
+                    continue
+
+                escalation = await RegulatorEscalation.objects.acreate(
+                    for_denial=denial,
+                    hashed_email=hashed_email,
+                    recipient_type=recipient.recipient_type,
+                    recipient_name=recipient.name,
+                    recipient_address=recipient.address,
+                    recipient_phone=recipient.phone,
+                    recipient_url=recipient.url,
+                    letter_text=letter_text,
+                )
+
                 yield json.dumps(
                     {
-                        "type": "status",
-                        "phase": "generating",
-                        "substep": recipient.recipient_type,
-                        "state": "error",
-                        "message": (
-                            f"Could not generate a letter for {recipient.name}; "
-                            "skipping."
-                        ),
+                        "type": "letter",
+                        "escalation_id": str(escalation.uuid),
+                        "recipient_type": recipient.recipient_type,
+                        "recipient_name": recipient.name,
+                        "recipient_address": recipient.address,
+                        "recipient_phone": recipient.phone,
+                        "recipient_url": recipient.url,
+                        "rationale": recipient.rationale,
+                        "content": letter_text,
                     }
                 ) + "\n"
-                continue
-
-            escalation = await RegulatorEscalation.objects.acreate(
-                for_denial=denial,
-                hashed_email=hashed_email,
-                recipient_type=recipient.recipient_type,
-                recipient_name=recipient.name,
-                recipient_address=recipient.address,
-                recipient_phone=recipient.phone,
-                recipient_url=recipient.url,
-                letter_text=letter_text,
-            )
-
-            yield json.dumps(
-                {
-                    "type": "letter",
-                    "escalation_id": str(escalation.uuid),
-                    "recipient_type": recipient.recipient_type,
-                    "recipient_name": recipient.name,
-                    "recipient_address": recipient.address,
-                    "recipient_phone": recipient.phone,
-                    "recipient_url": recipient.url,
-                    "rationale": recipient.rationale,
-                    "content": letter_text,
-                }
-            ) + "\n"
+        finally:
+            # If the consumer disconnected mid-stream, cancel any unfinished
+            # drafting tasks so we don't keep paying for ML calls nobody is
+            # listening to.
+            for t in tasks:
+                if not t.done():
+                    t.cancel()
 
         yield json.dumps(
             {
@@ -2743,14 +2773,8 @@ class EscalationPacketHelper:
         letter_text: str,
     ) -> Optional["RegulatorEscalation"]:
         """Persist the user's edited regulator letter as the chosen draft."""
-        hashed_email = Denial.get_hashed_email(email)
-        try:
-            denial = Denial.objects.get(
-                denial_id=denial_id,
-                semi_sekret=semi_sekret,
-                hashed_email=hashed_email,
-            )
-        except Denial.DoesNotExist:
+        denial = get_denial_for_action(denial_id, email, semi_sekret)
+        if denial is None:
             return None
         try:
             escalation = RegulatorEscalation.objects.get(

--- a/fighthealthinsurance/escalation_addresses.py
+++ b/fighthealthinsurance/escalation_addresses.py
@@ -1,0 +1,192 @@
+"""
+Address book for the escalation packet feature.
+
+Given a Denial, this module computes the list of regulator / executive
+recipients the user could escalate to in parallel with their appeal:
+
+- The state Department of Insurance / insurance commissioner — pulled
+  from `state_help.py` using the denial's `your_state` abbreviation.
+- The plan's medical director — a generic placeholder addressed to the
+  insurer's medical director in care of the insurer (the user fills in
+  the mailing address from the denial letter).
+- DOL EBSA — for plans likely to be ERISA-covered (self-funded employer
+  plans, including those administered by a TPA).
+
+The model `Regulator` already exists in the database for matching denial
+text; this module is the complementary "where do we send a letter"
+address book that combines per-state DOI data and national resources.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, List, Optional
+
+from fighthealthinsurance.state_help import (
+    StateHelp,
+    get_state_help_by_abbreviation,
+)
+
+# National address for the DOL EBSA — the federal agency that enforces
+# ERISA for self-funded employer health plans. Patients can request
+# enforcement assistance from EBSA when a fiduciary appears to have
+# violated ERISA's claims and appeals procedures (29 C.F.R. § 2560.503-1).
+DOL_EBSA_NAME = "U.S. Department of Labor, Employee Benefits Security Administration"
+DOL_EBSA_ADDRESS = (
+    "Employee Benefits Security Administration\n"
+    "U.S. Department of Labor\n"
+    "200 Constitution Ave NW\n"
+    "Washington, DC 20210"
+)
+DOL_EBSA_PHONE = "1-866-444-3272"
+DOL_EBSA_URL = "https://www.dol.gov/agencies/ebsa"
+
+
+@dataclass
+class EscalationRecipient:
+    """A single recipient on an escalation packet."""
+
+    recipient_type: str  # one of RegulatorEscalation.RECIPIENT_*
+    name: str
+    address: str = ""
+    phone: str = ""
+    url: str = ""
+    # Plain English description shown to the user describing why we suggest
+    # this recipient — used in the UI checklist and as light prompt context.
+    rationale: str = ""
+    # Free-form metadata the prompt builder can use (e.g. the state name).
+    extra: dict = field(default_factory=dict)
+
+
+def _doi_recipient(state: StateHelp) -> Optional[EscalationRecipient]:
+    """Build a DOI recipient from a StateHelp object, if it has one."""
+    dept = state.insurance_department
+    if not dept or not dept.name:
+        return None
+    rationale = (
+        f"State insurance regulators investigate complaints against insurers "
+        f"and can require {dept.name} to respond. They also oversee the "
+        f"external review process in {state.name}."
+    )
+    return EscalationRecipient(
+        recipient_type="doi",
+        name=dept.name,
+        address=dept.complaint_url or dept.url or "",
+        phone=dept.consumer_line or dept.phone or "",
+        url=dept.url or "",
+        rationale=rationale,
+        extra={
+            "state_name": state.name,
+            "state_abbreviation": state.abbreviation,
+            "external_review_available": bool(
+                state.external_review and state.external_review.available
+            ),
+            "external_review_url": (
+                state.external_review.info_url if state.external_review else None
+            ),
+        },
+    )
+
+
+def _medical_director_recipient(
+    insurance_company: Optional[str],
+) -> EscalationRecipient:
+    """Build a generic 'Medical Director' recipient for the plan."""
+    company = (
+        insurance_company
+        if insurance_company and insurance_company != "UNKNOWN"
+        else "Your Health Plan"
+    )
+    return EscalationRecipient(
+        recipient_type="medical_director",
+        name=f"Medical Director, {company}",
+        # We don't know the plan's mailing address; the user fills that in
+        # from the denial letter. We leave a placeholder block so the cover
+        # letter renders with an obvious blank to fill.
+        address="[Insurance company mailing address from your denial letter]",
+        phone="",
+        url="",
+        rationale=(
+            "The plan's medical director is the physician responsible for "
+            "coverage decisions. A direct, peer-to-peer-style letter to the "
+            "medical director can prompt a faster clinical re-review."
+        ),
+        extra={"insurance_company": company},
+    )
+
+
+def _dol_ebsa_recipient() -> EscalationRecipient:
+    """Build the DOL EBSA recipient for ERISA-covered plans."""
+    return EscalationRecipient(
+        recipient_type="dol_ebsa",
+        name=DOL_EBSA_NAME,
+        address=DOL_EBSA_ADDRESS,
+        phone=DOL_EBSA_PHONE,
+        url=DOL_EBSA_URL,
+        rationale=(
+            "ERISA self-funded employer plans are regulated federally by "
+            "DOL EBSA. EBSA investigates fiduciary breaches and violations "
+            "of the ERISA claims-and-appeals procedures (29 C.F.R. "
+            "§ 2560.503-1)."
+        ),
+    )
+
+
+def _is_erisa_likely(denial: Any) -> bool:
+    """Heuristic: is this denial likely to be from an ERISA plan?
+
+    We use any of:
+    - The denial is linked to the ERISA Regulator row.
+    - The structured insurance company is flagged as a TPA.
+    - The plan source ManyToMany contains an ERISA-tagged source.
+    """
+    try:
+        if denial.regulator and (denial.regulator.alt_name or "").upper() == "ERISA":
+            return True
+    except Exception:
+        pass
+    try:
+        ic = getattr(denial, "insurance_company_obj", None)
+        if ic is not None and getattr(ic, "is_tpa", False):
+            return True
+    except Exception:
+        pass
+    try:
+        for source in denial.plan_source.all():
+            label = (getattr(source, "name", "") or "").lower()
+            if "erisa" in label or "self-funded" in label or "self funded" in label:
+                return True
+    except Exception:
+        pass
+    return False
+
+
+def get_recipients_for_denial(denial: Any) -> List[EscalationRecipient]:
+    """
+    Build the list of escalation recipients for a denial.
+
+    Always returns at least the medical director recipient. Adds the DOI
+    recipient if the denial has a usable state, and the DOL EBSA recipient
+    if the plan looks ERISA-covered.
+    """
+    recipients: List[EscalationRecipient] = []
+
+    state_abbr = (
+        getattr(denial, "your_state", None) or getattr(denial, "state", None) or ""
+    )
+    if state_abbr:
+        state = get_state_help_by_abbreviation(state_abbr)
+        if state is not None:
+            doi = _doi_recipient(state)
+            if doi is not None:
+                recipients.append(doi)
+
+    insurance_company = getattr(denial, "insurance_company", None)
+    if not insurance_company:
+        ic_obj = getattr(denial, "insurance_company_obj", None)
+        if ic_obj is not None:
+            insurance_company = getattr(ic_obj, "name", None)
+    recipients.append(_medical_director_recipient(insurance_company))
+
+    if _is_erisa_likely(denial):
+        recipients.append(_dol_ebsa_recipient())
+
+    return recipients

--- a/fighthealthinsurance/escalation_addresses.py
+++ b/fighthealthinsurance/escalation_addresses.py
@@ -67,9 +67,10 @@ def _doi_recipient(state: StateHelp) -> Optional[EscalationRecipient]:
     if not dept or not dept.name:
         return None
     rationale = (
-        f"State insurance regulators investigate complaints against insurers "
-        f"and can require {dept.name} to respond. They also oversee the "
-        f"external review process in {state.name}."
+        f"State insurance regulators investigate complaints against "
+        f"insurers and can require the insurer to respond. "
+        f"{dept.name} also oversees the external review process in "
+        f"{state.name}."
     )
     return EscalationRecipient(
         recipient_type=RECIPIENT_DOI,

--- a/fighthealthinsurance/escalation_addresses.py
+++ b/fighthealthinsurance/escalation_addresses.py
@@ -20,10 +20,15 @@ address book that combines per-state DOI data and national resources.
 from dataclasses import dataclass, field
 from typing import Any, List, Optional
 
+from fighthealthinsurance.models import RegulatorEscalation
 from fighthealthinsurance.state_help import (
     StateHelp,
     get_state_help_by_abbreviation,
 )
+
+RECIPIENT_DOI = RegulatorEscalation.RECIPIENT_DOI
+RECIPIENT_MEDICAL_DIRECTOR = RegulatorEscalation.RECIPIENT_MEDICAL_DIRECTOR
+RECIPIENT_DOL_EBSA = RegulatorEscalation.RECIPIENT_DOL_EBSA
 
 # National address for the DOL EBSA — the federal agency that enforces
 # ERISA for self-funded employer health plans. Patients can request
@@ -67,7 +72,7 @@ def _doi_recipient(state: StateHelp) -> Optional[EscalationRecipient]:
         f"external review process in {state.name}."
     )
     return EscalationRecipient(
-        recipient_type="doi",
+        recipient_type=RECIPIENT_DOI,
         name=dept.name,
         address=dept.complaint_url or dept.url or "",
         phone=dept.consumer_line or dept.phone or "",
@@ -96,11 +101,11 @@ def _medical_director_recipient(
         else "Your Health Plan"
     )
     return EscalationRecipient(
-        recipient_type="medical_director",
+        recipient_type=RECIPIENT_MEDICAL_DIRECTOR,
         name=f"Medical Director, {company}",
-        # We don't know the plan's mailing address; the user fills that in
-        # from the denial letter. We leave a placeholder block so the cover
-        # letter renders with an obvious blank to fill.
+        # The plan's address isn't known; the letter renders with an
+        # obvious bracketed placeholder for the user to fill from the
+        # denial letter.
         address="[Insurance company mailing address from your denial letter]",
         phone="",
         url="",
@@ -116,7 +121,7 @@ def _medical_director_recipient(
 def _dol_ebsa_recipient() -> EscalationRecipient:
     """Build the DOL EBSA recipient for ERISA-covered plans."""
     return EscalationRecipient(
-        recipient_type="dol_ebsa",
+        recipient_type=RECIPIENT_DOL_EBSA,
         name=DOL_EBSA_NAME,
         address=DOL_EBSA_ADDRESS,
         phone=DOL_EBSA_PHONE,
@@ -130,32 +135,31 @@ def _dol_ebsa_recipient() -> EscalationRecipient:
     )
 
 
+_ERISA_PLAN_SOURCE_KEYWORDS = ("erisa", "self-funded", "self funded")
+
+
 def _is_erisa_likely(denial: Any) -> bool:
     """Heuristic: is this denial likely to be from an ERISA plan?
 
-    We use any of:
-    - The denial is linked to the ERISA Regulator row.
-    - The structured insurance company is flagged as a TPA.
-    - The plan source ManyToMany contains an ERISA-tagged source.
+    True if any of: the denial is linked to the ERISA Regulator row, the
+    structured insurance company is flagged as a TPA, or the plan source
+    M2M contains an ERISA-tagged source.
     """
-    try:
-        if denial.regulator and (denial.regulator.alt_name or "").upper() == "ERISA":
+    regulator = getattr(denial, "regulator", None)
+    if regulator is not None and (regulator.alt_name or "").upper() == "ERISA":
+        return True
+
+    ic = getattr(denial, "insurance_company_obj", None)
+    if ic is not None and getattr(ic, "is_tpa", False):
+        return True
+
+    plan_source_manager = getattr(denial, "plan_source", None)
+    if plan_source_manager is None or not hasattr(plan_source_manager, "all"):
+        return False
+    for source in plan_source_manager.all():
+        label = (getattr(source, "name", "") or "").lower()
+        if any(k in label for k in _ERISA_PLAN_SOURCE_KEYWORDS):
             return True
-    except Exception:
-        pass
-    try:
-        ic = getattr(denial, "insurance_company_obj", None)
-        if ic is not None and getattr(ic, "is_tpa", False):
-            return True
-    except Exception:
-        pass
-    try:
-        for source in denial.plan_source.all():
-            label = (getattr(source, "name", "") or "").lower()
-            if "erisa" in label or "self-funded" in label or "self funded" in label:
-                return True
-    except Exception:
-        pass
     return False
 
 

--- a/fighthealthinsurance/forms/__init__.py
+++ b/fighthealthinsurance/forms/__init__.py
@@ -175,6 +175,13 @@ class ChooseAppealForm(DenialRefForm):
     )
 
 
+class ChooseEscalationLetterForm(DenialRefForm):
+    escalation_uuid = forms.CharField(required=True, widget=forms.HiddenInput())
+    letter_text = forms.CharField(
+        widget=forms.Textarea(attrs={"class": "appeal_text"}), required=True
+    )
+
+
 class FaxForm(DenialRefForm):
     name = forms.CharField(
         required=True,

--- a/fighthealthinsurance/forms/__init__.py
+++ b/fighthealthinsurance/forms/__init__.py
@@ -176,7 +176,7 @@ class ChooseAppealForm(DenialRefForm):
 
 
 class ChooseEscalationLetterForm(DenialRefForm):
-    escalation_uuid = forms.CharField(required=True, widget=forms.HiddenInput())
+    escalation_uuid = forms.UUIDField(required=True, widget=forms.HiddenInput())
     letter_text = forms.CharField(
         widget=forms.Textarea(attrs={"class": "appeal_text"}), required=True
     )

--- a/fighthealthinsurance/generate_regulator_letter.py
+++ b/fighthealthinsurance/generate_regulator_letter.py
@@ -1,0 +1,183 @@
+"""
+ML-driven generation of regulator-friendly cover letters.
+
+Given a Denial and an EscalationRecipient (from
+`fighthealthinsurance.escalation_addresses`), produces a one-shot cover
+letter tailored to that recipient's role: state DOI, plan medical
+director, or DOL EBSA. Each recipient type gets a different prompt so
+the letter cites the right regulatory framing — investigation /
+external-review for DOI, peer-to-peer clinical review for the medical
+director, ERISA § 503 / fiduciary duty for DOL EBSA.
+
+We reuse `model.generate_prior_auth_response` because, like prior auths,
+these are short professional letters (rather than long appeal letters
+that benefit from parallel multi-temperature exploration).
+"""
+
+import datetime
+from typing import Any, Optional
+
+from loguru import logger
+
+from fighthealthinsurance.escalation_addresses import EscalationRecipient
+from fighthealthinsurance.ml.ml_router import ml_router
+
+_DOI_FRAMING = (
+    "Frame this letter as a complaint to the state Department of "
+    "Insurance / insurance commissioner. Politely ask the regulator to "
+    "(1) investigate whether the plan complied with state and federal "
+    "claims-handling rules, (2) confirm whether external (independent) "
+    "medical review is available for this denial, and (3) require the "
+    "insurer to respond. Cite that internal appeals are being pursued "
+    "in parallel. Use a respectful, factual tone — this is a regulator, "
+    "not the insurer."
+)
+
+_MEDICAL_DIRECTOR_FRAMING = (
+    "Frame this letter as a direct, peer-to-peer-style request to the "
+    "plan's medical director asking for a clinical re-review. Briefly "
+    "describe the patient's condition and the medical necessity of the "
+    "service. Request a peer-to-peer review with the treating clinician "
+    "and ask the medical director to personally re-examine the denial. "
+    "Use a clinical, collegial tone."
+)
+
+_DOL_EBSA_FRAMING = (
+    "Frame this letter as a request for enforcement assistance to the "
+    "U.S. Department of Labor's Employee Benefits Security "
+    "Administration (EBSA). The plan appears to be an ERISA-covered "
+    "self-funded employer plan. Reference the ERISA claims-and-appeals "
+    "regulations at 29 C.F.R. § 2560.503-1, summarize the denial and "
+    "the specific provisions that may have been violated (e.g. failure "
+    "to provide the specific reason for denial, failure to identify the "
+    "internal rule or guideline relied on, or failure to meet timing "
+    "requirements). Request that EBSA review the plan's compliance and "
+    "open an inquiry if appropriate. Tone: factual, formal, restrained."
+)
+
+_FRAMING_BY_RECIPIENT_TYPE = {
+    "doi": _DOI_FRAMING,
+    "medical_director": _MEDICAL_DIRECTOR_FRAMING,
+    "dol_ebsa": _DOL_EBSA_FRAMING,
+}
+
+
+def make_regulator_letter_prompt(
+    denial: Any,
+    recipient: EscalationRecipient,
+) -> str:
+    """Build the prompt for a single regulator/executive cover letter."""
+    framing = _FRAMING_BY_RECIPIENT_TYPE.get(
+        recipient.recipient_type,
+        "Frame this letter as a respectful request for the recipient to "
+        "review the denial.",
+    )
+
+    insurance_company = (
+        denial.insurance_company
+        if getattr(denial, "insurance_company", None)
+        and denial.insurance_company != "UNKNOWN"
+        else "the insurance company"
+    )
+    procedure = getattr(denial, "procedure", "") or "[procedure]"
+    diagnosis = getattr(denial, "diagnosis", "") or "[diagnosis]"
+    claim_id = getattr(denial, "claim_id", "") or "[claim id from your denial letter]"
+    plan_id = getattr(denial, "plan_id", "") or ""
+    state_name = recipient.extra.get("state_name", "")
+    external_review_available = recipient.extra.get("external_review_available", False)
+
+    extras = []
+    if state_name:
+        extras.append(f"State: {state_name}")
+    if recipient.recipient_type == "doi" and external_review_available:
+        extras.append(
+            "Note: external (independent) medical review IS available in this state — "
+            "ask the regulator to point the patient to the right form/process."
+        )
+    if plan_id:
+        extras.append(f"Plan ID: {plan_id}")
+
+    extras_block = "\n".join(extras)
+
+    qa_context = getattr(denial, "qa_context", "") or ""
+    denial_text = getattr(denial, "denial_text", "") or ""
+
+    prompt = f"""\
+Write a one-page cover letter from a patient (or, if marked, the
+treating professional) to the following recipient, accompanying a
+parallel internal appeal that is already being pursued. The letter
+should fit on a single page and be ready to print and mail or fax.
+
+Recipient: {recipient.name}
+Recipient role: {recipient.recipient_type}
+Recipient address: {recipient.address or "(see denial letter for address)"}
+
+{framing}
+
+Important rules:
+- Do NOT fabricate citations, statutes, regulations, study names, or
+  PMIDs. Only reference statutes you are explicitly given (e.g. ERISA
+  § 503 / 29 C.F.R. § 2560.503-1 above for the EBSA letter).
+- Use placeholders like {{{{FIRST_NAME}}}} {{{{LAST_NAME}}}}, {{{{Your Address}}}},
+  {{{{Your Phone Number}}}}, and {{{{SCSID}}}} where personal information is
+  needed; the user will fill those in.
+- Keep tone professional and restrained. This is being read by a
+  regulator or executive, not the insurer.
+- End with a concrete ask (investigation, peer-to-peer, EBSA inquiry).
+- Reference the denial below by its key facts: insurance company,
+  procedure, diagnosis, and claim id.
+
+Denial summary:
+- Insurance company: {insurance_company}
+- Procedure: {procedure}
+- Diagnosis: {diagnosis}
+- Claim id: {claim_id}
+{extras_block}
+
+Patient context (Q&A): {qa_context or "(none provided)"}
+
+Denial letter excerpt:
+{denial_text[:4000]}
+
+Today's date is {datetime.date.today().isoformat()}.
+
+Write the letter now. Output only the letter text — no preamble, no
+explanation, no markdown headings.
+"""
+    return prompt
+
+
+async def generate_regulator_letter(
+    denial: Any,
+    recipient: EscalationRecipient,
+    use_external: bool = False,
+) -> Optional[str]:
+    """
+    Generate a single regulator/executive cover letter for the denial.
+
+    Returns the letter text, or None if no model is available or
+    generation failed.
+    """
+    prompt = make_regulator_letter_prompt(denial, recipient)
+    models = ml_router.get_chat_backends(use_external=use_external)
+    if not models:
+        logger.warning("No chat backends available for regulator letter generation")
+        return None
+
+    last_error: Optional[Exception] = None
+    for model in models[:3]:
+        try:
+            text = await model.generate_prior_auth_response(prompt)
+            if text and len(text.strip()) > 50:
+                return text
+        except Exception as e:
+            last_error = e
+            logger.opt(exception=True).debug(
+                f"Regulator letter generation failed on {model}: {e}"
+            )
+    if last_error is not None:
+        logger.warning(
+            f"All regulator-letter backends failed for recipient "
+            f"{recipient.recipient_type}: {last_error}"
+        )
+    return None

--- a/fighthealthinsurance/generate_regulator_letter.py
+++ b/fighthealthinsurance/generate_regulator_letter.py
@@ -172,7 +172,7 @@ async def generate_regulator_letter(
     last_error: Optional[Exception] = None
     for model in models[:3]:
         try:
-            text = await model.generate_prior_auth_response(prompt)
+            text: Optional[str] = await model.generate_prior_auth_response(prompt)
             if text and len(text.strip()) > 50:
                 return text
         except Exception as e:

--- a/fighthealthinsurance/generate_regulator_letter.py
+++ b/fighthealthinsurance/generate_regulator_letter.py
@@ -19,7 +19,12 @@ from typing import Any, Optional
 
 from loguru import logger
 
-from fighthealthinsurance.escalation_addresses import EscalationRecipient
+from fighthealthinsurance.escalation_addresses import (
+    RECIPIENT_DOI,
+    RECIPIENT_DOL_EBSA,
+    RECIPIENT_MEDICAL_DIRECTOR,
+    EscalationRecipient,
+)
 from fighthealthinsurance.ml.ml_router import ml_router
 
 _DOI_FRAMING = (
@@ -56,9 +61,9 @@ _DOL_EBSA_FRAMING = (
 )
 
 _FRAMING_BY_RECIPIENT_TYPE = {
-    "doi": _DOI_FRAMING,
-    "medical_director": _MEDICAL_DIRECTOR_FRAMING,
-    "dol_ebsa": _DOL_EBSA_FRAMING,
+    RECIPIENT_DOI: _DOI_FRAMING,
+    RECIPIENT_MEDICAL_DIRECTOR: _MEDICAL_DIRECTOR_FRAMING,
+    RECIPIENT_DOL_EBSA: _DOL_EBSA_FRAMING,
 }
 
 
@@ -89,7 +94,7 @@ def make_regulator_letter_prompt(
     extras = []
     if state_name:
         extras.append(f"State: {state_name}")
-    if recipient.recipient_type == "doi" and external_review_available:
+    if recipient.recipient_type == RECIPIENT_DOI and external_review_available:
         extras.append(
             "Note: external (independent) medical review IS available in this state — "
             "ask the regulator to point the patient to the right form/process."

--- a/fighthealthinsurance/migrations/0160_regulatorescalation.py
+++ b/fighthealthinsurance/migrations/0160_regulatorescalation.py
@@ -1,0 +1,75 @@
+# Generated for the escalation packet feature.
+
+import uuid
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("fighthealthinsurance", "0159_chatdocument"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="RegulatorEscalation",
+            fields=[
+                ("id", models.AutoField(primary_key=True, serialize=False)),
+                (
+                    "uuid",
+                    models.CharField(
+                        default=uuid.uuid4,
+                        editable=False,
+                        max_length=100,
+                        unique=True,
+                    ),
+                ),
+                ("hashed_email", models.CharField(max_length=300)),
+                (
+                    "recipient_type",
+                    models.CharField(
+                        choices=[
+                            ("doi", "State DOI / Insurance Commissioner"),
+                            ("medical_director", "Plan Medical Director"),
+                            ("dol_ebsa", "DOL EBSA (ERISA)"),
+                        ],
+                        max_length=32,
+                    ),
+                ),
+                (
+                    "recipient_name",
+                    models.CharField(blank=True, default="", max_length=300),
+                ),
+                ("recipient_address", models.TextField(blank=True, default="")),
+                (
+                    "recipient_phone",
+                    models.CharField(blank=True, default="", max_length=80),
+                ),
+                (
+                    "recipient_url",
+                    models.CharField(blank=True, default="", max_length=400),
+                ),
+                ("letter_text", models.TextField(blank=True, default="")),
+                ("chosen", models.BooleanField(default=False)),
+                ("editted", models.BooleanField(default=False)),
+                ("sent", models.BooleanField(default=False)),
+                ("created", models.DateTimeField(auto_now_add=True)),
+                ("mod_date", models.DateTimeField(auto_now=True)),
+                (
+                    "for_denial",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="regulator_escalations",
+                        to="fighthealthinsurance.denial",
+                    ),
+                ),
+            ],
+            options={
+                "indexes": [
+                    models.Index(fields=["for_denial"], name="reg_escal_denial_idx"),
+                    models.Index(fields=["hashed_email"], name="reg_escal_email_idx"),
+                ],
+            },
+        ),
+    ]

--- a/fighthealthinsurance/migrations/0160_regulatorescalation.py
+++ b/fighthealthinsurance/migrations/0160_regulatorescalation.py
@@ -18,12 +18,7 @@ class Migration(migrations.Migration):
                 ("id", models.AutoField(primary_key=True, serialize=False)),
                 (
                     "uuid",
-                    models.CharField(
-                        default=uuid.uuid4,
-                        editable=False,
-                        max_length=100,
-                        unique=True,
-                    ),
+                    models.UUIDField(default=uuid.uuid4, editable=False, unique=True),
                 ),
                 ("hashed_email", models.CharField(max_length=300)),
                 (
@@ -52,7 +47,7 @@ class Migration(migrations.Migration):
                 ),
                 ("letter_text", models.TextField(blank=True, default="")),
                 ("chosen", models.BooleanField(default=False)),
-                ("editted", models.BooleanField(default=False)),
+                ("edited", models.BooleanField(default=False)),
                 ("sent", models.BooleanField(default=False)),
                 ("created", models.DateTimeField(auto_now_add=True)),
                 ("mod_date", models.DateTimeField(auto_now=True)),

--- a/fighthealthinsurance/migrations/0162_regulatorescalation.py
+++ b/fighthealthinsurance/migrations/0162_regulatorescalation.py
@@ -8,7 +8,7 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("fighthealthinsurance", "0159_chatdocument"),
+        ("fighthealthinsurance", "0161_loststripesession_secure_token"),
     ]
 
     operations = [

--- a/fighthealthinsurance/models.py
+++ b/fighthealthinsurance/models.py
@@ -1539,12 +1539,7 @@ class RegulatorEscalation(ExportModelOperationsMixin("RegulatorEscalation"), mod
     ]
 
     id = models.AutoField(primary_key=True)
-    uuid = models.CharField(
-        default=uuid.uuid4,
-        editable=False,
-        unique=True,
-        max_length=100,
-    )
+    uuid = models.UUIDField(default=uuid.uuid4, editable=False, unique=True)
     for_denial = models.ForeignKey(
         Denial, on_delete=models.CASCADE, related_name="regulator_escalations"
     )
@@ -1556,7 +1551,7 @@ class RegulatorEscalation(ExportModelOperationsMixin("RegulatorEscalation"), mod
     recipient_url = models.CharField(max_length=400, blank=True, default="")
     letter_text = models.TextField(blank=True, default="")
     chosen = models.BooleanField(default=False)
-    editted = models.BooleanField(default=False)
+    edited = models.BooleanField(default=False)
     sent = models.BooleanField(default=False)
     created = models.DateTimeField(auto_now_add=True)
     mod_date = models.DateTimeField(auto_now=True)

--- a/fighthealthinsurance/models.py
+++ b/fighthealthinsurance/models.py
@@ -1517,6 +1517,60 @@ class ProposedAppeal(ExportModelOperationsMixin("ProposedAppeal"), models.Model)
             return f"{self.appeal_text}"
 
 
+class RegulatorEscalation(ExportModelOperationsMixin("RegulatorEscalation"), models.Model):  # type: ignore
+    """
+    Tracks an escalation packet generated alongside an appeal.
+
+    A packet is a set of cover letters addressed in parallel to the regulator(s)
+    that oversee the plan: the state Department of Insurance / insurance
+    commissioner, the plan's medical director, and (for ERISA self-funded plans)
+    the U.S. Department of Labor's Employee Benefits Security Administration
+    (EBSA). Each entry stores the recipient metadata, the AI-generated draft,
+    and the user-chosen / edited final text.
+    """
+
+    RECIPIENT_DOI = "doi"
+    RECIPIENT_MEDICAL_DIRECTOR = "medical_director"
+    RECIPIENT_DOL_EBSA = "dol_ebsa"
+    RECIPIENT_CHOICES = [
+        (RECIPIENT_DOI, "State DOI / Insurance Commissioner"),
+        (RECIPIENT_MEDICAL_DIRECTOR, "Plan Medical Director"),
+        (RECIPIENT_DOL_EBSA, "DOL EBSA (ERISA)"),
+    ]
+
+    id = models.AutoField(primary_key=True)
+    uuid = models.CharField(
+        default=uuid.uuid4,
+        editable=False,
+        unique=True,
+        max_length=100,
+    )
+    for_denial = models.ForeignKey(
+        Denial, on_delete=models.CASCADE, related_name="regulator_escalations"
+    )
+    hashed_email = models.CharField(max_length=300)
+    recipient_type = models.CharField(max_length=32, choices=RECIPIENT_CHOICES)
+    recipient_name = models.CharField(max_length=300, blank=True, default="")
+    recipient_address = models.TextField(blank=True, default="")
+    recipient_phone = models.CharField(max_length=80, blank=True, default="")
+    recipient_url = models.CharField(max_length=400, blank=True, default="")
+    letter_text = models.TextField(blank=True, default="")
+    chosen = models.BooleanField(default=False)
+    editted = models.BooleanField(default=False)
+    sent = models.BooleanField(default=False)
+    created = models.DateTimeField(auto_now_add=True)
+    mod_date = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        indexes = [
+            models.Index(fields=["for_denial"], name="reg_escal_denial_idx"),
+            models.Index(fields=["hashed_email"], name="reg_escal_email_idx"),
+        ]
+
+    def __str__(self):
+        return f"RegulatorEscalation({self.recipient_type}) for denial {self.for_denial_id}"
+
+
 class Appeal(ExportModelOperationsMixin("Appeal"), models.Model):  # type: ignore
     """
     Represents a finalized appeal letter that has been or will be submitted.

--- a/fighthealthinsurance/routing.py
+++ b/fighthealthinsurance/routing.py
@@ -5,6 +5,7 @@ from fighthealthinsurance.websockets import (
     PriorAuthConsumer,
     StreamingAppealsBackend,
     StreamingEntityBackend,
+    StreamingEscalationBackend,
 )
 
 websocket_urlpatterns = [
@@ -17,6 +18,11 @@ websocket_urlpatterns = [
         "ws/streaming-appeals-backend/",
         StreamingAppealsBackend.as_asgi(),
         name="streamingappeals_json_backend",
+    ),
+    path(
+        "ws/streaming-escalation-backend/",
+        StreamingEscalationBackend.as_asgi(),
+        name="streamingescalation_json_backend",
     ),
     path(
         "ws/prior-auth/",

--- a/fighthealthinsurance/templates/appeal.html
+++ b/fighthealthinsurance/templates/appeal.html
@@ -173,6 +173,30 @@ Fight Your Health Insurance Denial: Edit and send in your appeal
   </p>
 </div>
 
+<div class="alert-box alert-info" style="margin:2rem 0; border-left:4px solid #ADD100;">
+  <h4 style="margin-bottom:0.75rem;">📣 Want to let the regulator know what's going on?</h4>
+  <p style="margin:0.5rem 0;">
+    Sometimes the most effective thing you can do alongside an internal appeal is
+    cc the people who hold the plan accountable: your <strong>state Department of
+    Insurance</strong>, the plan's <strong>medical director</strong>, and (for
+    ERISA self-funded plans) the <strong>U.S. Department of Labor's EBSA</strong>.
+    We'll draft regulator-friendly letters you can edit and send.
+  </p>
+  <form action="{% url 'escalation_packet' %}" method="post" target="_blank" style="margin:0.75rem 0;">
+    {% csrf_token %}
+    <input type="hidden" name="email" value="{{ user_email }}">
+    <input type="hidden" name="denial_id" value="{{ denial_id }}">
+    {% if semi_sekret %}<input type="hidden" name="semi_sekret" value="{{ semi_sekret }}">{% endif %}
+    <button type="submit" id="generate_escalation_packet" class="btn btn-default" style="font-size:1.05rem; padding:10px 20px;">
+      📨 Click here to draft regulator letters (opens in a new window)
+    </button>
+  </form>
+  <p style="margin:0.5rem 0; font-size:0.9rem; color:#555;">
+    This is especially useful for <em>secondary</em> appeals — once an internal
+    appeal has been denied, regulator escalation often unsticks things.
+  </p>
+</div>
+
 <div class="alert-box alert-warning" style="margin:2rem 0;">
   <h4>💡 Important Reminders:</h4>
   <ul style="margin:0.5rem 0 0 1.5rem; line-height:1.8;">

--- a/fighthealthinsurance/templates/escalation_packet.html
+++ b/fighthealthinsurance/templates/escalation_packet.html
@@ -1,0 +1,167 @@
+{% extends 'base.html' %}
+{% load static %}
+{% block title %}
+Fight Your Health Insurance Denial: Regulator Escalation Letters
+{% endblock title %}
+
+{% block content %}
+<div class="container" style="padding-top:1rem;">
+  <div class="alert-box alert-info">
+    <h3>📨 Regulator Escalation Packet</h3>
+    <p style="font-size:1.05rem;">
+      We're drafting parallel cover letters you can send alongside your
+      appeal — to the people who hold your plan accountable. Each letter
+      is tailored to its recipient's role.
+    </p>
+  </div>
+
+  {% if recipients_count == 0 %}
+  <div class="alert-box alert-warning">
+    <p>
+      We weren't able to identify any regulator recipients for this denial.
+      Make sure you've filled in your state on the earlier steps.
+    </p>
+    <p>
+      <a href="{{ back_url }}" class="btn btn-secondary">← {{ back_label }}</a>
+    </p>
+  </div>
+  {% else %}
+  <div class="alert-box" style="background:#f8f9fa; border:1px solid #dee2e6; padding:1rem;">
+    <h4 style="margin-top:0;">We'll generate {{ recipients_count }} letter{{ recipients_count|pluralize }} for:</h4>
+    <ul style="margin:0.5rem 0 0 1.5rem; line-height:1.6;">
+      {% for r in recipients %}
+        <li>
+          <strong>{{ r.name }}</strong>
+          {% if r.rationale %}<br><span style="color:#555; font-size:0.9rem;">{{ r.rationale }}</span>{% endif %}
+        </li>
+      {% endfor %}
+    </ul>
+  </div>
+
+  <div id="loading-text" style="text-align:center; padding:1rem; margin-top:1rem;">
+    <h4>Drafting your regulator letters…</h4>
+    <p style="color:#666;">This usually takes 1–2 minutes per recipient.</p>
+  </div>
+
+  <div id="escalation-letters"></div>
+
+  <div id="base-letter-form" style="display:none;">
+    <form action="{% url 'choose_escalation_letter' %}" method="post" class="col-md-12 d-flex flex-column align-items-center" style="margin:1rem 0;">
+      {% csrf_token %}
+      <input type="hidden" name="email" value="{{ user_email }}">
+      <input type="hidden" name="denial_id" value="{{ denial_id }}">
+      <input type="hidden" name="semi_sekret" value="{{ semi_sekret }}">
+      <input type="hidden" name="escalation_uuid" value="">
+      <textarea style="width:100%" rows="20" name="letter_text" class="appeal_text"></textarea>
+      <button type="submit" class="btn btn-green" style="margin-top:0.5rem;">Save and review this letter</button>
+    </form>
+  </div>
+
+  <div class="form-nav-centered" style="margin-top:1.5rem;">
+    <a href="{{ back_url }}" class="btn btn-secondary-custom">← {{ back_label }}</a>
+  </div>
+  {% endif %}
+</div>
+
+{% if recipients_count > 0 %}
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const backendUrl = `wss://${window.location.host}/ws/streaming-escalation-backend/`;
+    const data = {
+      {% autoescape off %}
+      ...{{ form_context }},
+      {% endautoescape %}
+      csrfmiddlewaretoken: '{{ csrf_token }}',
+    };
+
+    const lettersContainer = document.getElementById('escalation-letters');
+    const loadingText = document.getElementById('loading-text');
+    const baseForm = document.getElementById('base-letter-form');
+
+    function renderLetter(payload) {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'alert-box';
+      wrapper.style.cssText = 'background:#fff; border:1px solid #ADD100; padding:1rem; margin:1.5rem 0;';
+
+      const heading = document.createElement('h4');
+      heading.textContent = '📬 Letter to ' + payload.recipient_name;
+      wrapper.appendChild(heading);
+
+      if (payload.recipient_address) {
+        const addr = document.createElement('pre');
+        addr.style.cssText = 'background:#f5f5f5; padding:0.5rem; border-radius:4px; font-size:0.9rem; white-space:pre-wrap;';
+        addr.textContent = payload.recipient_address;
+        wrapper.appendChild(addr);
+      }
+      if (payload.rationale) {
+        const r = document.createElement('p');
+        r.style.cssText = 'color:#555; font-size:0.95rem;';
+        r.textContent = payload.rationale;
+        wrapper.appendChild(r);
+      }
+
+      const cloned = baseForm.cloneNode(true);
+      cloned.removeAttribute('style');
+      const form = cloned.querySelector('form');
+      const uuidInput = form.querySelector('input[name="escalation_uuid"]');
+      uuidInput.value = payload.escalation_id;
+      const textarea = form.querySelector('textarea');
+      textarea.value = payload.content;
+      wrapper.appendChild(cloned);
+
+      lettersContainer.appendChild(wrapper);
+    }
+
+    function processLine(line) {
+      line = line.trim();
+      if (!line) return;
+      let parsed;
+      try {
+        parsed = JSON.parse(line);
+      } catch (e) {
+        console.error('Failed to parse line:', line, e);
+        return;
+      }
+      if (parsed.type === 'letter') {
+        renderLetter(parsed);
+        return;
+      }
+      if (parsed.type === 'status' && parsed.phase === 'done') {
+        if (loadingText) loadingText.style.display = 'none';
+        return;
+      }
+      if (parsed.type === 'error') {
+        if (loadingText) loadingText.textContent = parsed.message || 'An error occurred.';
+        return;
+      }
+      // Status updates we surface in the loading text
+      if (parsed.type === 'status' && parsed.message) {
+        const inner = loadingText && loadingText.querySelector('p');
+        if (inner) inner.textContent = parsed.message;
+      }
+    }
+
+    let buffer = '';
+    const ws = new WebSocket(backendUrl);
+    ws.onopen = () => ws.send(JSON.stringify(data));
+    ws.onmessage = (event) => {
+      buffer += event.data;
+      while (buffer.includes('\n')) {
+        const idx = buffer.indexOf('\n');
+        const line = buffer.slice(0, idx);
+        buffer = buffer.slice(idx + 1);
+        processLine(line);
+      }
+    };
+    ws.onclose = () => {
+      if (buffer.trim()) processLine(buffer);
+      if (loadingText) loadingText.style.display = 'none';
+    };
+    ws.onerror = (e) => {
+      console.error('WebSocket error', e);
+      if (loadingText) loadingText.textContent = 'Connection error — please try again.';
+    };
+  });
+</script>
+{% endif %}
+{% endblock content %}

--- a/fighthealthinsurance/templates/escalation_packet.html
+++ b/fighthealthinsurance/templates/escalation_packet.html
@@ -64,14 +64,15 @@ Fight Your Health Insurance Denial: Regulator Escalation Letters
 </div>
 
 {% if recipients_count > 0 %}
+{{ form_context|json_script:"escalation-form-context" }}
 <script>
   document.addEventListener('DOMContentLoaded', () => {
     const backendUrl = `wss://${window.location.host}/ws/streaming-escalation-backend/`;
+    const formContextEl = document.getElementById('escalation-form-context');
+    const formContext = formContextEl ? JSON.parse(formContextEl.textContent) : {};
     const data = {
-      {% autoescape off %}
-      ...{{ form_context }},
-      {% endautoescape %}
-      csrfmiddlewaretoken: '{{ csrf_token }}',
+      ...formContext,
+      csrfmiddlewaretoken: '{{ csrf_token|escapejs }}',
     };
 
     const lettersContainer = document.getElementById('escalation-letters');

--- a/fighthealthinsurance/templates/escalation_packet.html
+++ b/fighthealthinsurance/templates/escalation_packet.html
@@ -67,7 +67,8 @@ Fight Your Health Insurance Denial: Regulator Escalation Letters
 {{ form_context|json_script:"escalation-form-context" }}
 <script>
   document.addEventListener('DOMContentLoaded', () => {
-    const backendUrl = `wss://${window.location.host}/ws/streaming-escalation-backend/`;
+    const wsScheme = window.location.protocol === 'https:' ? 'wss' : 'ws';
+    const backendUrl = `${wsScheme}://${window.location.host}/ws/streaming-escalation-backend/`;
     const formContextEl = document.getElementById('escalation-form-context');
     const formContext = formContextEl ? JSON.parse(formContextEl.textContent) : {};
     const data = {
@@ -102,6 +103,7 @@ Fight Your Health Insurance Denial: Regulator Escalation Letters
       }
 
       const cloned = baseForm.cloneNode(true);
+      cloned.removeAttribute('id');
       cloned.removeAttribute('style');
       const form = cloned.querySelector('form');
       const uuidInput = form.querySelector('input[name="escalation_uuid"]');

--- a/fighthealthinsurance/templates/escalation_packet_review.html
+++ b/fighthealthinsurance/templates/escalation_packet_review.html
@@ -42,9 +42,13 @@ Fight Your Health Insurance Denial: Send your regulator letter
   </div>
 
   <div class="form-nav-centered">
-    <a href="{% url 'escalation_packet' %}?denial_id={{ denial_id }}&email={{ user_email }}&semi_sekret={{ semi_sekret }}" class="btn btn-secondary-custom">
-      ← Back to all regulator letters
-    </a>
+    <form action="{% url 'escalation_packet' %}" method="post" style="display:inline;">
+      {% csrf_token %}
+      <input type="hidden" name="denial_id" value="{{ denial_id }}">
+      <input type="hidden" name="email" value="{{ user_email }}">
+      <input type="hidden" name="semi_sekret" value="{{ semi_sekret }}">
+      <button type="submit" class="btn btn-secondary-custom">← Back to all regulator letters</button>
+    </form>
   </div>
 </div>
 

--- a/fighthealthinsurance/templates/escalation_packet_review.html
+++ b/fighthealthinsurance/templates/escalation_packet_review.html
@@ -1,0 +1,68 @@
+{% extends 'base.html' %}
+{% load static %}
+{% block title %}
+Fight Your Health Insurance Denial: Send your regulator letter
+{% endblock title %}
+
+{% block content %}
+<div class="container" style="padding-top:1rem;">
+
+  <div class="alert-box alert-success">
+    <h3>📨 Your regulator letter is ready to send</h3>
+    <p>
+      Below is your final letter to <strong>{{ recipient_name }}</strong>.
+      Review it, fill in any remaining personal details, then send it.
+    </p>
+  </div>
+
+  <div class="alert-box" style="background:#f8f9fa; border:1px solid #dee2e6; padding:1rem;">
+    <h4 style="margin-top:0;">Recipient</h4>
+    <p style="margin:0.25rem 0;"><strong>{{ recipient_name }}</strong></p>
+    {% if recipient_address %}
+    <pre style="background:#fff; padding:0.5rem; border:1px solid #eee; border-radius:4px; white-space:pre-wrap; font-size:0.9rem;">{{ recipient_address }}</pre>
+    {% endif %}
+    {% if recipient_phone %}<p style="margin:0.25rem 0;">📞 {{ recipient_phone }}</p>{% endif %}
+    {% if recipient_url %}<p style="margin:0.25rem 0;">🔗 <a href="{{ recipient_url }}" target="_blank" rel="noopener noreferrer">{{ recipient_url }}</a></p>{% endif %}
+  </div>
+
+  <h3 class="section-header" style="margin-top:1.5rem;">Your letter</h3>
+  <textarea class="appeal_text" id="id_completed_appeal_text" rows="22">{{ letter_text }}</textarea>
+
+  <div style="margin:1.5rem 0;">
+    <h4>📤 How to send it</h4>
+    <ul style="margin-left:1.5rem; line-height:1.8;">
+      <li><strong>Print and mail:</strong> certified mail with return receipt is recommended.</li>
+      <li><strong>Email or web form:</strong> many state insurance commissioners accept complaints via their website (link above).</li>
+      {% if recipient_type == 'dol_ebsa' %}
+      <li><strong>DOL EBSA:</strong> you can also call 1-866-444-3272 or file online at
+        <a href="https://www.askebsa.dol.gov/" target="_blank" rel="noopener noreferrer">askebsa.dol.gov</a>.</li>
+      {% endif %}
+    </ul>
+    <button id="print_appeal" class="btn" style="font-size:1.05rem; padding:10px 20px;">🖨️ Print this letter</button>
+  </div>
+
+  <div class="form-nav-centered">
+    <a href="{% url 'escalation_packet' %}?denial_id={{ denial_id }}&email={{ user_email }}&semi_sekret={{ semi_sekret }}" class="btn btn-secondary-custom">
+      ← Back to all regulator letters
+    </a>
+  </div>
+</div>
+
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const printButton = document.getElementById('print_appeal');
+    const textarea = document.getElementById('id_completed_appeal_text');
+    if (printButton && textarea) {
+      printButton.addEventListener('click', () => {
+        const w = window.open('', '_blank');
+        if (!w) return;
+        w.document.write('<html><head><title>Regulator letter</title></head><body><pre style="white-space:pre-wrap; font-family: Georgia, serif;">' +
+          textarea.value.replace(/[<>&]/g, c => ({'<':'&lt;','>':'&gt;','&':'&amp;'}[c])) +
+          '</pre></body></html>');
+        w.document.close();
+        setTimeout(() => w.print(), 500);
+      });
+    }
+  });
+</script>
+{% endblock content %}

--- a/fighthealthinsurance/urls.py
+++ b/fighthealthinsurance/urls.py
@@ -344,12 +344,16 @@ urlpatterns: List[Union[URLPattern, URLResolver]] = [
     ),
     path(
         "escalation_packet",
-        sensitive_post_parameters("email")(views.GenerateEscalationPacket.as_view()),
+        sensitive_post_parameters("email", "semi_sekret")(
+            views.GenerateEscalationPacket.as_view()
+        ),
         name="escalation_packet",
     ),
     path(
         "choose_escalation_letter",
-        sensitive_post_parameters("email")(views.ChooseEscalationLetter.as_view()),
+        sensitive_post_parameters("email", "semi_sekret", "letter_text")(
+            views.ChooseEscalationLetter.as_view()
+        ),
         name="choose_escalation_letter",
     ),
     path(

--- a/fighthealthinsurance/urls.py
+++ b/fighthealthinsurance/urls.py
@@ -343,6 +343,16 @@ urlpatterns: List[Union[URLPattern, URLResolver]] = [
         name="choose_appeal",
     ),
     path(
+        "escalation_packet",
+        sensitive_post_parameters("email")(views.GenerateEscalationPacket.as_view()),
+        name="escalation_packet",
+    ),
+    path(
+        "choose_escalation_letter",
+        sensitive_post_parameters("email")(views.ChooseEscalationLetter.as_view()),
+        name="choose_escalation_letter",
+    ),
+    path(
         "contact",
         cache_control(public=True)(
             cache_page(60 * 60 * 2)(views.ContactView.as_view())

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -1177,7 +1177,9 @@ class GenerateEscalationPacket(View):
                 "semi_sekret": semi_sekret,
                 "recipients": recipients_for_template,
                 "recipients_count": len(recipients_for_template),
-                "back_url": reverse("share_appeal"),
+                "back_url": build_back_url(
+                    "generate_appeal", denial_id, email, semi_sekret
+                ),
                 "back_label": "Back to your appeal",
             },
         )

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -1010,6 +1010,7 @@ class ChooseAppeal(View):
                 "appeal": form.cleaned_data["appeal_text"],
                 "user_email": form.cleaned_data["email"],
                 "denial_id": form.cleaned_data["denial_id"],
+                "semi_sekret": form.cleaned_data["semi_sekret"],
                 "appeal_info_extract": appeal_info_extracted,
                 "fax_form": fax_form,
                 "current_step": 8,
@@ -1127,6 +1128,126 @@ class GenerateAppeal(View):
                     form.cleaned_data["semi_sekret"],
                 ),
                 "back_label": "Back to questions",
+            },
+        )
+
+
+class GenerateEscalationPacket(View):
+    """Render the regulator-letter generation page (a.k.a. escalation packet).
+
+    This is the entry point for the "Want to let the regulator know what's
+    going on?" flow. It validates the denial, computes the recipient list,
+    and hands the page over to a streaming WebSocket-driven UI that fills
+    in one editable letter per recipient.
+    """
+
+    def _build(self, request, denial_id, email, semi_sekret):
+        from fighthealthinsurance.escalation_addresses import (
+            get_recipients_for_denial,
+        )
+
+        if not (denial_id and email and semi_sekret):
+            return redirect("scan")
+        try:
+            denial = models.Denial.objects.filter(
+                denial_id=denial_id,
+                hashed_email=models.Denial.get_hashed_email(email),
+                semi_sekret=semi_sekret,
+            ).get()
+        except models.Denial.DoesNotExist:
+            return redirect("scan")
+
+        recipients = get_recipients_for_denial(denial)
+        recipients_for_template = [
+            {
+                "recipient_type": r.recipient_type,
+                "name": r.name,
+                "address": r.address,
+                "phone": r.phone,
+                "url": r.url,
+                "rationale": r.rationale,
+            }
+            for r in recipients
+        ]
+        elems = {
+            "denial_id": str(denial_id),
+            "email": email,
+            "semi_sekret": semi_sekret,
+        }
+        return render(
+            request,
+            "escalation_packet.html",
+            context={
+                "form_context": json.dumps(elems),
+                "user_email": email,
+                "denial_id": denial_id,
+                "semi_sekret": semi_sekret,
+                "recipients": recipients_for_template,
+                "recipients_count": len(recipients_for_template),
+                "back_url": reverse("share_appeal"),
+                "back_label": "Back to your appeal",
+            },
+        )
+
+    def get(self, request):
+        return self._build(
+            request,
+            request.GET.get("denial_id"),
+            request.GET.get("email"),
+            request.GET.get("semi_sekret"),
+        )
+
+    def post(self, request):
+        return self._build(
+            request,
+            request.POST.get("denial_id"),
+            request.POST.get("email"),
+            request.POST.get("semi_sekret"),
+        )
+
+
+class ChooseEscalationLetter(View):
+    """Persist the user's edited regulator letter and render the review page."""
+
+    def post(self, request):
+        denial_id = request.POST.get("denial_id")
+        email = request.POST.get("email")
+        semi_sekret = request.POST.get("semi_sekret")
+        escalation_uuid = request.POST.get("escalation_uuid")
+        letter_text = request.POST.get("letter_text", "")
+
+        if not (denial_id and email and semi_sekret and escalation_uuid):
+            return HttpResponseRedirect(reverse("scan"))
+
+        try:
+            denial_id_int = int(denial_id)
+        except (TypeError, ValueError):
+            return HttpResponseRedirect(reverse("scan"))
+
+        escalation = common_view_logic.EscalationPacketHelper.save_chosen_letter(
+            escalation_uuid=escalation_uuid,
+            denial_id=denial_id_int,
+            email=email,
+            semi_sekret=semi_sekret,
+            letter_text=letter_text,
+        )
+        if escalation is None:
+            return HttpResponseRedirect(reverse("scan"))
+
+        return render(
+            request,
+            "escalation_packet_review.html",
+            context={
+                "letter_text": escalation.letter_text,
+                "recipient_name": escalation.recipient_name,
+                "recipient_address": escalation.recipient_address,
+                "recipient_phone": escalation.recipient_phone,
+                "recipient_url": escalation.recipient_url,
+                "recipient_type": escalation.recipient_type,
+                "user_email": email,
+                "denial_id": denial_id,
+                "semi_sekret": semi_sekret,
+                "escalation_uuid": escalation_uuid,
             },
         )
 

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -1171,7 +1171,7 @@ class GenerateEscalationPacket(View):
             request,
             "escalation_packet.html",
             context={
-                "form_context": json.dumps(elems),
+                "form_context": elems,
                 "user_email": email,
                 "denial_id": denial_id,
                 "semi_sekret": semi_sekret,

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -1135,10 +1135,10 @@ class GenerateAppeal(View):
 class GenerateEscalationPacket(View):
     """Render the regulator-letter generation page (a.k.a. escalation packet).
 
-    This is the entry point for the "Want to let the regulator know what's
-    going on?" flow. It validates the denial, computes the recipient list,
-    and hands the page over to a streaming WebSocket-driven UI that fills
-    in one editable letter per recipient.
+    Entry point for the "Want to let the regulator know what's going on?"
+    flow. Validates the denial, computes the recipient list, and hands the
+    page over to a streaming WebSocket-driven UI that fills in one
+    editable letter per recipient.
     """
 
     def _build(self, request, denial_id, email, semi_sekret):
@@ -1146,15 +1146,8 @@ class GenerateEscalationPacket(View):
             get_recipients_for_denial,
         )
 
-        if not (denial_id and email and semi_sekret):
-            return redirect("scan")
-        try:
-            denial = models.Denial.objects.filter(
-                denial_id=denial_id,
-                hashed_email=models.Denial.get_hashed_email(email),
-                semi_sekret=semi_sekret,
-            ).get()
-        except models.Denial.DoesNotExist:
+        denial = common_view_logic.get_denial_for_action(denial_id, email, semi_sekret)
+        if denial is None:
             return redirect("scan")
 
         recipients = get_recipients_for_denial(denial)
@@ -1210,26 +1203,17 @@ class ChooseEscalationLetter(View):
     """Persist the user's edited regulator letter and render the review page."""
 
     def post(self, request):
-        denial_id = request.POST.get("denial_id")
-        email = request.POST.get("email")
-        semi_sekret = request.POST.get("semi_sekret")
-        escalation_uuid = request.POST.get("escalation_uuid")
-        letter_text = request.POST.get("letter_text", "")
-
-        if not (denial_id and email and semi_sekret and escalation_uuid):
+        form = core_forms.ChooseEscalationLetterForm(request.POST)
+        if not form.is_valid():
             return HttpResponseRedirect(reverse("scan"))
 
-        try:
-            denial_id_int = int(denial_id)
-        except (TypeError, ValueError):
-            return HttpResponseRedirect(reverse("scan"))
-
+        cleaned = form.cleaned_data
         escalation = common_view_logic.EscalationPacketHelper.save_chosen_letter(
-            escalation_uuid=escalation_uuid,
-            denial_id=denial_id_int,
-            email=email,
-            semi_sekret=semi_sekret,
-            letter_text=letter_text,
+            escalation_uuid=cleaned["escalation_uuid"],
+            denial_id=cleaned["denial_id"],
+            email=cleaned["email"],
+            semi_sekret=cleaned["semi_sekret"],
+            letter_text=cleaned["letter_text"],
         )
         if escalation is None:
             return HttpResponseRedirect(reverse("scan"))
@@ -1244,10 +1228,10 @@ class ChooseEscalationLetter(View):
                 "recipient_phone": escalation.recipient_phone,
                 "recipient_url": escalation.recipient_url,
                 "recipient_type": escalation.recipient_type,
-                "user_email": email,
-                "denial_id": denial_id,
-                "semi_sekret": semi_sekret,
-                "escalation_uuid": escalation_uuid,
+                "user_email": cleaned["email"],
+                "denial_id": cleaned["denial_id"],
+                "semi_sekret": cleaned["semi_sekret"],
+                "escalation_uuid": cleaned["escalation_uuid"],
             },
         )
 

--- a/fighthealthinsurance/websockets.py
+++ b/fighthealthinsurance/websockets.py
@@ -118,7 +118,9 @@ class StreamingEscalationBackend(AsyncWebsocketConsumer):
             data = json.loads(text_data)
         except json.JSONDecodeError as e:
             logger.warning(f"Invalid JSON received in escalation websocket: {e}")
-            await self.send(json.dumps({"error": "Invalid JSON format"}))
+            await self.send(
+                json.dumps({"type": "error", "message": "Invalid JSON format"})
+            )
             await self.close()
             return
         aitr: AsyncIterator[str] = (

--- a/fighthealthinsurance/websockets.py
+++ b/fighthealthinsurance/websockets.py
@@ -137,7 +137,17 @@ class StreamingEscalationBackend(AsyncWebsocketConsumer):
             logger.opt(exception=True).error(
                 f"Error sending back escalation letters: {e}"
             )
-            raise
+            try:
+                await self.send(
+                    json.dumps(
+                        {
+                            "type": "error",
+                            "message": "Server error while drafting letters.",
+                        }
+                    )
+                )
+            except Exception:
+                pass
         finally:
             await asyncio.sleep(0.1)
             try:

--- a/fighthealthinsurance/websockets.py
+++ b/fighthealthinsurance/websockets.py
@@ -97,6 +97,55 @@ class StreamingAppealsBackend(AsyncWebsocketConsumer):
         logger.debug("All sent")
 
 
+class StreamingEscalationBackend(AsyncWebsocketConsumer):
+    """Streaming back regulator/executive escalation letters as JSON.
+
+    Same envelope as StreamingAppealsBackend: client sends a single JSON
+    blob with {denial_id, email, semi_sekret}; server streams status and
+    `letter` payloads, one per recipient.
+    """
+
+    async def connect(self):
+        logger.debug("Accepting connection for escalation packet")
+        await self.accept()
+
+    async def disconnect(self, close_code):
+        logger.debug("Disconnecting escalation packet")
+        pass
+
+    async def receive(self, text_data):
+        try:
+            data = json.loads(text_data)
+        except json.JSONDecodeError as e:
+            logger.warning(f"Invalid JSON received in escalation websocket: {e}")
+            await self.send(json.dumps({"error": "Invalid JSON format"}))
+            await self.close()
+            return
+        aitr: AsyncIterator[str] = (
+            common_view_logic.EscalationPacketHelper.generate_escalation_letters(data)
+        )
+        try:
+            await asyncio.sleep(0)
+            await self.send("\n")
+            async for record in aitr:
+                await asyncio.sleep(0)
+                await self.send("\n")
+                await self.send(record)
+                await asyncio.sleep(0)
+                await self.send("\n")
+        except Exception as e:
+            logger.opt(exception=True).error(
+                f"Error sending back escalation letters: {e}"
+            )
+            raise
+        finally:
+            await asyncio.sleep(0.1)
+            try:
+                await self.close()
+            except Exception:
+                logger.debug("Error closing escalation connection")
+
+
 class StreamingEntityBackend(AsyncWebsocketConsumer):
     """Streaming Entity Extraction"""
 

--- a/tests/sync/test_escalation_packet.py
+++ b/tests/sync/test_escalation_packet.py
@@ -5,8 +5,12 @@ from unittest.mock import patch
 from django.test import TestCase, Client
 from django.urls import reverse
 
+from fighthealthinsurance.common_view_logic import get_denial_for_action
 from fighthealthinsurance.escalation_addresses import (
     DOL_EBSA_NAME,
+    RECIPIENT_DOI,
+    RECIPIENT_DOL_EBSA,
+    RECIPIENT_MEDICAL_DIRECTOR,
     EscalationRecipient,
     get_recipients_for_denial,
 )
@@ -160,6 +164,50 @@ class RegulatorLetterPromptTest(TestCase):
         self.assertIn("peer-to-peer", prompt.lower())
 
 
+class RecipientConstantsTest(TestCase):
+    """The escalation_addresses module re-exports model constants."""
+
+    def test_constants_match_model(self):
+        self.assertEqual(RECIPIENT_DOI, RegulatorEscalation.RECIPIENT_DOI)
+        self.assertEqual(
+            RECIPIENT_MEDICAL_DIRECTOR,
+            RegulatorEscalation.RECIPIENT_MEDICAL_DIRECTOR,
+        )
+        self.assertEqual(RECIPIENT_DOL_EBSA, RegulatorEscalation.RECIPIENT_DOL_EBSA)
+
+
+class GetDenialForActionTest(TestCase):
+    """The shared denial lookup used by views and the escalation helper."""
+
+    def setUp(self):
+        self.email = "lookup@example.com"
+        self.denial = Denial.objects.create(
+            denial_text="x",
+            hashed_email=Denial.get_hashed_email(self.email),
+            insurance_company="Aetna",
+        )
+
+    def test_returns_denial_when_all_match(self):
+        result = get_denial_for_action(
+            self.denial.denial_id, self.email, self.denial.semi_sekret
+        )
+        self.assertEqual(result.pk, self.denial.pk)
+
+    def test_returns_none_for_wrong_sekret(self):
+        result = get_denial_for_action(self.denial.denial_id, self.email, "wrong")
+        self.assertIsNone(result)
+
+    def test_returns_none_for_missing_args(self):
+        self.assertIsNone(get_denial_for_action(None, self.email, "x"))
+        self.assertIsNone(get_denial_for_action(1, "", "x"))
+        self.assertIsNone(get_denial_for_action(1, self.email, ""))
+
+    def test_returns_none_for_non_integer_denial_id(self):
+        self.assertIsNone(
+            get_denial_for_action("not-a-number", self.email, self.denial.semi_sekret)
+        )
+
+
 class RegulatorEscalationModelTest(TestCase):
     """Smoke tests for the new model."""
 
@@ -222,6 +270,11 @@ class EscalationPacketViewTest(TestCase):
         self.assertTemplateUsed(response, "escalation_packet.html")
         # Medical director recipient is always present.
         self.assertContains(response, "Medical Director")
+
+    def test_choose_escalation_letter_rejects_invalid_form(self):
+        url = reverse("choose_escalation_letter")
+        response = self.client.post(url, {"letter_text": "x"})
+        self.assertEqual(response.status_code, 302)
 
     def test_choose_escalation_letter_persists_chosen_text(self):
         escalation = RegulatorEscalation.objects.create(

--- a/tests/sync/test_escalation_packet.py
+++ b/tests/sync/test_escalation_packet.py
@@ -230,7 +230,7 @@ class RegulatorEscalationModelTest(TestCase):
         )
         self.assertEqual(escalation.recipient_type, "doi")
         self.assertFalse(escalation.chosen)
-        self.assertFalse(escalation.editted)
+        self.assertFalse(escalation.edited)
         self.assertEqual(
             list(denial.regulator_escalations.values_list("id", flat=True)),
             [escalation.id],
@@ -299,7 +299,7 @@ class EscalationPacketViewTest(TestCase):
         self.assertTemplateUsed(response, "escalation_packet_review.html")
         escalation.refresh_from_db()
         self.assertTrue(escalation.chosen)
-        self.assertTrue(escalation.editted)
+        self.assertTrue(escalation.edited)
         self.assertEqual(escalation.letter_text, "User-edited text.")
 
     def test_choose_escalation_letter_rejects_malformed_uuid(self):

--- a/tests/sync/test_escalation_packet.py
+++ b/tests/sync/test_escalation_packet.py
@@ -1,0 +1,250 @@
+"""Unit tests for the regulator escalation packet feature."""
+
+from unittest.mock import patch
+
+from django.test import TestCase, Client
+from django.urls import reverse
+
+from fighthealthinsurance.escalation_addresses import (
+    DOL_EBSA_NAME,
+    EscalationRecipient,
+    get_recipients_for_denial,
+)
+from fighthealthinsurance.generate_regulator_letter import (
+    make_regulator_letter_prompt,
+)
+from fighthealthinsurance.models import Denial, RegulatorEscalation
+from fighthealthinsurance.state_help import StateHelp
+
+CALIFORNIA_DATA = {
+    "slug": "california",
+    "name": "California",
+    "abbreviation": "CA",
+    "insurance_department": {
+        "name": "California Department of Insurance",
+        "url": "https://www.insurance.ca.gov/",
+        "phone": "916-492-3500",
+        "consumer_line": "800-927-4357",
+        "complaint_url": "https://cdi.ca.gov/complaint",
+    },
+    "consumer_assistance": {
+        "cap_name": "CHA",
+    },
+    "medicaid": {
+        "agency_name": "DHCS",
+    },
+    "external_review": {"available": True, "info_url": "https://example.com"},
+}
+
+
+class _FakeDenial:
+    """Lightweight stand-in for Denial when tests don't need DB."""
+
+    def __init__(
+        self,
+        state="CA",
+        insurance_company="Aetna",
+        regulator=None,
+        is_tpa=False,
+        denial_text="Service denied because not medically necessary.",
+        procedure="MRI",
+        diagnosis="Lower back pain",
+        claim_id="CLAIM123",
+        plan_id="PLAN9",
+        qa_context="",
+    ):
+        self.your_state = state
+        self.state = state
+        self.insurance_company = insurance_company
+        self.insurance_company_obj = (
+            type("ICO", (), {"is_tpa": is_tpa, "name": insurance_company})()
+            if insurance_company
+            else None
+        )
+        self.regulator = regulator
+        self.denial_text = denial_text
+        self.procedure = procedure
+        self.diagnosis = diagnosis
+        self.claim_id = claim_id
+        self.plan_id = plan_id
+        self.qa_context = qa_context
+        self.use_external = False
+
+        class _PlanSourceManager:
+            def all(self):
+                return []
+
+        self.plan_source = _PlanSourceManager()
+
+
+class EscalationAddressesTest(TestCase):
+    """Recipient assembly logic."""
+
+    @patch("fighthealthinsurance.escalation_addresses.get_state_help_by_abbreviation")
+    def test_recipients_with_state_includes_doi_and_medical_director(self, mock_state):
+        mock_state.return_value = StateHelp(CALIFORNIA_DATA)
+        denial = _FakeDenial(state="CA", insurance_company="Aetna")
+        recipients = get_recipients_for_denial(denial)
+        types = [r.recipient_type for r in recipients]
+        self.assertIn("doi", types)
+        self.assertIn("medical_director", types)
+        self.assertNotIn("dol_ebsa", types)
+
+        doi = next(r for r in recipients if r.recipient_type == "doi")
+        self.assertEqual(doi.name, "California Department of Insurance")
+        self.assertTrue(doi.extra["external_review_available"])
+
+    def test_recipients_without_state_still_includes_medical_director(self):
+        denial = _FakeDenial(state="", insurance_company="Cigna")
+        recipients = get_recipients_for_denial(denial)
+        types = [r.recipient_type for r in recipients]
+        self.assertEqual(types, ["medical_director"])
+        self.assertIn("Cigna", recipients[0].name)
+
+    def test_erisa_branch_via_tpa_flag_adds_dol_ebsa(self):
+        denial = _FakeDenial(
+            state="",
+            insurance_company="UnitedHealthcare",
+            is_tpa=True,
+        )
+        recipients = get_recipients_for_denial(denial)
+        types = [r.recipient_type for r in recipients]
+        self.assertIn("dol_ebsa", types)
+        ebsa = next(r for r in recipients if r.recipient_type == "dol_ebsa")
+        self.assertEqual(ebsa.name, DOL_EBSA_NAME)
+
+    def test_erisa_branch_via_regulator_alt_name_adds_dol_ebsa(self):
+        regulator = type("Reg", (), {"alt_name": "ERISA"})()
+        denial = _FakeDenial(state="", regulator=regulator, insurance_company="X")
+        recipients = get_recipients_for_denial(denial)
+        types = [r.recipient_type for r in recipients]
+        self.assertIn("dol_ebsa", types)
+
+
+class RegulatorLetterPromptTest(TestCase):
+    """Prompt construction for the LLM."""
+
+    def test_doi_prompt_mentions_state_and_insurance_company(self):
+        recipient = EscalationRecipient(
+            recipient_type="doi",
+            name="California Department of Insurance",
+            extra={
+                "state_name": "California",
+                "external_review_available": True,
+            },
+        )
+        denial = _FakeDenial()
+        prompt = make_regulator_letter_prompt(denial, recipient)
+        self.assertIn("California", prompt)
+        self.assertIn("external (independent) medical review", prompt)
+        self.assertIn("Aetna", prompt)
+        self.assertIn("MRI", prompt)
+
+    def test_dol_ebsa_prompt_mentions_erisa(self):
+        recipient = EscalationRecipient(
+            recipient_type="dol_ebsa",
+            name=DOL_EBSA_NAME,
+        )
+        denial = _FakeDenial()
+        prompt = make_regulator_letter_prompt(denial, recipient)
+        self.assertIn("ERISA", prompt)
+        self.assertIn("29 C.F.R. § 2560.503-1", prompt)
+
+    def test_medical_director_prompt_uses_peer_to_peer_framing(self):
+        recipient = EscalationRecipient(
+            recipient_type="medical_director",
+            name="Medical Director, Aetna",
+        )
+        denial = _FakeDenial()
+        prompt = make_regulator_letter_prompt(denial, recipient)
+        self.assertIn("peer-to-peer", prompt.lower())
+
+
+class RegulatorEscalationModelTest(TestCase):
+    """Smoke tests for the new model."""
+
+    def _make_denial(self):
+        return Denial.objects.create(
+            denial_text="some denial",
+            hashed_email="abc123",
+            insurance_company="Aetna",
+            your_state="CA",
+        )
+
+    def test_create_escalation_row(self):
+        denial = self._make_denial()
+        escalation = RegulatorEscalation.objects.create(
+            for_denial=denial,
+            hashed_email="abc123",
+            recipient_type=RegulatorEscalation.RECIPIENT_DOI,
+            recipient_name="California Department of Insurance",
+            letter_text="Dear Commissioner,",
+        )
+        self.assertEqual(escalation.recipient_type, "doi")
+        self.assertFalse(escalation.chosen)
+        self.assertFalse(escalation.editted)
+        self.assertEqual(
+            list(denial.regulator_escalations.values_list("id", flat=True)),
+            [escalation.id],
+        )
+
+
+class EscalationPacketViewTest(TestCase):
+    """Smoke tests for the new views and URL routes."""
+
+    def setUp(self):
+        self.client = Client()
+        # Create a denial that resolves through the GET path.
+        self.email = "tester@example.com"
+        self.denial = Denial.objects.create(
+            denial_text="denial body",
+            hashed_email=Denial.get_hashed_email(self.email),
+            insurance_company="Aetna",
+            your_state="CA",
+        )
+
+    def test_escalation_packet_get_redirects_without_params(self):
+        url = reverse("escalation_packet")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)
+
+    def test_escalation_packet_get_renders_when_valid(self):
+        url = reverse("escalation_packet")
+        response = self.client.get(
+            url,
+            {
+                "denial_id": self.denial.denial_id,
+                "email": self.email,
+                "semi_sekret": self.denial.semi_sekret,
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "escalation_packet.html")
+        # Medical director recipient is always present.
+        self.assertContains(response, "Medical Director")
+
+    def test_choose_escalation_letter_persists_chosen_text(self):
+        escalation = RegulatorEscalation.objects.create(
+            for_denial=self.denial,
+            hashed_email=self.denial.hashed_email,
+            recipient_type=RegulatorEscalation.RECIPIENT_DOI,
+            recipient_name="California Department of Insurance",
+            letter_text="Original draft.",
+        )
+        url = reverse("choose_escalation_letter")
+        response = self.client.post(
+            url,
+            {
+                "denial_id": str(self.denial.denial_id),
+                "email": self.email,
+                "semi_sekret": self.denial.semi_sekret,
+                "escalation_uuid": escalation.uuid,
+                "letter_text": "User-edited text.",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "escalation_packet_review.html")
+        escalation.refresh_from_db()
+        self.assertTrue(escalation.chosen)
+        self.assertTrue(escalation.editted)
+        self.assertEqual(escalation.letter_text, "User-edited text.")

--- a/tests/sync/test_escalation_packet.py
+++ b/tests/sync/test_escalation_packet.py
@@ -301,3 +301,17 @@ class EscalationPacketViewTest(TestCase):
         self.assertTrue(escalation.chosen)
         self.assertTrue(escalation.editted)
         self.assertEqual(escalation.letter_text, "User-edited text.")
+
+    def test_choose_escalation_letter_rejects_malformed_uuid(self):
+        url = reverse("choose_escalation_letter")
+        response = self.client.post(
+            url,
+            {
+                "denial_id": str(self.denial.denial_id),
+                "email": self.email,
+                "semi_sekret": self.denial.semi_sekret,
+                "escalation_uuid": "not-a-uuid",
+                "letter_text": "x",
+            },
+        )
+        self.assertEqual(response.status_code, 302)


### PR DESCRIPTION
## Summary

This PR introduces a new "escalation packet" feature that allows users to generate and send parallel cover letters to regulators and plan executives alongside their internal appeals. The system generates AI-drafted letters tailored to three recipient types: state Departments of Insurance, plan medical directors, and DOL EBSA (for ERISA-covered plans).

## Key Changes

- **New Model (`RegulatorEscalation`)**: Tracks generated escalation letters with recipient metadata, AI-drafted text, and user edits. Stores whether each letter was chosen, edited, and sent.

- **Escalation Address Book (`escalation_addresses.py`)**: 
  - Computes recipient list for a denial based on state, insurance company, and ERISA plan indicators
  - Builds `EscalationRecipient` objects with contact info, rationale, and metadata
  - Includes state DOI data from `state_help.py`, generic medical director placeholder, and DOL EBSA contact info

- **Letter Generation (`generate_regulator_letter.py`)**:
  - Creates recipient-specific prompts for the ML model (DOI, medical director, ERISA/EBSA)
  - Each prompt includes appropriate regulatory framing and citations
  - Generates one-page cover letters ready to print/mail or fax

- **View Layer**:
  - `GenerateEscalationPacket`: Entry point that validates denial and renders escalation packet page
  - `ChooseEscalationLetter`: Persists user-edited letter and renders review page
  - Added `get_denial_for_action()` helper for shared denial lookup across views
  - `EscalationPacketHelper`: Async generator for streaming letter generation via WebSocket

- **WebSocket Consumer (`StreamingEscalationBackend`)**: Streams status updates and generated letters as JSON, mirroring the existing appeals backend pattern

- **UI Templates**:
  - `escalation_packet.html`: Displays recipient list and streams in generated letters with editable textareas
  - `escalation_packet_review.html`: Final review page with recipient details and send instructions
  - Updated `appeal.html` with CTA to escalation packet feature

- **Forms**: Added `ChooseEscalationLetterForm` for letter submission with validation

- **URL Routing**: Added routes for escalation packet generation and letter selection; WebSocket route for streaming backend

## Notable Implementation Details

- Recipient selection uses heuristics to detect ERISA plans: checks regulator alt_name, insurance company TPA flag, and plan source keywords
- Letter generation reuses the existing ML router infrastructure (same as prior auth responses)
- Streaming architecture allows cancellation of in-flight ML calls if client disconnects mid-stream
- All letter text includes placeholder syntax (`{{FIRST_NAME}}`, etc.) for user to fill in personal details
- Denial lookup uses the canonical (denial_id, hashed_email, semi_sekret) triple for security

https://claude.ai/code/session_01MWvEUv4VtcUUyemV82uoCv