### PR TITLE
Add algorithmic-review detector and inject suggested appeal template blocks

### DIFF
--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -2144,8 +2144,13 @@ class AppealsBackendHelper:
             )
         )
 
-        algorithmic_detection = detect_algorithmic_review_terms(denial.denial_text or "")
-        if algorithmic_detection.matched and algorithmic_detection.confidence in {"medium", "high"}:
+        algorithmic_detection = detect_algorithmic_review_terms(
+            denial.denial_text or ""
+        )
+        if algorithmic_detection.matched and algorithmic_detection.confidence in {
+            "medium",
+            "high",
+        }:
             non_ai_appeals.extend(
                 render_template_blocks(algorithmic_detection.suggested_template_blocks)
             )

--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -41,6 +41,10 @@ from fhi_users import emails as fhi_emails
 from fhi_users.audit import TrackingInfo
 from fhi_users.models import ProfessionalUser, UserDomain
 from fighthealthinsurance import stripe_utils
+from fighthealthinsurance.denials.algorithmic_review_detector import (
+    detect_algorithmic_review_terms,
+    render_template_blocks,
+)
 from fighthealthinsurance.fax_actor_ref import fax_actor_ref
 from fighthealthinsurance.ml.bad_output_utils import strip_boilerplate_service
 from fighthealthinsurance.form_utils import *
@@ -2139,6 +2143,16 @@ class AppealsBackendHelper:
                 ),
             )
         )
+
+        algorithmic_detection = detect_algorithmic_review_terms(denial.denial_text or "")
+        if algorithmic_detection.matched:
+            non_ai_appeals.extend(
+                render_template_blocks(algorithmic_detection.suggested_template_blocks)
+            )
+            logger.info(
+                f"Algorithmic-review detection matched for denial {denial.denial_id}: "
+                f"{algorithmic_detection.debug_reason}"
+            )
 
         insurance_company = denial.insurance_company or "insurance company;"
         claim_id = denial.claim_id or "YOURCLAIMIDGOESHERE"

--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -2145,7 +2145,7 @@ class AppealsBackendHelper:
         )
 
         algorithmic_detection = detect_algorithmic_review_terms(denial.denial_text or "")
-        if algorithmic_detection.matched:
+        if algorithmic_detection.matched and algorithmic_detection.confidence in {"medium", "high"}:
             non_ai_appeals.extend(
                 render_template_blocks(algorithmic_detection.suggested_template_blocks)
             )

--- a/fighthealthinsurance/denials/README.md
+++ b/fighthealthinsurance/denials/README.md
@@ -1,0 +1,10 @@
+# Algorithmic-review detector notes
+
+`algorithmic_review_detector.py` uses two pattern maps:
+
+- `TERM_PATTERNS` for generic automation and criteria language.
+- `VENDOR_PATTERNS` for utilization-management vendors/tools.
+
+To add a future vendor, add a new key + regex to `VENDOR_PATTERNS`, and (optionally) add a matching template block in `TEMPLATE_BLOCKS` with a unique block id.
+
+The detector returns `suggested_template_blocks`, and `common_view_logic.py` appends the rendered block text into `non_ai_appeals` so the generated appeal asks for individualized review, criteria disclosure, and human clinician review without asserting legal violations.

--- a/fighthealthinsurance/denials/__init__.py
+++ b/fighthealthinsurance/denials/__init__.py
@@ -1,0 +1,1 @@
+"""Denial analysis helpers."""

--- a/fighthealthinsurance/denials/algorithmic_review_detector.py
+++ b/fighthealthinsurance/denials/algorithmic_review_detector.py
@@ -79,9 +79,13 @@ def _dedupe_overlapping_terms(matched_terms: list[str]) -> list[str]:
 
 def detect_algorithmic_review_terms(text: str) -> AlgorithmicReviewDetectionResult:
     lower = (text or "").lower()
-    matched_terms = [name for name, pat in TERM_PATTERNS.items() if re.search(pat, lower)]
+    matched_terms = [
+        name for name, pat in TERM_PATTERNS.items() if re.search(pat, lower)
+    ]
     matched_terms = _dedupe_overlapping_terms(matched_terms)
-    vendor_matches = [name for name, pat in VENDOR_PATTERNS.items() if re.search(pat, lower)]
+    vendor_matches = [
+        name for name, pat in VENDOR_PATTERNS.items() if re.search(pat, lower)
+    ]
 
     matched = bool(matched_terms or vendor_matches)
     score = sum(TERM_WEIGHTS.get(term, 1.0) for term in matched_terms) + (
@@ -101,12 +105,17 @@ def detect_algorithmic_review_terms(text: str) -> AlgorithmicReviewDetectionResu
 
     blocks: list[str] = []
     if matched:
-        blocks.extend([
-            "algorithmic_review_general",
-            "request_criteria_and_human_review",
-        ])
+        blocks.extend(
+            [
+                "algorithmic_review_general",
+                "request_criteria_and_human_review",
+            ]
+        )
 
-    if re.search(r"\bmedicare\s+advantage\b|\bpart\s*c\b|\bma\s+plan\b", lower) and matched:
+    if (
+        re.search(r"\bmedicare\s+advantage\b|\bpart\s*c\b|\bma\s+plan\b", lower)
+        and matched
+    ):
         blocks.append("algorithmic_review_medicare_advantage")
 
     if any(v == "NaviHealth" for v in vendor_matches):

--- a/fighthealthinsurance/denials/algorithmic_review_detector.py
+++ b/fighthealthinsurance/denials/algorithmic_review_detector.py
@@ -28,7 +28,7 @@ TERM_PATTERNS: dict[str, str] = {
 
 VENDOR_PATTERNS: dict[str, str] = {
     "InterQual": r"\binterqual\b",
-    "MCG": r"\bmcg\b",
+    "MCG": r"\bmcg\b(?:(?:\s*\(\s*care\s+guidelines?\s*\))|\s+(?:care\s+guidelines?|guideline(?:s)?|criteria|health))",
     "Milliman": r"\bmilliman\b",
     "NaviHealth": r"\bnavihealth\b|\bnh\s*predict\b",
     "EviCore": r"\bevicore\b",
@@ -40,24 +40,59 @@ def _footer_only_algorithm_match(text: str, matched_terms: list[str]) -> bool:
     if "algorithm" not in matched_terms:
         return False
     lower = text.lower()
-    if any(t in matched_terms for t in ["automated review", "algorithmic determination", "AI", "artificial intelligence", "machine learning"]):
+    if any(
+        t in matched_terms
+        for t in [
+            "automated review",
+            "algorithmic determination",
+            "AI",
+            "artificial intelligence",
+            "machine learning",
+        ]
+    ):
         return False
     return bool(re.search(r"footer|template|document\s+id|checksum", lower))
+
+
+TERM_WEIGHTS: dict[str, float] = {
+    "automated review": 2.0,
+    "algorithmic determination": 2.0,
+    "algorithm": 0.5,
+    "AI": 1.0,
+    "artificial intelligence": 1.0,
+    "machine learning": 1.5,
+    "clinical guideline": 0.75,
+    "proprietary criteria": 1.0,
+    "medical necessity criteria": 1.0,
+    "utilization management": 0.75,
+}
+
+
+def _dedupe_overlapping_terms(matched_terms: list[str]) -> list[str]:
+    deduped = set(matched_terms)
+    if "algorithmic determination" in deduped:
+        deduped.discard("algorithm")
+    if "artificial intelligence" in deduped:
+        deduped.discard("AI")
+    return sorted(deduped)
 
 
 def detect_algorithmic_review_terms(text: str) -> AlgorithmicReviewDetectionResult:
     lower = (text or "").lower()
     matched_terms = [name for name, pat in TERM_PATTERNS.items() if re.search(pat, lower)]
+    matched_terms = _dedupe_overlapping_terms(matched_terms)
     vendor_matches = [name for name, pat in VENDOR_PATTERNS.items() if re.search(pat, lower)]
 
     matched = bool(matched_terms or vendor_matches)
-    score = len(matched_terms) + (2 * len(vendor_matches))
+    score = sum(TERM_WEIGHTS.get(term, 1.0) for term in matched_terms) + (
+        2.0 * len(vendor_matches)
+    )
     if _footer_only_algorithm_match(lower, matched_terms):
         score = min(score, 1)
 
     if score >= 5:
         confidence: Literal["low", "medium", "high"] = "high"
-    elif score >= 2:
+    elif score >= 1.5:
         confidence = "medium"
     elif matched:
         confidence = "low"
@@ -126,4 +161,8 @@ TEMPLATE_BLOCKS: dict[str, str] = {
 
 
 def render_template_blocks(block_ids: list[str]) -> list[str]:
-    return [TEMPLATE_BLOCKS[block_id] for block_id in block_ids if block_id in TEMPLATE_BLOCKS]
+    return [
+        TEMPLATE_BLOCKS[block_id]
+        for block_id in block_ids
+        if block_id in TEMPLATE_BLOCKS
+    ]

--- a/fighthealthinsurance/denials/algorithmic_review_detector.py
+++ b/fighthealthinsurance/denials/algorithmic_review_detector.py
@@ -1,0 +1,129 @@
+from dataclasses import dataclass
+from typing import Literal
+import re
+
+
+@dataclass(frozen=True)
+class AlgorithmicReviewDetectionResult:
+    matched: bool
+    confidence: Literal["low", "medium", "high"]
+    matched_terms: list[str]
+    vendor_matches: list[str]
+    suggested_template_blocks: list[str]
+    debug_reason: str
+
+
+TERM_PATTERNS: dict[str, str] = {
+    "automated review": r"\bautomated\s+review\b",
+    "algorithmic determination": r"\balgorithmic\s+determination\b",
+    "algorithm": r"\balgorithm(?:s|ic)?\b",
+    "AI": r"\bai\b",
+    "artificial intelligence": r"\bartificial\s+intelligence\b",
+    "machine learning": r"\bmachine\s+learning\b",
+    "clinical guideline": r"\bclinical\s+guideline(?:s)?\b",
+    "proprietary criteria": r"\bproprietary\s+criteria\b",
+    "medical necessity criteria": r"\bmedical\s+necessity\s+criteria\b",
+    "utilization management": r"\butili[sz]ation\s+management\b",
+}
+
+VENDOR_PATTERNS: dict[str, str] = {
+    "InterQual": r"\binterqual\b",
+    "MCG": r"\bmcg\b",
+    "Milliman": r"\bmilliman\b",
+    "NaviHealth": r"\bnavihealth\b|\bnh\s*predict\b",
+    "EviCore": r"\bevicore\b",
+    "Carelon": r"\bcarelon\b|\baim\s+specialty\s+health\b",
+}
+
+
+def _footer_only_algorithm_match(text: str, matched_terms: list[str]) -> bool:
+    if "algorithm" not in matched_terms:
+        return False
+    lower = text.lower()
+    if any(t in matched_terms for t in ["automated review", "algorithmic determination", "AI", "artificial intelligence", "machine learning"]):
+        return False
+    return bool(re.search(r"footer|template|document\s+id|checksum", lower))
+
+
+def detect_algorithmic_review_terms(text: str) -> AlgorithmicReviewDetectionResult:
+    lower = (text or "").lower()
+    matched_terms = [name for name, pat in TERM_PATTERNS.items() if re.search(pat, lower)]
+    vendor_matches = [name for name, pat in VENDOR_PATTERNS.items() if re.search(pat, lower)]
+
+    matched = bool(matched_terms or vendor_matches)
+    score = len(matched_terms) + (2 * len(vendor_matches))
+    if _footer_only_algorithm_match(lower, matched_terms):
+        score = min(score, 1)
+
+    if score >= 5:
+        confidence: Literal["low", "medium", "high"] = "high"
+    elif score >= 2:
+        confidence = "medium"
+    elif matched:
+        confidence = "low"
+    else:
+        confidence = "low"
+
+    blocks: list[str] = []
+    if matched:
+        blocks.extend([
+            "algorithmic_review_general",
+            "request_criteria_and_human_review",
+        ])
+
+    if re.search(r"\bmedicare\s+advantage\b|\bpart\s*c\b|\bma\s+plan\b", lower) and matched:
+        blocks.append("algorithmic_review_medicare_advantage")
+
+    if any(v == "NaviHealth" for v in vendor_matches):
+        blocks.append("vendor_specific_navihealth")
+    if any(v == "EviCore" for v in vendor_matches):
+        blocks.append("vendor_specific_evicore")
+
+    reason = (
+        f"matched_terms={matched_terms}, vendor_matches={vendor_matches}, score={score}"
+        if matched
+        else "No algorithmic-review indicators detected"
+    )
+
+    return AlgorithmicReviewDetectionResult(
+        matched=matched,
+        confidence=confidence,
+        matched_terms=matched_terms,
+        vendor_matches=vendor_matches,
+        suggested_template_blocks=blocks,
+        debug_reason=reason,
+    )
+
+
+TEMPLATE_BLOCKS: dict[str, str] = {
+    "algorithmic_review_general": (
+        "I request disclosure of all criteria, guidelines, software tools, algorithms, vendor inputs, "
+        "and decision rules used in this determination, and whether any automated or algorithmic process "
+        "contributed to the denial."
+    ),
+    "algorithmic_review_medicare_advantage": (
+        "If this is a Medicare Advantage coverage determination, please confirm that any prior authorization "
+        "or decision-support tools were used only to assess diagnosis/medical criteria and medical necessity, "
+        "and did not override Medicare coverage rules or individualized clinical facts, consistent with CMS's "
+        "2024 Medicare Advantage final rule and CMS FAQ guidance on algorithm-assisted determinations."
+    ),
+    "vendor_specific_navihealth": (
+        "If any naviHealth/nH Predict or related post-acute decision-support tool was consulted, "
+        "please identify exactly how it was used in this case, the inputs relied on, and how the treating "
+        "clinician's findings were weighed. I note there has been reported litigation with allegations about "
+        "such tools; this request is to preserve my appeal rights and clarify the record for this individual case."
+    ),
+    "vendor_specific_evicore": (
+        "If EviCore was involved in utilization management or medical-necessity review for this decision, "
+        "please provide the specific criteria set, version, and rationale applied to my documented condition."
+    ),
+    "request_criteria_and_human_review": (
+        "Please provide copies of the medical-necessity criteria and plan provisions relied upon, explain how "
+        "those criteria apply to my specific documented condition, and ensure this appeal is reviewed by an "
+        "appropriately qualified clinician based on individualized clinical facts."
+    ),
+}
+
+
+def render_template_blocks(block_ids: list[str]) -> list[str]:
+    return [TEMPLATE_BLOCKS[block_id] for block_id in block_ids if block_id in TEMPLATE_BLOCKS]

--- a/tests/async-unit/test_algorithmic_review_detector.py
+++ b/tests/async-unit/test_algorithmic_review_detector.py
@@ -1,0 +1,40 @@
+from fighthealthinsurance.denials.algorithmic_review_detector import (
+    detect_algorithmic_review_terms,
+)
+
+
+def test_automated_review_triggers_general_block():
+    result = detect_algorithmic_review_terms("Your request was denied after automated review.")
+    assert result.matched is True
+    assert "algorithmic_review_general" in result.suggested_template_blocks
+
+
+def test_interqual_triggers_criteria_request():
+    result = detect_algorithmic_review_terms("Decision based on InterQual criteria.")
+    assert result.matched is True
+    assert "request_criteria_and_human_review" in result.suggested_template_blocks
+
+
+def test_navihealth_or_nh_predict_triggers_vendor_block():
+    result = detect_algorithmic_review_terms("Used nH Predict via naviHealth for post-acute review.")
+    assert "vendor_specific_navihealth" in result.suggested_template_blocks
+
+
+def test_footer_algorithm_does_not_overtrigger_high_confidence():
+    text = "Claim denial for missing referral. Footer: algorithm v2 checksum id"
+    result = detect_algorithmic_review_terms(text)
+    assert result.matched is True
+    assert result.confidence != "high"
+
+
+def test_medicare_advantage_with_automation_includes_ma_block():
+    text = "Medicare Advantage plan denial from automated review workflow."
+    result = detect_algorithmic_review_terms(text)
+    assert "algorithmic_review_medicare_advantage" in result.suggested_template_blocks
+
+
+def test_ordinary_denial_language_no_false_positive():
+    text = "Denied because prior authorization was not submitted and records were incomplete."
+    result = detect_algorithmic_review_terms(text)
+    assert result.matched is False
+    assert result.suggested_template_blocks == []

--- a/tests/async-unit/test_algorithmic_review_detector.py
+++ b/tests/async-unit/test_algorithmic_review_detector.py
@@ -21,10 +21,13 @@ def test_navihealth_or_nh_predict_triggers_vendor_block():
 
 
 def test_footer_algorithm_does_not_overtrigger_high_confidence():
-    text = "Claim denial for missing referral. Footer: algorithm v2 checksum id"
+    text = (
+        "Claim denial for missing referral. "
+        "Footer: algorithm v2 checksum id clinical guideline medical necessity criteria"
+    )
     result = detect_algorithmic_review_terms(text)
     assert result.matched is True
-    assert result.confidence != "high"
+    assert result.confidence == "low"
 
 
 def test_medicare_advantage_with_automation_includes_ma_block():
@@ -38,3 +41,9 @@ def test_ordinary_denial_language_no_false_positive():
     result = detect_algorithmic_review_terms(text)
     assert result.matched is False
     assert result.suggested_template_blocks == []
+
+
+def test_mcg_dosage_not_vendor_match():
+    result = detect_algorithmic_review_terms("Dose adjusted to 25 mcg daily.")
+    assert "MCG" not in result.vendor_matches
+


### PR DESCRIPTION
### Motivation

- Detect language in denial text that indicates automated/algorithmic or vendor-driven review so appeals request human review and criteria disclosure. 
- Provide vendor- and plan-specific template blocks to produce targeted, non-accusatory appeal language. 
- Avoid over-triggering from incidental mentions (e.g., footer metadata) and offer confidence scoring for downstream use.

### Description

- Added a new detector module `fighthealthinsurance.denials.algorithmic_review_detector` with `detect_algorithmic_review_terms`, `render_template_blocks`, `TERM_PATTERNS`, `VENDOR_PATTERNS`, `TEMPLATE_BLOCKS`, and the `AlgorithmicReviewDetectionResult` dataclass to identify matched terms, vendor hits, confidence, and suggested template block ids. 
- Implemented `_footer_only_algorithm_match` heuristics to reduce false high-confidence matches from footer-like text. 
- Updated `fighthealthinsurance/common_view_logic.py` to call `detect_algorithmic_review_terms` and, when matched, extend the `non_ai_appeals` list with rendered template blocks and log the detection. 
- Added package files `fighthealthinsurance/denials/__init__.py` and `fighthealthinsurance/denials/README.md` documenting the detector and how to add vendors/templates. 
- Added unit tests `tests/async-unit/test_algorithmic_review_detector.py` that cover general term detection, vendor-specific blocks, Medicare Advantage handling, footer heuristics, and a negative case.

### Testing

- Ran the new unit tests with `pytest tests/async-unit/test_algorithmic_review_detector.py`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f558d8bea083229e215d4e6bba45aa)