### PR TITLE
Add DomainRedirectMiddleware for alternate domain handling

### DIFF
--- a/fighthealthinsurance/middleware/DomainRedirectMiddleware.py
+++ b/fighthealthinsurance/middleware/DomainRedirectMiddleware.py
@@ -1,0 +1,29 @@
+from typing import Callable
+
+from django.conf import settings
+from django.http import HttpRequest, HttpResponse, HttpResponsePermanentRedirect
+
+
+class DomainRedirectMiddleware:
+    """
+    Permanent-redirects requests served on alternate domains to a canonical host.
+
+    The map is configured via settings.DOMAIN_REDIRECTS as {alt_host: canonical_host}.
+    Hostnames are matched case-insensitively and ignore the port.
+    """
+
+    def __init__(self, get_response: Callable[[HttpRequest], HttpResponse]) -> None:
+        self.get_response = get_response
+        self.redirects = {
+            k.lower(): v for k, v in getattr(settings, "DOMAIN_REDIRECTS", {}).items()
+        }
+
+    def __call__(self, request: HttpRequest) -> HttpResponse:
+        if self.redirects:
+            host = request.get_host().split(":")[0].lower()
+            target = self.redirects.get(host)
+            if target:
+                return HttpResponsePermanentRedirect(
+                    f"https://{target}{request.get_full_path()}"
+                )
+        return self.get_response(request)

--- a/fighthealthinsurance/middleware/DomainRedirectMiddleware.py
+++ b/fighthealthinsurance/middleware/DomainRedirectMiddleware.py
@@ -2,6 +2,13 @@ from typing import Callable
 
 from django.conf import settings
 from django.http import HttpRequest, HttpResponse, HttpResponsePermanentRedirect
+from django.http.response import HttpResponseRedirectBase
+
+
+class HttpResponsePermanentRedirectKeepMethod(HttpResponseRedirectBase):
+    """308 Permanent Redirect: tells clients to preserve method and body."""
+
+    status_code = 308
 
 
 class DomainRedirectMiddleware:
@@ -9,8 +16,11 @@ class DomainRedirectMiddleware:
     Permanent-redirects requests served on alternate domains to a canonical host.
 
     The map is configured via settings.DOMAIN_REDIRECTS as {alt_host: canonical_host}.
-    Hostnames are matched case-insensitively and ignore the port.
+    Hostnames are matched case-insensitively and ignore the port. GET/HEAD use 301
+    (better understood by crawlers); other methods use 308 so the body is preserved.
     """
+
+    _SAFE_METHODS = frozenset({"GET", "HEAD"})
 
     def __init__(self, get_response: Callable[[HttpRequest], HttpResponse]) -> None:
         self.get_response = get_response
@@ -23,7 +33,8 @@ class DomainRedirectMiddleware:
             host = request.get_host().split(":")[0].lower()
             target = self.redirects.get(host)
             if target:
-                return HttpResponsePermanentRedirect(
-                    f"https://{target}{request.get_full_path()}"
-                )
+                location = f"https://{target}{request.get_full_path()}"
+                if request.method in self._SAFE_METHODS:
+                    return HttpResponsePermanentRedirect(location)
+                return HttpResponsePermanentRedirectKeepMethod(location)
         return self.get_response(request)

--- a/fighthealthinsurance/middleware/__init__.py
+++ b/fighthealthinsurance/middleware/__init__.py
@@ -1,9 +1,11 @@
 from .AuditMiddleware import AuditMiddleware
 from .CsrfCookieToHeaderMiddleware import CsrfCookieToHeaderMiddleware
+from .DomainRedirectMiddleware import DomainRedirectMiddleware
 from .SessionMiddlewareDynamicDomain import SessionMiddlewareDynamicDomain
 
 __all__ = [
     "CsrfCookieToHeaderMiddleware",
+    "DomainRedirectMiddleware",
     "SessionMiddlewareDynamicDomain",
     "AuditMiddleware",
 ]

--- a/fighthealthinsurance/settings.py
+++ b/fighthealthinsurance/settings.py
@@ -110,6 +110,10 @@ class Base(Configuration):
     ALLOWED_HOSTS: list[str] = ["*"]
     USE_X_FORWARDED_HOST = True
 
+    # Map of alternate hosts to canonical hosts; matching requests are
+    # permanent-redirected by DomainRedirectMiddleware.
+    DOMAIN_REDIRECTS: dict[str, str] = {}
+
     SENTRY_ENDPOINT = os.getenv("SENTRY_ENDPOINT")
     # Application definition
 
@@ -180,6 +184,7 @@ class Base(Configuration):
     )
 
     MIDDLEWARE = [
+        "fighthealthinsurance.middleware.DomainRedirectMiddleware",
         "fighthealthinsurance.middleware.CsrfCookieToHeaderMiddleware",
         "corsheaders.middleware.CorsMiddleware",
         "django_prometheus.middleware.PrometheusBeforeMiddleware",
@@ -613,7 +618,14 @@ class Prod(Base):
         "www.fightpaperwork.com",
         "api.fightpaperwork.com",
         "staging.fighthealthinsurance.com",
+        "fuckhealthinsurance.com",
+        "www.fuckhealthinsurance.com",
     ]
+
+    DOMAIN_REDIRECTS = {
+        "fuckhealthinsurance.com": "www.fighthealthinsurance.com",
+        "www.fuckhealthinsurance.com": "www.fighthealthinsurance.com",
+    }
 
     # HSTS - tell browsers to always use HTTPS
     SECURE_HSTS_SECONDS = 31536000  # 1 year

--- a/fighthealthinsurance/settings.py
+++ b/fighthealthinsurance/settings.py
@@ -620,11 +620,15 @@ class Prod(Base):
         "staging.fighthealthinsurance.com",
         "fuckhealthinsurance.com",
         "www.fuckhealthinsurance.com",
+        "fightinsurance.ai",
+        "www.fightinsurance.ai",
     ]
 
     DOMAIN_REDIRECTS = {
         "fuckhealthinsurance.com": "www.fighthealthinsurance.com",
         "www.fuckhealthinsurance.com": "www.fighthealthinsurance.com",
+        "fightinsurance.ai": "www.fighthealthinsurance.com",
+        "www.fightinsurance.ai": "www.fighthealthinsurance.com",
     }
 
     # HSTS - tell browsers to always use HTTPS

--- a/k8s/deploy.yaml
+++ b/k8s/deploy.yaml
@@ -203,6 +203,8 @@ spec:
       - www.fuckhealthinsurance.com
       - www.appealhealthinsurance.com
       - api.fightpaperwork.com
+      - www.fightinsurance.ai
+      - fightinsurance.ai
     secretName: combined-tls-secret
   rules:
     - host: www.fuckhealthinsurance.com
@@ -266,6 +268,26 @@ spec:
                 port:
                   number: 80
     - host: fighthealthinsurance.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name:  web-svc
+                port:
+                  number: 80
+    - host: www.fightinsurance.ai
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name:  web-svc
+                port:
+                  number: 80
+    - host: fightinsurance.ai
       http:
         paths:
           - path: /

--- a/tests/sync/test_domain_redirect_middleware.py
+++ b/tests/sync/test_domain_redirect_middleware.py
@@ -68,3 +68,17 @@ class DomainRedirectMiddlewareTest(TestCase):
         response = middleware(request)
         self.assertEqual(response.status_code, 301)
         self.assertEqual(response["Location"], "https://www.fighthealthinsurance.com/")
+
+    @override_settings(
+        DOMAIN_REDIRECTS={"fuckhealthinsurance.com": "www.fighthealthinsurance.com"}
+    )
+    def test_post_uses_method_preserving_redirect(self):
+        middleware = DomainRedirectMiddleware(_ok)
+        request = self.factory.post(
+            "/submit", data={"a": "b"}, HTTP_HOST="fuckhealthinsurance.com"
+        )
+        response = middleware(request)
+        self.assertEqual(response.status_code, 308)
+        self.assertEqual(
+            response["Location"], "https://www.fighthealthinsurance.com/submit"
+        )

--- a/tests/sync/test_domain_redirect_middleware.py
+++ b/tests/sync/test_domain_redirect_middleware.py
@@ -1,0 +1,70 @@
+"""Tests for DomainRedirectMiddleware."""
+
+from django.http import HttpResponse
+from django.test import RequestFactory, TestCase, override_settings
+
+from fighthealthinsurance.middleware import DomainRedirectMiddleware
+
+
+def _ok(_request):
+    return HttpResponse("ok")
+
+
+class DomainRedirectMiddlewareTest(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    @override_settings(
+        DOMAIN_REDIRECTS={
+            "fuckhealthinsurance.com": "www.fighthealthinsurance.com",
+            "www.fuckhealthinsurance.com": "www.fighthealthinsurance.com",
+        }
+    )
+    def test_redirects_alt_host_to_canonical_host(self):
+        middleware = DomainRedirectMiddleware(_ok)
+        request = self.factory.get(
+            "/some/path?x=1", HTTP_HOST="fuckhealthinsurance.com"
+        )
+        response = middleware(request)
+        self.assertEqual(response.status_code, 301)
+        self.assertEqual(
+            response["Location"],
+            "https://www.fighthealthinsurance.com/some/path?x=1",
+        )
+
+    @override_settings(
+        DOMAIN_REDIRECTS={"www.fuckhealthinsurance.com": "www.fighthealthinsurance.com"}
+    )
+    def test_redirect_is_case_insensitive(self):
+        middleware = DomainRedirectMiddleware(_ok)
+        request = self.factory.get("/", HTTP_HOST="WWW.FuckHealthInsurance.COM")
+        response = middleware(request)
+        self.assertEqual(response.status_code, 301)
+        self.assertEqual(response["Location"], "https://www.fighthealthinsurance.com/")
+
+    @override_settings(
+        DOMAIN_REDIRECTS={"fuckhealthinsurance.com": "www.fighthealthinsurance.com"}
+    )
+    def test_canonical_host_is_passed_through(self):
+        middleware = DomainRedirectMiddleware(_ok)
+        request = self.factory.get("/", HTTP_HOST="www.fighthealthinsurance.com")
+        response = middleware(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b"ok")
+
+    @override_settings(DOMAIN_REDIRECTS={})
+    def test_empty_map_is_noop(self):
+        middleware = DomainRedirectMiddleware(_ok)
+        request = self.factory.get("/", HTTP_HOST="fuckhealthinsurance.com")
+        response = middleware(request)
+        self.assertEqual(response.status_code, 200)
+
+    @override_settings(
+        DOMAIN_REDIRECTS={"fuckhealthinsurance.com": "www.fighthealthinsurance.com"}
+    )
+    def test_host_with_port_is_matched(self):
+        middleware = DomainRedirectMiddleware(_ok)
+        request = self.factory.get("/", HTTP_HOST="fuckhealthinsurance.com:8080")
+        response = middleware(request)
+        self.assertEqual(response.status_code, 301)
+        self.assertEqual(response["Location"], "https://www.fighthealthinsurance.com/")


### PR DESCRIPTION
## Summary
Implements a new middleware to permanently redirect requests from alternate domains to a canonical host. This allows the application to handle multiple domain names while maintaining a single canonical domain for SEO and user consistency.

## Key Changes
- **New DomainRedirectMiddleware**: Middleware that performs permanent (301) redirects from alternate domains to a canonical host
  - Configured via `DOMAIN_REDIRECTS` setting as a mapping of alternate hosts to canonical hosts
  - Handles case-insensitive hostname matching and strips port numbers from the comparison
  - Preserves the original request path and query string in the redirect
  
- **Settings configuration**: Added `DOMAIN_REDIRECTS` setting to base configuration with production-specific mappings
  - Redirects `fuckhealthinsurance.com` and `www.fuckhealthinsurance.com` to `www.fighthealthinsurance.com`
  - Added alternate domains to `ALLOWED_HOSTS` for production environment

- **Middleware registration**: Registered `DomainRedirectMiddleware` as the first middleware in the stack to intercept domain redirects before other processing

- **Comprehensive test coverage**: Added full test suite covering:
  - Basic redirect functionality with path and query string preservation
  - Case-insensitive hostname matching
  - Canonical host passthrough (no redirect)
  - Empty redirect map handling
  - Port number handling in hostnames

## Implementation Details
- Middleware uses `HttpResponsePermanentRedirect` (301 status) for SEO-friendly redirects
- Hostnames are normalized to lowercase during initialization for efficient lookup
- Port numbers are stripped from the host header during matching but not included in the redirect target
- Redirects always use HTTPS protocol in the target URL

https://claude.ai/code/session_01DuWKPTcmDG7j53ZdZ514yU