### PR TITLE
Add specialized denial-type templates with targeted citations

### DIFF
--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -2382,6 +2382,28 @@ class AppealsBackendHelper:
                 f"{algorithmic_detection.debug_reason}"
             )
 
+        # Specialized denial-type templates (e.g., MentalHealthParityAppeal)
+        # surface a fully-formed letter as a static appeal AND seed a
+        # citation hint for the highest-quality internal model.
+        specialized_templates = detect_specialized_templates(
+            denial.denial_text,
+            denial.procedure,
+            denial.diagnosis,
+        )
+        if specialized_templates:
+            logger.info(
+                "Specialized denial-type templates matched for denial "
+                f"{denial.denial_id}: "
+                f"{[t.name for t in specialized_templates]}"
+            )
+            for t in specialized_templates:
+                try:
+                    non_ai_appeals.append(t.static_appeal())
+                except Exception as e:
+                    logger.opt(exception=True).warning(
+                        f"Failed to render specialized template {t.name}: {e}"
+                    )
+
         insurance_company = denial.insurance_company or "insurance company;"
         claim_id = denial.claim_id or "YOURCLAIMIDGOESHERE"
         prefaces = []
@@ -2746,6 +2768,7 @@ class AppealsBackendHelper:
             plan_context=model_plan_context,
             rag_context=rag_context,
             nice_context=nice_context,
+            specialized_templates=specialized_templates,
         )
         # Only filters out None
         filtered_appeals: Iterator[str] = filter(lambda x: x != None, appeals)

--- a/fighthealthinsurance/generate_appeal.py
+++ b/fighthealthinsurance/generate_appeal.py
@@ -59,6 +59,12 @@ class SpecializedDenialTemplate(object):
     negative_patterns: tuple[str, ...] = ()
     citations: tuple[str, ...] = ()
 
+    # IGNORECASE for forgiving matching across denial-letter prose;
+    # DOTALL so `.*` between key phrases (used in multi-keyword patterns
+    # like "post-surgical … rehab") still matches when the phrases are
+    # split across newlines, which is common in real denial letters.
+    _MATCH_FLAGS = re.IGNORECASE | re.DOTALL
+
     @classmethod
     def matches(
         cls,
@@ -70,25 +76,35 @@ class SpecializedDenialTemplate(object):
         proc = procedure or ""
         diag = diagnosis or ""
 
+        # Negative patterns are checked against every field we match on,
+        # not just denial_text — otherwise an exclusion phrase that lives
+        # in the procedure or diagnosis (e.g., a "physician assistant"
+        # specialty noted in the procedure field) would not block a
+        # spurious match.
         if cls.negative_patterns:
             for p in cls.negative_patterns:
-                if re.search(p, text, re.IGNORECASE):
-                    return False
+                for field in (text, proc, diag):
+                    if field and re.search(p, field, cls._MATCH_FLAGS):
+                        return False
 
         if cls.text_patterns and any(
-            re.search(p, text, re.IGNORECASE) for p in cls.text_patterns
+            re.search(p, text, cls._MATCH_FLAGS) for p in cls.text_patterns
         ):
             return True
         if (
             cls.procedure_patterns
             and proc
-            and any(re.search(p, proc, re.IGNORECASE) for p in cls.procedure_patterns)
+            and any(
+                re.search(p, proc, cls._MATCH_FLAGS) for p in cls.procedure_patterns
+            )
         ):
             return True
         if (
             cls.diagnosis_patterns
             and diag
-            and any(re.search(p, diag, re.IGNORECASE) for p in cls.diagnosis_patterns)
+            and any(
+                re.search(p, diag, cls._MATCH_FLAGS) for p in cls.diagnosis_patterns
+            )
         ):
             return True
         return False
@@ -115,18 +131,18 @@ class MentalHealthParityAppeal(SpecializedDenialTemplate):
     text_patterns = (
         r"\bmental\s+health\b",
         r"\bbehavioral\s+health\b",
-        r"\bsubstance\s+(use|abuse)\b",
+        r"\bsubstance\s+(?:use|abuse)\b",
         r"\bpsychiatric\b",
         r"\bpsychotherap",
-        r"\b(addiction|opioid use disorder|alcohol use disorder)\b",
+        r"\b(?:addiction|opioid\s+use\s+disorder|alcohol\s+use\s+disorder)\b",
         r"\beating\s+disorder\b",
         r"\bresidential\s+treatment\b",
         r"\bpartial\s+hospitalization\b",
         r"\bintensive\s+outpatient\b",
-        r"\bapplied\s+behavior\s+analysis\b|\bABA\s+therapy\b",
+        r"\b(?:applied\s+behavior\s+analysis|ABA\s+therapy)\b",
     )
     diagnosis_patterns = (
-        r"\b(depression|major\s+depressive|anxiety|bipolar|schizophreni|"
+        r"\b(?:depression|major\s+depressive|anxiety|bipolar|schizophreni|"
         r"ptsd|adhd|autism|substance\s+use\s+disorder|alcohol\s+use\s+disorder|"
         r"eating\s+disorder|anorexia|bulimia)\b",
     )
@@ -246,16 +262,16 @@ class AdvancedImagingAppeal(SpecializedDenialTemplate):
 class SpecialtyMedicationAppeal(SpecializedDenialTemplate):
     name = "Specialty medication denial"
     text_patterns = (
-        r"\bspecialty\s+(drug|medication|pharmac)",
+        r"\bspecialty\s+(?:drug|medication|pharmac)",
         r"\bbiologic\b",
-        r"\binfliximab|adalimumab|etanercept|ustekinumab|secukinumab|"
-        r"vedolizumab|rituximab|tocilizumab|dupilumab|omalizumab\b",
-        r"\bhumira|enbrel|stelara|remicade|cosentyx|entyvio|dupixent\b",
-        r"\bGLP-?1\b|\bsemaglutide|tirzepatide|liraglutide\b",
-        r"\bozempic|wegovy|mounjaro|zepbound\b",
+        r"\b(?:infliximab|adalimumab|etanercept|ustekinumab|secukinumab|"
+        r"vedolizumab|rituximab|tocilizumab|dupilumab|omalizumab)\b",
+        r"\b(?:humira|enbrel|stelara|remicade|cosentyx|entyvio|dupixent)\b",
+        r"\b(?:GLP-?1|semaglutide|tirzepatide|liraglutide)\b",
+        r"\b(?:ozempic|wegovy|mounjaro|zepbound)\b",
         r"\bgene\s+therapy\b",
         r"\bcar[\s\-]t\b",
-        r"\boncology\s+(infusion|drug|therapy)\b",
+        r"\boncology\s+(?:infusion|drug|therapy)\b",
         r"\bstep\s+therapy\b",
         r"\bfail[\s\-]first\b",
         r"\bnon[\s\-]formulary\b",
@@ -315,9 +331,9 @@ class PhysicalTherapyContinuationAppeal(SpecializedDenialTemplate):
     name = "Physical therapy continuation (visits beyond initial sessions)"
     text_patterns = (
         r"\bphysical\s+therapy\b",
-        r"\b\bPT\s+(visits|sessions|services)\b",
+        r"\bPT\s+(?:visits|sessions|services)\b",
         r"\boccupational\s+therapy\b",
-        r"\b\bOT\s+(visits|sessions|services)\b",
+        r"\bOT\s+(?:visits|sessions|services)\b",
         r"\bspeech\s+therapy\b",
         r"\bvisit\s+limit\b",
         r"\bmaximum\s+(number\s+of\s+)?visits\b",
@@ -327,8 +343,8 @@ class PhysicalTherapyContinuationAppeal(SpecializedDenialTemplate):
         r"\bmaintenance\s+(therapy|care)\b",
     )
     procedure_patterns = (
-        r"\bphysical\s+therapy\b|\bPT\b",
-        r"\boccupational\s+therapy\b|\bOT\b",
+        r"\b(?:physical\s+therapy|PT)\b",
+        r"\b(?:occupational\s+therapy|OT)\b",
     )
     negative_patterns = (r"\bphysician\s+assistant\b",)
     citations = (
@@ -473,10 +489,12 @@ def detect_specialized_templates(
 ) -> list[type[SpecializedDenialTemplate]]:
     """Return the specialized templates that match a denial.
 
-    A denial can match more than one template (e.g., a mental-health
-    residential admission could trigger both MentalHealthParityAppeal
-    and PostSurgicalRehabAppeal-adjacent rules); we return all matches
-    and let the caller decide what to surface.
+    A denial can match more than one template — for example, a denial
+    that says "outpatient substance use disorder therapy has reached the
+    maximum number of visits" matches both MentalHealthParityAppeal (via
+    the substance-use-disorder cue) and PhysicalTherapyContinuationAppeal
+    (via the visit-cap cue). We return every match and let the caller
+    decide what to surface.
     """
     if not denial_text and not procedure and not diagnosis:
         return []

--- a/fighthealthinsurance/generate_appeal.py
+++ b/fighthealthinsurance/generate_appeal.py
@@ -175,7 +175,6 @@ class MentalHealthParityAppeal(SpecializedDenialTemplate):
             "designated essential health benefits and may not be effectively "
             "excluded by NQTLs that are more restrictive than those used on "
             "the medical/surgical side.\n\n"
-            "{medical_reason}\n\n"
             "I respectfully request that you (a) overturn this denial, "
             "(b) provide the MHPAEA NQTL comparative analysis for the "
             "criterion applied, and (c) confirm in writing what role, if any, "
@@ -237,7 +236,6 @@ class AdvancedImagingAppeal(SpecializedDenialTemplate):
             "the sole basis for the adverse decision. Please disclose "
             "whether such a tool was used and provide the reviewer's "
             "clinical rationale.\n\n"
-            "{medical_reason}\n\n"
             "Delaying or denying this imaging risks missed diagnoses and "
             "downstream cost from lower-yield workups. I respectfully "
             "request that the denial be overturned.\n\n"
@@ -307,7 +305,6 @@ class SpecialtyMedicationAppeal(SpecializedDenialTemplate):
             "denial must still rest on an individualized clinical review by "
             "a qualified human reviewer applying this patient's full "
             "clinical picture, not solely on an algorithmic output.\n\n"
-            "{medical_reason}\n\n"
             "I respectfully request that the denial be overturned and the "
             "medication authorized without further delay.\n\n"
             "Sincerely,\n[Name]\n"
@@ -376,7 +373,6 @@ class PhysicalTherapyContinuationAppeal(SpecializedDenialTemplate):
             "rest on an individualized clinical review by a qualified human "
             "reviewer; the algorithm may not be the sole basis for the "
             "adverse decision.\n\n"
-            "{medical_reason}\n\n"
             "I respectfully request the denial be overturned and the "
             "additional sessions authorized.\n\n"
             "Sincerely,\n[Name]\n"
@@ -385,6 +381,11 @@ class PhysicalTherapyContinuationAppeal(SpecializedDenialTemplate):
 
 class PostSurgicalRehabAppeal(SpecializedDenialTemplate):
     name = "Post-surgical rehabilitation denial"
+    # Every pattern requires explicit rehab/therapy/SNF/IRF context so we
+    # don't mistake denials of the surgery itself (e.g., a bare "ACL
+    # repair" denial) for denials of the post-surgical rehabilitation.
+    # Specific surgery names without rehab context are intentionally not
+    # listed here.
     text_patterns = (
         r"\bpost[\s\-]?(surgical|operative|op)\b.*\b(rehab|therapy|care)\b",
         r"\b(rehab|therapy|care)\b.*\bpost[\s\-]?(surgical|operative|op)\b",
@@ -394,12 +395,12 @@ class PostSurgicalRehabAppeal(SpecializedDenialTemplate):
         r"\bSNF\b",
         r"\bacute\s+rehab\b",
         r"\bjoint\s+replacement\b.*\b(rehab|therapy)\b",
-        r"\bACL\s+(repair|reconstruction)\b",
-        r"\brotator\s+cuff\b",
         r"\bspinal\s+(fusion|surgery)\b.*\b(rehab|therapy)\b",
     )
     procedure_patterns = (
-        r"\b(post[\s\-]?op|post[\s\-]?surgical)\b",
+        # Procedure-only matches must be unambiguous rehab/post-acute
+        # contexts; "post-op" alone can describe the surgical episode and
+        # is intentionally excluded here.
         r"\binpatient\s+rehab",
         r"\bskilled\s+nursing\b|\bSNF\b",
     )
@@ -450,7 +451,6 @@ class PostSurgicalRehabAppeal(SpecializedDenialTemplate):
             "denial, the carrier must produce an individualized human "
             "clinical review; the algorithm cannot be the sole basis for "
             "the adverse decision.\n\n"
-            "{medical_reason}\n\n"
             "I respectfully request that the denial be overturned and the "
             "post-surgical rehabilitation authorized.\n\n"
             "Sincerely,\n[Name]\n"
@@ -686,7 +686,7 @@ class AppealGenerator(object):
             return None
         for name, instances in ml_router.models_by_name.items():
             if best in instances:
-                return name
+                return str(name)
         return None
 
     @staticmethod

--- a/fighthealthinsurance/generate_appeal.py
+++ b/fighthealthinsurance/generate_appeal.py
@@ -41,6 +41,452 @@ class AppealTemplateGenerator(object):
             return None
 
 
+class SpecializedDenialTemplate(object):
+    """Base class for specialized denial-type appeal templates.
+
+    Subclasses encode the specific laws/regulations to cite, a detection
+    rule, a fully-formed static letter (suitable for ``non_ai_appeals``),
+    and a prompt hint to nudge the largest model toward the right citations.
+
+    Placeholders ``{insurance_company}``, ``{claim_id}``, ``{procedure}``,
+    and ``{diagnosis}`` are filled in downstream by ``sub_in_appeals``.
+    """
+
+    name: str = ""
+    text_patterns: tuple[str, ...] = ()
+    procedure_patterns: tuple[str, ...] = ()
+    diagnosis_patterns: tuple[str, ...] = ()
+    negative_patterns: tuple[str, ...] = ()
+    citations: tuple[str, ...] = ()
+
+    @classmethod
+    def matches(
+        cls,
+        denial_text: Optional[str],
+        procedure: Optional[str] = None,
+        diagnosis: Optional[str] = None,
+    ) -> bool:
+        text = denial_text or ""
+        proc = procedure or ""
+        diag = diagnosis or ""
+
+        if cls.negative_patterns:
+            for p in cls.negative_patterns:
+                if re.search(p, text, re.IGNORECASE):
+                    return False
+
+        if cls.text_patterns and any(
+            re.search(p, text, re.IGNORECASE) for p in cls.text_patterns
+        ):
+            return True
+        if (
+            cls.procedure_patterns
+            and proc
+            and any(re.search(p, proc, re.IGNORECASE) for p in cls.procedure_patterns)
+        ):
+            return True
+        if (
+            cls.diagnosis_patterns
+            and diag
+            and any(re.search(p, diag, re.IGNORECASE) for p in cls.diagnosis_patterns)
+        ):
+            return True
+        return False
+
+    @classmethod
+    def static_appeal(cls) -> str:
+        raise NotImplementedError
+
+    @classmethod
+    def model_prompt_hint(cls) -> str:
+        bullets = "\n".join(f"- {c}" for c in cls.citations)
+        return (
+            f"This denial appears to involve {cls.name}. "
+            "When writing the appeal, ground the argument in the following "
+            "authorities and cite them by name where they support the patient's "
+            f"position:\n{bullets}\n"
+            "Do not fabricate case numbers, regulatory paragraphs, or quote text "
+            "you cannot verify; cite the laws/rules by name and section only."
+        )
+
+
+class MentalHealthParityAppeal(SpecializedDenialTemplate):
+    name = "Mental Health Parity / behavioral-health denial"
+    text_patterns = (
+        r"\bmental\s+health\b",
+        r"\bbehavioral\s+health\b",
+        r"\bsubstance\s+(use|abuse)\b",
+        r"\bpsychiatric\b",
+        r"\bpsychotherap",
+        r"\b(addiction|opioid use disorder|alcohol use disorder)\b",
+        r"\beating\s+disorder\b",
+        r"\bresidential\s+treatment\b",
+        r"\bpartial\s+hospitalization\b",
+        r"\bintensive\s+outpatient\b",
+        r"\bapplied\s+behavior\s+analysis\b|\bABA\s+therapy\b",
+    )
+    diagnosis_patterns = (
+        r"\b(depression|major\s+depressive|anxiety|bipolar|schizophreni|"
+        r"ptsd|adhd|autism|substance\s+use\s+disorder|alcohol\s+use\s+disorder|"
+        r"eating\s+disorder|anorexia|bulimia)\b",
+    )
+    citations = (
+        "Mental Health Parity and Addiction Equity Act of 2008 (MHPAEA), "
+        "29 U.S.C. § 1185a",
+        "CMS 2024 Final Rule on the use of algorithms and artificial intelligence "
+        "in coverage determinations",
+        "Affordable Care Act Essential Health Benefits, "
+        "42 U.S.C. § 18022(b)(1)(E) (mental health and substance use disorder services)",
+        "Department of Labor 2024 MHPAEA Final Rules on Nonquantitative Treatment "
+        "Limitations (NQTLs)",
+    )
+
+    @classmethod
+    def static_appeal(cls) -> str:
+        return (
+            "Re: Appeal of denied behavioral-health claim {claim_id}\n\n"
+            "Dear {insurance_company},\n\n"
+            "I am formally appealing the denial of coverage for {procedure} "
+            "(diagnosis: {diagnosis}). Because this denial concerns mental "
+            "health or substance use disorder services, it is governed by "
+            "behavioral-health parity protections that the carrier must satisfy "
+            "before any adverse determination can stand.\n\n"
+            "1. Mental Health Parity and Addiction Equity Act (MHPAEA, "
+            "29 U.S.C. § 1185a). Any nonquantitative treatment limitation "
+            "(NQTL) applied here — including medical-necessity criteria, "
+            "prior-authorization rules, fail-first/step-therapy protocols, "
+            "concurrent review, network composition, or reimbursement "
+            "methodology — must be no more restrictive in writing or in "
+            "operation than the comparable NQTLs applied to medical/surgical "
+            "benefits in the same classification. Please produce the "
+            "comparative analysis required by ERISA § 712(a)(8) and the "
+            "2024 DOL Final Rules for the NQTL relied upon in this denial.\n\n"
+            "2. CMS 2024 Final Rule on algorithmic coverage determinations. "
+            "If an algorithm, predictive model, or AI tool contributed to "
+            "this denial, the determination must still rest on an "
+            "individualized clinical assessment by a qualified human reviewer "
+            "applying the patient's full clinical picture; the algorithm may "
+            "not be the sole basis for the adverse decision. Please disclose "
+            "whether such a tool was used, identify it, and provide the "
+            "human reviewer's clinical reasoning.\n\n"
+            "3. Affordable Care Act Essential Health Benefits "
+            "(42 U.S.C. § 18022(b)(1)(E)). Mental health and substance use "
+            "disorder services, including behavioral-health treatment, are "
+            "designated essential health benefits and may not be effectively "
+            "excluded by NQTLs that are more restrictive than those used on "
+            "the medical/surgical side.\n\n"
+            "{medical_reason}\n\n"
+            "I respectfully request that you (a) overturn this denial, "
+            "(b) provide the MHPAEA NQTL comparative analysis for the "
+            "criterion applied, and (c) confirm in writing what role, if any, "
+            "an algorithm or AI tool played in the determination.\n\n"
+            "Sincerely,\n[Name]\n"
+        )
+
+
+class AdvancedImagingAppeal(SpecializedDenialTemplate):
+    name = "Advanced imaging denial (MRI/CT/PET)"
+    text_patterns = (
+        r"\bMRI\b",
+        r"\bmagnetic\s+resonance\b",
+        r"\bMRA\b",
+        r"\bMRCP\b",
+        r"\bCT\s+scan\b",
+        r"\bcomputed\s+tomograph",
+        r"\bPET\s+(scan|/CT)\b",
+        r"\bpositron\s+emission\b",
+        r"\bnuclear\s+medicine\b",
+        r"\badvanced\s+imaging\b",
+    )
+    procedure_patterns = (
+        r"\b(MRI|MRA|MRCP|CT|CTA|PET|SPECT)\b",
+        r"\bimaging\b",
+    )
+    citations = (
+        "American College of Radiology (ACR) Appropriateness Criteria",
+        "CMS National Coverage Determinations for diagnostic imaging "
+        "(NCD Manual chapter 220)",
+        "CMS 2024 Final Rule on the use of algorithms and artificial intelligence "
+        "in coverage determinations",
+    )
+
+    @classmethod
+    def static_appeal(cls) -> str:
+        return (
+            "Re: Appeal of denied advanced imaging claim {claim_id}\n\n"
+            "Dear {insurance_company},\n\n"
+            "I am appealing the denial of {procedure} ordered for {diagnosis}. "
+            "Advanced imaging decisions should be made under nationally "
+            "recognized appropriateness criteria, not blanket utilization-"
+            "management rules.\n\n"
+            "1. ACR Appropriateness Criteria. The American College of "
+            "Radiology publishes evidence-based criteria identifying the "
+            "appropriate imaging modality for specific clinical scenarios. "
+            "The presentation in this case meets ACR-published indications "
+            "for the requested study; lower-cost alternatives such as plain "
+            "radiographs or ultrasound are inadequate to answer the clinical "
+            "question and would predictably lead to repeat imaging.\n\n"
+            "2. CMS National Coverage Determinations (NCD chapter 220). "
+            "CMS NCDs set the community standard for advanced imaging "
+            "coverage and the requested study satisfies the relevant NCD's "
+            "indications.\n\n"
+            "3. CMS 2024 Final Rule on algorithmic coverage determinations. "
+            "If an automated utilization-management tool drove this denial, "
+            "the carrier must still produce an individualized clinical "
+            "review by a qualified human reviewer; the algorithm cannot be "
+            "the sole basis for the adverse decision. Please disclose "
+            "whether such a tool was used and provide the reviewer's "
+            "clinical rationale.\n\n"
+            "{medical_reason}\n\n"
+            "Delaying or denying this imaging risks missed diagnoses and "
+            "downstream cost from lower-yield workups. I respectfully "
+            "request that the denial be overturned.\n\n"
+            "Sincerely,\n[Name]\n"
+        )
+
+
+class SpecialtyMedicationAppeal(SpecializedDenialTemplate):
+    name = "Specialty medication denial"
+    text_patterns = (
+        r"\bspecialty\s+(drug|medication|pharmac)",
+        r"\bbiologic\b",
+        r"\binfliximab|adalimumab|etanercept|ustekinumab|secukinumab|"
+        r"vedolizumab|rituximab|tocilizumab|dupilumab|omalizumab\b",
+        r"\bhumira|enbrel|stelara|remicade|cosentyx|entyvio|dupixent\b",
+        r"\bGLP-?1\b|\bsemaglutide|tirzepatide|liraglutide\b",
+        r"\bozempic|wegovy|mounjaro|zepbound\b",
+        r"\bgene\s+therapy\b",
+        r"\bcar[\s\-]t\b",
+        r"\boncology\s+(infusion|drug|therapy)\b",
+        r"\bstep\s+therapy\b",
+        r"\bfail[\s\-]first\b",
+        r"\bnon[\s\-]formulary\b",
+    )
+    procedure_patterns = (
+        r"\bspecialty\b",
+        r"\binfusion\b",
+        r"\bbiologic\b",
+    )
+    citations = (
+        "Affordable Care Act non-discrimination provisions, "
+        "42 U.S.C. § 18116 (Section 1557)",
+        "ERISA § 503 / 29 C.F.R. § 2560.503-1 (full and fair review, "
+        "including the carrier's clinical criteria and reviewer credentials)",
+        "State step-therapy override statutes (where applicable; the "
+        "exception is required when stepping has been tried, is "
+        "contraindicated, or is expected to be ineffective)",
+        "CMS 2024 Final Rule on the use of algorithms and artificial intelligence "
+        "in coverage determinations",
+    )
+
+    @classmethod
+    def static_appeal(cls) -> str:
+        return (
+            "Re: Appeal of denied specialty-medication claim {claim_id}\n\n"
+            "Dear {insurance_company},\n\n"
+            "I am appealing the denial of {procedure} for {diagnosis}. "
+            "Specialty medications are typically prescribed because lower-"
+            "tier alternatives are unsuitable for the patient's clinical "
+            "circumstances; the denial as issued does not engage with that "
+            "individualized analysis.\n\n"
+            "1. Step-therapy / fail-first override. Where the carrier's "
+            "denial relies on step therapy, the patient qualifies for an "
+            "override under applicable state law and plan terms because "
+            "preferred agents are contraindicated, have been tried and "
+            "failed, or are expected to be ineffective for this indication. "
+            "Please apply the override and process the claim.\n\n"
+            "2. ERISA full-and-fair-review obligations "
+            "(29 C.F.R. § 2560.503-1). Please produce, with the appeal "
+            "decision, (a) the specific clinical criteria relied on, "
+            "(b) the credentials of the reviewing clinician, and (c) any "
+            "internal rule, guideline, protocol, or similar criterion that "
+            "was used. Generic 'not medically necessary' language without "
+            "this disclosure does not satisfy the regulation.\n\n"
+            "3. CMS 2024 Final Rule on algorithmic coverage determinations. "
+            "If an automated tool flagged this prescription, the final "
+            "denial must still rest on an individualized clinical review by "
+            "a qualified human reviewer applying this patient's full "
+            "clinical picture, not solely on an algorithmic output.\n\n"
+            "{medical_reason}\n\n"
+            "I respectfully request that the denial be overturned and the "
+            "medication authorized without further delay.\n\n"
+            "Sincerely,\n[Name]\n"
+        )
+
+
+class PhysicalTherapyContinuationAppeal(SpecializedDenialTemplate):
+    name = "Physical therapy continuation (visits beyond initial sessions)"
+    text_patterns = (
+        r"\bphysical\s+therapy\b",
+        r"\b\bPT\s+(visits|sessions|services)\b",
+        r"\boccupational\s+therapy\b",
+        r"\b\bOT\s+(visits|sessions|services)\b",
+        r"\bspeech\s+therapy\b",
+        r"\bvisit\s+limit\b",
+        r"\bmaximum\s+(number\s+of\s+)?visits\b",
+        r"\badditional\s+(visits|sessions)\b",
+        r"\bcontinued\s+(therapy|treatment)\b",
+        r"\bplateau\b",
+        r"\bmaintenance\s+(therapy|care)\b",
+    )
+    procedure_patterns = (
+        r"\bphysical\s+therapy\b|\bPT\b",
+        r"\boccupational\s+therapy\b|\bOT\b",
+    )
+    negative_patterns = (r"\bphysician\s+assistant\b",)
+    citations = (
+        "Jimmo v. Sebelius (1:11-cv-00017, D. Vt. 2013) — coverage may not "
+        "be denied solely because a patient has reached a 'plateau' or is "
+        "not improving; skilled therapy to maintain function or slow "
+        "decline is covered when otherwise medically necessary",
+        "CMS Medicare Benefit Policy Manual, chapter 15 (skilled therapy "
+        "and the maintenance-coverage standard)",
+        "Affordable Care Act Essential Health Benefits, "
+        "42 U.S.C. § 18022(b)(1)(G) (rehabilitative and habilitative "
+        "services and devices)",
+        "CMS 2024 Final Rule on the use of algorithms and artificial intelligence "
+        "in coverage determinations",
+    )
+
+    @classmethod
+    def static_appeal(cls) -> str:
+        return (
+            "Re: Appeal of denied therapy continuation, claim {claim_id}\n\n"
+            "Dear {insurance_company},\n\n"
+            "I am appealing the denial of additional {procedure} sessions "
+            "for {diagnosis}. The denial appears to rest on a visit cap or "
+            "a finding that the patient has stopped improving; both grounds "
+            "are inconsistent with controlling authority.\n\n"
+            "1. Jimmo v. Sebelius — improvement is NOT the standard. "
+            "Skilled therapy is covered when it is reasonable and necessary "
+            "to maintain the patient's current condition or to slow further "
+            "decline, even if the patient is not actively improving. "
+            "Plateau- or maintenance-based denials cannot stand under "
+            "Jimmo and the resulting CMS clarifications in chapter 15 of "
+            "the Medicare Benefit Policy Manual.\n\n"
+            "2. ACA Essential Health Benefits "
+            "(42 U.S.C. § 18022(b)(1)(G)). Rehabilitative and habilitative "
+            "services and devices are designated essential health benefits. "
+            "A blanket session cap that prevents continued medically "
+            "necessary therapy effectively excludes a covered EHB and is "
+            "not enforceable as written.\n\n"
+            "3. CMS 2024 Final Rule on algorithmic coverage determinations. "
+            "If a utilization-management algorithm flagged this case as "
+            "having reached its visit limit, the final denial must still "
+            "rest on an individualized clinical review by a qualified human "
+            "reviewer; the algorithm may not be the sole basis for the "
+            "adverse decision.\n\n"
+            "{medical_reason}\n\n"
+            "I respectfully request the denial be overturned and the "
+            "additional sessions authorized.\n\n"
+            "Sincerely,\n[Name]\n"
+        )
+
+
+class PostSurgicalRehabAppeal(SpecializedDenialTemplate):
+    name = "Post-surgical rehabilitation denial"
+    text_patterns = (
+        r"\bpost[\s\-]?(surgical|operative|op)\b.*\b(rehab|therapy|care)\b",
+        r"\b(rehab|therapy|care)\b.*\bpost[\s\-]?(surgical|operative|op)\b",
+        r"\bafter\s+surgery\b.*\b(rehab|therapy)\b",
+        r"\binpatient\s+rehab(ilitation)?\b",
+        r"\bskilled\s+nursing\b",
+        r"\bSNF\b",
+        r"\bacute\s+rehab\b",
+        r"\bjoint\s+replacement\b.*\b(rehab|therapy)\b",
+        r"\bACL\s+(repair|reconstruction)\b",
+        r"\brotator\s+cuff\b",
+        r"\bspinal\s+(fusion|surgery)\b.*\b(rehab|therapy)\b",
+    )
+    procedure_patterns = (
+        r"\b(post[\s\-]?op|post[\s\-]?surgical)\b",
+        r"\binpatient\s+rehab",
+        r"\bskilled\s+nursing\b|\bSNF\b",
+    )
+    citations = (
+        "Jimmo v. Sebelius (1:11-cv-00017, D. Vt. 2013) — maintenance and "
+        "slow-decline therapy is covered; improvement is not the standard",
+        "CMS Medicare Benefit Policy Manual, chapter 1 (inpatient "
+        "rehabilitation facility coverage) and chapter 8 (skilled nursing "
+        "facility coverage)",
+        "Affordable Care Act Essential Health Benefits, "
+        "42 U.S.C. § 18022(b)(1)(G) (rehabilitative and habilitative "
+        "services and devices)",
+        "CMS 2024 Final Rule on the use of algorithms and artificial intelligence "
+        "in coverage determinations",
+    )
+
+    @classmethod
+    def static_appeal(cls) -> str:
+        return (
+            "Re: Appeal of denied post-surgical rehabilitation, "
+            "claim {claim_id}\n\n"
+            "Dear {insurance_company},\n\n"
+            "I am appealing the denial of post-surgical rehabilitation "
+            "({procedure}) following surgery for {diagnosis}. Recovery from "
+            "surgery is precisely the scenario in which skilled "
+            "rehabilitation is most clearly medically necessary, and the "
+            "denial as issued is inconsistent with controlling authority.\n\n"
+            "1. CMS coverage standards for inpatient rehabilitation and "
+            "skilled nursing care (Medicare Benefit Policy Manual, "
+            "chapters 1 and 8). Coverage turns on whether the patient "
+            "requires skilled, multidisciplinary rehabilitation services on "
+            "an intensive basis (IRF) or daily skilled care (SNF). The "
+            "denial does not engage with the chapter 1/8 criteria as "
+            "applied to this patient's actual post-operative status.\n\n"
+            "2. Jimmo v. Sebelius. To the extent the denial relies on a "
+            "lack of measurable improvement or a 'plateau,' the "
+            "improvement standard was rejected in Jimmo and clarified in "
+            "subsequent CMS guidance. Skilled rehabilitation that maintains "
+            "function or prevents deterioration during post-surgical "
+            "recovery is covered.\n\n"
+            "3. ACA Essential Health Benefits "
+            "(42 U.S.C. § 18022(b)(1)(G)). Rehabilitative and habilitative "
+            "services and devices are essential health benefits and cannot "
+            "be effectively excluded through restrictive utilization "
+            "management.\n\n"
+            "4. CMS 2024 Final Rule on algorithmic coverage determinations. "
+            "If a length-of-stay algorithm or similar tool drove the "
+            "denial, the carrier must produce an individualized human "
+            "clinical review; the algorithm cannot be the sole basis for "
+            "the adverse decision.\n\n"
+            "{medical_reason}\n\n"
+            "I respectfully request that the denial be overturned and the "
+            "post-surgical rehabilitation authorized.\n\n"
+            "Sincerely,\n[Name]\n"
+        )
+
+
+SPECIALIZED_DENIAL_TEMPLATES: tuple[type[SpecializedDenialTemplate], ...] = (
+    MentalHealthParityAppeal,
+    AdvancedImagingAppeal,
+    SpecialtyMedicationAppeal,
+    PhysicalTherapyContinuationAppeal,
+    PostSurgicalRehabAppeal,
+)
+
+
+def detect_specialized_templates(
+    denial_text: Optional[str],
+    procedure: Optional[str] = None,
+    diagnosis: Optional[str] = None,
+) -> list[type[SpecializedDenialTemplate]]:
+    """Return the specialized templates that match a denial.
+
+    A denial can match more than one template (e.g., a mental-health
+    residential admission could trigger both MentalHealthParityAppeal
+    and PostSurgicalRehabAppeal-adjacent rules); we return all matches
+    and let the caller decide what to surface.
+    """
+    if not denial_text and not procedure and not diagnosis:
+        return []
+    return [
+        t
+        for t in SPECIALIZED_DENIAL_TEMPLATES
+        if t.matches(denial_text, procedure, diagnosis)
+    ]
+
+
 try:
     from english_words import get_english_words_set
 
@@ -223,6 +669,41 @@ class AppealGenerator(object):
 
     def __init__(self):
         self.regex_denial_processor = ProcessDenialRegex()
+
+    @staticmethod
+    def _best_internal_model_name() -> Optional[str]:
+        """Return the friendly name (used by ml_router.models_by_name) of the
+        highest-quality internal model, or None if none are available.
+
+        We deliberately route specialized-template hints through this single
+        model rather than every backend: the hints add prompt length and
+        instructions that benefit most from the strongest available model,
+        and broadcasting them across every backend would multiply cost
+        without proportional quality gain.
+        """
+        best = ml_router.best_internal_model()
+        if best is None:
+            return None
+        for name, instances in ml_router.models_by_name.items():
+            if best in instances:
+                return name
+        return None
+
+    @staticmethod
+    def _build_specialized_hint_block(
+        templates: List[type[SpecializedDenialTemplate]],
+    ) -> str:
+        """Combine the prompt hints from one or more specialized templates."""
+        seen: set[str] = set()
+        ordered: list[type[SpecializedDenialTemplate]] = []
+        for t in templates:
+            if t.name in seen:
+                continue
+            seen.add(t.name)
+            ordered.append(t)
+        if not ordered:
+            return ""
+        return "\n\n".join(t.model_prompt_hint() for t in ordered)
 
     async def _extract_entity_with_regexes_and_model(
         self,
@@ -904,6 +1385,7 @@ class AppealGenerator(object):
         plan_context=None,
         rag_context=None,
         nice_context=None,
+        specialized_templates: Optional[List[type[SpecializedDenialTemplate]]] = None,
     ) -> Iterator[str]:
         """
         Generates an iterator of appeal texts for a given insurance denial using templates, non-AI sources, and AI models.
@@ -918,6 +1400,9 @@ class AppealGenerator(object):
             pubmed_context: Optional PubMed context to provide to AI models.
             ml_citations_context: Optional list of citation contexts for AI models.
             plan_context: Optional plan context to provide to AI models
+            specialized_templates: Optional list of specialized denial-type
+                templates whose citation hints should be passed to the
+                highest-quality internal model only (one extra call).
 
         Returns:
             An iterator yielding generated appeal texts as strings.
@@ -1119,6 +1604,34 @@ class AppealGenerator(object):
             }
             for model_name in backup_model_names
         ]
+
+        # Specialized: when one or more specialized denial-type templates
+        # match, append a single extra call to the highest-quality internal
+        # model with the specialized citation hints embedded in the prompt.
+        # Hints are NOT broadcast to every model — only the best internal
+        # one — to keep cost down and let the strongest model use the
+        # additional structure.
+        if specialized_templates and open_prompt is not None:
+            best_model_name = self._best_internal_model_name()
+            if best_model_name is not None:
+                hint_block = self._build_specialized_hint_block(specialized_templates)
+                if hint_block:
+                    specialized_prompt = (
+                        f"{open_prompt}\n\n"
+                        f"--- Denial-type guidance ---\n{hint_block}"
+                    )
+                    calls.append(
+                        {
+                            "model_name": best_model_name,
+                            "prompt": specialized_prompt,
+                            "patient_context": medical_context,
+                            "plan_context": plan_context,
+                            "infer_type": "full",
+                            "pubmed_context": pubmed_context,
+                            "ml_citations_context": ml_citations_context,
+                            "prof_pov": prof_pov,
+                        }
+                    )
 
         # If we need to know the medical reason ask our friendly LLMs
         static_appeal = template_generator.generate_static()

--- a/tests/async-unit/test_specialized_denial_templates.py
+++ b/tests/async-unit/test_specialized_denial_templates.py
@@ -221,6 +221,38 @@ class TestPostSurgicalRehabAppealMatches(unittest.TestCase):
         self.assertIn("CMS 2024 Final Rule", text)
 
 
+class TestMatchingFlags(unittest.TestCase):
+    """`matches()` uses IGNORECASE and DOTALL so that real-world denial
+    letters (which routinely break key phrases across newlines) still
+    fire the appropriate template, and so that exclusion patterns can
+    block matches that would otherwise be triggered by procedure or
+    diagnosis fields.
+    """
+
+    def test_dotall_lets_post_surgical_rehab_span_newlines(self):
+        # Without DOTALL, `\bpost[\s\-]?(surgical|operative|op)\b.*\b(rehab|...)`
+        # would not match this letter because the keywords are on
+        # separate lines.
+        self.assertTrue(
+            PostSurgicalRehabAppeal.matches(
+                "We have reviewed your request for post-surgical care.\n"
+                "After review, the requested rehab is not approved.",
+            )
+        )
+
+    def test_negative_pattern_blocks_match_via_procedure_field(self):
+        # The PT continuation template excludes "physician assistant" so
+        # that an unrelated denial about a PA-led visit doesn't get
+        # misclassified. The exclusion must apply to the procedure
+        # field, not just the denial text.
+        self.assertFalse(
+            PhysicalTherapyContinuationAppeal.matches(
+                "Maximum number of visits reached.",
+                procedure="Physician assistant follow-up",
+            )
+        )
+
+
 class TestNoUnresolvedMedicalReasonInStaticAppeals(unittest.TestCase):
     """Specialized templates feed `non_ai_appeals` directly; sub_in_appeals
     only handles {insurance_company}, {claim_id}, {procedure}, and

--- a/tests/async-unit/test_specialized_denial_templates.py
+++ b/tests/async-unit/test_specialized_denial_templates.py
@@ -1,0 +1,401 @@
+"""Tests for specialized denial-type templates and the make_appeals
+specialized hint path.
+
+Specialized templates auto-cite the laws/regulations US News flagged as
+common appeal grounds (mental-health parity, advanced imaging, specialty
+meds, PT continuation, post-surgical rehab) and seed a single extra call
+to the highest-quality internal model so the strongest model gets a
+chance to use the targeted citations.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from fighthealthinsurance.generate_appeal import (
+    AdvancedImagingAppeal,
+    AppealGenerator,
+    AppealTemplateGenerator,
+    MentalHealthParityAppeal,
+    PhysicalTherapyContinuationAppeal,
+    PostSurgicalRehabAppeal,
+    SPECIALIZED_DENIAL_TEMPLATES,
+    SpecialtyMedicationAppeal,
+    detect_specialized_templates,
+)
+from fighthealthinsurance.ml.ml_models import RemoteModelLike
+
+
+class TestMentalHealthParityAppealMatches(unittest.TestCase):
+    def test_matches_residential_treatment_text(self):
+        self.assertTrue(
+            MentalHealthParityAppeal.matches(
+                "We are denying coverage for residential treatment.",
+            )
+        )
+
+    def test_matches_substance_use_phrase(self):
+        self.assertTrue(
+            MentalHealthParityAppeal.matches(
+                "Claim denied for inpatient substance use disorder care.",
+            )
+        )
+
+    def test_matches_diagnosis_only(self):
+        self.assertTrue(
+            MentalHealthParityAppeal.matches(
+                "Claim denied.",
+                diagnosis="Major depressive disorder",
+            )
+        )
+
+    def test_does_not_match_orthopedic_denial(self):
+        self.assertFalse(
+            MentalHealthParityAppeal.matches(
+                "Knee replacement is not medically necessary.",
+                procedure="Total knee arthroplasty",
+                diagnosis="Osteoarthritis",
+            )
+        )
+
+    def test_static_appeal_cites_required_laws(self):
+        text = MentalHealthParityAppeal.static_appeal()
+        self.assertIn("MHPAEA", text)
+        self.assertIn("29 U.S.C. § 1185a", text)
+        self.assertIn("CMS 2024 Final Rule", text)
+        self.assertIn("42 U.S.C. § 18022(b)(1)(E)", text)
+
+    def test_static_appeal_uses_substitution_placeholders(self):
+        text = MentalHealthParityAppeal.static_appeal()
+        # These are filled in downstream by sub_in_appeals
+        self.assertIn("{insurance_company}", text)
+        self.assertIn("{claim_id}", text)
+        self.assertIn("{procedure}", text)
+        self.assertIn("{diagnosis}", text)
+
+    def test_model_prompt_hint_includes_citations(self):
+        hint = MentalHealthParityAppeal.model_prompt_hint()
+        self.assertIn("MHPAEA", hint)
+        self.assertIn("CMS 2024 Final Rule", hint)
+        self.assertIn("Mental Health Parity", hint)
+
+
+class TestAdvancedImagingAppealMatches(unittest.TestCase):
+    def test_matches_mri_in_text(self):
+        self.assertTrue(
+            AdvancedImagingAppeal.matches(
+                "MRI of the lumbar spine is denied.",
+            )
+        )
+
+    def test_matches_ct_scan(self):
+        self.assertTrue(
+            AdvancedImagingAppeal.matches(
+                "CT scan is not medically necessary.",
+            )
+        )
+
+    def test_matches_pet_scan_phrase(self):
+        self.assertTrue(
+            AdvancedImagingAppeal.matches(
+                "We have denied coverage for the requested PET scan.",
+            )
+        )
+
+    def test_does_not_match_unrelated_denial(self):
+        self.assertFalse(
+            AdvancedImagingAppeal.matches(
+                "Therapy session limit has been reached.",
+            )
+        )
+
+    def test_static_appeal_cites_acr_and_cms(self):
+        text = AdvancedImagingAppeal.static_appeal()
+        self.assertIn("ACR Appropriateness Criteria", text)
+        self.assertIn("CMS National Coverage Determinations", text)
+        self.assertIn("CMS 2024 Final Rule", text)
+
+
+class TestSpecialtyMedicationAppealMatches(unittest.TestCase):
+    def test_matches_step_therapy(self):
+        self.assertTrue(
+            SpecialtyMedicationAppeal.matches(
+                "Patient must complete step therapy before this drug is approved.",
+            )
+        )
+
+    def test_matches_brand_name_biologic(self):
+        self.assertTrue(
+            SpecialtyMedicationAppeal.matches(
+                "Humira is non-formulary; denied.",
+            )
+        )
+
+    def test_matches_glp1(self):
+        self.assertTrue(
+            SpecialtyMedicationAppeal.matches(
+                "Wegovy is denied because patient does not meet criteria.",
+            )
+        )
+
+    def test_static_appeal_mentions_step_therapy_and_erisa(self):
+        text = SpecialtyMedicationAppeal.static_appeal()
+        self.assertIn("step therapy", text.lower())
+        self.assertIn("ERISA", text)
+        self.assertIn("CMS 2024 Final Rule", text)
+
+
+class TestPhysicalTherapyContinuationAppealMatches(unittest.TestCase):
+    def test_matches_visit_limit(self):
+        self.assertTrue(
+            PhysicalTherapyContinuationAppeal.matches(
+                "Patient has reached the maximum number of visits.",
+            )
+        )
+
+    def test_matches_plateau(self):
+        self.assertTrue(
+            PhysicalTherapyContinuationAppeal.matches(
+                "Physical therapy is denied because the patient has plateaued.",
+            )
+        )
+
+    def test_static_appeal_cites_jimmo_and_aca(self):
+        text = PhysicalTherapyContinuationAppeal.static_appeal()
+        self.assertIn("Jimmo", text)
+        self.assertIn("42 U.S.C. § 18022(b)(1)(G)", text)
+        self.assertIn("CMS 2024 Final Rule", text)
+
+
+class TestPostSurgicalRehabAppealMatches(unittest.TestCase):
+    def test_matches_inpatient_rehab(self):
+        self.assertTrue(
+            PostSurgicalRehabAppeal.matches(
+                "Inpatient rehabilitation is denied as not medically necessary.",
+            )
+        )
+
+    def test_matches_skilled_nursing(self):
+        self.assertTrue(
+            PostSurgicalRehabAppeal.matches(
+                "Skilled nursing facility stay is denied.",
+            )
+        )
+
+    def test_matches_post_op_rehab_phrase(self):
+        self.assertTrue(
+            PostSurgicalRehabAppeal.matches(
+                "Post-surgical rehab following the procedure is denied.",
+            )
+        )
+
+    def test_static_appeal_cites_cms_chapters(self):
+        text = PostSurgicalRehabAppeal.static_appeal()
+        self.assertIn("Medicare Benefit Policy Manual", text)
+        self.assertIn("Jimmo", text)
+        self.assertIn("CMS 2024 Final Rule", text)
+
+
+class TestDetectSpecializedTemplates(unittest.TestCase):
+    def test_detect_returns_empty_for_empty_inputs(self):
+        self.assertEqual(detect_specialized_templates(None), [])
+        self.assertEqual(detect_specialized_templates(""), [])
+
+    def test_detect_picks_mental_health_parity(self):
+        matches = detect_specialized_templates(
+            "Inpatient psychiatric admission denied.",
+        )
+        self.assertIn(MentalHealthParityAppeal, matches)
+
+    def test_detect_picks_advanced_imaging(self):
+        matches = detect_specialized_templates(
+            "MRI of the brain is denied.",
+        )
+        self.assertIn(AdvancedImagingAppeal, matches)
+
+    def test_detect_picks_pt_continuation(self):
+        matches = detect_specialized_templates(
+            "Physical therapy plateau noted; visits will end.",
+        )
+        self.assertIn(PhysicalTherapyContinuationAppeal, matches)
+
+    def test_detect_picks_specialty_meds(self):
+        matches = detect_specialized_templates(
+            "Humira step therapy required.",
+        )
+        self.assertIn(SpecialtyMedicationAppeal, matches)
+
+    def test_detect_picks_post_surgical_rehab(self):
+        matches = detect_specialized_templates(
+            "Skilled nursing stay following hip replacement is denied.",
+        )
+        self.assertIn(PostSurgicalRehabAppeal, matches)
+
+    def test_detect_can_return_multiple(self):
+        # Mental-health residential is itself a behavioral-health denial
+        # (parity) AND can match the post-acute rehab template via
+        # "residential treatment" → not — but a clear multi-match: PT
+        # continuation triggered by a denial that mentions both PT visit
+        # limits AND substance use disorder context for an addiction
+        # patient gets both behavioral-health and PT.
+        matches = detect_specialized_templates(
+            "Maximum number of visits reached for substance use disorder "
+            "outpatient therapy.",
+        )
+        self.assertIn(MentalHealthParityAppeal, matches)
+        self.assertIn(PhysicalTherapyContinuationAppeal, matches)
+
+    def test_detect_returns_empty_for_non_matching_denial(self):
+        matches = detect_specialized_templates(
+            "Routine annual checkup paid in full; no denial.",
+        )
+        self.assertEqual(matches, [])
+
+    def test_specialized_registry_contains_all_five_templates(self):
+        names = {t.__name__ for t in SPECIALIZED_DENIAL_TEMPLATES}
+        self.assertEqual(
+            names,
+            {
+                "MentalHealthParityAppeal",
+                "AdvancedImagingAppeal",
+                "SpecialtyMedicationAppeal",
+                "PhysicalTherapyContinuationAppeal",
+                "PostSurgicalRehabAppeal",
+            },
+        )
+
+
+class TestBuildSpecializedHintBlock(unittest.TestCase):
+    def test_combines_multiple_hints(self):
+        block = AppealGenerator._build_specialized_hint_block(
+            [MentalHealthParityAppeal, AdvancedImagingAppeal]
+        )
+        self.assertIn("MHPAEA", block)
+        self.assertIn("American College of Radiology", block)
+
+    def test_deduplicates_by_name(self):
+        # Passing the same template twice should not duplicate the hint;
+        # the per-template "involves <name>" preamble is unique per template
+        # and a clean counter for dedup.
+        block = AppealGenerator._build_specialized_hint_block(
+            [MentalHealthParityAppeal, MentalHealthParityAppeal]
+        )
+        self.assertEqual(block.count("involve Mental Health Parity"), 1)
+
+    def test_empty_input_returns_empty_string(self):
+        self.assertEqual(AppealGenerator._build_specialized_hint_block([]), "")
+
+
+class TestBestInternalModelName(unittest.TestCase):
+    @patch("fighthealthinsurance.generate_appeal.ml_router")
+    def test_returns_none_when_no_internal_model(self, mock_router):
+        mock_router.best_internal_model.return_value = None
+        mock_router.models_by_name = {}
+        self.assertIsNone(AppealGenerator._best_internal_model_name())
+
+    @patch("fighthealthinsurance.generate_appeal.ml_router")
+    def test_returns_friendly_name_for_best_model(self, mock_router):
+        best = MagicMock(spec=RemoteModelLike)
+        other = MagicMock(spec=RemoteModelLike)
+        mock_router.best_internal_model.return_value = best
+        mock_router.models_by_name = {
+            "some-other": [other],
+            "fhi-2025": [best],
+        }
+        self.assertEqual(AppealGenerator._best_internal_model_name(), "fhi-2025")
+
+
+class TestMakeAppealsSpecializedHint(unittest.TestCase):
+    """When specialized_templates is passed, make_appeals must invoke the
+    helpers that build a single extra call targeting the highest-quality
+    internal model.
+
+    We verify this by spying on the helper methods rather than the (deep,
+    closure-bound) call list, which keeps the test focused on the
+    observable contract.
+    """
+
+    def _build_denial(self):
+        return SimpleNamespace(
+            denial_text="Inpatient psychiatric admission denied.",
+            procedure="Inpatient psychiatric admission",
+            diagnosis="Major depressive disorder",
+            patient_user=None,
+            primary_professional=None,
+            qa_context=None,
+            health_history=None,
+            professional_to_finish=False,
+            plan_id=None,
+            claim_id="ABC123",
+            insurance_company="Acme Health",
+            insurance_company_obj=None,
+            plan_context=None,
+            plan_documents_summary=None,
+            use_external=False,
+            denial_id=42,
+        )
+
+    def _run_make_appeals(self, gen, denial, **kwargs):
+        with patch(
+            "fighthealthinsurance.generate_appeal.ml_router"
+        ) as mock_router, patch(
+            "fighthealthinsurance.generate_appeal.as_available_nested",
+            return_value=iter([]),
+        ):
+            best = MagicMock(spec=RemoteModelLike)
+            best.quality.return_value = 200
+            mock_router.generate_text_backend_names.return_value = []
+            mock_router.best_internal_model.return_value = best
+            mock_router.models_by_name = {"fhi-best": [best]}
+            template_gen = AppealTemplateGenerator([], [], [])
+            list(gen.make_appeals(denial, template_gen, **kwargs))
+
+    def test_helpers_called_when_specialized_templates_given(self):
+        gen = AppealGenerator()
+        denial = self._build_denial()
+        with patch.object(
+            AppealGenerator,
+            "_best_internal_model_name",
+            return_value="fhi-best",
+        ) as best_spy, patch.object(
+            AppealGenerator,
+            "_build_specialized_hint_block",
+            return_value="HINTS",
+        ) as block_spy:
+            self._run_make_appeals(
+                gen,
+                denial,
+                specialized_templates=[MentalHealthParityAppeal],
+            )
+            block_spy.assert_called_once_with([MentalHealthParityAppeal])
+            best_spy.assert_called_once()
+
+    def test_helpers_not_called_when_no_specialized_templates(self):
+        gen = AppealGenerator()
+        denial = self._build_denial()
+        with patch.object(
+            AppealGenerator, "_best_internal_model_name"
+        ) as best_spy, patch.object(
+            AppealGenerator, "_build_specialized_hint_block"
+        ) as block_spy:
+            self._run_make_appeals(gen, denial, specialized_templates=None)
+            best_spy.assert_not_called()
+            block_spy.assert_not_called()
+
+    def test_specialized_branch_skipped_when_no_best_model(self):
+        gen = AppealGenerator()
+        denial = self._build_denial()
+        with patch.object(
+            AppealGenerator, "_best_internal_model_name", return_value=None
+        ), patch.object(AppealGenerator, "_build_specialized_hint_block") as block_spy:
+            self._run_make_appeals(
+                gen,
+                denial,
+                specialized_templates=[MentalHealthParityAppeal],
+            )
+            # Without a best internal model we don't bother building hints.
+            block_spy.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/async-unit/test_specialized_denial_templates.py
+++ b/tests/async-unit/test_specialized_denial_templates.py
@@ -189,11 +189,49 @@ class TestPostSurgicalRehabAppealMatches(unittest.TestCase):
             )
         )
 
+    def test_does_not_match_bare_acl_repair_denial(self):
+        # Denial of the surgery itself (with no rehab context) must not
+        # be classified as a post-surgical rehab denial.
+        self.assertFalse(
+            PostSurgicalRehabAppeal.matches(
+                "ACL repair is not medically necessary.",
+                procedure="ACL reconstruction",
+            )
+        )
+
+    def test_does_not_match_bare_rotator_cuff_denial(self):
+        self.assertFalse(
+            PostSurgicalRehabAppeal.matches(
+                "Rotator cuff repair surgery is denied.",
+            )
+        )
+
+    def test_matches_post_surgical_therapy_phrase(self):
+        self.assertTrue(
+            PostSurgicalRehabAppeal.matches(
+                "Post-operative physical therapy following ACL "
+                "reconstruction is denied.",
+            )
+        )
+
     def test_static_appeal_cites_cms_chapters(self):
         text = PostSurgicalRehabAppeal.static_appeal()
         self.assertIn("Medicare Benefit Policy Manual", text)
         self.assertIn("Jimmo", text)
         self.assertIn("CMS 2024 Final Rule", text)
+
+
+class TestNoUnresolvedMedicalReasonInStaticAppeals(unittest.TestCase):
+    """Specialized templates feed `non_ai_appeals` directly; sub_in_appeals
+    only handles {insurance_company}, {claim_id}, {procedure}, and
+    {diagnosis}. Any leftover {medical_reason} placeholder would surface
+    verbatim in the user's appeal letter.
+    """
+
+    def test_no_medical_reason_placeholder_in_any_static_appeal(self):
+        for cls in SPECIALIZED_DENIAL_TEMPLATES:
+            with self.subTest(template=cls.__name__):
+                self.assertNotIn("{medical_reason}", cls.static_appeal())
 
 
 class TestDetectSpecializedTemplates(unittest.TestCase):


### PR DESCRIPTION
## Summary
Introduces a framework for specialized denial-type appeal templates that auto-cite relevant laws and regulations for common insurance denial scenarios. These templates provide both static appeal letters and prompt hints to guide the strongest AI model toward appropriate legal citations.

## Key Changes

- **New `SpecializedDenialTemplate` base class**: Defines a pattern-matching framework with configurable text, procedure, diagnosis, and negative patterns to detect specific denial types. Subclasses encode relevant laws/regulations as citations and provide both static appeal letters and model prompt hints.

- **Five specialized templates implemented**:
  - `MentalHealthParityAppeal`: Cites MHPAEA (29 U.S.C. § 1185a), ACA Essential Health Benefits, and CMS 2024 algorithmic rules for behavioral-health denials
  - `AdvancedImagingAppeal`: Cites ACR Appropriateness Criteria and CMS NCDs for MRI/CT/PET denials
  - `SpecialtyMedicationAppeal`: Cites ERISA § 503, state step-therapy overrides, and ACA non-discrimination provisions for specialty drug denials
  - `PhysicalTherapyContinuationAppeal`: Cites Jimmo v. Sebelius and ACA Essential Health Benefits for PT visit-limit denials
  - `PostSurgicalRehabAppeal`: Cites CMS Medicare Benefit Policy Manual chapters and Jimmo for post-surgical rehabilitation denials

- **Detection and routing logic**:
  - `detect_specialized_templates()` function identifies matching templates based on denial text, procedure, and diagnosis
  - `AppealGenerator._best_internal_model_name()` identifies the highest-quality internal model to receive specialized hints
  - `AppealGenerator._build_specialized_hint_block()` combines citation hints from multiple matched templates
  - `make_appeals()` now accepts optional `specialized_templates` parameter and injects a single extra call to the best internal model with embedded citation guidance

- **Integration with appeal generation**:
  - `common_view_logic.py` detects specialized templates and surfaces their static appeals alongside AI-generated ones
  - Specialized hints are routed only to the strongest internal model to optimize cost/quality tradeoff

- **Comprehensive test coverage**: 401-line test file covering template matching, static appeal generation, hint building, and integration with `make_appeals()`

## Implementation Details

- Templates use regex patterns for flexible matching (case-insensitive, supports multiple variations)
- Negative patterns allow exclusion (e.g., "physician assistant" excluded from PT template)
- Static appeals include placeholder substitution (`{insurance_company}`, `{claim_id}`, `{procedure}`, `{diagnosis}`) filled downstream
- Prompt hints explicitly instruct models not to fabricate citations and to cite by name/section only
- Deduplication logic prevents duplicate hints when multiple templates match
- Specialized branch gracefully skips if no best internal model is available

https://claude.ai/code/session_01Ga5YpMqCQJNgrYnowNxqnB