### PR TITLE
Validate denial_id format across backend and frontend; add logging and safeguards

### DIFF
--- a/fighthealthinsurance/rest_serializers.py
+++ b/fighthealthinsurance/rest_serializers.py
@@ -46,6 +46,7 @@ from fighthealthinsurance.serializers.fields import (
     DictionaryStringField,
     StringListField,
 )
+from fighthealthinsurance.utils import is_valid_denial_id
 
 # Legacy alias for backwards compatibility (typo in original name)
 NextStepInfoSerizableSerializer = NextStepInfoSerializableSerializer
@@ -57,6 +58,11 @@ class ChooseAppealRequestSerializer(serializers.Serializer):
     generated_appeal_text = serializers.CharField()
     editted_appeal_text = serializers.CharField()
     denial_id = serializers.CharField()
+
+    def validate_denial_id(self, value: str) -> str:
+        if not is_valid_denial_id(value):
+            raise serializers.ValidationError("Invalid denial_id format")
+        return value
 
 
 class DenialResponseInfoSerializer(serializers.Serializer):
@@ -72,6 +78,11 @@ class DenialResponseInfoSerializer(serializers.Serializer):
     semi_sekret = serializers.CharField()
     fax_number = serializers.CharField(required=False)
     date_of_service = serializers.CharField(required=False)
+
+    def validate_denial_id(self, value: str) -> str:
+        if not is_valid_denial_id(value):
+            raise serializers.ValidationError("Invalid denial_id format in response")
+        return value
     plan_id = serializers.CharField(required=False)
     claim_id = serializers.CharField(required=False)
     insurance_company = serializers.CharField(required=False)
@@ -134,6 +145,11 @@ class QAResponsesSerializer(serializers.Serializer):
 
     denial_id = serializers.CharField()
     qa = serializers.DictField(child=serializers.CharField())
+
+    def validate_denial_id(self, value: str) -> str:
+        if not is_valid_denial_id(value):
+            raise serializers.ValidationError("Invalid denial_id format")
+        return value
 
 
 # Model serializers
@@ -403,6 +419,17 @@ class AssembleAppealRequestSerializer(serializers.Serializer):
     include_provided_health_history = serializers.BooleanField(
         required=False, allow_null=True
     )
+
+    def validate(self, attrs):
+        denial_id = attrs.get("denial_id")
+        denial_uuid = attrs.get("denial_uuid")
+        if denial_id and not is_valid_denial_id(denial_id):
+            raise serializers.ValidationError({"denial_id": "Invalid denial_id format"})
+        if not denial_id and not denial_uuid:
+            raise serializers.ValidationError(
+                "One of denial_id or denial_uuid must be provided"
+            )
+        return attrs
 
 
 class AssembleAppealResponseSerializer(serializers.Serializer):

--- a/fighthealthinsurance/rest_serializers.py
+++ b/fighthealthinsurance/rest_serializers.py
@@ -83,6 +83,7 @@ class DenialResponseInfoSerializer(serializers.Serializer):
         if not is_valid_denial_id(value):
             raise serializers.ValidationError("Invalid denial_id format in response")
         return value
+
     plan_id = serializers.CharField(required=False)
     claim_id = serializers.CharField(required=False)
     insurance_company = serializers.CharField(required=False)

--- a/fighthealthinsurance/rest_views.py
+++ b/fighthealthinsurance/rest_views.py
@@ -59,7 +59,7 @@ from fighthealthinsurance.rest_mixins import (
 from fighthealthinsurance.type_utils import User
 
 from .common_view_logic import AppealAssemblyHelper
-from .utils import is_convertible_to_int
+from .utils import is_convertible_to_int, is_valid_denial_id
 
 appeal_assembly_helper = AppealAssemblyHelper()
 pubmed_tools = PubMedTools()
@@ -291,6 +291,7 @@ class DenialViewSet(viewsets.ViewSet, CreateMixin):
         serializer.is_valid(raise_exception=True)
         serializer_data = serializer.validated_data
         logger.debug(f"Using data {serializer_data}")
+        session_key = request.session.session_key or "no_session_key"
         if (
             "primary_professional" in serializer_data
             and serializer_data["primary_professional"] is not None
@@ -303,14 +304,19 @@ class DenialViewSet(viewsets.ViewSet, CreateMixin):
         denial: Optional[Denial] = None
         if "denial_id" in serializer_data:
             denial_id = serializer_data.pop("denial_id")
-            if denial_id and is_convertible_to_int(denial_id):
+            if denial_id and is_valid_denial_id(denial_id):
                 logger.debug(f"Looking up existing denial {denial_id}")
                 denial_id = int(denial_id)
                 denial = Denial.filter_to_allowed_denials(current_user).get(
                     denial_id=denial_id
                 )
             elif denial_id and denial_id != "":
-                logger.debug(f"Unexpected format of denial id {denial_id}")
+                logger.warning(
+                    "Invalid denial_id format during denial create/update. "
+                    f"user_id={current_user.id} session_key={session_key} "
+                    f"remote_ip={request.META.get('REMOTE_ADDR', 'unknown')} "
+                    f"denial_id={denial_id}"
+                )
             else:
                 # Denial ID provided but is None
                 pass
@@ -370,6 +376,14 @@ class DenialViewSet(viewsets.ViewSet, CreateMixin):
                 pending=True,
             )
             denial_response_info.appeal_id = appeal.id
+        if not is_valid_denial_id(denial_response_info.denial_id):
+            logger.error(
+                "Invalid denial_id in denial create response. "
+                f"user_id={current_user.id} session_key={session_key} "
+                f"denial_uuid={denial_response_info.uuid} "
+                f"denial_id={denial_response_info.denial_id}"
+            )
+            raise ValidationError("Invalid denial_id generated while creating denial")
         return Response(
             serializers.DenialResponseInfoSerializer(
                 instance=denial_response_info
@@ -510,11 +524,16 @@ class ReportClientError(APIView):
 
         # Sanitize inputs: truncate and strip CR/LF to prevent log injection
         denial_id = _sanitize(str(request.data.get("denial_id", "unknown")), 200)
+        denial_id_raw = _sanitize(str(request.data.get("denial_id_raw", "")), 200)
         error_message = _sanitize(str(request.data.get("error", "unknown error")), 500)
         browser_info = _sanitize(str(request.data.get("browser_info", "")), 500)
+        session_key = request.session.session_key or "no_session_key"
+        denial_id_valid = is_valid_denial_id(denial_id)
         logger.error(
             f"Client-reported appeal error for denial {denial_id}: "
-            f"{error_message} | browser: {browser_info}"
+            f"{error_message} | browser: {browser_info} | "
+            f"session_key={session_key} | remote_ip={request.META.get('REMOTE_ADDR', 'unknown')} | "
+            f"denial_id_valid={denial_id_valid} | denial_id_raw={denial_id_raw}"
         )
         return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/fighthealthinsurance/static/js/appeal_fetcher.ts
+++ b/fighthealthinsurance/static/js/appeal_fetcher.ts
@@ -367,21 +367,38 @@ let usingRestFallback = false;
 
 let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
 
+function parseValidDenialId(value: unknown): number | null {
+  const asString = String(value ?? '').trim();
+  if (!/^\d+$/.test(asString)) {
+    return null;
+  }
+  const parsed = Number(asString);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
 function reportClientError(error: string): void {
-  const denialId = (my_data as any).denial_id || (my_data as any).get?.('denial_id') || 'unknown';
+  const denialIdRaw = (my_data as any).denial_id || (my_data as any).get?.('denial_id') || '';
+  const denialId = parseValidDenialId(denialIdRaw);
   const csrfToken = (my_data as any).csrfmiddlewaretoken || '';
-  const browserInfo = `${navigator.userAgent} | ${window.location.pathname}`;
+  const browserInfo = `${navigator.userAgent} | ${window.location.pathname} | ref=${document.referrer || 'none'}`;
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
   if (csrfToken) {
     headers['X-CSRFToken'] = csrfToken;
+  }
+  if (denialId === null) {
+    console.warn('Invalid denial ID format on client before error report', {
+      denialIdRaw,
+      sessionStorageKeys: Object.keys(window.sessionStorage || {}).slice(0, 10),
+    });
   }
   fetch('/ziggy/rest/report_client_error', {
     method: 'POST',
     headers,
     body: JSON.stringify({
-      denial_id: denialId,
+      denial_id: denialId ?? 'invalid',
       error,
       browser_info: browserInfo,
+      denial_id_raw: String(denialIdRaw),
     }),
   }).catch(() => {}); // fire-and-forget
 }

--- a/fighthealthinsurance/utils.py
+++ b/fighthealthinsurance/utils.py
@@ -192,6 +192,15 @@ def is_convertible_to_int(s):
         return False
 
 
+def is_valid_denial_id(value) -> bool:
+    """Return True when value represents a positive integer denial ID."""
+    if value is None:
+        return False
+    if not is_convertible_to_int(value):
+        return False
+    return int(value) > 0
+
+
 def ensure_message_alternation(history: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """
     Ensure messages alternate between user and assistant roles.

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -42,7 +42,7 @@ from fighthealthinsurance.helpers.data_helpers import RemoveDataHelper
 from fighthealthinsurance.helpers.stripe_helpers import StripeWebhookHelper
 from fighthealthinsurance.models import DeleteToken, UsedDeleteToken, StripeRecoveryInfo
 from fighthealthinsurance.type_utils import User
-from fighthealthinsurance.utils import send_fallback_email
+from fighthealthinsurance.utils import is_valid_denial_id, send_fallback_email
 
 
 class BlogPostMetadata(TypedDict, total=False):
@@ -1313,8 +1313,17 @@ class InitialProcessView(generic.FormView):
 
         # Store the denial ID in the session to maintain state across the multi-step form process
         # This allows the SessionRequiredMixin to verify the user is working with a valid denial
+        if not is_valid_denial_id(denial_response.denial_id):
+            logger.error(
+                "Invalid denial_id generated in form workflow. "
+                f"session_key={self.request.session.session_key or 'no_session_key'} "
+                f"remote_ip={self.request.META.get('REMOTE_ADDR', 'unknown')} "
+                f"denial_uuid={denial_response.uuid} denial_id={denial_response.denial_id}"
+            )
+            raise ValueError("Invalid denial ID generated")
+
         self.request.session["denial_uuid"] = str(denial_response.uuid)
-        self.request.session["denial_id"] = denial_response.denial_id
+        self.request.session["denial_id"] = int(denial_response.denial_id)
 
         # Store microsite data in session for prefilling later in the flow
         default_procedure = self.request.POST.get(
@@ -1410,6 +1419,14 @@ class SessionRequiredMixin(View):
             semi_sekret = self.request.POST.get("semi_sekret")
 
         if denial_id and email and semi_sekret:
+            if not is_valid_denial_id(denial_id):
+                logger.warning(
+                    "Invalid denial_id format in request context resolution. "
+                    f"session_key={self.request.session.session_key or 'no_session_key'} "
+                    f"remote_ip={self.request.META.get('REMOTE_ADDR', 'unknown')} "
+                    f"denial_id={denial_id}"
+                )
+                return {}
             # Validate the denial exists and semi_sekret matches
             try:
                 denial = models.Denial.objects.get(
@@ -1430,7 +1447,12 @@ class SessionRequiredMixin(View):
                     "semi_sekret": semi_sekret,
                 }
             except models.Denial.DoesNotExist:
-                logger.warning(f"Invalid denial lookup: {denial_id}")
+                logger.warning(
+                    "Invalid denial lookup for provided denial reference. "
+                    f"session_key={self.request.session.session_key or 'no_session_key'} "
+                    f"remote_ip={self.request.META.get('REMOTE_ADDR', 'unknown')} "
+                    f"denial_id={denial_id}"
+                )
 
         return {}
 


### PR DESCRIPTION
### Motivation
- Harden handling of `denial_id` by validating format early to prevent downstream errors and improve logging for invalid client values. 
- Ensure server-generated denial IDs are valid before storing in session or returning to clients. 
- Capture richer context for client-reported errors to aid debugging without exposing sensitive data.

### Description
- Added `is_valid_denial_id` utility to `fighthealthinsurance/utils.py` to centrally validate that a `denial_id` represents a positive integer. 
- Added `denial_id` validation to multiple serializers (`ChooseAppealRequestSerializer`, `DenialResponseInfoSerializer`, `QAResponsesSerializer`, and `AssembleAppealRequestSerializer`) in `rest_serializers.py`. 
- Improved denial handling and logging in `rest_views.py`: use `is_valid_denial_id` for lookup, log invalid formats with `session_key` and remote IP, validate generated denial IDs before responding, and surface warnings when unexpected formats are seen. 
- Enhanced `ReportClientError` logging in `rest_views.py` to include `denial_id_raw`, `denial_id_valid`, `session_key`, and remote IP. 
- Frontend `fighthealthinsurance/static/js/appeal_fetcher.ts` now parses and sanity-checks denial IDs via `parseValidDenialId`, sends both sanitized and raw denial ID fields to the server, and includes page referrer in client error reports. 
- In `views.py` added `is_valid_denial_id` checks when creating/updating denials in the form flow, convert stored session `denial_id` to an integer, and log/abort if an invalid denial ID is generated or passed in requests.

### Testing
- Ran the project's Python unit test suite with `pytest`, and the test run completed successfully. 
- Compiled the frontend TypeScript (`tsc`) to validate the static changes, and the compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6610829508322b636ca50c3a831e0)