### PR TITLE
Add pro signups analytics dashboard and charts

### DIFF
--- a/charts/templates/pro_signups_dashboard.html
+++ b/charts/templates/pro_signups_dashboard.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Pro Signups Dashboard</title>
+    <link rel="stylesheet"
+          href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    <style>
+      body { padding: 20px; }
+      .summary { margin-bottom: 30px; }
+      .summary dt { display: inline-block; min-width: 280px; }
+      .summary dd { display: inline; margin-left: 0; }
+      .chart-list li { margin-bottom: 6px; }
+    </style>
+  </head>
+  <body>
+    <h1>Pro Signups Dashboard</h1>
+    <p>Analytics for users who signed up as interested in the pro version.</p>
+
+    <div class="summary">
+      <h2>Summary</h2>
+      <dl>
+        <dt>Total signups (rows):</dt><dd>{{ total }}</dd><br>
+        <dt>Unique emails:</dt><dd>{{ unique_emails }}</dd><br>
+        <dt>Clicked for paid:</dt><dd>{{ clicked_for_paid_count }}</dd><br>
+        <dt>Paid:</dt><dd>{{ paid_count }}</dd>
+      </dl>
+    </div>
+
+    <h2>Charts</h2>
+    <ul class="chart-list">
+      <li><a href="{% url 'charts:signups_by_day' %}">Signups by day (paid vs unpaid)</a></li>
+      <li><a href="{% url 'charts:pro_signups_cumulative' %}">Cumulative signups over time</a></li>
+      <li><a href="{% url 'charts:pro_signups_by_provider_type' %}">Signups by provider type</a></li>
+      <li><a href="{% url 'charts:pro_signups_by_denial_type' %}">Signups by most-common denial</a></li>
+    </ul>
+
+    <h2>Tables</h2>
+    <ul class="chart-list">
+      <li><a href="{% url 'charts:sf_signups' %}">San Francisco Bay Area signups</a></li>
+    </ul>
+
+    <h2>Exports</h2>
+    <ul class="chart-list">
+      <li><a href="{% url 'charts:pro_signups_csv' %}">All pro signups (CSV)</a></li>
+      <li><a href="{% url 'charts:pro_signups_csv_single_lines' %}">All pro signups, deduped by email (CSV)</a></li>
+    </ul>
+  </body>
+</html>

--- a/charts/urls.py
+++ b/charts/urls.py
@@ -8,6 +8,10 @@ from .views import (
     sf_signups,
     pro_signups_csv,
     pro_signups_csv_single_lines,
+    pro_signups_cumulative,
+    pro_signups_by_provider_type,
+    pro_signups_by_denial_type,
+    pro_signups_dashboard,
     OlderThanTwoWeeksEmailsCSV,
     LastTwoWeeksEmailsCSV,
     AllDenialEmailSansProCSV,
@@ -91,5 +95,25 @@ urlpatterns = [
         "procedures_denied_chart",
         procedures_denied_chart,
         name="procedures_denied_chart",
+    ),
+    path(
+        "pro_signups_cumulative",
+        pro_signups_cumulative,
+        name="pro_signups_cumulative",
+    ),
+    path(
+        "pro_signups_by_provider_type",
+        pro_signups_by_provider_type,
+        name="pro_signups_by_provider_type",
+    ),
+    path(
+        "pro_signups_by_denial_type",
+        pro_signups_by_denial_type,
+        name="pro_signups_by_denial_type",
+    ),
+    path(
+        "pro_signups_dashboard",
+        pro_signups_dashboard,
+        name="pro_signups_dashboard",
     ),
 ]

--- a/charts/views.py
+++ b/charts/views.py
@@ -78,6 +78,13 @@ def _get_verified_or_raw(denial, field):
     return getattr(denial, f"verified_{field}") or getattr(denial, field)
 
 
+def _interested_professionals_excluding_test_emails():
+    """Return base InterestedProfessional queryset with test emails excluded."""
+    return InterestedProfessional.objects.exclude(
+        Q(email="farts@farts.com") | Q(email="holden@pigscanfly.ca")
+    )
+
+
 def _make_jsonl_export_view(generator_func, filename):
     """Create a staff-only, export-gated streaming JSONL view."""
 
@@ -469,9 +476,7 @@ def generate_chat_lines():
 @staff_member_required
 def pro_signups_csv(request):
     interested_professionals_qs = (
-        InterestedProfessional.objects.exclude(
-            Q(email="farts@farts.com") | Q(email="holden@pigscanfly.ca")
-        )
+        _interested_professionals_excluding_test_emails()
         .values(
             "email",
             "name",
@@ -508,9 +513,7 @@ def pro_signups_csv(request):
 @staff_member_required
 def pro_signups_csv_single_lines(request):
     interested_professionals_qs = (
-        InterestedProfessional.objects.exclude(
-            Q(email="farts@farts.com") | Q(email="holden@pigscanfly.ca")
-        )
+        _interested_professionals_excluding_test_emails()
         .values(
             "email",
             "name",
@@ -565,9 +568,7 @@ def signups_by_day(request):
     # Query to count unique email signups per day, separated by paid status
     try:
         signups_per_day = (
-            InterestedProfessional.objects.exclude(
-                Q(email="farts@farts.com") | Q(email="holden@pigscanfly.ca")
-            )
+            _interested_professionals_excluding_test_emails()
             .distinct("email")
             .order_by("signup_date")
             .values("signup_date", "clicked_for_paid")
@@ -577,9 +578,7 @@ def signups_by_day(request):
         df = pd.DataFrame(list(signups_per_day))
     except NotSupportedError:
         signups_per_day = (
-            InterestedProfessional.objects.exclude(
-                Q(email="farts@farts.com") | Q(email="holden@pigscanfly.ca")
-            )
+            _interested_professionals_excluding_test_emails()
             .order_by("signup_date")
             .values("signup_date", "clicked_for_paid")
             .annotate(count=Count("email", distinct=True))
@@ -658,9 +657,7 @@ def signups_by_day(request):
 @staff_member_required
 def sf_signups(request):
     pro_signups = (
-        InterestedProfessional.objects.exclude(
-            Q(email="farts@farts.com") | Q(email="holden@pigscanfly.ca")
-        )
+        _interested_professionals_excluding_test_emails()
         .filter(
             Q(address__icontains="San Francisco")
             | Q(address__icontains="Daly City")
@@ -943,5 +940,247 @@ def procedures_denied_chart(request):
             "df_html": df_html,
             "totals_html": totals_html,
             "title": "Denied Procedures Analysis",
+        },
+    )
+
+
+def _render_pro_category_chart(request, *, field, title, axis_label, color, top_n=15):
+    """Render a bar chart of InterestedProfessional counts grouped by `field`.
+
+    Normalizes the value (lowercase + collapsed whitespace) and aggregates the
+    long tail beyond `top_n` into an "Other" bucket.
+    """
+    base_qs = _interested_professionals_excluding_test_emails().order_by(
+        "email", "signup_date"
+    )
+    try:
+        raw_pairs = list(base_qs.distinct("email").values_list("email", field))
+    except NotSupportedError:
+        # Fall back for SQLite (e.g. in tests): dedupe by email in Python,
+        # keeping the earliest row per email per the order_by above.
+        seen: set[str] = set()
+        raw_pairs = []
+        for email, value in base_qs.values_list("email", field):
+            if email in seen:
+                continue
+            seen.add(email)
+            raw_pairs.append((email, value))
+
+    counts: dict[str, int] = {}
+    for _, value in raw_pairs:
+        if not value:
+            normalized = "(not specified)"
+        else:
+            normalized = " ".join(value.lower().split())
+        counts[normalized] = counts.get(normalized, 0) + 1
+
+    df = pd.DataFrame(
+        {field: list(counts.keys()), "count": list(counts.values())}
+    ).sort_values("count", ascending=False)
+
+    if df.empty:
+        return HttpResponse("No pro signup data available.", content_type="text/plain")
+
+    if len(df) > top_n:
+        top_df = df.iloc[:top_n].copy()
+        other_count = df.iloc[top_n:]["count"].sum()
+        chart_df = pd.concat(
+            [top_df, pd.DataFrame({field: ["Other"], "count": [other_count]})]
+        )
+    else:
+        chart_df = df
+
+    p = figure(
+        title=title,
+        x_range=chart_df[field].tolist(),
+        height=500,
+        width=900,
+        toolbar_location="right",
+        tools="hover,pan,box_zoom,reset,save",
+        tooltips=[(axis_label, f"@{field}"), ("Count", "@count")],
+    )
+    source = ColumnDataSource(chart_df)
+    p.vbar(
+        x=field,
+        top="count",
+        width=0.8,
+        source=source,
+        color=color,
+        line_color="white",
+    )
+    p.xaxis.major_label_orientation = 3.14 / 4
+    p.xgrid.grid_line_color = None
+    p.y_range.start = 0
+    p.xaxis.axis_label = axis_label
+    p.yaxis.axis_label = "Number of Signups"
+
+    script, div = components(p)
+    df_html = df.to_html(classes=["table", "table-striped", "table-hover"], index=False)
+    total_signups = int(df["count"].sum())
+    total_unique = len(df)
+    totals_html = (
+        f"<p>Total unique pro signups: {total_signups}</p>"
+        f"<p>Distinct {axis_label.lower()} values: {total_unique}</p>"
+    )
+
+    return render(
+        request,
+        "bokeh.html",
+        {
+            "script": script,
+            "div": div,
+            "df_html": df_html,
+            "totals_html": totals_html,
+            "title": title,
+        },
+    )
+
+
+@staff_member_required
+def pro_signups_cumulative(request):
+    """Cumulative growth of unique InterestedProfessional signups over time."""
+    try:
+        signups_per_day = (
+            _interested_professionals_excluding_test_emails()
+            .distinct("email")
+            .order_by("signup_date")
+            .values("signup_date", "clicked_for_paid")
+            .annotate(count=Count("email"))
+        )
+        df = pd.DataFrame(list(signups_per_day))
+    except NotSupportedError:
+        signups_per_day = (
+            _interested_professionals_excluding_test_emails()
+            .order_by("signup_date")
+            .values("signup_date", "clicked_for_paid")
+            .annotate(count=Count("email", distinct=True))
+        )
+        df = pd.DataFrame(list(signups_per_day))
+
+    if df.empty or "signup_date" not in df.columns:
+        return HttpResponse("No signup data available.", content_type="text/plain")
+
+    df["signup_date"] = pd.to_datetime(df["signup_date"])
+    df_pivot = (
+        df.pivot_table(
+            index="signup_date",
+            columns="clicked_for_paid",
+            values="count",
+            aggfunc="sum",
+        )
+        .fillna(0)
+        .rename(columns={True: "Paid", False: "Unpaid"})
+    )
+    for col in ["Paid", "Unpaid"]:
+        if col not in df_pivot.columns:
+            df_pivot[col] = 0
+
+    df_pivot = df_pivot.sort_index()
+    df_pivot["Total"] = df_pivot["Paid"] + df_pivot["Unpaid"]
+    df_pivot["Cumulative Paid"] = df_pivot["Paid"].cumsum()
+    df_pivot["Cumulative Unpaid"] = df_pivot["Unpaid"].cumsum()
+    df_pivot["Cumulative Total"] = df_pivot["Total"].cumsum()
+
+    source = ColumnDataSource(df_pivot)
+    p = figure(
+        title="Cumulative Pro Signups",
+        x_axis_type="datetime",
+        height=500,
+        width=900,
+        tools="hover,pan,box_zoom,reset,save",
+        tooltips=[
+            ("Date", "@signup_date{%F}"),
+            ("Cumulative Total", "@{Cumulative Total}"),
+            ("Cumulative Paid", "@{Cumulative Paid}"),
+            ("Cumulative Unpaid", "@{Cumulative Unpaid}"),
+        ],
+    )
+    p.hover.formatters = {"@signup_date": "datetime"}
+    p.line(
+        x="signup_date",
+        y="Cumulative Total",
+        source=source,
+        color="navy",
+        line_width=2,
+        legend_label="Total",
+    )
+    p.line(
+        x="signup_date",
+        y="Cumulative Paid",
+        source=source,
+        color="green",
+        line_width=2,
+        legend_label="Paid",
+    )
+    p.line(
+        x="signup_date",
+        y="Cumulative Unpaid",
+        source=source,
+        color="red",
+        line_width=2,
+        legend_label="Unpaid",
+    )
+    p.legend.location = "top_left"
+    p.xaxis.axis_label = "Date"
+    p.yaxis.axis_label = "Cumulative Number of Signups"
+
+    script, div = components(p)
+    df_html = df_pivot.to_html()
+    totals_html = df_pivot[["Paid", "Unpaid", "Total"]].sum().to_frame().to_html()
+
+    return render(
+        request,
+        "bokeh.html",
+        {
+            "script": script,
+            "div": div,
+            "df_html": df_html,
+            "totals_html": totals_html,
+            "title": "Cumulative Pro Signups",
+        },
+    )
+
+
+@staff_member_required
+def pro_signups_by_provider_type(request):
+    """Bar chart of pro signups grouped by job title / provider type."""
+    return _render_pro_category_chart(
+        request,
+        field="job_title_or_provider_type",
+        title="Pro Signups by Provider Type",
+        axis_label="Provider Type",
+        color="steelblue",
+    )
+
+
+@staff_member_required
+def pro_signups_by_denial_type(request):
+    """Bar chart of pro signups grouped by their reported most-common denial."""
+    return _render_pro_category_chart(
+        request,
+        field="most_common_denial",
+        title="Pro Signups by Most-Common Denial",
+        axis_label="Most Common Denial",
+        color="darkorange",
+    )
+
+
+@staff_member_required
+def pro_signups_dashboard(request):
+    """Index page linking the pro-signup chart, table, and CSV views."""
+    qs = _interested_professionals_excluding_test_emails()
+    total = qs.count()
+    unique_emails = qs.values("email").distinct().count()
+    paid_count = qs.filter(paid=True).count()
+    clicked_for_paid_count = qs.filter(clicked_for_paid=True).count()
+
+    return render(
+        request,
+        "pro_signups_dashboard.html",
+        {
+            "total": total,
+            "unique_emails": unique_emails,
+            "paid_count": paid_count,
+            "clicked_for_paid_count": clicked_for_paid_count,
         },
     )

--- a/tests/sync/test_pro_signups_charts.py
+++ b/tests/sync/test_pro_signups_charts.py
@@ -1,0 +1,164 @@
+"""Tests for InterestedProfessional chart views."""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from fighthealthinsurance.models import InterestedProfessional
+
+User = get_user_model()
+
+
+class ProSignupChartViewTestBase(TestCase):
+    """Base for pro-signup chart view tests with authenticated staff user."""
+
+    def setUp(self):
+        self.staff_user = User.objects.create_user(
+            username="staffuser", password="testpass123", is_staff=True
+        )
+        self.client.login(username="staffuser", password="testpass123")
+
+    def _create_pro(self, email, **kwargs):
+        return InterestedProfessional.objects.create(email=email, **kwargs)
+
+
+class ProSignupChartStaffOnlyTest(TestCase):
+    """Non-staff users should not be able to view pro-signup charts."""
+
+    URL_NAMES = [
+        "pro_signups_cumulative",
+        "pro_signups_by_provider_type",
+        "pro_signups_by_denial_type",
+        "pro_signups_dashboard",
+    ]
+
+    def test_anonymous_blocked(self):
+        for name in self.URL_NAMES:
+            response = self.client.get(reverse(f"charts:{name}"))
+            self.assertIn(
+                response.status_code,
+                [302, 403],
+                f"Expected redirect/403 for anonymous user at {name}",
+            )
+
+    def test_non_staff_blocked(self):
+        User.objects.create_user(
+            username="regular", password="testpass123", is_staff=False
+        )
+        self.client.login(username="regular", password="testpass123")
+        for name in self.URL_NAMES:
+            response = self.client.get(reverse(f"charts:{name}"))
+            self.assertIn(
+                response.status_code,
+                [302, 403],
+                f"Expected redirect/403 for non-staff user at {name}",
+            )
+
+
+class ProSignupCumulativeChartTest(ProSignupChartViewTestBase):
+    def test_empty_returns_no_data_message(self):
+        response = self.client.get(reverse("charts:pro_signups_cumulative"))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "text/plain")
+        self.assertIn(b"No signup data available", response.content)
+
+    def test_renders_chart_with_data(self):
+        self._create_pro("a@example.com", clicked_for_paid=True)
+        self._create_pro("b@example.com", clicked_for_paid=False)
+        self._create_pro("c@example.com", clicked_for_paid=True)
+
+        response = self.client.get(reverse("charts:pro_signups_cumulative"))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Cumulative Pro Signups", response.content)
+        self.assertIn(b"bokeh", response.content.lower())
+
+    def test_excludes_test_emails(self):
+        self._create_pro("farts@farts.com")
+        self._create_pro("holden@pigscanfly.ca")
+        response = self.client.get(reverse("charts:pro_signups_cumulative"))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"No signup data available", response.content)
+
+
+class ProSignupsByProviderTypeChartTest(ProSignupChartViewTestBase):
+    def test_empty_returns_no_data_message(self):
+        response = self.client.get(reverse("charts:pro_signups_by_provider_type"))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"No pro signup data available", response.content)
+
+    def test_groups_normalized_provider_types(self):
+        self._create_pro("a@example.com", job_title_or_provider_type="Physician")
+        self._create_pro("b@example.com", job_title_or_provider_type=" physician ")
+        self._create_pro("c@example.com", job_title_or_provider_type="PHYSICIAN")
+        self._create_pro("d@example.com", job_title_or_provider_type="Nurse")
+
+        response = self.client.get(reverse("charts:pro_signups_by_provider_type"))
+        self.assertEqual(response.status_code, 200)
+        # All three "physician" entries should be merged into one row
+        content = response.content.decode()
+        self.assertIn("physician", content)
+        self.assertIn("nurse", content)
+        # 4 unique signups total
+        self.assertIn("Total unique pro signups: 4", content)
+        # 2 distinct provider types after normalization
+        self.assertIn("Distinct provider type values: 2", content)
+
+    def test_blank_provider_type_bucketed_as_not_specified(self):
+        self._create_pro("a@example.com", job_title_or_provider_type="")
+        self._create_pro("b@example.com", job_title_or_provider_type="Nurse")
+
+        response = self.client.get(reverse("charts:pro_signups_by_provider_type"))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"(not specified)", response.content)
+
+    def test_dedupes_by_email(self):
+        self._create_pro("dup@example.com", job_title_or_provider_type="Nurse")
+        self._create_pro("dup@example.com", job_title_or_provider_type="Nurse")
+
+        response = self.client.get(reverse("charts:pro_signups_by_provider_type"))
+        self.assertIn(b"Total unique pro signups: 1", response.content)
+
+
+class ProSignupsByDenialTypeChartTest(ProSignupChartViewTestBase):
+    def test_empty_returns_no_data_message(self):
+        response = self.client.get(reverse("charts:pro_signups_by_denial_type"))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"No pro signup data available", response.content)
+
+    def test_groups_normalized_denials(self):
+        self._create_pro("a@example.com", most_common_denial="Prior Auth")
+        self._create_pro("b@example.com", most_common_denial="prior auth")
+        self._create_pro("c@example.com", most_common_denial="Medical Necessity")
+
+        response = self.client.get(reverse("charts:pro_signups_by_denial_type"))
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertIn("Total unique pro signups: 3", content)
+        self.assertIn("Distinct most common denial values: 2", content)
+
+
+class ProSignupsDashboardTest(ProSignupChartViewTestBase):
+    def test_dashboard_renders_with_summary(self):
+        self._create_pro("a@example.com", clicked_for_paid=True, paid=True)
+        self._create_pro("b@example.com", clicked_for_paid=True, paid=False)
+        self._create_pro("c@example.com", clicked_for_paid=False, paid=False)
+        # Test email - should be excluded
+        self._create_pro("farts@farts.com", paid=True)
+
+        response = self.client.get(reverse("charts:pro_signups_dashboard"))
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertIn("Pro Signups Dashboard", content)
+        # 3 signups (test email excluded)
+        self.assertIn("3", content)
+        # Links to all chart views
+        self.assertIn(reverse("charts:signups_by_day"), content)
+        self.assertIn(reverse("charts:pro_signups_cumulative"), content)
+        self.assertIn(reverse("charts:pro_signups_by_provider_type"), content)
+        self.assertIn(reverse("charts:pro_signups_by_denial_type"), content)
+        self.assertIn(reverse("charts:pro_signups_csv"), content)
+
+    def test_dashboard_handles_empty(self):
+        response = self.client.get(reverse("charts:pro_signups_dashboard"))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Pro Signups Dashboard", response.content)


### PR DESCRIPTION
## Summary
This PR adds a comprehensive analytics dashboard and set of visualization views for tracking professional signups. It introduces new chart views for cumulative signups, provider type distribution, and denial type analysis, along with a central dashboard that links to all pro signup analytics.

## Key Changes

- **Extracted reusable helper function**: Created `_interested_professionals_excluding_test_emails()` to centralize the logic for filtering out test email addresses (`farts@farts.com` and `holden@pigscanfly.ca`). This function is now used across all pro signup views, replacing duplicated exclusion logic in 5 different locations.

- **New chart views**:
  - `pro_signups_cumulative`: Line chart showing cumulative growth of unique signups over time, split by paid/unpaid status
  - `pro_signups_by_provider_type`: Bar chart grouping signups by job title/provider type with normalization and "Other" bucketing
  - `pro_signups_by_denial_type`: Bar chart grouping signups by most-common denial reason with similar normalization
  - `pro_signups_dashboard`: Index page with summary statistics and links to all pro signup analytics

- **Generic chart rendering helper**: Implemented `_render_pro_category_chart()` to reduce code duplication between provider type and denial type charts. It handles:
  - Deduplication by email (with fallback for SQLite)
  - Value normalization (lowercase, collapsed whitespace)
  - Long-tail aggregation into "Other" bucket for values beyond top N
  - Bokeh visualization with hover tooltips and data table export

- **Dashboard template**: Added `pro_signups_dashboard.html` with summary statistics (total signups, unique emails, paid/clicked counts) and organized links to charts, tables, and CSV exports.

- **Comprehensive test coverage**: Added 164 lines of tests covering:
  - Staff-only access enforcement
  - Empty data handling
  - Data normalization and deduplication
  - Test email exclusion
  - Summary statistics accuracy

- **URL routing**: Registered all new views in `charts/urls.py`

## Notable Implementation Details

- The `_render_pro_category_chart()` function includes a fallback for SQLite (used in tests) that manually dedupes by email in Python when the database doesn't support `distinct()` on non-primary-key fields.
- All new views are protected with `@staff_member_required` decorator.
- Charts use Bokeh for interactive visualizations with hover tooltips and export capabilities.
- Blank/null values are normalized to "(not specified)" for consistent bucketing.

https://claude.ai/code/session_01NEx45tXWKS5eUhAWSRbNE9