### PR TITLE
Convert pro_version to interest form with conditional availability

### DIFF
--- a/fighthealthinsurance/followup_emails.py
+++ b/fighthealthinsurance/followup_emails.py
@@ -90,7 +90,7 @@ class ThankyouEmailSender(AsyncEmailSenderMixin):
         try:
             send_fallback_email(
                 template_name="professional_thankyou",
-                subject="Thank you for signing up for Fight Health Insurance Pro Beta!",
+                subject="Thanks for your interest in our new professional version!",
                 context=context,
                 to_email=email,
             )

--- a/fighthealthinsurance/forms/__init__.py
+++ b/fighthealthinsurance/forms/__init__.py
@@ -56,16 +56,10 @@ class InterestedProfessionalForm(forms.ModelForm):
             }
         ),
     )
-    clicked_for_paid = forms.BooleanField(
-        initial=True,
-        required=False,
-        label="Optional: Pay $10 now to get 3 months of the beta when we launch the new updated professional version, while we figure out what/if folks will pay for it.",
-        widget=forms.CheckboxInput(),
-    )
 
     class Meta:
         model = InterestedProfessional
-        exclude = ["paid", "signup_date"]
+        exclude = ["paid", "clicked_for_paid", "signup_date"]
 
 
 class DeleteDataForm(forms.Form):

--- a/fighthealthinsurance/forms/__init__.py
+++ b/fighthealthinsurance/forms/__init__.py
@@ -59,7 +59,14 @@ class InterestedProfessionalForm(forms.ModelForm):
 
     class Meta:
         model = InterestedProfessional
-        exclude = ["paid", "clicked_for_paid", "signup_date"]
+        # Block mass-assignment of internal/state-tracking fields via a public POST.
+        exclude = [
+            "paid",
+            "clicked_for_paid",
+            "signup_date",
+            "mod_date",
+            "thankyou_email_sent",
+        ]
 
 
 class DeleteDataForm(forms.Form):

--- a/fighthealthinsurance/forms/__init__.py
+++ b/fighthealthinsurance/forms/__init__.py
@@ -59,7 +59,7 @@ class InterestedProfessionalForm(forms.ModelForm):
     clicked_for_paid = forms.BooleanField(
         initial=True,
         required=False,
-        label="Optional: Pay $10 now to get 3-months of the beta when we launch the professional version while we figure out what/if folks will pay for it.",
+        label="Optional: Pay $10 now to get 3 months of the beta when we launch the new updated professional version, while we figure out what/if folks will pay for it.",
         widget=forms.CheckboxInput(),
     )
 

--- a/fighthealthinsurance/settings.py
+++ b/fighthealthinsurance/settings.py
@@ -84,6 +84,11 @@ class Base(Configuration):
         IMR_REFRESH_INTERVAL_HOURS = 168
     ENABLE_VOICE_INTAKE = os.getenv("ENABLE_VOICE_INTAKE", "false").lower() == "true"
     ENABLE_LOCAL_STT = os.getenv("ENABLE_LOCAL_STT", "true").lower() == "true"
+    # When true, /pro_version shows a "professional version is here" page with
+    # trial / learn-more CTAs instead of the "coming soon" interest form.
+    PRO_VERSION_AVAILABLE = (
+        os.getenv("PRO_VERSION_AVAILABLE", "false").lower() == "true"
+    )
     LOGIN_URL = "login"
     LOGIN_REDIRECT_URL = "/"
     THUMBNAIL_DEBUG = True

--- a/fighthealthinsurance/templates/emails/professional_thankyou.html
+++ b/fighthealthinsurance/templates/emails/professional_thankyou.html
@@ -2,19 +2,19 @@
 {% block content %}
 Dear {{ name }},
 <p>
-You are a PRO! Thank you for signing up for the Pro Version of Fight Health Insurance, which we call “Fight Paperwork” as we aim to solve more than just insurance problems in the long term.
+Thank you for your interest in the new updated professional version of Fight Health Insurance!
 </p>
 <p>
-We hope to launch our Pro Version BETA in March – but you know how optimistic engineers can be with timelines.
+We're hard at work on it — designed for providers, appeal specialists, lawyers, and patient-access teams who need to fight denials at scale, with faster appeal generation, smarter citations, and tooling tailored to professional workflows.
 </p>
 <p>
-<a href="https://www.fighthealthinsurance.com/pro_version">Please continue to support us by sharing with friends</a>, and stay tuned for your next update!
+We'll let you know the moment it's ready. In the meantime, <a href="https://www.fighthealthinsurance.com/pro_version">please continue to support us by sharing with friends</a>.
 </p>
 <p>
-Your participation has a huge impact!  If you’ve got any questions, please feel free to reach out to us at <a href="mailto:support42@fighthealthinsurance.com">support42@fighthealthinsurance.com</a> :) We are also planning on conducting some user studies the end of this month if your willing to share feedback with us on the new workflow before we release it drop us an e-mail at <a href="mailto:support42@fighthealthinsurance.com">support42@fighthealthinsurance.com</a> :)
+Your participation has a huge impact! If you have any questions, or if you'd like to take part in user studies and share feedback on the new workflow before we release it, please reach out to us at <a href="mailto:support42@fighthealthinsurance.com">support42@fighthealthinsurance.com</a>.
 </p>
 <p>
-  A huge thank you,
+A huge thank you,
 </p>
 <p>
 FHI Team

--- a/fighthealthinsurance/templates/emails/professional_thankyou.txt
+++ b/fighthealthinsurance/templates/emails/professional_thankyou.txt
@@ -1,13 +1,13 @@
 Dear {{name}},
 
-You are a PRO! Thank you for signing up for the Pro Version of Fight Health Insurance, which we call “Fight Paperwork” as we aim to solve more than just insurance problems in the long term. 
+Thank you for your interest in the new updated professional version of Fight Health Insurance!
 
-We hope to launch our Pro Version BETA in March – but you know how optimistic engineers can be with timelines. 
+We're hard at work on it — designed for providers, appeal specialists, lawyers, and patient-access teams who need to fight denials at scale, with faster appeal generation, smarter citations, and tooling tailored to professional workflows.
 
-Please continue to support us by sharing with friends, and stay tuned for your next update! 
+We'll let you know the moment it's ready. In the meantime, please continue to support us by sharing with friends: https://www.fighthealthinsurance.com/pro_version
 
-Your participation has a huge impact!  If you’ve got any questions, please feel free to reach out to us at support42@fighthealthinsurance.com :) We are also planning on conducting some user studies the end of this month if your willing to share feedback with us on the new workflow before we release it drop us an e-mail at support42@fighthealthinsurance.com :)
+Your participation has a huge impact! If you have any questions, or if you'd like to take part in user studies and share feedback on the new workflow before we release it, please reach out to us at support42@fighthealthinsurance.com.
 
-A huge thank you, 
+A huge thank you,
 
 FHI Team

--- a/fighthealthinsurance/templates/professional.html
+++ b/fighthealthinsurance/templates/professional.html
@@ -8,20 +8,22 @@ Fight Health Insurance Professional Version
 <section id="contact">
     <div class="container">
       <div class="section-header text-align-center">
-	<h3 class="pro-version-header" style="text-align: center; padding: 15px; margin-top: 10vh;">Fight Health Insurance: Professional Version</h3>
+	<h3 class="pro-version-header" style="text-align: center; padding: 15px; margin-top: 10vh;">New Updated Professional Version Coming Soon</h3>
       </div>
       <p>
-	We are actively working on a professional version. The available consumer version is not intended or certified for professional use.
-      We would love to keep in touch to let you know when we've got a professional version. Fill out the form below!
+	We are hard at work on a new, updated professional version of Fight Health Insurance. Our current professional offering lives at
+	<a href="https://www.fightpaperwork.com">Fight Paperwork</a>, and the new updated version builds on everything we've learned to make appeals
+	faster, smarter, and easier for providers, appeal specialists, lawyers, and patient-access teams. We'd love to keep you in the loop — fill out the form below
+	and we'll let you know the moment the new version is ready.
       </p>
       <p>
 	Not a professional (e.g. providers office, appeal specialist, lawyer, etc.) but still ended up here? Don't worry!
       <a href="{% url 'scan' %}">You can try the regular appeal generator here.</a>
       </p>
       <p>
-	If you're interested in becoming one of the first beta users, you have the option to pay $10 for a 3-month access of the professional beta
-      once it launches. If you change your mind at any time before or during the professional beta, we're more than happy to refund that.
-      Honestly the $10 is to show that folks are willing to pay for it so we can get more resources.
+	If you'd like early access, you have the option to pay $10 to get 3 months of the new updated professional beta once it launches.
+      If you change your mind at any time before or during the beta, we're happy to refund it.
+      Honestly the $10 is to show that folks are willing to pay for it so we can secure more resources to keep building.
       </p>
       <p>
 	<div class="main-form">

--- a/fighthealthinsurance/templates/professional.html
+++ b/fighthealthinsurance/templates/professional.html
@@ -20,11 +20,6 @@ Fight Health Insurance Professional Version
       <a href="{% url 'scan' %}">You can try the regular appeal generator here.</a>
       </p>
       <p>
-	If you'd like early access, you have the option to pay $10 to get 3 months of the new updated professional beta once it launches.
-      If you change your mind at any time before or during the beta, we're happy to refund it.
-      Honestly the $10 is to show that folks are willing to pay for it so we can secure more resources to keep building.
-      </p>
-      <p>
 	<div class="main-form">
 	<form method="post">
 	  {% csrf_token %}
@@ -66,10 +61,6 @@ Fight Health Insurance Professional Version
           <div class="form-group">
             <label for="id_comments">Comments:</label>
             {{ form.comments}}
-            <label for="clicked_for_paid">
-            {{ form.clicked_for_paid }}
-            {{ form.clicked_for_paid.label }}
-            </label>
           </div>
 
           <div class="form-group">

--- a/fighthealthinsurance/templates/professional.html
+++ b/fighthealthinsurance/templates/professional.html
@@ -11,10 +11,9 @@ Fight Health Insurance Professional Version
 	<h3 class="pro-version-header" style="text-align: center; padding: 15px; margin-top: 10vh;">New Updated Professional Version Coming Soon</h3>
       </div>
       <p>
-	We are hard at work on a new, updated professional version of Fight Health Insurance. Our current professional offering lives at
-	<a href="https://www.fightpaperwork.com">Fight Paperwork</a>, and the new updated version builds on everything we've learned to make appeals
-	faster, smarter, and easier for providers, appeal specialists, lawyers, and patient-access teams. We'd love to keep you in the loop — fill out the form below
-	and we'll let you know the moment the new version is ready.
+	We are hard at work on a new, updated professional version of Fight Health Insurance — built to help providers, appeal specialists, lawyers,
+	and patient-access teams fight denials at scale, with faster appeal generation, smarter citations, and tooling tailored to professional workflows.
+	We'd love to keep you in the loop — fill out the form below and we'll let you know the moment it's ready.
       </p>
       <p>
 	Not a professional (e.g. providers office, appeal specialist, lawyer, etc.) but still ended up here? Don't worry!

--- a/fighthealthinsurance/templates/professional_available.html
+++ b/fighthealthinsurance/templates/professional_available.html
@@ -2,8 +2,6 @@
 {% block title %}
 Fight Health Insurance Professional Version
 {% endblock title %}
-{% load static %}
-{% load absolute %}
 {% block content %}
 <section id="contact">
     <div class="container">

--- a/fighthealthinsurance/templates/professional_available.html
+++ b/fighthealthinsurance/templates/professional_available.html
@@ -8,11 +8,10 @@ Fight Health Insurance Professional Version
 <section id="contact">
     <div class="container">
       <div class="section-header text-align-center">
-	<h3 class="pro-version-header" style="text-align: center; padding: 15px; margin-top: 10vh;">The New Professional Version is Here</h3>
+	<h3 class="pro-version-header" style="text-align: center; padding: 15px; margin-top: 10vh;">The New Professional Version Is Here</h3>
       </div>
       <p>
-	The new updated professional version of Fight Health Insurance is now available at
-	<a href="https://www.fightpaperwork.com">Fight Paperwork</a>. It's built for providers, appeal specialists,
+	The new updated professional version of Fight Health Insurance is now available. It's built for providers, appeal specialists,
 	lawyers, and patient-access teams who need to fight denials at scale — with faster appeal generation,
 	smarter citations, and tooling tailored to professional workflows.
       </p>
@@ -21,16 +20,10 @@ Fight Health Insurance Professional Version
       <a href="{% url 'scan' %}">You can try the regular appeal generator here.</a>
       </p>
       <div class="text-align-center" style="margin-top: 2rem; margin-bottom: 2rem;">
-	<a href="https://www.fightpaperwork.com/signup" class="section-btn btn btn-default smoothScroll" style="display: inline-block; margin-right: 1rem;">
-	  Schedule a Trial
-	</a>
-	<a href="https://www.fightpaperwork.com" class="btn btn-outline-green smoothScroll" style="display: inline-block;">
-	  Learn More
+	<a href="mailto:support42@fighthealthinsurance.com?subject=Professional%20Version%20Trial%20Request" class="section-btn btn btn-default smoothScroll" style="display: inline-block;">
+	  Schedule a Trial or Learn More
 	</a>
       </div>
-      <p>
-	Questions? Reach out any time at <a href="mailto:support42@fighthealthinsurance.com">support42@fighthealthinsurance.com</a>.
-      </p>
     </div>
 </section>
 {% endblock content %}

--- a/fighthealthinsurance/templates/professional_available.html
+++ b/fighthealthinsurance/templates/professional_available.html
@@ -1,0 +1,36 @@
+{% extends 'base.html' %}
+{% block title %}
+Fight Health Insurance Professional Version
+{% endblock title %}
+{% load static %}
+{% load absolute %}
+{% block content %}
+<section id="contact">
+    <div class="container">
+      <div class="section-header text-align-center">
+	<h3 class="pro-version-header" style="text-align: center; padding: 15px; margin-top: 10vh;">The New Professional Version is Here</h3>
+      </div>
+      <p>
+	The new updated professional version of Fight Health Insurance is now available at
+	<a href="https://www.fightpaperwork.com">Fight Paperwork</a>. It's built for providers, appeal specialists,
+	lawyers, and patient-access teams who need to fight denials at scale — with faster appeal generation,
+	smarter citations, and tooling tailored to professional workflows.
+      </p>
+      <p>
+	Not a professional (e.g. providers office, appeal specialist, lawyer, etc.) but still ended up here? Don't worry!
+      <a href="{% url 'scan' %}">You can try the regular appeal generator here.</a>
+      </p>
+      <div class="text-align-center" style="margin-top: 2rem; margin-bottom: 2rem;">
+	<a href="https://www.fightpaperwork.com/signup" class="section-btn btn btn-default smoothScroll" style="display: inline-block; margin-right: 1rem;">
+	  Schedule a Trial
+	</a>
+	<a href="https://www.fightpaperwork.com" class="btn btn-outline-green smoothScroll" style="display: inline-block;">
+	  Learn More
+	</a>
+      </div>
+      <p>
+	Questions? Reach out any time at <a href="mailto:support42@fighthealthinsurance.com">support42@fighthealthinsurance.com</a>.
+      </p>
+    </div>
+</section>
+{% endblock content %}

--- a/fighthealthinsurance/templates/professional_thankyou.html
+++ b/fighthealthinsurance/templates/professional_thankyou.html
@@ -12,7 +12,7 @@ Fighthealthinsurance Professional Version -- Thank You!
 	<h2>Thank you!</h2>
       </div>
       <p>
-	Thank you for believing in us! We'll let you know as the new updated professional version progresses. In the meantime, our current professional offering is available at <a href="https://www.fightpaperwork.com">Fight Paperwork</a>. If you have <b>any</b> questions please reach out to <a href="mailto:support42@fighthealthinsurance.com">support42@fighthealthinsurance.com</a>!
+	Thank you for believing in us! We'll keep you posted as the new updated professional version comes together. If you have <b>any</b> questions, please reach out to <a href="mailto:support42@fighthealthinsurance.com">support42@fighthealthinsurance.com</a>!
       </p>
     </div>
 </section>

--- a/fighthealthinsurance/templates/professional_thankyou.html
+++ b/fighthealthinsurance/templates/professional_thankyou.html
@@ -8,11 +8,11 @@ Fighthealthinsurance Professional Version -- Thank You!
 <section id="contact">
     <div class="container">
       <div class="section-header text-align-center">
-	<h2>Fighthealthinsurance Professional Version</h2>
+	<h2>New Updated Professional Version</h2>
 	<h2>Thank you!</h2>
       </div>
       <p>
-	Thank you for believing in us! We'll let you know as we progress. If you have <b>any</b> questions please reach out <a href="mailto:support42@fighthealthinsurance.com">support42@fighthealthinsurance.com</a>!
+	Thank you for believing in us! We'll let you know as the new updated professional version progresses. In the meantime, our current professional offering is available at <a href="https://www.fightpaperwork.com">Fight Paperwork</a>. If you have <b>any</b> questions please reach out to <a href="mailto:support42@fighthealthinsurance.com">support42@fighthealthinsurance.com</a>!
       </p>
     </div>
 </section>

--- a/fighthealthinsurance/urls.py
+++ b/fighthealthinsurance/urls.py
@@ -292,9 +292,7 @@ urlpatterns: List[Union[URLPattern, URLResolver]] = [
         ),
         name="state_help",
     ),
-    path(
-        "pro_version", csrf_exempt(views.ProVersionView.as_view()), name="pro_version"
-    ),
+    path("pro_version", views.ProVersionView.as_view(), name="pro_version"),
     path(
         "professionals/patient-access",
         cache_control(public=True)(

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -296,6 +296,12 @@ class ProVersionView(generic.FormView):
             f"A new professional signed up via /pro_version.\n\n"
             f"Name: {interested_pro.name or 'N/A'}\n"
             f"Email: {interested_pro.email}\n"
+            f"Job title / provider type: {interested_pro.job_title_or_provider_type or 'N/A'}\n"
+            f"Business: {interested_pro.business_name or 'N/A'}\n"
+            f"Phone: {interested_pro.phone_number or 'N/A'}\n"
+            f"Address: {interested_pro.address or 'N/A'}\n"
+            f"Most common denial: {interested_pro.most_common_denial or 'N/A'}\n"
+            f"Comments: {interested_pro.comments or 'N/A'}\n"
             f"Admin: {admin_url}\n"
         )
         try:

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -31,6 +31,7 @@ from django.views.decorators.http import require_http_methods
 from django.views.generic.base import TemplateView
 from django.utils import timezone
 from django.views.generic.edit import FormView
+from django.core.mail import send_mail
 
 import stripe
 from django_encrypted_filefield.crypt import Cryptographer
@@ -39,6 +40,7 @@ from PIL import Image
 
 from fighthealthinsurance import common_view_logic, forms as core_forms, models
 from fighthealthinsurance.chat_forms import UnderstandPolicyForm, UserConsentForm
+from fighthealthinsurance.followup_emails import ThankyouEmailSender
 from fighthealthinsurance.helpers.data_helpers import RemoveDataHelper
 from fighthealthinsurance.helpers.stripe_helpers import StripeWebhookHelper
 from fighthealthinsurance.models import (
@@ -262,8 +264,47 @@ class ProVersionView(generic.FormView):
         return reverse("pro_version_thankyou")
 
     def form_valid(self, form):
-        form.save()
+        interested_pro = form.save()
+        self._notify_support_of_signup(interested_pro)
+        # Send the thank-you email synchronously so the signer gets it right
+        # away. The batched ThankyouEmailSender will skip records where
+        # thankyou_email_sent=True, which dosend() sets on success.
+        try:
+            ThankyouEmailSender().dosend(interested_pro=interested_pro)
+        except Exception:
+            logger.opt(exception=True).warning(
+                f"Error sending immediate pro signup thank-you "
+                f"(interested_professional_id={interested_pro.id})"
+            )
         return super().form_valid(form)
+
+    @staticmethod
+    def _notify_support_of_signup(
+        interested_pro: "models.InterestedProfessional",
+    ) -> None:
+        admin_path = reverse(
+            "admin:fighthealthinsurance_interestedprofessional_change",
+            args=[interested_pro.id],
+        )
+        admin_url = f"https://{settings.FIGHT_HEALTH_INSURANCE_DOMAIN}{admin_path}"
+        body = (
+            f"A new professional signed up via /pro_version.\n\n"
+            f"Name: {interested_pro.name or 'N/A'}\n"
+            f"Email: {interested_pro.email}\n"
+            f"Admin: {admin_url}\n"
+        )
+        try:
+            send_mail(
+                f"New pro version signup #{interested_pro.id}",
+                body,
+                settings.DEFAULT_FROM_EMAIL,
+                ["support42@fighthealthinsurance.com"],
+            )
+        except Exception:
+            logger.opt(exception=True).error(
+                f"Error sending pro signup notification email "
+                f"(interested_professional_id={interested_pro.id})"
+            )
 
 
 class PatientAccessView(generic.TemplateView):

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -16,6 +16,7 @@ from django.http import (
     HttpResponse,
     HttpResponseBase,
     HttpResponseForbidden,
+    HttpResponseNotAllowed,
     HttpResponseRedirect,
     JsonResponse,
 )
@@ -257,6 +258,11 @@ class ProVersionView(generic.FormView):
 
     def dispatch(self, request, *args, **kwargs):
         if getattr(settings, "PRO_VERSION_AVAILABLE", False):
+            # The available-now page is read-only — surface 405 on POST/other
+            # rather than silently 200-ing a submission the form path would
+            # otherwise have written to the DB.
+            if request.method not in ("GET", "HEAD"):
+                return HttpResponseNotAllowed(["GET", "HEAD"])
             return render(request, "professional_available.html")
         return super().dispatch(request, *args, **kwargs)
 

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -243,10 +243,20 @@ def mark_session_consent(session, email: str) -> None:
 
 
 class ProVersionView(generic.FormView):
-    """Coming-soon landing page for the new updated professional version."""
+    """Landing page for the professional version.
+
+    When settings.PRO_VERSION_AVAILABLE is True, renders an "available now"
+    page with trial / learn-more CTAs. Otherwise (the default), renders the
+    "new updated professional version coming soon" interest form.
+    """
 
     template_name = "professional.html"
     form_class = core_forms.InterestedProfessionalForm
+
+    def dispatch(self, request, *args, **kwargs):
+        if getattr(settings, "PRO_VERSION_AVAILABLE", False):
+            return render(request, "professional_available.html")
+        return super().dispatch(request, *args, **kwargs)
 
     def get_success_url(self):
         return reverse("pro_version_thankyou")

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -242,10 +242,18 @@ def mark_session_consent(session, email: str) -> None:
     session.save()
 
 
-class ProVersionView(generic.RedirectView):
-    """Redirect to the professional version site."""
+class ProVersionView(generic.FormView):
+    """Coming-soon landing page for the new updated professional version."""
 
-    url = "https://www.fightpaperwork.com"
+    template_name = "professional.html"
+    form_class = core_forms.InterestedProfessionalForm
+
+    def get_success_url(self):
+        return reverse("pro_version_thankyou")
+
+    def form_valid(self, form):
+        form.save()
+        return super().form_valid(form)
 
 
 class PatientAccessView(generic.TemplateView):

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -264,7 +264,12 @@ class ProVersionView(generic.FormView):
         return reverse("pro_version_thankyou")
 
     def form_valid(self, form):
-        interested_pro = form.save()
+        # The pay-to-express-interest checkbox is no longer collected; explicitly
+        # mark new records as not clicked so the (legacy default=True) model
+        # field reflects reality.
+        interested_pro = form.save(commit=False)
+        interested_pro.clicked_for_paid = False
+        interested_pro.save()
         self._notify_support_of_signup(interested_pro)
         # Send the thank-you email synchronously so the signer gets it right
         # away. The batched ThankyouEmailSender will skip records where

--- a/tests/sync/test_pro_version_signup.py
+++ b/tests/sync/test_pro_version_signup.py
@@ -3,7 +3,7 @@
 from unittest.mock import patch
 
 from django.core import mail
-from django.test import TestCase, override_settings
+from django.test import Client, TestCase, override_settings
 from django.urls import reverse
 
 from fighthealthinsurance.models import InterestedProfessional
@@ -45,19 +45,25 @@ class ProVersionSignupTest(TestCase):
         self.assertFalse(pro.clicked_for_paid)
 
         subjects = [m.subject for m in mail.outbox]
-        # Team notification to support42@
+        # Team notification to support42@ — includes all captured fields so the
+        # team can act without clicking into admin.
         self.assertIn(f"New pro version signup #{pro.id}", subjects)
         team_email = next(
             m for m in mail.outbox if m.subject == f"New pro version signup #{pro.id}"
         )
         self.assertEqual(team_email.to, ["support42@fighthealthinsurance.com"])
-        self.assertIn("jane@clinic.example", team_email.body)
         self.assertIn("Jane Doe", team_email.body)
+        self.assertIn("jane@clinic.example", team_email.body)
+        self.assertIn("Appeal specialist", team_email.body)
+        self.assertIn("Example Clinic", team_email.body)
+        self.assertIn("555-0100", team_email.body)
+        self.assertIn("Not medically necessary", team_email.body)
+        self.assertIn("Looking forward to it!", team_email.body)
 
         # Immediate thank-you email to the signer
         self.assertTrue(
             any(
-                "Thank you for signing up" in m.subject
+                "Thanks for your interest" in m.subject
                 and "jane@clinic.example" in m.to
                 for m in mail.outbox
             )
@@ -75,6 +81,38 @@ class ProVersionSignupTest(TestCase):
         self.assertTrue(
             InterestedProfessional.objects.filter(
                 email="resilient@clinic.example"
+            ).exists()
+        )
+
+    def test_post_rejects_mass_assignment_of_internal_fields(self):
+        """Public submitters can't preset thankyou_email_sent/paid via POST."""
+        self.client.post(
+            reverse("pro_version"),
+            {
+                "name": "Hacky",
+                "email": "hacky@clinic.example",
+                "thankyou_email_sent": "true",
+                "paid": "true",
+            },
+        )
+        pro = InterestedProfessional.objects.get(email="hacky@clinic.example")
+        # The values must come from the save path, not the POST body. The
+        # thank-you sender flips thankyou_email_sent after a successful send,
+        # so that's True; paid must remain False since it's not on a payment
+        # webhook path.
+        self.assertFalse(pro.paid)
+
+    def test_post_enforces_csrf(self):
+        """The POST endpoint must enforce CSRF — it now writes to the DB."""
+        csrf_client = Client(enforce_csrf_checks=True)
+        response = csrf_client.post(
+            reverse("pro_version"),
+            {"name": "CSRFless", "email": "csrfless@clinic.example"},
+        )
+        self.assertEqual(response.status_code, 403)
+        self.assertFalse(
+            InterestedProfessional.objects.filter(
+                email="csrfless@clinic.example"
             ).exists()
         )
 

--- a/tests/sync/test_pro_version_signup.py
+++ b/tests/sync/test_pro_version_signup.py
@@ -9,8 +9,74 @@ from django.urls import reverse
 from fighthealthinsurance.models import InterestedProfessional
 
 
-class ProVersionSignupTest(TestCase):
-    """Verify the coming-soon /pro_version form captures interest and triggers emails."""
+class ProVersionSignupSuccessTest(TestCase):
+    """Happy-path /pro_version signup.
+
+    setUp performs the canonical POST once per test so each assertion stays
+    focused on a single behavior.
+    """
+
+    PAYLOAD = {
+        "name": "Jane Doe",
+        "email": "jane@clinic.example",
+        "job_title_or_provider_type": "Appeal specialist",
+        "business_name": "Example Clinic",
+        "phone_number": "555-0100",
+        "address": "",
+        "most_common_denial": "Not medically necessary",
+        "comments": "Looking forward to it!",
+    }
+
+    def setUp(self):
+        self.response = self.client.post(reverse("pro_version"), self.PAYLOAD)
+        self.pro = InterestedProfessional.objects.get(email=self.PAYLOAD["email"])
+
+    def _team_email(self):
+        subject = f"New pro version signup #{self.pro.id}"
+        return next(m for m in mail.outbox if m.subject == subject)
+
+    def test_redirects_to_thankyou_page(self):
+        self.assertRedirects(self.response, reverse("pro_version_thankyou"))
+
+    def test_creates_interested_professional_record(self):
+        self.assertEqual(self.pro.name, "Jane Doe")
+
+    def test_marks_thankyou_email_sent(self):
+        # ThankyouEmailSender.dosend() flips this on a successful send.
+        self.assertTrue(self.pro.thankyou_email_sent)
+
+    def test_records_clicked_for_paid_as_false(self):
+        # Pay-to-express-interest is no longer collected.
+        self.assertFalse(self.pro.clicked_for_paid)
+
+    def test_sends_team_notification_to_support(self):
+        self.assertEqual(self._team_email().to, ["support42@fighthealthinsurance.com"])
+
+    def test_team_notification_includes_captured_fields(self):
+        body = self._team_email().body
+        for value in (
+            "Jane Doe",
+            "jane@clinic.example",
+            "Appeal specialist",
+            "Example Clinic",
+            "555-0100",
+            "Not medically necessary",
+            "Looking forward to it!",
+        ):
+            self.assertIn(value, body)
+
+    def test_sends_thankyou_email_to_signer(self):
+        self.assertTrue(
+            any(
+                "Thanks for your interest" in m.subject
+                and "jane@clinic.example" in m.to
+                for m in mail.outbox
+            )
+        )
+
+
+class ProVersionSignupEdgeCaseTest(TestCase):
+    """Rendering, failure-mode, and security guards for the signup form."""
 
     def test_get_renders_signup_form(self):
         response = self.client.get(reverse("pro_version"))
@@ -20,54 +86,6 @@ class ProVersionSignupTest(TestCase):
         # Pay-to-express-interest has been dropped.
         self.assertNotContains(response, "Pay $10")
         self.assertNotContains(response, "clicked_for_paid")
-
-    def test_post_creates_interested_professional_and_sends_emails(self):
-        response = self.client.post(
-            reverse("pro_version"),
-            {
-                "name": "Jane Doe",
-                "email": "jane@clinic.example",
-                "job_title_or_provider_type": "Appeal specialist",
-                "business_name": "Example Clinic",
-                "phone_number": "555-0100",
-                "address": "",
-                "most_common_denial": "Not medically necessary",
-                "comments": "Looking forward to it!",
-            },
-        )
-
-        self.assertRedirects(response, reverse("pro_version_thankyou"))
-        pro = InterestedProfessional.objects.get(email="jane@clinic.example")
-        self.assertEqual(pro.name, "Jane Doe")
-        # ThankyouEmailSender.dosend() flips this on a successful send.
-        self.assertTrue(pro.thankyou_email_sent)
-        # Pay-to-express-interest is no longer collected.
-        self.assertFalse(pro.clicked_for_paid)
-
-        subjects = [m.subject for m in mail.outbox]
-        # Team notification to support42@ — includes all captured fields so the
-        # team can act without clicking into admin.
-        self.assertIn(f"New pro version signup #{pro.id}", subjects)
-        team_email = next(
-            m for m in mail.outbox if m.subject == f"New pro version signup #{pro.id}"
-        )
-        self.assertEqual(team_email.to, ["support42@fighthealthinsurance.com"])
-        self.assertIn("Jane Doe", team_email.body)
-        self.assertIn("jane@clinic.example", team_email.body)
-        self.assertIn("Appeal specialist", team_email.body)
-        self.assertIn("Example Clinic", team_email.body)
-        self.assertIn("555-0100", team_email.body)
-        self.assertIn("Not medically necessary", team_email.body)
-        self.assertIn("Looking forward to it!", team_email.body)
-
-        # Immediate thank-you email to the signer
-        self.assertTrue(
-            any(
-                "Thanks for your interest" in m.subject
-                and "jane@clinic.example" in m.to
-                for m in mail.outbox
-            )
-        )
 
     def test_team_notification_failure_does_not_block_signup(self):
         with patch(
@@ -86,20 +104,22 @@ class ProVersionSignupTest(TestCase):
 
     def test_post_rejects_mass_assignment_of_internal_fields(self):
         """Public submitters can't preset thankyou_email_sent/paid via POST."""
-        self.client.post(
-            reverse("pro_version"),
-            {
-                "name": "Hacky",
-                "email": "hacky@clinic.example",
-                "thankyou_email_sent": "true",
-                "paid": "true",
-            },
-        )
+        # Patch out the immediate thank-you sender so the only path that could
+        # flip thankyou_email_sent is the POST body itself — which Meta.exclude
+        # must block. Without this patch, dosend() would always set it to True
+        # and we couldn't distinguish a real save-path flip from a leaked POST.
+        with patch("fighthealthinsurance.views.ThankyouEmailSender.dosend"):
+            self.client.post(
+                reverse("pro_version"),
+                {
+                    "name": "Hacky",
+                    "email": "hacky@clinic.example",
+                    "thankyou_email_sent": "true",
+                    "paid": "true",
+                },
+            )
         pro = InterestedProfessional.objects.get(email="hacky@clinic.example")
-        # The values must come from the save path, not the POST body. The
-        # thank-you sender flips thankyou_email_sent after a successful send,
-        # so that's True; paid must remain False since it's not on a payment
-        # webhook path.
+        self.assertFalse(pro.thankyou_email_sent)
         self.assertFalse(pro.paid)
 
     def test_post_enforces_csrf(self):

--- a/tests/sync/test_pro_version_signup.py
+++ b/tests/sync/test_pro_version_signup.py
@@ -1,0 +1,86 @@
+"""Tests for the /pro_version interest signup flow."""
+
+from unittest.mock import patch
+
+from django.core import mail
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from fighthealthinsurance.models import InterestedProfessional
+
+
+class ProVersionSignupTest(TestCase):
+    """Verify the coming-soon /pro_version form captures interest and triggers emails."""
+
+    def test_get_renders_signup_form(self):
+        response = self.client.get(reverse("pro_version"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "New Updated Professional Version Coming Soon")
+        self.assertContains(response, 'method="post"')
+
+    def test_post_creates_interested_professional_and_sends_emails(self):
+        response = self.client.post(
+            reverse("pro_version"),
+            {
+                "name": "Jane Doe",
+                "email": "jane@clinic.example",
+                "job_title_or_provider_type": "Appeal specialist",
+                "business_name": "Example Clinic",
+                "phone_number": "555-0100",
+                "address": "",
+                "most_common_denial": "Not medically necessary",
+                "comments": "Looking forward to it!",
+            },
+        )
+
+        self.assertRedirects(response, reverse("pro_version_thankyou"))
+        pro = InterestedProfessional.objects.get(email="jane@clinic.example")
+        self.assertEqual(pro.name, "Jane Doe")
+        # ThankyouEmailSender.dosend() flips this on a successful send.
+        self.assertTrue(pro.thankyou_email_sent)
+
+        subjects = [m.subject for m in mail.outbox]
+        # Team notification to support42@
+        self.assertIn(f"New pro version signup #{pro.id}", subjects)
+        team_email = next(
+            m for m in mail.outbox if m.subject == f"New pro version signup #{pro.id}"
+        )
+        self.assertEqual(team_email.to, ["support42@fighthealthinsurance.com"])
+        self.assertIn("jane@clinic.example", team_email.body)
+        self.assertIn("Jane Doe", team_email.body)
+
+        # Immediate thank-you email to the signer
+        self.assertTrue(
+            any(
+                "Thank you for signing up" in m.subject
+                and "jane@clinic.example" in m.to
+                for m in mail.outbox
+            )
+        )
+
+    def test_team_notification_failure_does_not_block_signup(self):
+        with patch(
+            "fighthealthinsurance.views.send_mail", side_effect=Exception("smtp down")
+        ):
+            response = self.client.post(
+                reverse("pro_version"),
+                {"name": "Resilient", "email": "resilient@clinic.example"},
+            )
+        self.assertRedirects(response, reverse("pro_version_thankyou"))
+        self.assertTrue(
+            InterestedProfessional.objects.filter(
+                email="resilient@clinic.example"
+            ).exists()
+        )
+
+
+@override_settings(PRO_VERSION_AVAILABLE=True)
+class ProVersionAvailableModeTest(TestCase):
+    """When the flag is on, /pro_version shows the available-now page (no form)."""
+
+    def test_get_renders_available_page(self):
+        response = self.client.get(reverse("pro_version"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "The New Professional Version Is Here")
+        self.assertContains(response, "Schedule a Trial or Learn More")
+        self.assertNotContains(response, 'method="post"')

--- a/tests/sync/test_pro_version_signup.py
+++ b/tests/sync/test_pro_version_signup.py
@@ -17,6 +17,9 @@ class ProVersionSignupTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "New Updated Professional Version Coming Soon")
         self.assertContains(response, 'method="post"')
+        # Pay-to-express-interest has been dropped.
+        self.assertNotContains(response, "Pay $10")
+        self.assertNotContains(response, "clicked_for_paid")
 
     def test_post_creates_interested_professional_and_sends_emails(self):
         response = self.client.post(
@@ -38,6 +41,8 @@ class ProVersionSignupTest(TestCase):
         self.assertEqual(pro.name, "Jane Doe")
         # ThankyouEmailSender.dosend() flips this on a successful send.
         self.assertTrue(pro.thankyou_email_sent)
+        # Pay-to-express-interest is no longer collected.
+        self.assertFalse(pro.clicked_for_paid)
 
         subjects = [m.subject for m in mail.outbox]
         # Team notification to support42@

--- a/tests/sync/test_pro_version_signup.py
+++ b/tests/sync/test_pro_version_signup.py
@@ -147,3 +147,16 @@ class ProVersionAvailableModeTest(TestCase):
         self.assertContains(response, "The New Professional Version Is Here")
         self.assertContains(response, "Schedule a Trial or Learn More")
         self.assertNotContains(response, 'method="post"')
+
+    def test_post_returns_405(self):
+        """POSTs must not be silently swallowed when the page is read-only."""
+        response = self.client.post(
+            reverse("pro_version"),
+            {"name": "Hopeful", "email": "hopeful@clinic.example"},
+        )
+        self.assertEqual(response.status_code, 405)
+        self.assertFalse(
+            InterestedProfessional.objects.filter(
+                email="hopeful@clinic.example"
+            ).exists()
+        )


### PR DESCRIPTION
## Summary
Converts the `/pro_version` endpoint from a simple redirect to a full landing page with an interest signup form. The page displays a "coming soon" form by default, but switches to an "available now" page when the `PRO_VERSION_AVAILABLE` feature flag is enabled.

## Key Changes

- **ProVersionView refactored**: Changed from `RedirectView` to `FormView` that handles both coming-soon interest capture and available-now landing pages
  - Uses `dispatch()` to conditionally render `professional_available.html` when `PRO_VERSION_AVAILABLE=True`
  - Otherwise renders the interest form at `professional.html`

- **Interest form processing**: 
  - Captures professional signups with name, email, job title, business name, phone, address, denial type, and comments
  - Automatically sets `clicked_for_paid=False` (legacy field no longer collected from users)
  - Sends immediate thank-you email to signee via `ThankyouEmailSender`
  - Notifies support team at `support42@fighthealthinsurance.com` with signup details and admin link
  - Gracefully handles email failures without blocking signup completion

- **Form updates**: Removed the `clicked_for_paid` checkbox field from `InterestedProfessionalForm` and excluded it from form processing

- **Template updates**:
  - Updated `professional.html` with new copy emphasizing the updated professional version and removed the $10 beta payment option
  - Added new `professional_available.html` template for when the feature flag is enabled
  - Updated `professional_thankyou.html` with refined messaging

- **Settings**: Added `PRO_VERSION_AVAILABLE` environment variable (defaults to `false`) to control which page is displayed

- **Comprehensive test coverage**: Added `ProVersionSignupTest` and `ProVersionAvailableModeTest` test classes covering form rendering, signup flow, email notifications, and resilience to email failures

## Implementation Details

The view uses a two-mode approach:
1. **Coming Soon Mode** (default): Displays interest form to capture professional contact information
2. **Available Now Mode** (when flag enabled): Shows marketing page with trial/learn-more CTA

Email notifications are sent synchronously on signup to ensure immediate delivery of thank-you emails, while team notifications are wrapped in exception handling to prevent signup failures if email service is unavailable.

https://claude.ai/code/session_01FMoRNytScSUncCandYir2v

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added professional version landing page with conditional availability messaging.
  * Professional version signups now automatically send thank-you emails to recipients.

* **Bug Fixes**
  * Enhanced form field protection to prevent unauthorized data modification.
  * CSRF security validation now enforced on professional version signup endpoint.

* **Updates**
  * Revised professional version thank-you email messaging and content.
  * Updated professional version page text and descriptions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fighthealthinsurance/fighthealthinsurance/pull/810)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->