### PR TITLE
Secure abandoned-cart recovery link with unguessable token

### DIFF
--- a/fighthealthinsurance/helpers/stripe_helpers.py
+++ b/fighthealthinsurance/helpers/stripe_helpers.py
@@ -232,8 +232,13 @@ class StripeWebhookHelper:
                 metadata=metadata,
             )
             if finish_link is None:
-                finish_link_base = reverse("complete_payment")
-                finish_link = f"{finish_link_base}?session_id={lost_session.id}"
+                # Use the unguessable secure_token rather than the row id so the
+                # recovery URL can't be brute-forced by enumerating ids.
+                params = urlencode({"token": lost_session.secure_token})
+                finish_link = (
+                    f"https://www.fightpaperwork.com"
+                    f"{reverse('complete_payment')}?{params}"
+                )
             if finish_link:
                 fhi_emails.send_checkout_session_expired(
                     request,

--- a/fighthealthinsurance/helpers/stripe_helpers.py
+++ b/fighthealthinsurance/helpers/stripe_helpers.py
@@ -7,6 +7,7 @@ Provides utilities for processing Stripe payment webhooks.
 from typing import Any, Optional
 from urllib.parse import urlencode
 
+from django.conf import settings
 from django.urls import reverse
 
 from loguru import logger
@@ -233,10 +234,12 @@ class StripeWebhookHelper:
             )
             if finish_link is None:
                 # Use the unguessable secure_token rather than the row id so the
-                # recovery URL can't be brute-forced by enumerating ids.
+                # recovery URL can't be brute-forced by enumerating ids. Build
+                # the host from settings so non-prod environments don't email
+                # users a production link.
                 params = urlencode({"token": lost_session.secure_token})
                 finish_link = (
-                    f"https://www.fightpaperwork.com"
+                    f"https://{settings.FIGHT_PAPERWORK_DOMAIN}"
                     f"{reverse('complete_payment')}?{params}"
                 )
             if finish_link:

--- a/fighthealthinsurance/migrations/0160_loststripesession_secure_token.py
+++ b/fighthealthinsurance/migrations/0160_loststripesession_secure_token.py
@@ -1,0 +1,34 @@
+from django.db import migrations, models
+
+from fighthealthinsurance.utils import sekret_gen
+
+
+def populate_secure_tokens(apps, schema_editor):
+    """Backfill a unique secure_token for any pre-existing rows."""
+    LostStripeSession = apps.get_model("fighthealthinsurance", "LostStripeSession")
+    for session in LostStripeSession.objects.filter(secure_token=""):
+        session.secure_token = sekret_gen()
+        session.save(update_fields=["secure_token"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("fighthealthinsurance", "0159_chatdocument"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="loststripesession",
+            name="secure_token",
+            field=models.CharField(db_index=True, default="", max_length=64),
+            preserve_default=False,
+        ),
+        migrations.RunPython(populate_secure_tokens, migrations.RunPython.noop),
+        migrations.AlterField(
+            model_name="loststripesession",
+            name="secure_token",
+            field=models.CharField(
+                default=sekret_gen, max_length=64, unique=True, db_index=True
+            ),
+        ),
+    ]

--- a/fighthealthinsurance/migrations/0161_loststripesession_secure_token.py
+++ b/fighthealthinsurance/migrations/0161_loststripesession_secure_token.py
@@ -13,7 +13,7 @@ def populate_secure_tokens(apps, schema_editor):
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("fighthealthinsurance", "0159_chatdocument"),
+        ("fighthealthinsurance", "0160_cmscoveragecache"),
     ]
 
     operations = [

--- a/fighthealthinsurance/models.py
+++ b/fighthealthinsurance/models.py
@@ -1758,6 +1758,11 @@ class LostStripeSession(models.Model):
 
     id = models.AutoField(primary_key=True)
     session_id = models.CharField(max_length=255, null=True, blank=True)
+    # Unguessable token used to authorize recovery via the abandoned-cart email
+    # link. Must be kept secret; only sent to the verified customer email.
+    secure_token = models.CharField(
+        max_length=64, unique=True, default=sekret_gen, db_index=True
+    )
     payment_type = models.CharField(max_length=255, null=True, blank=True)
     created_at = models.DateTimeField(auto_now_add=True, blank=True)
     cancel_url = models.CharField(max_length=255, null=True, blank=True)

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -1712,6 +1712,11 @@ class CompletePaymentView(View):
         data = json.loads(request.body)
         return self.process_payment(data)
 
+    # Row ids issued before the secure_token migration (#763) that we still
+    # honor when passed as ?session_id=<id>; everything above this id was
+    # created with a token so legacy lookups should be denied.
+    LEGACY_SESSION_ID_CUTOFF = 600
+
     def process_payment(self, data):
         token = data.get("token")
         session_id = data.get("session_id")
@@ -1720,9 +1725,23 @@ class CompletePaymentView(View):
             if token:
                 lost_session = models.LostStripeSession.objects.get(secure_token=token)
             elif session_id:
-                lost_session = models.LostStripeSession.objects.get(
-                    session_id=session_id
-                )
+                # Legacy emails sent before the token rollout used the row id
+                # as ?session_id=<int>. Honor those for ids below the cutoff
+                # only; newer ids must use the unguessable token.
+                legacy_id: typing.Optional[int] = None
+                try:
+                    legacy_id = int(session_id)
+                except (TypeError, ValueError):
+                    pass
+                if (
+                    legacy_id is not None
+                    and 0 < legacy_id < self.LEGACY_SESSION_ID_CUTOFF
+                ):
+                    lost_session = models.LostStripeSession.objects.get(id=legacy_id)
+                else:
+                    lost_session = models.LostStripeSession.objects.get(
+                        session_id=session_id
+                    )
             else:
                 return HttpResponse(
                     json.dumps({"error": "Missing token"}),

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -1687,6 +1687,11 @@ class StripeWebhookView(View):
 class CompletePaymentView(View):
     """View for completing payment after Stripe checkout redirect."""
 
+    # Row ids issued before the secure_token migration (#763) that we still
+    # honor when passed as ?session_id=<id>; everything above this id was
+    # created with a token so legacy lookups should be denied.
+    LEGACY_SESSION_ID_CUTOFF = 600
+
     def get(self, request):
         try:
             data = {
@@ -1711,11 +1716,6 @@ class CompletePaymentView(View):
     def do_post(self, request):
         data = json.loads(request.body)
         return self.process_payment(data)
-
-    # Row ids issued before the secure_token migration (#763) that we still
-    # honor when passed as ?session_id=<id>; everything above this id was
-    # created with a token so legacy lookups should be denied.
-    LEGACY_SESSION_ID_CUTOFF = 600
 
     def process_payment(self, data):
         token = data.get("token")

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -1727,21 +1727,24 @@ class CompletePaymentView(View):
             elif session_id:
                 # Legacy emails sent before the token rollout used the row id
                 # as ?session_id=<int>. Honor those for ids below the cutoff
-                # only; newer ids must use the unguessable token.
+                # only; anything else must come through the secure token, so
+                # that post-cutoff sessions can't be brute-forced or accessed
+                # by passing a Stripe session_id string.
                 legacy_id: typing.Optional[int] = None
                 try:
                     legacy_id = int(session_id)
                 except (TypeError, ValueError):
                     pass
                 if (
-                    legacy_id is not None
-                    and 0 < legacy_id < self.LEGACY_SESSION_ID_CUTOFF
+                    legacy_id is None
+                    or not 0 < legacy_id < self.LEGACY_SESSION_ID_CUTOFF
                 ):
-                    lost_session = models.LostStripeSession.objects.get(id=legacy_id)
-                else:
-                    lost_session = models.LostStripeSession.objects.get(
-                        session_id=session_id
+                    return HttpResponse(
+                        json.dumps({"error": "Invalid or expired link"}),
+                        status=400,
+                        content_type="application/json",
                     )
+                lost_session = models.LostStripeSession.objects.get(id=legacy_id)
             else:
                 return HttpResponse(
                     json.dumps({"error": "Missing token"}),

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -1689,9 +1689,9 @@ class CompletePaymentView(View):
 
     def get(self, request):
         try:
-            session_id = request.GET.get("session_id")
             data = {
-                "session_id": session_id,
+                "token": request.GET.get("token"),
+                "session_id": request.GET.get("session_id"),
             }
 
             return self.process_payment(data)
@@ -1713,17 +1713,22 @@ class CompletePaymentView(View):
         return self.process_payment(data)
 
     def process_payment(self, data):
+        token = data.get("token")
         session_id = data.get("session_id")
 
-        if not session_id:
-            return HttpResponse(
-                json.dumps({"error": "Missing session_id"}),
-                status=400,
-                content_type="application/json",
-            )
-
         try:
-            lost_session = models.LostStripeSession.objects.get(session_id=session_id)
+            if token:
+                lost_session = models.LostStripeSession.objects.get(secure_token=token)
+            elif session_id:
+                lost_session = models.LostStripeSession.objects.get(
+                    session_id=session_id
+                )
+            else:
+                return HttpResponse(
+                    json.dumps({"error": "Missing token"}),
+                    status=400,
+                    content_type="application/json",
+                )
             continue_url = lost_session.success_url
             cancel_url = lost_session.cancel_url
             payment_type = lost_session.payment_type

--- a/tests/async/test_non_professional_abandoned_cart.py
+++ b/tests/async/test_non_professional_abandoned_cart.py
@@ -23,17 +23,17 @@ def test_non_professional_abandoned_cart():
         email=email,
         metadata=metadata,
     )
+    token = lost_session.secure_token
 
-    # Test POST method
+    # Test POST method (token-based)
     with patch("stripe.checkout.Session.create") as mock_create:
         mock_create.return_value.url = "https://checkout.stripe.com/test"
 
-        # Call the CompletePaymentView
         response = client.post(
             reverse("complete_payment"),
             data=json.dumps(
                 {
-                    "session_id": session_id,
+                    "token": token,
                     "continue_url": "https://example.com/success",
                     "cancel_url": "https://example.com/cancel",
                 }
@@ -45,23 +45,24 @@ def test_non_professional_abandoned_cart():
         assert "next_url" in response.json()
         assert response.json()["next_url"] == "https://checkout.stripe.com/test"
 
-    # Test GET method
+    # Test GET method (token-based)
     with patch("stripe.checkout.Session.create") as mock_create:
         mock_create.return_value.url = "https://checkout.stripe.com/test"
 
-        # Call the CompletePaymentView with GET parameters
-        query_params = urlencode(
-            {
-                "session_id": session_id,
-                "continue_url": "https://example.com/success",
-                "cancel_url": "https://example.com/cancel",
-            }
-        )
+        query_params = urlencode({"token": token})
         response = client.get(f"{reverse('complete_payment')}?{query_params}")
 
         assert response.status_code == 200
         assert "next_url" in response.json()
         assert response.json()["next_url"] == "https://checkout.stripe.com/test"
+
+    # Brute-forcing the row id must not work — only the secure_token grants access.
+    response = client.get(f"{reverse('complete_payment')}?session_id={lost_session.id}")
+    assert response.status_code == 400
+
+    # An unknown / forged token must be rejected.
+    response = client.get(f"{reverse('complete_payment')}?token=not-a-real-token")
+    assert response.status_code == 400
 
     # Simulate Stripe webhook call to trigger the email
     stripe_event = {

--- a/tests/async/test_non_professional_abandoned_cart.py
+++ b/tests/async/test_non_professional_abandoned_cart.py
@@ -75,6 +75,13 @@ def test_non_professional_abandoned_cart():
     response = client.get(f"{reverse('complete_payment')}?token=not-a-real-token")
     assert response.status_code == 400
 
+    # Passing the raw Stripe session_id string is no longer a valid lookup —
+    # post-cutoff sessions must use the token.
+    response = client.get(
+        f"{reverse('complete_payment')}?session_id={high_id_session.session_id}"
+    )
+    assert response.status_code == 400
+
     # Legacy support: rows created before the token rollout were emailed with
     # ?session_id=<row_id>; honor that for ids below the cutoff so old emails
     # still work.

--- a/tests/async/test_non_professional_abandoned_cart.py
+++ b/tests/async/test_non_professional_abandoned_cart.py
@@ -56,13 +56,43 @@ def test_non_professional_abandoned_cart():
         assert "next_url" in response.json()
         assert response.json()["next_url"] == "https://checkout.stripe.com/test"
 
-    # Brute-forcing the row id must not work — only the secure_token grants access.
-    response = client.get(f"{reverse('complete_payment')}?session_id={lost_session.id}")
+    # Brute-forcing a post-rollout row id (>= the legacy cutoff) must not work —
+    # only the secure_token grants access for new sessions.
+    high_id_session = LostStripeSession(
+        pk=9999,
+        session_id="high_id_stripe_session",
+        payment_type="non_professional_item",
+        email=email,
+        metadata=metadata,
+    )
+    high_id_session.save()
+    response = client.get(
+        f"{reverse('complete_payment')}?session_id={high_id_session.pk}"
+    )
     assert response.status_code == 400
 
     # An unknown / forged token must be rejected.
     response = client.get(f"{reverse('complete_payment')}?token=not-a-real-token")
     assert response.status_code == 400
+
+    # Legacy support: rows created before the token rollout were emailed with
+    # ?session_id=<row_id>; honor that for ids below the cutoff so old emails
+    # still work.
+    legacy_session = LostStripeSession(
+        pk=42,
+        session_id="legacy_stripe_session",
+        payment_type="non_professional_item",
+        email=email,
+        metadata=metadata,
+    )
+    legacy_session.save()
+    with patch("stripe.checkout.Session.create") as mock_create:
+        mock_create.return_value.url = "https://checkout.stripe.com/legacy"
+        response = client.get(
+            f"{reverse('complete_payment')}?session_id={legacy_session.pk}"
+        )
+        assert response.status_code == 200
+        assert response.json()["next_url"] == "https://checkout.stripe.com/legacy"
 
     # Simulate Stripe webhook call to trigger the email
     stripe_event = {

--- a/tests/async/test_stripe_webhooks.py
+++ b/tests/async/test_stripe_webhooks.py
@@ -119,3 +119,29 @@ class StripeWebhookTests(TestCase):
 
         # Verify no additional session record was created
         self.assertEqual(LostStripeSession.objects.count(), 1)
+
+    @patch(
+        "fighthealthinsurance.helpers.stripe_helpers.fhi_emails.send_checkout_session_expired"
+    )
+    def test_checkout_session_expired_email_uses_absolute_link_and_token(
+        self, mock_send_email
+    ):
+        mock_session = MagicMock()
+        mock_session.id = "cs_unique_for_token_test"
+        mock_session.metadata = {
+            "payment_type": "non_professional_item",
+            "line_items": "[]",
+        }
+        mock_session.customer_email = "buyer@example.com"
+
+        StripeWebhookHelper.handle_checkout_session_expired(self.client, mock_session)
+
+        mock_send_email.assert_called_once()
+        link = mock_send_email.call_args.kwargs["link"]
+
+        lost_session = LostStripeSession.objects.get(session_id=mock_session.id)
+        # Link must be absolute and carry the unguessable token, never the row id.
+        self.assertTrue(link.startswith("https://www.fightpaperwork.com/"))
+        self.assertIn(f"token={lost_session.secure_token}", link)
+        self.assertNotIn(f"session_id={lost_session.id}", link)
+        self.assertNotIn(f"session_id={lost_session.pk}", link)

--- a/tests/async/test_stripe_webhooks.py
+++ b/tests/async/test_stripe_webhooks.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import patch, MagicMock
 
+from django.conf import settings
 from django.test import TestCase
 from django.urls import reverse
 from django.contrib.auth import get_user_model
@@ -140,8 +141,10 @@ class StripeWebhookTests(TestCase):
         link = mock_send_email.call_args.kwargs["link"]
 
         lost_session = LostStripeSession.objects.get(session_id=mock_session.id)
-        # Link must be absolute and carry the unguessable token, never the row id.
-        self.assertTrue(link.startswith("https://www.fightpaperwork.com/"))
+        # Link must be absolute, target the configured host (so non-prod
+        # environments don't email production links), and carry the
+        # unguessable token rather than the row id.
+        self.assertTrue(link.startswith(f"https://{settings.FIGHT_PAPERWORK_DOMAIN}/"))
         self.assertIn(f"token={lost_session.secure_token}", link)
         self.assertNotIn(f"session_id={lost_session.id}", link)
         self.assertNotIn(f"session_id={lost_session.pk}", link)


### PR DESCRIPTION
The checkout-session-expired email previously linked to /stripe/finish
with an auto-increment row id which shows how many abonded carts there are.
Switch the link to an absolute URL that carries a random secure_token stored on LostStripeSession; the recovery view now authorizes the request by token instead of by row id.

https://claude.ai/code/session_01CaguiqhsRz7xx4LpR16q5X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Abandoned-cart recovery links now use a secure, unique token and are generated as absolute URLs using the configured domain, improving security and preventing unauthorized access.
  * Requests without a valid token or legacy identifier now return a clear error.

* **Tests**
  * Added and updated tests validating token-based recovery links, absolute link generation, legacy access handling, and rejection of forged or invalid identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->