### PR TITLE
Remove sorl-thumbnail dependency and configuration

### DIFF
--- a/fighthealthinsurance/settings.py
+++ b/fighthealthinsurance/settings.py
@@ -159,8 +159,6 @@ class Base(Configuration):
     EXTERNAL_STORAGE_LOCATION = "/external_data"
     EXTERNAL_STORAGE_LOCATION_B = "external_data_b"
 
-    NEWSLETTER_THUMBNAIL = "sorl-thumbnail"
-
     ALLOWED_HOSTS: list[str] = ["*"]
     USE_X_FORWARDED_HOST = True
 
@@ -200,7 +198,6 @@ class Base(Configuration):
         "fighthealthinsurance",
         "fhi_users",
         "charts",
-        "sorl.thumbnail",
         "easy_thumbnails",
         "cookie_consent",
         "compressor",

--- a/requirements.txt
+++ b/requirements.txt
@@ -77,7 +77,6 @@ ray[client]==2.53.0 # Must update build_ray
 requests
 sentry-sdk[django]
 setuptools>=58,<80
-sorl-thumbnail
 sqlalchemy_mate==2.0.0.0 # uszipcode issue see https://github.com/MacHu-GWU/uszipcode-project/issues/79
 stopit
 stripe==12.2.0


### PR DESCRIPTION
## Summary
Removes the `sorl-thumbnail` package and its associated configuration from the project, consolidating thumbnail handling to use only `easy_thumbnails`.

## Changes
- Removed `sorl-thumbnail` from installed apps in Django settings
- Removed `NEWSLETTER_THUMBNAIL` configuration setting that referenced sorl-thumbnail
- Removed `sorl-thumbnail` from project dependencies

## Details
The project was maintaining two separate thumbnail libraries (`sorl-thumbnail` and `easy_thumbnails`). This change removes the unused `sorl-thumbnail` dependency and its configuration, simplifying the dependency tree and reducing maintenance overhead. The `easy_thumbnails` package remains as the sole thumbnail handling solution.

https://claude.ai/code/session_0142QvsmH554WDPsujR9VMx2