### PR TITLE
Import datetime in non-professional abandoned cart async test

### DIFF
--- a/tests/async/test_non_professional_abandoned_cart.py
+++ b/tests/async/test_non_professional_abandoned_cart.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import pytest
 from urllib.parse import urlencode


### PR DESCRIPTION
### Motivation
- The test constructs a legacy `LostStripeSession` using `datetime` but did not import the `datetime` module, causing a `NameError` during test import/collection.

### Description
- Add `import datetime` to the top of `tests/async/test_non_professional_abandoned_cart.py` to allow creation of the legacy session timestamp.

### Testing
- Ran `python -m py_compile tests/async/test_non_professional_abandoned_cart.py`, which succeeded; a targeted `pytest -q tests/async/test_non_professional_abandoned_cart.py::test_non_professional_abandoned_cart` was attempted but failed in this environment due to missing Django test settings (failure unrelated to the import fix).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7fe26751c83228e188675291a7398)