### PR TITLE
Extract context utilities for truncation, dedup, and merging

### DIFF
--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -52,6 +52,7 @@ from fhi_users import emails as fhi_emails
 from fhi_users.audit import TrackingInfo
 from fhi_users.models import ProfessionalUser, UserDomain
 from fighthealthinsurance import stripe_utils
+from fighthealthinsurance.context_utils import attach_supplemental_to_citations
 from fighthealthinsurance.denials.algorithmic_review_detector import (
     detect_algorithmic_review_terms,
     render_template_blocks,
@@ -3003,33 +3004,18 @@ class AppealsBackendHelper:
                     max_extralink_docs=3,
                     max_extralink_chars=1500,
                 )
-                if microsite_context:
-                    # Append to ml_citation_context or pubmed_context
-                    if ml_citation_context:
-                        if isinstance(ml_citation_context, list):
-                            ml_citation_context = "\n".join(
-                                str(c) for c in ml_citation_context if c
-                            )
-                        ml_citation_context = (
-                            f"{ml_citation_context}\n\n{microsite_context}"
-                        )
-                    elif pubmed_context:
-                        pubmed_context = f"{pubmed_context}\n\n{microsite_context}"
-                    else:
-                        # Use microsite context as standalone context
-                        ml_citation_context = microsite_context
 
-        if imr_context:
-            if ml_citation_context:
-                if isinstance(ml_citation_context, list):
-                    ml_citation_context = "\n".join(
-                        str(c) for c in ml_citation_context if c
-                    )
-                ml_citation_context = f"{ml_citation_context}\n\n{imr_context}"
-            elif pubmed_context:
-                pubmed_context = f"{pubmed_context}\n\n{imr_context}"
-            else:
-                ml_citation_context = imr_context
+        # Merge supplemental contexts into the citation pipeline. Both
+        # microsite and IMR context follow the same pattern: append to
+        # ml_citation_context if present, else pubmed_context, else use
+        # standalone. attach_supplemental_to_citations also dedupes against
+        # the existing block so a retry doesn't re-append the same content.
+        ml_citation_context, pubmed_context = attach_supplemental_to_citations(
+            ml_citation_context, pubmed_context, microsite_context
+        )
+        ml_citation_context, pubmed_context = attach_supplemental_to_citations(
+            ml_citation_context, pubmed_context, imr_context
+        )
 
         async def save_appeal(appeal_text: str) -> dict[str, str]:
             # Save all of the proposed appeals, so we can use RL later.

--- a/fighthealthinsurance/context_utils.py
+++ b/fighthealthinsurance/context_utils.py
@@ -48,13 +48,21 @@ def truncate_at_boundary(
     budget rather than e.g. cutting after the first sentence in a long
     document. Returns the input unchanged when it already fits, and an
     empty string when ``text`` is empty/None or ``max_chars`` <= 0.
+
+    Output length is guaranteed to be ``<= max_chars``. When
+    ``max_chars`` is smaller than ``len(ellipsis)`` there is no room to
+    signal truncation, so the function hard-cuts at ``max_chars`` and
+    omits the ellipsis entirely.
     """
     if not text or max_chars <= 0:
         return ""
     if len(text) <= max_chars:
         return text
 
-    budget = max(max_chars - len(ellipsis), 1)
+    if max_chars <= len(ellipsis):
+        return text[:max_chars]
+
+    budget = max_chars - len(ellipsis)
     window = text[:budget]
     min_cut = int(budget * min_keep_ratio)
 
@@ -68,11 +76,11 @@ def truncate_at_boundary(
         if end >= min_cut:
             last_sentence = end
     if last_sentence > 0:
-        return window[:last_sentence].rstrip() + " " + ellipsis
+        return window[:last_sentence].rstrip() + ellipsis
 
     space = window.rfind(" ")
     if space >= min_cut:
-        return window[:space].rstrip() + " " + ellipsis
+        return window[:space].rstrip() + ellipsis
 
     return window + ellipsis
 
@@ -146,17 +154,50 @@ def merge_context_blocks(
     return separator.join(parts)
 
 
+def _supplemental_already_present(existing: str, supplemental: str) -> bool:
+    """Whether ``supplemental`` already appears as a block in ``existing``.
+
+    Both strings are split on paragraph breaks (``\\n\\n``) and the
+    supplemental's normalized blocks must appear as a contiguous
+    subsequence within the existing blocks. This is stricter than a
+    naive substring check on the normalized text: a short supplemental
+    that coincidentally appears inside an unrelated longer block is not
+    treated as a duplicate.
+    """
+    if not existing or not supplemental:
+        return False
+
+    existing_blocks = [
+        _normalize_for_dedup(b) for b in existing.split("\n\n") if b.strip()
+    ]
+    supp_blocks = [
+        _normalize_for_dedup(b) for b in supplemental.split("\n\n") if b.strip()
+    ]
+    if not existing_blocks or not supp_blocks:
+        return False
+    n, m = len(existing_blocks), len(supp_blocks)
+    if m > n:
+        return False
+    for i in range(n - m + 1):
+        if existing_blocks[i : i + m] == supp_blocks:
+            return True
+    return False
+
+
 def flatten_citation_context(value: CitationContext) -> str:
     """Render a list-or-string citation context as a single string.
 
     ML citation helpers sometimes return ``list[str]`` and other times a
     pre-joined ``str``; downstream prompt construction needs a single
-    string regardless. Returns the empty string for None/empty inputs.
+    string regardless. Whitespace-only list entries are filtered out so
+    they don't render as blank lines. Returns the empty string for
+    None/empty inputs.
     """
     if value is None:
         return ""
     if isinstance(value, list):
-        return "\n".join(str(c).strip() for c in value if c)
+        cleaned = [str(c).strip() for c in value if c is not None]
+        return "\n".join(c for c in cleaned if c)
     return str(value).strip()
 
 
@@ -184,17 +225,16 @@ def attach_supplemental_to_citations(
         return ml_citation_context, pubmed_context
 
     supp = supplemental.strip()
-    supp_key = _normalize_for_dedup(supp)
 
     flat_ml = flatten_citation_context(ml_citation_context)
     if flat_ml:
-        if supp_key and supp_key in _normalize_for_dedup(flat_ml):
+        if _supplemental_already_present(flat_ml, supp):
             return flat_ml, pubmed_context
         return f"{flat_ml}\n\n{supp}", pubmed_context
 
     if pubmed_context and pubmed_context.strip():
         existing = pubmed_context.strip()
-        if supp_key and supp_key in _normalize_for_dedup(existing):
+        if _supplemental_already_present(existing, supp):
             return ml_citation_context, existing
         return ml_citation_context, f"{existing}\n\n{supp}"
 

--- a/fighthealthinsurance/context_utils.py
+++ b/fighthealthinsurance/context_utils.py
@@ -1,0 +1,201 @@
+"""Utilities for gathering, truncating, and merging appeal/denial context.
+
+Centralizes patterns that were previously scattered across the codebase:
+
+- ``truncate_at_boundary`` — boundary-aware truncation that prefers
+  paragraph/sentence breaks over abrupt mid-word cuts. Replaces ad-hoc
+  ``text[:N] + "..."`` slicing in extralink, RAG, PubMed, and plan-doc
+  helpers.
+
+- ``dedupe_blocks`` / ``merge_context_blocks`` — normalize-and-dedupe
+  optional context strings before joining them with a separator, with an
+  optional cumulative ``max_chars`` budget so a single oversized block
+  cannot crowd out the rest of the prompt.
+
+- ``flatten_citation_context`` / ``attach_supplemental_to_citations`` —
+  the recurring pattern in ``common_view_logic`` where microsite/IMR
+  context is appended to the ML citation context if present, else to the
+  PubMed context, else used standalone.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Iterable, List, Optional, Tuple, Union
+
+# Sentence-ending punctuation followed by whitespace or end-of-string.
+_SENTENCE_END_RE = re.compile(r"[.!?](?=\s|$)")
+
+DEFAULT_ELLIPSIS = "..."
+
+CitationContext = Optional[Union[str, List[Any]]]
+
+
+def truncate_at_boundary(
+    text: Optional[str],
+    max_chars: int,
+    ellipsis: str = DEFAULT_ELLIPSIS,
+    min_keep_ratio: float = 0.5,
+) -> str:
+    """Truncate ``text`` to at most ``max_chars`` characters at a boundary.
+
+    Preference order: paragraph break (``\\n\\n``), sentence terminator,
+    word boundary, hard cut. ``ellipsis`` is appended when truncation
+    occurs.
+
+    ``min_keep_ratio`` controls how aggressively we'll back off looking
+    for a clean boundary: at 0.5 (default) we keep at least half the
+    budget rather than e.g. cutting after the first sentence in a long
+    document. Returns the input unchanged when it already fits, and an
+    empty string when ``text`` is empty/None or ``max_chars`` <= 0.
+    """
+    if not text or max_chars <= 0:
+        return ""
+    if len(text) <= max_chars:
+        return text
+
+    budget = max(max_chars - len(ellipsis), 1)
+    window = text[:budget]
+    min_cut = int(budget * min_keep_ratio)
+
+    para_break = window.rfind("\n\n")
+    if para_break >= min_cut:
+        return window[:para_break].rstrip() + ellipsis
+
+    last_sentence = -1
+    for match in _SENTENCE_END_RE.finditer(window):
+        end = match.end()
+        if end >= min_cut:
+            last_sentence = end
+    if last_sentence > 0:
+        return window[:last_sentence].rstrip() + " " + ellipsis
+
+    space = window.rfind(" ")
+    if space >= min_cut:
+        return window[:space].rstrip() + " " + ellipsis
+
+    return window + ellipsis
+
+
+def _normalize_for_dedup(s: str) -> str:
+    """Collapse whitespace and lowercase for dedup comparisons."""
+    return " ".join(s.lower().split())
+
+
+def dedupe_blocks(
+    blocks: Iterable[Optional[str]],
+    *,
+    min_chars: int = 1,
+) -> List[str]:
+    """Drop empty, whitespace-only, and duplicate blocks.
+
+    Comparison is case- and whitespace-insensitive. The first occurrence
+    of each unique block is kept; later duplicates are dropped.
+    ``min_chars`` filters trivially short blocks (default keeps every
+    non-empty block).
+    """
+    seen: set[str] = set()
+    out: List[str] = []
+    for block in blocks:
+        if not block:
+            continue
+        stripped = block.strip()
+        if len(stripped) < min_chars:
+            continue
+        key = _normalize_for_dedup(stripped)
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        out.append(stripped)
+    return out
+
+
+def merge_context_blocks(
+    blocks: Iterable[Optional[str]],
+    *,
+    separator: str = "\n\n",
+    dedupe: bool = True,
+    max_chars: Optional[int] = None,
+) -> str:
+    """Join non-empty context blocks into a single string.
+
+    When ``dedupe`` is set, duplicate blocks (case- and
+    whitespace-insensitive) are removed before joining. When
+    ``max_chars`` is set, blocks are added in order until the next would
+    exceed the budget; remaining blocks are dropped. Returns the empty
+    string when no usable blocks remain.
+    """
+    if dedupe:
+        cleaned = dedupe_blocks(blocks)
+    else:
+        cleaned = [b.strip() for b in blocks if b and b.strip()]
+    if not cleaned:
+        return ""
+    if max_chars is None:
+        return separator.join(cleaned)
+
+    parts: List[str] = []
+    used = 0
+    sep_len = len(separator)
+    for block in cleaned:
+        cost = len(block) + (sep_len if parts else 0)
+        if used + cost > max_chars:
+            break
+        parts.append(block)
+        used += cost
+    return separator.join(parts)
+
+
+def flatten_citation_context(value: CitationContext) -> str:
+    """Render a list-or-string citation context as a single string.
+
+    ML citation helpers sometimes return ``list[str]`` and other times a
+    pre-joined ``str``; downstream prompt construction needs a single
+    string regardless. Returns the empty string for None/empty inputs.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, list):
+        return "\n".join(str(c).strip() for c in value if c)
+    return str(value).strip()
+
+
+def attach_supplemental_to_citations(
+    ml_citation_context: CitationContext,
+    pubmed_context: Optional[str],
+    supplemental: Optional[str],
+) -> Tuple[CitationContext, Optional[str]]:
+    """Append ``supplemental`` to whichever citation context is set.
+
+    Mirrors the pattern in ``common_view_logic.py`` for merging
+    microsite/IMR context into the appeal pipeline:
+      1. If ``ml_citation_context`` is non-empty, append to it (flattening
+         a list to a string first).
+      2. Otherwise, if ``pubmed_context`` is non-empty, append to it.
+      3. Otherwise, use ``supplemental`` as a standalone
+         ``ml_citation_context``.
+
+    Returns the updated ``(ml_citation_context, pubmed_context)`` pair.
+    Supplemental content is deduplicated against the existing block it's
+    being appended to, so re-running with the same supplemental does not
+    cause unbounded growth.
+    """
+    if not supplemental or not supplemental.strip():
+        return ml_citation_context, pubmed_context
+
+    supp = supplemental.strip()
+    supp_key = _normalize_for_dedup(supp)
+
+    flat_ml = flatten_citation_context(ml_citation_context)
+    if flat_ml:
+        if supp_key and supp_key in _normalize_for_dedup(flat_ml):
+            return flat_ml, pubmed_context
+        return f"{flat_ml}\n\n{supp}", pubmed_context
+
+    if pubmed_context and pubmed_context.strip():
+        existing = pubmed_context.strip()
+        if supp_key and supp_key in _normalize_for_dedup(existing):
+            return ml_citation_context, existing
+        return ml_citation_context, f"{existing}\n\n{supp}"
+
+    return supp, pubmed_context

--- a/fighthealthinsurance/extralink_context_helper.py
+++ b/fighthealthinsurance/extralink_context_helper.py
@@ -9,6 +9,7 @@ from typing import List
 
 from loguru import logger
 
+from fighthealthinsurance.context_utils import truncate_at_boundary
 from fighthealthinsurance.models import MicrositeExtraLink
 
 
@@ -76,9 +77,7 @@ class ExtraLinkContextHelper:
                 content = doc.summary or doc.raw_text
 
                 if content:
-                    # Truncate if needed
-                    if len(content) > max_chars_per_doc:
-                        content = content[:max_chars_per_doc] + "..."
+                    content = truncate_at_boundary(content, max_chars_per_doc)
 
                     title = link.title or f"Document {i}"
 

--- a/fighthealthinsurance/generate_appeal.py
+++ b/fighthealthinsurance/generate_appeal.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, Coroutine, Iterator, List, Optional, Tuple
 
 from loguru import logger
 
+from fighthealthinsurance.context_utils import truncate_at_boundary
 from fighthealthinsurance.denial_base import DenialBase
 
 from .exec import executor
@@ -2068,8 +2069,12 @@ class AppealGenerator(object):
         )
         context_parts = []
         if denial_text:
-            # Truncate very long denial text to leave room for drafts
-            context_parts.append(f"ORIGINAL DENIAL LETTER:\n{denial_text[:3000]}")
+            # Truncate very long denial text to leave room for drafts;
+            # prefer a paragraph/sentence boundary so the model gets a
+            # coherent excerpt rather than a half-finished sentence.
+            context_parts.append(
+                f"ORIGINAL DENIAL LETTER:\n{truncate_at_boundary(denial_text, 3000)}"
+            )
         if procedure:
             context_parts.append(f"PROCEDURE: {procedure}")
         if diagnosis:

--- a/fighthealthinsurance/ml/ml_plan_doc_helper.py
+++ b/fighthealthinsurance/ml/ml_plan_doc_helper.py
@@ -13,6 +13,7 @@ from typing import List, Optional, Set
 
 from loguru import logger
 
+from fighthealthinsurance.context_utils import truncate_at_boundary
 from fighthealthinsurance.ml.ml_document_extraction import extract_text_from_pdf_path
 from fighthealthinsurance.ml.ml_inference import infer_with_fallback
 from fighthealthinsurance.models import Denial, PlanDocuments
@@ -50,8 +51,11 @@ class MLPlanDocHelper:
         # Build context for the model
         context_parts = []
         if denial_text:
-            # Truncate denial text if too long
-            context_parts.append(f"Denial letter excerpt: {denial_text[:2000]}")
+            # Truncate denial text if too long, preferring a sentence
+            # boundary so the model isn't fed a half-finished sentence.
+            context_parts.append(
+                f"Denial letter excerpt: {truncate_at_boundary(denial_text, 2000)}"
+            )
         if procedure:
             context_parts.append(f"Denied procedure: {procedure}")
         if diagnosis:
@@ -240,7 +244,7 @@ Focus on:
 5. Relevant definitions
 
 Plan document excerpts:
-{relevant_text[:cls.MAX_CONTEXT_LENGTH]}
+{truncate_at_boundary(relevant_text, cls.MAX_CONTEXT_LENGTH)}
 
 Provide a concise summary (max 500 words) that would help craft an effective appeal.
 Include specific page references where helpful."""

--- a/fighthealthinsurance/pubmed_tools.py
+++ b/fighthealthinsurance/pubmed_tools.py
@@ -19,6 +19,7 @@ from django.utils import timezone
 from loguru import logger
 from metapub import FindIt
 
+from fighthealthinsurance.context_utils import truncate_at_boundary
 from fighthealthinsurance.microsites import get_microsite
 from fighthealthinsurance.ml.ml_router import ml_router
 from fighthealthinsurance.models import (
@@ -1197,7 +1198,7 @@ class PubMedTools(object):
         if article.basic_summary:
             summary = article.basic_summary
         elif article.abstract:
-            summary = article.abstract[0:500]
+            summary = truncate_at_boundary(article.abstract, 500)
 
         parts = []
         if article.authors:

--- a/fighthealthinsurance/rag_client.py
+++ b/fighthealthinsurance/rag_client.py
@@ -11,6 +11,7 @@ from typing import Optional
 import httpx
 from loguru import logger
 
+from fighthealthinsurance.context_utils import truncate_at_boundary
 from fighthealthinsurance.env_utils import get_env_variable
 
 
@@ -226,8 +227,9 @@ async def get_rag_context_for_denial(
         logger.info("RAG service not available, skipping context enrichment")
         return None
 
-    # Use first 500 chars as the denial reason query
-    denial_reason = denial_text[:500] if denial_text else ""
+    # Use first ~500 chars as the denial reason query, but cut at a
+    # sentence/word boundary so the RAG search isn't fed half a word.
+    denial_reason = truncate_at_boundary(denial_text, 500, ellipsis="")
     if not denial_reason:
         return None
 

--- a/tests/async-unit/test_appeal_synthesis.py
+++ b/tests/async-unit/test_appeal_synthesis.py
@@ -211,8 +211,12 @@ class TestSynthesizeAppeals(unittest.TestCase):
         )
 
         prompt = mock_model._infer_no_context.call_args.kwargs["prompt"]
-        # Should contain the truncated version (3000 chars), not the full 5000
-        self.assertIn("X" * 3000, prompt)
+        # Boundary-aware truncation keeps total length <= 3000 and marks
+        # truncation with an ellipsis. For an input with no sentence/word
+        # boundaries (all X's), the helper hard-cuts and appends "...",
+        # so the prompt contains 2997 X's followed by "..." rather than
+        # the full 5000-char input.
+        self.assertIn("X" * 2997 + "...", prompt)
         self.assertNotIn("X" * 3001, prompt)
 
     @patch("fighthealthinsurance.generate_appeal.best_within_timelimit")

--- a/tests/sync/test_context_utils.py
+++ b/tests/sync/test_context_utils.py
@@ -56,9 +56,10 @@ class TestTruncateAtBoundary(unittest.TestCase):
         text = "alpha beta gamma delta epsilon zeta eta theta iota"
         result = truncate_at_boundary(text, 20)
         self.assertTrue(result.endswith("..."))
-        # No partial word at the end.
-        body = result.rsplit(" ", 1)[0]
-        self.assertIn(body, text)
+        # No partial word: the part before the ellipsis must be a prefix
+        # of the source text.
+        body = result[: -len("...")].rstrip()
+        self.assertTrue(text.startswith(body))
 
     def test_hard_cut_when_no_boundary_in_window(self):
         text = "x" * 100
@@ -75,6 +76,46 @@ class TestTruncateAtBoundary(unittest.TestCase):
         text = "x" * 100
         result = truncate_at_boundary(text, 50, ellipsis="")
         self.assertEqual(len(result), 50)
+
+    def test_empty_ellipsis_no_trailing_space_on_sentence_cut(self):
+        # Regression: trailing " " was previously appended on the
+        # sentence/word boundary paths even when ellipsis="", giving the
+        # RAG query a stray trailing space.
+        text = "First sentence. Second sentence. Third sentence keeps going."
+        result = truncate_at_boundary(text, 40, ellipsis="")
+        self.assertFalse(result.endswith(" "))
+
+    def test_output_never_exceeds_max_chars(self):
+        # Regression: previous implementation could exceed max_chars by 1
+        # because " " + ellipsis was appended after only len(ellipsis)
+        # was reserved in the budget.
+        cases = [
+            ("First sentence. Second sentence. Third sentence.", 25, "..."),
+            ("alpha beta gamma delta epsilon zeta eta theta", 20, "..."),
+            ("paragraph one ends.\n\nparagraph two continues here.", 25, "..."),
+            ("x" * 200, 50, "..."),
+            ("First sentence. Second.", 22, " [more]"),
+            ("words " * 50, 40, ""),
+        ]
+        for text, max_chars, ellipsis in cases:
+            with self.subTest(text=text[:20], max_chars=max_chars):
+                result = truncate_at_boundary(text, max_chars, ellipsis=ellipsis)
+                self.assertLessEqual(
+                    len(result),
+                    max_chars,
+                    f"Output {len(result)} > max_chars {max_chars}: {result!r}",
+                )
+
+    def test_max_chars_smaller_than_ellipsis_falls_back_to_hard_cut(self):
+        # Regression: when max_chars < len(ellipsis) the previous code
+        # still appended the ellipsis, exceeding the budget. Now the
+        # function hard-cuts without an ellipsis.
+        text = "hello world"
+        for max_chars in (1, 2, 3):
+            with self.subTest(max_chars=max_chars):
+                result = truncate_at_boundary(text, max_chars, ellipsis="...")
+                self.assertEqual(result, text[:max_chars])
+                self.assertEqual(len(result), max_chars)
 
 
 class TestDedupeBlocks(unittest.TestCase):
@@ -138,6 +179,12 @@ class TestFlattenCitationContext(unittest.TestCase):
         result = flatten_citation_context(["a", "", None, "b"])
         self.assertEqual(result, "a\nb")
 
+    def test_list_skips_whitespace_only_entries(self):
+        # Regression: whitespace-only entries are truthy but strip to
+        # empty, previously rendering as blank lines.
+        result = flatten_citation_context(["a", "   ", "\t\n", "b"])
+        self.assertEqual(result, "a\nb")
+
 
 class TestAttachSupplementalToCitations(unittest.TestCase):
     def test_no_supplemental_returns_inputs_unchanged(self):
@@ -177,21 +224,43 @@ class TestAttachSupplementalToCitations(unittest.TestCase):
         self.assertEqual(pm, "")
 
     def test_dedupes_when_supplemental_already_present_in_ml(self):
-        existing = "Some background info. Microsite link: https://example.com/x"
-        ml, pm = attach_supplemental_to_citations(
-            existing, None, "microsite link: https://example.com/x"
+        # Realistic shape: existing already has the supplemental block
+        # appended via \n\n from a prior call.
+        microsite_block = (
+            "## Additional Medical Evidence\n\n"
+            "Microsite link: https://example.com/x"
         )
+        existing = f"original ml citations\n\n{microsite_block}"
+        ml, pm = attach_supplemental_to_citations(existing, None, microsite_block)
         # Already contained — must not re-append.
         self.assertEqual(ml, existing)
         self.assertIsNone(pm)
 
     def test_dedupes_when_supplemental_already_present_in_pubmed(self):
-        existing = "PubMed: something. Extra block content here."
-        ml, pm = attach_supplemental_to_citations(
-            None, existing, "Extra block content here."
-        )
+        imr_block = "Prior IMR decision: case 12345 reversed."
+        existing = f"PubMed reference list ...\n\n{imr_block}"
+        ml, pm = attach_supplemental_to_citations(None, existing, imr_block)
         self.assertIsNone(ml)
         self.assertEqual(pm, existing)
+
+    def test_dedupe_does_not_match_substring_inside_unrelated_block(self):
+        # Regression: previous implementation used substring containment
+        # on normalized text, so a short supplemental could be silently
+        # dropped if it happened to appear inside an unrelated block.
+        existing = "Lorem ipsum dolor sit amet. Background context here."
+        supp = "ipsum"
+        ml, pm = attach_supplemental_to_citations(existing, None, supp)
+        self.assertEqual(ml, f"{existing}\n\n{supp}")
+        self.assertIsNone(pm)
+
+    def test_dedupes_multi_paragraph_supplemental_appearing_in_middle(self):
+        # The supplemental can be multi-paragraph and may be sandwiched
+        # between other context. Block-sequence match should detect it.
+        supp = "## Heading\n\nFirst para of supp.\n\nSecond para of supp."
+        existing = f"head context\n\n{supp}\n\ntail context"
+        ml, pm = attach_supplemental_to_citations(existing, None, supp)
+        self.assertEqual(ml, existing)
+        self.assertIsNone(pm)
 
 
 if __name__ == "__main__":

--- a/tests/sync/test_context_utils.py
+++ b/tests/sync/test_context_utils.py
@@ -1,0 +1,198 @@
+"""Tests for fighthealthinsurance.context_utils.
+
+Covers boundary-aware truncation, deduplication, block merging, and the
+supplemental-citation attach pattern used in the appeal/denial flow.
+"""
+
+import unittest
+
+from fighthealthinsurance.context_utils import (
+    attach_supplemental_to_citations,
+    dedupe_blocks,
+    flatten_citation_context,
+    merge_context_blocks,
+    truncate_at_boundary,
+)
+
+
+class TestTruncateAtBoundary(unittest.TestCase):
+    def test_returns_empty_for_none_or_empty(self):
+        self.assertEqual(truncate_at_boundary(None, 100), "")
+        self.assertEqual(truncate_at_boundary("", 100), "")
+
+    def test_returns_empty_for_nonpositive_budget(self):
+        self.assertEqual(truncate_at_boundary("hello", 0), "")
+        self.assertEqual(truncate_at_boundary("hello", -5), "")
+
+    def test_returns_input_when_within_budget(self):
+        text = "Short enough text."
+        self.assertEqual(truncate_at_boundary(text, 100), text)
+
+    def test_prefers_paragraph_boundary(self):
+        text = (
+            "First paragraph with some sentences. Second one too.\n\n"
+            "Second paragraph keeps going here and is long enough."
+        )
+        result = truncate_at_boundary(text, 70)
+        self.assertTrue(result.endswith("..."))
+        # Cut should be at the paragraph break, not mid-sentence.
+        self.assertNotIn("Second paragraph", result)
+        self.assertIn("Second one too.", result)
+
+    def test_prefers_sentence_boundary_when_no_paragraph(self):
+        text = (
+            "First sentence here. Second sentence follows. "
+            "Third sentence keeps going and going."
+        )
+        result = truncate_at_boundary(text, 45)
+        self.assertTrue(result.endswith("..."))
+        # Should not end mid-word.
+        body = result.rstrip(".").rstrip()
+        self.assertFalse(body.endswith("Thir"))
+        # First sentence should be present.
+        self.assertIn("First sentence here.", result)
+
+    def test_falls_back_to_word_boundary(self):
+        text = "alpha beta gamma delta epsilon zeta eta theta iota"
+        result = truncate_at_boundary(text, 20)
+        self.assertTrue(result.endswith("..."))
+        # No partial word at the end.
+        body = result.rsplit(" ", 1)[0]
+        self.assertIn(body, text)
+
+    def test_hard_cut_when_no_boundary_in_window(self):
+        text = "x" * 100
+        result = truncate_at_boundary(text, 20)
+        self.assertEqual(len(result), 20)
+        self.assertTrue(result.endswith("..."))
+
+    def test_custom_ellipsis(self):
+        text = "First sentence. Second sentence. Third sentence."
+        result = truncate_at_boundary(text, 25, ellipsis=" [snip]")
+        self.assertTrue(result.endswith("[snip]"))
+
+    def test_empty_ellipsis_allows_full_budget(self):
+        text = "x" * 100
+        result = truncate_at_boundary(text, 50, ellipsis="")
+        self.assertEqual(len(result), 50)
+
+
+class TestDedupeBlocks(unittest.TestCase):
+    def test_skips_none_and_empty(self):
+        self.assertEqual(dedupe_blocks([None, "", "  ", "kept"]), ["kept"])
+
+    def test_dedupe_is_case_and_whitespace_insensitive(self):
+        result = dedupe_blocks(["Hello World", "  hello  WORLD  ", "Other"])
+        self.assertEqual(result, ["Hello World", "Other"])
+
+    def test_preserves_order_of_first_occurrence(self):
+        result = dedupe_blocks(["b", "a", "B", "c", "A"])
+        self.assertEqual(result, ["b", "a", "c"])
+
+    def test_min_chars_filter(self):
+        result = dedupe_blocks(["ok", "x", "longer text"], min_chars=3)
+        self.assertEqual(result, ["longer text"])
+
+
+class TestMergeContextBlocks(unittest.TestCase):
+    def test_empty_input_returns_empty_string(self):
+        self.assertEqual(merge_context_blocks([]), "")
+        self.assertEqual(merge_context_blocks([None, "", "  "]), "")
+
+    def test_joins_with_default_separator(self):
+        result = merge_context_blocks(["one", "two", "three"])
+        self.assertEqual(result, "one\n\ntwo\n\nthree")
+
+    def test_dedupes_by_default(self):
+        result = merge_context_blocks(["one", "ONE", "two"])
+        self.assertEqual(result, "one\n\ntwo")
+
+    def test_dedupe_can_be_disabled(self):
+        result = merge_context_blocks(["one", "ONE"], dedupe=False)
+        self.assertEqual(result, "one\n\nONE")
+
+    def test_respects_max_chars_budget(self):
+        result = merge_context_blocks(
+            ["aaaa", "bbbb", "cccc"], separator="|", max_chars=9
+        )
+        # First two cost 4 + 1 + 4 = 9; third would exceed.
+        self.assertEqual(result, "aaaa|bbbb")
+
+    def test_max_chars_drops_oversized_first_block(self):
+        result = merge_context_blocks(["a" * 100], max_chars=10)
+        self.assertEqual(result, "")
+
+
+class TestFlattenCitationContext(unittest.TestCase):
+    def test_none_returns_empty(self):
+        self.assertEqual(flatten_citation_context(None), "")
+
+    def test_string_returned_stripped(self):
+        self.assertEqual(flatten_citation_context("  hello  "), "hello")
+
+    def test_list_joined_with_newlines(self):
+        result = flatten_citation_context(["a", "b", "c"])
+        self.assertEqual(result, "a\nb\nc")
+
+    def test_list_skips_falsy_entries(self):
+        result = flatten_citation_context(["a", "", None, "b"])
+        self.assertEqual(result, "a\nb")
+
+
+class TestAttachSupplementalToCitations(unittest.TestCase):
+    def test_no_supplemental_returns_inputs_unchanged(self):
+        ml, pm = attach_supplemental_to_citations("ml ctx", "pm ctx", None)
+        self.assertEqual(ml, "ml ctx")
+        self.assertEqual(pm, "pm ctx")
+
+        ml, pm = attach_supplemental_to_citations(None, None, "  ")
+        self.assertIsNone(ml)
+        self.assertIsNone(pm)
+
+    def test_appends_to_ml_citation_when_present(self):
+        ml, pm = attach_supplemental_to_citations("existing", "pm", "new evidence")
+        self.assertEqual(ml, "existing\n\nnew evidence")
+        self.assertEqual(pm, "pm")
+
+    def test_flattens_list_ml_citation_before_appending(self):
+        ml, pm = attach_supplemental_to_citations(
+            ["citation A", "citation B"], None, "extra"
+        )
+        self.assertEqual(ml, "citation A\ncitation B\n\nextra")
+        self.assertIsNone(pm)
+
+    def test_appends_to_pubmed_when_ml_empty(self):
+        ml, pm = attach_supplemental_to_citations(None, "pubmed", "extra")
+        self.assertIsNone(ml)
+        self.assertEqual(pm, "pubmed\n\nextra")
+
+    def test_uses_supplemental_standalone_when_both_empty(self):
+        ml, pm = attach_supplemental_to_citations(None, None, "lonely citation")
+        self.assertEqual(ml, "lonely citation")
+        self.assertIsNone(pm)
+
+    def test_empty_string_citation_treated_as_empty(self):
+        ml, pm = attach_supplemental_to_citations("", "", "extra")
+        self.assertEqual(ml, "extra")
+        self.assertEqual(pm, "")
+
+    def test_dedupes_when_supplemental_already_present_in_ml(self):
+        existing = "Some background info. Microsite link: https://example.com/x"
+        ml, pm = attach_supplemental_to_citations(
+            existing, None, "microsite link: https://example.com/x"
+        )
+        # Already contained — must not re-append.
+        self.assertEqual(ml, existing)
+        self.assertIsNone(pm)
+
+    def test_dedupes_when_supplemental_already_present_in_pubmed(self):
+        existing = "PubMed: something. Extra block content here."
+        ml, pm = attach_supplemental_to_citations(
+            None, existing, "Extra block content here."
+        )
+        self.assertIsNone(ml)
+        self.assertEqual(pm, existing)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Centralizes recurring patterns for handling appeal/denial context into a new `context_utils.py` module. This refactoring eliminates scattered ad-hoc text truncation and context merging logic across the codebase, replacing it with reusable, well-tested utilities.

## Key Changes

- **New module: `fighthealthinsurance/context_utils.py`**
  - `truncate_at_boundary()` — Boundary-aware text truncation that prefers paragraph breaks, sentence endings, and word boundaries over hard cuts. Replaces ad-hoc `text[:N]` slicing throughout the codebase.
  - `dedupe_blocks()` — Removes duplicate context blocks with case- and whitespace-insensitive comparison.
  - `merge_context_blocks()` — Joins context blocks with optional deduplication and cumulative character budget enforcement.
  - `flatten_citation_context()` — Normalizes list-or-string citation contexts to a single string.
  - `attach_supplemental_to_citations()` — Implements the recurring pattern in `common_view_logic.py` for merging microsite/IMR context into the citation pipeline with deduplication.

- **Updated `common_view_logic.py`**
  - Replaced ~30 lines of manual context merging logic with two calls to `attach_supplemental_to_citations()`, eliminating code duplication and improving maintainability.

- **Updated `generate_appeal.py`**
  - Replaced `denial_text[:3000]` with `truncate_at_boundary(denial_text, 3000)` to ensure coherent excerpts at sentence/paragraph boundaries.

- **Updated `ml_plan_doc_helper.py`**
  - Replaced `denial_text[:2000]` with `truncate_at_boundary(denial_text, 2000)`.

- **Updated `rag_client.py`**
  - Replaced `denial_text[:500]` with `truncate_at_boundary(denial_text, 500)`.

- **Updated `extralink_context_helper.py`**
  - Replaced manual truncation logic with `truncate_at_boundary()`.

- **Updated `pubmed_tools.py`**
  - Replaced manual truncation logic with `truncate_at_boundary()`.

- **New test suite: `tests/sync/test_context_utils.py`**
  - Comprehensive coverage of all utilities with 30+ test cases covering boundary preferences, deduplication, budget enforcement, and edge cases.

- **Updated `tests/async-unit/test_appeal_synthesis.py`**
  - Adjusted assertion to account for boundary-aware truncation behavior (hard cut at 2997 chars + "..." rather than exact 3000).

## Implementation Details

- **Boundary preference order:** Paragraph breaks (`\n\n`) → sentence terminators → word boundaries → hard cut.
- **Deduplication:** Case- and whitespace-insensitive comparison using normalized keys, preserving first occurrence.
- **Budget enforcement:** When `max_chars` is set in `merge_context_blocks()`, blocks are added in order until the next would exceed the budget.
- **Supplemental attachment:** Follows the existing pattern in `common_view_logic.py` — appends to ML citation context if present, else PubMed context, else uses standalone. Deduplicates against the target block to prevent re-appending on retry.

https://claude.ai/code/session_019tQXKqyHnvhCsbgMPH5n23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved text truncation to break at natural boundaries (paragraphs, sentences, words) instead of mid-sentence.
  * Enhanced context merging with intelligent deduplication of supplemental content.

* **Refactor**
  * Consolidated context handling logic into a dedicated utility module for improved maintainability.

* **Tests**
  * Added comprehensive test coverage for context utilities and updated existing truncation tests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fighthealthinsurance/fighthealthinsurance/pull/809)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->