### PR TITLE
Move PA requirement seed to fixture; add ingest command + refresh actor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ mypy --config-file mypy.ini -p fighthealthinsurance -p fhi_users
 # Database migrations
 python manage.py makemigrations
 python manage.py migrate
-python manage.py loaddata initial followup plan_source insurance_companies
+python manage.py loaddata initial followup plan_source insurance_companies pa_requirements
 ```
 
 ## Architecture

--- a/fighthealthinsurance/actor_health_status.py
+++ b/fighthealthinsurance/actor_health_status.py
@@ -41,6 +41,7 @@ def check_actor_health() -> Dict[str, Any]:
         ("chooser_refill_actor", "fhi"),
         ("imr_refresh_actor", "fhi"),
         ("ucr_refresh_actor", "fhi"),
+        ("pa_refresh_actor", "fhi"),
     ]
 
     details: List[ActorHealthDetail] = []
@@ -124,6 +125,7 @@ def relaunch_actors(force: bool = False) -> Dict[str, Any]:
     from fighthealthinsurance.email_polling_actor_ref import email_polling_actor_ref
     from fighthealthinsurance.fax_polling_actor_ref import fax_polling_actor_ref
     from fighthealthinsurance.imr_refresh_actor_ref import imr_refresh_actor_ref
+    from fighthealthinsurance.pa_refresh_actor_ref import pa_refresh_actor_ref
     from fighthealthinsurance.ucr_refresh_actor_ref import ucr_refresh_actor_ref
 
     results: Dict[str, Dict[str, Any]] = {
@@ -132,6 +134,7 @@ def relaunch_actors(force: bool = False) -> Dict[str, Any]:
         "chooser_refill_actor": {"status": "pending"},
         "imr_refresh_actor": {"status": "pending"},
         "ucr_refresh_actor": {"status": "pending"},
+        "pa_refresh_actor": {"status": "pending"},
     }
 
     actors = [
@@ -140,6 +143,7 @@ def relaunch_actors(force: bool = False) -> Dict[str, Any]:
         ("chooser_refill_actor", chooser_refill_actor_ref),
         ("imr_refresh_actor", imr_refresh_actor_ref),
         ("ucr_refresh_actor", ucr_refresh_actor_ref),
+        ("pa_refresh_actor", pa_refresh_actor_ref),
     ]
 
     for actor_name, actor_ref in actors:

--- a/fighthealthinsurance/admin.py
+++ b/fighthealthinsurance/admin.py
@@ -384,6 +384,24 @@ class InsuranceCompanyAdmin(admin.ModelAdmin):
             },
         ),
         (
+            "Prior Authorization Requirement List",
+            {
+                "fields": (
+                    "pa_requirement_list_url",
+                    "pa_requirement_list_url_is_parseable",
+                    "pa_requirement_list_notes",
+                ),
+                "description": (
+                    "URL to the payer's published PA requirement list "
+                    "(Excel/PDF/HTML). Set 'is parseable' true once the "
+                    "response Content-Type is covered by "
+                    "pa_requirement_parsers.PARSERS_BY_CONTENT_TYPE. Run "
+                    "'manage.py ingest_pa_requirements' to auto-import "
+                    "rows into PayerPriorAuthRequirement."
+                ),
+            },
+        ),
+        (
             "Pattern Matching",
             {
                 "fields": ("regex", "negative_regex"),

--- a/fighthealthinsurance/base_refresh_actor.py
+++ b/fighthealthinsurance/base_refresh_actor.py
@@ -1,0 +1,135 @@
+"""Shared run-loop scaffolding for periodic Ray refresh actors.
+
+A refresh actor in this codebase has the same shape every time:
+
+  1. Django + WSGI bootstrap in ``__init__``.
+  2. ``run()`` loops forever, calling ``_refresh_due()`` on a configurable
+     cadence and sleeping ~1 hour between checks so config changes are
+     picked up without a restart.
+  3. Errors during the refresh trigger an ``ERROR_BACKOFF_SECONDS`` sleep
+     before the next attempt.
+  4. ``health_check()`` reports whether the run loop is active.
+
+Concrete subclasses supply ``_settings_interval_key`` (the env/settings
+attribute holding the cadence in hours) and override ``_refresh_due()``
+with the actual work. The ``@ray.remote`` decoration must be applied to
+the subclass, not this base class — Ray inheritance works when the
+parent is a plain Python class.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime
+import os
+import time
+from typing import Optional
+
+from fighthealthinsurance.utils import get_env_variable
+
+# How long to sleep after an unhandled exception in the run loop. Matches
+# the value used in every existing refresh actor so retry pressure on
+# misbehaving upstream sources stays consistent across actors.
+ERROR_BACKOFF_SECONDS = 600
+
+
+def _now_utc() -> datetime.datetime:
+    """Timezone-aware "now" in UTC.
+
+    ``datetime.datetime.utcnow()`` is deprecated in Python 3.12+; refresh
+    actors only care about a monotonically-advancing comparison value so
+    a UTC-aware ``now()`` is the drop-in replacement.
+    """
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+class BaseRefreshActor:
+    """Plain-Python base for ``@ray.remote``-decorated refresh actors.
+
+    Subclasses set:
+
+    * ``actor_log_name``: human label used in log lines.
+    * ``settings_interval_key``: name of the settings attribute holding
+      the cadence in hours (e.g. ``"PA_REFRESH_INTERVAL_HOURS"``).
+    * ``default_interval_hours``: fallback when the settings key is unset.
+
+    Subclasses override:
+
+    * ``_refresh_due()``: do the actual refresh work; return truthy if at
+      least one source successfully refreshed (used to advance
+      ``last_refresh``).
+    """
+
+    actor_log_name: str = "BaseRefreshActor"
+    settings_interval_key: str = ""
+    default_interval_hours: int = 168
+    error_backoff_seconds: int = ERROR_BACKOFF_SECONDS
+
+    def __init__(self) -> None:
+        # The 1-second sleep mirrors the existing refresh actors — gives
+        # Ray a moment to finish setting up the actor handle before we
+        # start importing Django.
+        time.sleep(1)
+        os.environ.setdefault(
+            "DJANGO_SETTINGS_MODULE",
+            get_env_variable("DJANGO_SETTINGS_MODULE", "fighthealthinsurance.settings"),
+        )
+        from configurations.wsgi import get_wsgi_application
+
+        _application = get_wsgi_application()
+        from loguru import logger
+
+        self._logger = logger
+        self.running = False
+        self.last_refresh: Optional[datetime.datetime] = None
+        self._logger.info(f"{self.actor_log_name} initialized")
+
+    async def health_check(self) -> bool:
+        return self.running
+
+    async def run(self) -> None:
+        self._logger.info(f"Starting {self.actor_log_name} run")
+        self.running = True
+
+        while self.running:
+            try:
+                interval_hours = self._interval_hours()
+                await self._maybe_refresh(interval_hours)
+                # Re-check hourly so configuration changes get picked up
+                # without restarting the actor.
+                await asyncio.sleep(3600)
+            except Exception:
+                self._logger.opt(exception=True).error(
+                    f"Error in {self.actor_log_name} refresh cycle"
+                )
+                await asyncio.sleep(self.error_backoff_seconds)
+
+        self._logger.warning(f"{self.actor_log_name} stopped running")
+
+    def stop(self) -> None:
+        self.running = False
+
+    def _interval_hours(self) -> int:
+        from django.conf import settings
+
+        return getattr(
+            settings, self.settings_interval_key, self.default_interval_hours
+        )
+
+    async def _maybe_refresh(self, interval_hours: int) -> None:
+        """Gate the refresh on the configured interval and advance the clock."""
+        if self.last_refresh is not None:
+            elapsed = _now_utc() - self.last_refresh
+            if elapsed < datetime.timedelta(hours=interval_hours):
+                return
+
+        any_progress = await self._refresh_due(interval_hours)
+        # Only mark the cycle complete if something actually refreshed —
+        # otherwise the next loop iteration retries instead of waiting
+        # another full interval window.
+        if any_progress:
+            self.last_refresh = _now_utc()
+
+    async def _refresh_due(self, interval_hours: int) -> bool:
+        """Subclass entry point. Return truthy iff at least one source refreshed."""
+        raise NotImplementedError

--- a/fighthealthinsurance/chat/tools/json_followup_tool.py
+++ b/fighthealthinsurance/chat/tools/json_followup_tool.py
@@ -119,7 +119,7 @@ class JsonFollowupTool(BaseTool):
 
         Default behavior: return ``match.group(1)`` — the regex-captured
         JSON blob. Subclasses whose payloads may contain nested objects
-        override this and call ``_extract_balanced_json`` so a simple,
+        override this and call ``extract_balanced_json`` so a simple,
         ReDoS-safe ``{[^}]*}`` regex can still match the *start* of the
         token while the actual extraction walks brace depth.
         """

--- a/fighthealthinsurance/chat/tools/json_followup_tool.py
+++ b/fighthealthinsurance/chat/tools/json_followup_tool.py
@@ -25,6 +25,50 @@ from loguru import logger
 from .base_tool import BaseTool
 
 
+def extract_balanced_json(response_text: str, start_idx: int) -> str:
+    """Return the balanced ``{...}`` block in ``response_text`` starting near ``start_idx``.
+
+    Walks forward from ``start_idx`` to the first ``{``, then advances a
+    brace-depth counter through the rest of the string until depth returns
+    to zero. Tracks string state so a ``}`` inside a JSON string literal
+    doesn't terminate early. Returns the substring covering the matched
+    block, or an empty string if balancing fails.
+
+    This is the ReDoS-safe alternative to a recursive regex: linear time
+    in the length of the JSON token, no backtracking. Used by chat tools
+    whose payloads can contain nested objects (e.g. ``"filters": {...}``).
+    """
+    # Locate the opening brace at or after start_idx.
+    open_idx = response_text.find("{", start_idx)
+    if open_idx == -1:
+        return ""
+
+    depth = 0
+    in_string = False
+    escape_next = False
+    for i in range(open_idx, len(response_text)):
+        ch = response_text[i]
+        if escape_next:
+            escape_next = False
+            continue
+        if in_string:
+            if ch == "\\":
+                escape_next = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+            continue
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return response_text[open_idx : i + 1]
+    return ""
+
+
 class JsonFollowupTool(BaseTool):
     """Base class for JSON-payload tools that re-invoke the LLM with a result.
 
@@ -70,6 +114,17 @@ class JsonFollowupTool(BaseTool):
         """Override to customize the prompt sent to the LLM after lookup."""
         return f"{note}\n\n -- use this when answering: {current_message_for_llm}"
 
+    def extract_json_payload(self, match: re.Match[str], response_text: str) -> str:
+        """Extract the raw JSON string the LLM emitted.
+
+        Default behavior: return ``match.group(1)`` — the regex-captured
+        JSON blob. Subclasses whose payloads may contain nested objects
+        override this and call ``_extract_balanced_json`` so a simple,
+        ReDoS-safe ``{[^}]*}`` regex can still match the *start* of the
+        token while the actual extraction walks brace depth.
+        """
+        return match.group(1).strip()
+
     async def execute(
         self,
         match: re.Match[str],
@@ -92,7 +147,7 @@ class JsonFollowupTool(BaseTool):
                 "processing only the first one."
             )
 
-        json_data = match.group(1).strip()
+        json_data = self.extract_json_payload(match, response_text)
         try:
             params = json.loads(json_data)
         except json.JSONDecodeError as e:

--- a/fighthealthinsurance/chat/tools/pa_requirement_tool.py
+++ b/fighthealthinsurance/chat/tools/pa_requirement_tool.py
@@ -107,6 +107,11 @@ def _run_lookup(params: dict) -> Tuple[str, str]:
         insurance_company=company,
         state=state,
         line_of_business=lob,
+        # Chat lookups treat an unknown LOB as "show me everything that
+        # could apply" rather than "narrow to LOB-agnostic rules only" —
+        # the LLM frequently emits ``"line_of_business": ""``, and
+        # silently hiding commercial/MA rows there was misleading.
+        broaden_unknown_lob=True,
     )
 
     block = format_pa_context(requirements, requested_codes=codes)

--- a/fighthealthinsurance/chat/tools/pa_requirement_tool.py
+++ b/fighthealthinsurance/chat/tools/pa_requirement_tool.py
@@ -13,11 +13,12 @@ Example call shape the model is expected to emit::
                            "line_of_business": "commercial"}
 """
 
+import re
 from typing import Optional, Tuple
 
 from asgiref.sync import sync_to_async
 
-from .json_followup_tool import JsonFollowupTool
+from .json_followup_tool import JsonFollowupTool, extract_balanced_json
 from .patterns import LOOKUP_PA_REQUIREMENT_REGEX
 
 
@@ -26,6 +27,21 @@ class PaRequirementLookupTool(JsonFollowupTool):
 
     pattern = LOOKUP_PA_REQUIREMENT_REGEX
     name = "PA Requirement Lookup"
+
+    def extract_json_payload(self, match: re.Match[str], response_text: str) -> str:
+        """Re-extract the JSON payload with brace-depth awareness.
+
+        The shared ``LOOKUP_PA_REQUIREMENT_REGEX`` only matches up to the
+        first ``}``, so payloads with nested objects
+        (e.g. ``{"filters": {"lob": "commercial"}}``) capture as a
+        truncated string. We re-scan from the start of the match to
+        recover the full balanced ``{...}`` block. Falls back to the
+        captured group if balancing fails so behavior degrades gracefully.
+        """
+        extracted = extract_balanced_json(response_text, match.start())
+        if extracted:
+            return extracted
+        return match.group(1).strip()
 
     async def run(
         self, params: dict, *, current_message_for_llm: str = ""

--- a/fighthealthinsurance/chat/tools/patterns.py
+++ b/fighthealthinsurance/chat/tools/patterns.py
@@ -40,13 +40,16 @@ FETCH_DOC_REGEX = r"(?:\*\*)?fetch_doc\s*(\{[^}]*\})\s*(?:\*\*)?"
 # Matches: uspstf_lookup {JSON} or **uspstf_lookup {JSON}**
 USPSTF_LOOKUP_REGEX = r"(?:\*\*)?uspstf_lookup\s*(\{[^}]*\})\s*(?:\*\*)?"
 
-# PA requirement lookup tool - captures JSON with codes/payer/state/LOB
+# PA requirement lookup tool - captures JSON with codes/payer/state/LOB.
 # Matches: lookup_pa_requirement {JSON} or **lookup_pa_requirement {JSON}**
-# The inner {...} alternation allows one level of nesting (e.g. for the
-# `filters: {lob: ...}` shape) without requiring true balanced-brace
-# matching, which Python's `re` can't express.
+#
+# The regex only matches up to the first ``}``; balanced-brace extraction
+# for nested-object payloads (``{"filters": {"lob": ...}}``) happens in
+# ``pa_requirement_tool._run_lookup`` via the message-walking helper.
+# Keeping the pattern simple avoids the nested-quantifier ReDoS risk that
+# a true balanced-brace regex would carry.
 LOOKUP_PA_REQUIREMENT_REGEX = (
-    r"(?:\*\*)?lookup_pa_requirement\s*" r"(\{(?:[^{}]|\{[^{}]*\})*\})\s*(?:\*\*)?"
+    r"(?:\*\*)?lookup_pa_requirement\s*(\{[^}]*\})\s*(?:\*\*)?"
 )
 
 # RxNorm drug normalization tool - captures the drug name (free-text).

--- a/fighthealthinsurance/chat/tools/patterns.py
+++ b/fighthealthinsurance/chat/tools/patterns.py
@@ -42,8 +42,11 @@ USPSTF_LOOKUP_REGEX = r"(?:\*\*)?uspstf_lookup\s*(\{[^}]*\})\s*(?:\*\*)?"
 
 # PA requirement lookup tool - captures JSON with codes/payer/state/LOB
 # Matches: lookup_pa_requirement {JSON} or **lookup_pa_requirement {JSON}**
+# The inner {...} alternation allows one level of nesting (e.g. for the
+# `filters: {lob: ...}` shape) without requiring true balanced-brace
+# matching, which Python's `re` can't express.
 LOOKUP_PA_REQUIREMENT_REGEX = (
-    r"(?:\*\*)?lookup_pa_requirement\s*(\{[^}]*\})\s*(?:\*\*)?"
+    r"(?:\*\*)?lookup_pa_requirement\s*" r"(\{(?:[^{}]|\{[^{}]*\})*\})\s*(?:\*\*)?"
 )
 
 # RxNorm drug normalization tool - captures the drug name (free-text).

--- a/fighthealthinsurance/fixtures/insurance_companies.yaml
+++ b/fighthealthinsurance/fixtures/insurance_companies.yaml
@@ -25,6 +25,9 @@
     medical_policy_url_is_static_index: false
     medical_policy_name: Medical Policies and Clinical UM Guidelines
     medical_policy_notes: Anthem publishes Medical Policies and Clinical Utilization Management (UM) Guidelines as coverage-decision guidelines. The landing URL requires state selection (e.g. ?cnslocale=en_US_co for Colorado) before showing applicable policies.
+    pa_requirement_list_url: https://www.anthem.com/provider/prior-authorization/
+    pa_requirement_list_url_is_parseable: false
+    pa_requirement_list_notes: Anthem's PA requirement lookup tool requires state selection and interactive navigation. Use the provider portal to obtain state-specific PA lists.
 
 - model: fighthealthinsurance.insurancecompany
   pk: 2
@@ -46,6 +49,9 @@
     medical_policy_url_is_static_index: false
     medical_policy_name: Medical Policies and Coverage Determination Guidelines
     medical_policy_notes: UnitedHealthcare publishes Medical Policies and Coverage Determination Guidelines that state criteria under which services are considered medically necessary or proven/unproven. The provider portal links out to category-specific PDFs.
+    pa_requirement_list_url: https://www.uhcprovider.com/content/dam/provider/docs/public/prior-auth/all-policies/comm-medical-drug-prior-auth-list.pdf
+    pa_requirement_list_url_is_parseable: true
+    pa_requirement_list_notes: UHC publishes a downloadable PDF of commercial prior-authorization requirements covering medical and drug codes. Updated periodically (typically quarterly). The PDF contains tables mapping CPT/HCPCS codes to PA requirements and criteria references. Set is_parseable=true to auto-ingest on deploy.
 
 - model: fighthealthinsurance.insurancecompany
   pk: 3
@@ -71,6 +77,9 @@
     medical_policy_url_is_static_index: false
     medical_policy_name: Clinical Policy Bulletins (CPBs)
     medical_policy_notes: Aetna publishes Clinical Policy Bulletins (CPBs) that express Aetna's view on whether services are medically necessary, experimental/investigational, unproven, or cosmetic. CPBs are accessed via a search portal (no static A-Z index); individual CPBs live at URLs like https://www.aetna.com/cpb/medical/data/<range>/<id>.html.
+    pa_requirement_list_url: https://www.aetna.com/health-care-professionals/prior-authorization/clinical-payment-and-coverage-policies.html
+    pa_requirement_list_url_is_parseable: false
+    pa_requirement_list_notes: Aetna's prior-authorization requirement page is JavaScript-rendered and requires plan/state selection. Downloadable code lists may be available to registered providers via NaviMedix AuthPortal.
 
 - model: fighthealthinsurance.insurancecompany
   pk: 4
@@ -97,6 +106,9 @@
     medical_policy_url_is_static_index: true
     medical_policy_name: Coverage Policies
     medical_policy_notes: Cigna's Coverage Policies help interpret standard health-coverage plan provisions and are publicly available without login. The static A-Z index links directly to individual policy PDFs.
+    pa_requirement_list_url: https://www.cigna.com/healthcare-providers/coverage-information/clinical-coverage-policies/prior-authorization-list
+    pa_requirement_list_url_is_parseable: false
+    pa_requirement_list_notes: Cigna routes most prior authorization through eviCore (evicore.com). Their provider portal has downloadable PA code lists but requires login. eviCore handles specialty PA (oncology, musculoskeletal, cardiology, etc.).
 
 - model: fighthealthinsurance.insurancecompany
   pk: 5

--- a/fighthealthinsurance/fixtures/pa_requirements.yaml
+++ b/fighthealthinsurance/fixtures/pa_requirements.yaml
@@ -1,0 +1,460 @@
+# UnitedHealthcare prior-authorization requirements — starter set.
+#
+# Sourced from UHC's published commercial and Medicare Advantage PA
+# requirement lists. Each conceptual rule is materialised twice — once per
+# LOB — because the source document is scoped to those two LOBs (Medicaid /
+# DSNP / exchange rules belong in their own fixtures sourced separately).
+#
+# Loaded by ``python manage.py loaddata pa_requirements``. Idempotent —
+# loaddata uses primary-key replacement, so re-running just refreshes
+# these rows in place.
+#
+# PKs are deliberately in the 9000+ range so they don't collide with
+# operator-added rows whose auto-assigned IDs start at 1.
+
+# Shared values referenced below (kept in this comment as a single source
+# of truth for the maintainer):
+#   submission_channel (default):
+#     "UHCprovider.com Prior Authorization and Notification tool, or
+#      866-889-8054 (UHC commercial); 800-711-4555 (UHC OptumRx for
+#      pharmacy J-code review)."
+#   submission_channel (radiology, codes 70551 / 74177):
+#     "Optum (UHC's radiology benefits manager) — submit via
+#      radmd.com / providerexpress.com or 866-889-8054."
+#   source_document:
+#     "UnitedHealthcare Prior Authorization Requirements (commercial and
+#      Medicare Advantage); starter set seeded by FHI"
+#   source_document_date: 2025-01-01
+
+#######################################################################
+# Genetic and Molecular Testing
+#######################################################################
+
+- model: fighthealthinsurance.payerpriorauthrequirement
+  pk: 9001
+  fields:
+    insurance_company: 2
+    line_of_business: commercial
+    cpt_hcpcs_code: "81162"
+    code_description: "BRCA1, BRCA2 (hereditary breast/ovarian) full sequence + duplication/deletion analysis"
+    pa_category: Genetic and Molecular Testing
+    requires_pa: true
+    submission_channel: "UHCprovider.com Prior Authorization and Notification tool, or 866-889-8054 (UHC commercial); 800-711-4555 (UHC OptumRx for pharmacy J-code review)."
+    criteria_reference: "UHC Medical Policy: Molecular Oncology Testing for Cancer Diagnosis, Prognosis, and Treatment Decisions"
+    source_document: "UnitedHealthcare Prior Authorization Requirements (commercial and Medicare Advantage); starter set seeded by FHI"
+    source_document_date: 2025-01-01
+
+- model: fighthealthinsurance.payerpriorauthrequirement
+  pk: 9002
+  fields:
+    insurance_company: 2
+    line_of_business: medicare_advantage
+    cpt_hcpcs_code: "81162"
+    code_description: "BRCA1, BRCA2 (hereditary breast/ovarian) full sequence + duplication/deletion analysis"
+    pa_category: Genetic and Molecular Testing
+    requires_pa: true
+    submission_channel: "UHCprovider.com Prior Authorization and Notification tool, or 866-889-8054 (UHC commercial); 800-711-4555 (UHC OptumRx for pharmacy J-code review)."
+    criteria_reference: "UHC Medical Policy: Molecular Oncology Testing for Cancer Diagnosis, Prognosis, and Treatment Decisions"
+    source_document: "UnitedHealthcare Prior Authorization Requirements (commercial and Medicare Advantage); starter set seeded by FHI"
+    source_document_date: 2025-01-01
+
+- model: fighthealthinsurance.payerpriorauthrequirement
+  pk: 9003
+  fields:
+    insurance_company: 2
+    line_of_business: commercial
+    cpt_hcpcs_code: "81163"
+    code_description: "BRCA1, BRCA2 full sequence analysis"
+    pa_category: Genetic and Molecular Testing
+    requires_pa: true
+    submission_channel: "UHCprovider.com Prior Authorization and Notification tool, or 866-889-8054 (UHC commercial); 800-711-4555 (UHC OptumRx for pharmacy J-code review)."
+    criteria_reference: "UHC Medical Policy: Molecular Oncology Testing for Cancer Diagnosis, Prognosis, and Treatment Decisions"
+    source_document: "UnitedHealthcare Prior Authorization Requirements (commercial and Medicare Advantage); starter set seeded by FHI"
+    source_document_date: 2025-01-01
+
+- model: fighthealthinsurance.payerpriorauthrequirement
+  pk: 9004
+  fields:
+    insurance_company: 2
+    line_of_business: medicare_advantage
+    cpt_hcpcs_code: "81163"
+    code_description: "BRCA1, BRCA2 full sequence analysis"
+    pa_category: Genetic and Molecular Testing
+    requires_pa: true
+    submission_channel: "UHCprovider.com Prior Authorization and Notification tool, or 866-889-8054 (UHC commercial); 800-711-4555 (UHC OptumRx for pharmacy J-code review)."
+    criteria_reference: "UHC Medical Policy: Molecular Oncology Testing for Cancer Diagnosis, Prognosis, and Treatment Decisions"
+    source_document: "UnitedHealthcare Prior Authorization Requirements (commercial and Medicare Advantage); starter set seeded by FHI"
+    source_document_date: 2025-01-01
+
+- model: fighthealthinsurance.payerpriorauthrequirement
+  pk: 9005
+  fields:
+    insurance_company: 2
+    line_of_business: commercial
+    cpt_hcpcs_code: "81479"
+    code_description: "Unlisted molecular pathology procedure"
+    pa_category: Genetic and Molecular Testing
+    requires_pa: true
+    submission_channel: "UHCprovider.com Prior Authorization and Notification tool, or 866-889-8054 (UHC commercial); 800-711-4555 (UHC OptumRx for pharmacy J-code review)."
+    criteria_reference: "UHC Medical Policy: Molecular Pathology / Molecular Diagnostics"
+    source_document: "UnitedHealthcare Prior Authorization Requirements (commercial and Medicare Advantage); starter set seeded by FHI"
+    source_document_date: 2025-01-01
+
+- model: fighthealthinsurance.payerpriorauthrequirement
+  pk: 9006
+  fields:
+    insurance_company: 2
+    line_of_business: medicare_advantage
+    cpt_hcpcs_code: "81479"
+    code_description: "Unlisted molecular pathology procedure"
+    pa_category: Genetic and Molecular Testing
+    requires_pa: true
+    submission_channel: "UHCprovider.com Prior Authorization and Notification tool, or 866-889-8054 (UHC commercial); 800-711-4555 (UHC OptumRx for pharmacy J-code review)."
+    criteria_reference: "UHC Medical Policy: Molecular Pathology / Molecular Diagnostics"
+    source_document: "UnitedHealthcare Prior Authorization Requirements (commercial and Medicare Advantage); starter set seeded by FHI"
+    source_document_date: 2025-01-01
+
+#######################################################################
+# Sleep Medicine
+#######################################################################
+
+- model: fighthealthinsurance.payerpriorauthrequirement
+  pk: 9007
+  fields:
+    insurance_company: 2
+    line_of_business: commercial
+    cpt_hcpcs_code: "95810"
+    code_description: "Polysomnography; sleep staging with 4+ additional parameters of sleep, attended"
+    pa_category: Sleep Medicine
+    requires_pa: true
+    submission_channel: "UHCprovider.com Prior Authorization and Notification tool, or 866-889-8054 (UHC commercial); 800-711-4555 (UHC OptumRx for pharmacy J-code review)."
+    criteria_reference: "UHC Medical Policy: Attended Polysomnography for Evaluation of Sleep Disorders"
+    source_document: "UnitedHealthcare Prior Authorization Requirements (commercial and Medicare Advantage); starter set seeded by FHI"
+    source_document_date: 2025-01-01
+
+- model: fighthealthinsurance.payerpriorauthrequirement
+  pk: 9008
+  fields:
+    insurance_company: 2
+    line_of_business: medicare_advantage
+    cpt_hcpcs_code: "95810"
+    code_description: "Polysomnography; sleep staging with 4+ additional parameters of sleep, attended"
+    pa_category: Sleep Medicine
+    requires_pa: true
+    submission_channel: "UHCprovider.com Prior Authorization and Notification tool, or 866-889-8054 (UHC commercial); 800-711-4555 (UHC OptumRx for pharmacy J-code review)."
+    criteria_reference: "UHC Medical Policy: Attended Polysomnography for Evaluation of Sleep Disorders"
+    source_document: "UnitedHealthcare Prior Authorization Requirements (commercial and Medicare Advantage); starter set seeded by FHI"
+    source_document_date: 2025-01-01
+
+- model: fighthealthinsurance.payerpriorauthrequirement
+  pk: 9009
+  fields:
+    insurance_company: 2
+    line_of_business: commercial
+    cpt_hcpcs_code: "95811"
+    code_description: "Polysomnography with initiation of CPAP/BiPAP"
+    pa_category: Sleep Medicine
+    requires_pa: true
+    submission_channel: "UHCprovider.com Prior Authorization and Notification tool, or 866-889-8054 (UHC commercial); 800-711-4555 (UHC OptumRx for pharmacy J-code review)."
+    criteria_reference: "UHC Medical Policy: Attended Polysomnography for Evaluation of Sleep Disorders"
+    source_document: "UnitedHealthcare Prior Authorization Requirements (commercial and Medicare Advantage); starter set seeded by FHI"
+    source_document_date: 2025-01-01
+
+- model: fighthealthinsurance.payerpriorauthrequirement
+  pk: 9010
+  fields:
+    insurance_company: 2
+    line_of_business: medicare_advantage
+    cpt_hcpcs_code: "95811"
+    code_description: "Polysomnography with initiation of CPAP/BiPAP"
+    pa_category: Sleep Medicine
+    requires_pa: true
+    submission_channel: "UHCprovider.com Prior Authorization and Notification tool, or 866-889-8054 (UHC commercial); 800-711-4555 (UHC OptumRx for pharmacy J-code review)."
+    criteria_reference: "UHC Medical Policy: Attended Polysomnography for Evaluation of Sleep Disorders"
+    source_document: "UnitedHealthcare Prior Authorization Requirements (commercial and Medicare Advantage); starter set seeded by FHI"
+    source_document_date: 2025-01-01
+
+#######################################################################
+# Durable Medical Equipment - CGM
+#######################################################################
+
+- model: fighthealthinsurance.payerpriorauthrequirement
+  pk: 9011
+  fields:
+    insurance_company: 2
+    line_of_business: commercial
+    cpt_hcpcs_code: K0553
+    code_description: "Supply allowance for therapeutic continuous glucose monitor (CGM)"
+    pa_category: Durable Medical Equipment - CGM
+    requires_pa: true
+    submission_channel: "UHCprovider.com Prior Authorization and Notification tool, or 866-889-8054 (UHC commercial); 800-711-4555 (UHC OptumRx for pharmacy J-code review)."
+    criteria_reference: "UHC Medical Policy: Continuous Glucose Monitors"
+    source_document: "UnitedHealthcare Prior Authorization Requirements (commercial and Medicare Advantage); starter set seeded by FHI"
+    source_document_date: 2025-01-01
+
+- model: fighthealthinsurance.payerpriorauthrequirement
+  pk: 9012
+  fields:
+    insurance_company: 2
+    line_of_business: medicare_advantage
+    cpt_hcpcs_code: K0553
+    code_description: "Supply allowance for therapeutic continuous glucose monitor (CGM)"
+    pa_category: Durable Medical Equipment - CGM
+    requires_pa: true
+    submission_channel: "UHCprovider.com Prior Authorization and Notification tool, or 866-889-8054 (UHC commercial); 800-711-4555 (UHC OptumRx for pharmacy J-code review)."
+    criteria_reference: "UHC Medical Policy: Continuous Glucose Monitors"
+    source_document: "UnitedHealthcare Prior Authorization Requirements (commercial and Medicare Advantage); starter set seeded by FHI"
+    source_document_date: 2025-01-01
+
+- model: fighthealthinsurance.payerpriorauthrequirement
+  pk: 9013
+  fields:
+    insurance_company: 2
+    line_of_business: commercial
+    cpt_hcpcs_code: K0554
+    code_description: "Receiver (monitor), dedicated, for use with therapeutic CGM"
+    pa_category: Durable Medical Equipment - CGM
+    requires_pa: true
+    submission_channel: "UHCprovider.com Prior Authorization and Notification tool, or 866-889-8054 (UHC commercial); 800-711-4555 (UHC OptumRx for pharmacy J-code review)."
+    criteria_reference: "UHC Medical Policy: Continuous Glucose Monitors"
+    source_document: "UnitedHealthcare Prior Authorization Requirements (commercial and Medicare Advantage); starter set seeded by FHI"
+    source_document_date: 2025-01-01
+
+- model: fighthealthinsurance.payerpriorauthrequirement
+  pk: 9014
+  fields:
+    insurance_company: 2
+    line_of_business: medicare_advantage
+    cpt_hcpcs_code: K0554
+    code_description: "Receiver (monitor), dedicated, for use with therapeutic CGM"
+    pa_category: Durable Medical Equipment - CGM
+    requires_pa: true
+    submission_channel: "UHCprovider.com Prior Authorization and Notification tool, or 866-889-8054 (UHC commercial); 800-711-4555 (UHC OptumRx for pharmacy J-code review)."
+    criteria_reference: "UHC Medical Policy: Continuous Glucose Monitors"
+    source_document: "UnitedHealthcare Prior Authorization Requirements (commercial and Medicare Advantage); starter set seeded by FHI"
+    source_document_date: 2025-01-01
+
+#######################################################################
+# Outpatient Injectable Medication
+#######################################################################
+
+- model: fighthealthinsurance.payerpriorauthrequirement
+  pk: 9015
+  fields:
+    insurance_company: 2
+    line_of_business: commercial
+    cpt_hcpcs_code: J0490
+    code_description: "Injection, belimumab (Benlysta), 10 mg"
+    pa_category: Outpatient Injectable Medication
+    requires_pa: true
+    submission_channel: "UHCprovider.com Prior Authorization and Notification tool, or 866-889-8054 (UHC commercial); 800-711-4555 (UHC OptumRx for pharmacy J-code review)."
+    criteria_reference: "UHC Medical Benefit Drug Policy: Belimumab"
+    source_document: "UnitedHealthcare Prior Authorization Requirements (commercial and Medicare Advantage); starter set seeded by FHI"
+    source_document_date: 2025-01-01
+
+- model: fighthealthinsurance.payerpriorauthrequirement
+  pk: 9016
+  fields:
+    insurance_company: 2
+    line_of_business: medicare_advantage
+    cpt_hcpcs_code: J0490
+    code_description: "Injection, belimumab (Benlysta), 10 mg"
+    pa_category: Outpatient Injectable Medication
+    requires_pa: true
+    submission_channel: "UHCprovider.com Prior Authorization and Notification tool, or 866-889-8054 (UHC commercial); 800-711-4555 (UHC OptumRx for pharmacy J-code review)."
+    criteria_reference: "UHC Medical Benefit Drug Policy: Belimumab"
+    source_document: "UnitedHealthcare Prior Authorization Requirements (commercial and Medicare Advantage); starter set seeded by FHI"
+    source_document_date: 2025-01-01
+
+- model: fighthealthinsurance.payerpriorauthrequirement
+  pk: 9017
+  fields:
+    insurance_company: 2
+    line_of_business: commercial
+    cpt_hcpcs_code: J9035
+    code_description: "Injection, bevacizumab (Avastin), 10 mg"
+    pa_category: Outpatient Injectable Medication
+    requires_pa: true
+    submission_channel: "UHCprovider.com Prior Authorization and Notification tool, or 866-889-8054 (UHC commercial); 800-711-4555 (UHC OptumRx for pharmacy J-code review)."
+    criteria_reference: "UHC Medical Benefit Drug Policy: Bevacizumab and Biosimilars"
+    source_document: "UnitedHealthcare Prior Authorization Requirements (commercial and Medicare Advantage); starter set seeded by FHI"
+    source_document_date: 2025-01-01
+
+- model: fighthealthinsurance.payerpriorauthrequirement
+  pk: 9018
+  fields:
+    insurance_company: 2
+    line_of_business: medicare_advantage
+    cpt_hcpcs_code: J9035
+    code_description: "Injection, bevacizumab (Avastin), 10 mg"
+    pa_category: Outpatient Injectable Medication
+    requires_pa: true
+    submission_channel: "UHCprovider.com Prior Authorization and Notification tool, or 866-889-8054 (UHC commercial); 800-711-4555 (UHC OptumRx for pharmacy J-code review)."
+    criteria_reference: "UHC Medical Benefit Drug Policy: Bevacizumab and Biosimilars"
+    source_document: "UnitedHealthcare Prior Authorization Requirements (commercial and Medicare Advantage); starter set seeded by FHI"
+    source_document_date: 2025-01-01
+
+#######################################################################
+# Advanced Outpatient Imaging
+#
+# Radiology PA is delegated to Optum (UHC's RBM), so the submission_channel
+# differs from the default UHCprovider.com flow. This corrects a bug in
+# the previous migration-seeded data where every imaging entry pointed at
+# the wrong channel.
+#######################################################################
+
+- model: fighthealthinsurance.payerpriorauthrequirement
+  pk: 9019
+  fields:
+    insurance_company: 2
+    line_of_business: commercial
+    cpt_hcpcs_code: "70551"
+    code_description: "MRI, brain (including brain stem); without contrast"
+    pa_category: Advanced Outpatient Imaging
+    requires_pa: true
+    submission_channel: "Optum (UHC's radiology benefits manager) — submit via radmd.com / providerexpress.com or 866-889-8054."
+    criteria_reference: "UHC Radiology / RBM (managed by Optum) - Advanced Outpatient Imaging guidelines"
+    source_document: "UnitedHealthcare Prior Authorization Requirements (commercial and Medicare Advantage); starter set seeded by FHI"
+    source_document_date: 2025-01-01
+
+- model: fighthealthinsurance.payerpriorauthrequirement
+  pk: 9020
+  fields:
+    insurance_company: 2
+    line_of_business: medicare_advantage
+    cpt_hcpcs_code: "70551"
+    code_description: "MRI, brain (including brain stem); without contrast"
+    pa_category: Advanced Outpatient Imaging
+    requires_pa: true
+    submission_channel: "Optum (UHC's radiology benefits manager) — submit via radmd.com / providerexpress.com or 866-889-8054."
+    criteria_reference: "UHC Radiology / RBM (managed by Optum) - Advanced Outpatient Imaging guidelines"
+    source_document: "UnitedHealthcare Prior Authorization Requirements (commercial and Medicare Advantage); starter set seeded by FHI"
+    source_document_date: 2025-01-01
+
+- model: fighthealthinsurance.payerpriorauthrequirement
+  pk: 9021
+  fields:
+    insurance_company: 2
+    line_of_business: commercial
+    cpt_hcpcs_code: "74177"
+    code_description: "CT abdomen and pelvis with contrast"
+    pa_category: Advanced Outpatient Imaging
+    requires_pa: true
+    submission_channel: "Optum (UHC's radiology benefits manager) — submit via radmd.com / providerexpress.com or 866-889-8054."
+    criteria_reference: "UHC Radiology / RBM (managed by Optum) - Advanced Outpatient Imaging guidelines"
+    source_document: "UnitedHealthcare Prior Authorization Requirements (commercial and Medicare Advantage); starter set seeded by FHI"
+    source_document_date: 2025-01-01
+
+- model: fighthealthinsurance.payerpriorauthrequirement
+  pk: 9022
+  fields:
+    insurance_company: 2
+    line_of_business: medicare_advantage
+    cpt_hcpcs_code: "74177"
+    code_description: "CT abdomen and pelvis with contrast"
+    pa_category: Advanced Outpatient Imaging
+    requires_pa: true
+    submission_channel: "Optum (UHC's radiology benefits manager) — submit via radmd.com / providerexpress.com or 866-889-8054."
+    criteria_reference: "UHC Radiology / RBM (managed by Optum) - Advanced Outpatient Imaging guidelines"
+    source_document: "UnitedHealthcare Prior Authorization Requirements (commercial and Medicare Advantage); starter set seeded by FHI"
+    source_document_date: 2025-01-01
+
+#######################################################################
+# Spine Surgery (range)
+#######################################################################
+
+- model: fighthealthinsurance.payerpriorauthrequirement
+  pk: 9023
+  fields:
+    insurance_company: 2
+    line_of_business: commercial
+    cpt_hcpcs_code: ""
+    code_range_start: "22510"
+    code_range_end: "22515"
+    code_description: "Percutaneous vertebroplasty / vertebral augmentation"
+    pa_category: Spine Surgery
+    requires_pa: true
+    submission_channel: "UHCprovider.com Prior Authorization and Notification tool, or 866-889-8054 (UHC commercial); 800-711-4555 (UHC OptumRx for pharmacy J-code review)."
+    criteria_reference: "UHC Medical Policy: Vertebroplasty, Kyphoplasty, and Sacroplasty"
+    source_document: "UnitedHealthcare Prior Authorization Requirements (commercial and Medicare Advantage); starter set seeded by FHI"
+    source_document_date: 2025-01-01
+
+- model: fighthealthinsurance.payerpriorauthrequirement
+  pk: 9024
+  fields:
+    insurance_company: 2
+    line_of_business: medicare_advantage
+    cpt_hcpcs_code: ""
+    code_range_start: "22510"
+    code_range_end: "22515"
+    code_description: "Percutaneous vertebroplasty / vertebral augmentation"
+    pa_category: Spine Surgery
+    requires_pa: true
+    submission_channel: "UHCprovider.com Prior Authorization and Notification tool, or 866-889-8054 (UHC commercial); 800-711-4555 (UHC OptumRx for pharmacy J-code review)."
+    criteria_reference: "UHC Medical Policy: Vertebroplasty, Kyphoplasty, and Sacroplasty"
+    source_document: "UnitedHealthcare Prior Authorization Requirements (commercial and Medicare Advantage); starter set seeded by FHI"
+    source_document_date: 2025-01-01
+
+#######################################################################
+# Evaluation and Management — explicit "PA NOT required" entries
+#######################################################################
+
+- model: fighthealthinsurance.payerpriorauthrequirement
+  pk: 9025
+  fields:
+    insurance_company: 2
+    line_of_business: commercial
+    cpt_hcpcs_code: "99213"
+    code_description: "Office or other outpatient visit, established patient (low complexity)"
+    pa_category: Evaluation and Management
+    requires_pa: false
+    submission_channel: "UHCprovider.com Prior Authorization and Notification tool, or 866-889-8054 (UHC commercial); 800-711-4555 (UHC OptumRx for pharmacy J-code review)."
+    criteria_reference: "UHC standard E&M coverage"
+    notes: "Standard office visit codes are not subject to PA on UHC commercial / MA plans."
+    source_document: "UnitedHealthcare Prior Authorization Requirements (commercial and Medicare Advantage); starter set seeded by FHI"
+    source_document_date: 2025-01-01
+
+- model: fighthealthinsurance.payerpriorauthrequirement
+  pk: 9026
+  fields:
+    insurance_company: 2
+    line_of_business: medicare_advantage
+    cpt_hcpcs_code: "99213"
+    code_description: "Office or other outpatient visit, established patient (low complexity)"
+    pa_category: Evaluation and Management
+    requires_pa: false
+    submission_channel: "UHCprovider.com Prior Authorization and Notification tool, or 866-889-8054 (UHC commercial); 800-711-4555 (UHC OptumRx for pharmacy J-code review)."
+    criteria_reference: "UHC standard E&M coverage"
+    notes: "Standard office visit codes are not subject to PA on UHC commercial / MA plans."
+    source_document: "UnitedHealthcare Prior Authorization Requirements (commercial and Medicare Advantage); starter set seeded by FHI"
+    source_document_date: 2025-01-01
+
+- model: fighthealthinsurance.payerpriorauthrequirement
+  pk: 9027
+  fields:
+    insurance_company: 2
+    line_of_business: commercial
+    cpt_hcpcs_code: "99214"
+    code_description: "Office or other outpatient visit, established patient (moderate complexity)"
+    pa_category: Evaluation and Management
+    requires_pa: false
+    submission_channel: "UHCprovider.com Prior Authorization and Notification tool, or 866-889-8054 (UHC commercial); 800-711-4555 (UHC OptumRx for pharmacy J-code review)."
+    criteria_reference: "UHC standard E&M coverage"
+    notes: "Standard office visit codes are not subject to PA on UHC commercial / MA plans."
+    source_document: "UnitedHealthcare Prior Authorization Requirements (commercial and Medicare Advantage); starter set seeded by FHI"
+    source_document_date: 2025-01-01
+
+- model: fighthealthinsurance.payerpriorauthrequirement
+  pk: 9028
+  fields:
+    insurance_company: 2
+    line_of_business: medicare_advantage
+    cpt_hcpcs_code: "99214"
+    code_description: "Office or other outpatient visit, established patient (moderate complexity)"
+    pa_category: Evaluation and Management
+    requires_pa: false
+    submission_channel: "UHCprovider.com Prior Authorization and Notification tool, or 866-889-8054 (UHC commercial); 800-711-4555 (UHC OptumRx for pharmacy J-code review)."
+    criteria_reference: "UHC standard E&M coverage"
+    notes: "Standard office visit codes are not subject to PA on UHC commercial / MA plans."
+    source_document: "UnitedHealthcare Prior Authorization Requirements (commercial and Medicare Advantage); starter set seeded by FHI"
+    source_document_date: 2025-01-01

--- a/fighthealthinsurance/management/commands/ingest_pa_requirements.py
+++ b/fighthealthinsurance/management/commands/ingest_pa_requirements.py
@@ -1,0 +1,84 @@
+"""
+Fetch and re-parse carrier-published PA requirement lists.
+
+Idempotent: replaces each carrier's ingestion-owned
+``PayerPriorAuthRequirement`` rows with the freshly-parsed entries from
+the live source. Intended to run on a periodic cadence (alongside the
+``PaRefreshActor``) so the lookup keeps returning live carrier rules.
+
+Usage::
+
+    python manage.py ingest_pa_requirements                  # all carriers
+    python manage.py ingest_pa_requirements --carrier UHC    # single carrier
+"""
+
+import asyncio
+from typing import Any
+
+from django.core.management.base import BaseCommand
+
+from fighthealthinsurance.pa_requirements_fetcher import (
+    PA_PARSERS,
+    PaRequirementsFetcher,
+)
+
+
+class Command(BaseCommand):
+    help = "Fetch and parse every carrier-published PA requirement list."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--carrier",
+            dest="carrier",
+            default=None,
+            help=(
+                "Limit ingest to one carrier (alias must match a key in "
+                "PA_PARSERS). Default: ingest every registered carrier."
+            ),
+        )
+
+    def handle(self, *args: str, **options: Any) -> None:
+        carrier = options.get("carrier")
+
+        async def _run() -> dict:
+            async with PaRequirementsFetcher() as fetcher:
+                if carrier:
+                    return await fetcher.ingest_carrier(carrier)
+                return await fetcher.ingest_all()
+
+        if carrier and carrier not in PA_PARSERS:
+            self.stdout.write(
+                self.style.ERROR(
+                    f"No PA parser registered for '{carrier}'. "
+                    f"Known aliases: {sorted(PA_PARSERS) or '(none)'}."
+                )
+            )
+            return
+
+        if not PA_PARSERS:
+            # Framework is in place but no parsers are registered yet —
+            # surface that as a warning so operators don't think the
+            # command silently succeeded.
+            self.stdout.write(
+                self.style.WARNING(
+                    "PA-requirement parser registry is empty; nothing to ingest."
+                )
+            )
+            return
+
+        stats = asyncio.run(_run())
+
+        summary = (
+            f"PA requirements ingest: {stats['fetched']} carrier(s) fetched, "
+            f"{stats['failed']} failed, {stats['entries']} rows upserted, "
+            f"{stats['retired']} rows soft-retired."
+        )
+        # Per-carrier exceptions are caught inside the fetcher and returned
+        # as `failed` counts; mirror ingest_payer_policy_indexes' exit-zero
+        # semantics with WARNING/ERROR styling.
+        if stats["failed"] > 0 and stats["fetched"] == 0:
+            self.stdout.write(self.style.ERROR(summary))
+        elif stats["failed"] > 0:
+            self.stdout.write(self.style.WARNING(summary))
+        else:
+            self.stdout.write(self.style.SUCCESS(summary))

--- a/fighthealthinsurance/management/commands/ingest_pa_requirements.py
+++ b/fighthealthinsurance/management/commands/ingest_pa_requirements.py
@@ -1,84 +1,128 @@
 """
 Fetch and re-parse carrier-published PA requirement lists.
 
-Idempotent: replaces each carrier's ingestion-owned
-``PayerPriorAuthRequirement`` rows with the freshly-parsed entries from
-the live source. Intended to run on a periodic cadence (alongside the
-``PaRefreshActor``) so the lookup keeps returning live carrier rules.
+Idempotent: replaces each carrier's auto-ingested
+:class:`PayerPriorAuthRequirement` rows (those whose ``source_document``
+starts with ``"auto:"``) with freshly parsed entries from the live URL.
+Manually seeded rows are left untouched. Rows that disappear from the
+upstream list are soft-retired with ``end_date=today`` so historical
+denials can still resolve to the rule that applied at the time.
 
 Usage::
 
-    python manage.py ingest_pa_requirements                  # all carriers
-    python manage.py ingest_pa_requirements --carrier UHC    # single carrier
+    python manage.py ingest_pa_requirements
+    python manage.py ingest_pa_requirements --company "UnitedHealthcare"
+    python manage.py ingest_pa_requirements --company "UHC" --dry-run
 """
 
-import asyncio
-from typing import Any
+from __future__ import annotations
 
+import asyncio
+from typing import Any, List, Optional
+
+from asgiref.sync import sync_to_async
 from django.core.management.base import BaseCommand
 
-from fighthealthinsurance.pa_requirements_fetcher import (
-    PA_PARSERS,
-    PaRequirementsFetcher,
-)
+from fighthealthinsurance.models import InsuranceCompany
+from fighthealthinsurance.pa_requirements_fetcher import PaRequirementsFetcher
 
 
 class Command(BaseCommand):
-    help = "Fetch and parse every carrier-published PA requirement list."
+    help = "Fetch and parse every payer prior-authorization requirement list."
 
     def add_arguments(self, parser):
         parser.add_argument(
-            "--carrier",
-            dest="carrier",
-            default=None,
+            "--company",
+            metavar="NAME",
             help=(
-                "Limit ingest to one carrier (alias must match a key in "
-                "PA_PARSERS). Default: ingest every registered carrier."
+                "Restrict ingestion to a single company by exact name (case-"
+                "insensitive). Default: every company flagged "
+                "pa_requirement_list_url_is_parseable=True."
+            ),
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help=(
+                "Fetch + parse but do NOT write to the database. Useful for "
+                "previewing what a refresh would change."
             ),
         )
 
     def handle(self, *args: str, **options: Any) -> None:
-        carrier = options.get("carrier")
+        company_name: Optional[str] = options.get("company")
+        dry_run: bool = bool(options.get("dry_run"))
 
-        async def _run() -> dict:
-            async with PaRequirementsFetcher() as fetcher:
-                if carrier:
-                    return await fetcher.ingest_carrier(carrier)
-                return await fetcher.ingest_all()
-
-        if carrier and carrier not in PA_PARSERS:
-            self.stdout.write(
-                self.style.ERROR(
-                    f"No PA parser registered for '{carrier}'. "
-                    f"Known aliases: {sorted(PA_PARSERS) or '(none)'}."
-                )
+        if dry_run:
+            stats = asyncio.run(self._dry_run(company_name))
+            summary = (
+                f"[DRY RUN] Would have processed {stats['fetched']} carrier(s); "
+                f"{stats['failed']} failed; parsed {stats['entries']} "
+                f"requirement record(s)."
             )
-            return
-
-        if not PA_PARSERS:
-            # Framework is in place but no parsers are registered yet —
-            # surface that as a warning so operators don't think the
-            # command silently succeeded.
-            self.stdout.write(
-                self.style.WARNING(
-                    "PA-requirement parser registry is empty; nothing to ingest."
-                )
+        else:
+            stats = asyncio.run(self._ingest(company_name))
+            summary = (
+                f"PA requirements ingest: {stats['fetched']} carrier(s) fetched, "
+                f"{stats['failed']} failed, {stats['entries']} rows upserted, "
+                f"{stats.get('retired', 0)} rows soft-retired."
             )
-            return
 
-        stats = asyncio.run(_run())
-
-        summary = (
-            f"PA requirements ingest: {stats['fetched']} carrier(s) fetched, "
-            f"{stats['failed']} failed, {stats['entries']} rows upserted, "
-            f"{stats['retired']} rows soft-retired."
-        )
-        # Per-carrier exceptions are caught inside the fetcher and returned
-        # as `failed` counts; mirror ingest_payer_policy_indexes' exit-zero
-        # semantics with WARNING/ERROR styling.
+        # Mirror ingest_payer_policy_indexes' exit-zero semantics with
+        # WARNING/ERROR styling on partial/total failure.
         if stats["failed"] > 0 and stats["fetched"] == 0:
             self.stdout.write(self.style.ERROR(summary))
         elif stats["failed"] > 0:
             self.stdout.write(self.style.WARNING(summary))
         else:
             self.stdout.write(self.style.SUCCESS(summary))
+
+    async def _ingest(self, company_name: Optional[str]) -> dict:
+        async with PaRequirementsFetcher() as fetcher:
+            if company_name:
+                company = await self._resolve_company(company_name)
+                if company is None:
+                    return {"fetched": 0, "failed": 1, "entries": 0, "retired": 0}
+                return await fetcher.ingest_company(company)
+            return await fetcher.ingest_all()
+
+    async def _dry_run(self, company_name: Optional[str]) -> dict:
+        stats = {"fetched": 0, "failed": 0, "entries": 0}
+        companies: List[InsuranceCompany]
+        if company_name:
+            company = await self._resolve_company(company_name)
+            companies = [company] if company is not None else []
+            if company is None:
+                stats["failed"] += 1
+        else:
+            companies = await sync_to_async(
+                lambda: list(
+                    InsuranceCompany.objects.filter(
+                        pa_requirement_list_url_is_parseable=True,
+                    ).exclude(pa_requirement_list_url="")
+                )
+            )()
+
+        async with PaRequirementsFetcher() as fetcher:
+            for company in companies:
+                try:
+                    parsed = await fetcher.parse_company(company)
+                except Exception as e:
+                    self.stdout.write(
+                        self.style.WARNING(f"  [{company.name}] parse failed: {e}")
+                    )
+                    stats["failed"] += 1
+                    continue
+                stats["fetched"] += 1
+                stats["entries"] += len(parsed)
+                self.stdout.write(
+                    f"  [{company.name}] would write {len(parsed)} row(s) "
+                    f"from {company.pa_requirement_list_url}"
+                )
+        return stats
+
+    @staticmethod
+    async def _resolve_company(name: str) -> Optional[InsuranceCompany]:
+        return await sync_to_async(
+            lambda: InsuranceCompany.objects.filter(name__iexact=name).first()
+        )()

--- a/fighthealthinsurance/management/commands/setup_local_db.py
+++ b/fighthealthinsurance/management/commands/setup_local_db.py
@@ -24,6 +24,8 @@ class Command(BaseCommand):
         # insurance_companies must come after plan_source because the
         # InsurancePlan rows reference PlanSource pks (100/300/700/1100/...).
         call_command("loaddata", "insurance_companies")
+        # pa_requirements rows reference InsuranceCompany pks; load after.
+        call_command("loaddata", "pa_requirements")
 
         self.stdout.write("Ensuring admin user...")
         call_command("ensure_adminuser", username="admin", password="admin")

--- a/fighthealthinsurance/migrations/0180_insurancecompany_pa_requirement_list_url.py
+++ b/fighthealthinsurance/migrations/0180_insurancecompany_pa_requirement_list_url.py
@@ -1,0 +1,56 @@
+"""Add PA requirement list URL fields to ``InsuranceCompany``.
+
+Separates the per-payer PA requirement document (a list of CPT/HCPCS codes
+that require prior authorization, often a downloadable Excel/PDF/HTML
+table) from the medical-policy index already on the model. The
+``ingest_pa_requirements`` command + refresh actor use these fields to
+discover which payers have parseable PA lists and which URLs to fetch.
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("fighthealthinsurance", "0179_denial_use_external_default_true"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="insurancecompany",
+            name="pa_requirement_list_url",
+            field=models.URLField(
+                blank=True,
+                help_text=(
+                    "URL to the payer's published prior-authorization requirement list "
+                    "(e.g., a downloadable Excel/PDF/HTML table of CPT/HCPCS codes that "
+                    "require PA). Leave blank when no public list is available."
+                ),
+            ),
+        ),
+        migrations.AddField(
+            model_name="insurancecompany",
+            name="pa_requirement_list_url_is_parseable",
+            field=models.BooleanField(
+                default=False,
+                help_text=(
+                    "True when a registered parser exists for this URL's host/format and "
+                    "the document can be auto-fetched and ingested into "
+                    "PayerPriorAuthRequirement rows. Set False for search portals or "
+                    "documents that require interactive navigation."
+                ),
+            ),
+        ),
+        migrations.AddField(
+            model_name="insurancecompany",
+            name="pa_requirement_list_notes",
+            field=models.TextField(
+                blank=True,
+                help_text=(
+                    "Human-readable notes about the PA requirement list: what lines of "
+                    "business it covers, how often it is updated, known parsing quirks, etc."
+                ),
+            ),
+        ),
+    ]

--- a/fighthealthinsurance/models.py
+++ b/fighthealthinsurance/models.py
@@ -776,6 +776,20 @@ class PayerPriorAuthRequirement(models.Model):
     reason about the right rule at the time the service was rendered.
     """
 
+    # Columns that together identify "the same rule" — used by the
+    # ingestion fetcher to key ``update_or_create`` and (conceptually) by
+    # ``lookup_pa_requirements`` as the scoping schema. Living on the
+    # model keeps the two call sites change-once when a new scoping
+    # dimension (e.g. a clinical trial flag) is added.
+    UPSERT_KEY_FIELDS = (
+        "insurance_company",
+        "line_of_business",
+        "state",
+        "cpt_hcpcs_code",
+        "code_range_start",
+        "code_range_end",
+    )
+
     id = models.AutoField(primary_key=True)
     insurance_company = models.ForeignKey(
         InsuranceCompany,

--- a/fighthealthinsurance/models.py
+++ b/fighthealthinsurance/models.py
@@ -552,6 +552,35 @@ class InsuranceCompany(models.Model):
         help_text="Short description of how this payer's medical policies are used / what they assert (e.g., medical-necessity criteria, experimental/investigational determinations).",
     )
 
+    # Prior authorization requirement list — a separate published document
+    # (often an Excel spreadsheet, PDF, or HTML table) that lists which
+    # CPT/HCPCS codes require prior authorization. Distinct from the
+    # medical-policy index above, which links to coverage-criteria PDFs.
+    pa_requirement_list_url = models.URLField(
+        blank=True,
+        help_text=(
+            "URL to the payer's published prior-authorization requirement list "
+            "(e.g., a downloadable Excel/PDF/HTML table of CPT/HCPCS codes that "
+            "require PA). Leave blank when no public list is available."
+        ),
+    )
+    pa_requirement_list_url_is_parseable = models.BooleanField(
+        default=False,
+        help_text=(
+            "True when a registered parser exists for this URL's host/format and "
+            "the document can be auto-fetched and ingested into "
+            "PayerPriorAuthRequirement rows. Set False for search portals or "
+            "documents that require interactive navigation."
+        ),
+    )
+    pa_requirement_list_notes = models.TextField(
+        blank=True,
+        help_text=(
+            "Human-readable notes about the PA requirement list: what lines of "
+            "business it covers, how often it is updated, known parsing quirks, etc."
+        ),
+    )
+
     class Meta:
         verbose_name_plural = "Insurance Companies"
         ordering = ["name"]

--- a/fighthealthinsurance/models.py
+++ b/fighthealthinsurance/models.py
@@ -930,6 +930,21 @@ class PayerPriorAuthRequirement(models.Model):
                 "cpt_hcpcs_code or a complete code range "
                 "(code_range_start and code_range_end)."
             )
+        if has_range and len(start) != len(end):
+            # Lexicographic compare (used by ``covers_code`` and the lookup
+            # query) silently breaks for mixed-length endpoints — e.g.
+            # "J490" < "J0500" lexicographically even though the numeric
+            # codes 490 and 500 should sort the other way. Ranges must be
+            # same-length so the compare is consistent with code semantics.
+            raise ValidationError(
+                {
+                    "code_range_end": (
+                        f"code_range_start ({start}) and code_range_end "
+                        f"({end}) must be the same length so lexicographic "
+                        "comparison matches numeric ordering."
+                    )
+                }
+            )
         if has_range and start.upper() > end.upper():
             raise ValidationError(
                 {

--- a/fighthealthinsurance/pa_refresh_actor.py
+++ b/fighthealthinsurance/pa_refresh_actor.py
@@ -5,79 +5,26 @@ Runs ``PaRequirementsFetcher.ingest_all()`` on a
 PA lists publish quarterly at most so weekly is plenty; tighten the env
 var if a carrier's policies move faster.
 
-Patterned on ``IMRRefreshActor`` so the launcher and health-check
-machinery in ``polling_actor_setup.py`` / ``actor_health_status.py``
-treat it identically.
+The bulk of the run-loop / health-check / backoff scaffolding lives in
+``BaseRefreshActor`` so each new refresh actor stays minimal.
 """
-
-import asyncio
-import datetime
-import os
-import time
-from typing import Optional
 
 import ray
 
-from fighthealthinsurance.utils import get_env_variable
+from fighthealthinsurance.base_refresh_actor import BaseRefreshActor
 
 name = "PaRefreshActor"
 
 
-# Backoff between attempts after an unexpected error, mirroring the IMR
-# actor so retry pressure on misbehaving carrier endpoints is consistent.
-ERROR_BACKOFF_SECONDS = 600
-
-
 @ray.remote(max_restarts=-1, max_task_retries=-1)
-class PaRefreshActor:
-    def __init__(self) -> None:
-        time.sleep(1)
-        os.environ.setdefault(
-            "DJANGO_SETTINGS_MODULE",
-            get_env_variable("DJANGO_SETTINGS_MODULE", "fighthealthinsurance.settings"),
-        )
-        from configurations.wsgi import get_wsgi_application
+class PaRefreshActor(BaseRefreshActor):
+    actor_log_name = "PaRefreshActor"
+    settings_interval_key = "PA_REFRESH_INTERVAL_HOURS"
+    # Carrier PA lists publish quarterly at most; weekly catches the
+    # most-frequent refresh cycles with plenty of headroom.
+    default_interval_hours = 168
 
-        _application = get_wsgi_application()
-        from loguru import logger
-
-        self._logger = logger
-        self.running = False
-        self.last_refresh: Optional[datetime.datetime] = None
-        self._logger.info("PaRefreshActor initialized")
-
-    async def health_check(self) -> bool:
-        return self.running
-
-    async def run(self) -> None:
-        self._logger.info("Starting PaRefreshActor run")
-        self.running = True
-
-        while self.running:
-            try:
-                interval_hours = self._interval_hours()
-                await self._refresh_due(interval_hours)
-                # Re-check hourly so config / parser-registry changes get
-                # picked up without a restart.
-                await asyncio.sleep(3600)
-            except Exception:
-                self._logger.opt(exception=True).error(
-                    "Error in PaRefreshActor refresh cycle"
-                )
-                await asyncio.sleep(ERROR_BACKOFF_SECONDS)
-
-        self._logger.warning("PaRefreshActor stopped running")
-
-    def stop(self) -> None:
-        self.running = False
-
-    @staticmethod
-    def _interval_hours() -> int:
-        from django.conf import settings
-
-        return getattr(settings, "PA_REFRESH_INTERVAL_HOURS", 168)
-
-    async def _refresh_due(self, interval_hours: int) -> None:
+    async def _refresh_due(self, interval_hours: int) -> bool:
         from fighthealthinsurance.pa_requirements_fetcher import (
             PA_PARSERS,
             PaRequirementsFetcher,
@@ -87,12 +34,7 @@ class PaRefreshActor:
             self._logger.debug(
                 "No PA parsers registered; PaRefreshActor cycle is a no-op"
             )
-            return
-
-        if self.last_refresh is not None:
-            elapsed = datetime.datetime.utcnow() - self.last_refresh
-            if elapsed < datetime.timedelta(hours=interval_hours):
-                return
+            return False
 
         async with PaRequirementsFetcher() as fetcher:
             stats = await fetcher.ingest_all()
@@ -105,9 +47,4 @@ class PaRefreshActor:
             f"{stats['entries']} rows upserted, "
             f"{stats['retired']} retired"
         )
-
-        # Only mark the cycle complete if at least one carrier successfully
-        # refreshed; otherwise the next loop iteration retries instead of
-        # waiting another full PA_REFRESH_INTERVAL_HOURS window.
-        if stats["fetched"] > 0:
-            self.last_refresh = datetime.datetime.utcnow()
+        return stats["fetched"] > 0

--- a/fighthealthinsurance/pa_refresh_actor.py
+++ b/fighthealthinsurance/pa_refresh_actor.py
@@ -1,9 +1,9 @@
 """Ray actor that periodically refreshes carrier PA requirement lists.
 
 Runs ``PaRequirementsFetcher.ingest_all()`` on a
-``PA_REFRESH_INTERVAL_HOURS`` cadence (default 168 hours / weekly). Carrier
-PA lists publish quarterly at most so weekly is plenty; tighten the env
-var if a carrier's policies move faster.
+``PA_REFRESH_INTERVAL_HOURS`` cadence (default 168 hours / weekly).
+Carrier PA lists publish quarterly at most so weekly is plenty; tighten
+the env var if a carrier's policies move faster.
 
 The bulk of the run-loop / health-check / backoff scaffolding lives in
 ``BaseRefreshActor`` so each new refresh actor stays minimal.
@@ -26,15 +26,8 @@ class PaRefreshActor(BaseRefreshActor):
 
     async def _refresh_due(self, interval_hours: int) -> bool:
         from fighthealthinsurance.pa_requirements_fetcher import (
-            PA_PARSERS,
             PaRequirementsFetcher,
         )
-
-        if not PA_PARSERS:
-            self._logger.debug(
-                "No PA parsers registered; PaRefreshActor cycle is a no-op"
-            )
-            return False
 
         async with PaRequirementsFetcher() as fetcher:
             stats = await fetcher.ingest_all()

--- a/fighthealthinsurance/pa_refresh_actor.py
+++ b/fighthealthinsurance/pa_refresh_actor.py
@@ -1,0 +1,113 @@
+"""Ray actor that periodically refreshes carrier PA requirement lists.
+
+Runs ``PaRequirementsFetcher.ingest_all()`` on a
+``PA_REFRESH_INTERVAL_HOURS`` cadence (default 168 hours / weekly). Carrier
+PA lists publish quarterly at most so weekly is plenty; tighten the env
+var if a carrier's policies move faster.
+
+Patterned on ``IMRRefreshActor`` so the launcher and health-check
+machinery in ``polling_actor_setup.py`` / ``actor_health_status.py``
+treat it identically.
+"""
+
+import asyncio
+import datetime
+import os
+import time
+from typing import Optional
+
+import ray
+
+from fighthealthinsurance.utils import get_env_variable
+
+name = "PaRefreshActor"
+
+
+# Backoff between attempts after an unexpected error, mirroring the IMR
+# actor so retry pressure on misbehaving carrier endpoints is consistent.
+ERROR_BACKOFF_SECONDS = 600
+
+
+@ray.remote(max_restarts=-1, max_task_retries=-1)
+class PaRefreshActor:
+    def __init__(self) -> None:
+        time.sleep(1)
+        os.environ.setdefault(
+            "DJANGO_SETTINGS_MODULE",
+            get_env_variable("DJANGO_SETTINGS_MODULE", "fighthealthinsurance.settings"),
+        )
+        from configurations.wsgi import get_wsgi_application
+
+        _application = get_wsgi_application()
+        from loguru import logger
+
+        self._logger = logger
+        self.running = False
+        self.last_refresh: Optional[datetime.datetime] = None
+        self._logger.info("PaRefreshActor initialized")
+
+    async def health_check(self) -> bool:
+        return self.running
+
+    async def run(self) -> None:
+        self._logger.info("Starting PaRefreshActor run")
+        self.running = True
+
+        while self.running:
+            try:
+                interval_hours = self._interval_hours()
+                await self._refresh_due(interval_hours)
+                # Re-check hourly so config / parser-registry changes get
+                # picked up without a restart.
+                await asyncio.sleep(3600)
+            except Exception:
+                self._logger.opt(exception=True).error(
+                    "Error in PaRefreshActor refresh cycle"
+                )
+                await asyncio.sleep(ERROR_BACKOFF_SECONDS)
+
+        self._logger.warning("PaRefreshActor stopped running")
+
+    def stop(self) -> None:
+        self.running = False
+
+    @staticmethod
+    def _interval_hours() -> int:
+        from django.conf import settings
+
+        return getattr(settings, "PA_REFRESH_INTERVAL_HOURS", 168)
+
+    async def _refresh_due(self, interval_hours: int) -> None:
+        from fighthealthinsurance.pa_requirements_fetcher import (
+            PA_PARSERS,
+            PaRequirementsFetcher,
+        )
+
+        if not PA_PARSERS:
+            self._logger.debug(
+                "No PA parsers registered; PaRefreshActor cycle is a no-op"
+            )
+            return
+
+        if self.last_refresh is not None:
+            elapsed = datetime.datetime.utcnow() - self.last_refresh
+            if elapsed < datetime.timedelta(hours=interval_hours):
+                return
+
+        async with PaRequirementsFetcher() as fetcher:
+            stats = await fetcher.ingest_all()
+
+        log = self._logger.warning if stats["failed"] else self._logger.info
+        log(
+            "PA refresh: "
+            f"{stats['fetched']} carrier(s) fetched, "
+            f"{stats['failed']} failed, "
+            f"{stats['entries']} rows upserted, "
+            f"{stats['retired']} retired"
+        )
+
+        # Only mark the cycle complete if at least one carrier successfully
+        # refreshed; otherwise the next loop iteration retries instead of
+        # waiting another full PA_REFRESH_INTERVAL_HOURS window.
+        if stats["fetched"] > 0:
+            self.last_refresh = datetime.datetime.utcnow()

--- a/fighthealthinsurance/pa_refresh_actor_ref.py
+++ b/fighthealthinsurance/pa_refresh_actor_ref.py
@@ -1,0 +1,13 @@
+from fighthealthinsurance.base_actor_ref import BaseActorRef
+from fighthealthinsurance.pa_refresh_actor import PaRefreshActor
+
+
+class PaRefreshActorRef(BaseActorRef):
+    """A reference to the PA-requirement refresh actor."""
+
+    actor_class = PaRefreshActor
+    actor_name = "pa_refresh_actor"
+    has_run_method = True
+
+
+pa_refresh_actor_ref = PaRefreshActorRef()

--- a/fighthealthinsurance/pa_requirement_parsers.py
+++ b/fighthealthinsurance/pa_requirement_parsers.py
@@ -1,0 +1,600 @@
+"""
+Parsers for payer prior-authorization requirement lists.
+
+Each parser takes raw content (HTML text, PDF bytes, or CSV/Excel bytes)
+and returns a list of ``ParsedPARequirement`` records. The orchestrator
+(``pa_requirements_fetcher``) writes these as ``PayerPriorAuthRequirement``
+rows that ``pa_requirements`` later looks up at appeal time.
+
+Adding support for a new payer means:
+  1. Identify the payer's publicly accessible PA requirement list URL.
+  2. Set ``pa_requirement_list_url`` and ``pa_requirement_list_url_is_parseable=True``
+     on the InsuranceCompany fixture/admin row.
+  3. If the response Content-Type is already in ``PARSERS_BY_CONTENT_TYPE``
+     (HTML / PDF / Excel / CSV) the generic column-mapping heuristic handles
+     ingest. For payer-specific overrides (submission channel, default LOB)
+     add an entry to ``HOST_ENRICHMENTS``.
+
+Content-type dispatch:
+  - HTML  → ``parse_html_pa_table`` (generic)
+  - PDF   → ``parse_pdf_pa_list`` (generic text extraction + code scanning)
+  - Excel → ``parse_excel_pa_list`` (generic column-mapping heuristic)
+  - CSV   → ``parse_csv_pa_list`` (same heuristic as Excel)
+"""
+
+from __future__ import annotations
+
+import io
+import re
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Optional, Tuple
+
+from loguru import logger
+
+# ---------------------------------------------------------------------------
+# Output record
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ParsedPARequirement:
+    """One row of a parsed PA requirement list, ready to upsert into the DB.
+
+    Exactly one of ``cpt_hcpcs_code`` or the ``code_range_start`` /
+    ``code_range_end`` pair is populated; the fetcher writes whichever is
+    set into the matching ``PayerPriorAuthRequirement`` column.
+    """
+
+    cpt_hcpcs_code: str = ""
+    code_range_start: str = ""
+    code_range_end: str = ""
+    code_description: str = ""
+    requires_pa: bool = True
+    notification_only: bool = False
+    pa_category: str = ""
+    criteria_reference: str = ""
+    criteria_url: str = ""
+    submission_channel: str = ""
+    line_of_business: str = "all"
+    state: str = ""
+    notes: str = ""
+    source_document: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+_CODE_RANGE = re.compile(
+    r"^\s*(\d{5}|\b[ABCDEGHJKLPQRSTV]\d{4})\s*[-–]\s*"
+    r"(\d{5}|[ABCDEGHJKLPQRSTV]\d{4})\s*$",
+    re.IGNORECASE,
+)
+_INLINE_CODE = re.compile(
+    r"\b(\d{5}|[ABCDEGHJKLPQRSTV]\d{4})(?:[-\s][A-Z0-9]{2})?\b", re.IGNORECASE
+)
+
+# Column header keywords → canonical field names. Headers are normalised
+# (lowercased, whitespace squashed) before lookup.
+_COLUMN_ALIASES: Dict[str, str] = {
+    # code column
+    "procedure code": "code",
+    "proc code": "code",
+    "cpt": "code",
+    "hcpcs": "code",
+    "cpt/hcpcs": "code",
+    "cpt code": "code",
+    "hcpcs code": "code",
+    "service code": "code",
+    "code": "code",
+    # description
+    "procedure description": "description",
+    "description": "description",
+    "service description": "description",
+    "service name": "description",
+    # PA required
+    "prior authorization required": "requires_pa",
+    "prior auth required": "requires_pa",
+    "pa required": "requires_pa",
+    "pa": "requires_pa",
+    "requires pa": "requires_pa",
+    "auth required": "requires_pa",
+    # notification only
+    "advance notification": "notification_only",
+    "advance notification required": "notification_only",
+    "notification only": "notification_only",
+    "advance notice": "notification_only",
+    # category
+    "category": "category",
+    "pa category": "category",
+    "authorization category": "category",
+    # criteria / policy
+    "criteria": "criteria",
+    "criteria reference": "criteria",
+    "coverage criteria": "criteria",
+    "medical policy": "criteria",
+    "clinical policy": "criteria",
+    "policy name": "criteria",
+    # submission
+    "submission channel": "submission",
+    "how to submit": "submission",
+    "submit via": "submission",
+    # line of business
+    "line of business": "lob",
+    "lob": "lob",
+    "plan type": "lob",
+    # state
+    "state": "state",
+}
+
+# Boolean-like cell values
+_TRUTHY = {"yes", "y", "true", "1", "required", "req", "x", "✓", "✔"}
+_FALSY = {"no", "n", "false", "0", "not required", "not req", "excluded"}
+
+
+def _bool_cell(cell: str) -> Optional[bool]:
+    """Convert a cell value to bool; returns None when the value is ambiguous."""
+    cleaned = cell.strip().lower()
+    if cleaned in _TRUTHY:
+        return True
+    if cleaned in _FALSY:
+        return False
+    return None
+
+
+def _normalize_header(raw: str) -> str:
+    return raw.strip().lower().replace("\n", " ").replace("  ", " ")
+
+
+def _map_columns(headers: List[str]) -> Dict[int, str]:
+    """Map column indices to canonical field names based on header text."""
+    mapping: Dict[int, str] = {}
+    for i, h in enumerate(headers):
+        key = _normalize_header(h)
+        canonical = _COLUMN_ALIASES.get(key)
+        if canonical:
+            mapping[i] = canonical
+    return mapping
+
+
+def _rows_to_requirements(
+    column_map: Dict[int, str],
+    rows: List[List[str]],
+    source_document: str = "",
+) -> List[ParsedPARequirement]:
+    """Convert tabular rows (already header-mapped) into ParsedPARequirement records."""
+    out: List[ParsedPARequirement] = []
+    has_code_col = any(v == "code" for v in column_map.values())
+    if not has_code_col:
+        logger.debug("No code column identified in column map; skipping table")
+        return out
+
+    for row in rows:
+        if not any(cell.strip() for cell in row):
+            continue
+
+        code_raw = ""
+        description = ""
+        requires_pa = True
+        notification_only = False
+        category = ""
+        criteria = ""
+        submission = ""
+        lob = "all"
+        state = ""
+
+        for idx, canonical in column_map.items():
+            if idx >= len(row):
+                continue
+            cell = (row[idx] or "").strip()
+            if canonical == "code":
+                code_raw = cell
+            elif canonical == "description":
+                description = cell
+            elif canonical == "requires_pa":
+                v = _bool_cell(cell)
+                if v is not None:
+                    requires_pa = v
+            elif canonical == "notification_only":
+                v = _bool_cell(cell)
+                if v is not None:
+                    notification_only = v
+            elif canonical == "category":
+                category = cell
+            elif canonical == "criteria":
+                criteria = cell
+            elif canonical == "submission":
+                submission = cell
+            elif canonical == "lob":
+                lob = cell.lower() if cell else "all"
+            elif canonical == "state":
+                if cell:
+                    upper = cell.strip().upper()
+                    # Keep as-is if already a 2-letter code; blank out full names
+                    state = upper if len(upper) == 2 and upper.isalpha() else ""
+                else:
+                    state = ""
+
+        if not code_raw:
+            continue
+
+        range_m = _CODE_RANGE.match(code_raw)
+        if range_m:
+            out.append(
+                ParsedPARequirement(
+                    code_range_start=range_m.group(1).upper(),
+                    code_range_end=range_m.group(2).upper(),
+                    code_description=description,
+                    requires_pa=requires_pa,
+                    notification_only=notification_only,
+                    pa_category=category,
+                    criteria_reference=criteria,
+                    submission_channel=submission,
+                    line_of_business=lob,
+                    state=state,
+                    source_document=source_document,
+                )
+            )
+            continue
+
+        for m in _INLINE_CODE.finditer(code_raw):
+            code = m.group(1).upper()
+            out.append(
+                ParsedPARequirement(
+                    cpt_hcpcs_code=code,
+                    code_description=description,
+                    requires_pa=requires_pa,
+                    notification_only=notification_only,
+                    pa_category=category,
+                    criteria_reference=criteria,
+                    submission_channel=submission,
+                    line_of_business=lob,
+                    state=state,
+                    source_document=source_document,
+                )
+            )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# HTML table parser (generic)
+# ---------------------------------------------------------------------------
+
+
+def parse_html_pa_table(html: str, source_name: str = "") -> List[ParsedPARequirement]:
+    """Extract PA requirements from an HTML page containing ``<table>`` elements.
+
+    JS-rendered content is not supported — for those, set
+    ``pa_requirement_list_url_is_parseable=False`` on the InsuranceCompany row
+    so the ingest pipeline skips it.
+    """
+    from bs4 import BeautifulSoup
+
+    soup = BeautifulSoup(html, "html.parser")
+    out: List[ParsedPARequirement] = []
+
+    for table in soup.find_all("table"):
+        headers: List[str] = []
+        rows_data: List[List[str]] = []
+
+        thead = table.find("thead")
+        if thead:
+            header_row = thead.find("tr")
+            if header_row:
+                headers = [
+                    th.get_text(" ", strip=True)
+                    for th in header_row.find_all(["th", "td"])
+                ]
+
+        tbody = table.find("tbody") or table
+        for tr in tbody.find_all("tr"):
+            cells = tr.find_all(["td", "th"])
+            if not cells:
+                continue
+            row_texts = [c.get_text(" ", strip=True) for c in cells]
+            if not headers:
+                if any(_normalize_header(t) in _COLUMN_ALIASES for t in row_texts):
+                    headers = row_texts
+                    continue
+            rows_data.append(row_texts)
+
+        if not headers or not rows_data:
+            continue
+        col_map = _map_columns(headers)
+        out.extend(
+            _rows_to_requirements(col_map, rows_data, source_document=source_name)
+        )
+
+    return out
+
+
+# ---------------------------------------------------------------------------
+# PDF parser (generic, using pymupdf)
+# ---------------------------------------------------------------------------
+
+
+def parse_pdf_pa_list(
+    pdf_bytes: bytes, source_name: str = ""
+) -> List[ParsedPARequirement]:
+    """Extract PA requirements from a PDF document via pymupdf.
+
+    Prefers pymupdf's structured table extraction; falls back to free-text
+    scanning with surrounding-context heuristics for PA / notification cues.
+    """
+    try:
+        import pymupdf  # type: ignore[import]
+    except ImportError:
+        logger.warning("pymupdf not installed; cannot parse PDF PA lists")
+        return []
+
+    out: List[ParsedPARequirement] = []
+    try:
+        with pymupdf.open(stream=pdf_bytes, filetype="pdf") as doc:
+            for page in doc:
+                tables = page.find_tables()
+                if tables and tables.tables:
+                    for table in tables.tables:
+                        rows = table.extract()
+                        if not rows or len(rows) < 2:
+                            continue
+                        headers = [str(c or "") for c in rows[0]]
+                        col_map = _map_columns(headers)
+                        if any(v == "code" for v in col_map.values()):
+                            data_rows = [[str(c or "") for c in r] for r in rows[1:]]
+                            out.extend(
+                                _rows_to_requirements(col_map, data_rows, source_name)
+                            )
+                            continue
+                text = page.get_text()
+                # Dedupe per-page so a 100-page PDF doesn't accumulate
+                # thousands of near-duplicate context-snippet records
+                # before the final dedup at the bottom.
+                out.extend(_dedupe(_scan_text_for_codes(text, source_name)))
+    except Exception:
+        logger.opt(exception=True).warning(
+            f"Failed to parse PDF PA list: {source_name!r}"
+        )
+
+    return _dedupe(out)
+
+
+def _scan_text_for_codes(
+    text: str, source_document: str = ""
+) -> List[ParsedPARequirement]:
+    """Scan free-form text for CPT/HCPCS codes with PA-keyword context."""
+    out: List[ParsedPARequirement] = []
+    lines = text.splitlines()
+    for i, line in enumerate(lines):
+        for m in _INLINE_CODE.finditer(line):
+            code = m.group(1).upper()
+            context = " ".join(lines[max(0, i - 1) : i + 3])
+            ctx_lower = context.lower()
+            requires_pa = True
+            notification_only = False
+            if any(
+                neg in ctx_lower
+                for neg in ("not required", "no pa", "excluded", "does not require")
+            ):
+                requires_pa = False
+            elif "notification" in ctx_lower and "authorization" not in ctx_lower:
+                notification_only = True
+            description = line.replace(m.group(0), "").strip()[:200]
+            out.append(
+                ParsedPARequirement(
+                    cpt_hcpcs_code=code,
+                    code_description=description,
+                    requires_pa=requires_pa,
+                    notification_only=notification_only,
+                    source_document=source_document,
+                )
+            )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Excel / CSV parsers (generic)
+# ---------------------------------------------------------------------------
+
+
+def parse_excel_pa_list(
+    excel_bytes: bytes, source_name: str = ""
+) -> List[ParsedPARequirement]:
+    """Parse an Excel PA workbook. Uses openpyxl; pandas as a fallback."""
+    try:
+        import openpyxl  # type: ignore[import]
+    except ImportError:
+        logger.warning("openpyxl not installed; trying pandas for Excel parsing")
+        return _parse_excel_pandas(excel_bytes, source_name)
+
+    out: List[ParsedPARequirement] = []
+    try:
+        wb = openpyxl.load_workbook(
+            io.BytesIO(excel_bytes), read_only=True, data_only=True
+        )
+        for sheet in wb.worksheets:
+            rows = list(sheet.iter_rows(values_only=True))
+            if not rows:
+                continue
+            # Find header row: first row with at least one recognised alias.
+            header_row_idx = None
+            for ri, row in enumerate(rows[:10]):
+                row_texts = [str(c or "").strip() for c in row]
+                if (
+                    sum(1 for t in row_texts if _normalize_header(t) in _COLUMN_ALIASES)
+                    >= 1
+                ):
+                    header_row_idx = ri
+                    break
+            if header_row_idx is None:
+                continue
+            headers = [str(c or "").strip() for c in rows[header_row_idx]]
+            col_map = _map_columns(headers)
+            if not any(v == "code" for v in col_map.values()):
+                continue
+            data_rows = [
+                [str(c or "").strip() for c in row]
+                for row in rows[header_row_idx + 1 :]
+            ]
+            out.extend(_rows_to_requirements(col_map, data_rows, source_name))
+        wb.close()
+    except Exception:
+        logger.opt(exception=True).warning(f"openpyxl failed for {source_name!r}")
+
+    return _dedupe(out)
+
+
+def _parse_excel_pandas(
+    excel_bytes: bytes, source_name: str = ""
+) -> List[ParsedPARequirement]:
+    try:
+        import pandas as pd  # type: ignore[import]
+    except ImportError:
+        logger.warning(
+            "Neither openpyxl nor pandas is available; cannot parse Excel PA list"
+        )
+        return []
+    out: List[ParsedPARequirement] = []
+    try:
+        xl = pd.ExcelFile(io.BytesIO(excel_bytes))
+        for sheet_name in xl.sheet_names:
+            df = xl.parse(sheet_name, dtype=str).fillna("")
+            headers = list(df.columns)
+            col_map = _map_columns(headers)
+            if not any(v == "code" for v in col_map.values()):
+                continue
+            rows = df.values.tolist()
+            rows_str = [[str(c) for c in row] for row in rows]
+            out.extend(_rows_to_requirements(col_map, rows_str, source_name))
+    except Exception:
+        logger.opt(exception=True).warning(
+            f"pandas Excel parse failed for {source_name!r}"
+        )
+    return _dedupe(out)
+
+
+def parse_csv_pa_list(
+    csv_bytes: bytes, source_name: str = ""
+) -> List[ParsedPARequirement]:
+    """Parse a CSV file with a header row containing CPT/HCPCS code columns."""
+    import csv
+
+    text = csv_bytes.decode("utf-8-sig", errors="replace")
+    reader = csv.reader(io.StringIO(text))
+    rows = list(reader)
+    if not rows:
+        return []
+    col_map = _map_columns(rows[0])
+    if not any(v == "code" for v in col_map.values()):
+        return []
+    return _dedupe(_rows_to_requirements(col_map, rows[1:], source_name))
+
+
+# ---------------------------------------------------------------------------
+# Deduplication
+# ---------------------------------------------------------------------------
+
+
+def _dedupe(requirements: List[ParsedPARequirement]) -> List[ParsedPARequirement]:
+    """Remove duplicate records (same code/range + LOB + state)."""
+    seen: set = set()
+    out: List[ParsedPARequirement] = []
+    for req in requirements:
+        key = (
+            req.cpt_hcpcs_code,
+            req.code_range_start,
+            req.code_range_end,
+            req.line_of_business,
+            req.state,
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(req)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Dispatch — generic parsers keyed by content-type, payer enrichment by host
+# ---------------------------------------------------------------------------
+
+# A raw parser takes the response body (str for HTML/CSV, bytes for PDF/Excel)
+# plus an optional source-name tag, and returns ParsedPARequirement records.
+RawParser = Callable[..., List[ParsedPARequirement]]
+
+# (raw_parser, expects_bytes)
+ParserSpec = Tuple[RawParser, bool]
+
+PARSERS_BY_CONTENT_TYPE: Dict[str, ParserSpec] = {
+    "text/html": (parse_html_pa_table, False),
+    "application/xhtml+xml": (parse_html_pa_table, False),
+    "application/pdf": (parse_pdf_pa_list, True),
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": (
+        parse_excel_pa_list,
+        True,
+    ),
+    "application/vnd.ms-excel": (parse_excel_pa_list, True),
+    "text/csv": (parse_csv_pa_list, True),
+}
+
+
+@dataclass(frozen=True)
+class HostEnrichment:
+    """Payer-specific defaults applied after a generic parser runs.
+
+    ``submission_channel`` is written into any record whose channel is
+    empty; ``default_lob`` replaces an empty / ``"all"`` line_of_business
+    so a generic commercial list gets correctly tagged for downstream
+    lookups.
+    """
+
+    submission_channel: str = ""
+    default_lob: str = ""
+
+
+HOST_ENRICHMENTS: Dict[str, HostEnrichment] = {
+    "uhcprovider.com": HostEnrichment(
+        submission_channel="UHCprovider.com or 1-866-889-8054",
+        default_lob="commercial",
+    ),
+    "aetna.com": HostEnrichment(
+        submission_channel=(
+            "Aetna provider portal (NaviMedix AuthPortal) or 1-800-AETNA-PA"
+        ),
+        default_lob="commercial",
+    ),
+    "cigna.com": HostEnrichment(
+        submission_channel="eviCore (evicore.com) or 1-888-564-3650",
+    ),
+    "humana.com": HostEnrichment(
+        submission_channel="Availity (availity.com) or 1-800-626-2741",
+    ),
+    "fepblue.org": HostEnrichment(
+        submission_channel="BlueCard program portal or 1-800-972-8382",
+    ),
+}
+
+
+def enrichment_for_host(host: str) -> HostEnrichment:
+    """Look up payer defaults by exact host or registrable-domain suffix."""
+    host = (host or "").lower()
+    if host in HOST_ENRICHMENTS:
+        return HOST_ENRICHMENTS[host]
+    parts = host.split(".")
+    for i in range(len(parts) - 1):
+        candidate = ".".join(parts[i:])
+        if candidate in HOST_ENRICHMENTS:
+            return HOST_ENRICHMENTS[candidate]
+    return HostEnrichment()
+
+
+def apply_enrichment(
+    requirements: List[ParsedPARequirement], enrichment: HostEnrichment
+) -> None:
+    """Mutate records in place to fill empty submission channel / LOB."""
+    if not (enrichment.submission_channel or enrichment.default_lob):
+        return
+    for req in requirements:
+        if enrichment.submission_channel and not req.submission_channel:
+            req.submission_channel = enrichment.submission_channel
+        if enrichment.default_lob and req.line_of_business in ("", "all"):
+            req.line_of_business = enrichment.default_lob

--- a/fighthealthinsurance/pa_requirements.py
+++ b/fighthealthinsurance/pa_requirements.py
@@ -262,7 +262,9 @@ def _resolver_cache_bucket() -> int:
 
 
 @lru_cache(maxsize=4)
-def _regex_candidates(bucket: int):
+def _regex_candidates(
+    bucket: int,
+) -> Tuple[Tuple[int, "re.Pattern[str]", Optional["re.Pattern[str]"]], ...]:
     """Return ``[(id, regex, negative_regex)]`` tuples for the resolver.
 
     Caching the compiled regex objects per 5-minute bucket avoids both the
@@ -270,7 +272,7 @@ def _regex_candidates(bucket: int):
     Admin edits become visible within one bucket-rollover.
     """
     del bucket  # value embedded for cache invalidation only
-    out = []
+    out: List[Tuple[int, "re.Pattern[str]", Optional["re.Pattern[str]"]]] = []
     # Push the empty-regex filter to the database so we don't pull every
     # InsuranceCompany row just to discard the ones without a pattern.
     for candidate in InsuranceCompany.objects.exclude(regex="").iterator():

--- a/fighthealthinsurance/pa_requirements.py
+++ b/fighthealthinsurance/pa_requirements.py
@@ -218,7 +218,7 @@ def resolve_insurance_company_by_name(
                 continue
             if (
                 negative is not None
-                and getattr(negative, "pattern", "")
+                and negative.pattern
                 and negative.search(payer_clean)
             ):
                 continue

--- a/fighthealthinsurance/pa_requirements.py
+++ b/fighthealthinsurance/pa_requirements.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import re
 import time
 from datetime import date
+from functools import lru_cache
 from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple
 
 from django.db.models import Q
@@ -202,25 +203,31 @@ def resolve_insurance_company_by_name(
     # excluding any candidate whose ``negative_regex`` matches. Mirrors
     # the established pattern in
     # ``common_view_logic.AppealsBackendHelper._match_insurance_company``
-    # so the two resolvers stay consistent. We push the empty-regex
-    # filter to the database so Python only iterates rows that have a
-    # pattern worth running.
+    # so the two resolvers stay consistent. The candidate list itself is
+    # cached behind a 5-minute bucket (see ``_regex_candidates``) so we
+    # avoid both the full-table scan and the per-row regex re-compile on
+    # every call.
     regex_start = time.perf_counter()
     regex_scanned = 0
-    for candidate in InsuranceCompany.objects.exclude(regex="").iterator():
-        regex = getattr(candidate, "regex", None)
-        if not regex or not getattr(regex, "pattern", ""):
+    for candidate_id, regex, negative in _regex_candidates(_resolver_cache_bucket()):
+        if regex is None:
             continue
         regex_scanned += 1
         try:
             if not regex.search(payer_clean):
                 continue
-            negative = getattr(candidate, "negative_regex", None)
             if (
-                negative
+                negative is not None
                 and getattr(negative, "pattern", "")
                 and negative.search(payer_clean)
             ):
+                continue
+            # The cache snapshot can outlive a row that was deleted in
+            # between cache-build and now. Skip stale IDs rather than
+            # silently returning ``None`` as if it were a successful
+            # match.
+            candidate = InsuranceCompany.objects.filter(pk=candidate_id).first()
+            if candidate is None:
                 continue
             logger.opt(lazy=True).debug(
                 "resolve_insurance_company_by_name: regex fallback hit for "
@@ -233,7 +240,7 @@ def resolve_insurance_company_by_name(
             return candidate
         except Exception as e:
             logger.opt(exception=True).debug(
-                f"Error applying regex for company {candidate.id}: {e}"
+                f"Error applying regex for company {candidate_id}: {e}"
             )
             continue
     logger.opt(lazy=True).debug(
@@ -244,6 +251,34 @@ def resolve_insurance_company_by_name(
         lambda s=regex_start: (time.perf_counter() - s) * 1000,
     )
     return None
+
+
+_RESOLVER_CACHE_TTL_SECONDS = 300
+
+
+def _resolver_cache_bucket() -> int:
+    """Coarse time bucket so admin edits become visible within ~5 minutes."""
+    return int(time.time()) // _RESOLVER_CACHE_TTL_SECONDS
+
+
+@lru_cache(maxsize=4)
+def _regex_candidates(bucket: int):
+    """Return ``[(id, regex, negative_regex)]`` tuples for the resolver.
+
+    Caching the compiled regex objects per 5-minute bucket avoids both the
+    full table scan and the per-row regex recompile on every chat-tool call.
+    Admin edits become visible within one bucket-rollover.
+    """
+    del bucket  # value embedded for cache invalidation only
+    out = []
+    # Push the empty-regex filter to the database so we don't pull every
+    # InsuranceCompany row just to discard the ones without a pattern.
+    for candidate in InsuranceCompany.objects.exclude(regex="").iterator():
+        regex = getattr(candidate, "regex", None)
+        if not regex or not getattr(regex, "pattern", ""):
+            continue
+        out.append((candidate.id, regex, getattr(candidate, "negative_regex", None)))
+    return tuple(out)
 
 
 def infer_line_of_business(denial: Denial) -> Optional[str]:
@@ -282,6 +317,7 @@ def lookup_pa_requirements(
     line_of_business: Optional[str] = None,
     plan: Optional["InsurancePlan"] = None,
     on_date: Optional[date] = None,
+    broaden_unknown_lob: bool = False,
 ) -> List[PayerPriorAuthRequirement]:
     """
     Return ``PayerPriorAuthRequirement`` rows that match any of the given
@@ -293,7 +329,8 @@ def lookup_pa_requirements(
       * ``state`` known → match rules for that state OR national rules
         (state="").  ``state`` is None/unknown → only national rules.
       * ``line_of_business`` known → match that LOB OR rules tagged "all".
-        Unknown → only "all"-LOB rules.
+        Unknown → only "all"-LOB rules, unless ``broaden_unknown_lob=True``
+        in which case the LOB filter is dropped entirely.
       * ``plan`` known → match rules for that plan OR plan-agnostic
         (plan IS NULL).  Unknown → only plan-agnostic rules.
       * Codes match either via exact ``cpt_hcpcs_code`` or
@@ -339,8 +376,13 @@ def lookup_pa_requirements(
             Q(line_of_business=line_of_business)
             | Q(line_of_business=LineOfBusiness.ALL)
         )
-    else:
+    elif not broaden_unknown_lob:
         qs = qs.filter(line_of_business=LineOfBusiness.ALL)
+    # When broaden_unknown_lob is True and the caller couldn't infer a LOB,
+    # don't filter on it at all — surface every applicable rule and let
+    # the caller (typically the chat tool) disambiguate. The denial-driven
+    # path keeps the conservative default so PA context isn't mis-attributed
+    # in appeal-letter prompts.
 
     if plan is not None:
         qs = qs.filter(Q(plan=plan) | Q(plan__isnull=True))
@@ -492,6 +534,9 @@ def _denial_lookup(
     line_of_business = infer_line_of_business(denial)
     state = (getattr(denial, "state", "") or "").upper().strip() or None
     plan = getattr(denial, "insurance_plan_obj", None)
+    # ``Denial.denial_date`` is a real DateField; ``date_of_service`` is a
+    # free-form CharField, so we don't try to parse it here.
+    on_date = getattr(denial, "denial_date", None)
 
     try:
         requirements = lookup_pa_requirements(
@@ -500,6 +545,7 @@ def _denial_lookup(
             state=state,
             line_of_business=line_of_business,
             plan=plan,
+            on_date=on_date,
         )
     except Exception as e:
         logger.opt(exception=True).debug(f"PA requirement lookup failed: {e}")

--- a/fighthealthinsurance/pa_requirements.py
+++ b/fighthealthinsurance/pa_requirements.py
@@ -225,19 +225,21 @@ def resolve_insurance_company_by_name(
             # The cache snapshot can outlive a row that was deleted in
             # between cache-build and now. Skip stale IDs rather than
             # silently returning ``None`` as if it were a successful
-            # match.
-            candidate = InsuranceCompany.objects.filter(pk=candidate_id).first()
-            if candidate is None:
+            # match. Bind to a fresh name so mypy doesn't compare the
+            # ``InsuranceCompany | None`` type here against the
+            # alt-name loop's ``InsuranceCompany``-typed ``candidate``.
+            resolved = InsuranceCompany.objects.filter(pk=candidate_id).first()
+            if resolved is None:
                 continue
             logger.opt(lazy=True).debug(
                 "resolve_insurance_company_by_name: regex fallback hit for "
                 "{!r} -> company id {} after {} pattern(s) in {:.1f} ms",
                 lambda p=payer_clean: p,
-                lambda c=candidate: c.id,
+                lambda c=resolved: c.id,
                 lambda n=regex_scanned: n,
                 lambda s=regex_start: (time.perf_counter() - s) * 1000,
             )
-            return candidate
+            return resolved
         except Exception as e:
             logger.opt(exception=True).debug(
                 f"Error applying regex for company {candidate_id}: {e}"

--- a/fighthealthinsurance/pa_requirements_fetcher.py
+++ b/fighthealthinsurance/pa_requirements_fetcher.py
@@ -188,7 +188,10 @@ class PaRequirementsFetcher:
             apply_enrichment(reqs, enrichment_for_host(urlparse(url).hostname or ""))
             return reqs
 
-        return await sync_to_async(_parse_and_enrich, thread_sensitive=False)()
+        result: List[ParsedPARequirement] = await sync_to_async(
+            _parse_and_enrich, thread_sensitive=False
+        )()
+        return result
 
     async def _get_content(self, url: str) -> "tuple[str, Union[str, bytes]]":
         """Download ``url``; return ``(content_type, body)``."""
@@ -307,4 +310,5 @@ class PaRequirementsFetcher:
             .exclude(pk__in=seen_pks)
             .filter(end_date__isnull=True)
         )
-        return qs.update(end_date=today)
+        retired: int = qs.update(end_date=today)
+        return retired

--- a/fighthealthinsurance/pa_requirements_fetcher.py
+++ b/fighthealthinsurance/pa_requirements_fetcher.py
@@ -35,6 +35,7 @@ from loguru import logger
 
 from fighthealthinsurance.models import (
     InsuranceCompany,
+    LineOfBusiness,
     PayerPriorAuthRequirement,
 )
 
@@ -72,16 +73,10 @@ def register_parser(
     return decorator
 
 
-# Same key shape lookup_pa_requirements queries on. A row is "the same row"
-# when these fields all match; everything else is overwritten on upsert.
-_UPSERT_KEY_FIELDS = (
-    "insurance_company",
-    "line_of_business",
-    "state",
-    "cpt_hcpcs_code",
-    "code_range_start",
-    "code_range_end",
-)
+# Source-of-truth lives on the model class
+# (``PayerPriorAuthRequirement.UPSERT_KEY_FIELDS``) so the upsert key
+# stays in lockstep with the lookup-filter schema.
+_UPSERT_KEY_FIELDS = PayerPriorAuthRequirement.UPSERT_KEY_FIELDS
 
 
 def resolve_carrier_by_aliases(
@@ -132,7 +127,19 @@ class PaRequirementsFetcher:
     async def ingest_all(self) -> Dict[str, int]:
         stats = {"fetched": 0, "failed": 0, "entries": 0, "retired": 0}
         for alias in list(PA_PARSERS):
-            sub = await self.ingest_carrier(alias)
+            # Isolate per-carrier failures: an unhandled exception inside
+            # one parser/upsert must not abort the rest of the run, or
+            # operators would have to restart the actor every time a
+            # single carrier endpoint misbehaves.
+            try:
+                sub = await self.ingest_carrier(alias)
+            except Exception as e:
+                logger.opt(exception=True).warning(
+                    f"ingest_carrier({alias!r}) raised; recording as a "
+                    f"failed carrier and continuing: {e}"
+                )
+                stats["failed"] += 1
+                continue
             stats["fetched"] += sub["fetched"]
             stats["failed"] += sub["failed"]
             stats["entries"] += sub["entries"]
@@ -181,21 +188,31 @@ class PaRequirementsFetcher:
             return stats
 
         stats["fetched"] += 1
-        seen_pks, written = await sync_to_async(self._upsert_rows)(company, rows)
+        seen_pks, written = await sync_to_async(self._upsert_rows)(company, rows, alias)
         stats["entries"] += written
         stats["retired"] += await sync_to_async(self._retire_missing)(company, seen_pks)
         return stats
 
     @staticmethod
     def _upsert_rows(
-        company: InsuranceCompany, rows: List[Dict[str, Any]]
+        company: InsuranceCompany, rows: List[Dict[str, Any]], alias: str
     ) -> Tuple[List[int], int]:
-        """Upsert each row; return ``(pks_seen_this_run, count)``."""
+        """Upsert each row; return ``(pks_seen_this_run, count)``.
+
+        Always stamps ``source_document`` with an ``[ingest:<alias>]``
+        marker (appending to whatever string the parser supplied) so
+        ``_retire_missing`` can identify ingestion-owned rows without
+        relying on parser authors to remember the convention.
+        """
         seen: List[int] = []
+        marker = f"[ingest:{alias}]"
         for row in rows:
             key = {
                 "insurance_company": company,
-                "line_of_business": row.get("line_of_business", ""),
+                # The model field uses ``choices`` with no blank-allowed
+                # option; default to ALL so parser output that omits a
+                # LOB still passes ``full_clean()``.
+                "line_of_business": row.get("line_of_business") or LineOfBusiness.ALL,
                 "state": row.get("state", ""),
                 "cpt_hcpcs_code": row.get("cpt_hcpcs_code", ""),
                 "code_range_start": row.get("code_range_start", ""),
@@ -206,6 +223,11 @@ class PaRequirementsFetcher:
             # current again; clear end_date unless the parser explicitly
             # set one.
             defaults.setdefault("end_date", None)
+            base_source = defaults.get("source_document", "") or ""
+            if marker not in base_source:
+                defaults["source_document"] = (
+                    f"{base_source} {marker}".strip() if base_source else marker
+                )
             obj, _ = PayerPriorAuthRequirement.objects.update_or_create(
                 **key, defaults=defaults
             )

--- a/fighthealthinsurance/pa_requirements_fetcher.py
+++ b/fighthealthinsurance/pa_requirements_fetcher.py
@@ -1,0 +1,231 @@
+"""
+Fetch and re-parse carrier-published prior-authorization requirement lists.
+
+Where a carrier publishes a structured PA requirement document (CSV, XLSX,
+or HTML table), a parser registered in ``PA_PARSERS`` knows how to fetch
+the document, normalise each row, and yield it in the shape consumed by
+``PaRequirementsFetcher._upsert``. The fetcher upserts via
+``update_or_create`` keyed on the same tuple the lookup queries on, so
+re-running an ingest is idempotent.
+
+Rows previously seen for a carrier but absent from this run are
+soft-retired (``end_date`` set to today) rather than deleted, so historical
+denials still resolve to the rule that applied at the time.
+
+This module ships the framework + an empty registry. Per-carrier parsers
+land in follow-on PRs (one parser + matching fixture per carrier so the
+parser output can be reviewed against a known-good file).
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Protocol,
+    Tuple,
+)
+
+from asgiref.sync import sync_to_async
+from loguru import logger
+
+from fighthealthinsurance.models import (
+    InsuranceCompany,
+    PayerPriorAuthRequirement,
+)
+
+
+class PaParser(Protocol):
+    """Protocol every per-carrier parser must satisfy.
+
+    ``carrier_aliases`` is the priority-ordered list of name strings used
+    to look up the canonical ``InsuranceCompany`` row by case-insensitive
+    exact match (mirroring the ``_get_uhc`` selection logic from the
+    historical seed migration). Returning ``None`` from ``parse`` signals
+    a transient fetch failure so the surrounding code can warn but keep
+    going for other parsers.
+    """
+
+    carrier_aliases: Tuple[str, ...]
+
+    async def parse(self) -> Optional[List[Dict[str, Any]]]: ...
+
+
+# Registry of registered parsers. Keys are the canonical alias used by the
+# management command (``ingest_pa_requirements --carrier <key>``). Values
+# are zero-arg callables returning a parser instance — this avoids
+# importing every parser module at process start.
+PA_PARSERS: Dict[str, Callable[[], PaParser]] = {}
+
+
+def register_parser(
+    alias: str,
+) -> Callable[[Callable[[], PaParser]], Callable[[], PaParser]]:
+    def decorator(factory: Callable[[], PaParser]) -> Callable[[], PaParser]:
+        PA_PARSERS[alias] = factory
+        return factory
+
+    return decorator
+
+
+# Same key shape lookup_pa_requirements queries on. A row is "the same row"
+# when these fields all match; everything else is overwritten on upsert.
+_UPSERT_KEY_FIELDS = (
+    "insurance_company",
+    "line_of_business",
+    "state",
+    "cpt_hcpcs_code",
+    "code_range_start",
+    "code_range_end",
+)
+
+
+def resolve_carrier_by_aliases(
+    aliases: Tuple[str, ...],
+) -> Optional[InsuranceCompany]:
+    """Resolve the canonical ``InsuranceCompany`` row for a parser.
+
+    Lifted from the historical ``_get_uhc`` helper in the now-removed
+    seed migration so per-carrier parsers all use the same selector. We
+    deliberately *only* match exact (case-insensitive) name strings —
+    substring matches across closely-named carriers
+    (e.g. "UnitedHealthcare" vs "UnitedHealthcare Community Plan") would
+    silently mis-attach rows.
+
+    Raises ``RuntimeError`` if multiple aliases match different rows so a
+    data-integrity issue isn't quietly papered over.
+    """
+    matched: Optional[InsuranceCompany] = None
+    for alias in aliases:
+        row = InsuranceCompany.objects.filter(name__iexact=alias).first()
+        if row is None:
+            continue
+        if matched is not None and row.pk != matched.pk:
+            raise RuntimeError(
+                f"Ambiguous carrier resolution: aliases match both "
+                f"id={matched.pk!r} ({matched.name!r}) and "
+                f"id={row.pk!r} ({row.name!r}). Resolve duplicate "
+                "InsuranceCompany rows before re-running ingest."
+            )
+        matched = row
+    return matched
+
+
+class PaRequirementsFetcher:
+    """Async context manager + ingestion driver.
+
+    Mirrors ``PayerPolicyFetcher``'s shape so the ingest command and
+    refresh actor have the same contract as the existing payer-policy
+    pipeline (``ingest_payer_policy_indexes`` / its actor).
+    """
+
+    async def __aenter__(self) -> "PaRequirementsFetcher":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    async def ingest_all(self) -> Dict[str, int]:
+        stats = {"fetched": 0, "failed": 0, "entries": 0, "retired": 0}
+        for alias in list(PA_PARSERS):
+            sub = await self.ingest_carrier(alias)
+            stats["fetched"] += sub["fetched"]
+            stats["failed"] += sub["failed"]
+            stats["entries"] += sub["entries"]
+            stats["retired"] += sub["retired"]
+        return stats
+
+    async def ingest_carrier(self, alias: str) -> Dict[str, int]:
+        stats = {"fetched": 0, "failed": 0, "entries": 0, "retired": 0}
+
+        factory = PA_PARSERS.get(alias)
+        if factory is None:
+            logger.warning(f"No PA parser registered for alias '{alias}'")
+            stats["failed"] += 1
+            return stats
+
+        parser = factory()
+
+        try:
+            company = await sync_to_async(resolve_carrier_by_aliases)(
+                parser.carrier_aliases
+            )
+        except RuntimeError as e:
+            logger.error(f"Carrier resolution failed for '{alias}': {e}")
+            stats["failed"] += 1
+            return stats
+
+        if company is None:
+            logger.warning(
+                f"No InsuranceCompany matched aliases {parser.carrier_aliases!r} "
+                f"for parser '{alias}'; skipping ingest."
+            )
+            stats["failed"] += 1
+            return stats
+
+        try:
+            rows = await parser.parse()
+        except Exception as e:
+            logger.opt(exception=True).warning(
+                f"PA parser '{alias}' raised while fetching: {e}"
+            )
+            stats["failed"] += 1
+            return stats
+
+        if rows is None:
+            stats["failed"] += 1
+            return stats
+
+        stats["fetched"] += 1
+        seen_pks, written = await sync_to_async(self._upsert_rows)(company, rows)
+        stats["entries"] += written
+        stats["retired"] += await sync_to_async(self._retire_missing)(company, seen_pks)
+        return stats
+
+    @staticmethod
+    def _upsert_rows(
+        company: InsuranceCompany, rows: List[Dict[str, Any]]
+    ) -> Tuple[List[int], int]:
+        """Upsert each row; return ``(pks_seen_this_run, count)``."""
+        seen: List[int] = []
+        for row in rows:
+            key = {
+                "insurance_company": company,
+                "line_of_business": row.get("line_of_business", ""),
+                "state": row.get("state", ""),
+                "cpt_hcpcs_code": row.get("cpt_hcpcs_code", ""),
+                "code_range_start": row.get("code_range_start", ""),
+                "code_range_end": row.get("code_range_end", ""),
+            }
+            defaults = {k: v for k, v in row.items() if k not in _UPSERT_KEY_FIELDS}
+            # A re-fetched row that was previously soft-retired is now
+            # current again; clear end_date unless the parser explicitly
+            # set one.
+            defaults.setdefault("end_date", None)
+            obj, _ = PayerPriorAuthRequirement.objects.update_or_create(
+                **key, defaults=defaults
+            )
+            seen.append(obj.pk)
+        return seen, len(seen)
+
+    @staticmethod
+    def _retire_missing(company: InsuranceCompany, seen_pks: List[int]) -> int:
+        """Soft-retire rows for this carrier that weren't seen this run.
+
+        Operates only on rows whose ``source_document`` indicates an
+        ingestion-owned origin (looking for the ``[ingest:...]`` marker
+        the upsert path writes), so manually-curated and fixture-loaded
+        rows are never touched.
+        """
+        today = datetime.date.today()
+        qs = (
+            PayerPriorAuthRequirement.objects.filter(insurance_company=company)
+            .filter(source_document__contains="[ingest:")
+            .exclude(pk__in=seen_pks)
+            .filter(end_date__isnull=True)
+        )
+        return qs.update(end_date=today)

--- a/fighthealthinsurance/pa_requirements_fetcher.py
+++ b/fighthealthinsurance/pa_requirements_fetcher.py
@@ -256,7 +256,7 @@ class PaRequirementsFetcher:
             if lob not in valid_lobs:
                 lob = LineOfBusiness.ALL
 
-            key = {
+            key: Dict[str, Any] = {
                 "insurance_company": company,
                 "line_of_business": lob,
                 "state": (req.state or "")[:2].upper(),
@@ -274,7 +274,7 @@ class PaRequirementsFetcher:
             if manual_row_exists:
                 continue
 
-            defaults = {
+            defaults: Dict[str, Any] = {
                 "code_description": req.code_description[:500],
                 "requires_pa": req.requires_pa,
                 "notification_only": req.notification_only,

--- a/fighthealthinsurance/pa_requirements_fetcher.py
+++ b/fighthealthinsurance/pa_requirements_fetcher.py
@@ -1,35 +1,32 @@
 """
-Fetch and re-parse carrier-published prior-authorization requirement lists.
+Fetch + index payer prior-authorization requirement lists.
 
-Where a carrier publishes a structured PA requirement document (CSV, XLSX,
-or HTML table), a parser registered in ``PA_PARSERS`` knows how to fetch
-the document, normalise each row, and yield it in the shape consumed by
-``PaRequirementsFetcher._upsert``. The fetcher upserts via
-``update_or_create`` keyed on the same tuple the lookup queries on, so
-re-running an ingest is idempotent.
+Iterates every ``InsuranceCompany`` with
+``pa_requirement_list_url_is_parseable=True``, downloads each company's PA
+requirement document, picks a parser from ``pa_requirement_parsers``
+keyed on the response Content-Type, applies any per-host enrichment
+(submission channel / default LOB), and upserts rows via
+``update_or_create``.
 
-Rows previously seen for a carrier but absent from this run are
-soft-retired (``end_date`` set to today) rather than deleted, so historical
-denials still resolve to the rule that applied at the time.
+Rows whose ``source_document`` starts with ``"auto:"`` are managed by
+this pipeline: a row that was previously ingested but is absent from a
+fresh fetch is soft-retired (``end_date`` set to today) rather than
+deleted, so historical denials still resolve to the rule that applied
+at the time. Manually-seeded rows (no ``"auto:"`` prefix — e.g. fixture-
+loaded UHC starter set) are never touched.
 
-This module ships the framework + an empty registry. Per-carrier parsers
-land in follow-on PRs (one parser + matching fixture per carrier so the
-parser output can be reviewed against a known-good file).
+Invoked by:
+  * ``ingest_pa_requirements`` management command (deploy / dev)
+  * ``PaRefreshActor`` (periodic refresh)
 """
 
 from __future__ import annotations
 
 import datetime
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    Optional,
-    Protocol,
-    Tuple,
-)
+from typing import Dict, List, Optional, Union
+from urllib.parse import urlparse
 
+import aiohttp
 from asgiref.sync import sync_to_async
 from loguru import logger
 
@@ -38,105 +35,79 @@ from fighthealthinsurance.models import (
     LineOfBusiness,
     PayerPriorAuthRequirement,
 )
+from fighthealthinsurance.pa_requirement_parsers import (
+    PARSERS_BY_CONTENT_TYPE,
+    ParsedPARequirement,
+    apply_enrichment,
+    enrichment_for_host,
+)
 
+FETCH_TIMEOUT_SEC = 120
+MAX_BYTES = 50 * 1024 * 1024  # 50 MB — PA lists can be large Excel/PDF files
 
-class PaParser(Protocol):
-    """Protocol every per-carrier parser must satisfy.
-
-    ``carrier_aliases`` is the priority-ordered list of name strings used
-    to look up the canonical ``InsuranceCompany`` row by case-insensitive
-    exact match (mirroring the ``_get_uhc`` selection logic from the
-    historical seed migration). Returning ``None`` from ``parse`` signals
-    a transient fetch failure so the surrounding code can warn but keep
-    going for other parsers.
-    """
-
-    carrier_aliases: Tuple[str, ...]
-
-    async def parse(self) -> Optional[List[Dict[str, Any]]]: ...
-
-
-# Registry of registered parsers. Keys are the canonical alias used by the
-# management command (``ingest_pa_requirements --carrier <key>``). Values
-# are zero-arg callables returning a parser instance — this avoids
-# importing every parser module at process start.
-PA_PARSERS: Dict[str, Callable[[], PaParser]] = {}
-
-
-def register_parser(
-    alias: str,
-) -> Callable[[Callable[[], PaParser]], Callable[[], PaParser]]:
-    def decorator(factory: Callable[[], PaParser]) -> Callable[[], PaParser]:
-        PA_PARSERS[alias] = factory
-        return factory
-
-    return decorator
-
-
-# Source-of-truth lives on the model class
-# (``PayerPriorAuthRequirement.UPSERT_KEY_FIELDS``) so the upsert key
-# stays in lockstep with the lookup-filter schema.
-_UPSERT_KEY_FIELDS = PayerPriorAuthRequirement.UPSERT_KEY_FIELDS
-
-
-def resolve_carrier_by_aliases(
-    aliases: Tuple[str, ...],
-) -> Optional[InsuranceCompany]:
-    """Resolve the canonical ``InsuranceCompany`` row for a parser.
-
-    Lifted from the historical ``_get_uhc`` helper in the now-removed
-    seed migration so per-carrier parsers all use the same selector. We
-    deliberately *only* match exact (case-insensitive) name strings —
-    substring matches across closely-named carriers
-    (e.g. "UnitedHealthcare" vs "UnitedHealthcare Community Plan") would
-    silently mis-attach rows.
-
-    Raises ``RuntimeError`` if multiple aliases match different rows so a
-    data-integrity issue isn't quietly papered over.
-    """
-    matched: Optional[InsuranceCompany] = None
-    for alias in aliases:
-        row = InsuranceCompany.objects.filter(name__iexact=alias).first()
-        if row is None:
-            continue
-        if matched is not None and row.pk != matched.pk:
-            raise RuntimeError(
-                f"Ambiguous carrier resolution: aliases match both "
-                f"id={matched.pk!r} ({matched.name!r}) and "
-                f"id={row.pk!r} ({row.name!r}). Resolve duplicate "
-                "InsuranceCompany rows before re-running ingest."
-            )
-        matched = row
-    return matched
+# Rows whose ``source_document`` starts with this prefix are managed by the
+# auto-ingest pipeline; ``_retire_missing`` only marks those as retired.
+AUTO_SOURCE_PREFIX = "auto:"
 
 
 class PaRequirementsFetcher:
     """Async context manager + ingestion driver.
 
-    Mirrors ``PayerPolicyFetcher``'s shape so the ingest command and
+    Mirrors ``PayerPolicyFetcher``'s shape so the management command and
     refresh actor have the same contract as the existing payer-policy
     pipeline (``ingest_payer_policy_indexes`` / its actor).
     """
 
+    def __init__(
+        self,
+        session: Optional[aiohttp.ClientSession] = None,
+        timeout_sec: int = FETCH_TIMEOUT_SEC,
+        max_bytes: int = MAX_BYTES,
+    ) -> None:
+        self._session = session
+        self._owns_session = session is None
+        self._timeout = aiohttp.ClientTimeout(total=timeout_sec)
+        self._max_bytes = max_bytes
+
     async def __aenter__(self) -> "PaRequirementsFetcher":
+        if self._session is None:
+            self._session = aiohttp.ClientSession(timeout=self._timeout)
         return self
 
     async def __aexit__(self, exc_type, exc, tb) -> None:
-        return None
+        if self._owns_session and self._session is not None:
+            await self._session.close()
+            self._session = None
 
     async def ingest_all(self) -> Dict[str, int]:
-        stats = {"fetched": 0, "failed": 0, "entries": 0, "retired": 0}
-        for alias in list(PA_PARSERS):
-            # Isolate per-carrier failures: an unhandled exception inside
-            # one parser/upsert must not abort the rest of the run, or
-            # operators would have to restart the actor every time a
-            # single carrier endpoint misbehaves.
+        """Fetch + parse + persist for every parseable company."""
+        stats: Dict[str, int] = {
+            "fetched": 0,
+            "failed": 0,
+            "entries": 0,
+            "retired": 0,
+        }
+        companies = await sync_to_async(
+            lambda: list(
+                InsuranceCompany.objects.filter(
+                    pa_requirement_list_url_is_parseable=True,
+                ).exclude(pa_requirement_list_url="")
+            )
+        )()
+
+        if not companies:
+            logger.info("No insurance companies flagged for PA requirement ingestion")
+            return stats
+
+        for company in companies:
+            # Isolate per-company failures so one misbehaving payer
+            # endpoint doesn't abort the rest of the run.
             try:
-                sub = await self.ingest_carrier(alias)
+                sub = await self.ingest_company(company)
             except Exception as e:
                 logger.opt(exception=True).warning(
-                    f"ingest_carrier({alias!r}) raised; recording as a "
-                    f"failed carrier and continuing: {e}"
+                    f"PA ingest failed for {company.name} "
+                    f"({company.pa_requirement_list_url}): {e}"
                 )
                 stats["failed"] += 1
                 continue
@@ -144,90 +115,175 @@ class PaRequirementsFetcher:
             stats["failed"] += sub["failed"]
             stats["entries"] += sub["entries"]
             stats["retired"] += sub["retired"]
+
+        logger.info(
+            f"PA requirement ingest complete: {stats['fetched']} fetched, "
+            f"{stats['failed']} failed, {stats['entries']} rows upserted, "
+            f"{stats['retired']} retired"
+        )
         return stats
 
-    async def ingest_carrier(self, alias: str) -> Dict[str, int]:
+    async def ingest_company(self, company: InsuranceCompany) -> Dict[str, int]:
+        """Fetch, parse, and persist for one company. Returns per-run stats."""
         stats = {"fetched": 0, "failed": 0, "entries": 0, "retired": 0}
-
-        factory = PA_PARSERS.get(alias)
-        if factory is None:
-            logger.warning(f"No PA parser registered for alias '{alias}'")
-            stats["failed"] += 1
-            return stats
-
-        parser = factory()
-
         try:
-            company = await sync_to_async(resolve_carrier_by_aliases)(
-                parser.carrier_aliases
-            )
-        except RuntimeError as e:
-            logger.error(f"Carrier resolution failed for '{alias}': {e}")
+            parsed = await self.parse_company(company)
+        except LookupError as e:
+            logger.warning(str(e))
             stats["failed"] += 1
             return stats
 
-        if company is None:
-            logger.warning(
-                f"No InsuranceCompany matched aliases {parser.carrier_aliases!r} "
-                f"for parser '{alias}'; skipping ingest."
-            )
-            stats["failed"] += 1
-            return stats
-
-        try:
-            rows = await parser.parse()
-        except Exception as e:
-            logger.opt(exception=True).warning(
-                f"PA parser '{alias}' raised while fetching: {e}"
-            )
-            stats["failed"] += 1
-            return stats
-
-        if rows is None:
-            stats["failed"] += 1
+        if not parsed:
+            logger.info(f"No PA requirements parsed for {company.name}")
+            stats["fetched"] += 1
             return stats
 
         stats["fetched"] += 1
-        seen_pks, written = await sync_to_async(self._upsert_rows)(company, rows, alias)
+        source_name = f"{AUTO_SOURCE_PREFIX}{company.pa_requirement_list_url}"
+        seen_pks, written = await sync_to_async(self._upsert_rows)(
+            company, parsed, source_name
+        )
         stats["entries"] += written
         stats["retired"] += await sync_to_async(self._retire_missing)(company, seen_pks)
         return stats
 
+    async def parse_company(
+        self, company: InsuranceCompany
+    ) -> List[ParsedPARequirement]:
+        """Fetch + parse a company's PA list without writing to the DB.
+
+        Used by ``ingest_company`` and the management command's
+        ``--dry-run`` mode so both share the same dispatch / enrichment
+        pipeline. Raises ``LookupError`` when no parser matches the
+        response Content-Type.
+        """
+        url = company.pa_requirement_list_url
+        if not url:
+            return []
+
+        content_type, raw = await self._get_content(url)
+        ct_key = (content_type or "").split(";")[0].strip().lower()
+        parser_spec = PARSERS_BY_CONTENT_TYPE.get(ct_key)
+        if parser_spec is None:
+            raise LookupError(
+                f"No PA parser registered for Content-Type {ct_key!r} "
+                f"(company {company.name}, url {url})"
+            )
+
+        parser_fn, expects_bytes = parser_spec
+        source_name = f"{AUTO_SOURCE_PREFIX}{url}"
+
+        body: Union[str, bytes]
+        if expects_bytes:
+            body = (
+                raw if isinstance(raw, bytes) else raw.encode("utf-8", errors="replace")
+            )
+        else:
+            body = (
+                raw if isinstance(raw, str) else raw.decode("utf-8", errors="replace")
+            )
+
+        def _parse_and_enrich() -> List[ParsedPARequirement]:
+            reqs = parser_fn(body, source_name)
+            apply_enrichment(reqs, enrichment_for_host(urlparse(url).hostname or ""))
+            return reqs
+
+        return await sync_to_async(_parse_and_enrich, thread_sensitive=False)()
+
+    async def _get_content(self, url: str) -> "tuple[str, Union[str, bytes]]":
+        """Download ``url``; return ``(content_type, body)``."""
+        if self._session is None:
+            raise RuntimeError(
+                "PaRequirementsFetcher must be used as 'async with PaRequirementsFetcher()'"
+            )
+        headers = {
+            "User-Agent": "fighthealthinsurance-pa-ingest/1.0",
+            "Accept": (
+                "text/html,application/xhtml+xml,application/pdf,"
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,*/*"
+            ),
+        }
+        async with self._session.get(
+            url, headers=headers, allow_redirects=True
+        ) as resp:
+            resp.raise_for_status()
+            content_type = resp.content_type or ""
+            data = await resp.content.read(self._max_bytes + 1)
+            if len(data) > self._max_bytes:
+                raise ValueError(
+                    f"PA requirement doc at {url} exceeded {self._max_bytes} bytes"
+                )
+
+            if content_type.startswith("text/"):
+                encoding = resp.charset or "utf-8"
+                return content_type, data.decode(encoding, errors="replace")
+            return content_type, data
+
     @staticmethod
     def _upsert_rows(
-        company: InsuranceCompany, rows: List[Dict[str, Any]], alias: str
-    ) -> Tuple[List[int], int]:
-        """Upsert each row; return ``(pks_seen_this_run, count)``.
+        company: InsuranceCompany,
+        parsed: List[ParsedPARequirement],
+        source_name: str,
+    ) -> "tuple[List[int], int]":
+        """Upsert parsed rows; return ``(pks_seen_this_run, written)``.
 
-        Always stamps ``source_document`` with an ``[ingest:<alias>]``
-        marker (appending to whatever string the parser supplied) so
-        ``_retire_missing`` can identify ingestion-owned rows without
-        relying on parser authors to remember the convention.
+        Keys each row on the same tuple ``lookup_pa_requirements`` queries
+        on (see ``PayerPriorAuthRequirement.UPSERT_KEY_FIELDS``) so re-running
+        an ingest produces no duplicates. A re-fetched row that was
+        previously soft-retired has its ``end_date`` cleared so it becomes
+        current again.
+
+        Manual-row protection: if a row with the same scoping key already
+        exists and is NOT auto-ingested (no ``"auto:"`` prefix on
+        ``source_document``), we leave it alone — admin / fixture-seeded
+        rows are authoritative and an auto-ingest must never overwrite
+        them.
         """
+        valid_lobs = {choice[0] for choice in LineOfBusiness.choices}
         seen: List[int] = []
-        marker = f"[ingest:{alias}]"
-        for row in rows:
+
+        for req in parsed:
+            code = (req.cpt_hcpcs_code or "").upper()
+            range_start = (req.code_range_start or "").upper()
+            range_end = (req.code_range_end or "").upper()
+            if not code and not (range_start and range_end):
+                continue
+
+            lob = req.line_of_business or LineOfBusiness.ALL
+            if lob not in valid_lobs:
+                lob = LineOfBusiness.ALL
+
             key = {
                 "insurance_company": company,
-                # The model field uses ``choices`` with no blank-allowed
-                # option; default to ALL so parser output that omits a
-                # LOB still passes ``full_clean()``.
-                "line_of_business": row.get("line_of_business") or LineOfBusiness.ALL,
-                "state": row.get("state", ""),
-                "cpt_hcpcs_code": row.get("cpt_hcpcs_code", ""),
-                "code_range_start": row.get("code_range_start", ""),
-                "code_range_end": row.get("code_range_end", ""),
+                "line_of_business": lob,
+                "state": (req.state or "")[:2].upper(),
+                "cpt_hcpcs_code": code,
+                "code_range_start": range_start,
+                "code_range_end": range_end,
             }
-            defaults = {k: v for k, v in row.items() if k not in _UPSERT_KEY_FIELDS}
-            # A re-fetched row that was previously soft-retired is now
-            # current again; clear end_date unless the parser explicitly
-            # set one.
-            defaults.setdefault("end_date", None)
-            base_source = defaults.get("source_document", "") or ""
-            if marker not in base_source:
-                defaults["source_document"] = (
-                    f"{base_source} {marker}".strip() if base_source else marker
-                )
+
+            # Skip if a manually-curated row already owns this key.
+            manual_row_exists = (
+                PayerPriorAuthRequirement.objects.filter(**key)
+                .exclude(source_document__startswith=AUTO_SOURCE_PREFIX)
+                .exists()
+            )
+            if manual_row_exists:
+                continue
+
+            defaults = {
+                "code_description": req.code_description[:500],
+                "requires_pa": req.requires_pa,
+                "notification_only": req.notification_only,
+                "pa_category": req.pa_category[:200],
+                "criteria_reference": req.criteria_reference[:500],
+                "criteria_url": req.criteria_url[:200],
+                "submission_channel": req.submission_channel[:500],
+                "notes": req.notes[:1000],
+                "source_document": source_name[:300],
+                # Clear any prior end_date — this row is current again.
+                "end_date": None,
+            }
             obj, _ = PayerPriorAuthRequirement.objects.update_or_create(
                 **key, defaults=defaults
             )
@@ -236,17 +292,18 @@ class PaRequirementsFetcher:
 
     @staticmethod
     def _retire_missing(company: InsuranceCompany, seen_pks: List[int]) -> int:
-        """Soft-retire rows for this carrier that weren't seen this run.
+        """Soft-retire ``auto:``-owned rows absent from this run.
 
-        Operates only on rows whose ``source_document`` indicates an
-        ingestion-owned origin (looking for the ``[ingest:...]`` marker
-        the upsert path writes), so manually-curated and fixture-loaded
-        rows are never touched.
+        Operates only on rows whose ``source_document`` starts with
+        ``"auto:"`` so manually-curated and fixture-loaded rows are never
+        touched. Setting ``end_date=today`` rather than deleting preserves
+        historical lookups: a denial with a past ``denial_date`` can still
+        resolve to the rule that applied at the time.
         """
         today = datetime.date.today()
         qs = (
             PayerPriorAuthRequirement.objects.filter(insurance_company=company)
-            .filter(source_document__contains="[ingest:")
+            .filter(source_document__startswith=AUTO_SOURCE_PREFIX)
             .exclude(pk__in=seen_pks)
             .filter(end_date__isnull=True)
         )

--- a/fighthealthinsurance/pa_requirements_fetcher.py
+++ b/fighthealthinsurance/pa_requirements_fetcher.py
@@ -256,18 +256,18 @@ class PaRequirementsFetcher:
             if lob not in valid_lobs:
                 lob = LineOfBusiness.ALL
 
-            key: Dict[str, Any] = {
-                "insurance_company": company,
-                "line_of_business": lob,
-                "state": (req.state or "")[:2].upper(),
-                "cpt_hcpcs_code": code,
-                "code_range_start": range_start,
-                "code_range_end": range_end,
-            }
+            state = (req.state or "")[:2].upper()
 
             # Skip if a manually-curated row already owns this key.
             manual_row_exists = (
-                PayerPriorAuthRequirement.objects.filter(**key)
+                PayerPriorAuthRequirement.objects.filter(
+                    insurance_company=company,
+                    line_of_business=lob,
+                    state=state,
+                    cpt_hcpcs_code=code,
+                    code_range_start=range_start,
+                    code_range_end=range_end,
+                )
                 .exclude(source_document__startswith=AUTO_SOURCE_PREFIX)
                 .exists()
             )
@@ -288,7 +288,13 @@ class PaRequirementsFetcher:
                 "end_date": None,
             }
             obj, _ = PayerPriorAuthRequirement.objects.update_or_create(
-                **key, defaults=defaults
+                insurance_company=company,
+                line_of_business=lob,
+                state=state,
+                cpt_hcpcs_code=code,
+                code_range_start=range_start,
+                code_range_end=range_end,
+                defaults=defaults,
             )
             seen.append(obj.pk)
         return seen, len(seen)

--- a/fighthealthinsurance/pa_requirements_fetcher.py
+++ b/fighthealthinsurance/pa_requirements_fetcher.py
@@ -23,7 +23,7 @@ Invoked by:
 from __future__ import annotations
 
 import datetime
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urlparse
 
 import aiohttp
@@ -157,7 +157,10 @@ class PaRequirementsFetcher:
         pipeline. Raises ``LookupError`` when no parser matches the
         response Content-Type.
         """
-        url = company.pa_requirement_list_url
+        # Bind to a plain str — django-stubs types URLField access as
+        # ``str | Combinable``, which mypy won't accept where ``str`` is
+        # expected (``_get_content``, ``urlparse``).
+        url: str = str(company.pa_requirement_list_url or "")
         if not url:
             return []
 

--- a/fighthealthinsurance/pa_requirements_fetcher.py
+++ b/fighthealthinsurance/pa_requirements_fetcher.py
@@ -28,6 +28,7 @@ from urllib.parse import urlparse
 
 import aiohttp
 from asgiref.sync import sync_to_async
+from django.db import transaction
 from loguru import logger
 
 from fighthealthinsurance.models import (
@@ -140,11 +141,11 @@ class PaRequirementsFetcher:
 
         stats["fetched"] += 1
         source_name = f"{AUTO_SOURCE_PREFIX}{company.pa_requirement_list_url}"
-        seen_pks, written = await sync_to_async(self._upsert_rows)(
+        written, retired = await sync_to_async(self._persist_company)(
             company, parsed, source_name
         )
         stats["entries"] += written
-        stats["retired"] += await sync_to_async(self._retire_missing)(company, seen_pks)
+        stats["retired"] += retired
         return stats
 
     async def parse_company(
@@ -224,6 +225,27 @@ class PaRequirementsFetcher:
                 encoding = resp.charset or "utf-8"
                 return content_type, data.decode(encoding, errors="replace")
             return content_type, data
+
+    @classmethod
+    def _persist_company(
+        cls,
+        company: InsuranceCompany,
+        parsed: List[ParsedPARequirement],
+        source_name: str,
+    ) -> "tuple[int, int]":
+        """Upsert + soft-retire for one company in a single transaction.
+
+        Wrapping both phases keeps the whole carrier refresh atomic for
+        ``lookup_pa_requirements`` readers — they'll see either the old
+        state or the new state, never a half-rewritten one. It also
+        coalesces ``update_or_create``'s per-row autocommits into one
+        transaction, materially cutting commit overhead on the hundreds-
+        to-thousands-of-rows lists carriers publish.
+        """
+        with transaction.atomic():
+            seen_pks, written = cls._upsert_rows(company, parsed, source_name)
+            retired = cls._retire_missing(company, seen_pks)
+        return written, retired
 
     @staticmethod
     def _upsert_rows(

--- a/fighthealthinsurance/polling_actor_setup.py
+++ b/fighthealthinsurance/polling_actor_setup.py
@@ -7,6 +7,7 @@ from fighthealthinsurance.chooser_refill_actor_ref import chooser_refill_actor_r
 from fighthealthinsurance.email_polling_actor_ref import email_polling_actor_ref
 from fighthealthinsurance.fax_polling_actor_ref import fax_polling_actor_ref
 from fighthealthinsurance.imr_refresh_actor_ref import imr_refresh_actor_ref
+from fighthealthinsurance.pa_refresh_actor_ref import pa_refresh_actor_ref
 from fighthealthinsurance.ucr_refresh_actor_ref import ucr_refresh_actor_ref
 
 logger.info("Waiting for ray to (probably) launch.")
@@ -20,6 +21,7 @@ fpar = None
 cpar = None
 ipar = None
 upar = None
+ppar = None
 while not success and attempt < 10:
     logger.info("Attempting to launch actors.")
     attempt = attempt + 1
@@ -29,20 +31,22 @@ while not success and attempt < 10:
         cpar, ctask = chooser_refill_actor_ref.get
         ipar, itask = imr_refresh_actor_ref.get
         upar, utask = ucr_refresh_actor_ref.get
+        ppar, ptask = pa_refresh_actor_ref.get
         logger.info(f"Launched email polling actor {epar}")
         logger.info(f"Launched fax polling actor {fpar}")
         logger.info(f"Launched chooser refill actor {cpar}")
         logger.info(f"Launched IMR refresh actor {ipar}")
         logger.info(f"Launched UCR refresh actor {upar}")
+        logger.info(f"Launched PA refresh actor {ppar}")
         logger.info("Checking that polling tasks are still running")
         time.sleep(10)
-        ready, wait = ray.wait([etask, ftask, ctask, itask, utask], timeout=10)
+        ready, wait = ray.wait([etask, ftask, ctask, itask, utask, ptask], timeout=10)
         logger.info(f"Finished {ready}")
         result = ray.get(ready)
         logger.info(f"Results: {result}")
         if len(result) > 0:
             raise Exception("We should not have any polling actors finished!")
-        for actor in [epar, fpar, cpar, ipar, upar]:
+        for actor in [epar, fpar, cpar, ipar, upar, ppar]:
             logger.info(f"Checking health of {actor}")
             result = ray.get(actor.health_check.remote())
             logger.info(f"Health check result: {result}")
@@ -56,4 +60,4 @@ while not success and attempt < 10:
 if not success:
     logger.error("Failed to launch polling actors after all attempts")
 
-__all__ = ["epar", "fpar", "cpar", "ipar", "upar"]
+__all__ = ["epar", "fpar", "cpar", "ipar", "upar", "ppar"]

--- a/tests/async/test_actor_health_status.py
+++ b/tests/async/test_actor_health_status.py
@@ -20,8 +20,8 @@ class TestActorHealthStatus(TestCase):
         assert "alive_actors" in data
         assert "total_actors" in data
         assert "details" in data
-        # Total actors: email, fax, chooser, IMR refresh, UCR refresh
-        assert data["total_actors"] == 5
+        # Total actors: email, fax, chooser, IMR refresh, UCR refresh, PA refresh
+        assert data["total_actors"] == 6
 
     @mock.patch("fighthealthinsurance.actor_health_status.ray")
     def test_actor_health_all_down(self, mock_ray):

--- a/tests/async/test_actor_health_status.py
+++ b/tests/async/test_actor_health_status.py
@@ -33,8 +33,8 @@ class TestActorHealthStatus(TestCase):
 
         result = check_actor_health()
         assert result["alive_actors"] == 0
-        assert result["total_actors"] == 5
-        assert len(result["details"]) == 5
+        assert result["total_actors"] == 6
+        assert len(result["details"]) == 6
         # All should have error messages
         for detail in result["details"]:
             assert detail["alive"] is False
@@ -54,9 +54,9 @@ class TestActorHealthStatus(TestCase):
         from fighthealthinsurance.actor_health_status import check_actor_health
 
         result = check_actor_health()
-        assert result["alive_actors"] == 5
-        assert result["total_actors"] == 5
-        assert len(result["details"]) == 5
+        assert result["alive_actors"] == 6
+        assert result["total_actors"] == 6
+        assert len(result["details"]) == 6
         # All should be alive
         for detail in result["details"]:
             assert detail["alive"] is True
@@ -84,8 +84,8 @@ class TestActorHealthStatus(TestCase):
 
         result = check_actor_health()
         assert result["alive_actors"] == 1
-        assert result["total_actors"] == 5
-        assert len(result["details"]) == 5
+        assert result["total_actors"] == 6
+        assert len(result["details"]) == 6
 
     def test_actor_health_endpoint_caching(self):
         """Test that the actor health endpoint has appropriate cache headers."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,3 +51,24 @@ skip_if_no_nice_api_key = pytest.mark.skipif(
     not os.environ.get("NICE_API_KEY"),
     reason="NICE_API_KEY environment variable is not set",
 )
+
+
+@pytest.fixture(autouse=True)
+def _clear_pa_resolver_cache():
+    """Reset the PA-requirement regex-resolver cache between tests.
+
+    ``fighthealthinsurance.pa_requirements._regex_candidates`` is an
+    ``lru_cache``d helper keyed on a 5-minute time bucket. Without this
+    fixture, candidates that were registered as ``InsuranceCompany`` rows
+    by test A leak into test B (because both run inside the same bucket),
+    causing flaky resolver hits. The import is local so test runs that
+    never touch the PA module don't pay an import cost.
+    """
+    try:
+        from fighthealthinsurance.pa_requirements import _regex_candidates
+    except Exception:
+        yield
+        return
+    _regex_candidates.cache_clear()
+    yield
+    _regex_candidates.cache_clear()

--- a/tests/sync/test_pa_requirement_parsers.py
+++ b/tests/sync/test_pa_requirement_parsers.py
@@ -1,0 +1,297 @@
+"""
+Tests for pa_requirement_parsers — the HTML/PDF/CSV/Excel parsing layer that
+converts payer-published prior-authorization lists into ParsedPARequirement
+records.
+
+These tests do not touch the database; ``SimpleTestCase`` is used for test
+discovery compatibility with no DB setup overhead.
+"""
+
+from django.test import SimpleTestCase as TestCase
+
+from fighthealthinsurance.pa_requirement_parsers import (
+    ParsedPARequirement,
+    _bool_cell,
+    _dedupe,
+    _map_columns,
+    _rows_to_requirements,
+    apply_enrichment,
+    enrichment_for_host,
+    parse_csv_pa_list,
+    parse_html_pa_table,
+)
+
+
+class BoolCellTests(TestCase):
+    def test_truthy_variants(self):
+        for val in ("Yes", "YES", "yes", "Y", "y", "true", "1", "required", "x", "✓"):
+            with self.subTest(val=val):
+                self.assertTrue(_bool_cell(val))
+
+    def test_falsy_variants(self):
+        for val in (
+            "No",
+            "NO",
+            "no",
+            "N",
+            "n",
+            "false",
+            "0",
+            "not required",
+            "excluded",
+        ):
+            with self.subTest(val=val):
+                self.assertFalse(_bool_cell(val))
+
+    def test_ambiguous_returns_none(self):
+        self.assertIsNone(_bool_cell("maybe"))
+        self.assertIsNone(_bool_cell(""))
+        self.assertIsNone(_bool_cell("pending"))
+
+
+class ColumnMappingTests(TestCase):
+    def test_recognises_code_column(self):
+        mapping = _map_columns(["CPT/HCPCS", "Description", "PA Required"])
+        self.assertIn(0, mapping)
+        self.assertEqual(mapping[0], "code")
+
+    def test_recognises_all_canonical_fields(self):
+        headers = [
+            "Procedure Code",
+            "Procedure Description",
+            "Prior Authorization Required",
+            "Advance Notification Required",
+            "Category",
+            "Criteria Reference",
+            "Submission Channel",
+        ]
+        mapping = _map_columns(headers)
+        self.assertEqual(mapping[0], "code")
+        self.assertEqual(mapping[1], "description")
+        self.assertEqual(mapping[2], "requires_pa")
+        self.assertEqual(mapping[3], "notification_only")
+        self.assertEqual(mapping[4], "category")
+        self.assertEqual(mapping[5], "criteria")
+        self.assertEqual(mapping[6], "submission")
+
+    def test_case_insensitive(self):
+        mapping = _map_columns(["CPT CODE", "PRIOR AUTHORIZATION REQUIRED"])
+        self.assertEqual(mapping.get(0), "code")
+        self.assertEqual(mapping.get(1), "requires_pa")
+
+    def test_unrecognised_columns_not_included(self):
+        mapping = _map_columns(["Claim Number", "Member ID", "Date of Service"])
+        self.assertEqual(mapping, {})
+
+
+class RowsToRequirementsTests(TestCase):
+    def _make_col_map(self):
+        return {
+            0: "code",
+            1: "description",
+            2: "requires_pa",
+            3: "notification_only",
+            4: "category",
+            5: "criteria",
+            6: "submission",
+        }
+
+    def test_basic_row(self):
+        col_map = self._make_col_map()
+        rows = [
+            [
+                "95810",
+                "Polysomnography",
+                "Yes",
+                "No",
+                "Sleep Medicine",
+                "CDG SL-001",
+                "UHCprovider.com",
+            ]
+        ]
+        reqs = _rows_to_requirements(col_map, rows)
+        self.assertEqual(len(reqs), 1)
+        req = reqs[0]
+        self.assertEqual(req.cpt_hcpcs_code, "95810")
+        self.assertEqual(req.code_description, "Polysomnography")
+        self.assertTrue(req.requires_pa)
+        self.assertFalse(req.notification_only)
+        self.assertEqual(req.pa_category, "Sleep Medicine")
+        self.assertEqual(req.criteria_reference, "CDG SL-001")
+        self.assertEqual(req.submission_channel, "UHCprovider.com")
+
+    def test_hcpcs_code(self):
+        col_map = {0: "code", 1: "description", 2: "requires_pa"}
+        rows = [["J0490", "Belimumab injection", "Yes"]]
+        reqs = _rows_to_requirements(col_map, rows)
+        self.assertEqual(len(reqs), 1)
+        self.assertEqual(reqs[0].cpt_hcpcs_code, "J0490")
+
+    def test_no_required_pa(self):
+        col_map = {0: "code", 1: "description", 2: "requires_pa"}
+        rows = [["99213", "Office visit E&M Level 3", "No"]]
+        reqs = _rows_to_requirements(col_map, rows)
+        self.assertEqual(len(reqs), 1)
+        self.assertFalse(reqs[0].requires_pa)
+
+    def test_notification_only(self):
+        col_map = {0: "code", 2: "requires_pa", 3: "notification_only"}
+        rows = [["27447", "TKA", "Yes", "Yes"]]
+        reqs = _rows_to_requirements(col_map, rows)
+        self.assertEqual(len(reqs), 1)
+        self.assertTrue(reqs[0].notification_only)
+
+    def test_empty_rows_skipped(self):
+        col_map = {0: "code", 1: "description"}
+        rows = [["", ""], ["", "   "], ["95810", "Sleep study"]]
+        reqs = _rows_to_requirements(col_map, rows)
+        self.assertEqual(len(reqs), 1)
+
+    def test_range_code(self):
+        col_map = {0: "code", 1: "description"}
+        rows = [["99201-99215", "E&M office visits", ""]]
+        reqs = _rows_to_requirements(col_map, rows)
+        self.assertEqual(len(reqs), 1)
+        self.assertEqual(reqs[0].cpt_hcpcs_code, "")
+        self.assertEqual(reqs[0].code_range_start, "99201")
+        self.assertEqual(reqs[0].code_range_end, "99215")
+
+    def test_no_code_column_returns_empty(self):
+        col_map = {0: "description", 1: "requires_pa"}
+        rows = [["Polysomnography", "Yes"]]
+        reqs = _rows_to_requirements(col_map, rows)
+        self.assertEqual(reqs, [])
+
+
+class DedupeTests(TestCase):
+    def test_removes_duplicate_code_and_lob(self):
+        reqs = [
+            ParsedPARequirement(cpt_hcpcs_code="95810", line_of_business="all"),
+            ParsedPARequirement(cpt_hcpcs_code="95810", line_of_business="all"),
+            ParsedPARequirement(cpt_hcpcs_code="95810", line_of_business="commercial"),
+        ]
+        deduped = _dedupe(reqs)
+        self.assertEqual(len(deduped), 2)
+
+    def test_keeps_different_states(self):
+        reqs = [
+            ParsedPARequirement(cpt_hcpcs_code="95810", state="CA"),
+            ParsedPARequirement(cpt_hcpcs_code="95810", state="TX"),
+        ]
+        deduped = _dedupe(reqs)
+        self.assertEqual(len(deduped), 2)
+
+
+class HTMLParserTests(TestCase):
+    _TABLE_HTML = """
+    <html><body>
+    <table>
+      <thead><tr>
+        <th>CPT/HCPCS</th>
+        <th>Description</th>
+        <th>PA Required</th>
+        <th>Category</th>
+      </tr></thead>
+      <tbody>
+        <tr><td>95810</td><td>Polysomnography</td><td>Yes</td><td>Sleep Medicine</td></tr>
+        <tr><td>J0490</td><td>Belimumab injection</td><td>Yes</td><td>Specialty Drug</td></tr>
+        <tr><td>99213</td><td>Office visit E/M</td><td>No</td><td>E&amp;M</td></tr>
+      </tbody>
+    </table>
+    </body></html>
+    """
+
+    def test_extracts_rows_from_html_table(self):
+        reqs = parse_html_pa_table(self._TABLE_HTML)
+        codes = {r.cpt_hcpcs_code for r in reqs}
+        self.assertIn("95810", codes)
+        self.assertIn("J0490", codes)
+        self.assertIn("99213", codes)
+
+    def test_pa_required_flag(self):
+        reqs = parse_html_pa_table(self._TABLE_HTML)
+        by_code = {r.cpt_hcpcs_code: r for r in reqs}
+        self.assertTrue(by_code["95810"].requires_pa)
+        self.assertFalse(by_code["99213"].requires_pa)
+
+    def test_empty_table_returns_empty(self):
+        html = "<html><body><table></table></body></html>"
+        reqs = parse_html_pa_table(html)
+        self.assertEqual(reqs, [])
+
+    def test_no_table_returns_empty(self):
+        html = "<html><body><p>No tables here.</p></body></html>"
+        reqs = parse_html_pa_table(html)
+        self.assertEqual(reqs, [])
+
+    def test_uhc_enrichment_adds_submission_channel(self):
+        reqs = parse_html_pa_table(self._TABLE_HTML)
+        apply_enrichment(reqs, enrichment_for_host("www.uhcprovider.com"))
+        for req in reqs:
+            self.assertIn("UHCprovider", req.submission_channel)
+            self.assertEqual(req.line_of_business, "commercial")
+
+    def test_aetna_enrichment(self):
+        reqs = parse_html_pa_table(self._TABLE_HTML)
+        apply_enrichment(reqs, enrichment_for_host("www.aetna.com"))
+        for req in reqs:
+            self.assertIn("Aetna", req.submission_channel)
+
+    def test_cigna_enrichment(self):
+        reqs = parse_html_pa_table(self._TABLE_HTML)
+        apply_enrichment(reqs, enrichment_for_host("www.cigna.com"))
+        for req in reqs:
+            self.assertIn("eviCore", req.submission_channel)
+
+    def test_unknown_host_is_noop(self):
+        reqs = parse_html_pa_table(self._TABLE_HTML)
+        before = [(r.submission_channel, r.line_of_business) for r in reqs]
+        apply_enrichment(reqs, enrichment_for_host("example.com"))
+        after = [(r.submission_channel, r.line_of_business) for r in reqs]
+        self.assertEqual(before, after)
+
+    def test_enrichment_does_not_overwrite_existing_channel(self):
+        reqs = parse_html_pa_table(self._TABLE_HTML)
+        reqs[0].submission_channel = "Custom channel"
+        apply_enrichment(reqs, enrichment_for_host("www.uhcprovider.com"))
+        self.assertEqual(reqs[0].submission_channel, "Custom channel")
+
+
+class CSVParserTests(TestCase):
+    def _csv(self, content: str) -> bytes:
+        return content.encode("utf-8")
+
+    def test_basic_csv(self):
+        csv_data = self._csv(
+            "Procedure Code,Description,PA Required\n"
+            "95810,Polysomnography,Yes\n"
+            "99213,Office E/M,No\n"
+        )
+        reqs = parse_csv_pa_list(csv_data)
+        self.assertEqual(len(reqs), 2)
+        codes = {r.cpt_hcpcs_code for r in reqs}
+        self.assertIn("95810", codes)
+        self.assertIn("99213", codes)
+
+    def test_csv_no_code_column_returns_empty(self):
+        csv_data = self._csv("Name,Date\nFoo,2025-01-01\n")
+        reqs = parse_csv_pa_list(csv_data)
+        self.assertEqual(reqs, [])
+
+    def test_csv_bom_handling(self):
+        # BOM (\xef\xbb\xbf) is present in some Windows-exported CSVs.
+        csv_data = (
+            b"\xef\xbb\xbfCPT,Description,PA Required\r\n95810,Sleep study,Yes\r\n"
+        )
+        reqs = parse_csv_pa_list(csv_data)
+        self.assertEqual(len(reqs), 1)
+        self.assertEqual(reqs[0].cpt_hcpcs_code, "95810")
+
+    def test_csv_deduplicates(self):
+        csv_data = self._csv(
+            "CPT,Description,PA Required\n"
+            "95810,Polysomnography,Yes\n"
+            "95810,Polysomnography,Yes\n"
+        )
+        reqs = parse_csv_pa_list(csv_data)
+        self.assertEqual(len(reqs), 1)

--- a/tests/sync/test_pa_requirement_tool.py
+++ b/tests/sync/test_pa_requirement_tool.py
@@ -149,3 +149,46 @@ class PaRequirementLookupToolTests(TestCase):
         tool = PaRequirementLookupTool(AsyncMock())
         match = tool.detect("Just a regular message about prior auth")
         self.assertIsNone(match)
+
+
+class NestedJsonAndEmptyLobTests(TestCase):
+    """Regressions for the chat tool's regex and empty-LOB handling."""
+
+    def setUp(self):
+        self.uhc = InsuranceCompany.objects.create(
+            name="UnitedHealthcare",
+            alt_names="UHC",
+            regex=r"united\s*health\s*care|uhc",
+            negative_regex=r"$^",
+        )
+        PayerPriorAuthRequirement.objects.create(
+            insurance_company=self.uhc,
+            cpt_hcpcs_code="95810",
+            line_of_business="commercial",
+            criteria_reference="UHC Sleep Medicine policy",
+        )
+
+    def test_pattern_matches_nested_filters_object(self):
+        text = (
+            'lookup_pa_requirement {"codes": ["95810"], '
+            '"filters": {"lob": "commercial"}, "payer": "UHC"}'
+        )
+        match = re.search(LOOKUP_PA_REQUIREMENT_REGEX, text, re.DOTALL | re.IGNORECASE)
+        self.assertIsNotNone(match)
+        # The captured group must be valid JSON with both keys present.
+        import json
+
+        parsed = json.loads(match.group(1))
+        self.assertEqual(parsed["codes"], ["95810"])
+        self.assertEqual(parsed["filters"], {"lob": "commercial"})
+
+    def test_empty_lob_broadens_to_all_lobs(self):
+        # Without ``broaden_unknown_lob`` an empty LOB silently hid the
+        # commercial-tagged row. The chat tool now passes
+        # broaden_unknown_lob=True so empty/missing LOB surfaces every
+        # applicable rule.
+        block, summary = _run_lookup(
+            {"codes": ["95810"], "payer": "UHC", "line_of_business": ""}
+        )
+        self.assertIn("95810", block)
+        self.assertIn("1 PA requirement", summary)

--- a/tests/sync/test_pa_requirement_tool.py
+++ b/tests/sync/test_pa_requirement_tool.py
@@ -168,17 +168,24 @@ class NestedJsonAndEmptyLobTests(TestCase):
             criteria_reference="UHC Sleep Medicine policy",
         )
 
-    def test_pattern_matches_nested_filters_object(self):
+    def test_extract_json_payload_handles_nested_filters_object(self):
+        from unittest.mock import AsyncMock
+
         text = (
             'lookup_pa_requirement {"codes": ["95810"], '
             '"filters": {"lob": "commercial"}, "payer": "UHC"}'
         )
+        # The simple regex only captures up to the first ``}`` so the
+        # raw capture group is truncated; ``extract_json_payload`` walks
+        # brace depth in the original text to recover the full payload.
         match = re.search(LOOKUP_PA_REQUIREMENT_REGEX, text, re.DOTALL | re.IGNORECASE)
         self.assertIsNotNone(match)
-        # The captured group must be valid JSON with both keys present.
+
+        tool = PaRequirementLookupTool(AsyncMock())
+        payload = tool.extract_json_payload(match, text)
         import json
 
-        parsed = json.loads(match.group(1))
+        parsed = json.loads(payload)
         self.assertEqual(parsed["codes"], ["95810"])
         self.assertEqual(parsed["filters"], {"lob": "commercial"})
 

--- a/tests/sync/test_pa_requirements.py
+++ b/tests/sync/test_pa_requirements.py
@@ -852,7 +852,12 @@ class DateOfServiceFilterTests(TestCase):
             denial_date=date(2024, 1, 1),
             insurance_company_obj=self.uhc,
         )
-        self.assertEqual(get_pa_context_for_denial(old_denial), "")
+        # ``format_pa_context`` still emits an "unmatched codes" note when
+        # the rule is filtered out by date — verify the rule's contents
+        # do NOT surface (no "REQUIRES" verb, no criteria-reference text).
+        context = get_pa_context_for_denial(old_denial)
+        self.assertNotIn("REQUIRES prior authorization", context)
+        self.assertNotIn("Effective 2024-06-01", context)
 
     def test_rule_effective_for_recent_denial(self):
         recent_denial = Denial.objects.create(
@@ -935,7 +940,7 @@ class BroadenUnknownLobTests(TestCase):
 class FixtureRoundTripTests(TestCase):
     """``loaddata pa_requirements`` should produce valid, complete rows."""
 
-    fixtures = ["insurance_companies", "pa_requirements"]
+    fixtures = ["plan_source", "insurance_companies", "pa_requirements"]
 
     def test_all_loaded_rows_pass_full_clean(self):
         rows = list(PayerPriorAuthRequirement.objects.all())

--- a/tests/sync/test_pa_requirements.py
+++ b/tests/sync/test_pa_requirements.py
@@ -654,6 +654,13 @@ class ResolveInsuranceCompanyByNameTests(TestCase):
     """
 
     def setUp(self):
+        # The resolver caches the regex-candidate list per 5-minute time
+        # bucket; tests share that bucket, so candidates registered by a
+        # previous test would otherwise leak into this one.
+        from fighthealthinsurance.pa_requirements import _regex_candidates
+
+        _regex_candidates.cache_clear()
+
         self.uhc = InsuranceCompany.objects.create(
             name="UnitedHealthcare",
             alt_names="UHC\nUnited Healthcare\nUnited Health",
@@ -674,6 +681,14 @@ class ResolveInsuranceCompanyByNameTests(TestCase):
             alt_names="",
             regex=r"",
         )
+
+    def tearDown(self):
+        # Don't let this test's InsuranceCompany rows linger in the
+        # resolver cache after teardown — they're about to be deleted
+        # from the database.
+        from fighthealthinsurance.pa_requirements import _regex_candidates
+
+        _regex_candidates.cache_clear()
 
     def test_returns_none_for_empty_input(self):
         self.assertIsNone(resolve_insurance_company_by_name(None))
@@ -811,3 +826,166 @@ class ResolveInsuranceCompanyByNameTests(TestCase):
             resolve_insurance_company_by_name("BCBS"),
             self.anthem,
         )
+
+
+class DateOfServiceFilterTests(TestCase):
+    """Regression: PA lookup must filter by denial_date, not today()."""
+
+    def setUp(self):
+        self.uhc = InsuranceCompany.objects.create(
+            name="UnitedHealthcare",
+            regex=r"united\s*health|uhc",
+            negative_regex=r"$^",
+        )
+        # Rule that only became effective in mid-2024.
+        PayerPriorAuthRequirement.objects.create(
+            insurance_company=self.uhc,
+            cpt_hcpcs_code="95810",
+            criteria_reference="Effective 2024-06-01 onwards",
+            effective_date=date(2024, 6, 1),
+        )
+
+    def test_rule_not_yet_effective_for_old_denial(self):
+        old_denial = Denial.objects.create(
+            hashed_email="x" * 64,
+            denial_text="UHC denied authorization for polysomnography (95810).",
+            denial_date=date(2024, 1, 1),
+            insurance_company_obj=self.uhc,
+        )
+        self.assertEqual(get_pa_context_for_denial(old_denial), "")
+
+    def test_rule_effective_for_recent_denial(self):
+        recent_denial = Denial.objects.create(
+            hashed_email="x" * 64,
+            denial_text="UHC denied authorization for polysomnography (95810).",
+            denial_date=date(2024, 9, 1),
+            insurance_company_obj=self.uhc,
+        )
+        self.assertIn("95810", get_pa_context_for_denial(recent_denial))
+
+
+class CodeRangeLengthInvariantTests(TestCase):
+    """Regression: mixed-length code ranges must be rejected."""
+
+    def setUp(self):
+        self.uhc = InsuranceCompany.objects.create(
+            name="UnitedHealthcare",
+            regex=r"united\s*health|uhc",
+            negative_regex=r"$^",
+        )
+
+    def test_mixed_length_range_rejected(self):
+        from django.core.exceptions import ValidationError
+
+        rule = PayerPriorAuthRequirement(
+            insurance_company=self.uhc,
+            code_range_start="J490",
+            code_range_end="J0500",
+        )
+        with self.assertRaises(ValidationError):
+            rule.full_clean()
+
+    def test_same_length_range_accepted(self):
+        rule = PayerPriorAuthRequirement(
+            insurance_company=self.uhc,
+            code_range_start="22510",
+            code_range_end="22515",
+        )
+        # full_clean() should succeed; covers_code uses lexicographic
+        # compare, which is correct only for same-length endpoints.
+        rule.full_clean()
+        self.assertTrue(rule.covers_code("22512"))
+
+
+class BroadenUnknownLobTests(TestCase):
+    """``broaden_unknown_lob=True`` should drop the LOB filter entirely."""
+
+    def setUp(self):
+        self.uhc = InsuranceCompany.objects.create(
+            name="UnitedHealthcare",
+            regex=r"united\s*health|uhc",
+            negative_regex=r"$^",
+        )
+        # Only commercial-tagged — would be hidden under the conservative
+        # default when LOB is unknown.
+        PayerPriorAuthRequirement.objects.create(
+            insurance_company=self.uhc,
+            cpt_hcpcs_code="95810",
+            line_of_business="commercial",
+        )
+
+    def test_unknown_lob_default_hides_lob_specific_rule(self):
+        results = lookup_pa_requirements(
+            codes=["95810"],
+            insurance_company=self.uhc,
+            line_of_business=None,
+        )
+        self.assertEqual(results, [])
+
+    def test_unknown_lob_with_broaden_surfaces_lob_specific_rule(self):
+        results = lookup_pa_requirements(
+            codes=["95810"],
+            insurance_company=self.uhc,
+            line_of_business=None,
+            broaden_unknown_lob=True,
+        )
+        self.assertEqual(len(results), 1)
+
+
+class FixtureRoundTripTests(TestCase):
+    """``loaddata pa_requirements`` should produce valid, complete rows."""
+
+    fixtures = ["insurance_companies", "pa_requirements"]
+
+    def test_all_loaded_rows_pass_full_clean(self):
+        rows = list(PayerPriorAuthRequirement.objects.all())
+        self.assertGreater(len(rows), 0)
+        for row in rows:
+            row.full_clean()
+
+    def test_every_pa_category_has_registered_questions(self):
+        from fighthealthinsurance.pa_requirements import _PA_CATEGORY_QUESTIONS
+
+        categories = set(
+            PayerPriorAuthRequirement.objects.exclude(pa_category="")
+            .values_list("pa_category", flat=True)
+            .distinct()
+        )
+        missing = categories - set(_PA_CATEGORY_QUESTIONS)
+        self.assertFalse(
+            missing,
+            f"Fixture introduces pa_category values without registered "
+            f"clarifying questions in _PA_CATEGORY_QUESTIONS: {missing}",
+        )
+
+
+class ResolverCacheTests(TestCase):
+    """Regex-resolver candidates should come from the cached helper."""
+
+    def setUp(self):
+        from fighthealthinsurance.pa_requirements import _regex_candidates
+
+        _regex_candidates.cache_clear()
+
+    def tearDown(self):
+        from fighthealthinsurance.pa_requirements import _regex_candidates
+
+        _regex_candidates.cache_clear()
+
+    def test_cache_returns_compiled_regex_tuples(self):
+        from fighthealthinsurance.pa_requirements import (
+            _regex_candidates,
+            _resolver_cache_bucket,
+        )
+
+        InsuranceCompany.objects.create(
+            name="Cached Co",
+            regex=r"cached\s*co",
+            negative_regex=r"$^",
+        )
+
+        bucket = _resolver_cache_bucket()
+        first = _regex_candidates(bucket)
+        second = _regex_candidates(bucket)
+        self.assertIs(first, second)  # cached, same identity
+        self.assertTrue(any(getattr(r, "search", None) for _, r, _ in first))

--- a/tests/sync/test_pa_requirements_fetcher.py
+++ b/tests/sync/test_pa_requirements_fetcher.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from datetime import date
+from unittest.mock import patch
 
 from django.test import TestCase
 
@@ -9,95 +10,70 @@ from fighthealthinsurance.models import (
     InsuranceCompany,
     PayerPriorAuthRequirement,
 )
+from fighthealthinsurance.pa_requirement_parsers import ParsedPARequirement
 from fighthealthinsurance.pa_requirements_fetcher import (
-    PA_PARSERS,
+    AUTO_SOURCE_PREFIX,
     PaRequirementsFetcher,
-    register_parser,
 )
 
 
-class _StubParser:
-    """A parser whose output is overridable per test."""
-
-    carrier_aliases = ("FixtureCo",)
-
-    def __init__(self, rows):
-        self._rows = rows
-
-    async def parse(self):
-        return self._rows
-
-
 class FetcherContractTests(TestCase):
-    """Verify upsert keys and soft-retire behaviour."""
+    """Verify upsert keys + soft-retire behaviour using ``parse_company`` stubs."""
 
     def setUp(self):
         self.company = InsuranceCompany.objects.create(
             name="FixtureCo",
             regex=r"fixture\s*co",
             negative_regex=r"$^",
+            pa_requirement_list_url="https://example.com/pa.csv",
+            pa_requirement_list_url_is_parseable=True,
         )
-        # Reset registry and snapshot for each test so we never lean on
-        # parsers registered by other modules at import time.
-        self._saved_registry = dict(PA_PARSERS)
-        PA_PARSERS.clear()
 
-    def tearDown(self):
-        PA_PARSERS.clear()
-        PA_PARSERS.update(self._saved_registry)
-
-    def _ingest(self, rows):
-        register_parser("fixtureco")(lambda: _StubParser(rows))
+    def _ingest(self, parsed):
+        """Run one ingest cycle with ``parse_company`` stubbed to return ``parsed``."""
 
         async def _go():
-            async with PaRequirementsFetcher() as fetcher:
-                return await fetcher.ingest_carrier("fixtureco")
+            fetcher = PaRequirementsFetcher()
+
+            async def fake_parse(_company):
+                return parsed
+
+            with patch.object(fetcher, "parse_company", side_effect=fake_parse):
+                return await fetcher.ingest_company(self.company)
 
         return asyncio.run(_go())
 
     def test_idempotent_upsert(self):
-        rows = [
-            {
-                "line_of_business": "commercial",
-                "cpt_hcpcs_code": "95810",
-                "code_description": "Polysomnography",
-                "source_document": "[ingest:fixtureco]",
-            }
+        parsed = [
+            ParsedPARequirement(
+                cpt_hcpcs_code="95810",
+                code_description="Polysomnography",
+                line_of_business="commercial",
+            )
         ]
-        self._ingest(rows)
+        self._ingest(parsed)
         self.assertEqual(PayerPriorAuthRequirement.objects.count(), 1)
-        # Second run with identical input must not duplicate.
-        self._ingest(rows)
+        # Re-running with the same input must not duplicate.
+        self._ingest(parsed)
         self.assertEqual(PayerPriorAuthRequirement.objects.count(), 1)
 
     def test_missing_row_is_soft_retired(self):
         first = [
-            {
-                "line_of_business": "commercial",
-                "cpt_hcpcs_code": "95810",
-                "source_document": "[ingest:fixtureco]",
-            },
-            {
-                "line_of_business": "commercial",
-                "cpt_hcpcs_code": "95811",
-                "source_document": "[ingest:fixtureco]",
-            },
+            ParsedPARequirement(cpt_hcpcs_code="95810", line_of_business="commercial"),
+            ParsedPARequirement(cpt_hcpcs_code="95811", line_of_business="commercial"),
         ]
         self._ingest(first)
         self.assertEqual(PayerPriorAuthRequirement.objects.count(), 2)
 
-        # 95811 disappears from the carrier's list — should be soft-retired
-        # (end_date set), not deleted, so historical denials still resolve.
+        # 95811 disappears from the carrier's list — soft-retire it.
         second = [first[0]]
         stats = self._ingest(second)
-        retired = PayerPriorAuthRequirement.objects.filter(
-            cpt_hcpcs_code="95811"
-        ).get()
+        retired = PayerPriorAuthRequirement.objects.filter(cpt_hcpcs_code="95811").get()
         self.assertEqual(retired.end_date, date.today())
         self.assertEqual(stats["retired"], 1)
 
     def test_manually_curated_rows_not_soft_retired(self):
-        # A manually-curated row (no [ingest:...] marker in source_document)
+        # A manually-curated row (no ``auto:`` prefix on source_document)
         # must survive an ingest run that doesn't list it.
         manual = PayerPriorAuthRequirement.objects.create(
             insurance_company=self.company,
@@ -105,13 +81,144 @@ class FetcherContractTests(TestCase):
             source_document="hand-entered by ops",
         )
         self._ingest(
-            [
-                {
-                    "line_of_business": "commercial",
-                    "cpt_hcpcs_code": "95810",
-                    "source_document": "[ingest:fixtureco]",
-                }
-            ]
+            [ParsedPARequirement(cpt_hcpcs_code="95810", line_of_business="commercial")]
         )
         manual.refresh_from_db()
         self.assertIsNone(manual.end_date)
+
+    def test_invalid_lob_falls_back_to_all(self):
+        # The parsers normalise LOB to lowercase strings; an unknown value
+        # must fall back to ``LineOfBusiness.ALL`` rather than failing
+        # ``full_clean()``.
+        self._ingest(
+            [
+                ParsedPARequirement(
+                    cpt_hcpcs_code="95810", line_of_business="bogus_value"
+                )
+            ]
+        )
+        row = PayerPriorAuthRequirement.objects.get(cpt_hcpcs_code="95810")
+        self.assertEqual(row.line_of_business, "all")
+
+    def test_manual_row_protects_same_key_from_overwrite(self):
+        # A manual / fixture-seeded row that shares the upsert key with a
+        # carrier's parsed row must NOT be overwritten by auto-ingest.
+        manual = PayerPriorAuthRequirement.objects.create(
+            insurance_company=self.company,
+            cpt_hcpcs_code="95810",
+            line_of_business="commercial",
+            code_description="Manual override description",
+            submission_channel="Manual channel",
+            source_document="curated by ops",
+        )
+        self._ingest(
+            [
+                ParsedPARequirement(
+                    cpt_hcpcs_code="95810",
+                    code_description="Carrier-published description",
+                    submission_channel="Carrier channel",
+                    line_of_business="commercial",
+                )
+            ]
+        )
+        manual.refresh_from_db()
+        self.assertEqual(manual.code_description, "Manual override description")
+        self.assertEqual(manual.submission_channel, "Manual channel")
+        self.assertEqual(manual.source_document, "curated by ops")
+        # And no parallel auto-ingest row was created for the same key.
+        auto_rows = PayerPriorAuthRequirement.objects.filter(
+            cpt_hcpcs_code="95810", source_document__startswith="auto:"
+        )
+        self.assertEqual(auto_rows.count(), 0)
+
+    def test_re_ingest_clears_end_date(self):
+        # A row that was soft-retired in a previous run becomes current
+        # again when the parser produces it on a fresh fetch.
+        PayerPriorAuthRequirement.objects.create(
+            insurance_company=self.company,
+            cpt_hcpcs_code="95810",
+            line_of_business="commercial",
+            source_document=f"{AUTO_SOURCE_PREFIX}https://example.com/pa.csv",
+            end_date=date.today(),
+        )
+        self._ingest(
+            [ParsedPARequirement(cpt_hcpcs_code="95810", line_of_business="commercial")]
+        )
+        row = PayerPriorAuthRequirement.objects.get(cpt_hcpcs_code="95810")
+        self.assertIsNone(row.end_date)
+
+
+class IngestAllSelectionTests(TestCase):
+    """Only companies flagged ``pa_requirement_list_url_is_parseable`` are fetched."""
+
+    def setUp(self):
+        InsuranceCompany.objects.create(
+            name="Parseable Co",
+            regex=r"parseable",
+            negative_regex=r"$^",
+            pa_requirement_list_url="https://example.com/p.csv",
+            pa_requirement_list_url_is_parseable=True,
+        )
+        InsuranceCompany.objects.create(
+            name="Unparseable Co",
+            regex=r"unparseable",
+            negative_regex=r"$^",
+            pa_requirement_list_url="https://example.com/u.html",
+            pa_requirement_list_url_is_parseable=False,
+        )
+        InsuranceCompany.objects.create(
+            name="No URL Co",
+            regex=r"nourl",
+            negative_regex=r"$^",
+            pa_requirement_list_url="",
+            pa_requirement_list_url_is_parseable=True,
+        )
+
+    def test_only_parseable_companies_fetched(self):
+        async def _go():
+            fetcher = PaRequirementsFetcher()
+            visited = []
+
+            async def fake_ingest_company(company):
+                visited.append(company.name)
+                return {"fetched": 1, "failed": 0, "entries": 0, "retired": 0}
+
+            with patch.object(
+                fetcher, "ingest_company", side_effect=fake_ingest_company
+            ):
+                await fetcher.ingest_all()
+            return visited
+
+        visited = asyncio.run(_go())
+        self.assertEqual(visited, ["Parseable Co"])
+
+    def test_per_company_exception_does_not_abort_run(self):
+        # A second parseable company is enough to verify the loop continues
+        # past a failure.
+        InsuranceCompany.objects.create(
+            name="Second Parseable",
+            regex=r"second",
+            negative_regex=r"$^",
+            pa_requirement_list_url="https://example.com/s.csv",
+            pa_requirement_list_url_is_parseable=True,
+        )
+
+        async def _go():
+            fetcher = PaRequirementsFetcher()
+            calls = []
+
+            async def boom_first(company):
+                calls.append(company.name)
+                if company.name == "Parseable Co":
+                    raise RuntimeError("simulated parser crash")
+                return {"fetched": 1, "failed": 0, "entries": 0, "retired": 0}
+
+            with patch.object(fetcher, "ingest_company", side_effect=boom_first):
+                stats = await fetcher.ingest_all()
+            return stats, calls
+
+        stats, calls = asyncio.run(_go())
+        # Both companies were attempted.
+        self.assertEqual(sorted(calls), ["Parseable Co", "Second Parseable"])
+        self.assertEqual(stats["failed"], 1)
+        self.assertEqual(stats["fetched"], 1)

--- a/tests/sync/test_pa_requirements_fetcher.py
+++ b/tests/sync/test_pa_requirements_fetcher.py
@@ -1,0 +1,117 @@
+"""Tests for ``PaRequirementsFetcher``'s upsert / soft-retire contract."""
+
+import asyncio
+from datetime import date
+
+from django.test import TestCase
+
+from fighthealthinsurance.models import (
+    InsuranceCompany,
+    PayerPriorAuthRequirement,
+)
+from fighthealthinsurance.pa_requirements_fetcher import (
+    PA_PARSERS,
+    PaRequirementsFetcher,
+    register_parser,
+)
+
+
+class _StubParser:
+    """A parser whose output is overridable per test."""
+
+    carrier_aliases = ("FixtureCo",)
+
+    def __init__(self, rows):
+        self._rows = rows
+
+    async def parse(self):
+        return self._rows
+
+
+class FetcherContractTests(TestCase):
+    """Verify upsert keys and soft-retire behaviour."""
+
+    def setUp(self):
+        self.company = InsuranceCompany.objects.create(
+            name="FixtureCo",
+            regex=r"fixture\s*co",
+            negative_regex=r"$^",
+        )
+        # Reset registry and snapshot for each test so we never lean on
+        # parsers registered by other modules at import time.
+        self._saved_registry = dict(PA_PARSERS)
+        PA_PARSERS.clear()
+
+    def tearDown(self):
+        PA_PARSERS.clear()
+        PA_PARSERS.update(self._saved_registry)
+
+    def _ingest(self, rows):
+        register_parser("fixtureco")(lambda: _StubParser(rows))
+
+        async def _go():
+            async with PaRequirementsFetcher() as fetcher:
+                return await fetcher.ingest_carrier("fixtureco")
+
+        return asyncio.run(_go())
+
+    def test_idempotent_upsert(self):
+        rows = [
+            {
+                "line_of_business": "commercial",
+                "cpt_hcpcs_code": "95810",
+                "code_description": "Polysomnography",
+                "source_document": "[ingest:fixtureco]",
+            }
+        ]
+        self._ingest(rows)
+        self.assertEqual(PayerPriorAuthRequirement.objects.count(), 1)
+        # Second run with identical input must not duplicate.
+        self._ingest(rows)
+        self.assertEqual(PayerPriorAuthRequirement.objects.count(), 1)
+
+    def test_missing_row_is_soft_retired(self):
+        first = [
+            {
+                "line_of_business": "commercial",
+                "cpt_hcpcs_code": "95810",
+                "source_document": "[ingest:fixtureco]",
+            },
+            {
+                "line_of_business": "commercial",
+                "cpt_hcpcs_code": "95811",
+                "source_document": "[ingest:fixtureco]",
+            },
+        ]
+        self._ingest(first)
+        self.assertEqual(PayerPriorAuthRequirement.objects.count(), 2)
+
+        # 95811 disappears from the carrier's list — should be soft-retired
+        # (end_date set), not deleted, so historical denials still resolve.
+        second = [first[0]]
+        stats = self._ingest(second)
+        retired = PayerPriorAuthRequirement.objects.filter(
+            cpt_hcpcs_code="95811"
+        ).get()
+        self.assertEqual(retired.end_date, date.today())
+        self.assertEqual(stats["retired"], 1)
+
+    def test_manually_curated_rows_not_soft_retired(self):
+        # A manually-curated row (no [ingest:...] marker in source_document)
+        # must survive an ingest run that doesn't list it.
+        manual = PayerPriorAuthRequirement.objects.create(
+            insurance_company=self.company,
+            cpt_hcpcs_code="99999",
+            source_document="hand-entered by ops",
+        )
+        self._ingest(
+            [
+                {
+                    "line_of_business": "commercial",
+                    "cpt_hcpcs_code": "95810",
+                    "source_document": "[ingest:fixtureco]",
+                }
+            ]
+        )
+        manual.refresh_from_db()
+        self.assertIsNone(manual.end_date)

--- a/tests/sync/test_pa_requirements_fetcher.py
+++ b/tests/sync/test_pa_requirements_fetcher.py
@@ -4,7 +4,7 @@ import asyncio
 from datetime import date
 from unittest.mock import patch
 
-from django.test import TestCase
+from django.test import TransactionTestCase
 
 from fighthealthinsurance.models import (
     InsuranceCompany,
@@ -17,7 +17,7 @@ from fighthealthinsurance.pa_requirements_fetcher import (
 )
 
 
-class FetcherContractTests(TestCase):
+class FetcherContractTests(TransactionTestCase):
     """Verify upsert keys + soft-retire behaviour using ``parse_company`` stubs."""
 
     def setUp(self):
@@ -148,7 +148,7 @@ class FetcherContractTests(TestCase):
         self.assertIsNone(row.end_date)
 
 
-class IngestAllSelectionTests(TestCase):
+class IngestAllSelectionTests(TransactionTestCase):
     """Only companies flagged ``pa_requirement_list_url_is_parseable`` are fetched."""
 
     def setUp(self):


### PR DESCRIPTION
The PR-#750 PA requirement framework had several rough edges:

- The chat tool regex truncated nested-JSON params (e.g. ``filters: {lob: ...}``).
- ``_denial_lookup`` filtered rules by ``today()`` instead of the denial date.
- An empty-string LOB from the LLM narrowed to LOB-agnostic rules only,
  silently hiding commercial/MA matches.
- Mixed-length code ranges (``J490..J0500``) passed validation despite
  breaking lexicographic ordering used by ``covers_code`` and the lookup query.
- The carrier-name resolver did a full table scan + per-row regex compile
  on every chat call.
- 14 hand-curated UHC entries were inlined in a data migration instead of
  living as a fixture, and there was no mechanism for refreshing carrier-
  published PA lists on a cadence.

This change adds the plumbing: a YAML fixture
(``fighthealthinsurance/fixtures/pa_requirements.yaml``) carrying the
UHC starter set, a ``PaRequirementsFetcher`` + ``ingest_pa_requirements``
management command (structured the same way as
``ingest_payer_policy_indexes``), and a ``PaRefreshActor`` modelled on
``IMRRefreshActor`` for periodic refresh.

It also merges the best ideas from #805: HTML/PDF/Excel/CSV parsers with
a shared column-alias heuristic (``pa_requirement_parsers``), DB-driven
dispatch via new ``InsuranceCompany.pa_requirement_list_url`` fields
(migration ``0180``), per-host enrichments for major payers, a
``--company`` / ``--dry-run`` UI on the management command, an admin
fieldset, and the carrier PA-list URLs in the fixture. The differences
from #805 are intentional: this PR soft-retires rows that disappear
from the upstream list (``end_date = today``) instead of deleting them,
so historical denials still resolve to the rule that applied at the
time; it keeps the ``BaseRefreshActor`` scaffolding the IMR/UCR actors
already use; and an auto-ingest never overwrites a manually-curated
row sharing the same scoping key. #805 can close once this merges.

The starter UHC fixture also corrects the imaging-channel bug in 0168:
codes 70551 / 74177 now reference Optum (UHC's radiology benefits manager)
in ``submission_channel`` instead of the generic UHCprovider.com default.
