### PR TITLE
Add data deletion request detection and self-service handoff

### DIFF
--- a/fighthealthinsurance/chat/safety_filters.py
+++ b/fighthealthinsurance/chat/safety_filters.py
@@ -76,6 +76,48 @@ _FALSE_PROMISE_REGEX: Pattern[str] = re.compile(
     re.IGNORECASE,
 )
 
+# Delete-data request detection - phrases where the user is asking us to
+# delete their account or data. We do NOT delete data from chat; instead we
+# point them at the self-service flow at /remove_data which verifies email
+# ownership before deleting anything.
+#
+# Patterns are narrow enough to avoid matching things like "delete this
+# paragraph from my appeal" or "remove the diagnosis from the record".
+_DELETE_DATA_PHRASES = [
+    r"delete my (?:data|account|info(?:rmation)?|profile|records?)",
+    r"remove my (?:data|account|info(?:rmation)?|profile|records?)",
+    r"erase my (?:data|account|info(?:rmation)?|profile|records?)",
+    r"wipe my (?:data|account|info(?:rmation)?|profile|records?)",
+    r"close my account",
+    r"cancel my account",
+    r"deactivate my account",
+    r"delete everything (?:about|on) me",
+    r"forget (?:me|my data|my account)",
+    r"gdpr (?:delete|deletion|erasure|request)",
+    r"right to (?:be forgotten|erasure)",
+    r"opt out of (?:data|having my data)",
+]
+
+_DELETE_DATA_REGEX: Pattern[str] = re.compile(
+    r"|".join(rf"(?:\b{phrase}\b)" for phrase in _DELETE_DATA_PHRASES),
+    re.IGNORECASE,
+)
+
+# Sentinel the LLM can emit (per system-prompt instructions) to hand off to
+# the canned response when the user's phrasing is too oblique for the regex.
+DELETE_DATA_SENTINEL = "[[DELETE_DATA_REQUEST]]"
+_DELETE_DATA_SENTINEL_REGEX: Pattern[str] = re.compile(
+    re.escape(DELETE_DATA_SENTINEL), re.IGNORECASE
+)
+
+DELETE_DATA_RESPONSE = """It looks like you're asking us to delete your data. I can't do that from chat, but you can request deletion yourself:
+
+**[Go to the Remove My Data page](/remove_data)**
+
+Enter your email there and we'll send you a confirmation link. After you click it, your data will be deleted. This two-step flow exists so we can verify you actually own the email before removing anything.
+
+If you have other questions about your appeal or denial, I'm happy to keep helping."""
+
 
 def detect_crisis_keywords(text: str) -> bool:
     """
@@ -101,3 +143,29 @@ def detect_false_promises(text: str) -> bool:
     if text is None:
         return False
     return bool(_FALSE_PROMISE_REGEX.search(text))
+
+
+def detect_delete_data_request(text: str) -> bool:
+    """
+    Check if a user message is asking us to delete their data or account.
+
+    Returns True when the message matches a known data-deletion phrasing.
+    Used to short-circuit the chat and direct the user to the self-service
+    /remove_data flow instead of asking the LLM to handle it.
+    """
+    if not text:
+        return False
+    return bool(_DELETE_DATA_REGEX.search(text))
+
+
+def llm_requested_delete_handoff(text: str) -> bool:
+    """
+    Check if an LLM response contains the delete-data sentinel token.
+
+    The system prompt instructs the model to emit this sentinel when it
+    recognizes a deletion request the regex missed. We swap the entire
+    response for the canned text when the sentinel is present.
+    """
+    if not text:
+        return False
+    return bool(_DELETE_DATA_SENTINEL_REGEX.search(text))

--- a/fighthealthinsurance/chat/safety_filters.py
+++ b/fighthealthinsurance/chat/safety_filters.py
@@ -6,7 +6,7 @@ Extracted from chat_interface.py for better organization and testability.
 """
 
 import re
-from typing import Pattern
+from typing import Optional, Pattern
 
 # Crisis/self-harm detection - phrases indicating the user may need immediate help
 # IMPORTANT: These must be specific enough to NOT block legitimate mental health
@@ -145,7 +145,7 @@ def detect_false_promises(text: str) -> bool:
     return bool(_FALSE_PROMISE_REGEX.search(text))
 
 
-def detect_delete_data_request(text: str) -> bool:
+def detect_delete_data_request(text: Optional[str]) -> bool:
     """
     Check if a user message is asking us to delete their data or account.
 
@@ -158,13 +158,16 @@ def detect_delete_data_request(text: str) -> bool:
     return bool(_DELETE_DATA_REGEX.search(text))
 
 
-def llm_requested_delete_handoff(text: str) -> bool:
+def llm_requested_delete_handoff(text: Optional[str]) -> bool:
     """
     Check if an LLM response contains the delete-data sentinel token.
 
     The system prompt instructs the model to emit this sentinel when it
     recognizes a deletion request the regex missed. We swap the entire
     response for the canned text when the sentinel is present.
+
+    Accepts Optional[str] because the LLM-output cleaning helpers
+    (remove_repeated_blocks / remove_repeated_sentences) can return None.
     """
     if not text:
         return False

--- a/fighthealthinsurance/chat_interface.py
+++ b/fighthealthinsurance/chat_interface.py
@@ -25,7 +25,10 @@ from fighthealthinsurance.chat.retry_handler import (
 )
 from fighthealthinsurance.chat.safety_filters import (
     CRISIS_RESOURCES,
+    DELETE_DATA_RESPONSE,
     detect_crisis_keywords,
+    detect_delete_data_request,
+    llm_requested_delete_handoff,
 )
 from fighthealthinsurance.chat.tools import (
     AppealTool,
@@ -471,6 +474,21 @@ class ChatInterface:
             # Don't continue with normal processing - let the user respond
             return
 
+        # SAFETY: Check for data-deletion requests in user-authored messages.
+        # We can't (and shouldn't) delete data from chat — direct the user to
+        # the self-service /remove_data flow which verifies email ownership.
+        # Skip for document uploads since OCR'd text often contains the word
+        # "delete" out of context.
+        if not is_document and detect_delete_data_request(user_message):
+            logger.info(
+                f"Delete-data request detected in chat {chat.id}, providing self-service link"
+            )
+            await self.send_message_to_client(DELETE_DATA_RESPONSE)
+            self._append_to_history(chat, "user", user_message)
+            self._append_to_history(chat, "assistant", DELETE_DATA_RESPONSE)
+            await chat.asave()
+            return
+
         # Handle document uploads: store separately and replace with marker in chat
         if is_document and user_message:
             doc_name = document_name or "uploaded_document"
@@ -820,6 +838,11 @@ class ChatInterface:
             if response_text and response_text.strip():
                 cleaned = remove_repeated_blocks(response_text.strip())
                 cleaned = remove_repeated_sentences(cleaned) or cleaned
+                if llm_requested_delete_handoff(cleaned):
+                    logger.info(
+                        f"LLM emitted delete-data sentinel in chat {chat.id}, swapping in canned response"
+                    )
+                    cleaned = DELETE_DATA_RESPONSE
                 final_response_text = cleaned
                 final_context_part = context_part
         except Exception as e:

--- a/fighthealthinsurance/chat_interface.py
+++ b/fighthealthinsurance/chat_interface.py
@@ -486,6 +486,10 @@ class ChatInterface:
             await self.send_message_to_client(DELETE_DATA_RESPONSE)
             self._append_to_history(chat, "user", user_message)
             self._append_to_history(chat, "assistant", DELETE_DATA_RESPONSE)
+            # Merge any background-task updates from the DB before saving so
+            # we don't clobber summary_for_next_call or microsite context that
+            # was written while this request was in flight.
+            await self._merge_summary_from_db(chat)
             await chat.asave()
             return
 

--- a/fighthealthinsurance/prompt_templates.py
+++ b/fighthealthinsurance/prompt_templates.py
@@ -6,6 +6,7 @@ This module contains templates for both professional and patient users.
 import string
 from typing import Any, Dict, Optional, Union
 
+from fighthealthinsurance.chat.safety_filters import DELETE_DATA_SENTINEL
 from fighthealthinsurance.models import ChatType
 
 
@@ -33,7 +34,7 @@ DELETE_DATA_INSTRUCTION = (
     "forget their data, account, profile, or records — or otherwise invokes "
     "deletion, right-to-be-forgotten, or GDPR erasure — do NOT attempt to "
     "delete anything and do NOT reassure them that you have. Reply with "
-    "ONLY the exact token [[DELETE_DATA_REQUEST]] on its own line and "
+    "ONLY the exact token " + DELETE_DATA_SENTINEL + " on its own line and "
     "nothing else; the system will substitute the correct self-service "
     "instructions."
 )

--- a/fighthealthinsurance/prompt_templates.py
+++ b/fighthealthinsurance/prompt_templates.py
@@ -24,11 +24,27 @@ class PromptTemplate:
             raise ValueError(f"Missing required key: {missing_key} for prompt template")
 
 
+# Instruction appended to every intro template so the LLM can hand off
+# data-deletion requests to the self-service flow. The sentinel must match
+# DELETE_DATA_SENTINEL in fighthealthinsurance/chat/safety_filters.py; the
+# server detects it and substitutes the canned response (DELETE_DATA_RESPONSE).
+DELETE_DATA_INSTRUCTION = (
+    "IMPORTANT: If the user asks you to delete, erase, remove, wipe, or "
+    "forget their data, account, profile, or records — or otherwise invokes "
+    "deletion, right-to-be-forgotten, or GDPR erasure — do NOT attempt to "
+    "delete anything and do NOT reassure them that you have. Reply with "
+    "ONLY the exact token [[DELETE_DATA_REQUEST]] on its own line and "
+    "nothing else; the system will substitute the correct self-service "
+    "instructions."
+)
+
 # Templates for different user types
 NEW_CHAT_PROFESSIONAL_TEMPLATE = PromptTemplate(
     "You are a helpful assistant talking with {user_info}. "
     "You are helping them with their ongoing chat. You likely do not need to immediately generate a prior auth or appeal; "
-    "instead, you'll have a chat with {user_info} about their needs. Now, here is what they said to start the conversation:\n{message}"
+    "instead, you'll have a chat with {user_info} about their needs. "
+    + DELETE_DATA_INSTRUCTION
+    + " Now, here is what they said to start the conversation:\n{message}"
 )
 
 NEW_CHAT_PATIENT_TEMPLATE = PromptTemplate(
@@ -36,7 +52,8 @@ NEW_CHAT_PATIENT_TEMPLATE = PromptTemplate(
     "This is a patient who may need help understanding or appealing a health insurance denial. "
     "Be compassionate, clear, and avoid medical jargon when possible. Explain concepts in simple terms. "
     "Never recommend specific treatments - focus on helping them understand and navigate the insurance process. "
-    "Here is what they said to start the conversation:\n{message}"
+    + DELETE_DATA_INSTRUCTION
+    + " Here is what they said to start the conversation:\n{message}"
 )
 
 

--- a/tests/sync/test_chat_safety.py
+++ b/tests/sync/test_chat_safety.py
@@ -4,13 +4,18 @@ from django.test import TestCase
 
 from fighthealthinsurance.chat.safety_filters import (
     detect_crisis_keywords,
+    detect_delete_data_request,
     detect_false_promises,
+    llm_requested_delete_handoff,
     CRISIS_RESOURCES,
+    DELETE_DATA_RESPONSE,
+    DELETE_DATA_SENTINEL,
 )
 
 # Import internal variables for testing
 from fighthealthinsurance.chat.safety_filters import (
     _CRISIS_PHRASES,
+    _DELETE_DATA_PHRASES,
     _FALSE_PROMISE_PATTERNS,
 )
 
@@ -241,4 +246,133 @@ class TestFalsePromisePatternList(TestCase):
             len(_FALSE_PROMISE_PATTERNS),
             len(set(_FALSE_PROMISE_PATTERNS)),
             "False promise patterns list contains duplicates",
+        )
+
+
+class TestDeleteDataDetection(TestCase):
+    """Tests for detection of user requests to delete their data."""
+
+    def test_detects_explicit_delete_data_requests(self):
+        """Direct deletion phrasings should be detected."""
+        delete_messages = [
+            "Please delete my data",
+            "I want you to delete my account",
+            "Remove my information from your system",
+            "Erase my profile",
+            "Wipe my records",
+            "Please close my account",
+            "I'd like to cancel my account",
+            "Can you deactivate my account?",
+            "Delete everything about me",
+            "Please forget me",
+            "I want you to forget my data",
+            "I am submitting a GDPR deletion request",
+            "I want to invoke my right to be forgotten",
+            "I want to opt out of having my data stored",
+        ]
+        for message in delete_messages:
+            self.assertTrue(
+                detect_delete_data_request(message),
+                f"Failed to detect delete-data request in: {message}",
+            )
+
+    def test_case_insensitive_detection(self):
+        """Detection should be case-insensitive."""
+        self.assertTrue(detect_delete_data_request("DELETE MY ACCOUNT"))
+        self.assertTrue(detect_delete_data_request("Erase My Data"))
+        self.assertTrue(detect_delete_data_request("close my account"))
+
+    def test_does_not_flag_unrelated_delete_phrases(self):
+        """Deleting parts of a document or unrelated content should not trigger."""
+        unrelated_messages = [
+            "Please delete this paragraph from my appeal",
+            "Remove the diagnosis from the record I uploaded",
+            "Can you delete the wrong date in my submission?",
+            "I'd like to close my claim with the insurer",
+            "Please cancel my appointment with the doctor",
+            "Forget that I mentioned the deductible earlier",
+            "Erase the second sentence of the letter",
+            "Wipe the formatting from the pasted text",
+        ]
+        for message in unrelated_messages:
+            self.assertFalse(
+                detect_delete_data_request(message),
+                f"Incorrectly flagged unrelated message: {message}",
+            )
+
+    def test_does_not_flag_normal_health_messages(self):
+        """Normal insurance-appeal questions should never trigger."""
+        normal_messages = [
+            "My insurance denied my MRI claim",
+            "Can you help me write an appeal letter?",
+            "How do I appeal a prior authorization denial?",
+            "What information do you need from me?",
+        ]
+        for message in normal_messages:
+            self.assertFalse(
+                detect_delete_data_request(message),
+                f"Incorrectly flagged normal message: {message}",
+            )
+
+    def test_handles_empty_or_none(self):
+        """Empty/None input should return False without error."""
+        self.assertFalse(detect_delete_data_request(""))
+        self.assertFalse(detect_delete_data_request(None))  # type: ignore[arg-type]
+
+    def test_canned_response_links_to_self_service_page(self):
+        """Canned response must point users at /remove_data."""
+        self.assertIn("/remove_data", DELETE_DATA_RESPONSE)
+
+
+class TestLLMDeleteHandoff(TestCase):
+    """Tests for detecting the LLM-emitted delete-data sentinel."""
+
+    def test_detects_sentinel_alone(self):
+        self.assertTrue(llm_requested_delete_handoff(DELETE_DATA_SENTINEL))
+
+    def test_detects_sentinel_case_insensitive(self):
+        self.assertTrue(llm_requested_delete_handoff("[[delete_data_request]]"))
+        self.assertTrue(llm_requested_delete_handoff("[[Delete_Data_Request]]"))
+
+    def test_detects_sentinel_embedded_in_text(self):
+        """Even if the model adds stray whitespace or text, the sentinel triggers."""
+        self.assertTrue(llm_requested_delete_handoff(f"\n{DELETE_DATA_SENTINEL}\n"))
+        self.assertTrue(llm_requested_delete_handoff(f"Sure. {DELETE_DATA_SENTINEL}"))
+
+    def test_does_not_trigger_on_plain_text(self):
+        plain_responses = [
+            "Sure, I can help you with that appeal.",
+            "Please share more details about the denial.",
+            "Here is a draft of your appeal letter.",
+            "delete data request",  # bare phrase without brackets
+        ]
+        for response in plain_responses:
+            self.assertFalse(
+                llm_requested_delete_handoff(response),
+                f"Incorrectly triggered on: {response}",
+            )
+
+    def test_handles_empty_or_none(self):
+        self.assertFalse(llm_requested_delete_handoff(""))
+        self.assertFalse(llm_requested_delete_handoff(None))  # type: ignore[arg-type]
+
+
+class TestDeleteDataPhraseList(TestCase):
+    """Sanity checks on the delete-data phrase list."""
+
+    def test_patterns_compile(self):
+        """All phrases should be valid regex fragments."""
+        import re
+
+        for phrase in _DELETE_DATA_PHRASES:
+            try:
+                re.compile(phrase)
+            except re.error as e:
+                self.fail(f"Phrase '{phrase}' failed to compile: {e}")
+
+    def test_phrases_are_unique(self):
+        self.assertEqual(
+            len(_DELETE_DATA_PHRASES),
+            len(set(_DELETE_DATA_PHRASES)),
+            "Delete-data phrases list contains duplicates",
         )

--- a/tests/sync/test_chat_safety.py
+++ b/tests/sync/test_chat_safety.py
@@ -300,6 +300,17 @@ class TestDeleteDataDetection(TestCase):
                 f"Incorrectly flagged unrelated message: {message}",
             )
 
+    def test_known_overmatches_are_documented(self):
+        """Document known false positives so reviewers see them in failing diffs.
+
+        "Delete my profile picture" matches `delete my profile` and triggers
+        the deletion handoff. This is intentional — directing such users at the
+        deletion flow is a reasonable response to a non-existent feature
+        request — but if we ever narrow the pattern, this test should fail and
+        force a deliberate decision.
+        """
+        self.assertTrue(detect_delete_data_request("Please delete my profile picture"))
+
     def test_does_not_flag_normal_health_messages(self):
         """Normal insurance-appeal questions should never trigger."""
         normal_messages = [
@@ -376,3 +387,25 @@ class TestDeleteDataPhraseList(TestCase):
             len(set(_DELETE_DATA_PHRASES)),
             "Delete-data phrases list contains duplicates",
         )
+
+
+class TestPromptTemplateSentinelCoupling(TestCase):
+    """Guard against drift between the LLM-facing instruction and the sentinel."""
+
+    def test_intro_templates_reference_the_sentinel(self):
+        """If the sentinel changes, both intro templates must update with it."""
+        from fighthealthinsurance.prompt_templates import (
+            DELETE_DATA_INSTRUCTION,
+            NEW_CHAT_PATIENT_TEMPLATE,
+            NEW_CHAT_PROFESSIONAL_TEMPLATE,
+        )
+
+        self.assertIn(DELETE_DATA_SENTINEL, DELETE_DATA_INSTRUCTION)
+        self.assertIn(DELETE_DATA_SENTINEL, NEW_CHAT_PATIENT_TEMPLATE.template)
+        self.assertIn(DELETE_DATA_SENTINEL, NEW_CHAT_PROFESSIONAL_TEMPLATE.template)
+
+    def test_sentinel_in_template_is_detected(self):
+        """The exact sentinel embedded in the template must round-trip through the detector."""
+        from fighthealthinsurance.prompt_templates import DELETE_DATA_INSTRUCTION
+
+        self.assertTrue(llm_requested_delete_handoff(DELETE_DATA_INSTRUCTION))


### PR DESCRIPTION
## Summary
Implements detection of user requests to delete their data or account, with automatic handoff to a self-service deletion flow. This prevents the LLM from attempting to delete data from chat and ensures users are directed to a verified email-based deletion process.

## Key Changes

- **User-facing deletion detection** (`detect_delete_data_request`): Regex-based detection of common data deletion phrasings (e.g., "delete my account", "GDPR deletion request", "right to be forgotten") that triggers an immediate response with a link to `/remove_data`

- **LLM sentinel detection** (`llm_requested_delete_handoff`): Detects a special token (`[[DELETE_DATA_REQUEST]]`) that the LLM can emit when it recognizes oblique deletion requests the regex missed, allowing the model to hand off to the canned response

- **System prompt integration**: Added `DELETE_DATA_INSTRUCTION` to both patient and professional chat templates, instructing the LLM to emit the sentinel token rather than attempting to delete data

- **Chat interface safety checks**:
  - Early return with canned response when user message matches deletion patterns (skipped for document uploads to avoid false positives from OCR'd text)
  - Post-LLM check to swap responses when the sentinel is detected

- **Comprehensive test coverage**: 
  - Tests for explicit deletion phrasings and case-insensitivity
  - Tests to ensure unrelated "delete" phrases (e.g., "delete this paragraph") don't trigger
  - Tests for LLM sentinel detection with various formatting
  - Validation that the canned response links to `/remove_data`
  - Guard tests ensuring prompt templates reference the sentinel consistently

## Implementation Details

- Deletion phrases are narrowly scoped to avoid matching document-editing requests ("delete this paragraph from my appeal")
- The canned response (`DELETE_DATA_RESPONSE`) provides a two-step verification flow (email confirmation before deletion) to prevent accidental data loss
- Sentinel is case-insensitive and can be embedded in LLM output with surrounding whitespace
- Known overmatch documented: "delete my profile picture" triggers the flow (intentional, as the feature doesn't exist)

https://claude.ai/code/session_01Xhkq2Nu7tiFmaKB5UpLwCB