### PR TITLE
Auto-scroll to first generated appeal on appeals page

### DIFF
--- a/fighthealthinsurance/static/js/appeal_fetcher.ts
+++ b/fighthealthinsurance/static/js/appeal_fetcher.ts
@@ -364,6 +364,7 @@ let my_data: Map<string, string> = new Map<string, string>();
 let my_backend_url = "";
 let my_rest_fallback_url = "";
 let usingRestFallback = false;
+let hasAutoScrolledToFirstAppeal = false;
 
 let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
 
@@ -614,6 +615,11 @@ function processResponseChunk(chunk: string): void {
         appealTextElem[0].setAttribute("form", `form_${appealId}`);
 
         outputContainer.append(clonedForm);
+
+        if (!hasAutoScrolledToFirstAppeal) {
+          hasAutoScrolledToFirstAppeal = true;
+          (clonedForm[0] as HTMLElement).scrollIntoView({ behavior: "smooth", block: "start" });
+        }
       } catch (error) {
         console.error("Error parsing line:", error);
       }


### PR DESCRIPTION
### Motivation
- Improve UX on the appeal generation page by automatically bringing the first generated appeal into view so users aren't left at the top while content appears below.

### Description
- Added a one-time guard flag `hasAutoScrolledToFirstAppeal` and, in `fighthealthinsurance/static/js/appeal_fetcher.ts`, call `(clonedForm[0] as HTMLElement).scrollIntoView({ behavior: "smooth", block: "start" })` immediately after appending the first generated appeal form.

### Testing
- No automated tests were run for this change; the TypeScript file diff was inspected and the change was committed (`fighthealthinsurance/static/js/appeal_fetcher.ts`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7f63f35a083228aeca3ddcac514b9)