### PR TITLE
Stop repeated-line runaways in bad-output detection and citation parsing

### DIFF
--- a/fighthealthinsurance/ml/bad_output_utils.py
+++ b/fighthealthinsurance/ml/bad_output_utils.py
@@ -69,6 +69,27 @@ def strip_boilerplate_service(val: str) -> Optional[str]:
     return cleaned
 
 
+def _has_repeated_line_runaway(text: str, repeat_threshold: int = 3) -> bool:
+    """Return True when a normalized line repeats consecutively >= repeat_threshold."""
+    if repeat_threshold < 2:
+        repeat_threshold = 2
+
+    last_line: Optional[str] = None
+    streak = 0
+    for raw_line in text.splitlines():
+        normalized = re.sub(r"\s+", " ", raw_line.strip().lower())
+        if len(normalized) < 8:
+            continue
+        if normalized == last_line:
+            streak += 1
+        else:
+            last_line = normalized
+            streak = 1
+        if streak >= repeat_threshold:
+            return True
+    return False
+
+
 def is_bad_output(
     result: Optional[str],
     *,
@@ -90,11 +111,10 @@ def is_bad_output(
     ):
         return True
 
-    if (
-        check_severe_repetition
-        and repetition_checker is not None
-        and repetition_checker(result)
-    ):
-        return True
+    if check_severe_repetition:
+        if repetition_checker is not None and repetition_checker(result):
+            return True
+        if _has_repeated_line_runaway(result, repeat_threshold=3):
+            return True
 
     return False

--- a/fighthealthinsurance/ml/bad_output_utils.py
+++ b/fighthealthinsurance/ml/bad_output_utils.py
@@ -70,7 +70,12 @@ def strip_boilerplate_service(val: str) -> Optional[str]:
 
 
 def _has_repeated_line_runaway(text: str, repeat_threshold: int = 3) -> bool:
-    """Return True when a normalized line repeats consecutively >= repeat_threshold."""
+    """Return True when a normalized significant line repeats >= threshold.
+
+    Lines are normalized by lowercasing, trimming, and collapsing internal
+    whitespace. Short/blank normalized lines (length < 8) are ignored and do
+    not break an existing repetition streak.
+    """
     if repeat_threshold < 2:
         repeat_threshold = 2
 

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -2452,6 +2452,7 @@ class RemoteFullOpenLike(RemoteOpenLike):
 
         # Process the result into a list of citations
         citations: List[str] = []
+        seen_line_counts: dict[str, int] = {}
 
         # Split by newlines and process each line
         for line in text_result.split("\n"):
@@ -2464,8 +2465,20 @@ class RemoteFullOpenLike(RemoteOpenLike):
             # Remove numbering and bullet points at the beginning of the line
             line = re.sub(r"^\s*(?:\d+[.)\-]|\*|\•|\-)\s+", "", line)
 
-            # Skip header lines
-            if line.lower().startswith(("here are", "citations", "references")):
+            normalized_line = re.sub(r"\s+", " ", line.lower()).strip()
+            count = seen_line_counts.get(normalized_line, 0) + 1
+            seen_line_counts[normalized_line] = count
+
+            # Treat repeated identical lines as an implicit stop token.
+            # If a line appears again, assume the model has gone off the rails
+            # and cut output starting at the first repeated line.
+            if count >= 3:
+                while citations and re.sub(r"\s+", " ", citations[-1].strip().lower()) == normalized_line:
+                    citations.pop()
+                break
+
+            # Skip short standalone headers, but keep informative single-line entries.
+            if line.lower().startswith(("here are", "citations", "references")) and len(line) <= 32:
                 continue
 
             citations.append(line)

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -2469,11 +2469,14 @@ class RemoteFullOpenLike(RemoteOpenLike):
             count = seen_line_counts.get(normalized_line, 0) + 1
             seen_line_counts[normalized_line] = count
 
-            # Treat repeated identical lines as an implicit stop token.
-            # If a line appears again, assume the model has gone off the rails
-            # and cut output starting at the first repeated line.
+            # Treat 3+ repeats of the same normalized line as a runaway pattern.
+            # When the threshold is hit, trim trailing copies of that line and
+            # stop parsing additional lines.
             if count >= 3:
-                while citations and re.sub(r"\s+", " ", citations[-1].strip().lower()) == normalized_line:
+                while citations and (
+                    re.sub(r"\s+", " ", citations[-1].strip().lower())
+                    == normalized_line
+                ):
                     citations.pop()
                 break
 

--- a/tests/async-unit/test_ml_citations.py
+++ b/tests/async-unit/test_ml_citations.py
@@ -147,6 +147,64 @@ class TestMLCitationFunctionality:
                 for citation in citations:
                     assert "Here are relevant citations" not in citation
 
+
+    @pytest.mark.asyncio
+    async def test_get_citations_stops_on_repeated_line(self):
+        """Treat repeated identical lines as an implicit stop token."""
+        model = RemoteFullOpenLike("http://test-api.com", "test-token", "test-model")
+
+        mock_response = """
+        1. CDC PrEP Clinical Guidance, 2025, https://www.cdc.gov/hiv/clinicians/prevention/prep.html
+        - Template line that starts repeating unexpectedly
+        - Template line that starts repeating unexpectedly
+        - Template line that starts repeating unexpectedly
+        - USPSTF recommendation should not be parsed because it appears after repeated-line noise
+        """
+
+        with patch.object(model, "get_system_prompts", return_value=["System prompt"]):
+            with patch.object(
+                model,
+                "_infer",
+                new_callable=AsyncMock,
+                return_value=(mock_response, []),
+            ):
+                citations = await model.get_citations(
+                    denial_text="This is a denial",
+                    procedure="Truvada",
+                    diagnosis=None,
+                )
+
+                assert len(citations) == 1
+                assert "CDC PrEP Clinical Guidance" in citations[0]
+                assert all("Template line that starts repeating" not in c for c in citations)
+
+
+    @pytest.mark.asyncio
+    async def test_get_citations_keeps_long_single_line_header_with_citation(self):
+        """Do not drop long lines that begin with a header prefix but contain citation content."""
+        model = RemoteFullOpenLike("http://test-api.com", "test-token", "test-model")
+
+        mock_response = (
+            "Citations: CDC Clinical Guidance for PrEP, 2025, "
+            "https://www.cdc.gov/hiv/clinicians/prevention/prep.html"
+        )
+
+        with patch.object(model, "get_system_prompts", return_value=["System prompt"]):
+            with patch.object(
+                model,
+                "_infer",
+                new_callable=AsyncMock,
+                return_value=(mock_response, []),
+            ):
+                citations = await model.get_citations(
+                    denial_text="This is a denial",
+                    procedure="Truvada",
+                    diagnosis=None,
+                )
+
+                assert len(citations) == 1
+                assert citations[0].startswith("Citations: CDC Clinical Guidance for PrEP")
+
     def test_full_find_citation_backends(self):
         """Test the full_find_citation_backends router method."""
         # Setup mocks


### PR DESCRIPTION
### Motivation

- Prevent LLM-generated output that contains long runs of repeated template lines from being treated as valid citations or usable output.
- Improve robustness of `is_bad_output` and citation parsing so that repetition acts as an implicit stop token instead of polluting results.

### Description

- Add `_has_repeated_line_runaway` in `fighthealthinsurance/ml/bad_output_utils.py` to detect normalized lines repeated consecutively and integrate it into `is_bad_output` when `check_severe_repetition` is enabled.
- In `fighthealthinsurance/ml/ml_models.py`, track `seen_line_counts` while parsing `text_result` and treat a line that appears 3+ times as an implicit stop token by trimming trailing repeated entries and breaking out of parsing.
- Adjust header-skipping logic to only drop short header-like lines (<= 32 chars) while preserving longer single-line entries that include citation content.
- Add two async tests in `tests/async-unit/test_ml_citations.py`: `test_get_citations_stops_on_repeated_line` to validate stopping on repeated lines and `test_get_citations_keeps_long_single_line_header_with_citation` to validate preserving long header+content lines.

### Testing

- Ran the async unit tests in `tests/async-unit/test_ml_citations.py` including the two new tests, and they passed.
- Ran the package test suite for citation parsing flows that exercise `RemoteFullOpenLike.get_citations`, and these tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7f8058e9483229dbddf862769ef20)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of repetitive output patterns to identify unusable responses
  * Enhanced citation parsing to stop processing when repeated content is detected
  * Refined header line filtering for more accurate citation extraction

* **Tests**
  * Added tests for citation parsing with repeated lines and extended header handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->