### PR TITLE
Clarify email reply option in feedback follow-up templates

### DIFF
--- a/fighthealthinsurance/templates/emails/followup.html
+++ b/fighthealthinsurance/templates/emails/followup.html
@@ -13,7 +13,10 @@ It looks like we didn't manage to generate a proposal this time. Thank you for g
 </p>
 
 <p>
-  If you can fill-out <a href="{{ followup_link }}">the follow up form that would be greatly appreciated</a> (alternatively, you can also respond to this e-mail and I'll take a look at your response :))
+  If you can fill-out <a href="{{ followup_link }}">the follow up form that would be greatly appreciated</a>.
+</p>
+<p>
+  If you're more comfortable sharing feedback over e-mail, you can also just reply to this message and I'll take a look :) Please keep in mind that e-mail is not encrypted, so if you'd rather not include personal or medical details in your reply, the follow-up form above is the more private option.
 </p>
 <p>
   Thank you for being part of our community! If you found Fight Health Insurance helpful, there are many ways you can help us and others fighting unfair denials:

--- a/fighthealthinsurance/templates/emails/followup.txt
+++ b/fighthealthinsurance/templates/emails/followup.txt
@@ -12,7 +12,7 @@ It looks like we didn't manage to generate a proposal this time. Thank you for g
 
 If you can fill out the follow-up form at {{ followup_link }} that would be greatly appreciated.
 
-If you're more comfortable sharing feedback over e-mail, you can also just reply to this message and I'll take a look :) Please keep in mind that e-mail is not encrypted, so if you'd rather not include personal or medical details in your reply, the follow-up form above is the more private option.
+If you're more comfortable sharing feedback over e-mail, you can also just reply to this message and I'll take a look :) Please keep in mind that e-mail is not a secure channel, so if you'd rather not include personal or medical details in your reply, the follow-up form above is the more private option.
 
 Thank you for being part of our community! If you found Fight Health Insurance helpful, there are many ways you can help us and others fighting unfair denials:
 - Share your experience with friends and family who might need help

--- a/fighthealthinsurance/templates/emails/followup.txt
+++ b/fighthealthinsurance/templates/emails/followup.txt
@@ -10,7 +10,9 @@ It looks like we generated draft proposals, but you may not have found one that 
 It looks like we didn't manage to generate a proposal this time. Thank you for giving Fight Health Insurance a try — we'd really value your feedback on how we can improve.
 {% endif %}
 
-If you can fill-out the follow up form at {{ followup_link }} that would be greatly appreciated (alternatively, you can also respond to this e-mail and I'll take a look at your response :))
+If you can fill-out the follow up form at {{ followup_link }} that would be greatly appreciated.
+
+If you're more comfortable sharing feedback over e-mail, you can also just reply to this message and I'll take a look :) Please keep in mind that e-mail is not encrypted, so if you'd rather not include personal or medical details in your reply, the follow-up form above is the more private option.
 
 Thank you for being part of our community! If you found Fight Health Insurance helpful, there are many ways you can help us and others fighting unfair denials:
 - Share your experience with friends and family who might need help

--- a/fighthealthinsurance/templates/emails/followup.txt
+++ b/fighthealthinsurance/templates/emails/followup.txt
@@ -10,7 +10,7 @@ It looks like we generated draft proposals, but you may not have found one that 
 It looks like we didn't manage to generate a proposal this time. Thank you for giving Fight Health Insurance a try — we'd really value your feedback on how we can improve.
 {% endif %}
 
-If you can fill-out the follow up form at {{ followup_link }} that would be greatly appreciated.
+If you can fill out the follow-up form at {{ followup_link }} that would be greatly appreciated.
 
 If you're more comfortable sharing feedback over e-mail, you can also just reply to this message and I'll take a look :) Please keep in mind that e-mail is not encrypted, so if you'd rather not include personal or medical details in your reply, the follow-up form above is the more private option.
 

--- a/fighthealthinsurance/templates/emails/followup_1day.html
+++ b/fighthealthinsurance/templates/emails/followup_1day.html
@@ -14,5 +14,8 @@ Quick check-in: it looks like we weren't able to generate a usable proposal this
 <p>
 If you can fill-out <a href="{{ followup_link }}">the follow up form that would be greatly appreciated</a>.
 </p>
+<p>
+If you'd rather share feedback over e-mail, you're welcome to reply directly to this message. Just a heads-up that e-mail is not encrypted, so if you'd rather not include personal or medical details in your reply, the follow-up form above is the more private option.
+</p>
 <p>Thank you for being part of our community.</p>
 The Fight Health Insurance team<br/>

--- a/fighthealthinsurance/templates/emails/followup_1day.txt
+++ b/fighthealthinsurance/templates/emails/followup_1day.txt
@@ -12,6 +12,8 @@ Quick check-in: it looks like we weren't able to generate a usable proposal this
 
 If you can fill-out the follow up form at {{ followup_link }} that would be greatly appreciated.
 
+If you'd rather share feedback over e-mail, you're welcome to reply directly to this message. Just a heads-up that e-mail is not encrypted, so if you'd rather not include personal or medical details in your reply, the follow-up form above is the more private option.
+
 Thank you for being part of our community.
 
 The Fight Health Insurance team

--- a/fighthealthinsurance/templates/emails/followup_30day.html
+++ b/fighthealthinsurance/templates/emails/followup_30day.html
@@ -25,6 +25,9 @@ It looks like we may not have generated an appeal that worked for you last time.
   Please <a href="{{ followup_link }}">update us on your appeal status</a> — your feedback helps us track outcomes and improve our service for everyone.
 </p>
 <p>
+  Prefer e-mail? You can also just reply to this message with your update. Please keep in mind that e-mail is not encrypted, so if you'd rather not include personal or medical details in your reply, the follow-up form above is the more private option.
+</p>
+<p>
   Thank you for being part of our community! If you found Fight Health Insurance helpful, there are many ways you can help us and others fighting unfair denials:
 </p>
 <ul>

--- a/fighthealthinsurance/templates/emails/followup_30day.txt
+++ b/fighthealthinsurance/templates/emails/followup_30day.txt
@@ -16,6 +16,8 @@ It looks like we may not have generated an appeal that worked for you last time.
 
 Please update us on your appeal status at {{ followup_link }} — your feedback helps us track outcomes and improve our service for everyone.
 
+Prefer e-mail? You can also just reply to this message with your update. Please keep in mind that e-mail is not encrypted, so if you'd rather not include personal or medical details in your reply, the follow-up form above is the more private option.
+
 Thank you for being part of our community! If you found Fight Health Insurance helpful, there are many ways you can help us and others fighting unfair denials:
 - Share your experience with friends and family who might need help
 - Follow us on social media to help spread awareness

--- a/fighthealthinsurance/templates/emails/followup_7day.html
+++ b/fighthealthinsurance/templates/emails/followup_7day.html
@@ -25,6 +25,9 @@ It looks like we may not have generated an appeal that worked for you. We'd love
   Please <a href="{{ followup_link }}">let us know how things are going</a> — it only takes a minute and helps us improve our service.
 </p>
 <p>
+  Prefer e-mail? You can also just reply to this message with your feedback. Please keep in mind that e-mail is not encrypted, so if you'd rather not include personal or medical details in your reply, the follow-up form above is the more private option.
+</p>
+<p>
   Thank you for being part of our community! If you found Fight Health Insurance helpful, there are many ways you can help us and others fighting unfair denials:
 </p>
 <ul>

--- a/fighthealthinsurance/templates/emails/followup_7day.txt
+++ b/fighthealthinsurance/templates/emails/followup_7day.txt
@@ -16,6 +16,8 @@ It looks like we may not have generated an appeal that worked for you. We'd love
 
 Please let us know how things are going at {{ followup_link }} — it only takes a minute and helps us improve our service.
 
+Prefer e-mail? You can also just reply to this message with your feedback. Please keep in mind that e-mail is not encrypted, so if you'd rather not include personal or medical details in your reply, the follow-up form above is the more private option.
+
 Thank you for being part of our community! If you found Fight Health Insurance helpful, there are many ways you can help us and others fighting unfair denials:
 - Share your experience with friends and family who might need help
 - Follow us on social media to help spread awareness

--- a/fighthealthinsurance/templates/emails/followup_90day.html
+++ b/fighthealthinsurance/templates/emails/followup_90day.html
@@ -22,6 +22,9 @@ If you still need help with your denial, we're here for you. Health insurance de
   Please <a href="{{ followup_link }}">share your experience with us</a> — hearing about outcomes helps us improve and helps others in similar situations know what to expect.
 </p>
 <p>
+  Prefer e-mail? You can also just reply to this message with your story. Please keep in mind that e-mail is not encrypted, so if you'd rather not include personal or medical details in your reply, the follow-up form above is the more private option.
+</p>
+<p>
   Thank you for being part of our community! If you found Fight Health Insurance helpful, there are many ways you can help us and others fighting unfair denials:
 </p>
 <ul>

--- a/fighthealthinsurance/templates/emails/followup_90day.txt
+++ b/fighthealthinsurance/templates/emails/followup_90day.txt
@@ -14,6 +14,8 @@ If you still need help with your denial, we're here for you. Health insurance de
 
 Please share your experience with us at {{ followup_link }} — hearing about outcomes helps us improve and helps others in similar situations know what to expect.
 
+Prefer e-mail? You can also just reply to this message with your story. Please keep in mind that e-mail is not encrypted, so if you'd rather not include personal or medical details in your reply, the follow-up form above is the more private option.
+
 Thank you for being part of our community! If you found Fight Health Insurance helpful, there are many ways you can help us and others fighting unfair denials:
 - Share your experience with friends and family who might need help
 - Follow us on social media to help spread awareness


### PR DESCRIPTION
Updates the follow-up email templates to explicitly invite recipients
to share feedback by replying to the email directly, while warning
that email is not encrypted so the in-app follow-up form remains the
more private option for personal or medical details.