### PR TITLE
Fix migration order: rename RxNorm 0173 to 0175

### DIFF
--- a/fighthealthinsurance/migrations/0175_rxnormconcept.py
+++ b/fighthealthinsurance/migrations/0175_rxnormconcept.py
@@ -6,7 +6,7 @@ from django.db.models.functions import Now
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("fighthealthinsurance", "0172_payerpriorauthrequirement"),
+        ("fighthealthinsurance", "0174_seed_medication_contexts"),
     ]
 
     operations = [


### PR DESCRIPTION
PRs #744 (RxNormConcept) and #746 (MedicationContext) both landed
migrations numbered 0173 with the same parent (0172_payerpriorauth-
requirement), creating a branched history. Renumber the RxNorm
migration to 0175 and chain it after 0174_seed_medication_contexts
so the migration graph is linear again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database migration sequencing to maintain proper initialization order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->