### PR TITLE
Add SMTP Domain FAQ page, view, URL, and template link

### DIFF
--- a/fighthealthinsurance/static/faq/smtp-domain-snowjob.md
+++ b/fighthealthinsurance/static/faq/smtp-domain-snowjob.md
@@ -1,0 +1,37 @@
+title: "I got a weird email from FightHealthInsurance.com. What's up?"
+slug: "smtp-domain-snowjob"
+excerpt: "What to do if you receive a suspicious or weird email that looks like it came from FightHealthInsurance.com."
+author: "Fight Health Insurance Team"
+publishedAt: "2026-05-02"
+description: "FAQ for users who receive suspicious emails that appear to come from FightHealthInsurance.com."
+tags: ["email", "phishing", "security", "faq"]
+---
+
+## I got a weird email from FightHealthInsurance.com. What's going on?
+
+Sometimes bad actors spoof or imitate real domains to send scammy or misleading messages. If something looked off, you're not imagining it.
+
+## What should I do right now?
+
+1. **Do not click links or open attachments** in that message.
+2. **Forward the email to us** so we can investigate: `support42@fighthealthinsurance.com`
+3. If possible, **forward it as an attachment** so we can inspect full headers.
+
+## What happens after I forward it?
+
+We'll review the message details and, when appropriate, report abuse to the sender's hosting provider or ISP. In our experience, some providers act quickly, and others unfortunately do very little.
+
+## How can I tell if an email is legit?
+
+- Check the sender address carefully (not just the display name).
+- Watch for pressure tactics ("urgent action required").
+- Be suspicious of login/payment links you didn't request.
+- When in doubt, contact us directly instead of replying to the message.
+
+## Did your systems get hacked?
+
+Not necessarily. Spoofed messages can be sent without direct access to our internal systems. We still treat every report seriously and investigate patterns across reports.
+
+## Want to learn more about spam and scam operations?
+
+If you're curious how large-scale spam ecosystems work, this book is a good background read: [Spam Nation](https://amzn.to/4usRco7).

--- a/fighthealthinsurance/templates/faq.html
+++ b/fighthealthinsurance/templates/faq.html
@@ -39,6 +39,9 @@ Frequently asked questions (FAQ)
             <form action="{% url 'medicaid-faq' %}" method="get" style="display:inline;">
             <button type="submit" class="fhi-btn">Medicaid FAQ</button>
             </form>
+            <form action="{% url 'smtp-domain-faq' %}" method="get" style="display:inline;">
+            <button type="submit" class="fhi-btn">SMTP Domain FAQ</button>
+            </form>
       </div>
       
       <!-- General FAQ Content -->

--- a/fighthealthinsurance/urls.py
+++ b/fighthealthinsurance/urls.py
@@ -265,6 +265,13 @@ urlpatterns: List[Union[URLPattern, URLResolver]] = [
         name="medicaid-faq",
     ),
     path(
+        "faq/smtp-domain/",
+        cache_control(public=True)(
+            cache_page(60 * 60 * 2)(views.SMTPDomainFAQView.as_view())
+        ),
+        name="smtp-domain-faq",
+    ),
+    path(
         "denial-language/",
         cache_control(public=True)(
             cache_page(60 * 60 * 2)(views.DenialLanguageLibraryView.as_view())

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -582,6 +582,39 @@ class MedicaidFAQView(generic.TemplateView):
         return context
 
 
+class SMTPDomainFAQView(generic.TemplateView):
+    """FAQ page about SMTP domain impersonation claims."""
+
+    template_name = "faq_post.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        slug = "smtp-domain-snowjob"
+
+        # Validate slug and load FAQ content from static file
+        if not re.match(r"^[a-zA-Z0-9_-]+$", slug):
+            logger.warning(f"Invalid slug format: {slug}")
+            context.update({"slug": slug, "faq_title": None, "faq_excerpt": None})
+            return context
+
+        try:
+            # Securely find the path to the FAQ markdown file.
+            staticfiles_storage.path(f"faq/{slug}.md")
+            context.update(
+                {
+                    "title": "SMTP Domain Snowjob FAQ",
+                    "slug": slug,
+                    "faq_title": "SMTP Domain Snowjob FAQ",
+                    "faq_excerpt": "What to do when someone makes false or misleading claims about your SMTP sending domain.",
+                }
+            )
+        except Exception:
+            logger.warning(f"FAQ markdown file not found for slug: {slug}")
+            context.update({"slug": slug, "faq_title": None, "faq_excerpt": None})
+
+        return context
+
+
 class ShareDenialView(View):
     """View for sharing denial information."""
 


### PR DESCRIPTION
### Motivation

- Provide guidance for users who receive suspicious emails impersonating FightHealthInsurance domains and give a way to report them.

### Description

- Added a new FAQ markdown file `fighthealthinsurance/static/faq/smtp-domain-snowjob.md` containing guidance on spoofed emails, reporting to `support42@fighthealthinsurance.com`, and how to verify messages. 
- Added a new `SMTPDomainFAQView` in `fighthealthinsurance/views.py` that serves the `smtp-domain-snowjob` slug and populates the FAQ context similarly to the existing FAQ views. 
- Registered a new route `faq/smtp-domain/` in `fighthealthinsurance/urls.py` with the existing `cache_page` and `cache_control` wrappers and the name `smtp-domain-faq`.
- Exposed the new FAQ from the FAQ index by adding a button/form to `fighthealthinsurance/templates/faq.html` that links to the `smtp-domain-faq` endpoint.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f66193e3508322be83fbb9fd133627)