### PR TITLE
Add client-side 20MB upload guard to Explain Denial OCR

### DIFF
--- a/fighthealthinsurance/static/js/explain_denial.ts
+++ b/fighthealthinsurance/static/js/explain_denial.ts
@@ -41,7 +41,8 @@ async function recognizeEvent(event: Event): Promise<void> {
     return;
   }
 
-  const oversizedFiles = Array.from(files).filter(
+  const fileList = Array.from(files);
+  const oversizedFiles = fileList.filter(
     (file) => file.size > MAX_UPLOAD_SIZE_BYTES
   );
   if (oversizedFiles.length > 0) {
@@ -49,6 +50,12 @@ async function recognizeEvent(event: Event): Promise<void> {
     alert(
       `These files exceed the 20MB upload limit and were not processed: ${tooLargeNames}`
     );
+  }
+
+  const filesToProcess = fileList.filter(
+    (file) => file.size <= MAX_UPLOAD_SIZE_BYTES
+  );
+  if (filesToProcess.length === 0) {
     input.value = "";
     return;
   }
@@ -63,9 +70,11 @@ async function recognizeEvent(event: Event): Promise<void> {
   }
 
   try {
-    for (let i = 0; i < files.length; i++) {
-      const file = files[i];
-      console.log(`Processing file ${i + 1}/${files.length}: ${file.name}`);
+    for (let i = 0; i < filesToProcess.length; i++) {
+      const file = filesToProcess[i];
+      console.log(
+        `Processing file ${i + 1}/${filesToProcess.length}: ${file.name}`
+      );
       await recognize(file, addText);
     }
   } catch (error) {

--- a/fighthealthinsurance/static/js/explain_denial.ts
+++ b/fighthealthinsurance/static/js/explain_denial.ts
@@ -7,6 +7,8 @@
 
 import { recognize } from "./scrub_ocr";
 
+const MAX_UPLOAD_SIZE_BYTES = 20 * 1024 * 1024;
+
 /**
  * Add recognized text to the denial_text textarea.
  * Appends text with a newline separator if textarea already has content.
@@ -36,6 +38,18 @@ async function recognizeEvent(event: Event): Promise<void> {
   const files = input.files;
 
   if (!files || files.length === 0) {
+    return;
+  }
+
+  const oversizedFiles = Array.from(files).filter(
+    (file) => file.size > MAX_UPLOAD_SIZE_BYTES
+  );
+  if (oversizedFiles.length > 0) {
+    const tooLargeNames = oversizedFiles.map((file) => file.name).join(", ");
+    alert(
+      `These files exceed the 20MB upload limit and were not processed: ${tooLargeNames}`
+    );
+    input.value = "";
     return;
   }
 

--- a/fighthealthinsurance/templates/explain_denial.html
+++ b/fighthealthinsurance/templates/explain_denial.html
@@ -74,7 +74,7 @@
                                     accept="image/*,.pdf"
                                     multiple>
                                 <div class="form-text">
-                                    Upload an image or PDF of your denial letter. Our OCR will extract the text for you.
+                                    Upload an image or PDF of your denial letter (max 20MB per file). Our OCR will extract the text for you.
                                 </div>
                             </div>
 


### PR DESCRIPTION
### Motivation
- Prevent the browser-side OCR pipeline from attempting very large files that exceed the policy-analysis limits and may hang or consume excessive resources.
- Align the Explain Denial upload UX with the existing server-side 20MB per-file constraint so users get immediate feedback before processing starts.

### Description
- Add `MAX_UPLOAD_SIZE_BYTES = 20 * 1024 * 1024` and a pre-processing check in `fighthealthinsurance/static/js/explain_denial.ts` that rejects files larger than 20MB, alerts the user with offending filenames, and clears the file input to prevent accidental retries.
- Keep existing OCR processing flow (`recognize`) intact for accepted files and preserve the processing indicator and error handling.
- Update the Explain Denial template `fighthealthinsurance/templates/explain_denial.html` helper text to state the `max 20MB per file` limit.

### Testing
- Running `pytest -q tests/async/test_explain_denial.py` in this environment encountered a collection error due to Django settings not being configured for direct pytest collection (error during import of encrypted filefield constants), so that invocation failed.
- Running Django's test runner `python manage.py test tests.async.test_explain_denial --verbosity 1` executed successfully and passed the test suite (10 tests ran and passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6bfb6990083228279e6904587a344)