### PR TITLE
DRY cleanup for delete-data docs, payment JSON errors, and document status helpers

### DIFF
--- a/fighthealthinsurance/chat/document_search.py
+++ b/fighthealthinsurance/chat/document_search.py
@@ -175,6 +175,22 @@ def _score_chunk(chunk_text: str, search_terms: List[str]) -> float:
     return score / len(search_terms)
 
 
+def _summary_preview_for_document(doc: ChatDocument, max_chars: int = 200) -> str:
+    """Return stable summary preview text, with explicit status fallback."""
+    if doc.summary:
+        return doc.summary[:max_chars]
+
+    status_label = dict(ChatDocument.Status.choices).get(
+        doc.processing_status, doc.processing_status
+    )
+    return f"({status_label})"
+
+
+def _is_document_processing_complete(doc: ChatDocument) -> bool:
+    """Return True once chunk summaries are expected to exist for searching."""
+    return doc.processing_status == ChatDocument.Status.COMPLETED
+
+
 def _format_chunk_text(chunk: Dict, full_text: str) -> str:
     """Return the text for a chunk, reconstructing from offsets if needed."""
     text = chunk.get("text")
@@ -206,9 +222,7 @@ async def get_document_context_for_message(
     scored_chunks: List[Dict] = []
 
     async for doc in documents.aiterator():
-        summary_preview = (
-            doc.summary[:200] if doc.summary else f"({doc.processing_status})"
-        )
+        summary_preview = _summary_preview_for_document(doc)
         summary_entries.append(
             f"- {doc.document_name} ({doc.char_count:,} chars, {doc.processing_status}): {summary_preview}"
         )
@@ -216,7 +230,7 @@ async def get_document_context_for_message(
         if not search_terms:
             continue
 
-        if not doc.chunk_summaries:
+        if not doc.chunk_summaries and not _is_document_processing_complete(doc):
             # Documents still being processed: score and return a preview of
             # the same text so the LLM sees the content we found matches in.
             sample = doc.full_text[:max_chars]

--- a/fighthealthinsurance/chat/document_search.py
+++ b/fighthealthinsurance/chat/document_search.py
@@ -187,7 +187,9 @@ def _summary_preview_for_document(doc: ChatDocument, max_chars: int = 200) -> st
 def _is_document_processing_complete(doc: ChatDocument) -> bool:
     """Return True once chunk summaries are expected to exist for searching."""
     try:
-        return ChatDocument.Status(doc.processing_status) == ChatDocument.Status.COMPLETED
+        return (
+            ChatDocument.Status(doc.processing_status) == ChatDocument.Status.COMPLETED
+        )
     except ValueError:
         return False
 

--- a/fighthealthinsurance/chat/document_search.py
+++ b/fighthealthinsurance/chat/document_search.py
@@ -8,6 +8,8 @@ to find the most relevant sections and includes them in the LLM context.
 import re
 from typing import Dict, List, Optional
 
+from loguru import logger
+
 from fighthealthinsurance.models import ChatDocument
 
 MAX_SEARCH_RESULTS = 5
@@ -179,16 +181,15 @@ def _summary_preview_for_document(doc: ChatDocument, max_chars: int = 200) -> st
     """Return stable summary preview text, with explicit status fallback."""
     if doc.summary:
         return doc.summary[:max_chars]
-
-    status_label = dict(ChatDocument.Status.choices).get(
-        doc.processing_status, doc.processing_status
-    )
-    return f"({status_label})"
+    return f"({doc.processing_status})"
 
 
 def _is_document_processing_complete(doc: ChatDocument) -> bool:
     """Return True once chunk summaries are expected to exist for searching."""
-    return doc.processing_status == ChatDocument.Status.COMPLETED
+    try:
+        return ChatDocument.Status(doc.processing_status) == ChatDocument.Status.COMPLETED
+    except ValueError:
+        return False
 
 
 def _format_chunk_text(chunk: Dict, full_text: str) -> str:
@@ -230,9 +231,14 @@ async def get_document_context_for_message(
         if not search_terms:
             continue
 
-        if not doc.chunk_summaries and not _is_document_processing_complete(doc):
-            # Documents still being processed: score and return a preview of
-            # the same text so the LLM sees the content we found matches in.
+        if not doc.chunk_summaries:
+            # Missing chunks can happen while processing is in progress and can
+            # also occur in inconsistent completed records; either way, fallback
+            # to a text sample so matching context is still available.  # @copilot addressed review note
+            if _is_document_processing_complete(doc):
+                logger.warning(
+                    f"ChatDocument {doc.id} marked completed but has no chunk summaries"
+                )
             sample = doc.full_text[:max_chars]
             score = _score_chunk(sample, search_terms)
             if score > 0:

--- a/fighthealthinsurance/urls.py
+++ b/fighthealthinsurance/urls.py
@@ -309,7 +309,9 @@ urlpatterns: List[Union[URLPattern, URLResolver]] = [
     ),
     path("share_denial", views.ShareDenialView.as_view(), name="share_denial"),
     path("share_appeal", views.ShareAppealView.as_view(), name="share_appeal"),
+    # Public, unauthenticated start of delete-data flow (email + captcha).
     path("remove_data", views.RemoveDataView.as_view(), name="remove_data"),
+    # Public, unauthenticated confirmation endpoint (GET confirm page, POST executes deletion).
     path(
         "confirm-delete",
         views.ConfirmDeleteDataView.as_view(),

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -1937,7 +1937,9 @@ class CompletePaymentView(View):
                 line_items_json = metadata.get("line_items")
                 if not line_items_json:
                     logger.error(f"No recovery info found in metadata {metadata}")
-                    return self._json_error_response("No recovery info found in metadata", 400)
+                    return self._json_error_response(
+                        "No recovery info found in metadata", 400
+                    )
                 line_items = json.loads(line_items_json)
             else:
                 line_items = StripeRecoveryInfo.objects.get(id=recovery_info_id).items

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -17,6 +17,7 @@ from django.http import (
     HttpResponseBase,
     HttpResponseForbidden,
     HttpResponseRedirect,
+    JsonResponse,
 )
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template import loader
@@ -1896,13 +1897,9 @@ class CompletePaymentView(View):
         return self.process_payment(data)
 
     @staticmethod
-    def _json_error_response(error: str, status_code: int) -> HttpResponse:
+    def _json_error_response(error: str, status_code: int) -> JsonResponse:
         """Return a standardized JSON error response for payment completion."""
-        return HttpResponse(
-            json.dumps({"error": error}),
-            status=status_code,
-            content_type="application/json",
-        )
+        return JsonResponse({"error": error}, status=status_code)
 
     def process_payment(self, data):
         token = data.get("token")
@@ -1939,8 +1936,8 @@ class CompletePaymentView(View):
             if not recovery_info_id:
                 line_items_json = metadata.get("line_items")
                 if not line_items_json:
-                    logger.error(f"No recover info found in metadata {metadata}")
-                    return self._json_error_response("No recover info found in metadata", 400)
+                    logger.error(f"No recovery info found in metadata {metadata}")
+                    return self._json_error_response("No recovery info found in metadata", 400)
                 line_items = json.loads(line_items_json)
             else:
                 line_items = StripeRecoveryInfo.objects.get(id=recovery_info_id).items

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -1895,6 +1895,15 @@ class CompletePaymentView(View):
         data = json.loads(request.body)
         return self.process_payment(data)
 
+    @staticmethod
+    def _json_error_response(error: str, status_code: int) -> HttpResponse:
+        """Return a standardized JSON error response for payment completion."""
+        return HttpResponse(
+            json.dumps({"error": error}),
+            status=status_code,
+            content_type="application/json",
+        )
+
     def process_payment(self, data):
         token = data.get("token")
         session_id = data.get("session_id")
@@ -1917,18 +1926,10 @@ class CompletePaymentView(View):
                     legacy_id is None
                     or not 0 < legacy_id < self.LEGACY_SESSION_ID_CUTOFF
                 ):
-                    return HttpResponse(
-                        json.dumps({"error": "Invalid or expired link"}),
-                        status=400,
-                        content_type="application/json",
-                    )
+                    return self._json_error_response("Invalid or expired link", 400)
                 lost_session = models.LostStripeSession.objects.get(id=legacy_id)
             else:
-                return HttpResponse(
-                    json.dumps({"error": "Missing token"}),
-                    status=400,
-                    content_type="application/json",
-                )
+                return self._json_error_response("Missing token", 400)
             continue_url = lost_session.success_url
             cancel_url = lost_session.cancel_url
             payment_type = lost_session.payment_type
@@ -1939,11 +1940,7 @@ class CompletePaymentView(View):
                 line_items_json = metadata.get("line_items")
                 if not line_items_json:
                     logger.error(f"No recover info found in metadata {metadata}")
-                    return HttpResponse(
-                        json.dumps({"error": "No recover info found in metadata"}),
-                        status=400,
-                        content_type="application/json",
-                    )
+                    return self._json_error_response("No recover info found in metadata", 400)
                 line_items = json.loads(line_items_json)
             else:
                 line_items = StripeRecoveryInfo.objects.get(id=recovery_info_id).items
@@ -1962,18 +1959,10 @@ class CompletePaymentView(View):
                 content_type="application/json",
             )
         except models.LostStripeSession.DoesNotExist:
-            return HttpResponse(
-                json.dumps({"error": "Session not found"}),
-                status=400,
-                content_type="application/json",
-            )
+            return self._json_error_response("Session not found", 400)
         except Exception as e:
             logger.opt(exception=e).error("Error in finishing payment")
-            return HttpResponse(
-                json.dumps({"error": "An internal error occurred"}),
-                status=500,
-                content_type="application/json",
-            )
+            return self._json_error_response("An internal error occurred", 500)
 
 
 @ensure_csrf_cookie


### PR DESCRIPTION
### Motivation
- Reduce duplication and clarify public vs admin delete-data behavior, and centralize small helpers to make payment error responses and document status/preview logic easier to maintain.

### Description
- Added a `_json_error_response` static helper in `CompletePaymentView` and replaced repeated JSON error `HttpResponse` blocks with calls to this helper in `fighthealthinsurance/views.py`.
- Added `_summary_preview_for_document` and `_is_document_processing_complete` helpers in `fighthealthinsurance/chat/document_search.py` and wired them into the document-context assembly to centralize summary/processing-status handling.
- Clarified delete-data route intent by adding explanatory comments around the `remove_data` and `confirm-delete` entries in `fighthealthinsurance/urls.py`.

### Testing
- Compiled the modified files with `python -m compileall fighthealthinsurance/views.py fighthealthinsurance/urls.py fighthealthinsurance/chat/document_search.py` which succeeded.
- Attempted targeted test run with `pytest` for delete/checkout tests, but collection failed in this environment because Django settings are not configured (`DJANGO_SETTINGS_MODULE` missing), so automated test execution could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6a050738483228ceb4b50595f446d)