### PR TITLE
Add local browser voice intake (Moonshine STT) and feature flags to chat UI

### DIFF
--- a/fighthealthinsurance/settings.py
+++ b/fighthealthinsurance/settings.py
@@ -50,6 +50,8 @@ class Base(Configuration):
 
     # Audit logging - disabled by default, enable via environment variable
     ENABLE_AUDIT_LOGGING = os.getenv("ENABLE_AUDIT_LOGGING", "false").lower() == "true"
+    ENABLE_VOICE_INTAKE = os.getenv("ENABLE_VOICE_INTAKE", "false").lower() == "true"
+    ENABLE_LOCAL_STT = os.getenv("ENABLE_LOCAL_STT", "true").lower() == "true"
     LOGIN_URL = "login"
     LOGIN_REDIRECT_URL = "/"
     THUMBNAIL_DEBUG = True

--- a/fighthealthinsurance/static/js/VOICE_INTAKE_NOTES.md
+++ b/fighthealthinsurance/static/js/VOICE_INTAKE_NOTES.md
@@ -1,0 +1,7 @@
+# Voice Intake MVP Notes
+
+- Transcription is intended to run locally in-browser via Moonshine Web (`window.MoonshineWeb`).
+- Raw microphone audio is captured in memory only and never posted to the backend.
+- Only user-reviewed, user-submitted transcript text is sent to the existing chat WebSocket path.
+- If local STT or microphone APIs are unavailable, the UI offers a text-only fallback.
+- Media stream tracks are stopped when recording ends and when the component unmounts.

--- a/fighthealthinsurance/static/js/VoiceIntake.tsx
+++ b/fighthealthinsurance/static/js/VoiceIntake.tsx
@@ -1,0 +1,95 @@
+import React, { useEffect, useRef, useState } from "react";
+import { Alert, Box, Button, Group, Text, Textarea } from "@mantine/core";
+import { createMoonshineClient } from "./moonshine_local_stt";
+
+interface VoiceIntakeProps {
+  enabledLocalSTT: boolean;
+  onSubmitTranscript: (transcript: string) => void;
+  onSwitchToTyping: () => void;
+}
+
+const VoiceIntake: React.FC<VoiceIntakeProps> = ({ enabledLocalSTT, onSubmitTranscript, onSwitchToTyping }) => {
+  const [isInitializing, setIsInitializing] = useState(false);
+  const [isRecording, setIsRecording] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [transcript, setTranscript] = useState("");
+  const streamRef = useRef<MediaStream | null>(null);
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const supportsVoiceCapture = Boolean(navigator.mediaDevices?.getUserMedia) && typeof MediaRecorder !== "undefined";
+
+  const stopActiveStreamTracks = () => {
+    streamRef.current?.getTracks().forEach((track) => track.stop());
+    streamRef.current = null;
+  };
+
+  useEffect(() => () => stopActiveStreamTracks(), []);
+
+  const startRecording = async () => {
+    setError(null);
+    if (!enabledLocalSTT || !supportsVoiceCapture) {
+      setError("Voice capture is unavailable in this browser. Please switch to typing.");
+      return;
+    }
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      streamRef.current = stream;
+      chunksRef.current = [];
+      const rec = new MediaRecorder(stream);
+      rec.ondataavailable = (e) => chunksRef.current.push(e.data);
+      rec.start();
+      recorderRef.current = rec;
+      setIsRecording(true);
+    } catch {
+      setError("Microphone permission was denied or unavailable. Please switch to typing.");
+      stopActiveStreamTracks();
+    }
+  };
+
+  const stopRecording = async () => {
+    if (!recorderRef.current) return;
+    setIsRecording(false);
+    recorderRef.current.stop();
+    stopActiveStreamTracks();
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    const audioBlob = new Blob(chunksRef.current, { type: "audio/webm" });
+    setIsInitializing(true);
+    try {
+      const client = await createMoonshineClient();
+      const nextTranscript = await client.transcribe(audioBlob);
+      setTranscript(nextTranscript);
+    } catch {
+      setError("Local transcription unavailable. You can switch to typing.");
+    } finally {
+      chunksRef.current = [];
+      recorderRef.current = null;
+      setIsInitializing(false);
+    }
+  };
+
+  return (
+    <Box mt="sm" p="sm" style={{ border: "1px solid #ddd", borderRadius: 8 }}>
+      <Text size="sm" mb="xs">Voice transcription runs in your browser when supported. Your audio is not uploaded; only the transcript you choose to submit is sent.</Text>
+      {!enabledLocalSTT && <Alert color="yellow">Local browser transcription is currently disabled. You can continue by typing.</Alert>}
+      {!supportsVoiceCapture && <Alert color="yellow">Your browser does not support microphone capture for this feature. Please continue by typing.</Alert>}
+      {error && <Alert color="yellow">{error}</Alert>}
+      <Group mt="xs">
+        {!isRecording ? <Button size="xs" disabled={isInitializing || !enabledLocalSTT || !supportsVoiceCapture} onClick={startRecording}>Start recording</Button> : <Button size="xs" color="red" onClick={stopRecording}>Stop recording</Button>}
+        <Button size="xs" variant="default" onClick={onSwitchToTyping}>Switch to typing</Button>
+        <Button size="xs" variant="light" onClick={() => setTranscript("")}>Clear transcript</Button>
+      </Group>
+      {isInitializing && <Text size="xs" mt="xs">Loading local speech model and transcribing…</Text>}
+      <Textarea
+        mt="xs"
+        minRows={4}
+        value={transcript}
+        onChange={(e) => setTranscript(e.currentTarget.value)}
+        placeholder="Review and edit your transcript before sending. Voice transcripts can contain mistakes."
+      />
+      <Button mt="xs" size="xs" disabled={!transcript.trim()} onClick={() => onSubmitTranscript(transcript.trim())}>Submit transcript</Button>
+    </Box>
+  );
+};
+
+export default VoiceIntake;

--- a/fighthealthinsurance/static/js/VoiceIntake.tsx
+++ b/fighthealthinsurance/static/js/VoiceIntake.tsx
@@ -23,7 +23,13 @@ const VoiceIntake: React.FC<VoiceIntakeProps> = ({ enabledLocalSTT, onSubmitTran
     streamRef.current = null;
   };
 
-  useEffect(() => () => stopActiveStreamTracks(), []);
+  useEffect(() => () => {
+    if (recorderRef.current && recorderRef.current.state !== "inactive") {
+      recorderRef.current.stop();
+    }
+    recorderRef.current = null;
+    stopActiveStreamTracks();
+  }, []);
 
   const startRecording = async () => {
     setError(null);
@@ -49,11 +55,17 @@ const VoiceIntake: React.FC<VoiceIntakeProps> = ({ enabledLocalSTT, onSubmitTran
   const stopRecording = async () => {
     if (!recorderRef.current) return;
     setIsRecording(false);
-    recorderRef.current.stop();
+    const recorder = recorderRef.current;
+    const recorderMimeType = recorder.mimeType || "audio/webm";
+    const stopPromise = new Promise<void>((resolve) => {
+      recorder.onstop = () => resolve();
+    });
+    recorder.stop();
     stopActiveStreamTracks();
 
-    await new Promise((resolve) => setTimeout(resolve, 100));
-    const audioBlob = new Blob(chunksRef.current, { type: "audio/webm" });
+    await stopPromise;
+    const blobChunks = chunksRef.current.filter((chunk) => chunk.size > 0);
+    const audioBlob = new Blob(blobChunks, { type: recorderMimeType });
     setIsInitializing(true);
     try {
       const client = await createMoonshineClient();

--- a/fighthealthinsurance/static/js/chat_interface.tsx
+++ b/fighthealthinsurance/static/js/chat_interface.tsx
@@ -24,6 +24,7 @@ import { IconPaperclip, IconSend, IconUser, IconRefresh } from "./icons";
 import { recognize } from "./scrub_ocr";
 import { THEME } from "./theme";
 import ErrorBoundary from "./ErrorBoundary";
+import VoiceIntake from "./VoiceIntake";
 import {
   getUserInfo,
   saveUserInfo,
@@ -125,6 +126,7 @@ interface ChatState {
   statusMessage: string | null;
   requestStartTime: number | null;
   useExternalModels: boolean;
+  showVoiceIntake: boolean;
 }
 
 // Typing animation component for loading state with elapsed time
@@ -205,6 +207,8 @@ const getSessionKey = (): string => {
 };
 
 interface ChatInterfaceProps {
+  enableVoiceIntake?: boolean;
+  enableLocalSTT?: boolean;
   defaultProcedure?: string;
   defaultCondition?: string;
   medicare?: string;
@@ -212,7 +216,7 @@ interface ChatInterfaceProps {
   initialMessage?: string;
 }
 
-const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, defaultCondition, medicare, micrositeSlug, initialMessage }) => {
+const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, defaultCondition, medicare, micrositeSlug, initialMessage, enableVoiceIntake, enableLocalSTT }) => {
   // State for our chat interface
   const [state, setState] = useState<ChatState>({
     messages: [],
@@ -226,6 +230,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
     statusMessage: null,
     requestStartTime: null,
     useExternalModels: localStorage.getItem("fhi_use_external_models") === "true",
+    showVoiceIntake: Boolean(enableVoiceIntake),
   });
 
   // Track when to show retry button (separate state to avoid re-render issues)
@@ -644,12 +649,28 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
     [state.chatId],
   );
 
+  const sendChatMessage = (content: string, source?: "typed" | "voice_transcript") => {
+    if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return;
+
+    const userInfo = getUserInfo();
+    const scrubbedContent = userInfo ? scrubPersonalInfo(content, userInfo) : content;
+
+    const messageToSend = {
+      chat_id: state.chatId,
+      email: userInfo?.email,
+      content: scrubbedContent,
+      is_patient: true,
+      session_key: getSessionKey(),
+      use_external_models: state.useExternalModels,
+      metadata: source ? { intake_source: source } : undefined,
+    };
+
+    wsRef.current.send(JSON.stringify(messageToSend));
+  };
+
   // Handle sending a new message
   const handleSendMessage = () => {
-    if (!state.input.trim() || !wsRef.current || state.isLoading) return;
-
-    // Get user info for scrubbing
-    const userInfo = getUserInfo();
+    if (!state.input.trim() || state.isLoading) return;
 
     // Add the user message to the UI immediately - show the original (unscrubbed) message to the user
     const userMessage: ChatMessage = {
@@ -668,22 +689,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
       statusMessage: null,
     }));
 
-    // Scrub personal information before sending
-    const scrubbedContent = userInfo
-      ? scrubPersonalInfo(state.input, userInfo)
-      : state.input;
-
-    // Send the message to the server
-    const messageToSend = {
-      chat_id: state.chatId, // Can be null if starting a new chat
-      email: userInfo?.email, // Include email for server-side processing
-      content: scrubbedContent,
-      is_patient: true, // This is for the patient-facing version
-      session_key: getSessionKey(),
-      use_external_models: state.useExternalModels,
-    };
-
-    wsRef.current.send(JSON.stringify(messageToSend));
+    sendChatMessage(state.input, "typed");
   };
 
   // Handle retrying the last message
@@ -699,9 +705,6 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
 
     if (!lastUserMessage) return;
 
-    // Get user info for scrubbing
-    const userInfo = getUserInfo();
-
     setState((prev) => ({
       ...prev,
       isLoading: true,
@@ -710,25 +713,29 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
       error: null,
     }));
 
-    // Scrub personal information before sending
-    const scrubbedContent = userInfo
-      ? scrubPersonalInfo(lastUserMessage.content, userInfo)
-      : lastUserMessage.content;
-
-    // Send the message to the server
-    const messageToSend = {
-      chat_id: state.chatId,
-      email: userInfo?.email,
-      content: scrubbedContent,
-      is_patient: true,
-      session_key: getSessionKey(),
-      use_external_models: state.useExternalModels,
-    };
-
-    wsRef.current.send(JSON.stringify(messageToSend));
+    sendChatMessage(lastUserMessage.content, "typed");
   };
 
-  // Handle toggling external models
+  
+  const submitVoiceTranscript = (transcript: string) => {
+    if (!transcript.trim() || state.isLoading) return;
+    const userMessage: ChatMessage = {
+      role: "user",
+      content: transcript,
+      timestamp: new Date().toISOString(),
+      status: "done",
+    };
+    setState((prev) => ({
+      ...prev,
+      messages: [...prev.messages, userMessage],
+      input: "",
+      isLoading: true,
+      requestStartTime: Date.now(),
+      statusMessage: null,
+    }));
+    sendChatMessage(transcript, "voice_transcript");
+  };
+// Handle toggling external models
   const handleToggleExternalModels = (checked: boolean) => {
     localStorage.setItem("fhi_use_external_models", checked.toString());
     setState((prev) => ({ ...prev, useExternalModels: checked }));
@@ -762,6 +769,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
       statusMessage: null,
       requestStartTime: null,
       useExternalModels: useExternalModels,
+      showVoiceIntake: Boolean(enableVoiceIntake),
     });
 
     // Handle WebSocket for a new chat
@@ -1035,6 +1043,14 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
           </Box>
         </ScrollArea>
 
+        {state.showVoiceIntake && (
+          <VoiceIntake
+            enabledLocalSTT={Boolean(enableLocalSTT)}
+            onSubmitTranscript={submitVoiceTranscript}
+            onSwitchToTyping={() => setState((prev) => ({ ...prev, showVoiceIntake: false }))}
+          />
+        )}
+
         <Box p="xs" style={{ width: "100%", marginTop: "10px" }}>
           <Paper
             radius="lg"
@@ -1170,6 +1186,8 @@ document.addEventListener("DOMContentLoaded", () => {
     const medicare = chatRoot.dataset.medicare || undefined;
     const micrositeSlug = chatRoot.dataset.micrositeSlug || undefined;
     const initialMessage = chatRoot.dataset.initialMessage || undefined;
+    const enableVoiceIntake = chatRoot.dataset.enableVoiceIntake === "true";
+    const enableLocalSTT = chatRoot.dataset.enableLocalStt === "true";
     console.log("Using microsite settings", chatRoot.dataset)  
     if (defaultProcedure) {
       console.log("Default procedure from microsite:", defaultProcedure);
@@ -1197,6 +1215,8 @@ document.addEventListener("DOMContentLoaded", () => {
             medicare={medicare}
             micrositeSlug={micrositeSlug}
             initialMessage={initialMessage}
+            enableVoiceIntake={enableVoiceIntake}
+            enableLocalSTT={enableLocalSTT}
           />
         </ErrorBoundary>
       </MantineProvider>,

--- a/fighthealthinsurance/static/js/chat_interface.tsx
+++ b/fighthealthinsurance/static/js/chat_interface.tsx
@@ -650,7 +650,9 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
   );
 
   const sendChatMessage = (content: string, source?: "typed" | "voice_transcript") => {
-    if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return;
+    if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) {
+      return false;
+    }
 
     const userInfo = getUserInfo();
     const scrubbedContent = userInfo ? scrubPersonalInfo(content, userInfo) : content;
@@ -666,11 +668,21 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
     };
 
     wsRef.current.send(JSON.stringify(messageToSend));
+    return true;
   };
 
   // Handle sending a new message
   const handleSendMessage = () => {
     if (!state.input.trim() || state.isLoading) return;
+
+    const didSend = sendChatMessage(state.input, "typed");
+    if (!didSend) {
+      setState((prev) => ({
+        ...prev,
+        error: "Connection is still starting. Please try again in a moment.",
+      }));
+      return;
+    }
 
     // Add the user message to the UI immediately - show the original (unscrubbed) message to the user
     const userMessage: ChatMessage = {
@@ -689,7 +701,6 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
       statusMessage: null,
     }));
 
-    sendChatMessage(state.input, "typed");
   };
 
   // Handle retrying the last message
@@ -705,6 +716,16 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
 
     if (!lastUserMessage) return;
 
+    const didSend = sendChatMessage(lastUserMessage.content, "typed");
+    if (!didSend) {
+      setState((prev) => ({
+        ...prev,
+        isLoading: false,
+        error: "Connection is still starting. Please try retry again in a moment.",
+      }));
+      return;
+    }
+
     setState((prev) => ({
       ...prev,
       isLoading: true,
@@ -712,13 +733,20 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
       statusMessage: null,
       error: null,
     }));
-
-    sendChatMessage(lastUserMessage.content, "typed");
   };
 
   
   const submitVoiceTranscript = (transcript: string) => {
     if (!transcript.trim() || state.isLoading) return;
+    const didSend = sendChatMessage(transcript, "voice_transcript");
+    if (!didSend) {
+      setState((prev) => ({
+        ...prev,
+        error: "Connection is still starting. Please submit your transcript again in a moment.",
+      }));
+      return;
+    }
+
     const userMessage: ChatMessage = {
       role: "user",
       content: transcript,
@@ -733,7 +761,6 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
       requestStartTime: Date.now(),
       statusMessage: null,
     }));
-    sendChatMessage(transcript, "voice_transcript");
   };
 // Handle toggling external models
   const handleToggleExternalModels = (checked: boolean) => {

--- a/fighthealthinsurance/static/js/moonshine_local_stt.ts
+++ b/fighthealthinsurance/static/js/moonshine_local_stt.ts
@@ -10,13 +10,31 @@ declare global {
   }
 }
 
-export const getPreferredBackend = (): "webgpu" | "wasm" => {
-  return typeof navigator !== "undefined" && "gpu" in navigator ? "webgpu" : "wasm";
+export const getPreferredBackend = async (): Promise<"webgpu" | "wasm"> => {
+  if (typeof navigator === "undefined" || !("gpu" in navigator)) {
+    return "wasm";
+  }
+
+  try {
+    const adapter = await (navigator as Navigator & { gpu?: { requestAdapter: () => Promise<unknown> } }).gpu?.requestAdapter();
+    return adapter ? "webgpu" : "wasm";
+  } catch {
+    return "wasm";
+  }
 };
 
 export const createMoonshineClient = async (): Promise<LocalSTTClient> => {
   if (!window.MoonshineWeb?.createTranscriber) {
     throw new Error("Moonshine Web is unavailable in this browser build.");
   }
-  return window.MoonshineWeb.createTranscriber({ backend: getPreferredBackend() });
+
+  const preferredBackend = await getPreferredBackend();
+  try {
+    return await window.MoonshineWeb.createTranscriber({ backend: preferredBackend });
+  } catch (error) {
+    if (preferredBackend === "webgpu") {
+      return window.MoonshineWeb.createTranscriber({ backend: "wasm" });
+    }
+    throw error;
+  }
 };

--- a/fighthealthinsurance/static/js/moonshine_local_stt.ts
+++ b/fighthealthinsurance/static/js/moonshine_local_stt.ts
@@ -1,0 +1,22 @@
+export interface LocalSTTClient {
+  transcribe(audioBlob: Blob): Promise<string>;
+}
+
+declare global {
+  interface Window {
+    MoonshineWeb?: {
+      createTranscriber: (opts: { backend: "webgpu" | "wasm" }) => Promise<LocalSTTClient>;
+    };
+  }
+}
+
+export const getPreferredBackend = (): "webgpu" | "wasm" => {
+  return typeof navigator !== "undefined" && "gpu" in navigator ? "webgpu" : "wasm";
+};
+
+export const createMoonshineClient = async (): Promise<LocalSTTClient> => {
+  if (!window.MoonshineWeb?.createTranscriber) {
+    throw new Error("Moonshine Web is unavailable in this browser build.");
+  }
+  return window.MoonshineWeb.createTranscriber({ backend: getPreferredBackend() });
+};

--- a/fighthealthinsurance/templates/chat_interface.html
+++ b/fighthealthinsurance/templates/chat_interface.html
@@ -14,6 +14,8 @@
      data-default-condition="{{ default_condition|default:'' }}" 
      data-microsite-slug="{{ microsite_slug|default:'' }}"
      data-medicare="{{ medicare|default:'' }}"
-     data-initial-message="{{ initial_message|default:''|escapejs }}"></div>
+     data-initial-message="{{ initial_message|default:''|escapejs }}"
+     data-enable-voice-intake="{{ enable_voice_intake|yesno:'true,false' }}"
+     data-enable-local-stt="{{ enable_local_stt|yesno:'true,false' }}"></div>
 <script src="{% static 'js/dist/chat_interface.bundle.js' %}"></script>
 {% endblock %}

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -1832,6 +1832,8 @@ def chat_interface_view(request):
         "medicare": medicare,
         "microsite_slug": microsite_slug,
         "initial_message": initial_message,
+        "enable_voice_intake": getattr(settings, "ENABLE_VOICE_INTAKE", False),
+        "enable_local_stt": getattr(settings, "ENABLE_LOCAL_STT", True),
     }
     logger.debug(
         f"Rendering chat interface: microsite_slug={microsite_slug}, has_default_procedure={bool(default_procedure)}, has_default_condition={bool(default_condition)}, medicare={medicare}, has_initial_message={bool(initial_message)}"

--- a/tests/sync/test_voice_intake_flags.py
+++ b/tests/sync/test_voice_intake_flags.py
@@ -1,0 +1,26 @@
+from django.test import TestCase, override_settings
+
+
+class TestVoiceIntakeFlags(TestCase):
+    def _set_consent(self):
+        session = self.client.session
+        session["consent_completed"] = True
+        session.save()
+
+    @override_settings(ENABLE_VOICE_INTAKE=True, ENABLE_LOCAL_STT=True)
+    def test_chat_template_shows_voice_flags_enabled(self):
+        self._set_consent()
+        response = self.client.get("/chat/")
+        self.assertEqual(response.status_code, 200)
+        html = response.content.decode("utf-8")
+        self.assertIn('data-enable-voice-intake="true"', html)
+        self.assertIn('data-enable-local-stt="true"', html)
+
+    @override_settings(ENABLE_VOICE_INTAKE=False, ENABLE_LOCAL_STT=False)
+    def test_chat_template_shows_voice_flags_disabled(self):
+        self._set_consent()
+        response = self.client.get("/chat/")
+        self.assertEqual(response.status_code, 200)
+        html = response.content.decode("utf-8")
+        self.assertIn('data-enable-voice-intake="false"', html)
+        self.assertIn('data-enable-local-stt="false"', html)


### PR DESCRIPTION
### Motivation

- Enable an in-browser voice intake MVP where users can record, transcribe locally, review, and submit transcripts without uploading raw audio. 
- Expose runtime toggles so voice intake and local speech-to-text can be enabled/disabled via settings or environment variables. 
- Integrate voice intake into the existing chat flow while preserving privacy and reusing existing scrubbing/sending logic.

### Description

- Add two new settings flags `ENABLE_VOICE_INTAKE` and `ENABLE_LOCAL_STT` in `fighthealthinsurance/settings.py` to control feature availability. 
- Add a new React component `VoiceIntake.tsx` that captures audio using `getUserMedia`/`MediaRecorder`, stops tracks on unmount, and transcribes locally via a pluggable Moonshine client. 
- Add `moonshine_local_stt.ts` which exposes `createMoonshineClient` and `getPreferredBackend` to create a local STT transcriber from the global `window.MoonshineWeb`. 
- Integrate voice intake UI into `chat_interface.tsx` by adding props `enableVoiceIntake`/`enableLocalSTT`, component state `showVoiceIntake`, a `VoiceIntake` render branch, and a consolidated `sendChatMessage` helper that scrubs content and attaches `metadata.intake_source`. 
- Add `submitVoiceTranscript` to push reviewed transcripts into the chat UI and send them with `intake_source: "voice_transcript"`. 
- Add `data-enable-voice-intake` and `data-enable-local-stt` attributes to the chat template in `chat_interface.html` and wire values from the view via `chat_interface_view` context keys. 
- Add `VOICE_INTAKE_NOTES.md` documenting privacy and behavior for the MVP. 
- Add a unit test `tests/sync/test_voice_intake_flags.py` to assert the template exposes the correct data attributes based on settings.

### Testing

- Ran the new Django test `./manage.py test tests.sync.test_voice_intake_flags.TestVoiceIntakeFlags` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5599fe26883229b27d19003e33e45)