### PR TITLE
Run payer-policy prefetch in a Ray actor so the deploy job is non-blocking

### DIFF
--- a/fighthealthinsurance/extralink_prefetch_actor_ref.py
+++ b/fighthealthinsurance/extralink_prefetch_actor_ref.py
@@ -4,8 +4,6 @@ ExtraLink Pre-fetch Actor Reference.
 Provides a cached reference to the extralink pre-fetch actor.
 """
 
-from functools import cached_property
-
 from fighthealthinsurance.base_actor_ref import BaseActorRef
 from fighthealthinsurance.extralink_prefetch_actor import ExtraLinkPrefetchActor
 
@@ -24,7 +22,8 @@ class ExtraLinkPrefetchActorRef(BaseActorRef):
         Returns:
             Tuple of (actor_ref, task_ref)
         """
-        actor = self.get()
+        # ``BaseActorRef.get`` is a ``cached_property``; access without parens.
+        actor = self.get
         task = actor.prefetch_all.remote()
         print(f"Started extralink pre-fetch task: {task}")
 

--- a/fighthealthinsurance/management/commands/ingest_payer_policy_indexes.py
+++ b/fighthealthinsurance/management/commands/ingest_payer_policy_indexes.py
@@ -2,10 +2,11 @@
 Fetch and re-parse every static payer medical-policy index.
 
 Idempotent: replaces each company's :class:`PayerPolicyEntry` rows with the
-freshly-parsed entries from the live URL. Intended to be run at deploy
-time (alongside ``launch_prefetch_actor``) and on a periodic cron so that
-``payer_policy_helper`` keeps surfacing live, working URLs in appeal
-prompts.
+freshly-parsed entries from the live URL. Deploys run the ingest via the
+``PayerPolicyPrefetchActor`` Ray actor (kicked off by ``launch_prefetch_actor``);
+this synchronous management command stays around for periodic cron and
+manual invocations so ``payer_policy_helper`` keeps surfacing live, working
+URLs in appeal prompts.
 """
 
 import asyncio

--- a/fighthealthinsurance/management/commands/launch_prefetch_actor.py
+++ b/fighthealthinsurance/management/commands/launch_prefetch_actor.py
@@ -1,8 +1,13 @@
 """
-Management command to launch the extralink pre-fetch actor.
+Management command to launch deploy-time pre-fetch actors.
 
-This command starts the actor that pre-fetches external documents and PubMed
-articles at deploy time. It's designed to run once per deployment.
+Launches:
+- ``ExtraLinkPrefetchActor`` — pre-fetches external documents and PubMed articles.
+- ``PayerPolicyPrefetchActor`` — refreshes static payer medical-policy indexes.
+
+Both actors run once per deployment and the command is non-blocking: if either
+task hasn't completed within the timeout, the command exits cleanly and the
+actor continues in the background.
 """
 
 from typing import Any
@@ -11,7 +16,10 @@ from django.core.management.base import BaseCommand
 
 
 class Command(BaseCommand):
-    help = "Launch the extralink pre-fetch actor (runs once at deploy time)"
+    help = (
+        "Launch the extralink and payer-policy pre-fetch actors "
+        "(both run once at deploy time, non-blocking)"
+    )
 
     def handle(self, *args: str, **options: Any) -> None:
         import ray
@@ -19,8 +27,11 @@ class Command(BaseCommand):
         from fighthealthinsurance.extralink_prefetch_actor_ref import (
             extralink_prefetch_actor_ref,
         )
+        from fighthealthinsurance.payer_policy_prefetch_actor_ref import (
+            payer_policy_prefetch_actor_ref,
+        )
 
-        self.stdout.write("Starting extralink pre-fetch actor...")
+        self.stdout.write("Starting deploy-time pre-fetch actors...")
 
         # Check Ray connectivity
         if not ray.is_initialized():
@@ -33,33 +44,63 @@ class Command(BaseCommand):
                 self.stderr.write("Continuing despite Ray connection failure")
                 return
 
+        # Kick off each actor independently so a failure on one doesn't block
+        # the other. ``tasks`` maps the Ray ObjectRef to a human-readable label
+        # for clearer log output as each task settles.
+        tasks: dict[Any, str] = {}
+
         try:
-            actor_ref, task = extralink_prefetch_actor_ref.start()
-            self.stdout.write(f"Actor launched: {actor_ref}")
-            self.stdout.write(f"Pre-fetch task started: {task}")
-
-            # Wait for task to complete (with timeout)
-            # This is non-blocking for deployment - if it times out, we continue
-            timeout = 600  # 10 minutes
-            self.stdout.write(f"Waiting up to {timeout}s for pre-fetch to complete...")
-
-            ready, _ = ray.wait([task], timeout=timeout)
-
-            if ready:
-                result = ray.get(ready[0])
-                self.stdout.write(
-                    self.style.SUCCESS("Pre-fetch completed successfully!")
-                )
-                self.stdout.write(f"Results: {result}")
-            else:
-                self.stdout.write(
-                    f"Pre-fetch timed out after {timeout}s (continuing in background)"
-                )
-                self.stdout.write(
-                    "This is normal - pre-fetch will continue asynchronously"
-                )
-
+            extralink_actor, extralink_task = extralink_prefetch_actor_ref.start()
+            self.stdout.write(f"Extralink actor launched: {extralink_actor}")
+            self.stdout.write(f"Extralink pre-fetch task started: {extralink_task}")
+            tasks[extralink_task] = "extralink"
         except Exception as e:
-            self.stderr.write(self.style.ERROR(f"Error launching pre-fetch actor: {e}"))
-            self.stderr.write("Continuing despite pre-fetch failure (non-blocking)")
-            # Don't raise - we don't want to fail deployment if pre-fetch fails
+            self.stderr.write(
+                self.style.ERROR(f"Error launching extralink pre-fetch actor: {e}")
+            )
+            self.stderr.write("Continuing despite extralink pre-fetch failure")
+
+        try:
+            payer_actor, payer_task = payer_policy_prefetch_actor_ref.start()
+            self.stdout.write(f"Payer-policy actor launched: {payer_actor}")
+            self.stdout.write(f"Payer-policy pre-fetch task started: {payer_task}")
+            tasks[payer_task] = "payer-policy"
+        except Exception as e:
+            self.stderr.write(
+                self.style.ERROR(f"Error launching payer-policy pre-fetch actor: {e}")
+            )
+            self.stderr.write("Continuing despite payer-policy pre-fetch failure")
+
+        if not tasks:
+            self.stderr.write(
+                self.style.ERROR("No pre-fetch tasks were launched; nothing to wait on")
+            )
+            return
+
+        # Wait for each task to settle, but don't block the deploy job on it.
+        # ``ray.wait`` returns whatever has completed within the timeout; the
+        # remainder keeps running in the background.
+        timeout = 600  # 10 minutes total across both tasks
+        self.stdout.write(
+            f"Waiting up to {timeout}s for {len(tasks)} pre-fetch task(s)..."
+        )
+
+        pending = list(tasks.keys())
+        ready, pending = ray.wait(pending, num_returns=len(pending), timeout=timeout)
+
+        for task_ref in ready:
+            label = tasks[task_ref]
+            try:
+                result = ray.get(task_ref)
+                self.stdout.write(
+                    self.style.SUCCESS(f"{label} pre-fetch completed: {result}")
+                )
+            except Exception as e:
+                self.stderr.write(self.style.ERROR(f"{label} pre-fetch raised: {e}"))
+
+        for task_ref in pending:
+            label = tasks[task_ref]
+            self.stdout.write(
+                f"{label} pre-fetch did not finish within {timeout}s; "
+                "continuing in background (non-blocking)"
+            )

--- a/fighthealthinsurance/payer_policy_fetcher.py
+++ b/fighthealthinsurance/payer_policy_fetcher.py
@@ -7,9 +7,10 @@ page over HTTP, dispatches it to the parser registered for the URL's host
 in :mod:`fighthealthinsurance.payer_policy_parsers`, and replaces that
 company's :class:`PayerPolicyEntry` rows with the parsed entries.
 
-This is invoked by the ``ingest_payer_policy_indexes`` management command,
-which can run at deploy time alongside the existing extralink prefetch
-actor.
+At deploy time this is driven by the ``PayerPolicyPrefetchActor`` Ray actor
+(launched by ``launch_prefetch_actor`` alongside the extralink prefetch
+actor); the ``ingest_payer_policy_indexes`` management command wraps the
+same fetcher for cron / manual invocations.
 """
 
 from typing import Optional

--- a/fighthealthinsurance/payer_policy_prefetch_actor.py
+++ b/fighthealthinsurance/payer_policy_prefetch_actor.py
@@ -1,0 +1,111 @@
+"""
+Payer-Policy Pre-fetch Ray Actor.
+
+This actor runs once at deploy time to pre-fetch the static medical-policy
+index for each ``InsuranceCompany`` flagged with
+``medical_policy_url_is_static_index=True`` and replace that company's
+``PayerPolicyEntry`` rows with the freshly-parsed entries.
+
+Wrapping the ingest in a Ray actor lets the deploy-time ``PREFETCH_EXTRALINKS``
+job kick this off alongside the existing extralink pre-fetch instead of
+blocking the job on a synchronous ``asyncio.run`` over every payer index.
+"""
+
+import os
+import time
+
+import ray
+from loguru import logger
+
+
+@ray.remote(max_restarts=-1, max_task_retries=-1)
+class PayerPolicyPrefetchActor:
+    """
+    Ray actor that pre-fetches payer medical-policy indexes at deploy time.
+
+    Like :class:`ExtraLinkPrefetchActor`, this actor:
+    1. Runs once at deploy time
+    2. Fetches every static medical-policy index it knows about
+    3. Replaces each company's ``PayerPolicyEntry`` rows with the parsed entries
+    4. Exits when complete
+    """
+
+    def __init__(self):
+        """Initialize the actor and Django application."""
+        logger.info("Starting Payer-Policy Pre-fetch Actor")
+
+        # Initialize Django WSGI application inside the actor
+        os.environ.setdefault("DJANGO_SETTINGS_MODULE", "fighthealthinsurance.settings")
+        from configurations.wsgi import get_wsgi_application
+
+        _application = get_wsgi_application()
+
+        self.fetched = 0
+        self.failed = 0
+        self.entries = 0
+
+        logger.info("Payer-Policy Pre-fetch Actor initialized")
+
+    async def prefetch_all(self) -> dict:
+        """
+        Pre-fetch every static payer medical-policy index.
+
+        Returns:
+            Dict with results:
+            {
+                'fetched': int,   # number of payers fetched successfully
+                'failed': int,    # number of payers whose ingest failed
+                'entries': int,   # total PayerPolicyEntry rows written
+                'duration_seconds': float,
+            }
+        """
+        logger.info("Starting payer-policy pre-fetch operation")
+        start_time = time.time()
+
+        try:
+            from fighthealthinsurance.payer_policy_fetcher import PayerPolicyFetcher
+
+            async with PayerPolicyFetcher() as fetcher:
+                stats = await fetcher.ingest_all()
+
+            self.fetched = stats.get("fetched", 0)
+            self.failed = stats.get("failed", 0)
+            self.entries = stats.get("entries", 0)
+
+            elapsed = time.time() - start_time
+            logger.info(
+                f"Payer-policy pre-fetch completed in {elapsed:.2f}s: "
+                f"{self.fetched} payers fetched, {self.failed} failed, "
+                f"{self.entries} entries written"
+            )
+
+            return {
+                "fetched": self.fetched,
+                "failed": self.failed,
+                "entries": self.entries,
+                "duration_seconds": elapsed,
+            }
+
+        except Exception as e:
+            logger.opt(exception=True).error(
+                f"Error in payer-policy pre-fetch operation: {e}"
+            )
+            return {
+                "fetched": self.fetched,
+                "failed": self.failed + 1,
+                "entries": self.entries,
+                "error": str(e),
+            }
+
+    async def get_stats(self) -> dict:
+        """
+        Get current fetch statistics.
+
+        Returns:
+            Dict with current stats
+        """
+        return {
+            "fetched": self.fetched,
+            "failed": self.failed,
+            "entries": self.entries,
+        }

--- a/fighthealthinsurance/payer_policy_prefetch_actor_ref.py
+++ b/fighthealthinsurance/payer_policy_prefetch_actor_ref.py
@@ -1,0 +1,32 @@
+"""
+Payer-Policy Pre-fetch Actor Reference.
+
+Provides a cached reference to the payer-policy pre-fetch actor.
+"""
+
+from fighthealthinsurance.base_actor_ref import BaseActorRef
+from fighthealthinsurance.payer_policy_prefetch_actor import PayerPolicyPrefetchActor
+
+
+class PayerPolicyPrefetchActorRef(BaseActorRef):
+    """Reference to the payer-policy pre-fetch actor."""
+
+    actor_class = PayerPolicyPrefetchActor
+    actor_name = "payer_policy_prefetch_actor"
+    has_run_method = False
+
+    def start(self):
+        """
+        Get or create the payer-policy pre-fetch actor and kick off ingest.
+
+        Returns:
+            Tuple of (actor_ref, task_ref)
+        """
+        actor = self.get
+        task = actor.prefetch_all.remote()
+        print(f"Started payer-policy pre-fetch task: {task}")
+
+        return (actor, task)
+
+
+payer_policy_prefetch_actor_ref = PayerPolicyPrefetchActorRef()

--- a/scripts/start-server.sh
+++ b/scripts/start-server.sh
@@ -22,10 +22,9 @@ elif [ -n "$POLLING_ACTORS" ]; then
   sleep 10
   exit 0
 elif [ -n "$PREFETCH_EXTRALINKS" ]; then
-  # Launch extralink pre-fetch (one-time job, non-blocking)
+  # Launch extralink + payer-policy pre-fetch actors (one-time job, non-blocking).
+  # Both run as Ray actors so neither blocks the deploy on slow upstream payers.
   python manage.py launch_prefetch_actor || echo "Pre-fetch failed (non-blocking)"
-  # Refresh payer medical-policy indexes (used by payer_policy_helper).
-  python manage.py ingest_payer_policy_indexes || echo "Payer-policy ingest failed (non-blocking)"
   sleep 10
   exit 0
 fi

--- a/tests/async-unit/test_payer_policy_prefetch_actor.py
+++ b/tests/async-unit/test_payer_policy_prefetch_actor.py
@@ -1,0 +1,84 @@
+"""Unit tests for PayerPolicyPrefetchActor's testable helpers (without Ray)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from fighthealthinsurance.payer_policy_prefetch_actor import PayerPolicyPrefetchActor
+
+# Access the underlying class through the Ray decorator's __ray_metadata__.
+# When @ray.remote wraps a class, the original class is accessible at this
+# attribute; falling back to the decorated object if Ray isn't loaded.
+_Klass = getattr(PayerPolicyPrefetchActor, "__ray_metadata__", None)
+_Underlying = _Klass.modified_class if _Klass else PayerPolicyPrefetchActor
+
+
+def _make_actor() -> "_Underlying":  # type: ignore[valid-type]
+    """Build an actor instance without running __init__ (which boots Django)."""
+    actor = _Underlying.__new__(_Underlying)
+    actor.fetched = 0
+    actor.failed = 0
+    actor.entries = 0
+    return actor
+
+
+class TestPrefetchAll:
+    @pytest.mark.asyncio
+    async def test_prefetch_all_records_stats_from_fetcher(self):
+        actor = _make_actor()
+
+        fake_fetcher = MagicMock()
+        fake_fetcher.__aenter__ = AsyncMock(return_value=fake_fetcher)
+        fake_fetcher.__aexit__ = AsyncMock(return_value=None)
+        fake_fetcher.ingest_all = AsyncMock(
+            return_value={"fetched": 2, "failed": 1, "entries": 17}
+        )
+
+        with patch(
+            "fighthealthinsurance.payer_policy_fetcher.PayerPolicyFetcher",
+            return_value=fake_fetcher,
+        ):
+            result = await actor.prefetch_all()
+
+        assert result["fetched"] == 2
+        assert result["failed"] == 1
+        assert result["entries"] == 17
+        assert "duration_seconds" in result
+        assert actor.fetched == 2
+        assert actor.failed == 1
+        assert actor.entries == 17
+        fake_fetcher.ingest_all.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_prefetch_all_surfaces_errors_without_raising(self):
+        actor = _make_actor()
+
+        fake_fetcher = MagicMock()
+        fake_fetcher.__aenter__ = AsyncMock(return_value=fake_fetcher)
+        fake_fetcher.__aexit__ = AsyncMock(return_value=None)
+        fake_fetcher.ingest_all = AsyncMock(side_effect=RuntimeError("upstream down"))
+
+        with patch(
+            "fighthealthinsurance.payer_policy_fetcher.PayerPolicyFetcher",
+            return_value=fake_fetcher,
+        ):
+            result = await actor.prefetch_all()
+
+        # Errors must not propagate -- the deploy-time job should keep going.
+        assert "error" in result
+        assert "upstream down" in result["error"]
+        # An ingest_all failure counts as one bumped failure on top of the
+        # stats we managed to capture (none, since the call raised).
+        assert result["failed"] == 1
+
+
+class TestGetStats:
+    @pytest.mark.asyncio
+    async def test_get_stats_returns_current_counters(self):
+        actor = _make_actor()
+        actor.fetched = 5
+        actor.failed = 2
+        actor.entries = 42
+
+        stats = await actor.get_stats()
+        assert stats == {"fetched": 5, "failed": 2, "entries": 42}


### PR DESCRIPTION
The PREFETCH_EXTRALINKS deploy job previously chained
``launch_prefetch_actor`` (Ray, non-blocking) with
``ingest_payer_policy_indexes`` (asyncio.run, blocking). A slow payer
index could wedge the whole job. Wrap the payer-policy fetch in a Ray
actor mirroring the extralink prefetch pattern, launch both from the
same management command, and drop the blocking call from start-server.sh.

Also fix a latent bug in ExtraLinkPrefetchActorRef.start() that called
the ``get`` cached_property with parens.

https://claude.ai/code/session_01RtdrGavMoTVEMzqpF44c17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated pre-fetching of payer policy indexes at deployment time to improve data availability and performance.

* **Improvements**
  * Enhanced deployment prefetch process with better error handling and independent task management for multiple async operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fighthealthinsurance/fighthealthinsurance/pull/804)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->