### PR TITLE
Fix follow-up form handling and URL routing issues

### DIFF
--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -598,9 +598,9 @@ class FollowUpHelper:
         uuid: str,
         follow_up_semi_sekret: str,
         hashed_email: str,
-        user_comments: str,
-        appeal_result: str,
-        follow_up_again: bool,
+        user_comments: str = "",
+        appeal_result: str = "",
+        follow_up_again: bool = False,
         medicare_someone_to_help: bool = False,
         email: Optional[str] = None,
         quote: Optional[str] = None,
@@ -615,8 +615,6 @@ class FollowUpHelper:
             follow_up_semi_sekret=follow_up_semi_sekret,
             hashed_email=hashed_email,
         )
-        # Store the follow up response returns nothing but may raise
-        denial_id = denial.denial_id
         follow_up = FollowUp.objects.create(
             hashed_email=hashed_email,
             denial_id=denial,
@@ -626,6 +624,8 @@ class FollowUpHelper:
             email=email,
             name_for_quote=name_for_quote,
             quote=quote,
+            user_comments=user_comments,
+            appeal_result=appeal_result,
         )
         # If they asked for additional follow up, schedule from today
         # so they get a fresh round of check-ins rather than re-using
@@ -635,10 +635,11 @@ class FollowUpHelper:
                 denial.raw_email, denial, from_date=datetime.date.today()
             )
         for document in followup_documents:
-            fd = FollowUpDocuments.objects.create(
+            if not document:
+                continue
+            FollowUpDocuments.objects.create(
                 follow_up_document_enc=document, denial=denial, follow_up_id=follow_up
             )
-            fd.save()
         denial.appeal_result = appeal_result
         denial.save()
         cls._notify_support_of_feedback(follow_up, denial)

--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -640,7 +640,7 @@ class FollowUpHelper:
             FollowUpDocuments.objects.create(
                 follow_up_document_enc=document, denial=denial, follow_up_id=follow_up
             )
-        denial.appeal_result = appeal_result
+        denial.appeal_result = appeal_result or None
         denial.save()
         cls._notify_support_of_feedback(follow_up, denial)
 

--- a/fighthealthinsurance/urls.py
+++ b/fighthealthinsurance/urls.py
@@ -124,7 +124,7 @@ urlpatterns: List[Union[URLPattern, URLResolver]] = [
         name="followup-with-a-period",
     ),
     path(
-        "v0/followup/<uuid:uuid>/<slug:hashed_email>/<slug:followup_semi_sekret>/",
+        "v0/followup/<uuid:uuid>/<slug:hashed_email>/<slug:follow_up_semi_sekret>/",
         views.FollowUpView.as_view(),
         name="followup-with-trailing-slash",
     ),

--- a/tests/selenium/test_selenium_follow_up.py
+++ b/tests/selenium/test_selenium_follow_up.py
@@ -88,3 +88,48 @@ class SeleniumFollowUp(BaseCase, StaticLiveServerTestCase):
         )
         self.open(f"{self.live_server_url}/{mylink}")
         self.assert_title("Something Went Wrong - Fight Health Insurance")
+
+    def test_follow_up_trailing_slash_link(self):
+        """Email clients sometimes add a trailing slash; the page must load.
+        Regression test for a URL-pattern typo that crashed the view."""
+        email = "timbit@test.com"
+        hashed_email = Denial.get_hashed_email(email)
+        denial = Denial.objects.create(
+            denial_text="I am evil so no health care for you.",
+            hashed_email=hashed_email,
+            use_external=False,
+            raw_email=email,
+            health_history="",
+        )
+        mylink = (
+            f"v0/followup/{denial.uuid}/{denial.hashed_email}/"
+            f"{denial.follow_up_semi_sekret}/"
+        )
+        self.open(f"{self.live_server_url}/{mylink}")
+        self.assert_title("Follow Up On Your Health Insurance Appeal")
+        self.click("button#submit")
+        self.assert_title("Thank you!")
+
+    def test_follow_up_persists_comments_and_appeal_result(self):
+        """Submitting comments + appeal_result must be saved on FollowUp."""
+        email = "timbit@test.com"
+        hashed_email = Denial.get_hashed_email(email)
+        denial = Denial.objects.create(
+            denial_text="I am evil so no health care for you.",
+            hashed_email=hashed_email,
+            use_external=False,
+            raw_email=email,
+            health_history="",
+        )
+        mylink = f"v0/followup/{denial.uuid}/{denial.hashed_email}/{denial.follow_up_semi_sekret}"
+        self.open(f"{self.live_server_url}/{mylink}")
+        self.assert_title("Follow Up On Your Health Insurance Appeal")
+        self.type("textarea#id_user_comments", "Insurer reversed the denial.")
+        self.select_option_by_value("select#id_appeal_result", "Yes")
+        self.click("button#submit")
+        self.assert_title("Thank you!")
+        followup = FollowUp.objects.get(denial_id=denial)
+        assert followup.user_comments == "Insurer reversed the denial."
+        assert followup.appeal_result == "Yes"
+        denial.refresh_from_db()
+        assert denial.appeal_result == "Yes"

--- a/tests/sync/test_followup_view.py
+++ b/tests/sync/test_followup_view.py
@@ -157,23 +157,53 @@ class TestFollowUpViewSubmit(TestCase):
         followup = FollowUp.objects.get(denial_id=self.denial)
         self.assertTrue(followup.more_follow_up_requested)
 
-    def test_invalid_secret_returns_500_error_page(self):
-        """Wrong secret must not allow submission. Currently the helper
-        raises which surfaces the generic error page; the important thing
-        is that no FollowUp row is written."""
+    def test_invalid_secret_does_not_render_form(self):
+        """Wrong secret must NOT render the follow-up form (and must not
+        write a FollowUp row). The view currently lets the DoesNotExist
+        propagate, so the test client either surfaces the exception (when
+        request-exception propagation is on) or renders the custom 500
+        page — never the follow-up form."""
         bad_path = (
             f"/v0/followup/{self.denial.uuid}/"
             f"{self.denial.hashed_email}/not-the-real-sekret"
         )
-        try:
-            response = self.client.get(bad_path)
-        except Exception:
-            response = None
-        # Either a 500 error page is rendered or an exception propagated;
-        # in both cases, no follow-up row is created.
+        self.client.raise_request_exception = False
+        response = self.client.get(bad_path)
+        self.assertEqual(response.status_code, 500)
+        self.assertNotContains(
+            response,
+            "Follow Up On Your Health Insurance Appeal",
+            status_code=500,
+        )
         self.assertEqual(FollowUp.objects.filter(denial_id=self.denial).count(), 0)
-        if response is not None:
-            self.assertIn(response.status_code, (200, 404, 500))
+
+    def test_invalid_secret_post_does_not_persist(self):
+        """A POST with a wrong secret must not create a FollowUp row."""
+        bad_path = (
+            f"/v0/followup/{self.denial.uuid}/"
+            f"{self.denial.hashed_email}/not-the-real-sekret"
+        )
+        self.client.raise_request_exception = False
+        response = self.client.post(bad_path, data=self._payload())
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(FollowUp.objects.filter(denial_id=self.denial).count(), 0)
+
+    def test_blank_appeal_result_leaves_denial_pending(self):
+        """Regression: storing a blank appeal_result must NOT mark the
+        denial as having a result. Code in ucr_refresh_actor filters
+        by ``appeal_result__isnull=True`` to find still-pending denials,
+        so an empty string here would silently exclude them from
+        downstream processing."""
+        self.client.post(self.path, data=self._payload(appeal_result=""))
+        self.denial.refresh_from_db()
+        self.assertIsNone(self.denial.appeal_result)
+        # The denial should still match the "pending" filter used by
+        # ucr_refresh_actor.
+        self.assertTrue(
+            Denial.objects.filter(
+                pk=self.denial.pk, appeal_result__isnull=True
+            ).exists()
+        )
 
     def test_no_documents_does_not_create_empty_document_rows(self):
         """Regression: when the user uploads no files we should not write

--- a/tests/sync/test_followup_view.py
+++ b/tests/sync/test_followup_view.py
@@ -1,0 +1,257 @@
+"""End-to-end tests for the follow-up page (view + helper)."""
+
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from fighthealthinsurance.common_view_logic import FollowUpHelper
+from fighthealthinsurance.models import (
+    Denial,
+    FollowUp,
+    FollowUpDocuments,
+    FollowUpSched,
+)
+
+
+def _make_denial(email: str = "followup-tester@test-fhi.com") -> Denial:
+    """Create a minimal Denial suitable for follow-up tests."""
+    hashed_email = Denial.get_hashed_email(email)
+    return Denial.objects.create(
+        denial_text="Some denial text.",
+        hashed_email=hashed_email,
+        use_external=False,
+        raw_email=email,
+        health_history="",
+    )
+
+
+class TestFollowUpURLRouting(TestCase):
+    """The view must accept the link variants we email out (with trailing
+    slash or trailing period) without 404-ing or crashing."""
+
+    def setUp(self):
+        self.client = Client()
+        self.denial = _make_denial()
+
+    def _base_path(self) -> str:
+        return (
+            f"/v0/followup/{self.denial.uuid}/"
+            f"{self.denial.hashed_email}/{self.denial.follow_up_semi_sekret}"
+        )
+
+    def test_get_canonical_url_renders_form(self):
+        response = self.client.get(self._base_path())
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Follow Up On Your Health Insurance Appeal")
+        self.assertContains(response, 'id="submit"')
+        self.assertContains(response, 'enctype="multipart/form-data"')
+
+    def test_get_url_with_trailing_period(self):
+        """Some email clients append a period to the link."""
+        response = self.client.get(self._base_path() + ".")
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Follow Up On Your Health Insurance Appeal")
+
+    def test_get_url_with_trailing_slash(self):
+        """Some email clients append a trailing slash. Regression test for
+        the URL-pattern typo that mismatched the kwarg name and made the
+        view crash with a TypeError."""
+        response = self.client.get(self._base_path() + "/")
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Follow Up On Your Health Insurance Appeal")
+
+    def test_get_canonical_url_via_named_route(self):
+        url = reverse(
+            "followup",
+            kwargs={
+                "uuid": self.denial.uuid,
+                "hashed_email": self.denial.hashed_email,
+                "follow_up_semi_sekret": self.denial.follow_up_semi_sekret,
+            },
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+
+class TestFollowUpViewSubmit(TestCase):
+    """POSTing the follow-up form persists the user's response."""
+
+    def setUp(self):
+        self.client = Client()
+        self.denial = _make_denial()
+        self.path = (
+            f"/v0/followup/{self.denial.uuid}/"
+            f"{self.denial.hashed_email}/{self.denial.follow_up_semi_sekret}"
+        )
+
+    def _payload(self, **overrides):
+        data = {
+            "uuid": str(self.denial.uuid),
+            "hashed_email": self.denial.hashed_email,
+            "follow_up_semi_sekret": self.denial.follow_up_semi_sekret,
+            "user_comments": "",
+            "quote": "",
+            "name_for_quote": "",
+            "email": "",
+            "appeal_result": "",
+        }
+        data.update(overrides)
+        return data
+
+    def test_post_minimum_payload_renders_thank_you(self):
+        response = self.client.post(self.path, data=self._payload())
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Thank you!")
+        # A FollowUp record should have been created.
+        self.assertEqual(FollowUp.objects.filter(denial_id=self.denial).count(), 1)
+
+    def test_post_persists_user_comments(self):
+        """Regression: user_comments must be saved on the FollowUp row."""
+        response = self.client.post(
+            self.path,
+            data=self._payload(
+                user_comments="Insurer reversed after the appeal letter.",
+                appeal_result="Yes",
+            ),
+        )
+        self.assertEqual(response.status_code, 200)
+        followup = FollowUp.objects.get(denial_id=self.denial)
+        self.assertEqual(
+            followup.user_comments,
+            "Insurer reversed after the appeal letter.",
+        )
+        self.assertEqual(followup.appeal_result, "Yes")
+
+    def test_appeal_result_stored_on_denial_and_followup(self):
+        self.client.post(self.path, data=self._payload(appeal_result="Partial"))
+        self.denial.refresh_from_db()
+        self.assertEqual(self.denial.appeal_result, "Partial")
+        followup = FollowUp.objects.get(denial_id=self.denial)
+        self.assertEqual(followup.appeal_result, "Partial")
+
+    def test_quote_fields_persisted(self):
+        self.client.post(
+            self.path,
+            data=self._payload(
+                quote="The system actually worked.",
+                use_quote="on",
+                name_for_quote="A. Patient",
+                email="contact@example.com",
+            ),
+        )
+        followup = FollowUp.objects.get(denial_id=self.denial)
+        self.assertEqual(followup.quote, "The system actually worked.")
+        self.assertTrue(followup.use_quote)
+        self.assertEqual(followup.name_for_quote, "A. Patient")
+        self.assertEqual(followup.email, "contact@example.com")
+
+    def test_follow_up_again_unchecked_does_not_schedule(self):
+        self.client.post(self.path, data=self._payload())
+        self.assertEqual(FollowUpSched.objects.filter(denial_id=self.denial).count(), 0)
+        followup = FollowUp.objects.get(denial_id=self.denial)
+        self.assertFalse(followup.more_follow_up_requested)
+
+    def test_follow_up_again_checked_schedules_new_round(self):
+        self.client.post(self.path, data=self._payload(follow_up_again="on"))
+        # 1-day, 7-day, 30-day, 90-day = 4 scheduled rows
+        self.assertEqual(FollowUpSched.objects.filter(denial_id=self.denial).count(), 4)
+        followup = FollowUp.objects.get(denial_id=self.denial)
+        self.assertTrue(followup.more_follow_up_requested)
+
+    def test_invalid_secret_returns_500_error_page(self):
+        """Wrong secret must not allow submission. Currently the helper
+        raises which surfaces the generic error page; the important thing
+        is that no FollowUp row is written."""
+        bad_path = (
+            f"/v0/followup/{self.denial.uuid}/"
+            f"{self.denial.hashed_email}/not-the-real-sekret"
+        )
+        try:
+            response = self.client.get(bad_path)
+        except Exception:
+            response = None
+        # Either a 500 error page is rendered or an exception propagated;
+        # in both cases, no follow-up row is created.
+        self.assertEqual(FollowUp.objects.filter(denial_id=self.denial).count(), 0)
+        if response is not None:
+            self.assertIn(response.status_code, (200, 404, 500))
+
+    def test_no_documents_does_not_create_empty_document_rows(self):
+        """Regression: when the user uploads no files we should not write
+        empty FollowUpDocuments rows."""
+        self.client.post(self.path, data=self._payload())
+        self.assertEqual(
+            FollowUpDocuments.objects.filter(denial=self.denial).count(), 0
+        )
+
+
+class TestFollowUpHelper(TestCase):
+    """Direct unit tests of the helper, independent of the view."""
+
+    def setUp(self):
+        self.denial = _make_denial()
+
+    def test_fetch_denial_finds_denial(self):
+        found = FollowUpHelper.fetch_denial(
+            uuid=self.denial.uuid,
+            follow_up_semi_sekret=self.denial.follow_up_semi_sekret,
+            hashed_email=self.denial.hashed_email,
+        )
+        self.assertEqual(found.pk, self.denial.pk)
+
+    def test_fetch_denial_rejects_bad_sekret(self):
+        with self.assertRaises(Denial.DoesNotExist):
+            FollowUpHelper.fetch_denial(
+                uuid=self.denial.uuid,
+                follow_up_semi_sekret="bogus-sekret",
+                hashed_email=self.denial.hashed_email,
+            )
+
+    def test_store_follow_up_result_saves_all_fields(self):
+        FollowUpHelper.store_follow_up_result(
+            uuid=self.denial.uuid,
+            follow_up_semi_sekret=self.denial.follow_up_semi_sekret,
+            hashed_email=self.denial.hashed_email,
+            user_comments="Helpful tool!",
+            appeal_result="Yes",
+            follow_up_again=False,
+            medicare_someone_to_help=True,
+            email="me@example.com",
+            quote="It worked.",
+            name_for_quote="Pat",
+            use_quote=True,
+        )
+        followup = FollowUp.objects.get(denial_id=self.denial)
+        self.assertEqual(followup.user_comments, "Helpful tool!")
+        self.assertEqual(followup.appeal_result, "Yes")
+        self.assertEqual(followup.email, "me@example.com")
+        self.assertEqual(followup.quote, "It worked.")
+        self.assertEqual(followup.name_for_quote, "Pat")
+        self.assertTrue(followup.use_quote)
+        self.assertTrue(followup.follow_up_medicare_someone_to_help)
+
+    def test_store_follow_up_result_with_documents_filters_none(self):
+        """None entries (e.g. from MultipleFileField with no upload) must
+        not turn into empty FollowUpDocuments rows."""
+        FollowUpHelper.store_follow_up_result(
+            uuid=self.denial.uuid,
+            follow_up_semi_sekret=self.denial.follow_up_semi_sekret,
+            hashed_email=self.denial.hashed_email,
+            user_comments="",
+            appeal_result="",
+            follow_up_again=False,
+            followup_documents=[None],
+        )
+        self.assertEqual(
+            FollowUpDocuments.objects.filter(denial=self.denial).count(), 0
+        )
+
+    def test_store_follow_up_result_with_follow_up_again_schedules(self):
+        FollowUpHelper.store_follow_up_result(
+            uuid=self.denial.uuid,
+            follow_up_semi_sekret=self.denial.follow_up_semi_sekret,
+            hashed_email=self.denial.hashed_email,
+            user_comments="",
+            appeal_result="",
+            follow_up_again=True,
+        )
+        self.assertEqual(FollowUpSched.objects.filter(denial_id=self.denial).count(), 4)

--- a/tests/sync/test_form_validation.py
+++ b/tests/sync/test_form_validation.py
@@ -385,3 +385,59 @@ class TestFollowUpForm(TestCase):
         self.assertIn("uuid", form.errors)
         self.assertIn("follow_up_semi_sekret", form.errors)
         self.assertIn("hashed_email", form.errors)
+
+    def test_appeal_result_optional(self):
+        """appeal_result is optional and an empty value should be accepted."""
+        import uuid
+
+        form = FollowUpForm(
+            data={
+                "uuid": str(uuid.uuid4()),
+                "follow_up_semi_sekret": "sekret123",
+                "hashed_email": "hashed123",
+            }
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertEqual(form.cleaned_data["appeal_result"], "")
+
+    def test_invalid_appeal_result_choice_rejected(self):
+        """Values not in the choice list must be rejected."""
+        import uuid
+
+        form = FollowUpForm(
+            data={
+                "uuid": str(uuid.uuid4()),
+                "follow_up_semi_sekret": "sekret123",
+                "hashed_email": "hashed123",
+                "appeal_result": "TotallyMadeUpOption",
+            }
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("appeal_result", form.errors)
+
+    def test_full_payload_with_quote_and_comments(self):
+        """A submission with all optional text fields should validate."""
+        import uuid
+
+        form = FollowUpForm(
+            data={
+                "uuid": str(uuid.uuid4()),
+                "follow_up_semi_sekret": "sekret123",
+                "hashed_email": "hashed123",
+                "appeal_result": "Partial",
+                "user_comments": "It worked but only partially.",
+                "quote": "FHI helped me push back.",
+                "use_quote": "on",
+                "name_for_quote": "Jane Doe",
+                "email": "follow@example.com",
+                "follow_up_again": "on",
+                "medicare_someone_to_help": "on",
+            }
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        cleaned = form.cleaned_data
+        self.assertEqual(cleaned["user_comments"], "It worked but only partially.")
+        self.assertEqual(cleaned["appeal_result"], "Partial")
+        self.assertTrue(cleaned["use_quote"])
+        self.assertTrue(cleaned["follow_up_again"])
+        self.assertTrue(cleaned["medicare_someone_to_help"])


### PR DESCRIPTION
## Summary
This PR fixes several issues with the follow-up form submission and URL routing, including a URL pattern typo that caused crashes, missing field persistence, and form validation improvements.

## Key Changes

- **Fixed URL routing typo**: Corrected the URL pattern parameter name from `followup_semi_sekret` to `follow_up_semi_sekret` to match the view's expected kwarg, fixing crashes when accessing follow-up links with trailing slashes
- **Fixed field persistence**: Added missing `user_comments` and `appeal_result` fields to the `FollowUp` model creation in `store_follow_up_result()`, ensuring user input is properly saved
- **Improved form validation**: Added comprehensive tests for `FollowUpForm` including optional field handling, invalid choice rejection, and full payload validation
- **Enhanced document handling**: Added filtering to skip `None` entries from `MultipleFileField` uploads, preventing empty `FollowUpDocuments` rows from being created
- **Made helper parameters optional**: Updated `store_follow_up_result()` method signature to have sensible defaults (`user_comments=""`, `appeal_result=""`, `follow_up_again=False`)
- **Removed redundant code**: Eliminated unnecessary variable assignment and duplicate `save()` call in document creation

## Testing
- Added comprehensive end-to-end tests in `test_followup_view.py` covering URL routing variants, form submission, field persistence, and scheduling
- Added unit tests for `FollowUpHelper` class
- Added Selenium tests for trailing slash handling and field persistence
- Extended form validation tests with edge cases and full payload scenarios

## Notable Implementation Details
- The URL pattern now correctly handles email client quirks (trailing periods/slashes) without 404s or crashes
- The `appeal_result` field is now properly stored on both the `Denial` and `FollowUp` models
- Document upload filtering prevents database pollution from empty form submissions

https://claude.ai/code/session_014kALNVpYSTuYPh6wwr9wiF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end and integration tests covering follow-up form submission, validation, trailing-slash URL handling, persistence of comments/appeal selection, document uploads, and scheduling behavior.

* **Bug Fixes**
  * Follow-up submissions now reliably persist user comments and appeal selection; blank appeal selection is treated as pending.
  * Empty/blank uploaded documents are ignored so no empty entries are stored.
  * Scheduling now respects the “follow up again” choice.

* **Chores**
  * Made optional follow-up parameters default to sensible values.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fighthealthinsurance/fighthealthinsurance/pull/794)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->