### PR TITLE
Integrate USPSTF preventive-services recommendations into appeals

### DIFF
--- a/fighthealthinsurance/chat/tools/json_followup_tool.py
+++ b/fighthealthinsurance/chat/tools/json_followup_tool.py
@@ -38,10 +38,13 @@ class JsonFollowupTool(BaseTool):
       * ``build_followup_prompt`` — customize the prompt sent back to the LLM
       * ``append_note_to_context`` — when True, the raw note is also appended
         to the running context so downstream tools can reuse it.
+      * ``followup_context_summary`` — value passed as ``previous_context_summary``
+        to ``call_llm_callback`` when re-invoking the LLM. Defaults to empty.
     """
 
     detect_flags: int = re.DOTALL | re.IGNORECASE
     append_note_to_context: bool = False
+    followup_context_summary: str = ""
 
     def __init__(
         self,
@@ -141,7 +144,7 @@ class JsonFollowupTool(BaseTool):
             ) = await self.call_llm_callback(
                 model_backends,
                 self.build_followup_prompt(note, current_message_for_llm),
-                "",
+                self.followup_context_summary,
                 history_for_llm,
                 depth=depth + 1,
                 is_logged_in=is_logged_in,

--- a/fighthealthinsurance/chat/tools/uspstf_tool.py
+++ b/fighthealthinsurance/chat/tools/uspstf_tool.py
@@ -34,6 +34,7 @@ class USPSTFLookupTool(JsonFollowupTool):
     # output is appended — the LLM-targeted instruction text lives in
     # ``build_followup_prompt`` so it doesn't bloat downstream prompts.
     append_note_to_context: bool = True
+    followup_context_summary: str = "USPSTF preventive-services lookup"
 
     async def run(
         self, params: dict, *, current_message_for_llm: str = ""

--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -2557,6 +2557,7 @@ class AppealsBackendHelper:
         nice_context: Optional[str] = None
         imr_context: Optional[str] = None
         pa_context: Optional[str] = None
+        uspstf_context: Optional[str] = None
 
         # Get PubMed context
         logger.debug("Looking up the pubmed context")
@@ -2682,6 +2683,24 @@ class AppealsBackendHelper:
                 done_msg="Payer PA requirements lookup complete",
             )
 
+            # Look up USPSTF preventive-services recommendations for any
+            # preventive-care codes (e.g., screening colonoscopy, mammogram,
+            # vaccines) referenced in the denial. A/B graded services trigger
+            # ACA cost-sharing protections, which is the appeal angle. Cheap
+            # synchronous ORM call against the cached recommendation table.
+            from fighthealthinsurance.uspstf_api import (
+                get_uspstf_context_for_denial,
+            )
+
+            uspstf_context_awaitable = tracked_awaitable(
+                asyncio.wait_for(
+                    sync_to_async(get_uspstf_context_for_denial)(denial),
+                    timeout=10,
+                ),
+                substep="uspstf",
+                done_msg="USPSTF preventive-services lookup complete",
+            )
+
             # Skip the NICE task entirely when no key is configured: avoids a
             # misleading "NICE guidance lookup complete" status and the wait_for
             # overhead in environments without syndication access.
@@ -2691,6 +2710,7 @@ class AppealsBackendHelper:
                 rag_context_awaitable,
                 imr_context_awaitable,
                 pa_context_awaitable,
+                uspstf_context_awaitable,
             ]
             if cls.nice.api_key:
                 gather_awaitables.append(
@@ -2744,8 +2764,11 @@ class AppealsBackendHelper:
                 if isinstance(results[4], str) and results[4]:
                     pa_context = results[4]
                     logger.info("Payer PA requirements context retrieved")
-                if len(results) > 5 and isinstance(results[5], str):
-                    nice_context = results[5]
+                if isinstance(results[5], str) and results[5]:
+                    uspstf_context = results[5]
+                    logger.info("USPSTF preventive-services context retrieved")
+                if len(results) > 6 and isinstance(results[6], str):
+                    nice_context = results[6]
                 else:
                     # No fresh NICE result (skipped task or non-string error). Fall
                     # back to whatever is already persisted on the denial so cached
@@ -2786,6 +2809,22 @@ class AppealsBackendHelper:
                         f"PA context refresh during fallback failed: {inner}"
                     )
                     pa_context = None
+                # USPSTF context isn't persisted; re-run the cheap ORM query so
+                # retries don't drop preventive-services recommendations either.
+                try:
+                    from fighthealthinsurance.uspstf_api import (
+                        get_uspstf_context_for_denial,
+                    )
+
+                    uspstf_context = (
+                        await sync_to_async(get_uspstf_context_for_denial)(denial)
+                        or None
+                    )
+                except Exception as inner:
+                    logger.opt(exception=True).debug(
+                        f"USPSTF context refresh during fallback failed: {inner}"
+                    )
+                    uspstf_context = None
                 logger.debug("Used saved contexts")
         else:
             logger.debug("Too many retries, skipping ML/pubmed/RAG ctx")
@@ -2807,6 +2846,21 @@ class AppealsBackendHelper:
                     f"PA context refresh on retry failed: {e}"
                 )
                 pa_context = None
+            # USPSTF lookup is the same shape — cheap ORM against the cached
+            # recommendation table — so re-run it on retries too.
+            try:
+                from fighthealthinsurance.uspstf_api import (
+                    get_uspstf_context_for_denial,
+                )
+
+                uspstf_context = (
+                    await sync_to_async(get_uspstf_context_for_denial)(denial) or None
+                )
+            except Exception as e:
+                logger.opt(exception=True).debug(
+                    f"USPSTF context refresh on retry failed: {e}"
+                )
+                uspstf_context = None
             yield json.dumps(
                 {
                     "type": "status",
@@ -2907,6 +2961,7 @@ class AppealsBackendHelper:
             nice_context=nice_context,
             specialized_templates=specialized_templates,
             pa_context=pa_context,
+            uspstf_context=uspstf_context,
         )
         # Only filters out None
         filtered_appeals: Iterator[str] = filter(lambda x: x != None, appeals)

--- a/fighthealthinsurance/generate_appeal.py
+++ b/fighthealthinsurance/generate_appeal.py
@@ -1272,6 +1272,7 @@ class AppealGenerator(object):
         ucr_context=None,
         payer_policy_context=None,
         pa_context=None,
+        uspstf_context=None,
         medication_context=None,
     ) -> Optional[str]:
         """
@@ -1351,6 +1352,12 @@ class AppealGenerator(object):
                 "are not listed below.\n"
                 f"{pa_context}"
             )
+        if uspstf_context is not None and uspstf_context.strip():
+            # USPSTF context is preventive-services guidance. A/B-graded
+            # services trigger the ACA cost-sharing mandate, which is the
+            # primary appeal angle for preventive-care denials. The header
+            # block already carries the "only cite A/B for ACA" caveat.
+            base = f"{base}\n\n{uspstf_context}"
         # Add citation instructions - be explicit about not hallucinating
         has_citations = (
             (ml_context is not None and ml_context != "")
@@ -1513,6 +1520,7 @@ class AppealGenerator(object):
         payer_policy_context=None,
         specialized_templates: Optional[List[type[SpecializedDenialTemplate]]] = None,
         pa_context=None,
+        uspstf_context=None,
     ) -> Iterator[str]:
         """
         Generates an iterator of appeal texts for a given insurance denial using templates, non-AI sources, and AI models.
@@ -1603,6 +1611,7 @@ class AppealGenerator(object):
             ucr_context=ucr_narrative,
             payer_policy_context=payer_policy_context,
             pa_context=pa_context,
+            uspstf_context=uspstf_context,
             medication_context=medication_context,
         )
         open_medically_necessary_prompt = self.make_open_med_prompt(

--- a/fighthealthinsurance/generate_appeal.py
+++ b/fighthealthinsurance/generate_appeal.py
@@ -1352,18 +1352,17 @@ class AppealGenerator(object):
                 "are not listed below.\n"
                 f"{pa_context}"
             )
-        if uspstf_context is not None and uspstf_context.strip():
-            # USPSTF context is preventive-services guidance. A/B-graded
-            # services trigger the ACA cost-sharing mandate, which is the
-            # primary appeal angle for preventive-care denials. The header
-            # block already carries the "only cite A/B for ACA" caveat.
-            base = f"{base}\n\n{uspstf_context}"
-        # Add citation instructions - be explicit about not hallucinating
+        # Add citation instructions - be explicit about not hallucinating.
+        # USPSTF is included in the citation set because its header explicitly
+        # asks the model to cite the recommendation/URL; placing it below the
+        # "may ONLY cite references provided below" instruction keeps that
+        # guidance consistent.
         has_citations = (
             (ml_context is not None and ml_context != "")
             or (pubmed_context is not None and pubmed_context != "")
             or (rag_context is not None and rag_context != "")
             or (nice_context is not None and nice_context != "")
+            or (uspstf_context is not None and uspstf_context != "")
         )
         if has_citations:
             base = f"{base}\n\nCITATION INSTRUCTIONS: You may ONLY cite medical literature, studies, or references that are explicitly provided below. Do NOT invent, fabricate, or hallucinate any citations, PMIDs, journal names, author names, or study details. If you want to make a medical claim, either cite from the provided references or state it as general medical knowledge without a specific citation."
@@ -1378,6 +1377,11 @@ class AppealGenerator(object):
                 # (see INTERNATIONAL_GUIDANCE_CAVEAT in nice_tools); the header
                 # here is just a section label.
                 base = f"{base}\n\nNICE (UK) guidance:\n{nice_context}"
+            if uspstf_context is not None and uspstf_context != "":
+                # The header inside ``uspstf_context`` already explains the
+                # ACA cost-sharing angle and the A/B-only caveat, so no extra
+                # section label is needed here.
+                base = f"{base}\n\n{uspstf_context}"
         else:
             # No citations provided - explicitly tell the model not to make any up
             base = f"{base}\n\nIMPORTANT: No specific medical citations have been provided. Do NOT invent or hallucinate any citations, PMIDs, journal names, or study references. You may state general medical knowledge without citations, but do not fabricate specific study references."

--- a/fighthealthinsurance/uspstf_api.py
+++ b/fighthealthinsurance/uspstf_api.py
@@ -730,12 +730,78 @@ def get_uspstf_info(query: Dict[str, Any]) -> str:
     return intro + "\n\n".join(blocks)
 
 
+# Header used on the formatted USPSTF context block injected into appeal
+# prompts. Kept as a module-level constant so the appeal-prompt builder and
+# tests can reference the exact text without duplicating it.
+USPSTF_APPEAL_CONTEXT_HEADER = (
+    "USPSTF preventive-service recommendations relevant to this denial. "
+    "Under the ACA, non-grandfathered private plans, the marketplace, and "
+    "Medicaid expansion populations generally must cover Grade A or B "
+    "preventive services without cost-sharing. Cite the specific "
+    "recommendation (title, grade, source URL) when arguing this point; "
+    "do not assert ACA coverage for non-A/B services."
+)
+
+
+def get_uspstf_context_for_denial(denial: Any) -> str:
+    """Compute a USPSTF preventive-services context block for a denial.
+
+    Extracts CPT/HCPCS and ICD-10 codes from the denial's text fields, maps
+    them to USPSTF topics via :func:`find_recommendations_for_codes`, and
+    returns a formatted context string suitable for inclusion in an appeal
+    prompt. Returns an empty string when no preventive codes are present
+    or no matching recommendations are found.
+
+    This is the appeal-generation counterpart to :func:`get_uspstf_info`,
+    which is wired into the chat surface. It runs as a cheap synchronous
+    ORM lookup wrapped via ``sync_to_async`` in the gather block.
+    """
+    from fighthealthinsurance.medical_code_extractor import (
+        extract_icd10_codes,
+        extract_procedure_codes,
+    )
+
+    sources: List[str] = []
+    for value in (
+        getattr(denial, "denial_text", None),
+        getattr(denial, "procedure", None),
+        getattr(denial, "diagnosis", None),
+        getattr(denial, "candidate_procedure", None),
+        getattr(denial, "verified_procedure", None),
+        getattr(denial, "candidate_diagnosis", None),
+        getattr(denial, "verified_diagnosis", None),
+    ):
+        if value:
+            sources.append(str(value))
+    if not sources:
+        return ""
+
+    combined = "\n".join(sources)
+    codes = extract_procedure_codes(combined) | extract_icd10_codes(combined)
+    if not codes:
+        return ""
+
+    try:
+        recs = find_recommendations_for_codes(codes, limit=5)
+    except Exception as e:
+        logger.opt(exception=True).debug(f"USPSTF context lookup failed: {e}")
+        return ""
+
+    if not recs:
+        return ""
+
+    blocks = [format_recommendation(r) for r in recs]
+    return USPSTF_APPEAL_CONTEXT_HEADER + "\n\n" + "\n\n".join(blocks)
+
+
 __all__ = [
     "DEFAULT_API_URL",
     "FALLBACK_RECOMMENDATIONS",
     "USPSTFClient",
+    "USPSTF_APPEAL_CONTEXT_HEADER",
     "find_recommendations_for_codes",
     "format_recommendation",
+    "get_uspstf_context_for_denial",
     "get_uspstf_info",
     "search_recommendations",
 ]

--- a/tests/async-unit/test_appeals_backend_citations.py
+++ b/tests/async-unit/test_appeals_backend_citations.py
@@ -69,18 +69,26 @@ def _make_empty_proposed_appeal_query():
     return mock_queryset
 
 
-def _sync_to_async_router(pa_wrapper, make_appeals_wrapper):
+def _sync_to_async_router(pa_wrapper, make_appeals_wrapper, uspstf_wrapper=None):
     """
-    Build a side_effect for the patched ``sync_to_async`` so the PA-context
-    lookup and the make_appeals call each route to their own AsyncMock.
+    Build a side_effect for the patched ``sync_to_async`` so the PA-context,
+    USPSTF-context, and make_appeals calls each route to their own AsyncMock.
     Unexpected call sites raise so a future production change can't quietly
     funnel its sync_to_async target through the make_appeals mock.
+
+    ``uspstf_wrapper`` defaults to an AsyncMock returning ``""`` (no
+    matching preventive recommendations) so tests that don't care about
+    the USPSTF integration don't have to wire it up.
     """
+    if uspstf_wrapper is None:
+        uspstf_wrapper = AsyncMock(return_value="")
 
     def route(fn, *args, **kwargs):
         name = getattr(fn, "__name__", "") or repr(fn)
         if "get_pa_context_for_denial" in name:
             return pa_wrapper
+        if "get_uspstf_context_for_denial" in name:
+            return uspstf_wrapper
         if "make_appeals" in name:
             return make_appeals_wrapper
         raise AssertionError(
@@ -355,3 +363,87 @@ class TestAppealsBackendHelperWithCitations:
             call_kwargs = mock_make_appeals_wrapper.call_args[1]
             assert call_kwargs["pubmed_context"] == "PubMed context data"
             assert call_kwargs["ml_citations_context"] == "ML Citation 1"
+
+    @pytest.mark.asyncio
+    async def test_uspstf_context_passed_to_make_appeals(self):
+        """USPSTF context from the gather block is threaded into make_appeals.
+
+        Mirrors the PA-context routing pattern: a stub
+        ``get_uspstf_context_for_denial`` returns a known string and we
+        verify it shows up as the ``uspstf_context`` kwarg on make_appeals.
+        """
+        mock_denial = _make_mock_denial()
+        mock_denial_query = _make_mock_denial_query(mock_denial)
+
+        parameters = {
+            "denial_id": "12345",
+            "email": "test@example.com",
+            "semi_sekret": "test-secret",
+        }
+
+        uspstf_payload = (
+            "USPSTF preventive-service recommendations relevant to this denial."
+        )
+
+        with (
+            patch(
+                "fighthealthinsurance.common_view_logic.Denial.objects.filter",
+                return_value=mock_denial_query,
+            ),
+            patch(
+                "fighthealthinsurance.common_view_logic.Denial.get_hashed_email",
+                return_value="hashed",
+            ),
+            patch.object(
+                AppealsBackendHelper,
+                "regex_denial_processor",
+            ) as mock_regex_processor,
+            patch(
+                "fighthealthinsurance.common_view_logic.MLCitationsHelper.generate_citations_for_denial",
+                new_callable=AsyncMock,
+                return_value="ML Citation 1",
+            ),
+            patch.object(
+                AppealsBackendHelper.pmt,
+                "find_context_for_denial",
+                new_callable=AsyncMock,
+                return_value="PubMed context data",
+            ),
+            patch(
+                "fighthealthinsurance.common_view_logic.sync_to_async",
+            ) as mock_sync_to_async,
+            patch(
+                "fighthealthinsurance.common_view_logic.interleave_iterator_for_keep_alive",
+            ) as mock_interleave,
+            patch(
+                "fighthealthinsurance.common_view_logic.ProposedAppeal",
+            ) as mock_proposed_appeal_cls,
+        ):
+            mock_regex_processor.get_appeal_templates = AsyncMock(return_value=[])
+
+            mock_make_appeals_wrapper = AsyncMock(
+                return_value=["Appeal with USPSTF context"]
+            )
+            mock_pa_wrapper = AsyncMock(return_value="")
+            mock_uspstf_wrapper = AsyncMock(return_value=uspstf_payload)
+            mock_sync_to_async.side_effect = _sync_to_async_router(
+                mock_pa_wrapper, mock_make_appeals_wrapper, mock_uspstf_wrapper
+            )
+
+            mock_pa_instance = MagicMock()
+            mock_pa_instance.id = 1
+            mock_pa_instance.asave = AsyncMock()
+            mock_proposed_appeal_cls.return_value = mock_pa_instance
+
+            mock_proposed_appeal_cls.objects.filter.return_value = (
+                _make_empty_proposed_appeal_query()
+            )
+
+            mock_interleave.side_effect = passthrough_interleave
+
+            async for _ in AppealsBackendHelper.generate_appeals(parameters):
+                pass
+
+            mock_make_appeals_wrapper.assert_called_once()
+            call_kwargs = mock_make_appeals_wrapper.call_args[1]
+            assert call_kwargs["uspstf_context"] == uspstf_payload

--- a/tests/sync/test_chat_tools.py
+++ b/tests/sync/test_chat_tools.py
@@ -643,3 +643,7 @@ class TestUSPSTFLookupTool(TestCase):
         self.assertIn("LLM expanded reply", response)
         # Raw lookup is also included in the context.
         self.assertIn("Diabetes", context)
+        # ``previous_context_summary`` (3rd positional arg) must identify the
+        # lookup so the LLM follow-up call gets the correct provenance label.
+        call_args = callback.call_args
+        self.assertEqual(call_args.args[2], "USPSTF preventive-services lookup")

--- a/tests/sync/test_uspstf_api.py
+++ b/tests/sync/test_uspstf_api.py
@@ -7,11 +7,13 @@ from django.test import TestCase
 from fighthealthinsurance.models import USPSTFRecommendation
 from fighthealthinsurance.uspstf_api import (
     FALLBACK_RECOMMENDATIONS,
+    USPSTF_APPEAL_CONTEXT_HEADER,
     _coerce_record,
     _extract_records,
     _normalize_grade,
     find_recommendations_for_codes,
     format_recommendation,
+    get_uspstf_context_for_denial,
     get_uspstf_info,
     search_recommendations,
 )
@@ -281,3 +283,98 @@ class SyncRecommendationsTests(TestCase):
 
         self.assertEqual(count, len(FALLBACK_RECOMMENDATIONS))
         self.assertGreater(USPSTFRecommendation.objects.count(), 0)
+
+
+class _StubDenial:
+    """Minimal duck-typed stand-in for a Denial used in helper tests."""
+
+    def __init__(self, **kwargs):
+        # Default every field the helper inspects to None so tests only
+        # populate the ones they care about.
+        for field in (
+            "denial_text",
+            "procedure",
+            "diagnosis",
+            "candidate_procedure",
+            "verified_procedure",
+            "candidate_diagnosis",
+            "verified_diagnosis",
+        ):
+            setattr(self, field, None)
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+class GetUSPSTFContextForDenialTests(TestCase):
+    """``get_uspstf_context_for_denial`` is the appeal-flow entry point."""
+
+    def test_returns_empty_when_no_text_fields(self):
+        self.assertEqual(get_uspstf_context_for_denial(_StubDenial()), "")
+
+    def test_returns_empty_when_no_codes_in_text(self):
+        denial = _StubDenial(denial_text="generic denial with no codes whatsoever")
+        self.assertEqual(get_uspstf_context_for_denial(denial), "")
+
+    def test_returns_context_for_screening_colonoscopy_cpt(self):
+        """A CPT for screening colonoscopy should pull in the colorectal rec."""
+        denial = _StubDenial(
+            denial_text="Claim for CPT 45378 denied as not medically necessary."
+        )
+        result = get_uspstf_context_for_denial(denial)
+        self.assertIn(USPSTF_APPEAL_CONTEXT_HEADER, result)
+        self.assertIn("colorectal", result.lower())
+
+    def test_returns_context_for_icd10_screening_diagnosis(self):
+        """A dotted ICD-10 screening code in the diagnosis field also triggers."""
+        denial = _StubDenial(
+            denial_text="Routine screening claim denied.",
+            diagnosis="Z12.11",
+        )
+        result = get_uspstf_context_for_denial(denial)
+        self.assertIn(USPSTF_APPEAL_CONTEXT_HEADER, result)
+        self.assertIn("colorectal", result.lower())
+
+    def test_returns_empty_when_code_unrelated_to_preventive_services(self):
+        """A non-preventive procedure code yields no USPSTF context."""
+        denial = _StubDenial(denial_text="CPT 27447 (knee arthroplasty) denied.")
+        self.assertEqual(get_uspstf_context_for_denial(denial), "")
+
+
+class MakeOpenPromptIncludesUSPSTFContextTests(TestCase):
+    """Verify the appeal-generation prompt picks up uspstf_context.
+
+    Mirrors the PA-context coverage in test_pa_requirements.py — the
+    parallel case for the preventive-services lookup.
+    """
+
+    def test_make_open_prompt_includes_uspstf_context_block(self):
+        from fighthealthinsurance.generate_appeal import AppealGenerator
+
+        generator = AppealGenerator()
+        prompt = generator.make_open_prompt(
+            denial_text="Insurer denied screening colonoscopy.",
+            procedure="Screening colonoscopy",
+            diagnosis="Z12.11",
+            insurance_company="ExamplePayer",
+            uspstf_context=(
+                f"{USPSTF_APPEAL_CONTEXT_HEADER}\n\n"
+                "Colorectal Cancer: Screening (Grade A)"
+            ),
+        )
+        self.assertIsNotNone(prompt)
+        assert prompt is not None
+        self.assertIn("USPSTF preventive-service recommendations", prompt)
+        self.assertIn("Colorectal Cancer: Screening (Grade A)", prompt)
+
+    def test_make_open_prompt_omits_uspstf_block_when_empty(self):
+        from fighthealthinsurance.generate_appeal import AppealGenerator
+
+        generator = AppealGenerator()
+        prompt = generator.make_open_prompt(
+            denial_text="Insurer denied screening colonoscopy.",
+            insurance_company="ExamplePayer",
+            uspstf_context="",
+        )
+        self.assertIsNotNone(prompt)
+        assert prompt is not None
+        self.assertNotIn("USPSTF preventive-service recommendations", prompt)


### PR DESCRIPTION
## Summary
This PR adds USPSTF (U.S. Preventive Services Task Force) preventive-services recommendations to the appeal generation flow. When a denial involves preventive-care codes (e.g., screening colonoscopy, mammograms), the system now extracts relevant USPSTF guidance and includes it in the appeal prompt to strengthen arguments around ACA cost-sharing protections for Grade A/B services.

## Key Changes

- **New `get_uspstf_context_for_denial()` function** in `uspstf_api.py`: Extracts CPT/HCPCS and ICD-10 codes from denial fields, maps them to USPSTF recommendations, and returns a formatted context block. Returns empty string when no preventive codes are found.

- **USPSTF context header constant**: Added `USPSTF_APPEAL_CONTEXT_HEADER` to provide consistent messaging about ACA coverage requirements and guidance on citing only Grade A/B services.

- **Appeal generation integration** in `common_view_logic.py`:
  - Added `uspstf_context` to the gather block alongside PA and RAG contexts
  - Wrapped `get_uspstf_context_for_denial()` with `sync_to_async` for async execution
  - Implemented retry logic to re-run the cheap ORM query on fallback/retry paths (similar to PA context handling)
  - Threaded `uspstf_context` through to `make_appeals()`

- **Prompt integration** in `generate_appeal.py`:
  - Updated `make_open_prompt()` to accept and conditionally include `uspstf_context`
  - Updated `make_appeals()` signature to accept and pass through `uspstf_context`
  - Context is only included when non-empty, avoiding unnecessary prompt bloat

- **Chat tool updates** in `json_followup_tool.py` and `uspstf_tool.py`:
  - Added `followup_context_summary` parameter to `JsonFollowupTool` for proper LLM callback labeling
  - Configured `USPSTFLookupTool` to use "USPSTF preventive-services lookup" as the context summary

- **Comprehensive test coverage**:
  - Updated `_sync_to_async_router()` test helper to route USPSTF context lookups
  - Added `test_uspstf_context_passed_to_make_appeals()` to verify end-to-end integration
  - Added `GetUSPSTFContextForDenialTests` covering code extraction and empty cases
  - Added `MakeOpenPromptIncludesUSPSTFContextTests` to verify prompt inclusion logic

## Implementation Details

- The USPSTF lookup is a synchronous ORM query against the cached recommendation table, making it cheap enough to run on every appeal attempt (including retries)
- Context is only included in prompts when non-empty, maintaining clean output for non-preventive denials
- The implementation mirrors the existing PA context pattern for consistency
- Error handling gracefully degrades to empty context on lookup failures, preventing appeal generation from failing

https://claude.ai/code/session_01JJ4oFZyZafRbwJmUdVmvG6