### PR TITLE
Add REST fallback for appeal streaming when WebSocket unavailable

### DIFF
--- a/fighthealthinsurance/rest_urls.py
+++ b/fighthealthinsurance/rest_urls.py
@@ -58,6 +58,11 @@ urlpatterns = [
         rest_views.ReportClientError.as_view(),
         name="report_client_error",
     ),
+    path(
+        "streaming_appeals_fallback",
+        rest_views.streaming_appeals_rest_fallback,
+        name="streaming_appeals_fallback",
+    ),
     path("check_storage", rest_views.CheckStorage.as_view(), name="check_storage"),
     path(
         "external_review_wizard",

--- a/fighthealthinsurance/rest_views.py
+++ b/fighthealthinsurance/rest_views.py
@@ -613,6 +613,24 @@ def streaming_appeals_rest_fallback(request: Request):
         )
 
     denial_id = data.get("denial_id")
+    # Magic-key auth gate: verify (denial_id, email, semi_sekret)
+    # triple resolves to a real Denial BEFORE starting the stream.
+    # Without this, malformed/wrong credentials would burn ML
+    # generation cycles and return 200 + an in-band error frame,
+    # which is harder for clients to handle deterministically.
+    # Uniform 404 for any auth failure so we don't leak which field
+    # was wrong.
+    denial = common_view_logic.get_denial_for_action(
+        denial_id=denial_id,
+        email=data.get("email") or "",
+        semi_sekret=data.get("semi_sekret") or "",
+    )
+    if denial is None:
+        logger.warning(f"REST appeals fallback auth failure for denial {denial_id!r}")
+        return Response(
+            {"error": "Not found"},
+            status=status.HTTP_404_NOT_FOUND,
+        )
 
     async def stream():
         appeal_count = 0

--- a/fighthealthinsurance/rest_views.py
+++ b/fighthealthinsurance/rest_views.py
@@ -8,7 +8,9 @@ from django.conf import settings
 from django.core.exceptions import SuspiciousFileOperation
 from django.db import IntegrityError, models
 from django.db.models import Count, Q
-from django.http import FileResponse
+from django.http import FileResponse, HttpResponse, StreamingHttpResponse
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 
@@ -548,6 +550,108 @@ class ReportClientError(APIView):
             f"denial_id_valid={denial_id_valid} | denial_id_raw={denial_id_raw}"
         )
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+@csrf_exempt
+@require_POST
+async def streaming_appeals_rest_fallback(request):
+    """REST/HTTP fallback for the WebSocket appeal stream.
+
+    Some clients can't hold a WebSocket open long enough to receive
+    appeals: iPhone Safari with strict ITP, corporate proxies that
+    reject WebSocket upgrades, captive portals, browsers behind
+    transparent proxies that buffer streaming responses, etc. After
+    the JS client exhausts its WebSocket retries, it POSTs the same
+    JSON payload here and consumes the same NDJSON stream that
+    `StreamingAppealsBackend` produces.
+
+    Auth model mirrors the WebSocket: the (denial_id, email,
+    semi_sekret) triple inside the body is the only credential, so
+    CSRF is exempted just like the WebSocket isn't checked.
+    """
+    from fighthealthinsurance.websockets import log_zero_appeal_diagnostics
+
+    try:
+        data = json.loads(request.body)
+    except json.JSONDecodeError as e:
+        logger.warning(f"Invalid JSON received in REST appeals fallback: {e}")
+        return HttpResponse(
+            json.dumps({"error": "Invalid JSON format"}),
+            content_type="application/json",
+            status=400,
+        )
+
+    denial_id = data.get("denial_id")
+
+    async def stream():
+        appeal_count = 0
+        status_count = 0
+        last_status_phase: Optional[str] = None
+        try:
+            async for record in common_view_logic.AppealsBackendHelper.generate_appeals(
+                data
+            ):
+                # Mirror the WebSocket framing: each record is already
+                # newline-terminated JSON, but we add an extra "\n"
+                # framing newline so intermediaries that buffer per-line
+                # still flush early, matching the WS keepalive cadence.
+                yield record
+                yield "\n"
+                stripped = record.strip()
+                if stripped:
+                    try:
+                        parsed = json.loads(stripped)
+                        if isinstance(parsed, dict):
+                            if "content" in parsed:
+                                appeal_count += 1
+                            elif parsed.get("type") == "status":
+                                status_count += 1
+                                last_status_phase = parsed.get("phase")
+                    except (json.JSONDecodeError, TypeError):
+                        pass
+            if appeal_count == 0:
+                await log_zero_appeal_diagnostics(
+                    denial_id=denial_id,
+                    status_count=status_count,
+                    last_status_phase=last_status_phase,
+                    transport="rest",
+                )
+        except Exception as e:
+            logger.opt(exception=True).error(
+                f"Error streaming REST fallback appeals for denial "
+                f"{denial_id} after {appeal_count} appeals / "
+                f"{status_count} status frames (last phase="
+                f"{last_status_phase}): {e}"
+            )
+            if appeal_count == 0:
+                await log_zero_appeal_diagnostics(
+                    denial_id=denial_id,
+                    status_count=status_count,
+                    last_status_phase=last_status_phase,
+                    transport="rest",
+                    stream_error=str(e),
+                )
+            # Inform the client rather than terminating silently
+            yield (
+                json.dumps(
+                    {
+                        "type": "error",
+                        "message": "Server error while generating appeals.",
+                    }
+                )
+                + "\n"
+            )
+
+    response = StreamingHttpResponse(
+        streaming_content=stream(),
+        content_type="application/x-ndjson",
+    )
+    # Disable nginx/proxy response buffering so each chunk reaches the
+    # client as it's produced. Without this, intermediaries hold back
+    # the body until generation completes, defeating the fallback.
+    response["Cache-Control"] = "no-cache, no-store"
+    response["X-Accel-Buffering"] = "no"
+    return response
 
 
 class ExternalReviewWizardView(APIView):

--- a/fighthealthinsurance/rest_views.py
+++ b/fighthealthinsurance/rest_views.py
@@ -64,6 +64,7 @@ from fighthealthinsurance.rest_mixins import (
     SerializerMixin,
 )
 from fighthealthinsurance.type_utils import User
+from fighthealthinsurance.websockets import log_zero_appeal_diagnostics
 
 from .common_view_logic import AppealAssemblyHelper
 from .utils import is_convertible_to_int, is_valid_denial_id
@@ -575,8 +576,6 @@ async def streaming_appeals_rest_fallback(request):
     semi_sekret) triple inside the body is the only credential, so
     CSRF is exempted just like the WebSocket isn't checked.
     """
-    from fighthealthinsurance.websockets import log_zero_appeal_diagnostics
-
     try:
         data = json.loads(request.body)
     except json.JSONDecodeError as e:

--- a/fighthealthinsurance/rest_views.py
+++ b/fighthealthinsurance/rest_views.py
@@ -8,9 +8,8 @@ from django.conf import settings
 from django.core.exceptions import SuspiciousFileOperation
 from django.db import IntegrityError, models
 from django.db.models import Count, Q
-from django.http import FileResponse, HttpResponse, StreamingHttpResponse
+from django.http import FileResponse, StreamingHttpResponse
 from django.views.decorators.csrf import csrf_exempt
-from django.views.decorators.http import require_POST
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 
@@ -21,7 +20,12 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from loguru import logger
 from rest_framework import status, viewsets
-from rest_framework.decorators import action
+from rest_framework.decorators import (
+    action,
+    api_view,
+    authentication_classes,
+    permission_classes,
+)
 from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import AllowAny
 from rest_framework.request import Request
@@ -559,40 +563,53 @@ class ReportClientError(APIView):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
+@extend_schema(
+    description=(
+        "REST/HTTP fallback for the WebSocket appeal stream used by "
+        "clients that can't hold a WebSocket open long enough (iOS "
+        "Safari ITP, corporate proxies blocking WS upgrades, captive "
+        "portals). Auth model mirrors the WebSocket: the "
+        "(denial_id, email, semi_sekret) triple inside the body is "
+        "the only credential. Response body is NDJSON: one JSON "
+        "object per line — either a status frame "
+        '`{type: "status", phase, message}`, an appeal payload '
+        "`{id, content}`, or an error frame "
+        '`{type: "error", message}`.'
+    ),
+    request=OpenApiTypes.OBJECT,
+    responses={
+        200: OpenApiTypes.STR,
+        400: OpenApiTypes.OBJECT,
+    },
+)
+@api_view(["POST"])
+@authentication_classes([])
+@permission_classes([AllowAny])
 @csrf_exempt
-@require_POST
-async def streaming_appeals_rest_fallback(request):
+def streaming_appeals_rest_fallback(request: Request):
     """REST/HTTP fallback for the WebSocket appeal stream.
 
-    Some clients can't hold a WebSocket open long enough to receive
-    appeals: iPhone Safari with strict ITP, corporate proxies that
-    reject WebSocket upgrades, captive portals, browsers behind
-    transparent proxies that buffer streaming responses, etc. After
-    the JS client exhausts its WebSocket retries, it POSTs the same
-    JSON payload here and consumes the same NDJSON stream that
-    `StreamingAppealsBackend` produces.
-
-    Auth model mirrors the WebSocket: the (denial_id, email,
-    semi_sekret) triple inside the body is the only credential, so
-    CSRF is exempted just like the WebSocket isn't checked.
+    The view is sync but returns a `StreamingHttpResponse` whose
+    `streaming_content` is an async generator. Django 4.2+ on ASGI
+    drives the async iterator directly, preserving true streaming
+    semantics — the client sees each frame as the underlying
+    `AppealsBackendHelper.generate_appeals` async generator yields it.
     """
     try:
-        data = json.loads(request.body)
-    except json.JSONDecodeError as e:
-        logger.warning(f"Invalid JSON received in REST appeals fallback: {e}")
-        return HttpResponse(
-            json.dumps({"error": "Invalid JSON format"}),
-            content_type="application/json",
-            status=400,
+        data = request.data
+    except Exception as e:
+        logger.warning(f"Invalid request body in REST appeals fallback: {e}")
+        return Response(
+            {"error": "Invalid JSON format"},
+            status=status.HTTP_400_BAD_REQUEST,
         )
     if not isinstance(data, dict):
         logger.warning(
             f"REST appeals fallback got non-object JSON: {type(data).__name__}"
         )
-        return HttpResponse(
-            json.dumps({"error": "Expected a JSON object"}),
-            content_type="application/json",
-            status=400,
+        return Response(
+            {"error": "Expected a JSON object"},
+            status=status.HTTP_400_BAD_REQUEST,
         )
 
     denial_id = data.get("denial_id")

--- a/fighthealthinsurance/rest_views.py
+++ b/fighthealthinsurance/rest_views.py
@@ -637,6 +637,11 @@ def streaming_appeals_rest_fallback(request: Request):
         status_count = 0
         last_status_phase: Optional[str] = None
         try:
+            # Flush a leading newline before awaiting generate_appeals
+            # so anti-buffering headers and intermediary heuristics
+            # engage immediately. Otherwise a slow first ML call can
+            # make the fallback look hung even when it's working.
+            yield "\n"
             async for record in common_view_logic.AppealsBackendHelper.generate_appeals(
                 data
             ):

--- a/fighthealthinsurance/rest_views.py
+++ b/fighthealthinsurance/rest_views.py
@@ -541,11 +541,17 @@ class ReportClientError(APIView):
         denial_id_raw = _sanitize(str(request.data.get("denial_id_raw", "")), 200)
         error_message = _sanitize(str(request.data.get("error", "unknown error")), 500)
         browser_info = _sanitize(str(request.data.get("browser_info", "")), 500)
+        # Delivery diagnostics are client-collected counters (status frames,
+        # ws close code/reason, server-reported totals, etc). They share the
+        # same sanitization rules but get their own field so a long mobile
+        # user-agent string in browser_info doesn't crowd them out.
+        diagnostics = _sanitize(str(request.data.get("diagnostics", "")), 1000)
         session_key = request.session.session_key or "no_session_key"
         denial_id_valid = is_valid_denial_id(denial_id)
         logger.error(
             f"Client-reported appeal error for denial {denial_id}: "
             f"{error_message} | browser: {browser_info} | "
+            f"diagnostics: {diagnostics} | "
             f"session_key={session_key} | remote_ip={request.META.get('REMOTE_ADDR', 'unknown')} | "
             f"denial_id_valid={denial_id_valid} | denial_id_raw={denial_id_raw}"
         )
@@ -577,6 +583,15 @@ async def streaming_appeals_rest_fallback(request):
         logger.warning(f"Invalid JSON received in REST appeals fallback: {e}")
         return HttpResponse(
             json.dumps({"error": "Invalid JSON format"}),
+            content_type="application/json",
+            status=400,
+        )
+    if not isinstance(data, dict):
+        logger.warning(
+            f"REST appeals fallback got non-object JSON: {type(data).__name__}"
+        )
+        return HttpResponse(
+            json.dumps({"error": "Expected a JSON object"}),
             content_type="application/json",
             status=400,
         )

--- a/fighthealthinsurance/static/js/appeal_fetcher.ts
+++ b/fighthealthinsurance/static/js/appeal_fetcher.ts
@@ -383,6 +383,26 @@ let lastWsCloseReason = '';
 let lastWsErrorMessage = '';
 let lastRestErrorMessage = '';
 
+// Wait-time tracking so Sentry shows how long the user waited
+// before we gave up. `doQueryStartedAtMs` is the moment doQuery()
+// was first called (page load -> appeals page); attemptDurationsMs
+// collects each WS attempt + the REST fallback in order, so triage
+// can see whether one attempt timed out vs many failed quickly.
+let doQueryStartedAtMs = 0;
+let currentAttemptStartedAtMs = 0;
+const attemptDurationsMs: number[] = [];
+
+function endCurrentAttempt(): void {
+  if (currentAttemptStartedAtMs > 0) {
+    attemptDurationsMs.push(Date.now() - currentAttemptStartedAtMs);
+    currentAttemptStartedAtMs = 0;
+  }
+}
+
+function beginAttempt(): void {
+  currentAttemptStartedAtMs = Date.now();
+}
+
 let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
 
 function parseValidDenialId(value: unknown): number | null {
@@ -398,6 +418,14 @@ function reportClientError(error: string): void {
   const denialIdRaw = (my_data as any).denial_id || (my_data as any).get?.('denial_id') || '';
   const denialId = parseValidDenialId(denialIdRaw);
   const csrfToken = (my_data as any).csrfmiddlewaretoken || '';
+  // Wait times: aggregate is page-time-since-doQuery. Per-attempt is
+  // each completed WS attempt + the REST fallback. If we're still
+  // inside an attempt when reporting, surface that too so we can tell
+  // "stuck forever on attempt 1" apart from "many quick failures".
+  const aggregateWaitMs = doQueryStartedAtMs > 0
+    ? Date.now() - doQueryStartedAtMs : -1;
+  const inflightWaitMs = currentAttemptStartedAtMs > 0
+    ? Date.now() - currentAttemptStartedAtMs : -1;
   // Delivery diagnostics live in their own field so a long mobile
   // user-agent string in browser_info doesn't truncate them.
   const diagnostics = [
@@ -412,6 +440,9 @@ function reportClientError(error: string): void {
     `ws_err=${lastWsErrorMessage || 'none'}`,
     `rest_fallback=${usingRestFallback}`,
     `rest_err=${lastRestErrorMessage || 'none'}`,
+    `wait_total_ms=${aggregateWaitMs}`,
+    `wait_attempts_ms=${attemptDurationsMs.join(',') || 'none'}`,
+    `wait_inflight_ms=${inflightWaitMs}`,
   ].join(' ');
   const browserInfo = `${navigator.userAgent} | ${window.location.pathname} | ref=${document.referrer || 'none'}`;
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
@@ -459,6 +490,9 @@ function done(): void {
 async function fetchFallback(url: string, data: object, csrfToken: string): Promise<void> {
   console.log("Using REST fallback for appeal generation");
   usingRestFallback = true;
+  // ws.onerror already called endCurrentAttempt() before handoff, so
+  // start a fresh attempt timer for the REST leg.
+  beginAttempt();
   const statusMessage = document.getElementById('status-message');
   if (statusMessage) {
     statusMessage.textContent = 'Using alternative connection method...';
@@ -518,6 +552,8 @@ async function fetchFallback(url: string, data: object, csrfToken: string): Prom
       statusMessage.style.color = '#dc3545';
     }
   }
+  // Record REST attempt duration before reporting / hiding UI.
+  endCurrentAttempt();
   done();
 }
 
@@ -711,6 +747,8 @@ function connectWebSocket(
       console.error("No messages received in 240 seconds. Reconnecting...");
       if (retries < maxRetries) {
         retries++;
+        // Inactivity timeout ended the current attempt; record duration.
+        endCurrentAttempt();
         setTimeout(
           () =>
             connectWebSocket(websocketUrl, data, processResponseChunk, done),
@@ -718,12 +756,16 @@ function connectWebSocket(
         );
       } else {
         console.error("Max retries reached. Closing connection.");
+        endCurrentAttempt();
         done();
       }
     }, 240000); // 240 seconds timeout
   };
 
   const startWebSocket = () => {
+    // Start the per-attempt wait timer. connectWebSocket is called
+    // recursively for retries, so each invocation gets its own start.
+    beginAttempt();
     // Per-attempt flag: ws.onerror may decide to retry or hand off to
     // REST. The same socket's ws.onclose then fires on the normal
     // error->close sequence; without a guard, onclose would also call
@@ -752,12 +794,16 @@ function connectWebSocket(
       lastWsCloseCode = event.code;
       lastWsCloseReason = event.reason || '';
       // Two reasons to short-circuit done():
-      //   1. handingOffToRest: REST fallback owns the final done() call.
+      //   1. handingOffToRest: REST fallback owns the final done() call
+      //      and will record its own attempt duration.
       //   2. retryScheduled: ws.onerror already queued a reconnect for
-      //      this attempt; calling done() here would stomp on it.
+      //      this attempt and recorded its duration; calling done()
+      //      here would stomp on it.
       if (handingOffToRest || retryScheduled) {
         return;
       }
+      // Normal close path: record the attempt duration before done().
+      endCurrentAttempt();
       updateStatusIndicator('done', appealsSoFar.length);
       done();
     };
@@ -767,6 +813,9 @@ function connectWebSocket(
       console.error("WebSocket error:", error);
       lastWsErrorMessage = (error as any)?.message || (error as any)?.type || 'unknown';
       updateStatusIndicator('error', appealsSoFar.length);
+      // Record this attempt's duration regardless of which branch we
+      // take next (retry / fallback / give up).
+      endCurrentAttempt();
       if (retries < maxRetries) {
         console.log(
           `Retrying WebSocket connection (${retries + 1}/${maxRetries})...`,
@@ -805,6 +854,12 @@ export function doQuery(backend_url: string, data: Map<string, string>, rest_fal
   my_rest_fallback_url = rest_fallback_url || '';
   usingRestFallback = false;
   handingOffToRest = false;
+  // Start the aggregate wait clock only on the first call. doQuery
+  // recurses on retry via done(), and we want the total to span the
+  // entire user-visible wait, not just the latest retry.
+  if (doQueryStartedAtMs === 0) {
+    doQueryStartedAtMs = Date.now();
+  }
   return connectWebSocket(backend_url, data, processResponseChunk, done);
 }
 

--- a/fighthealthinsurance/static/js/appeal_fetcher.ts
+++ b/fighthealthinsurance/static/js/appeal_fetcher.ts
@@ -364,6 +364,10 @@ let my_data: Map<string, string> = new Map<string, string>();
 let my_backend_url = "";
 let my_rest_fallback_url = "";
 let usingRestFallback = false;
+// Set when ws.onerror has decided to delegate to REST, so the
+// concurrent ws.onclose doesn't run done() in parallel and tear
+// down the UI while the REST stream is still in flight.
+let handingOffToRest = false;
 let hasAutoScrolledToFirstAppeal = false;
 
 // Diagnostic counters used in the client error report so server logs
@@ -394,8 +398,8 @@ function reportClientError(error: string): void {
   const denialIdRaw = (my_data as any).denial_id || (my_data as any).get?.('denial_id') || '';
   const denialId = parseValidDenialId(denialIdRaw);
   const csrfToken = (my_data as any).csrfmiddlewaretoken || '';
-  // Pack delivery diagnostics into browser_info so the existing
-  // /report_client_error endpoint surfaces them without a schema change.
+  // Delivery diagnostics live in their own field so a long mobile
+  // user-agent string in browser_info doesn't truncate them.
   const diagnostics = [
     `appeals_received=${appealsSoFar.length}`,
     `retries=${retries}`,
@@ -409,7 +413,7 @@ function reportClientError(error: string): void {
     `rest_fallback=${usingRestFallback}`,
     `rest_err=${lastRestErrorMessage || 'none'}`,
   ].join(' ');
-  const browserInfo = `${navigator.userAgent} | ${window.location.pathname} | ref=${document.referrer || 'none'} | ${diagnostics}`;
+  const browserInfo = `${navigator.userAgent} | ${window.location.pathname} | ref=${document.referrer || 'none'}`;
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
   if (csrfToken) {
     headers['X-CSRFToken'] = csrfToken;
@@ -427,6 +431,7 @@ function reportClientError(error: string): void {
       denial_id: denialId ?? 'invalid',
       error,
       browser_info: browserInfo,
+      diagnostics,
       denial_id_raw: String(denialIdRaw),
     }),
   }).catch(() => {}); // fire-and-forget
@@ -593,7 +598,14 @@ function processResponseChunk(chunk: string): void {
         // handler and push an `undefined` appeal into the UI.
         if (parsedLine.type === 'error') {
           console.error('Server reported error:', parsedLine.message);
-          lastRestErrorMessage = String(parsedLine.message || 'server error');
+          const msg = String(parsedLine.message || 'server error');
+          // Attribute to the active transport so triage doesn't get
+          // pointed at REST when the failure was on the WS path.
+          if (usingRestFallback) {
+            lastRestErrorMessage = msg;
+          } else {
+            lastWsErrorMessage = msg;
+          }
           return;
         }
 
@@ -732,6 +744,12 @@ function connectWebSocket(
       console.log("WebSocket connection closed:", event.code, event.reason);
       lastWsCloseCode = event.code;
       lastWsCloseReason = event.reason || '';
+      // If we've handed off to REST (or it has already finished), don't
+      // race the fallback's own done() — the fetchFallback path will
+      // call done() when its stream ends.
+      if (handingOffToRest) {
+        return;
+      }
       updateStatusIndicator('done', appealsSoFar.length);
       done();
     };
@@ -754,6 +772,7 @@ function connectWebSocket(
       } else if (my_rest_fallback_url && !usingRestFallback) {
         // WebSocket retries exhausted — try REST fallback
         console.log("WebSocket retries exhausted, falling back to REST endpoint");
+        handingOffToRest = true;
         const csrfToken = (data as any).csrfmiddlewaretoken || '';
         fetchFallback(my_rest_fallback_url, data, csrfToken);
       } else {
@@ -776,6 +795,7 @@ export function doQuery(backend_url: string, data: Map<string, string>, rest_fal
   my_data = data;
   my_rest_fallback_url = rest_fallback_url || '';
   usingRestFallback = false;
+  handingOffToRest = false;
   return connectWebSocket(backend_url, data, processResponseChunk, done);
 }
 

--- a/fighthealthinsurance/static/js/appeal_fetcher.ts
+++ b/fighthealthinsurance/static/js/appeal_fetcher.ts
@@ -741,40 +741,51 @@ function connectWebSocket(
   processResponseChunk: (chunk: string) => void,
   done: () => void,
 ) {
-  const resetTimeout = () => {
-    if (timeoutHandle) clearTimeout(timeoutHandle);
-    timeoutHandle = setTimeout(() => {
-      console.error("No messages received in 240 seconds. Reconnecting...");
-      if (retries < maxRetries) {
-        retries++;
-        // Inactivity timeout ended the current attempt; record duration.
-        endCurrentAttempt();
-        setTimeout(
-          () =>
-            connectWebSocket(websocketUrl, data, processResponseChunk, done),
-          1000,
-        );
-      } else {
-        console.error("Max retries reached. Closing connection.");
-        endCurrentAttempt();
-        done();
-      }
-    }, 240000); // 240 seconds timeout
-  };
-
   const startWebSocket = () => {
     // Start the per-attempt wait timer. connectWebSocket is called
     // recursively for retries, so each invocation gets its own start.
     beginAttempt();
-    // Per-attempt flag: ws.onerror may decide to retry or hand off to
-    // REST. The same socket's ws.onclose then fires on the normal
-    // error->close sequence; without a guard, onclose would also call
-    // done() and trigger ANOTHER reconnect via retry logic, leaving
-    // overlapping streams. retryScheduled lets onerror own the retry
-    // decision exclusively for this attempt.
+    // Per-attempt flag: ws.onerror or the inactivity-timeout path may
+    // decide to retry or hand off to REST. The same socket's
+    // ws.onclose then fires on the normal error->close (or
+    // close-after-explicit-close) sequence; without this guard,
+    // onclose would also call done() and call endCurrentAttempt()
+    // again, mangling the NEW attempt's duration and potentially
+    // spawning overlapping retries via doQuery recursion.
     let retryScheduled = false;
 
     const ws = new WebSocket(websocketUrl);
+
+    // Defined inside startWebSocket so it can close `ws` and mark
+    // `retryScheduled` on the right per-attempt closure.
+    const resetTimeout = () => {
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+      timeoutHandle = setTimeout(() => {
+        console.error("No messages received in 240 seconds. Reconnecting...");
+        // Mark this socket stale, end its attempt timer, and explicitly
+        // close it. ws.onclose will short-circuit on retryScheduled,
+        // so it can't double-call done() or stomp on the next attempt.
+        retryScheduled = true;
+        endCurrentAttempt();
+        try {
+          ws.close();
+        } catch (e) {
+          /* ignore */
+        }
+        if (retries < maxRetries) {
+          retries++;
+          setTimeout(
+            () =>
+              connectWebSocket(websocketUrl, data, processResponseChunk, done),
+            1000,
+          );
+        } else {
+          console.error("Max retries reached. Closing connection.");
+          done();
+        }
+      }, 240000); // 240 seconds timeout
+    };
+
     ws.onopen = () => {
       console.log("WebSocket connection opened");
       updateStatusIndicator('connected', appealsSoFar.length);
@@ -796,9 +807,10 @@ function connectWebSocket(
       // Two reasons to short-circuit done():
       //   1. handingOffToRest: REST fallback owns the final done() call
       //      and will record its own attempt duration.
-      //   2. retryScheduled: ws.onerror already queued a reconnect for
-      //      this attempt and recorded its duration; calling done()
-      //      here would stomp on it.
+      //   2. retryScheduled: ws.onerror or the inactivity-timeout path
+      //      already queued a reconnect for this attempt and recorded
+      //      its duration; calling done()/endCurrentAttempt() here
+      //      would stomp on it.
       if (handingOffToRest || retryScheduled) {
         return;
       }

--- a/fighthealthinsurance/static/js/appeal_fetcher.ts
+++ b/fighthealthinsurance/static/js/appeal_fetcher.ts
@@ -366,6 +366,19 @@ let my_rest_fallback_url = "";
 let usingRestFallback = false;
 let hasAutoScrolledToFirstAppeal = false;
 
+// Diagnostic counters used in the client error report so server logs
+// can distinguish "we never reached the server" from "we reached the
+// server, got status frames, but never saw an appeal payload".
+let statusMessagesReceived = 0;
+let lastPhaseReceived = '';
+let serverReportedTotalAppeals = -1;
+let serverReportedNewAppeals = -1;
+let serverReportedExistingAppeals = -1;
+let lastWsCloseCode = -1;
+let lastWsCloseReason = '';
+let lastWsErrorMessage = '';
+let lastRestErrorMessage = '';
+
 let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
 
 function parseValidDenialId(value: unknown): number | null {
@@ -381,7 +394,22 @@ function reportClientError(error: string): void {
   const denialIdRaw = (my_data as any).denial_id || (my_data as any).get?.('denial_id') || '';
   const denialId = parseValidDenialId(denialIdRaw);
   const csrfToken = (my_data as any).csrfmiddlewaretoken || '';
-  const browserInfo = `${navigator.userAgent} | ${window.location.pathname} | ref=${document.referrer || 'none'}`;
+  // Pack delivery diagnostics into browser_info so the existing
+  // /report_client_error endpoint surfaces them without a schema change.
+  const diagnostics = [
+    `appeals_received=${appealsSoFar.length}`,
+    `retries=${retries}`,
+    `status_msgs=${statusMessagesReceived}`,
+    `last_phase=${lastPhaseReceived || 'none'}`,
+    `server_total=${serverReportedTotalAppeals}`,
+    `server_new=${serverReportedNewAppeals}`,
+    `server_existing=${serverReportedExistingAppeals}`,
+    `ws_close=${lastWsCloseCode}/${lastWsCloseReason || 'none'}`,
+    `ws_err=${lastWsErrorMessage || 'none'}`,
+    `rest_fallback=${usingRestFallback}`,
+    `rest_err=${lastRestErrorMessage || 'none'}`,
+  ].join(' ');
+  const browserInfo = `${navigator.userAgent} | ${window.location.pathname} | ref=${document.referrer || 'none'} | ${diagnostics}`;
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
   if (csrfToken) {
     headers['X-CSRFToken'] = csrfToken;
@@ -412,7 +440,10 @@ function done(): void {
     doQuery(my_backend_url, my_data, my_rest_fallback_url);
   } else {
     if (appealsSoFar.length === 0) {
-      reportClientError(`Client exhausted ${retries} retries with 0 appeals received`);
+      const transport = usingRestFallback ? 'rest-fallback' : 'websocket';
+      reportClientError(
+        `Client exhausted ${retries} retries with 0 appeals received via ${transport}`
+      );
     }
     clearTimeout(timeoutHandle!);
     hideLoading();
@@ -476,6 +507,7 @@ async function fetchFallback(url: string, data: object, csrfToken: string): Prom
     updateStatusIndicator('done', appealsSoFar.length);
   } catch (error) {
     console.error("REST fallback error:", error);
+    lastRestErrorMessage = (error as any)?.message || String(error);
     if (statusMessage) {
       statusMessage.textContent = 'Connection failed. Please try refreshing the page.';
       statusMessage.style.color = '#dc3545';
@@ -504,16 +536,26 @@ function processResponseChunk(chunk: string): void {
         if (parsedLine.type === 'status') {
           const phase = parsedLine.phase;
           const substep = parsedLine.substep;
+          statusMessagesReceived++;
+          if (phase) {
+            lastPhaseReceived = phase;
+          }
 
           if (phase === 'done') {
             // Explicit end-of-stream from server
             const total = parsedLine.total_appeals || 0;
             const newAppeals = parsedLine.new_appeals || 0;
             const existing = parsedLine.existing_appeals || 0;
+            serverReportedTotalAppeals = total;
+            serverReportedNewAppeals = newAppeals;
+            serverReportedExistingAppeals = existing;
             console.log(`Server stream complete: ${total} total appeals (${newAppeals} new, ${existing} existing), client has ${appealsSoFar.length}`);
             if (total > 0 && appealsSoFar.length === 0) {
               console.error(`BUG: Server sent ${total} appeals but client received none!`);
-              reportClientError(`Server sent ${total} appeals but client received 0`);
+              reportClientError(`Server sent ${total} appeals but client received 0 (lost in transit)`);
+            } else if (total > appealsSoFar.length) {
+              console.warn(`Partial delivery: server reported ${total} appeals, client got ${appealsSoFar.length}`);
+              reportClientError(`Partial delivery: server reported ${total} appeals, client got ${appealsSoFar.length}`);
             }
             markAllDone();
             renderChecklist();
@@ -673,7 +715,9 @@ function connectWebSocket(
 
     // Handle connection closure
     ws.onclose = (event) => {
-      console.log("WebSocket connection closed:", event.reason);
+      console.log("WebSocket connection closed:", event.code, event.reason);
+      lastWsCloseCode = event.code;
+      lastWsCloseReason = event.reason || '';
       updateStatusIndicator('done', appealsSoFar.length);
       done();
     };
@@ -681,6 +725,7 @@ function connectWebSocket(
     // Handle errors
     ws.onerror = (error) => {
       console.error("WebSocket error:", error);
+      lastWsErrorMessage = (error as any)?.message || (error as any)?.type || 'unknown';
       updateStatusIndicator('error', appealsSoFar.length);
       if (retries < maxRetries) {
         console.log(

--- a/fighthealthinsurance/static/js/appeal_fetcher.ts
+++ b/fighthealthinsurance/static/js/appeal_fetcher.ts
@@ -587,8 +587,22 @@ function processResponseChunk(chunk: string): void {
           return;
         }
 
+        // Server-side error frames from the REST fallback (and the
+        // escalation WS) use {"type": "error", "message": "..."}.
+        // Without this branch they'd fall through to the appeal-content
+        // handler and push an `undefined` appeal into the UI.
+        if (parsedLine.type === 'error') {
+          console.error('Server reported error:', parsedLine.message);
+          lastRestErrorMessage = String(parsedLine.message || 'server error');
+          return;
+        }
+
         // Handle regular appeal content
         const appealText = parsedLine.content;
+        if (appealText === undefined || appealText === null) {
+          console.warn('Skipping non-appeal frame without content', parsedLine);
+          return;
+        }
 
         if (
           appealsSoFar.some(

--- a/fighthealthinsurance/static/js/appeal_fetcher.ts
+++ b/fighthealthinsurance/static/js/appeal_fetcher.ts
@@ -724,7 +724,14 @@ function connectWebSocket(
   };
 
   const startWebSocket = () => {
-    // Open the connection and send data
+    // Per-attempt flag: ws.onerror may decide to retry or hand off to
+    // REST. The same socket's ws.onclose then fires on the normal
+    // error->close sequence; without a guard, onclose would also call
+    // done() and trigger ANOTHER reconnect via retry logic, leaving
+    // overlapping streams. retryScheduled lets onerror own the retry
+    // decision exclusively for this attempt.
+    let retryScheduled = false;
+
     const ws = new WebSocket(websocketUrl);
     ws.onopen = () => {
       console.log("WebSocket connection opened");
@@ -744,10 +751,11 @@ function connectWebSocket(
       console.log("WebSocket connection closed:", event.code, event.reason);
       lastWsCloseCode = event.code;
       lastWsCloseReason = event.reason || '';
-      // If we've handed off to REST (or it has already finished), don't
-      // race the fallback's own done() — the fetchFallback path will
-      // call done() when its stream ends.
-      if (handingOffToRest) {
+      // Two reasons to short-circuit done():
+      //   1. handingOffToRest: REST fallback owns the final done() call.
+      //   2. retryScheduled: ws.onerror already queued a reconnect for
+      //      this attempt; calling done() here would stomp on it.
+      if (handingOffToRest || retryScheduled) {
         return;
       }
       updateStatusIndicator('done', appealsSoFar.length);
@@ -764,6 +772,7 @@ function connectWebSocket(
           `Retrying WebSocket connection (${retries + 1}/${maxRetries})...`,
         );
         retries = retries + 1;
+        retryScheduled = true;
         setTimeout(
           () =>
             connectWebSocket(websocketUrl, data, processResponseChunk, done),

--- a/fighthealthinsurance/templates/appeals.html
+++ b/fighthealthinsurance/templates/appeals.html
@@ -100,7 +100,11 @@ Fight Your Health Insurance Denial: Choose an Appeal
 <script>
   // Call the typescript on load
   document.addEventListener('DOMContentLoaded', () => {
-      const backendUrl = `wss://${window.location.host}/ws/streaming-appeals-backend/`;
+      const wsScheme = window.location.protocol === 'https:' ? 'wss' : 'ws';
+      const backendUrl = `${wsScheme}://${window.location.host}/ws/streaming-appeals-backend/`;
+      // REST fallback for clients that can't hold a WebSocket open
+      // (iOS Safari ITP, corporate proxies that block WS upgrades, etc).
+      const restFallbackUrl = `${window.location.protocol}//${window.location.host}{% url 'streaming_appeals_fallback' %}`;
       const data = {
 	  {% autoescape off %}
           ...{{form_context}},
@@ -110,7 +114,7 @@ Fight Your Health Insurance Denial: Choose an Appeal
               'timbit': 'is most awesomex2'}}
 
       // Call the doQuery function
-      doQuery(backendUrl, data);
+      doQuery(backendUrl, data, restFallbackUrl);
   });
 </script>
 {% endblock content %}

--- a/fighthealthinsurance/websockets.py
+++ b/fighthealthinsurance/websockets.py
@@ -171,6 +171,19 @@ class StreamingAppealsBackend(AsyncWebsocketConsumer):
             )
             await self.close()
             return
+        if not isinstance(data, dict):
+            # Valid JSON but not an object (e.g. `[]`, `"x"`, `123`).
+            # Without this guard, data.get(...) below would raise and
+            # the client would just see a server-side close.
+            logger.warning(
+                "Non-object JSON received in appeals websocket: "
+                f"{type(data).__name__}"
+            )
+            await self.send(
+                json.dumps({"type": "error", "message": "Expected a JSON object"})
+            )
+            await self.close()
+            return
         # Test hook: simulate a silent WS death so the JS client falls
         # back to REST. We close cleanly with no payload so the client
         # sees the same shape as a real broken-pipe / proxy-drop.

--- a/fighthealthinsurance/websockets.py
+++ b/fighthealthinsurance/websockets.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import os
 import re
 import uuid
 from typing import AsyncIterator, Callable, Optional, Tuple, cast
@@ -165,7 +166,12 @@ class StreamingAppealsBackend(AsyncWebsocketConsumer):
         # Test hook: simulate a silent WS death so the JS client falls
         # back to REST. We close cleanly with no payload so the client
         # sees the same shape as a real broken-pipe / proxy-drop.
-        if SUPPRESS_APPEAL_WS_DELIVERY:
+        # Double-gate: the module flag alone isn't enough — also
+        # require os.environ["TESTING"] == "True" (set only by the
+        # TestSync settings class) so a misconfigured production
+        # process that somehow toggled the flag still serves real
+        # users.
+        if SUPPRESS_APPEAL_WS_DELIVERY and os.environ.get("TESTING") == "True":
             logger.warning(
                 "WS appeal delivery suppressed by test flag for denial "
                 f"{data.get('denial_id')}"

--- a/fighthealthinsurance/websockets.py
+++ b/fighthealthinsurance/websockets.py
@@ -74,9 +74,14 @@ async def log_zero_appeal_diagnostics(
     """
     # Coerce arbitrary JSON values to int for the FK/AutoField lookup.
     # Anything we can't coerce skips the DB cross-reference and just
-    # gets logged as-is so we still surface the failure.
+    # gets logged as-is so we still surface the failure. bool is a
+    # subclass of int in Python, so a JSON `true`/`false` would
+    # otherwise coerce to 1/0 and point diagnostics at the wrong
+    # denial record.
     denial_id_int: Optional[int] = None
-    if isinstance(denial_id, int):
+    if isinstance(denial_id, bool):
+        denial_id_int = None
+    elif isinstance(denial_id, int):
         denial_id_int = denial_id
     elif isinstance(denial_id, str):
         try:

--- a/fighthealthinsurance/websockets.py
+++ b/fighthealthinsurance/websockets.py
@@ -24,6 +24,7 @@ from fighthealthinsurance.models import (
     OngoingChat,
     PriorAuthRequest,
     ProfessionalUser,
+    ProposedAppeal,
     ProposedPriorAuth,
 )
 
@@ -54,6 +55,59 @@ def _get_client_ip_from_scope(scope: Optional[dict] = None) -> Optional[str]:
     return None
 
 
+async def log_zero_appeal_diagnostics(
+    denial_id: Optional[object],
+    status_count: int,
+    last_status_phase: Optional[str],
+    transport: str,
+    stream_error: Optional[str] = None,
+) -> None:
+    """Emit a structured ERROR when an appeal session ends with 0 appeals delivered.
+
+    Looks up persisted ProposedAppeal rows for the denial so we can
+    distinguish 'server generated nothing' from 'server generated N
+    appeals but they never made it to the client'. The latter case is
+    invisible to the client-side error report.
+
+    `transport` is "websocket" or "rest" so the same log surfaces both
+    delivery paths in alerting.
+    """
+    persisted_count = -1
+    denial_attempts: Optional[int] = None
+    try:
+        if denial_id is not None:
+            persisted_count = await ProposedAppeal.objects.filter(
+                for_denial__denial_id=denial_id
+            ).acount()
+            denial = await Denial.objects.filter(denial_id=denial_id).afirst()
+            if denial is not None:
+                denial_attempts = denial.gen_attempts
+    except Exception as lookup_error:
+        logger.opt(exception=True).warning(
+            f"Failed to look up persisted appeal count for denial "
+            f"{denial_id}: {lookup_error}"
+        )
+    error_suffix = f" stream_error={stream_error}" if stream_error else ""
+    if persisted_count > 0:
+        logger.error(
+            f"[{transport}] Appeal session sent 0 appeals to client BUT "
+            f"server has {persisted_count} ProposedAppeal row(s) for "
+            f"denial {denial_id}. This is a delivery/wire failure, not "
+            f"a generation failure. status_frames={status_count} "
+            f"last_phase={last_status_phase} gen_attempts={denial_attempts}"
+            f"{error_suffix}"
+        )
+    else:
+        logger.error(
+            f"[{transport}] Appeal session completed with 0 appeals sent "
+            f"AND 0 ProposedAppeal rows persisted for denial {denial_id}. "
+            f"Generation produced nothing. status_frames={status_count} "
+            f"last_phase={last_status_phase} "
+            f"persisted={persisted_count} gen_attempts={denial_attempts}"
+            f"{error_suffix}"
+        )
+
+
 class StreamingAppealsBackend(AsyncWebsocketConsumer):
     """Streaming back the appeals as json :D"""
 
@@ -75,14 +129,17 @@ class StreamingAppealsBackend(AsyncWebsocketConsumer):
             await self.close()
             return
         logger.debug("Starting generation of appeals...")
+        denial_id = data.get("denial_id")
         aitr: AsyncIterator[str] = (
             common_view_logic.AppealsBackendHelper.generate_appeals(data)
         )
         # We do a try/except here to log since the WS framework swallow exceptions sometimes
+        appeal_count = 0
+        status_count = 0
+        last_status_phase: Optional[str] = None
         try:
             await asyncio.sleep(1)
             await self.send("\n")
-            appeal_count = 0
             async for record in aitr:
                 await asyncio.sleep(0)
                 await self.send("\n")
@@ -96,18 +153,41 @@ class StreamingAppealsBackend(AsyncWebsocketConsumer):
                 if stripped:
                     try:
                         parsed = json.loads(stripped)
-                        if isinstance(parsed, dict) and "content" in parsed:
-                            appeal_count += 1
+                        if isinstance(parsed, dict):
+                            if "content" in parsed:
+                                appeal_count += 1
+                            elif parsed.get("type") == "status":
+                                status_count += 1
+                                last_status_phase = parsed.get("phase")
                     except (json.JSONDecodeError, TypeError):
                         pass
             if appeal_count == 0:
-                logger.error(
-                    "WebSocket appeal session completed with 0 appeal payloads sent"
+                # Cross-reference: did the server actually generate appeals
+                # for this denial that just didn't make it down the wire?
+                # This is the key signal that distinguishes a server-side
+                # generation failure from a client-side delivery failure.
+                await log_zero_appeal_diagnostics(
+                    denial_id=denial_id,
+                    status_count=status_count,
+                    last_status_phase=last_status_phase,
+                    transport="websocket",
                 )
             else:
                 logger.debug(f"All appeals sent, {appeal_count} payloads total.")
         except Exception as e:
-            logger.opt(exception=True).error(f"Error sending back appeals: {e}")
+            logger.opt(exception=True).error(
+                f"Error sending back appeals for denial {denial_id} after "
+                f"{appeal_count} appeals and {status_count} status frames "
+                f"(last phase={last_status_phase}): {e}"
+            )
+            if appeal_count == 0:
+                await log_zero_appeal_diagnostics(
+                    denial_id=denial_id,
+                    status_count=status_count,
+                    last_status_phase=last_status_phase,
+                    transport="websocket",
+                    stream_error=str(e),
+                )
             raise
         finally:
             logger.debug("Yielding before closing connection")

--- a/fighthealthinsurance/websockets.py
+++ b/fighthealthinsurance/websockets.py
@@ -72,14 +72,28 @@ async def log_zero_appeal_diagnostics(
     `transport` is "websocket" or "rest" so the same log surfaces both
     delivery paths in alerting.
     """
+    # Coerce arbitrary JSON values to int for the FK/AutoField lookup.
+    # Anything we can't coerce skips the DB cross-reference and just
+    # gets logged as-is so we still surface the failure.
+    denial_id_int: Optional[int] = None
+    if isinstance(denial_id, int):
+        denial_id_int = denial_id
+    elif isinstance(denial_id, str):
+        try:
+            denial_id_int = int(denial_id)
+        except ValueError:
+            denial_id_int = None
+
     persisted_count = -1
     denial_attempts: Optional[int] = None
     try:
-        if denial_id is not None:
+        if denial_id_int is not None:
             persisted_count = await ProposedAppeal.objects.filter(
-                for_denial__denial_id=denial_id
+                for_denial__denial_id=denial_id_int
             ).acount()
-            denial = await Denial.objects.filter(denial_id=denial_id).afirst()
+            denial = await Denial.objects.filter(
+                denial_id=denial_id_int
+            ).afirst()
             if denial is not None:
                 denial_attempts = denial.gen_attempts
     except Exception as lookup_error:

--- a/fighthealthinsurance/websockets.py
+++ b/fighthealthinsurance/websockets.py
@@ -94,8 +94,11 @@ async def log_zero_appeal_diagnostics(
     denial_attempts: Optional[int] = None
     try:
         if denial_id_int is not None:
+            # `denial_id` is Denial's PK so `for_denial_id=N` matches
+            # the FK column directly. Using `for_denial__denial_id=`
+            # would add a needless JOIN to the diagnostic path.
             persisted_count = await ProposedAppeal.objects.filter(
-                for_denial__denial_id=denial_id_int
+                for_denial_id=denial_id_int
             ).acount()
             denial = await Denial.objects.filter(denial_id=denial_id_int).afirst()
             if denial is not None:
@@ -160,7 +163,12 @@ class StreamingAppealsBackend(AsyncWebsocketConsumer):
             data = json.loads(text_data)
         except json.JSONDecodeError as e:
             logger.warning(f"Invalid JSON received in appeals websocket: {e}")
-            await self.send(json.dumps({"error": "Invalid JSON format"}))
+            # Match the streaming protocol shape so the client's
+            # type==='error' branch in processResponseChunk fires
+            # instead of treating this as an unrecognized frame.
+            await self.send(
+                json.dumps({"type": "error", "message": "Invalid JSON format"})
+            )
             await self.close()
             return
         # Test hook: simulate a silent WS death so the JS client falls

--- a/fighthealthinsurance/websockets.py
+++ b/fighthealthinsurance/websockets.py
@@ -129,6 +129,14 @@ async def log_zero_appeal_diagnostics(
         )
 
 
+# Test hook: when truthy, StreamingAppealsBackend accepts the
+# connection and closes immediately without yielding any appeal
+# payloads. Lets tests exercise the REST fallback path without
+# injecting a real transport-level failure. Should never be set in
+# production.
+SUPPRESS_APPEAL_WS_DELIVERY = False
+
+
 class StreamingAppealsBackend(AsyncWebsocketConsumer):
     """Streaming back the appeals as json :D"""
 
@@ -147,6 +155,16 @@ class StreamingAppealsBackend(AsyncWebsocketConsumer):
         except json.JSONDecodeError as e:
             logger.warning(f"Invalid JSON received in appeals websocket: {e}")
             await self.send(json.dumps({"error": "Invalid JSON format"}))
+            await self.close()
+            return
+        # Test hook: simulate a silent WS death so the JS client falls
+        # back to REST. We close cleanly with no payload so the client
+        # sees the same shape as a real broken-pipe / proxy-drop.
+        if SUPPRESS_APPEAL_WS_DELIVERY:
+            logger.warning(
+                "WS appeal delivery suppressed by test flag for denial "
+                f"{data.get('denial_id')}"
+            )
             await self.close()
             return
         logger.debug("Starting generation of appeals...")

--- a/fighthealthinsurance/websockets.py
+++ b/fighthealthinsurance/websockets.py
@@ -91,9 +91,7 @@ async def log_zero_appeal_diagnostics(
             persisted_count = await ProposedAppeal.objects.filter(
                 for_denial__denial_id=denial_id_int
             ).acount()
-            denial = await Denial.objects.filter(
-                denial_id=denial_id_int
-            ).afirst()
+            denial = await Denial.objects.filter(denial_id=denial_id_int).afirst()
             if denial is not None:
                 denial_attempts = denial.gen_attempts
     except Exception as lookup_error:

--- a/fighthealthinsurance/websockets.py
+++ b/fighthealthinsurance/websockets.py
@@ -109,14 +109,23 @@ async def log_zero_appeal_diagnostics(
             f"last_phase={last_status_phase} gen_attempts={denial_attempts}"
             f"{error_suffix}"
         )
-    else:
+    elif persisted_count == 0:
         logger.error(
             f"[{transport}] Appeal session completed with 0 appeals sent "
             f"AND 0 ProposedAppeal rows persisted for denial {denial_id}. "
             f"Generation produced nothing. status_frames={status_count} "
             f"last_phase={last_status_phase} "
-            f"persisted={persisted_count} gen_attempts={denial_attempts}"
-            f"{error_suffix}"
+            f"gen_attempts={denial_attempts}{error_suffix}"
+        )
+    else:
+        # persisted_count == -1: lookup never ran (no/invalid denial_id)
+        # or DB call raised. Don't pretend we know the persisted total.
+        logger.error(
+            f"[{transport}] Appeal session sent 0 appeals to client; "
+            f"persisted-count lookup unavailable for denial {denial_id} "
+            f"(coerced={denial_id_int!r}). status_frames={status_count} "
+            f"last_phase={last_status_phase} "
+            f"gen_attempts={denial_attempts}{error_suffix}"
         )
 
 

--- a/tests/async-unit/test_websocket_diagnostics.py
+++ b/tests/async-unit/test_websocket_diagnostics.py
@@ -179,7 +179,7 @@ async def test_int_denial_id_passes_through_to_filter():
             last_status_phase=None,
             transport="websocket",
         )
-    objects.filter.assert_called_once_with(for_denial__denial_id=42)
+    objects.filter.assert_called_once_with(for_denial_id=42)
 
 
 @pytest.mark.asyncio
@@ -196,7 +196,7 @@ async def test_str_denial_id_is_coerced_to_int():
             last_status_phase=None,
             transport="websocket",
         )
-    objects.filter.assert_called_once_with(for_denial__denial_id=42)
+    objects.filter.assert_called_once_with(for_denial_id=42)
 
 
 @pytest.mark.asyncio

--- a/tests/async-unit/test_websocket_diagnostics.py
+++ b/tests/async-unit/test_websocket_diagnostics.py
@@ -1,0 +1,218 @@
+"""Unit tests for fighthealthinsurance.websockets.log_zero_appeal_diagnostics.
+
+The diagnostic helper distinguishes three failure modes when an appeal
+session ends with 0 appeals delivered:
+
+1. persisted_count > 0:  server has rows -> delivery/wire failure
+2. persisted_count == 0: server has no rows -> generation failure
+3. persisted_count == -1: lookup never ran or failed -> unknown
+
+Each branch produces a different log message so triage can be pointed
+at the right thing. These tests pin the behavior so future refactors
+don't accidentally collapse the lookup-failed case back into the
+"generation produced nothing" bucket.
+"""
+
+from unittest.mock import patch, AsyncMock, MagicMock
+
+import pytest
+
+from fighthealthinsurance.websockets import log_zero_appeal_diagnostics
+
+
+def _make_count_mock(return_value=None, side_effect=None):
+    """Build a chained mock for ProposedAppeal.objects.filter(...).acount()."""
+    queryset = MagicMock()
+    if side_effect is not None:
+        queryset.acount = AsyncMock(side_effect=side_effect)
+    else:
+        queryset.acount = AsyncMock(return_value=return_value)
+    objects = MagicMock()
+    objects.filter = MagicMock(return_value=queryset)
+    return objects
+
+
+def _patch_models(persisted_count_mock, denial_first_mock=None):
+    """Patch ProposedAppeal and Denial managers used by the helper."""
+    if denial_first_mock is None:
+        denial_first_mock = AsyncMock(return_value=None)
+    denial_qs = MagicMock()
+    denial_qs.afirst = denial_first_mock
+    denial_objects = MagicMock()
+    denial_objects.filter = MagicMock(return_value=denial_qs)
+    return (
+        patch(
+            "fighthealthinsurance.websockets.ProposedAppeal.objects",
+            persisted_count_mock,
+        ),
+        patch(
+            "fighthealthinsurance.websockets.Denial.objects",
+            denial_objects,
+        ),
+    )
+
+
+def _captured_logger():
+    """Return a context-manager + recorder for the loguru logger used in
+    the websockets module. Patches `logger.error` to a MagicMock so we
+    can inspect the formatted message; loguru otherwise bypasses
+    Python's logging module so caplog doesn't see it.
+    """
+    captured: list = []
+
+    def _record(msg, *args, **kwargs):
+        captured.append(msg)
+
+    cm = patch("fighthealthinsurance.websockets.logger.error", side_effect=_record)
+    return cm, captured
+
+
+@pytest.mark.asyncio
+async def test_persisted_gt_zero_logs_delivery_failure():
+    """3 persisted rows, 0 delivered -> delivery/wire failure log."""
+    objects = _make_count_mock(return_value=3)
+    p1, p2 = _patch_models(objects)
+    log_cm, captured = _captured_logger()
+    with p1, p2, log_cm:
+        await log_zero_appeal_diagnostics(
+            denial_id=42,
+            status_count=5,
+            last_status_phase="generating",
+            transport="websocket",
+        )
+
+    assert len(captured) == 1
+    msg = captured[0]
+    assert "delivery/wire failure" in msg
+    assert "3 ProposedAppeal" in msg
+    assert "[websocket]" in msg
+
+
+@pytest.mark.asyncio
+async def test_persisted_zero_logs_generation_failure():
+    """0 persisted rows -> generation produced nothing log."""
+    objects = _make_count_mock(return_value=0)
+    p1, p2 = _patch_models(objects)
+    log_cm, captured = _captured_logger()
+    with p1, p2, log_cm:
+        await log_zero_appeal_diagnostics(
+            denial_id=99,
+            status_count=2,
+            last_status_phase="init",
+            transport="rest",
+        )
+
+    assert len(captured) == 1
+    msg = captured[0]
+    assert "Generation produced nothing" in msg
+    assert "[rest]" in msg
+
+
+@pytest.mark.asyncio
+async def test_lookup_unavailable_when_db_raises():
+    """DB failure during lookup must NOT be classified as 'generation
+    produced nothing'. The unknown branch (-1) emits its own message."""
+    objects = _make_count_mock(side_effect=RuntimeError("db down"))
+    p1, p2 = _patch_models(objects)
+    log_cm, captured = _captured_logger()
+    with p1, p2, log_cm:
+        await log_zero_appeal_diagnostics(
+            denial_id=42,
+            status_count=1,
+            last_status_phase="research",
+            transport="websocket",
+        )
+
+    msg = captured[-1]  # the diagnostic log; an earlier warning may
+    # come from the lookup_error handler but it goes through
+    # logger.opt(...).warning(), not logger.error()
+    assert "lookup unavailable" in msg
+    # And critically, NOT misclassified as a generation failure
+    assert "Generation produced nothing" not in msg
+
+
+@pytest.mark.asyncio
+async def test_invalid_string_denial_id_skips_db_call_and_logs_unavailable():
+    """A denial_id that can't be coerced to int must skip the DB call
+    entirely and emit the lookup-unavailable log."""
+    objects = _make_count_mock(return_value=0)
+    p1, p2 = _patch_models(objects)
+    log_cm, captured = _captured_logger()
+    with p1, p2, log_cm:
+        await log_zero_appeal_diagnostics(
+            denial_id="not-an-int",
+            status_count=0,
+            last_status_phase=None,
+            transport="rest",
+        )
+
+    assert "lookup unavailable" in captured[-1]
+    # acount() must not have been awaited — we never had a valid id
+    objects.filter.return_value.acount.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_none_denial_id_skips_db_call():
+    objects = _make_count_mock(return_value=0)
+    p1, p2 = _patch_models(objects)
+    log_cm, _captured = _captured_logger()
+    with p1, p2, log_cm:
+        await log_zero_appeal_diagnostics(
+            denial_id=None,
+            status_count=0,
+            last_status_phase=None,
+            transport="websocket",
+        )
+    objects.filter.return_value.acount.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_int_denial_id_passes_through_to_filter():
+    """Integer denial_id must reach the queryset filter as an int."""
+    objects = _make_count_mock(return_value=0)
+    p1, p2 = _patch_models(objects)
+    log_cm, _captured = _captured_logger()
+    with p1, p2, log_cm:
+        await log_zero_appeal_diagnostics(
+            denial_id=42,
+            status_count=0,
+            last_status_phase=None,
+            transport="websocket",
+        )
+    objects.filter.assert_called_once_with(for_denial__denial_id=42)
+
+
+@pytest.mark.asyncio
+async def test_str_denial_id_is_coerced_to_int():
+    """Numeric string from JSON payload must be coerced to int before
+    the queryset lookup so Django's int field accepts it."""
+    objects = _make_count_mock(return_value=0)
+    p1, p2 = _patch_models(objects)
+    log_cm, _captured = _captured_logger()
+    with p1, p2, log_cm:
+        await log_zero_appeal_diagnostics(
+            denial_id="42",
+            status_count=0,
+            last_status_phase=None,
+            transport="websocket",
+        )
+    objects.filter.assert_called_once_with(for_denial__denial_id=42)
+
+
+@pytest.mark.asyncio
+async def test_stream_error_appended_to_log():
+    """When stream_error is set, it must appear in the log so the
+    triggering exception is visible alongside the diagnostic."""
+    objects = _make_count_mock(return_value=2)
+    p1, p2 = _patch_models(objects)
+    log_cm, captured = _captured_logger()
+    with p1, p2, log_cm:
+        await log_zero_appeal_diagnostics(
+            denial_id=42,
+            status_count=1,
+            last_status_phase="generating",
+            transport="rest",
+            stream_error="connection reset",
+        )
+
+    assert "stream_error=connection reset" in captured[-1]

--- a/tests/async-unit/test_websocket_diagnostics.py
+++ b/tests/async-unit/test_websocket_diagnostics.py
@@ -200,6 +200,28 @@ async def test_str_denial_id_is_coerced_to_int():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("denial_id", [True, False])
+async def test_bool_denial_id_does_not_coerce_to_int(denial_id):
+    """`isinstance(True, int)` is True in Python -- without the bool
+    guard, a JSON `true`/`false` would coerce to 1/0 and point
+    diagnostics at the wrong denial record. Lock the bool exclusion in."""
+    objects = _make_count_mock(return_value=0)
+    p1, p2 = _patch_models(objects)
+    log_cm, captured = _captured_logger()
+    with p1, p2, log_cm:
+        await log_zero_appeal_diagnostics(
+            denial_id=denial_id,
+            status_count=0,
+            last_status_phase=None,
+            transport="websocket",
+        )
+    # No DB lookup attempted, and the log message indicates lookup
+    # unavailable -- not "Generation produced nothing".
+    objects.filter.return_value.acount.assert_not_called()
+    assert "lookup unavailable" in captured[-1]
+
+
+@pytest.mark.asyncio
 async def test_stream_error_appended_to_log():
     """When stream_error is set, it must appear in the log so the
     triggering exception is visible alongside the diagnostic."""

--- a/tests/sync/test_rest_api.py
+++ b/tests/sync/test_rest_api.py
@@ -1,6 +1,6 @@
 """Test the rest API functionality"""
 
-from asgiref.sync import sync_to_async
+from asgiref.sync import async_to_sync, sync_to_async
 from unittest.mock import patch
 
 import asyncio
@@ -465,6 +465,42 @@ class StreamingAppealsRestFallbackTest(APITestCase):
 
     fixtures = ["./fighthealthinsurance/fixtures/initial.yaml"]
 
+    @staticmethod
+    def _drain_streaming_response(response) -> str:
+        """Drain a StreamingHttpResponse with an async iterator body.
+
+        The view is async, so streaming_content is an async iterator —
+        b"".join() can't consume it directly. Use async_to_sync rather
+        than asyncio.get_event_loop() because the latter raises
+        RuntimeError when a prior test in the suite has closed the
+        default loop (Python 3.12+ behavior).
+        """
+
+        async def _drain(stream):
+            chunks = []
+            async for chunk in stream:
+                chunks.append(
+                    chunk.encode() if isinstance(chunk, str) else chunk
+                )
+            return b"".join(chunks)
+
+        return async_to_sync(_drain)(response.streaming_content).decode()
+
+    @staticmethod
+    def _content_lines(body: str) -> list:
+        return [
+            line
+            for line in body.split("\n")
+            if line.strip() and '"content"' in line
+        ]
+
+    def _post_fallback(self, payload: dict):
+        return self.client.post(
+            reverse("streaming_appeals_fallback"),
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
     def test_invalid_json_returns_400(self):
         url = reverse("streaming_appeals_fallback")
         response = self.client.post(
@@ -515,16 +551,6 @@ class StreamingAppealsRestFallbackTest(APITestCase):
 
         from fighthealthinsurance.common_view_logic import AppealsBackendHelper
 
-        # The view is async, so streaming_content is an async iterator.
-        # Drain it to bytes the way a real HTTP client would.
-        async def _drain(stream):
-            chunks = []
-            async for chunk in stream:
-                chunks.append(
-                    chunk.encode() if isinstance(chunk, str) else chunk
-                )
-            return b"".join(chunks)
-
         # Patch on the class directly. `new=fake_generate_appeals`
         # replaces the classmethod descriptor with a plain async
         # generator function — when the view calls
@@ -558,15 +584,9 @@ class StreamingAppealsRestFallbackTest(APITestCase):
             self.assertEqual(response["X-Accel-Buffering"], "no")
             self.assertIn("no-cache", response["Cache-Control"])
 
-            body = asyncio.get_event_loop().run_until_complete(
-                _drain(response.streaming_content)
-            ).decode()
+            body = self._drain_streaming_response(response)
         # Expect at least the appeal frame and the done status frame
-        appeal_lines = [
-            line
-            for line in body.split("\n")
-            if line.strip() and '"content"' in line
-        ]
+        appeal_lines = self._content_lines(body)
         done_lines = [
             line
             for line in body.split("\n")
@@ -574,6 +594,171 @@ class StreamingAppealsRestFallbackTest(APITestCase):
         ]
         self.assertEqual(len(appeal_lines), 1)
         self.assertEqual(len(done_lines), 1)
+
+    # ------------------------------------------------------------------
+    # Magic-key auth tests
+    # ------------------------------------------------------------------
+    # The PR explicitly mandates that appeals never release on denial_id
+    # alone — the (denial_id, email, semi_sekret) triple is the
+    # canonical credential. These tests drive the *real* generate_appeals
+    # (no mocking) to assert that a wrong / missing key produces zero
+    # "content" frames in the streamed response, regardless of what
+    # status / error frames the server emits along the way.
+
+    def _make_real_denial(self, email: str = "owner@example.com") -> Denial:
+        """Create a Denial directly via ORM, mirroring how the denial
+        creation API ultimately persists one. Tests use this so we can
+        exercise auth paths without the full denial-creation flow."""
+        return Denial.objects.create(
+            denial_text="Test denial body",
+            hashed_email=Denial.get_hashed_email(email),
+        )
+
+    def test_rejects_wrong_semi_sekret(self):
+        denial = self._make_real_denial()
+        response = self._post_fallback(
+            {
+                "denial_id": denial.denial_id,
+                "email": "owner@example.com",
+                "semi_sekret": "wrong-sekret-not-the-real-one",
+            }
+        )
+        body = self._drain_streaming_response(response)
+        # Must never leak appeal text when the credential triple is bad
+        self.assertEqual(self._content_lines(body), [])
+
+    def test_rejects_wrong_email(self):
+        denial = self._make_real_denial()
+        response = self._post_fallback(
+            {
+                "denial_id": denial.denial_id,
+                "email": "different-user@example.com",
+                "semi_sekret": denial.semi_sekret,
+            }
+        )
+        body = self._drain_streaming_response(response)
+        self.assertEqual(self._content_lines(body), [])
+
+    def test_rejects_missing_credentials(self):
+        denial = self._make_real_denial()
+        response = self._post_fallback({"denial_id": denial.denial_id})
+        body = self._drain_streaming_response(response)
+        self.assertEqual(self._content_lines(body), [])
+
+    def test_cross_session_isolation(self):
+        """Denial A's id with Denial B's credentials must not leak A's
+        appeals (or any appeals at all)."""
+        denial_a = self._make_real_denial(email="alice@example.com")
+        denial_b = self._make_real_denial(email="bob@example.com")
+        response = self._post_fallback(
+            {
+                "denial_id": denial_a.denial_id,
+                "email": "bob@example.com",
+                "semi_sekret": denial_b.semi_sekret,
+            }
+        )
+        body = self._drain_streaming_response(response)
+        self.assertEqual(self._content_lines(body), [])
+
+    # ------------------------------------------------------------------
+    # WS -> REST handoff dedup
+    # ------------------------------------------------------------------
+    @pytest.mark.asyncio
+    async def test_ws_suppression_flag_yields_no_appeals(self):
+        """With SUPPRESS_APPEAL_WS_DELIVERY=True, the WS must accept
+        the connection and close without yielding any appeal payloads.
+        This is the seam we use to drive the JS client's REST fallback
+        path in tests without real WS failure injection."""
+        from fighthealthinsurance import websockets
+
+        denial = await sync_to_async(self._make_real_denial)()
+
+        original = websockets.SUPPRESS_APPEAL_WS_DELIVERY
+        websockets.SUPPRESS_APPEAL_WS_DELIVERY = True
+        try:
+            communicator = WebsocketCommunicator(
+                StreamingAppealsBackend.as_asgi(), "/testws/"
+            )
+            connected, _ = await communicator.connect()
+            assert connected
+            await communicator.send_json_to(
+                {
+                    "denial_id": denial.denial_id,
+                    "email": "owner@example.com",
+                    "semi_sekret": denial.semi_sekret,
+                }
+            )
+            # Consume frames until close. With suppression on, no
+            # content frames should ever arrive.
+            content_frames = 0
+            try:
+                while True:
+                    frame = await communicator.receive_from(timeout=5)
+                    if frame and '"content"' in frame:
+                        content_frames += 1
+            except (asyncio.TimeoutError, AssertionError):
+                # AssertionError: server-side close
+                pass
+            finally:
+                await communicator.disconnect()
+        finally:
+            websockets.SUPPRESS_APPEAL_WS_DELIVERY = original
+
+        self.assertEqual(content_frames, 0)
+
+    def test_handoff_emits_unique_appeal_ids(self):
+        """After a suppressed WS attempt, the REST fallback must
+        emit each appeal with a unique id. The client's dedup logic
+        relies on this contract — duplicate ids would render the same
+        appeal twice in the UI."""
+        from fighthealthinsurance.common_view_logic import AppealsBackendHelper
+
+        async def fake_three_appeals(_data):
+            for i in (1, 2, 3):
+                yield (
+                    json.dumps({"id": f"appeal-{i}", "content": f"Body {i}"})
+                    + "\n"
+                )
+            yield (
+                json.dumps(
+                    {
+                        "type": "status",
+                        "phase": "done",
+                        "total_appeals": 3,
+                        "new_appeals": 3,
+                        "existing_appeals": 0,
+                    }
+                )
+                + "\n"
+            )
+
+        with patch.object(
+            AppealsBackendHelper,
+            "generate_appeals",
+            new=fake_three_appeals,
+        ):
+            response = self._post_fallback(
+                {
+                    "denial_id": 1,
+                    "email": "x@example.com",
+                    "semi_sekret": "x",
+                }
+            )
+            self.assertEqual(response.status_code, 200)
+            body = self._drain_streaming_response(response)
+
+        # Collect ids from every content-bearing frame
+        ids = []
+        for line in body.split("\n"):
+            stripped = line.strip()
+            if not stripped or '"content"' not in stripped:
+                continue
+            parsed = json.loads(stripped)
+            ids.append(parsed["id"])
+
+        self.assertEqual(len(ids), 3)
+        # Dedup contract: every id is unique within a single stream
+        self.assertEqual(len(set(ids)), len(ids))
 
 
 class NotifyPatientTest(APITestCase):

--- a/tests/sync/test_rest_api.py
+++ b/tests/sync/test_rest_api.py
@@ -469,9 +469,10 @@ class StreamingAppealsRestFallbackTest(APITestCase):
     def _drain_streaming_response(response) -> str:
         """Drain a StreamingHttpResponse with an async iterator body.
 
-        The view is async, so streaming_content is an async iterator —
-        b"".join() can't consume it directly. Use async_to_sync rather
-        than asyncio.get_event_loop() because the latter raises
+        The view itself is sync but its StreamingHttpResponse wraps an
+        async generator as `streaming_content`, so b"".join() can't
+        consume it directly. Use async_to_sync rather than
+        asyncio.get_event_loop() because the latter raises
         RuntimeError when a prior test in the suite has closed the
         default loop (Python 3.12+ behavior).
         """

--- a/tests/sync/test_rest_api.py
+++ b/tests/sync/test_rest_api.py
@@ -675,15 +675,23 @@ class StreamingAppealsRestFallbackTest(APITestCase):
 
     def test_rejects_bogus_denial_id(self):
         """Unknown denial_id with any credentials must 404 — and not
-        invoke backend generation."""
-        response = self._post_fallback(
-            {
-                "denial_id": 999999,
-                "email": "x@example.com",
-                "semi_sekret": "anything",
-            }
-        )
+        invoke backend generation. Patching generate_appeals makes
+        the 'no generation' guarantee executable: a regression that
+        triggered generation before the 404 would fail this assert."""
+        from fighthealthinsurance.common_view_logic import AppealsBackendHelper
+
+        with patch.object(
+            AppealsBackendHelper, "generate_appeals"
+        ) as generate_appeals:
+            response = self._post_fallback(
+                {
+                    "denial_id": 999999,
+                    "email": "x@example.com",
+                    "semi_sekret": "anything",
+                }
+            )
         self._assert_auth_failure(response)
+        generate_appeals.assert_not_called()
 
     # ------------------------------------------------------------------
     # WS -> REST handoff dedup

--- a/tests/sync/test_rest_api.py
+++ b/tests/sync/test_rest_api.py
@@ -455,6 +455,127 @@ class DenialEndToEnd(APITestCase):
         ), "Appeal should start with 'Dear'"
 
 
+class StreamingAppealsRestFallbackTest(APITestCase):
+    """Test the REST/HTTP fallback for the WebSocket appeals stream.
+
+    Clients that can't hold a WebSocket open (iOS Safari ITP, corporate
+    proxies blocking WS upgrades, captive portals) fall back to this
+    endpoint after exhausting WebSocket retries.
+    """
+
+    fixtures = ["./fighthealthinsurance/fixtures/initial.yaml"]
+
+    def test_invalid_json_returns_400(self):
+        url = reverse("streaming_appeals_fallback")
+        response = self.client.post(
+            url, data="not-json", content_type="application/json"
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Invalid JSON", response.content.decode())
+
+    def test_non_object_json_returns_400(self):
+        url = reverse("streaming_appeals_fallback")
+        # Valid JSON but not an object — must not crash with AttributeError
+        # on data.get(...).
+        response = self.client.post(
+            url, data=json.dumps([1, 2, 3]), content_type="application/json"
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("JSON object", response.content.decode())
+
+    def test_get_method_not_allowed(self):
+        url = reverse("streaming_appeals_fallback")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 405)
+
+    def test_streams_ndjson_with_anti_buffering_headers(self):
+        """Mock generate_appeals so we can assert framing without a denial."""
+        url = reverse("streaming_appeals_fallback")
+
+        async def fake_generate_appeals(_data):
+            yield (
+                json.dumps(
+                    {"type": "status", "phase": "init", "message": "starting"}
+                )
+                + "\n"
+            )
+            yield json.dumps({"id": "1", "content": "Dear Insurer,..."}) + "\n"
+            yield (
+                json.dumps(
+                    {
+                        "type": "status",
+                        "phase": "done",
+                        "total_appeals": 1,
+                        "new_appeals": 1,
+                        "existing_appeals": 0,
+                    }
+                )
+                + "\n"
+            )
+
+        from fighthealthinsurance.common_view_logic import AppealsBackendHelper
+
+        # The view is async, so streaming_content is an async iterator.
+        # Drain it to bytes the way a real HTTP client would.
+        async def _drain(stream):
+            chunks = []
+            async for chunk in stream:
+                chunks.append(
+                    chunk.encode() if isinstance(chunk, str) else chunk
+                )
+            return b"".join(chunks)
+
+        # Patch on the class directly. `new=fake_generate_appeals`
+        # replaces the classmethod descriptor with a plain async
+        # generator function — when the view calls
+        # `AppealsBackendHelper.generate_appeals(data)`, Python
+        # invokes our function with just `(data,)`.
+        # IMPORTANT: drain inside the patch context. StreamingHttpResponse
+        # holds a lazy async iterator — body bytes are produced only when
+        # consumed, so unpatching before drain lets the real code run.
+        with patch.object(
+            AppealsBackendHelper,
+            "generate_appeals",
+            new=fake_generate_appeals,
+        ):
+            response = self.client.post(
+                url,
+                data=json.dumps(
+                    {
+                        "denial_id": 42,
+                        "email": "test@example.com",
+                        "semi_sekret": "shhh",
+                    }
+                ),
+                content_type="application/json",
+            )
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(
+                response["Content-Type"], "application/x-ndjson"
+            )
+            # Anti-buffering headers — defeating these proxies is the
+            # whole point of the fallback existing.
+            self.assertEqual(response["X-Accel-Buffering"], "no")
+            self.assertIn("no-cache", response["Cache-Control"])
+
+            body = asyncio.get_event_loop().run_until_complete(
+                _drain(response.streaming_content)
+            ).decode()
+        # Expect at least the appeal frame and the done status frame
+        appeal_lines = [
+            line
+            for line in body.split("\n")
+            if line.strip() and '"content"' in line
+        ]
+        done_lines = [
+            line
+            for line in body.split("\n")
+            if line.strip() and '"phase": "done"' in line
+        ]
+        self.assertEqual(len(appeal_lines), 1)
+        self.assertEqual(len(done_lines), 1)
+
+
 class NotifyPatientTest(APITestCase):
     """Test the notify_patient API endpoint."""
 

--- a/tests/sync/test_rest_api.py
+++ b/tests/sync/test_rest_api.py
@@ -507,7 +507,13 @@ class StreamingAppealsRestFallbackTest(APITestCase):
             url, data="not-json", content_type="application/json"
         )
         self.assertEqual(response.status_code, 400)
-        self.assertIn("Invalid JSON", response.content.decode())
+        # DRF's JSON parser raises ParseError -> default exception
+        # handler renders {"detail": "JSON parse error - ..."}.
+        body = response.content.decode().lower()
+        self.assertTrue(
+            "json" in body and ("parse" in body or "invalid" in body),
+            f"Expected JSON parse error in body, got {body!r}",
+        )
 
     def test_non_object_json_returns_400(self):
         url = reverse("streaming_appeals_fallback")

--- a/tests/sync/test_rest_api.py
+++ b/tests/sync/test_rest_api.py
@@ -531,8 +531,11 @@ class StreamingAppealsRestFallbackTest(APITestCase):
         self.assertEqual(response.status_code, 405)
 
     def test_streams_ndjson_with_anti_buffering_headers(self):
-        """Mock generate_appeals so we can assert framing without a denial."""
+        """Mock generate_appeals so we can assert framing without
+        invoking the real ML pipeline. A real denial is created so the
+        upfront magic-key auth gate passes."""
         url = reverse("streaming_appeals_fallback")
+        denial = self._make_real_denial(email="framing@example.com")
 
         async def fake_generate_appeals(_data):
             yield (
@@ -574,9 +577,9 @@ class StreamingAppealsRestFallbackTest(APITestCase):
                 url,
                 data=json.dumps(
                     {
-                        "denial_id": 42,
-                        "email": "test@example.com",
-                        "semi_sekret": "shhh",
+                        "denial_id": denial.denial_id,
+                        "email": "framing@example.com",
+                        "semi_sekret": denial.semi_sekret,
                     }
                 ),
                 content_type="application/json",
@@ -606,10 +609,10 @@ class StreamingAppealsRestFallbackTest(APITestCase):
     # ------------------------------------------------------------------
     # The PR explicitly mandates that appeals never release on denial_id
     # alone — the (denial_id, email, semi_sekret) triple is the
-    # canonical credential. These tests drive the *real* generate_appeals
-    # (no mocking) to assert that a wrong / missing key produces zero
-    # "content" frames in the streamed response, regardless of what
-    # status / error frames the server emits along the way.
+    # canonical credential. The view validates the triple upfront and
+    # returns 404 before invoking generation, so these tests assert
+    # both the status code AND that the response body (which is now a
+    # short JSON error rather than a stream) contains no appeal text.
 
     def _make_real_denial(self, email: str = "owner@example.com") -> Denial:
         """Create a Denial directly via ORM, mirroring how the denial
@@ -620,6 +623,14 @@ class StreamingAppealsRestFallbackTest(APITestCase):
             hashed_email=Denial.get_hashed_email(email),
         )
 
+    def _assert_auth_failure(self, response) -> None:
+        """Auth gate must produce a 4xx response with no appeal content
+        in the body. Uniform 404 means we don't leak which field was
+        wrong."""
+        self.assertEqual(response.status_code, 404)
+        body = response.content.decode()
+        self.assertNotIn('"content"', body)
+
     def test_rejects_wrong_semi_sekret(self):
         denial = self._make_real_denial()
         response = self._post_fallback(
@@ -629,9 +640,7 @@ class StreamingAppealsRestFallbackTest(APITestCase):
                 "semi_sekret": "wrong-sekret-not-the-real-one",
             }
         )
-        body = self._drain_streaming_response(response)
-        # Must never leak appeal text when the credential triple is bad
-        self.assertEqual(self._content_lines(body), [])
+        self._assert_auth_failure(response)
 
     def test_rejects_wrong_email(self):
         denial = self._make_real_denial()
@@ -642,14 +651,12 @@ class StreamingAppealsRestFallbackTest(APITestCase):
                 "semi_sekret": denial.semi_sekret,
             }
         )
-        body = self._drain_streaming_response(response)
-        self.assertEqual(self._content_lines(body), [])
+        self._assert_auth_failure(response)
 
     def test_rejects_missing_credentials(self):
         denial = self._make_real_denial()
         response = self._post_fallback({"denial_id": denial.denial_id})
-        body = self._drain_streaming_response(response)
-        self.assertEqual(self._content_lines(body), [])
+        self._assert_auth_failure(response)
 
     def test_cross_session_isolation(self):
         """Denial A's id with Denial B's credentials must not leak A's
@@ -663,8 +670,19 @@ class StreamingAppealsRestFallbackTest(APITestCase):
                 "semi_sekret": denial_b.semi_sekret,
             }
         )
-        body = self._drain_streaming_response(response)
-        self.assertEqual(self._content_lines(body), [])
+        self._assert_auth_failure(response)
+
+    def test_rejects_bogus_denial_id(self):
+        """Unknown denial_id with any credentials must 404 — and not
+        invoke backend generation."""
+        response = self._post_fallback(
+            {
+                "denial_id": 999999,
+                "email": "x@example.com",
+                "semi_sekret": "anything",
+            }
+        )
+        self._assert_auth_failure(response)
 
     # ------------------------------------------------------------------
     # WS -> REST handoff dedup
@@ -719,6 +737,10 @@ class StreamingAppealsRestFallbackTest(APITestCase):
         appeal twice in the UI."""
         from fighthealthinsurance.common_view_logic import AppealsBackendHelper
 
+        # Real denial so the upfront auth gate passes; generation is
+        # then mocked to keep the test deterministic.
+        denial = self._make_real_denial(email="handoff@example.com")
+
         async def fake_three_appeals(_data):
             for i in (1, 2, 3):
                 yield (
@@ -745,9 +767,9 @@ class StreamingAppealsRestFallbackTest(APITestCase):
         ):
             response = self._post_fallback(
                 {
-                    "denial_id": 1,
-                    "email": "x@example.com",
-                    "semi_sekret": "x",
+                    "denial_id": denial.denial_id,
+                    "email": "handoff@example.com",
+                    "semi_sekret": denial.semi_sekret,
                 }
             )
             self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
## Summary
This PR adds a REST/HTTP fallback endpoint for clients that cannot maintain WebSocket connections long enough to receive appeals. This addresses issues with iOS Safari (ITP), corporate proxies blocking WebSocket upgrades, captive portals, and transparent proxies that buffer streaming responses.

## Key Changes

- **New REST fallback endpoint** (`streaming_appeals_rest_fallback`): Accepts POST requests with the same JSON payload as the WebSocket, streams NDJSON responses using `StreamingHttpResponse` with proper cache-control headers to prevent proxy buffering
- **Enhanced diagnostics**: Added `log_zero_appeal_diagnostics()` function to distinguish between server-side generation failures and client-side delivery failures by checking persisted `ProposedAppeal` rows
- **WebSocket improvements**: Updated `StreamingAppealsBackend` to track status messages, phases, and appeal counts; logs detailed diagnostics when zero appeals are delivered
- **Client-side enhancements**:
  - Added diagnostic counters (status messages, phases, server-reported counts, WebSocket close codes/reasons, error messages)
  - Implemented REST fallback retry logic after WebSocket exhaustion
  - Enhanced error reporting to include delivery diagnostics in browser_info field
  - Added detection for partial delivery (server sent N appeals but client received fewer)
  - Fixed protocol scheme detection for WebSocket URL (wss vs ws)
  - Added error frame handling for server-side errors
- **URL routing**: Registered new `streaming_appeals_fallback` endpoint in REST URLs

## Implementation Details

- Both WebSocket and REST transports use identical `AppealsBackendHelper.generate_appeals()` backend logic
- Authentication mirrors WebSocket: (denial_id, email, semi_sekret) triple in request body is the only credential
- CSRF exemption applied to REST endpoint (matching WebSocket behavior)
- Streaming response includes extra newline framing to ensure intermediaries flush per-line, matching WebSocket keepalive cadence
- Comprehensive error handling with structured logging that includes transport type, appeal/status counts, and last phase for alerting
- Client error reports now include full delivery diagnostics to help distinguish network failures from server issues

https://claude.ai/code/session_01BxAumXS7fq7QqTrKhzLgoG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * REST fallback endpoint for streaming appeals.

* **Improvements**
  * Enhanced diagnostics distinguishing “no appeals generated” vs delivery/wire failures; includes transport-specific details and stream-status tracking.
  * Client now records connection/hand-off metrics and sends enriched diagnostics; streaming responses include anti-buffering headers and explicit NDJSON error frames.
  * Server-side error-reporting input is sanitized before logging.

* **Tests**
  * New unit and integration tests covering diagnostics, REST fallback, and streaming behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fighthealthinsurance/fighthealthinsurance/pull/788)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->