### PR TITLE
Follow-up to #806: every-turn delete instruction + integration tests

### DIFF
--- a/fighthealthinsurance/chat/retry_handler.py
+++ b/fighthealthinsurance/chat/retry_handler.py
@@ -105,6 +105,7 @@ async def retry_llm_with_fallback(
     timeout: float = 35.0,
     status_callback: Optional[Callable[[str], Awaitable[None]]] = None,
     chat_history: Optional[List[Dict[str, str]]] = None,
+    user_message_for_scoring: Optional[str] = None,
 ) -> Tuple[Optional[str], Optional[str]]:
     """
     Retry LLM call with shortened context and fallback backends.
@@ -125,6 +126,10 @@ async def retry_llm_with_fallback(
         timeout: Timeout in seconds for retry attempts
         status_callback: Optional async callback for status messages
         chat_history: Current chat history for context-aware scoring
+        user_message_for_scoring: Raw user message used by repetition-penalty
+            scoring. Distinct from current_message, which may be wrapped with
+            intro-template content or the delete-data instruction. Defaults to
+            current_message when not provided.
 
     Returns:
         Tuple of (response_text, context_part) or (None, None) on failure
@@ -133,6 +138,12 @@ async def retry_llm_with_fallback(
         await status_callback("Retrying with optimized context...")
 
     logger.info("Primary attempt failed, retrying with compacted context")
+
+    scoring_message = (
+        user_message_for_scoring
+        if user_message_for_scoring is not None
+        else current_message
+    )
 
     # Build retry calls with shortened history and fallbacks
     retry_calls, retry_scores = build_retry_calls(
@@ -147,7 +158,7 @@ async def retry_llm_with_fallback(
 
     # Create simplified scorer for retries
     retry_scorer = create_simple_retry_scorer(
-        retry_scores, chat_history=chat_history, current_message=current_message
+        retry_scores, chat_history=chat_history, current_message=scoring_message
     )
 
     try:

--- a/fighthealthinsurance/chat_interface.py
+++ b/fighthealthinsurance/chat_interface.py
@@ -58,7 +58,10 @@ from fighthealthinsurance.models import (
     PriorAuthRequest,
 )
 from fighthealthinsurance.microsites import get_microsite
-from fighthealthinsurance.prompt_templates import get_intro_template
+from fighthealthinsurance.prompt_templates import (
+    DELETE_DATA_INSTRUCTION,
+    get_intro_template,
+)
 from fighthealthinsurance.clinicaltrials_tools import ClinicalTrialsTools
 from fighthealthinsurance.pubmed_tools import PubMedTools
 from fighthealthinsurance.rxnorm_tools import RxNormTools
@@ -786,6 +789,12 @@ class ChatInterface:
             llm_input_message = template.format(
                 user_info=user_info_str, message=user_message
             )
+        else:
+            # Re-inject the delete-data handoff instruction on every ongoing
+            # turn. The intro template (which contains it) only fires for new
+            # chats, so without this the sentinel fallback would silently stop
+            # working past the first message.
+            llm_input_message = f"{DELETE_DATA_INSTRUCTION}\n\n{user_message}"
 
         # Prepare history for LLM using the context manager
         # This handles truncation, summarization, and full history preservation

--- a/fighthealthinsurance/chat_interface.py
+++ b/fighthealthinsurance/chat_interface.py
@@ -262,6 +262,7 @@ class ChatInterface:
         is_professional: bool = True,
         fallback_backends: Optional[List[RemoteModelLike]] = None,
         full_history: Optional[List[Dict[str, str]]] = None,
+        user_message_for_scoring: Optional[str] = None,
     ) -> Tuple[Optional[str], Optional[str]]:
         """
         Calls the LLM, handles PubMed query requests if present and returns the response.
@@ -278,11 +279,24 @@ class ChatInterface:
             fallback_backends: Backup models to try if primary fails
             full_history: Full untruncated history (optional) - will also try with this
                          if provided and model context allows it
+            user_message_for_scoring: The raw user message used by repetition-penalty
+                scoring. Distinct from current_message_for_llm, which may be wrapped
+                with intro-template content or the delete-data instruction. Defaults
+                to current_message_for_llm when not provided.
         """
         if depth > 3:
             return None, None
         chat = self.chat
         history = history_for_llm
+
+        # Fall back to the model-facing string for scoring when no raw user
+        # message was supplied (e.g. recursive tool calls that already carry
+        # the wrapped message and don't have access to the original).
+        scoring_message = (
+            user_message_for_scoring
+            if user_message_for_scoring is not None
+            else current_message_for_llm
+        )
 
         # Build LLM calls using the extracted module
         calls, call_scores = build_llm_calls(
@@ -300,7 +314,7 @@ class ChatInterface:
             call_scores,
             primary_calls=calls,
             chat_history=chat.chat_history,
-            current_message=current_message_for_llm,
+            current_message=scoring_message,
         )
 
         try:
@@ -329,6 +343,7 @@ class ChatInterface:
                 timeout=35.0,
                 status_callback=self.send_status_message,
                 chat_history=chat.chat_history,
+                user_message_for_scoring=scoring_message,
             )
             if retry_response and len(retry_response.strip()) > 5:
                 response_text = retry_response
@@ -354,6 +369,7 @@ class ChatInterface:
             is_professional=is_professional,
             fallback_backends=fallback_backends,
             full_history=full_history,
+            user_message_for_scoring=scoring_message,
         )
 
         # Non-recursive tools: appeal, prior auth
@@ -846,6 +862,7 @@ class ChatInterface:
                 is_professional=self.is_professional or self.is_trial_professional,
                 fallback_backends=fallback_models if fallback_models else None,
                 full_history=full_history_for_llm,  # Also try with full history if model supports it
+                user_message_for_scoring=user_message,
             )
 
             if response_text and response_text.strip():

--- a/tests/sync/test_chat_delete_data_integration.py
+++ b/tests/sync/test_chat_delete_data_integration.py
@@ -1,0 +1,196 @@
+"""Integration tests for the delete-data safety handoff in ChatInterface.
+
+Two end-to-end paths through `ChatInterface.handle_chat_message`:
+
+1. User-side regex match short-circuits before the LLM is consulted.
+2. LLM response containing the delete-data sentinel is swapped for the
+   canned `DELETE_DATA_RESPONSE`. The second test uses an ongoing
+   (non-empty-history) chat so it also exercises the every-turn instruction
+   injection that keeps the sentinel handoff working past the first message.
+"""
+
+import typing
+from unittest.mock import AsyncMock, patch
+
+from asgiref.sync import sync_to_async
+from django.contrib.auth import get_user_model
+from rest_framework.test import APITestCase
+
+from fighthealthinsurance.chat.safety_filters import (
+    DELETE_DATA_RESPONSE,
+    DELETE_DATA_SENTINEL,
+)
+from fighthealthinsurance.chat_interface import ChatInterface
+from fighthealthinsurance.models import (
+    ChatType,
+    OngoingChat,
+    ProfessionalUser,
+)
+from fighthealthinsurance.prompt_templates import DELETE_DATA_INSTRUCTION
+
+from .mock_chat_model import MockChatModel
+
+if typing.TYPE_CHECKING:
+    from django.contrib.auth.models import User
+else:
+    User = get_user_model()
+
+
+class DeleteDataHandoffIntegrationTest(APITestCase):
+    """End-to-end coverage for the delete-data short-circuit and sentinel swap."""
+
+    async def asyncSetUp(self):
+        self.mock_model = MockChatModel()
+
+        self.get_chat_backends_patcher = patch(
+            "fighthealthinsurance.ml.ml_router.ml_router.get_chat_backends"
+        )
+        self.mock_get_chat_backends = self.get_chat_backends_patcher.start()
+        self.mock_get_chat_backends.return_value = [self.mock_model]
+
+        self.get_chat_backends_with_fallback_patcher = patch(
+            "fighthealthinsurance.ml.ml_router.ml_router.get_chat_backends_with_fallback"
+        )
+        self.mock_get_chat_backends_with_fallback = (
+            self.get_chat_backends_with_fallback_patcher.start()
+        )
+        self.mock_get_chat_backends_with_fallback.return_value = (
+            [self.mock_model],
+            [],
+        )
+
+    async def asyncTearDown(self):
+        self.get_chat_backends_patcher.stop()
+        self.get_chat_backends_with_fallback_patcher.stop()
+
+    async def _make_chat_and_interface(
+        self,
+        captured: list,
+        username: str,
+        npi_number: str,
+        chat_history=None,
+    ):
+        """Create a professional user, chat, and ChatInterface wired to `captured`."""
+        user = await sync_to_async(User.objects.create_user)(
+            username=username,
+            password="testpass",
+            email=f"{username}@example.com",
+        )
+        professional = await sync_to_async(ProfessionalUser.objects.create)(
+            user=user, active=True, npi_number=npi_number
+        )
+        chat = await sync_to_async(OngoingChat.objects.create)(
+            professional_user=professional,
+            chat_type=ChatType.PROFESSIONAL,
+            chat_history=chat_history if chat_history is not None else [],
+            summary_for_next_call=[],
+        )
+
+        async def send_json(payload):
+            captured.append(payload)
+
+        chat_interface = ChatInterface(
+            send_json_message_func=send_json,
+            chat=chat,
+            user=user,
+        )
+        return chat, chat_interface
+
+    async def test_user_delete_request_short_circuits_without_llm_call(self):
+        """Regex match on user message must skip the LLM and reply with the canned text."""
+        await self.asyncSetUp()
+        try:
+            captured: list = []
+            chat, chat_interface = await self._make_chat_and_interface(
+                captured,
+                username="deleteshortcircuit",
+                npi_number="1112223333",
+            )
+
+            llm_spy = AsyncMock(return_value=("would-be-LLM-reply", "{}"))
+            self.mock_model.generate_chat_response = llm_spy
+
+            await chat_interface.handle_chat_message("Please delete my account")
+
+            llm_spy.assert_not_called()
+
+            assistant_payloads = [p for p in captured if p.get("role") == "assistant"]
+            self.assertEqual(len(assistant_payloads), 1)
+            self.assertEqual(assistant_payloads[0]["content"], DELETE_DATA_RESPONSE)
+
+            await sync_to_async(chat.refresh_from_db)()
+            self.assertEqual(len(chat.chat_history), 2)
+            self.assertEqual(chat.chat_history[0]["role"], "user")
+            self.assertEqual(
+                chat.chat_history[0]["content"], "Please delete my account"
+            )
+            self.assertEqual(chat.chat_history[1]["role"], "assistant")
+            self.assertEqual(chat.chat_history[1]["content"], DELETE_DATA_RESPONSE)
+        finally:
+            await self.asyncTearDown()
+
+    async def test_llm_sentinel_response_is_swapped_on_ongoing_chat(self):
+        """LLM emits the sentinel on a non-new chat; response must be swapped.
+
+        Pre-populating chat_history makes this an ongoing chat, which exercises
+        the every-turn DELETE_DATA_INSTRUCTION injection. We also assert that
+        the LLM received the instruction in its prompt to lock in that path.
+        """
+        await self.asyncSetUp()
+        try:
+            captured: list = []
+            chat, chat_interface = await self._make_chat_and_interface(
+                captured,
+                username="deletesentinelswap",
+                npi_number="4445556666",
+                chat_history=[
+                    {
+                        "role": "user",
+                        "content": "hi",
+                        "timestamp": "2026-01-01T00:00:00",
+                    },
+                    {
+                        "role": "assistant",
+                        "content": "Hello, how can I help?",
+                        "timestamp": "2026-01-01T00:00:01",
+                    },
+                ],
+            )
+
+            # User phrasing that the regex does NOT match, so we exercise the
+            # LLM path and the sentinel-swap branch rather than the
+            # short-circuit branch.
+            oblique_user_message = (
+                "I'd appreciate it if you'd wipe everything you have on me, please."
+            )
+
+            # Capture the message the LLM saw so we can verify the every-turn
+            # instruction was injected. set_next_response controls what the
+            # mock returns; we wrap generate_chat_response only to record the
+            # message argument.
+            self.mock_model.set_next_response(
+                f"Sure thing.\n{DELETE_DATA_SENTINEL}\n",
+                str({"summary": "sentinel-emitted"}),
+            )
+
+            seen_messages: list = []
+            original_generate = self.mock_model.generate_chat_response
+
+            async def recording_generate(message, *args, **kwargs):
+                seen_messages.append(message)
+                return await original_generate(message, *args, **kwargs)
+
+            self.mock_model.generate_chat_response = recording_generate
+
+            await chat_interface.handle_chat_message(oblique_user_message)
+
+            assistant_payloads = [p for p in captured if p.get("role") == "assistant"]
+            self.assertTrue(assistant_payloads, "Expected at least one assistant reply")
+            self.assertEqual(assistant_payloads[-1]["content"], DELETE_DATA_RESPONSE)
+
+            self.assertTrue(
+                seen_messages, "LLM should have been invoked on an ongoing chat"
+            )
+            self.assertIn(DELETE_DATA_INSTRUCTION, seen_messages[0])
+        finally:
+            await self.asyncTearDown()


### PR DESCRIPTION
Follow-up to #806. Two review items from that PR landed after merge.

## Summary

- **Every-turn instruction injection** (`chat_interface.py`): `DELETE_DATA_INSTRUCTION` was previously only sent to the LLM as part of the intro template, which only fires on the first turn of a chat. For ongoing conversations the sentinel handoff couldn't fire — defeating the point of the LLM-side fallback for oblique deletion phrasings the regex misses. Prepend the instruction to `llm_input_message` on non-new-chat turns too. Addresses the codex P2 comment on #806.
- **Integration tests** (`tests/sync/test_chat_delete_data_integration.py`): two new tests for `handle_chat_message`. Addresses the Copilot integration-coverage comments on #806.
  1. User message matching the deletion regex short-circuits without calling the LLM, replies with `DELETE_DATA_RESPONSE`, and writes the expected user + assistant history entries.
  2. On an ongoing (non-empty-history) chat, an LLM response containing the sentinel is swapped for `DELETE_DATA_RESPONSE`. Also asserts the LLM received `DELETE_DATA_INSTRUCTION` to lock in the every-turn injection.

## Test plan

- [x] `tox -e py313-django52-sync -- tests/sync/test_chat_delete_data_integration.py tests/sync/test_chat_safety.py` — 35 passed
- [x] `tox -e py313-django52-sync -- tests/sync/test_chat_status_messages.py` — 9 passed (no regression on existing chat tests)
- [x] `tox -e mypy` — clean
- [x] `tox -e py313-black` — clean

https://claude.ai/code/session_01Xhkq2Nu7tiFmaKB5UpLwCB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xhkq2Nu7tiFmaKB5UpLwCB)_