### PR TITLE
Allow chat retry while request is loading

### DIFF
--- a/fighthealthinsurance/static/js/chat_interface.tsx
+++ b/fighthealthinsurance/static/js/chat_interface.tsx
@@ -706,8 +706,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
   // Handle retrying the last message
   const handleRetryLastMessage = () => {
     if (!wsRef.current) return;
-    // Allow retry if there's an error OR if currently loading
-    if (state.isLoading && !state.error) return;
+    // Allow retry even while loading so long-running requests can be manually re-sent.
 
     // Find the last user message
     const lastUserMessage = [...state.messages]


### PR DESCRIPTION
### Motivation
- The retry button was shown for long-running chat requests but clicks were blocked by a guard that returned early when `state.isLoading` was true and there was no `state.error`, preventing users from resending the last message.

### Description
- Remove the early-return `if (state.isLoading && !state.error) return;` in `handleRetryLastMessage` within `fighthealthinsurance/static/js/chat_interface.tsx` so the Retry action is allowed even while a request is still marked loading.

### Testing
- Ran `python manage.py check`, which completed successfully (Django reports an unrelated template-tag warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6b04ec1988322bf82cdc6176d3ba7)