### PR TITLE
Add signup abandonment chart for staff analytics

### DIFF
--- a/charts/urls.py
+++ b/charts/urls.py
@@ -21,6 +21,7 @@ from .views import (
     pubmed_article_export,
     incomplete_signups_csv,
     procedures_denied_chart,
+    signup_abandonment_chart,
 )
 
 urlpatterns = [
@@ -91,5 +92,10 @@ urlpatterns = [
         "procedures_denied_chart",
         procedures_denied_chart,
         name="procedures_denied_chart",
+    ),
+    path(
+        "signup_abandonment_chart",
+        signup_abandonment_chart,
+        name="signup_abandonment_chart",
     ),
 ]

--- a/charts/views.py
+++ b/charts/views.py
@@ -233,6 +233,204 @@ class MailingListSubscriberCSV(View):
 
 
 @staff_member_required
+def signup_abandonment_chart(request):
+    """
+    Chart showing professional signups that were abandoned: people who started
+    the registration flow but where neither the professional nor the domain was
+    ever activated. Includes location breakdown (state/city) and a daily trend.
+    """
+    inactive_relations = (
+        ProfessionalDomainRelation.objects.filter(
+            professional__active=False, domain__active=False
+        )
+        .select_related("professional__user", "domain")
+        .order_by("professional__user__date_joined")
+    )
+
+    rows = []
+    for relation in inactive_relations:
+        prof = relation.professional
+        domain = relation.domain
+        email = prof.user.email if prof.user else ""
+        # Skip test/seed accounts.
+        if email in ("farts@farts.com", "holden@pigscanfly.ca"):
+            continue
+
+        date_joined = prof.user.date_joined if prof.user else None
+        rows.append(
+            {
+                "email": email,
+                "state": (domain.state or "Unknown").strip() or "Unknown",
+                "city": (domain.city or "Unknown").strip() or "Unknown",
+                "zipcode": (domain.zipcode or "").strip(),
+                "country": (domain.country or "").strip(),
+                "date_joined": date_joined,
+            }
+        )
+
+    if not rows:
+        return HttpResponse(
+            "No abandoned signup data available.", content_type="text/plain"
+        )
+
+    df = pd.DataFrame(rows)
+
+    # Chart 1: by state (bar chart of where abandoned signups are from).
+    state_counts = (
+        df.groupby("state")
+        .size()
+        .reset_index(name="count")
+        .sort_values("count", ascending=False)
+    )
+    state_source = ColumnDataSource(state_counts)
+    p_state = figure(
+        title="Abandoned Signups by State",
+        x_range=state_counts["state"].tolist(),
+        height=420,
+        width=820,
+        toolbar_location="right",
+        tools="hover,pan,box_zoom,reset,save",
+        tooltips=[("State", "@state"), ("Count", "@count")],
+    )
+    p_state.vbar(
+        x="state",
+        top="count",
+        width=0.8,
+        source=state_source,
+        color="steelblue",
+        line_color="white",
+    )
+    p_state.xaxis.major_label_orientation = 3.14 / 4
+    p_state.xgrid.grid_line_color = None
+    p_state.y_range.start = 0
+    p_state.xaxis.axis_label = "State"
+    p_state.yaxis.axis_label = "Number of Abandoned Signups"
+
+    # Chart 2: top cities (limited to 15, rest grouped as "Other").
+    city_counts_full = (
+        df.groupby(["state", "city"])
+        .size()
+        .reset_index(name="count")
+        .sort_values("count", ascending=False)
+    )
+    city_counts_full["label"] = (
+        city_counts_full["city"] + ", " + city_counts_full["state"]
+    )
+    top_n = 15
+    if len(city_counts_full) > top_n:
+        top_cities = city_counts_full.iloc[:top_n].copy()
+        other_count = int(city_counts_full.iloc[top_n:]["count"].sum())
+        top_cities = pd.concat(
+            [
+                top_cities[["label", "count"]],
+                pd.DataFrame({"label": ["Other"], "count": [other_count]}),
+            ],
+            ignore_index=True,
+        )
+    else:
+        top_cities = city_counts_full[["label", "count"]].copy()
+
+    city_source = ColumnDataSource(top_cities)
+    p_city = figure(
+        title="Abandoned Signups by City (Top 15)",
+        x_range=top_cities["label"].tolist(),
+        height=420,
+        width=820,
+        toolbar_location="right",
+        tools="hover,pan,box_zoom,reset,save",
+        tooltips=[("Location", "@label"), ("Count", "@count")],
+    )
+    p_city.vbar(
+        x="label",
+        top="count",
+        width=0.8,
+        source=city_source,
+        color="darkorange",
+        line_color="white",
+    )
+    p_city.xaxis.major_label_orientation = 3.14 / 4
+    p_city.xgrid.grid_line_color = None
+    p_city.y_range.start = 0
+    p_city.xaxis.axis_label = "City, State"
+    p_city.yaxis.axis_label = "Number of Abandoned Signups"
+
+    # Chart 3: by day (when did they abandon).
+    df_dated = df.dropna(subset=["date_joined"]).copy()
+    if not df_dated.empty:
+        df_dated["day"] = pd.to_datetime(df_dated["date_joined"]).dt.normalize()
+        by_day = (
+            df_dated.groupby("day").size().reset_index(name="count").sort_values("day")
+        )
+        day_source = ColumnDataSource(by_day)
+        p_day = figure(
+            title="Abandoned Signups by Day",
+            x_axis_type="datetime",
+            height=420,
+            width=820,
+            toolbar_location="right",
+            tools="hover,pan,box_zoom,reset,save",
+            tooltips=[("Day", "@day{%F}"), ("Count", "@count")],
+        )
+        # The hover tool needs a datetime formatter for the @day field.
+        from bokeh.models import HoverTool
+
+        for tool in p_day.tools:
+            if isinstance(tool, HoverTool):
+                tool.formatters = {"@day": "datetime"}
+        p_day.varea(
+            x="day",
+            y1=0,
+            y2="count",
+            source=day_source,
+            color="firebrick",
+        )
+        p_day.line(x="day", y="count", source=day_source, color="firebrick")
+        p_day.xaxis.axis_label = "Date"
+        p_day.yaxis.axis_label = "Number of Abandoned Signups"
+    else:
+        p_day = None
+
+    # Combine the figures vertically.
+    from bokeh.layouts import column
+
+    plots = [p_state, p_city]
+    if p_day is not None:
+        plots.append(p_day)
+    layout = column(*plots)
+    script, div = components(layout)
+
+    # Build display DataFrames.
+    state_html = state_counts.to_html(
+        classes=["table", "table-striped", "table-hover"], index=False
+    )
+    city_html = city_counts_full[["state", "city", "count"]].to_html(
+        classes=["table", "table-striped", "table-hover"], index=False
+    )
+    df_html = f"<h3>By State</h3>{state_html}<h3>By City</h3>{city_html}"
+
+    total = len(df)
+    unique_states = df["state"].nunique()
+    unique_cities = df.groupby(["state", "city"]).ngroups
+    totals_html = (
+        f"<p>Total abandoned signups: {total}</p>"
+        f"<p>Unique states: {unique_states}</p>"
+        f"<p>Unique cities: {unique_cities}</p>"
+    )
+
+    return render(
+        request,
+        "bokeh.html",
+        {
+            "script": script,
+            "div": div,
+            "df_html": df_html,
+            "totals_html": totals_html,
+            "title": "Signup Abandonment Analysis",
+        },
+    )
+
+
+@staff_member_required
 def incomplete_signups_csv(request):
     response = HttpResponse(content_type="text/csv")
     response["Content-Disposition"] = 'attachment; filename="incomplete_signups.csv"'

--- a/fighthealthinsurance/templates/staff_dashboard.html
+++ b/fighthealthinsurance/templates/staff_dashboard.html
@@ -168,6 +168,12 @@
           <div class="link-description">View chart of denied procedures</div>
         </a>
       </li>
+      <li>
+        <a href="{% url 'charts:signup_abandonment_chart' %}">
+          <strong>Signup Abandonment Chart</strong>
+          <div class="link-description">View where abandoned professional signups are from (state/city) and when they happened</div>
+        </a>
+      </li>
     </ul>
   </div>
   

--- a/tests/sync/test_signup_abandonment_chart.py
+++ b/tests/sync/test_signup_abandonment_chart.py
@@ -1,0 +1,199 @@
+"""Tests for the signup_abandonment_chart staff view."""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from fhi_users.models import (
+    ProfessionalDomainRelation,
+    ProfessionalUser,
+    UserDomain,
+)
+
+User = get_user_model()
+
+
+def _make_pro_with_domain(
+    *,
+    username,
+    email,
+    state,
+    city,
+    visible_phone_number,
+    professional_active=False,
+    domain_active=False,
+    pending_domain_relation=True,
+):
+    """Create a ProfessionalUser + UserDomain + ProfessionalDomainRelation tuple."""
+    auth_user = User.objects.create_user(
+        username=username, password="testpass123", email=email
+    )
+    professional = ProfessionalUser.objects.create(
+        user=auth_user, active=professional_active
+    )
+    domain = UserDomain.objects.create(
+        name=username + "_domain",
+        visible_phone_number=visible_phone_number,
+        active=domain_active,
+        display_name=f"{username} Practice",
+        country="USA",
+        state=state,
+        city=city,
+        address1="123 Test St",
+        zipcode="12345",
+    )
+    ProfessionalDomainRelation.objects.create(
+        professional=professional,
+        domain=domain,
+        pending_domain_relation=pending_domain_relation,
+    )
+    return professional, domain
+
+
+class SignupAbandonmentChartStaffOnlyTest(TestCase):
+    def test_requires_staff(self):
+        regular = User.objects.create_user(
+            username="regular", password="testpass123", is_staff=False
+        )
+        self.client.login(username="regular", password="testpass123")
+        response = self.client.get(reverse("charts:signup_abandonment_chart"))
+        self.assertIn(response.status_code, [302, 403])
+
+    def test_anonymous_redirected(self):
+        response = self.client.get(reverse("charts:signup_abandonment_chart"))
+        self.assertIn(response.status_code, [302, 403])
+
+
+class SignupAbandonmentChartContentTest(TestCase):
+    def setUp(self):
+        self.staff = User.objects.create_user(
+            username="staff", password="testpass123", is_staff=True
+        )
+        self.client.login(username="staff", password="testpass123")
+
+    def test_empty_returns_no_data_message(self):
+        response = self.client.get(reverse("charts:signup_abandonment_chart"))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"No abandoned signup data available", response.content)
+
+    def test_renders_chart_with_abandoned_signups(self):
+        _make_pro_with_domain(
+            username="aban1",
+            email="a@example.com",
+            state="CA",
+            city="Oakland",
+            visible_phone_number="1110000001",
+        )
+        _make_pro_with_domain(
+            username="aban2",
+            email="b@example.com",
+            state="CA",
+            city="Oakland",
+            visible_phone_number="1110000002",
+        )
+        _make_pro_with_domain(
+            username="aban3",
+            email="c@example.com",
+            state="NY",
+            city="Brooklyn",
+            visible_phone_number="1110000003",
+        )
+
+        response = self.client.get(reverse("charts:signup_abandonment_chart"))
+        self.assertEqual(response.status_code, 200)
+        body = response.content.decode()
+
+        # Total + per-state counts should appear in the rendered output.
+        self.assertIn("Total abandoned signups: 3", body)
+        self.assertIn("Unique states: 2", body)
+        self.assertIn("CA", body)
+        self.assertIn("NY", body)
+        self.assertIn("Oakland", body)
+        self.assertIn("Brooklyn", body)
+        # Bokeh script tag should be rendered.
+        self.assertIn("Signup Abandonment Analysis", body)
+
+    def test_excludes_active_signups(self):
+        # Active professional + active domain - should be excluded.
+        _make_pro_with_domain(
+            username="active1",
+            email="active@example.com",
+            state="CA",
+            city="San Francisco",
+            visible_phone_number="2220000001",
+            professional_active=True,
+            domain_active=True,
+            pending_domain_relation=False,
+        )
+        # Active professional but inactive domain - excluded (only both inactive count).
+        _make_pro_with_domain(
+            username="active2",
+            email="halfactive@example.com",
+            state="CA",
+            city="San Jose",
+            visible_phone_number="2220000002",
+            professional_active=True,
+            domain_active=False,
+        )
+        # Truly abandoned.
+        _make_pro_with_domain(
+            username="aban_only",
+            email="aban@example.com",
+            state="TX",
+            city="Austin",
+            visible_phone_number="2220000003",
+        )
+
+        response = self.client.get(reverse("charts:signup_abandonment_chart"))
+        self.assertEqual(response.status_code, 200)
+        body = response.content.decode()
+        self.assertIn("Total abandoned signups: 1", body)
+        self.assertIn("Austin", body)
+        self.assertNotIn("San Francisco", body)
+        self.assertNotIn("San Jose", body)
+
+    def test_excludes_test_emails(self):
+        _make_pro_with_domain(
+            username="testuser1",
+            email="farts@farts.com",
+            state="CA",
+            city="Berkeley",
+            visible_phone_number="3330000001",
+        )
+        _make_pro_with_domain(
+            username="testuser2",
+            email="holden@pigscanfly.ca",
+            state="CA",
+            city="Berkeley",
+            visible_phone_number="3330000002",
+        )
+
+        response = self.client.get(reverse("charts:signup_abandonment_chart"))
+        self.assertEqual(response.status_code, 200)
+        # All abandoned signups are test emails - should report empty.
+        self.assertIn(b"No abandoned signup data available", response.content)
+
+    def test_handles_missing_state_and_city(self):
+        auth_user = User.objects.create_user(
+            username="nocoords", password="testpass123", email="d@example.com"
+        )
+        professional = ProfessionalUser.objects.create(user=auth_user, active=False)
+        domain = UserDomain.objects.create(
+            name="nocoords_domain",
+            visible_phone_number="4440000001",
+            active=False,
+            display_name="No Coords Practice",
+            country="USA",
+            zipcode="00000",
+        )
+        ProfessionalDomainRelation.objects.create(
+            professional=professional,
+            domain=domain,
+            pending_domain_relation=True,
+        )
+
+        response = self.client.get(reverse("charts:signup_abandonment_chart"))
+        self.assertEqual(response.status_code, 200)
+        body = response.content.decode()
+        self.assertIn("Total abandoned signups: 1", body)
+        self.assertIn("Unknown", body)


### PR DESCRIPTION
## Summary
This PR adds a new staff-only analytics view that visualizes professional signups that were abandoned during the registration flow. The chart provides geographic and temporal breakdowns of abandoned signups to help identify patterns and problem areas.

## Key Changes
- **New view `signup_abandonment_chart`**: Staff-only endpoint that identifies and visualizes signups where neither the professional nor domain was ever activated
- **Three interactive Bokeh charts**:
  - Bar chart showing abandoned signups by state
  - Bar chart showing top 15 cities (with "Other" grouping for remaining)
  - Area chart showing abandoned signups over time by day
- **Data filtering**: Automatically excludes test/seed accounts (farts@farts.com, holden@pigscanfly.ca) and handles missing location data gracefully
- **Summary statistics**: Displays total abandoned signups, unique states, and unique cities
- **URL routing**: Added new route at `/charts/signup_abandonment_chart`
- **Staff dashboard integration**: Added link to the new chart in the staff dashboard

## Implementation Details
- Uses `@staff_member_required` decorator to restrict access to staff users only
- Queries `ProfessionalDomainRelation` objects where both professional and domain are inactive
- Handles edge cases like missing state/city values (displays as "Unknown")
- Returns plain text response when no abandoned signup data is available
- Renders using the existing `bokeh.html` template with interactive hover tooltips
- Includes comprehensive test coverage with 5 test cases covering access control, empty state, data filtering, and edge cases

https://claude.ai/code/session_012Kt12f6nUNDrtz8T67GGQK