### PR TITLE
Add friendly loading step before questions page

### DIFF
--- a/fighthealthinsurance/templates/categorize.html
+++ b/fighthealthinsurance/templates/categorize.html
@@ -23,7 +23,7 @@ Categorize Your Denial
     <p>We've tried our best to extract information from your denial letter. Please review and correct anything that looks wrong below.</p>
   </div>
 
-  <form action="{% url 'find_next_steps' %}" method="post">
+  <form action="{% url 'find_next_steps_loading' %}" method="post">
     {% csrf_token %}
     <table class="post-infered-table">
       {{ post_infered_form.as_table }}

--- a/fighthealthinsurance/templates/find_next_steps_loading.html
+++ b/fighthealthinsurance/templates/find_next_steps_loading.html
@@ -19,22 +19,62 @@ Getting Your Questions Ready
     </div>
   </div>
 
-  <form id="next-steps-form" action="{% url 'find_next_steps' %}" method="post" style="display:none;">
+  <form id="next-steps-form" action="{% url 'find_next_steps' %}" method="post">
     {% csrf_token %}
-    {% for key, value in payload.items %}
-      <input type="hidden" name="{{ key }}" value="{{ value }}">
+    {% for key, values in payload.lists %}
+      {% if key != 'csrfmiddlewaretoken' %}
+        {% for value in values %}
+          <input type="hidden" name="{{ key }}" value="{{ value }}">
+        {% endfor %}
+      {% endif %}
     {% endfor %}
+
+    <div id="manual-continue" style="display:none; text-align:center; margin-top:1rem;">
+      <p style="margin-bottom:0.75rem; color:#4f5b67;">Ready to keep going? Hit continue.</p>
+      <button type="submit" class="btn btn-green">Continue →</button>
+    </div>
+    <noscript>
+      <div style="text-align:center; margin-top:1rem;">
+        <p style="margin-bottom:0.75rem; color:#4f5b67;">JavaScript is off, so this step needs a quick click.</p>
+        <button type="submit" class="btn btn-green">Continue →</button>
+      </div>
+    </noscript>
   </form>
 </div>
 
 <script>
-  window.addEventListener('load', function () {
-    window.setTimeout(function () {
-      const form = document.getElementById('next-steps-form');
-      if (form) {
-        form.submit();
+  (function () {
+    function cameFromBackForward(event) {
+      if (event && event.persisted) {
+        return true;
       }
-    }, 250);
-  });
+      if (window.performance && typeof window.performance.getEntriesByType === 'function') {
+        const navEntries = window.performance.getEntriesByType('navigation');
+        if (navEntries.length > 0 && navEntries[0].type === 'back_forward') {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    window.addEventListener('pageshow', function (event) {
+      const form = document.getElementById('next-steps-form');
+      if (!form) {
+        return;
+      }
+
+      if (cameFromBackForward(event)) {
+        const manualContinue = document.getElementById('manual-continue');
+        if (manualContinue) {
+          manualContinue.style.display = 'block';
+        }
+        return;
+      }
+
+      window.setTimeout(function () {
+        form.submit();
+      }, 250);
+    });
+  }());
 </script>
 {% endblock content %}

--- a/fighthealthinsurance/templates/find_next_steps_loading.html
+++ b/fighthealthinsurance/templates/find_next_steps_loading.html
@@ -14,9 +14,9 @@ Getting Your Questions Ready
   </div>
 
   <div style="display:flex; justify-content:center; margin:1.5rem 0 1rem;">
-    <div class="spinner-border text-success" role="status" aria-label="Loading questions">
-      <span class="visually-hidden">Loading...</span>
-    </div>
+    <i class="fa fa-spinner fa-spin" role="status" aria-label="Loading questions" style="font-size:2rem; color:#2a9d58;">
+      <span class="sr-only">Loading…</span>
+    </i>
   </div>
 
   <form id="next-steps-form" action="{% url 'find_next_steps' %}" method="post">

--- a/fighthealthinsurance/templates/find_next_steps_loading.html
+++ b/fighthealthinsurance/templates/find_next_steps_loading.html
@@ -1,0 +1,40 @@
+{% extends 'base.html' %}
+{% block title %}
+Getting Your Questions Ready
+{% endblock title %}
+{% load static %}
+{% block content %}
+<div class="container container-narrow">
+  {% include 'partials/flow_progress.html' with current_step=current_step|default:6 %}
+
+  <div class="alert-box alert-box-info" style="text-align:center; margin-top:1rem;">
+    <h3 style="margin-bottom:0.5rem;">Good vibes loading ✨</h3>
+    <p style="margin-bottom:0.25rem;"><strong>Figuring out which questions we need to ask...</strong></p>
+    <p style="margin:0; color:#4f5b67;">This usually takes just a few seconds.</p>
+  </div>
+
+  <div style="display:flex; justify-content:center; margin:1.5rem 0 1rem;">
+    <div class="spinner-border text-success" role="status" aria-label="Loading questions">
+      <span class="visually-hidden">Loading...</span>
+    </div>
+  </div>
+
+  <form id="next-steps-form" action="{% url 'find_next_steps' %}" method="post" style="display:none;">
+    {% csrf_token %}
+    {% for key, value in payload.items %}
+      <input type="hidden" name="{{ key }}" value="{{ value }}">
+    {% endfor %}
+  </form>
+</div>
+
+<script>
+  window.addEventListener('load', function () {
+    window.setTimeout(function () {
+      const form = document.getElementById('next-steps-form');
+      if (form) {
+        form.submit();
+      }
+    }, 250);
+  });
+</script>
+{% endblock content %}

--- a/fighthealthinsurance/urls.py
+++ b/fighthealthinsurance/urls.py
@@ -337,6 +337,11 @@ urlpatterns: List[Union[URLPattern, URLResolver]] = [
         name="mhmda",
     ),
     path(
+        "find_next_steps_loading",
+        sensitive_post_parameters("email")(views.FindNextStepsLoading.as_view()),
+        name="find_next_steps_loading",
+    ),
+    path(
         "find_next_steps",
         sensitive_post_parameters("email")(views.FindNextSteps.as_view()),
         name="find_next_steps",

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -1032,7 +1032,7 @@ class FindNextStepsLoading(View):
     """Interim loading screen before the questions page is rendered."""
 
     def post(self, request):
-        form = core_forms.PostInferedForm(request.POST)
+        form = core_forms.BasePostInferedForm(request.POST)
         if not form.is_valid():
             return render(
                 request,

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -1028,6 +1028,31 @@ class FindNextSteps(View):
         )
 
 
+class FindNextStepsLoading(View):
+    """Interim loading screen before the questions page is rendered."""
+
+    def post(self, request):
+        form = core_forms.PostInferedForm(request.POST)
+        if not form.is_valid():
+            return render(
+                request,
+                "categorize.html",
+                context={
+                    "post_infered_form": form,
+                    "upload_more": True,
+                },
+            )
+
+        return render(
+            request,
+            "find_next_steps_loading.html",
+            context={
+                "payload": form.cleaned_data,
+                "current_step": 6,
+            },
+        )
+
+
 class ChooseAppeal(View):
     """View for selecting and finalizing appeal text before sending."""
 

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -1047,7 +1047,7 @@ class FindNextStepsLoading(View):
             request,
             "find_next_steps_loading.html",
             context={
-                "payload": form.cleaned_data,
+                "payload": request.POST,
                 "current_step": 6,
             },
         )


### PR DESCRIPTION
### Motivation
- Provide immediate feedback while the app computes which follow-up questions to ask so users aren't left staring at a slow or blank transition. 
- Keep navigation semantics intact so the browser back/forward buttons continue to work normally and the flow remains familiar and friendly.

### Description
- Updated the categorize form to POST to a new interim endpoint `find_next_steps_loading` instead of posting directly to `find_next_steps` by changing the form action in `categorize.html` to `'{% url 'find_next_steps_loading' %}'`.
- Added a new `FindNextStepsLoading` view that validates the same `core_forms.PostInferedForm` payload and renders a lightweight `find_next_steps_loading.html` template when valid, or returns the user to `categorize.html` with form errors when invalid.
- Added a new URL route `find_next_steps_loading` wired with `sensitive_post_parameters("email")` in `fighthealthinsurance/urls.py`.
- Created `find_next_steps_loading.html` with the progress indicator, friendly copy, spinner, a hidden form populated from the validated payload, and an automatic short-delay form submit to the existing `find_next_steps` endpoint so the real question page is reached next.

### Testing
- Ran `python manage.py check` and it completed successfully with a pre-existing Django template-tag warning reported but no new errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7a28fa1588322917c5dde8d7f6ea6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a loading screen that displays while the app prepares your next steps after you review and correct your information. The screen provides visual feedback and automatically continues after a brief delay, with a manual continue option available if you navigate away and return to the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->