### PR TITLE
Update schedule_follow_ups docstring to mention 1-day follow-up

### DIFF
--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -539,7 +539,7 @@ def schedule_follow_ups(
     denial: "Denial",
     from_date: Optional[datetime.date] = None,
 ) -> None:
-    """Schedule 7-day, 30-day, and 90-day follow-up emails for a denial.
+    """Schedule 1-day, 7-day, 30-day, and 90-day follow-up emails for a denial.
 
     Args:
         email: Recipient email address.


### PR DESCRIPTION
The docstring still listed only 7-day, 30-day, and 90-day follow-ups
even though PR #786 added a 1-day follow-up type to the scheduling
function. Match the implementation, which now schedules four types.

https://claude.ai/code/session_01QfYp9kHwE62mzQPg9b7vwJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced follow-up email scheduling to include an additional 1-day follow-up interval alongside existing 7-day, 30-day, and 90-day follow-ups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->