### PR TITLE
Add Django caching layer for PubMed API calls

### DIFF
--- a/fighthealthinsurance/pubmed_tools.py
+++ b/fighthealthinsurance/pubmed_tools.py
@@ -476,14 +476,19 @@ class PubMedTools(object):
                         continue
                     if article_ids:
                         return article_ids
-                    # Empty result -> only honor as a cache hit inside the
-                    # shorter negative-cache window. Past that, fall through
-                    # and re-query NCBI in case new articles were indexed.
+                    # The most recent informative row is an empty result.
+                    # Honor it as a cache hit inside the shorter negative-
+                    # cache window.
                     if (
                         query_data.created is not None
                         and query_data.created >= neg_cache_cutoff
                     ):
                         return []
+                    # Stale empty: the newest signal says "no hits", but it
+                    # is past the negative-cache window. Don't fall back to
+                    # an even-older non-empty row — that would serve PMIDs
+                    # we already know are no longer matching. Re-query NCBI.
+                    break
 
                 # If no cache or cache error, fetch from PubMed API
                 logger.debug(f"Querying pubmed for query {query}")

--- a/fighthealthinsurance/pubmed_tools.py
+++ b/fighthealthinsurance/pubmed_tools.py
@@ -1,19 +1,21 @@
 import asyncio
 import io
 import json
+import os
 import re
 import sys
 import tempfile
 import xml.etree.ElementTree as ET
 from contextlib import asynccontextmanager
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import Any, AsyncIterator, Dict, List, Optional, Set, Tuple
 from urllib.parse import quote, urlencode, urljoin
 
 import aiohttp
-import eutils
 import PyPDF2
 from asgiref.sync import async_to_sync, sync_to_async
+from django.core.cache import cache
+from django.utils import timezone
 from loguru import logger
 from metapub import FindIt
 
@@ -61,14 +63,33 @@ _FETCH_HEADERS = {
 # efetch (MeSH terms / publication types). NCBI requests that ``tool`` and
 # ``email`` be supplied per their usage guidelines.
 _EUTILS_BASE = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils"
-_EUTILS_PARAMS = {
+# When NCBI_API_KEY is set, NCBI raises per-IP limits from 3 -> 10 req/s for
+# both metapub and direct E-utilities calls.
+_NCBI_API_KEY = os.environ.get("NCBI_API_KEY") or None
+_EUTILS_PARAMS: Dict[str, str] = {
     "tool": _TOOL_NAME,
     "email": _CONTACT_EMAIL,
 }
+if _NCBI_API_KEY:
+    _EUTILS_PARAMS["api_key"] = _NCBI_API_KEY
 
 # NCBI documents 200 IDs as the practical limit for an efetch GET; chunk to
 # stay well under URL-length caps regardless of caller-supplied list size.
 _EFETCH_BATCH_SIZE = 200
+
+# MeSH terms and publication types are effectively immutable once an article
+# is indexed; elink "related" sets drift only as new articles are published.
+# A 7-day TTL keeps NCBI off the hot path without staying out of date for
+# the appeal use-case.
+_EFETCH_CACHE_TTL_SECONDS = 7 * 24 * 60 * 60
+_ELINK_CACHE_TTL_SECONDS = 7 * 24 * 60 * 60
+_EFETCH_CACHE_PREFIX = "pubmed:efetch:meshpub:"
+_ELINK_CACHE_PREFIX = "pubmed:elink:related:"
+
+# Negative-cache window for queries that legitimately return no PMIDs. Kept
+# shorter than the 30-day positive cache because absence is more volatile
+# than presence (new articles get indexed).
+_EMPTY_QUERY_NEGCACHE_DAYS = 2
 
 
 @asynccontextmanager
@@ -429,8 +450,11 @@ class PubMedTools(object):
 
         try:
             async with async_timeout(timeout):
-                # Check if we already have query results from the last month
-                month_ago = datetime.now() - timedelta(days=30)
+                # Use timezone-aware "now" so comparisons against the DB's
+                # tz-aware ``created`` field work without raising.
+                now = timezone.now()
+                month_ago = now - timedelta(days=30)
+                neg_cache_cutoff = now - timedelta(days=_EMPTY_QUERY_NEGCACHE_DAYS)
                 existing_queries = PubMedQueryData.objects.filter(
                     query=query,
                     created__gte=month_ago,
@@ -438,20 +462,28 @@ class PubMedTools(object):
                     denial_id__isnull=True,
                 ).order_by("-created")
 
-                if await existing_queries.aexists():
-                    # Use cached query results
-                    async for query_data in existing_queries:
-                        if query_data.articles:
-                            try:
-                                article_ids: list[str] = json.loads(
-                                    query_data.articles.replace("\x00", "")
-                                )
-                                if article_ids:
-                                    return article_ids
-                            except json.JSONDecodeError:
-                                logger.error(
-                                    f"Error parsing cached articles JSON for {query}"
-                                )
+                async for query_data in existing_queries:
+                    if not query_data.articles:
+                        # Legacy row with NULL/empty payload: treat as miss
+                        # rather than risk an unbounded negative cache.
+                        continue
+                    try:
+                        article_ids: list[str] = json.loads(
+                            query_data.articles.replace("\x00", "")
+                        )
+                    except json.JSONDecodeError:
+                        logger.error(f"Error parsing cached articles JSON for {query}")
+                        continue
+                    if article_ids:
+                        return article_ids
+                    # Empty result -> only honor as a cache hit inside the
+                    # shorter negative-cache window. Past that, fall through
+                    # and re-query NCBI in case new articles were indexed.
+                    if (
+                        query_data.created is not None
+                        and query_data.created >= neg_cache_cutoff
+                    ):
+                        return []
 
                 # If no cache or cache error, fetch from PubMed API
                 logger.debug(f"Querying pubmed for query {query}")
@@ -459,15 +491,18 @@ class PubMedTools(object):
                     query, since=since
                 )
                 logger.debug(f"Got back initial pmids {pmids}")
-                if pmids and len(pmids) > 0:
-                    # Sometimes we get nulls...
-                    articles_json = json.dumps(pmids).replace("\x00", "")
-                    await PubMedQueryData.objects.acreate(
-                        query=query,
-                        since=since,
-                        articles=articles_json,
-                    )
-                    return pmids
+                # Reaching this line means metapub returned without raising:
+                # safe to persist whatever it returned (including []) so the
+                # next caller gets a cheap negative-cache hit for a couple of
+                # days. We only skip the write on timeout/cancel/error below.
+                pmids = pmids or []
+                articles_json = json.dumps(pmids).replace("\x00", "")
+                await PubMedQueryData.objects.acreate(
+                    query=query,
+                    since=since,
+                    articles=articles_json,
+                )
+                return pmids
         except asyncio.TimeoutError as e:
             # We might timeout
             logger.opt(exception=True).debug(
@@ -505,12 +540,31 @@ class PubMedTools(object):
             return {}
 
         result: Dict[str, Dict[str, List[str]]] = {}
+
+        # Per-PMID cache lookup; only the misses go to NCBI.
+        cache_keys = {p: f"{_EFETCH_CACHE_PREFIX}{p}" for p in pmids}
+        try:
+            cached = await cache.aget_many(list(cache_keys.values()))
+        except Exception as e:
+            logger.opt(exception=True).debug(f"efetch cache read failed: {e}")
+            cached = {}
+        misses: List[str] = []
+        for pmid in pmids:
+            hit = cached.get(cache_keys[pmid])
+            if hit is not None:
+                result[pmid] = hit
+            else:
+                misses.append(pmid)
+        if not misses:
+            return result
+
+        fresh: Dict[str, Dict[str, List[str]]] = {}
         url = f"{_EUTILS_BASE}/efetch.fcgi"
         try:
             async with _ensure_session(session) as s:
                 async with async_timeout(timeout):
-                    for i in range(0, len(pmids), batch_size):
-                        batch = pmids[i : i + batch_size]
+                    for i in range(0, len(misses), batch_size):
+                        batch = misses[i : i + batch_size]
                         params = {
                             **_EUTILS_PARAMS,
                             "db": "pubmed",
@@ -525,13 +579,23 @@ class PubMedTools(object):
                                 )
                                 continue
                             body = await resp.text()
-                        self._merge_efetch_xml_into(body, result)
+                        self._merge_efetch_xml_into(body, fresh)
         except asyncio.CancelledError:
             raise
         except asyncio.TimeoutError as e:
             logger.debug(f"Timeout in fetch_mesh_and_pub_types: {e}")
         except Exception as e:
             logger.opt(exception=True).debug(f"Error in fetch_mesh_and_pub_types: {e}")
+
+        result.update(fresh)
+        if fresh:
+            try:
+                await cache.aset_many(
+                    {_EFETCH_CACHE_PREFIX + p: row for p, row in fresh.items()},
+                    timeout=_EFETCH_CACHE_TTL_SECONDS,
+                )
+            except Exception as e:
+                logger.opt(exception=True).debug(f"efetch cache write failed: {e}")
         return result
 
     @staticmethod
@@ -579,6 +643,15 @@ class PubMedTools(object):
         if not pmid:
             return []
 
+        cache_key = f"{_ELINK_CACHE_PREFIX}{pmid}:{max_results}"
+        try:
+            cached = await cache.aget(cache_key)
+        except Exception as e:
+            logger.opt(exception=True).debug(f"elink cache read failed: {e}")
+            cached = None
+        if cached is not None:
+            return list(cached)
+
         related: List[str] = []
         params = {
             **_EUTILS_PARAMS,
@@ -589,6 +662,9 @@ class PubMedTools(object):
             "retmode": "json",
         }
         url = f"{_EUTILS_BASE}/elink.fcgi"
+        # Only cache when the call completed without error; on timeout/network
+        # failure we want the next caller to retry rather than serve stale "[]".
+        successful = False
         try:
             async with _ensure_session(session) as s:
                 async with async_timeout(timeout):
@@ -605,7 +681,12 @@ class PubMedTools(object):
                         if related_id_str != pmid and related_id_str not in related:
                             related.append(related_id_str)
                         if len(related) >= max_results:
-                            return related
+                            break
+                    if len(related) >= max_results:
+                        break
+                if len(related) >= max_results:
+                    break
+            successful = True
         except asyncio.CancelledError:
             raise
         except asyncio.TimeoutError as e:
@@ -614,6 +695,12 @@ class PubMedTools(object):
             logger.opt(exception=True).debug(
                 f"Error in find_related_pmids({pmid}): {e}"
             )
+
+        if successful:
+            try:
+                await cache.aset(cache_key, related, timeout=_ELINK_CACHE_TTL_SECONDS)
+            except Exception as e:
+                logger.opt(exception=True).debug(f"elink cache write failed: {e}")
         return related
 
     async def structured_search(

--- a/fighthealthinsurance/utils.py
+++ b/fighthealthinsurance/utils.py
@@ -45,7 +45,13 @@ from requests.exceptions import RequestException
 from fighthealthinsurance.email_utils import is_blocked_email
 from fighthealthinsurance.env_utils import *
 
-pubmed_fetcher = PubMedFetcher()
+# NCBI raises the rate limit from 3 -> 10 requests/second when an API key
+# is supplied. metapub also reads this env var on its own, but pass it
+# explicitly so the source of truth is visible.
+_NCBI_API_KEY = os.environ.get("NCBI_API_KEY") or None
+pubmed_fetcher = (
+    PubMedFetcher(api_key=_NCBI_API_KEY) if _NCBI_API_KEY else PubMedFetcher()
+)
 
 
 class RateLimiter:

--- a/tests/async-unit/test_pubmed_search.py
+++ b/tests/async-unit/test_pubmed_search.py
@@ -847,3 +847,144 @@ class StructuredSearchE2ETest(TransactionTestCase):
             # Both the seed and the related PMID should appear.
             assert "11111111" in all_pmids
             assert "22222222" in all_pmids
+
+
+# ---------------------------------------------------------------------------
+# Django-cache layer on efetch / elink
+#
+# The test config defaults to DummyCache (so test responses retain their
+# context), so cache assertions are scoped to a LocMemCache override per
+# test below.
+# ---------------------------------------------------------------------------
+
+
+_LOCMEM_CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "pubmed-test",
+    }
+}
+
+
+@pytest.mark.asyncio
+async def test_fetch_mesh_and_pub_types_serves_second_call_from_cache():
+    from django.core.cache import cache
+    from django.test.utils import override_settings
+
+    with override_settings(CACHES=_LOCMEM_CACHES):
+        # LocMemCache is keyed on backend instance, so we re-resolve it via
+        # the proxy to pick up the override.
+        await cache.aclear()
+        tools = PubMedTools()
+        session = _make_aiohttp_session(
+            _make_aiohttp_response(text=_EFETCH_XML_FIXTURE)
+        )
+        first = await tools.fetch_mesh_and_pub_types(
+            ["11111111", "22222222"], session=session, timeout=5.0
+        )
+        assert "11111111" in first
+        assert session.get.call_count == 1
+
+        # Second call with the same PMIDs must not hit the network.
+        session2 = _make_aiohttp_session(_make_aiohttp_response(text=""))
+        second = await tools.fetch_mesh_and_pub_types(
+            ["11111111", "22222222"], session=session2, timeout=5.0
+        )
+        assert second["11111111"]["pub_types"] == ["Journal Article", "Meta-Analysis"]
+        assert session2.get.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_fetch_mesh_and_pub_types_only_fetches_cache_misses():
+    """A mix of cached and uncached PMIDs should send only the misses to NCBI."""
+    from django.core.cache import cache
+    from django.test.utils import override_settings
+
+    with override_settings(CACHES=_LOCMEM_CACHES):
+        await cache.aclear()
+        tools = PubMedTools()
+        # Prime the cache with PMID 11111111.
+        seed_xml = (
+            "<PubmedArticleSet>"
+            "<PubmedArticle><MedlineCitation><PMID>11111111</PMID>"
+            "<Article><PublicationTypeList>"
+            "<PublicationType>Review</PublicationType>"
+            "</PublicationTypeList></Article></MedlineCitation></PubmedArticle>"
+            "</PubmedArticleSet>"
+        )
+        seed_session = _make_aiohttp_session(_make_aiohttp_response(text=seed_xml))
+        await tools.fetch_mesh_and_pub_types(
+            ["11111111"], session=seed_session, timeout=5.0
+        )
+
+        # Now ask for both 11111111 (cached) and 22222222 (miss).
+        miss_xml = (
+            "<PubmedArticleSet>"
+            "<PubmedArticle><MedlineCitation><PMID>22222222</PMID>"
+            "<Article><PublicationTypeList>"
+            "<PublicationType>Meta-Analysis</PublicationType>"
+            "</PublicationTypeList></Article></MedlineCitation></PubmedArticle>"
+            "</PubmedArticleSet>"
+        )
+        miss_session = _make_aiohttp_session(_make_aiohttp_response(text=miss_xml))
+        result = await tools.fetch_mesh_and_pub_types(
+            ["11111111", "22222222"], session=miss_session, timeout=5.0
+        )
+        # One GET, and its `id` param should only contain the miss.
+        assert miss_session.get.call_count == 1
+        assert miss_session.get.call_args.kwargs["params"]["id"] == "22222222"
+        assert result["11111111"]["pub_types"] == ["Review"]
+        assert result["22222222"]["pub_types"] == ["Meta-Analysis"]
+
+
+@pytest.mark.asyncio
+async def test_find_related_pmids_caches_successful_results():
+    from django.core.cache import cache
+    from django.test.utils import override_settings
+
+    with override_settings(CACHES=_LOCMEM_CACHES):
+        await cache.aclear()
+        tools = PubMedTools()
+        session = _make_aiohttp_session(
+            _make_aiohttp_response(json_data=_ELINK_JSON_FIXTURE)
+        )
+        first = await tools.find_related_pmids(
+            "11111111", session=session, max_results=10
+        )
+        assert first == ["33333333", "44444444", "55555555"]
+        assert session.get.call_count == 1
+
+        # Second call should not hit the network.
+        session2 = _make_aiohttp_session(_make_aiohttp_response(json_data={}))
+        second = await tools.find_related_pmids(
+            "11111111", session=session2, max_results=10
+        )
+        assert second == first
+        assert session2.get.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_find_related_pmids_does_not_cache_on_timeout():
+    """A timed-out elink call must not leave a stale empty-list in the cache."""
+    from django.core.cache import cache
+    from django.test.utils import override_settings
+
+    with override_settings(CACHES=_LOCMEM_CACHES):
+        await cache.aclear()
+        tools = PubMedTools()
+        timeout_session = AsyncMock()
+        timeout_session.get = MagicMock(side_effect=asyncio.TimeoutError())
+        result = await tools.find_related_pmids(
+            "11111111", session=timeout_session, max_results=10
+        )
+        assert result == []
+
+        # A subsequent call with a real fixture must actually hit the network.
+        session2 = _make_aiohttp_session(
+            _make_aiohttp_response(json_data=_ELINK_JSON_FIXTURE)
+        )
+        second = await tools.find_related_pmids(
+            "11111111", session=session2, max_results=10
+        )
+        assert session2.get.call_count == 1
+        assert "33333333" in second

--- a/tests/sync/test_pubmed_api.py
+++ b/tests/sync/test_pubmed_api.py
@@ -1000,3 +1000,37 @@ class PubMedNegativeCachingTest(TransactionTestCase):
             self.assertEqual(rows, [], "Errors must not produce negative-cache rows")
 
         async_to_sync(run_test)()
+
+    @mock.patch("fighthealthinsurance.utils.pubmed_fetcher.pmids_for_query")
+    def test_stale_empty_supersedes_older_non_empty(self, mock_pmids):
+        """A stale empty row is *newer* information than an older non-empty
+        row, so the older non-empty PMIDs must not be served. The function
+        should re-query NCBI instead."""
+        query = "supersession query"
+        # Older row (20 days ago): non-empty.
+        older = PubMedQueryData.objects.create(
+            query=query, articles=json.dumps(["aaaaa", "bbbbb"])
+        )
+        PubMedQueryData.objects.filter(pk=older.pk).update(
+            created=timezone.now() - timedelta(days=20)
+        )
+        # Newer row (5 days ago): empty but past the 2-day negative-cache
+        # window. This is the most recent signal and it says "no hits".
+        newer = PubMedQueryData.objects.create(query=query, articles=json.dumps([]))
+        PubMedQueryData.objects.filter(pk=newer.pk).update(
+            created=timezone.now() - timedelta(days=5)
+        )
+
+        mock_pmids.return_value = ["fresh"]
+
+        async def run_test():
+            tools = PubMedTools()
+            result = await tools.find_pubmed_article_ids_for_query(query)
+            mock_pmids.assert_called_once()
+            self.assertEqual(
+                result,
+                ["fresh"],
+                "Must re-fetch from NCBI, not serve older non-empty cached PMIDs",
+            )
+
+        async_to_sync(run_test)()

--- a/tests/sync/test_pubmed_api.py
+++ b/tests/sync/test_pubmed_api.py
@@ -819,13 +819,23 @@ class PubMedE2EAppealFlowTest(TransactionTestCase):
                 summary_count, 0, "Empty results should not create summary row"
             )
 
-            # No per-query cache rows either (empty results aren't cached)
-            cache_count = await sync_to_async(
-                PubMedQueryData.objects.filter(denial_id__isnull=True).count
+            # Empty results from a successful NCBI call ARE negative-cached
+            # so repeated empty-query lookups don't hammer NCBI. (Errors and
+            # timeouts still aren't persisted; see negative-cache tests.)
+            cache_rows = await sync_to_async(
+                lambda: list(PubMedQueryData.objects.filter(denial_id__isnull=True))
             )()
-            self.assertEqual(
-                cache_count, 0, "Empty results should not create cache rows"
+            self.assertGreater(
+                len(cache_rows),
+                0,
+                "Successful empty results should be negative-cached",
             )
+            for row in cache_rows:
+                self.assertEqual(
+                    json.loads(row.articles or "[]"),
+                    [],
+                    "Negative-cache rows should hold an empty article list",
+                )
 
         async_to_sync(run_test)()
 
@@ -895,5 +905,98 @@ class PubMedE2EAppealFlowTest(TransactionTestCase):
             await sync_to_async(denial.refresh_from_db)()
             self.assertEqual(denial.procedure, "")
             self.assertEqual(denial.diagnosis, "")
+
+        async_to_sync(run_test)()
+
+
+class PubMedNegativeCachingTest(TransactionTestCase):
+    """find_pubmed_article_ids_for_query negative-caching behavior.
+
+    Empty results from a *successful* NCBI call are persisted so repeated
+    no-result queries don't keep hitting NCBI. The window is shorter than
+    the positive cache because absence is more volatile than presence.
+    Errors and timeouts must not be persisted.
+    """
+
+    @mock.patch("fighthealthinsurance.utils.pubmed_fetcher.pmids_for_query")
+    def test_empty_result_creates_negative_cache_row(self, mock_pmids):
+        mock_pmids.return_value = []
+
+        async def run_test():
+            tools = PubMedTools()
+            result = await tools.find_pubmed_article_ids_for_query("no hits query")
+            self.assertEqual(result, [])
+
+            rows = await sync_to_async(
+                lambda: list(
+                    PubMedQueryData.objects.filter(
+                        query="no hits query", denial_id__isnull=True
+                    )
+                )
+            )()
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(json.loads(rows[0].articles), [])
+
+        async_to_sync(run_test)()
+
+    @mock.patch("fighthealthinsurance.utils.pubmed_fetcher.pmids_for_query")
+    def test_recent_negative_cache_short_circuits_api(self, mock_pmids):
+        """Inside the 2-day window, a cached empty row is served without
+        calling NCBI again."""
+        # Pre-seed an empty cache row created "now".
+        PubMedQueryData.objects.create(
+            query="recently empty query",
+            articles=json.dumps([]),
+            created=timezone.now(),
+        )
+        mock_pmids.return_value = ["should", "not", "be", "returned"]
+
+        async def run_test():
+            tools = PubMedTools()
+            result = await tools.find_pubmed_article_ids_for_query(
+                "recently empty query"
+            )
+            self.assertEqual(result, [])
+            mock_pmids.assert_not_called()
+
+        async_to_sync(run_test)()
+
+    @mock.patch("fighthealthinsurance.utils.pubmed_fetcher.pmids_for_query")
+    def test_stale_negative_cache_falls_through_to_api(self, mock_pmids):
+        """Outside the 2-day window (but still inside the 30-day positive
+        window), an empty cached row is treated as a miss so NCBI gets a
+        retry. New articles might have been indexed since."""
+        stale_created = timezone.now() - timedelta(days=5)
+        row = PubMedQueryData.objects.create(
+            query="stale empty query",
+            articles=json.dumps([]),
+        )
+        # Bypass auto_now_add by updating after create.
+        PubMedQueryData.objects.filter(pk=row.pk).update(created=stale_created)
+
+        mock_pmids.return_value = ["11111111"]
+
+        async def run_test():
+            tools = PubMedTools()
+            result = await tools.find_pubmed_article_ids_for_query("stale empty query")
+            mock_pmids.assert_called_once()
+            self.assertEqual(result, ["11111111"])
+
+        async_to_sync(run_test)()
+
+    @mock.patch("fighthealthinsurance.utils.pubmed_fetcher.pmids_for_query")
+    def test_errors_are_not_negative_cached(self, mock_pmids):
+        """If metapub raises, no cache row should be written."""
+        mock_pmids.side_effect = RuntimeError("simulated NCBI failure")
+
+        async def run_test():
+            tools = PubMedTools()
+            with self.assertRaises(RuntimeError):
+                await tools.find_pubmed_article_ids_for_query("failing query")
+
+            rows = await sync_to_async(
+                lambda: list(PubMedQueryData.objects.filter(query="failing query"))
+            )()
+            self.assertEqual(rows, [], "Errors must not produce negative-cache rows")
 
         async_to_sync(run_test)()


### PR DESCRIPTION
## Summary
Implements a Django cache layer for PubMed API calls to reduce load on NCBI servers and improve query performance. Adds caching for both efetch (MeSH terms/publication types) and elink (related articles) calls, with separate TTLs and negative-caching support for empty results.

## Key Changes

- **Cache infrastructure**: Added Django cache integration with configurable TTLs (7 days for efetch/elink, 2 days for negative cache)
  - `_EFETCH_CACHE_TTL_SECONDS`: 7-day cache for MeSH terms and publication types
  - `_ELINK_CACHE_TTL_SECONDS`: 7-day cache for related article sets
  - `_EMPTY_QUERY_NEGCACHE_DAYS`: 2-day negative cache for empty query results

- **Negative caching for empty results**: Empty results from successful NCBI queries are now cached with a shorter 2-day TTL (vs 30-day positive cache) since absence is more volatile than presence as new articles get indexed

- **Selective fetching**: `fetch_mesh_and_pub_types()` now only fetches cache misses from NCBI, combining cached and fresh results

- **Error handling**: Cache read/write failures are logged but don't break functionality; timeouts and errors are not cached to avoid serving stale data

- **NCBI API key support**: Added explicit `NCBI_API_KEY` environment variable handling to enable higher rate limits (3 → 10 req/s) from NCBI

- **Query result caching improvements**: Refactored `find_pubmed_article_ids_for_query()` to properly handle empty results and respect the shorter negative-cache window

- **Comprehensive test coverage**: Added 6 new async tests covering cache hits, cache misses, mixed cached/uncached requests, and error scenarios

## Implementation Details

- Cache keys use prefixes (`pubmed:efetch:meshpub:`, `pubmed:elink:related:`) to avoid collisions
- Cache operations use async variants (`aget`, `aset`, `aget_many`, `aset_many`) for non-blocking behavior
- Successful flag prevents caching on timeouts/cancellations while allowing empty-list caching on successful NCBI calls
- Tests use `LocMemCache` override to verify cache behavior in isolation

https://claude.ai/code/session_01PnuxYtUtvCsinm2MnmNjgN