### PR TITLE
Fix mypy attr-defined errors in ProcessDenialCodes

### DIFF
--- a/fighthealthinsurance/process_denial.py
+++ b/fighthealthinsurance/process_denial.py
@@ -51,13 +51,12 @@ class ProcessDenialCodes(DenialBase):
         return (None, None)
 
     def _extract_codes(self, denial_text: str) -> list[str]:
-        """Return ICD-10 and CPT codes pulled from the denial text."""
-        codes: list[str] = []
-        for match in self.icd10_re.finditer(denial_text):
-            codes.append(match.group(1))
-        for match in self.cpt_code_re.finditer(denial_text):
-            codes.append(match.group(1))
-        return codes
+        """Return ICD-10/CPT/HCPCS codes pulled from the denial text."""
+        return list(
+            extract_icd10_codes(denial_text)
+            | extract_cpt_codes(denial_text)
+            | extract_hcpcs_codes(denial_text)
+        )
 
     def find_uspstf_evidence(self, denial_text: str, limit: int = 3) -> list[dict]:
         """Find USPSTF recommendations relevant to codes referenced in a denial.

--- a/tests/async-unit/test_denial_types.py
+++ b/tests/async-unit/test_denial_types.py
@@ -265,6 +265,27 @@ class TestDenialTypes(TestCase):
         assert len(result) == 1
         assert result[0].name == "Preventive Care"
 
+
+
+    @pytest.mark.asyncio
+    async def test_find_uspstf_evidence_extracts_cpt_and_hcpcs_codes(self):
+        """find_uspstf_evidence should pass non-ICD procedure codes through
+        to USPSTF lookup so CPT/HCPCS-only denials still surface guidance."""
+        processor = await sync_to_async(ProcessDenialCodes)()
+        fake_recs = [{"id": "rec-1", "grade": "B"}]
+
+        with patch(
+            "fighthealthinsurance.uspstf_api.find_recommendations_for_codes",
+            return_value=fake_recs,
+        ) as mock_lookup:
+            result = processor.find_uspstf_evidence(
+                "Denied services include CPT 99396 and HCPCS G0439."
+            )
+
+        assert result == fake_recs
+        (codes_arg,) = mock_lookup.call_args.args
+        assert {"99396", "G0439"}.issubset(set(codes_arg))
+
     @pytest.mark.asyncio
     async def test_find_uspstf_evidence_returns_empty_on_error(self):
         """find_uspstf_evidence swallows exceptions so classification never breaks."""


### PR DESCRIPTION
### Motivation
- Resolve mypy `attr-defined` failures caused by `ProcessDenialCodes` referencing undefined regex attributes and make code extraction consistent with other denial logic.

### Description
- Replace the handwritten `_extract_codes` implementation with a call to the shared helpers `extract_icd10_codes`, `extract_cpt_codes`, and `extract_hcpcs_codes` (returning their union as a `list`) and update the docstring to reflect ICD-10/CPT/HCPCS extraction.

### Testing
- Ran `mypy --config-file mypy.ini fighthealthinsurance/process_denial.py` which passed; running full-package `mypy --config-file mypy.ini -p fighthealthinsurance -p fhi_users` still reports unrelated pre-existing errors in other files (`charts/views.py`, `fighthealthinsurance/rest_views.py`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6ae810ec08322adc3faa50c921f24)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization for medical code extraction to enhance maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->