### PR TITLE
Widen OngoingChat denied_item/denied_reason and cap LLM output

### DIFF
--- a/fighthealthinsurance/migrations/0177_alter_ongoingchat_denied_item_and_more.py
+++ b/fighthealthinsurance/migrations/0177_alter_ongoingchat_denied_item_and_more.py
@@ -1,0 +1,34 @@
+# Increase OngoingChat.denied_item / denied_reason from 500 to 2000 chars
+# to avoid DataError when LLM analysis returns long values.
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("fighthealthinsurance", "0176_add_1day_followup_type"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="ongoingchat",
+            name="denied_item",
+            field=models.CharField(
+                blank=True,
+                help_text="The item that was denied, extracted from chat context",
+                max_length=2000,
+                null=True,
+            ),
+        ),
+        migrations.AlterField(
+            model_name="ongoingchat",
+            name="denied_reason",
+            field=models.CharField(
+                blank=True,
+                help_text="The reason for denial, extracted from chat context",
+                max_length=2000,
+                null=True,
+            ),
+        ),
+    ]

--- a/fighthealthinsurance/models.py
+++ b/fighthealthinsurance/models.py
@@ -2846,13 +2846,13 @@ class OngoingChat(models.Model):
         null=True, blank=True
     )  # JSON List of strings
     denied_item = models.CharField(
-        max_length=500,
+        max_length=2000,
         null=True,
         blank=True,
         help_text="The item that was denied, extracted from chat context",
     )
     denied_reason = models.CharField(
-        max_length=500,
+        max_length=2000,
         null=True,
         blank=True,
         help_text="The reason for denial, extracted from chat context",

--- a/fighthealthinsurance/websockets.py
+++ b/fighthealthinsurance/websockets.py
@@ -480,6 +480,9 @@ class OngoingChatConsumer(AsyncWebsocketConsumer):
                                 return str(val).strip().lower() not in _UNCLEAR_PHRASES
 
                             updated = False
+                            # Cap to the column max_length to avoid DB
+                            # DataError when models return overly long text.
+                            _MAX_LEN = 2000
                             # Strip boilerplate from denied_item, then
                             # clarity-check the *stripped* result.
                             if denied_item:
@@ -487,7 +490,7 @@ class OngoingChatConsumer(AsyncWebsocketConsumer):
                                     str(denied_item)
                                 )
                             if is_clear(denied_item):
-                                chat.denied_item = denied_item
+                                chat.denied_item = denied_item[:_MAX_LEN]
                                 updated = True
                                 logger.info(
                                     f"Updated chat {chat_id} with denied item: {denied_item}"
@@ -500,7 +503,7 @@ class OngoingChatConsumer(AsyncWebsocketConsumer):
                             else:
                                 denied_reason = None
                             if denied_reason:
-                                chat.denied_reason = denied_reason
+                                chat.denied_reason = denied_reason[:_MAX_LEN]
                                 updated = True
                                 logger.info(
                                     f"Updated chat {chat_id} with denied reason: {denied_reason}"


### PR DESCRIPTION
Increases the columns from CharField(500) to CharField(2000) and
truncates extracted values before assignment so an over-long LLM
response can't trigger DataError: value too long for type character
varying(500) when saving an OngoingChat.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * System now handles longer denial explanations in insurance appeals without encountering database errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->