### PR TITLE
Add email notification when follow-up feedback is received

### DIFF
--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -646,8 +646,8 @@ class FollowUpHelper:
     @staticmethod
     def _notify_support_of_feedback(follow_up: "FollowUp", denial: "Denial") -> None:
         admin_path = reverse(
-            "admin:fighthealthinsurance_followup_change",
-            args=[follow_up.followup_result_id],
+            "admin:fighthealthinsurance_denial_change",
+            args=[denial.denial_id],
         )
         admin_url = f"https://{settings.FIGHT_HEALTH_INSURANCE_DOMAIN}{admin_path}"
         body = (

--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -22,7 +22,9 @@ from typing import (
 )
 from urllib.parse import urlencode
 
+from django.conf import settings
 from django.core.files import File
+from django.core.mail import send_mail
 from django.core.validators import validate_email
 from django.db.models import Q, QuerySet
 from django.forms import Form
@@ -639,6 +641,35 @@ class FollowUpHelper:
             fd.save()
         denial.appeal_result = appeal_result
         denial.save()
+        cls._notify_support_of_feedback(follow_up, denial, user_comments)
+
+    @staticmethod
+    def _notify_support_of_feedback(
+        follow_up: "FollowUp", denial: "Denial", user_comments: Optional[str]
+    ) -> None:
+        body = (
+            f"New feedback received via the follow-up webform.\n\n"
+            f"Denial ID: {denial.denial_id}\n"
+            f"UUID: {denial.uuid}\n"
+            f"Appeal result: {denial.appeal_result or 'N/A'}\n"
+            f"More follow-up requested: {follow_up.more_follow_up_requested}\n"
+            f"Use quote: {follow_up.use_quote}\n"
+            f"Name for quote: {follow_up.name_for_quote or 'N/A'}\n"
+            f"Quote: {follow_up.quote or 'N/A'}\n"
+            f"User comments: {user_comments or 'N/A'}\n"
+            f"Reply email: {follow_up.email or 'N/A'}\n"
+        )
+        try:
+            send_mail(
+                f"New webform feedback - denial {denial.denial_id}",
+                body,
+                settings.DEFAULT_FROM_EMAIL,
+                ["support42@fighthealthinsurance.com"],
+            )
+        except Exception:
+            logger.opt(exception=True).error(
+                "Error sending feedback notification email"
+            )
 
 
 class FindNextStepsHelper:

--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -641,23 +641,22 @@ class FollowUpHelper:
             fd.save()
         denial.appeal_result = appeal_result
         denial.save()
-        cls._notify_support_of_feedback(follow_up, denial, user_comments)
+        cls._notify_support_of_feedback(follow_up, denial)
 
     @staticmethod
     def _notify_support_of_feedback(
-        follow_up: "FollowUp", denial: "Denial", user_comments: Optional[str]
+        follow_up: "FollowUp", denial: "Denial"
     ) -> None:
+        admin_path = reverse(
+            "admin:fighthealthinsurance_followup_change",
+            args=[follow_up.followup_result_id],
+        )
+        admin_url = f"https://www.fighthealthinsurance.com{admin_path}"
         body = (
             f"New feedback received via the follow-up webform.\n\n"
             f"Denial ID: {denial.denial_id}\n"
-            f"UUID: {denial.uuid}\n"
             f"Appeal result: {denial.appeal_result or 'N/A'}\n"
-            f"More follow-up requested: {follow_up.more_follow_up_requested}\n"
-            f"Use quote: {follow_up.use_quote}\n"
-            f"Name for quote: {follow_up.name_for_quote or 'N/A'}\n"
-            f"Quote: {follow_up.quote or 'N/A'}\n"
-            f"User comments: {user_comments or 'N/A'}\n"
-            f"Reply email: {follow_up.email or 'N/A'}\n"
+            f"Admin: {admin_url}\n"
         )
         try:
             send_mail(

--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -644,9 +644,7 @@ class FollowUpHelper:
         cls._notify_support_of_feedback(follow_up, denial)
 
     @staticmethod
-    def _notify_support_of_feedback(
-        follow_up: "FollowUp", denial: "Denial"
-    ) -> None:
+    def _notify_support_of_feedback(follow_up: "FollowUp", denial: "Denial") -> None:
         admin_path = reverse(
             "admin:fighthealthinsurance_followup_change",
             args=[follow_up.followup_result_id],

--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -649,7 +649,7 @@ class FollowUpHelper:
             "admin:fighthealthinsurance_followup_change",
             args=[follow_up.followup_result_id],
         )
-        admin_url = f"https://www.fighthealthinsurance.com{admin_path}"
+        admin_url = f"https://{settings.FIGHT_HEALTH_INSURANCE_DOMAIN}{admin_path}"
         body = (
             f"New feedback received via the follow-up webform.\n\n"
             f"Denial ID: {denial.denial_id}\n"
@@ -665,7 +665,9 @@ class FollowUpHelper:
             )
         except Exception:
             logger.opt(exception=True).error(
-                "Error sending feedback notification email"
+                f"Error sending feedback notification email "
+                f"(denial_id={denial.denial_id}, "
+                f"followup_result_id={follow_up.followup_result_id})"
             )
 
 

--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -646,8 +646,8 @@ class FollowUpHelper:
     @staticmethod
     def _notify_support_of_feedback(follow_up: "FollowUp", denial: "Denial") -> None:
         admin_path = reverse(
-            "admin:fighthealthinsurance_denial_change",
-            args=[denial.denial_id],
+            "admin:fighthealthinsurance_followup_change",
+            args=[follow_up.followup_result_id],
         )
         admin_url = f"https://{settings.FIGHT_HEALTH_INSURANCE_DOMAIN}{admin_path}"
         body = (


### PR DESCRIPTION
## Summary
Added functionality to notify the support team via email when users submit follow-up feedback through the webform about their appeal results.

## Key Changes
- Added new `_notify_support_of_feedback()` static method to send email notifications to support when follow-up results are stored
- Email includes relevant denial information (denial ID, appeal result) and a direct link to the follow-up record in the Django admin
- Implemented error handling with logging to gracefully handle email delivery failures
- Added necessary imports: `django.conf.settings` and `django.core.mail.send_mail`

## Implementation Details
- The notification is triggered automatically when `store_follow_up_result()` completes successfully
- Email is sent to `support42@fighthealthinsurance.com` with the denial ID in the subject line
- Admin URL is constructed using Django's `reverse()` function pointing to the follow-up change view
- Any exceptions during email sending are caught and logged without interrupting the main flow

https://claude.ai/code/session_01M5t7tf2kJPrSdgSFk2BD7i