### PR TITLE
Reuse existing escalation letters to avoid duplicate LLM calls

### DIFF
--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -3280,15 +3280,16 @@ class EscalationPacketHelper:
             }
         ) + "\n"
 
+        # We deliberately don't ``select_related("regulator",
+        # "insurance_company_obj")`` here: those tables hold ``RegexField``
+        # columns whose ``from_db_value`` raises ``ValidationError`` on NULL,
+        # so a LEFT JOIN against an un-matched denial blows up the whole
+        # stream. Related access happens inside ``sync_to_async`` below.
         try:
-            denial = await (
-                Denial.objects.select_related("regulator", "insurance_company_obj")
-                .prefetch_related("plan_source")
-                .aget(
-                    denial_id=denial_id,
-                    semi_sekret=semi_sekret,
-                    hashed_email=hashed_email,
-                )
+            denial = await Denial.objects.aget(
+                denial_id=denial_id,
+                semi_sekret=semi_sekret,
+                hashed_email=hashed_email,
             )
         except Denial.DoesNotExist:
             yield json.dumps({"type": "error", "message": "Denial not found"}) + "\n"
@@ -3301,14 +3302,51 @@ class EscalationPacketHelper:
             ) + "\n"
             return
 
+        # Reuse any letters we've already drafted for this denial so that
+        # navigating back to the page (e.g. via the "Back to all regulator
+        # letters" button on the review screen, or a browser refresh) doesn't
+        # burn fresh ML calls and accumulate duplicate draft rows.
+        existing_by_type: dict[str, RegulatorEscalation] = {}
+        async for esc in RegulatorEscalation.objects.filter(
+            for_denial=denial, hashed_email=hashed_email
+        ).order_by("-created"):
+            # Keep only the most recent draft per recipient type.
+            existing_by_type.setdefault(esc.recipient_type, esc)
+
+        needing_generation = [
+            r for r in recipients if r.recipient_type not in existing_by_type
+        ]
+
         yield json.dumps(
             {
                 "type": "status",
                 "phase": "generating",
-                "message": f"Generating {len(recipients)} regulator letter(s)...",
-                "total": len(recipients),
+                "message": (
+                    f"Generating {len(needing_generation)} regulator " f"letter(s)..."
+                ),
+                "total": len(needing_generation),
             }
         ) + "\n"
+
+        # Stream existing drafts first so the user sees them immediately
+        # without waiting on the ML calls for the still-missing recipients.
+        for recipient in recipients:
+            existing = existing_by_type.get(recipient.recipient_type)
+            if existing is None:
+                continue
+            yield json.dumps(
+                {
+                    "type": "letter",
+                    "escalation_id": str(existing.uuid),
+                    "recipient_type": existing.recipient_type,
+                    "recipient_name": existing.recipient_name,
+                    "recipient_address": existing.recipient_address,
+                    "recipient_phone": existing.recipient_phone,
+                    "recipient_url": existing.recipient_url,
+                    "rationale": recipient.rationale,
+                    "content": existing.letter_text,
+                }
+            ) + "\n"
 
         use_external = bool(getattr(denial, "use_external", False))
 
@@ -3318,7 +3356,7 @@ class EscalationPacketHelper:
             )
             return recipient, text
 
-        tasks = [asyncio.create_task(_draft(r)) for r in recipients]
+        tasks = [asyncio.create_task(_draft(r)) for r in needing_generation]
         try:
             for fut in asyncio.as_completed(tasks):
                 recipient, letter_text = await fut

--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -3284,9 +3284,11 @@ class EscalationPacketHelper:
         # "insurance_company_obj")`` here: those tables hold ``RegexField``
         # columns whose ``from_db_value`` raises ``ValidationError`` on NULL,
         # so a LEFT JOIN against an un-matched denial blows up the whole
-        # stream. Related access happens inside ``sync_to_async`` below.
+        # stream. ``prefetch_related("plan_source")`` is safe (separate
+        # query, no JOIN) and avoids an extra round-trip when
+        # ``get_recipients_for_denial`` checks ERISA likelihood.
         try:
-            denial = await Denial.objects.aget(
+            denial = await Denial.objects.prefetch_related("plan_source").aget(
                 denial_id=denial_id,
                 semi_sekret=semi_sekret,
                 hashed_email=hashed_email,
@@ -3306,12 +3308,19 @@ class EscalationPacketHelper:
         # navigating back to the page (e.g. via the "Back to all regulator
         # letters" button on the review screen, or a browser refresh) doesn't
         # burn fresh ML calls and accumulate duplicate draft rows.
+        recipient_types = [r.recipient_type for r in recipients]
         existing_by_type: dict[str, RegulatorEscalation] = {}
         async for esc in RegulatorEscalation.objects.filter(
-            for_denial=denial, hashed_email=hashed_email
+            for_denial=denial,
+            hashed_email=hashed_email,
+            recipient_type__in=recipient_types,
         ).order_by("-created"):
-            # Keep only the most recent draft per recipient type.
+            # Keep only the most recent draft per recipient type. Stop
+            # as soon as every relevant type has been covered so we don't
+            # scan unbounded history.
             existing_by_type.setdefault(esc.recipient_type, esc)
+            if len(existing_by_type) == len(recipient_types):
+                break
 
         needing_generation = [
             r for r in recipients if r.recipient_type not in existing_by_type

--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -3331,7 +3331,7 @@ class EscalationPacketHelper:
                 "type": "status",
                 "phase": "generating",
                 "message": (
-                    f"Generating {len(needing_generation)} regulator " f"letter(s)..."
+                    f"Generating {len(needing_generation)} regulator letter(s)..."
                 ),
                 "total": len(needing_generation),
             }

--- a/fighthealthinsurance/templates/appeals.html
+++ b/fighthealthinsurance/templates/appeals.html
@@ -81,6 +81,30 @@ Fight Your Health Insurance Denial: Choose an Appeal
 <div id="output-container">
 </div>
 
+<div class="alert-box alert-info" style="margin:2rem 0; border-left:4px solid #ADD100;">
+  <h4 style="margin-bottom:0.75rem;">📣 Want to let the regulator know what's going on?</h4>
+  <p style="margin:0.5rem 0;">
+    Alongside your internal appeal, you can cc the people who hold the plan
+    accountable: your <strong>state Department of Insurance</strong>, the plan's
+    <strong>medical director</strong>, and (for ERISA self-funded plans) the
+    <strong>U.S. Department of Labor's EBSA</strong>. We'll draft
+    regulator-friendly letters you can edit and send.
+  </p>
+  <form action="{% url 'escalation_packet' %}" method="post" target="_blank" style="margin:0.75rem 0;">
+    {% csrf_token %}
+    <input type="hidden" name="email" value="{{ user_email }}">
+    <input type="hidden" name="denial_id" value="{{ denial_id }}">
+    {% if semi_sekret %}<input type="hidden" name="semi_sekret" value="{{ semi_sekret }}">{% endif %}
+    <button type="submit" id="generate_escalation_packet" class="btn btn-default" style="font-size:1.05rem; padding:10px 20px;">
+      📨 Click here to draft regulator letters (opens in a new window)
+    </button>
+  </form>
+  <p style="margin:0.5rem 0; font-size:0.9rem; color:#555;">
+    This is especially useful for <em>secondary</em> appeals — once an internal
+    appeal has been denied, regulator escalation often unsticks things.
+  </p>
+</div>
+
 <div class="form-nav-centered">
   {% if back_url %}
   <a href="{{ back_url }}" class="btn btn-secondary-custom">

--- a/tests/sync/test_escalation_packet.py
+++ b/tests/sync/test_escalation_packet.py
@@ -323,7 +323,11 @@ class EscalationPacketViewTest(TestCase):
 
 
 def _collect_stream(parameters: dict):
-    """Drive the async generator to completion and return parsed JSON records."""
+    """Drive the async generator to completion and return parsed JSON records.
+
+    Fails the caller's test if any chunk is non-empty but not valid JSON —
+    we never want a malformed stream record to be silently dropped.
+    """
 
     async def _consume():
         results = []
@@ -333,10 +337,7 @@ def _collect_stream(parameters: dict):
             line = chunk.strip()
             if not line:
                 continue
-            try:
-                results.append(json.loads(line))
-            except json.JSONDecodeError:
-                pass
+            results.append(json.loads(line))
         return results
 
     return async_to_sync(_consume)()

--- a/tests/sync/test_escalation_packet.py
+++ b/tests/sync/test_escalation_packet.py
@@ -1,11 +1,16 @@
 """Unit tests for the regulator escalation packet feature."""
 
-from unittest.mock import patch
+import json
+from unittest.mock import AsyncMock, patch
 
+from asgiref.sync import async_to_sync
 from django.test import TestCase, Client
 from django.urls import reverse
 
-from fighthealthinsurance.common_view_logic import get_denial_for_action
+from fighthealthinsurance.common_view_logic import (
+    EscalationPacketHelper,
+    get_denial_for_action,
+)
 from fighthealthinsurance.escalation_addresses import (
     DOL_EBSA_NAME,
     RECIPIENT_DOI,
@@ -315,3 +320,174 @@ class EscalationPacketViewTest(TestCase):
             },
         )
         self.assertEqual(response.status_code, 302)
+
+
+def _collect_stream(parameters: dict):
+    """Drive the async generator to completion and return parsed JSON records."""
+
+    async def _consume():
+        results = []
+        async for chunk in EscalationPacketHelper.generate_escalation_letters(
+            parameters
+        ):
+            line = chunk.strip()
+            if not line:
+                continue
+            try:
+                results.append(json.loads(line))
+            except json.JSONDecodeError:
+                pass
+        return results
+
+    return async_to_sync(_consume)()
+
+
+class EscalationStreamReusesExistingTest(TestCase):
+    """The streaming generator must not regenerate or duplicate prior drafts.
+
+    Without this, every revisit to the escalation page (e.g. clicking
+    "Back to all regulator letters" from the review screen) would burn
+    fresh LLM calls and accumulate duplicate `RegulatorEscalation` rows.
+    """
+
+    def setUp(self):
+        self.email = "stream@example.com"
+        self.denial = Denial.objects.create(
+            denial_text="some denial",
+            hashed_email=Denial.get_hashed_email(self.email),
+            insurance_company="Aetna",
+            # No state -> only the medical_director recipient is built.
+            your_state="",
+        )
+
+    def _params(self):
+        return {
+            "denial_id": self.denial.denial_id,
+            "email": self.email,
+            "semi_sekret": self.denial.semi_sekret,
+        }
+
+    def test_existing_letter_is_streamed_without_calling_llm(self):
+        existing = RegulatorEscalation.objects.create(
+            for_denial=self.denial,
+            hashed_email=self.denial.hashed_email,
+            recipient_type=RegulatorEscalation.RECIPIENT_MEDICAL_DIRECTOR,
+            recipient_name="Medical Director, Aetna",
+            letter_text="A previously generated draft we should reuse.",
+        )
+
+        # If the LLM is invoked we fail the test loudly.
+        with patch(
+            "fighthealthinsurance.generate_regulator_letter.generate_regulator_letter",
+            new=AsyncMock(side_effect=AssertionError("LLM must not be called")),
+        ):
+            results = _collect_stream(self._params())
+
+        letters = [r for r in results if r.get("type") == "letter"]
+        self.assertEqual(len(letters), 1)
+        self.assertEqual(letters[0]["escalation_id"], str(existing.uuid))
+        self.assertEqual(letters[0]["content"], existing.letter_text)
+        # No duplicate row was created.
+        self.assertEqual(
+            RegulatorEscalation.objects.filter(for_denial=self.denial).count(),
+            1,
+        )
+
+    def test_missing_recipient_is_generated_existing_is_reused(self):
+        # Pre-seed only the medical_director letter; pretend the denial is
+        # also ERISA-flagged so DOL EBSA is in the recipient list and must
+        # be generated fresh.
+        self.denial.your_state = ""
+        self.denial.save()
+        # Mark the denial as ERISA-likely via the insurance_company_obj path.
+        from fighthealthinsurance.models import InsuranceCompany
+
+        ic = InsuranceCompany.objects.create(
+            name="SomeTPA", is_tpa=True, regex="sometpa", negative_regex="zzznever"
+        )
+        self.denial.insurance_company_obj = ic
+        self.denial.save()
+
+        existing_md = RegulatorEscalation.objects.create(
+            for_denial=self.denial,
+            hashed_email=self.denial.hashed_email,
+            recipient_type=RegulatorEscalation.RECIPIENT_MEDICAL_DIRECTOR,
+            recipient_name="Medical Director, Aetna",
+            letter_text="Existing MD letter.",
+        )
+
+        async def fake_llm(denial, recipient, use_external=False):
+            return f"Fresh letter for {recipient.recipient_type}"
+
+        with patch(
+            "fighthealthinsurance.generate_regulator_letter.generate_regulator_letter",
+            new=AsyncMock(side_effect=fake_llm),
+        ) as mock_llm:
+            results = _collect_stream(self._params())
+
+        letters = [r for r in results if r.get("type") == "letter"]
+        types = {r["recipient_type"] for r in letters}
+        self.assertIn(RegulatorEscalation.RECIPIENT_MEDICAL_DIRECTOR, types)
+        self.assertIn(RegulatorEscalation.RECIPIENT_DOL_EBSA, types)
+        # LLM was only invoked for the missing recipient.
+        self.assertEqual(mock_llm.call_count, 1)
+        called_recipient = mock_llm.call_args.args[1]
+        self.assertEqual(
+            called_recipient.recipient_type, RegulatorEscalation.RECIPIENT_DOL_EBSA
+        )
+        # Existing MD row was reused, not duplicated.
+        md_rows = RegulatorEscalation.objects.filter(
+            for_denial=self.denial,
+            recipient_type=RegulatorEscalation.RECIPIENT_MEDICAL_DIRECTOR,
+        )
+        self.assertEqual(md_rows.count(), 1)
+        self.assertEqual(md_rows.first().pk, existing_md.pk)
+        # A new EBSA row exists.
+        self.assertEqual(
+            RegulatorEscalation.objects.filter(
+                for_denial=self.denial,
+                recipient_type=RegulatorEscalation.RECIPIENT_DOL_EBSA,
+            ).count(),
+            1,
+        )
+
+    def test_fresh_run_generates_one_row_per_recipient(self):
+        async def fake_llm(denial, recipient, use_external=False):
+            return f"Letter for {recipient.recipient_type}"
+
+        with patch(
+            "fighthealthinsurance.generate_regulator_letter.generate_regulator_letter",
+            new=AsyncMock(side_effect=fake_llm),
+        ):
+            results = _collect_stream(self._params())
+
+        letters = [r for r in results if r.get("type") == "letter"]
+        self.assertEqual(len(letters), 1)
+        self.assertEqual(
+            letters[0]["recipient_type"],
+            RegulatorEscalation.RECIPIENT_MEDICAL_DIRECTOR,
+        )
+        # Exactly one row per recipient.
+        self.assertEqual(
+            RegulatorEscalation.objects.filter(for_denial=self.denial).count(),
+            1,
+        )
+
+    def test_invalid_denial_yields_error(self):
+        results = _collect_stream(
+            {
+                "denial_id": self.denial.denial_id,
+                "email": self.email,
+                "semi_sekret": "wrong",
+            }
+        )
+        errors = [r for r in results if r.get("type") == "error"]
+        self.assertTrue(errors)
+        self.assertEqual(
+            RegulatorEscalation.objects.filter(for_denial=self.denial).count(), 0
+        )
+
+    def test_missing_parameters_yield_error(self):
+        results = _collect_stream({"denial_id": "", "email": "", "semi_sekret": ""})
+        errors = [r for r in results if r.get("type") == "error"]
+        self.assertTrue(errors)

--- a/tests/sync/test_escalation_packet.py
+++ b/tests/sync/test_escalation_packet.py
@@ -276,6 +276,24 @@ class EscalationPacketViewTest(TestCase):
         # Medical director recipient is always present.
         self.assertContains(response, "Medical Director")
 
+    def test_appeals_generation_page_exposes_escalation_button(self):
+        """The appeals.html page (where users choose between drafts) must
+        link to the regulator escalation flow. Without this, the only entry
+        point is the final review page, which many users never reach.
+        """
+        response = self.client.get(
+            reverse("generate_appeal"),
+            {
+                "denial_id": self.denial.denial_id,
+                "email": self.email,
+                "semi_sekret": self.denial.semi_sekret,
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "appeals.html")
+        self.assertContains(response, 'id="generate_escalation_packet"')
+        self.assertContains(response, reverse("escalation_packet"))
+
     def test_choose_escalation_letter_rejects_invalid_form(self):
         url = reverse("choose_escalation_letter")
         response = self.client.post(url, {"letter_text": "x"})


### PR DESCRIPTION
## Summary
Optimize the escalation letter generation workflow to reuse previously drafted letters instead of regenerating them on every page revisit. This prevents unnecessary LLM calls and duplicate `RegulatorEscalation` database rows when users navigate back to the escalation page or refresh the browser.

## Key Changes

- **Stream existing letters first**: Modified `EscalationPacketHelper.generate_escalation_letters()` to query and stream any previously drafted letters before generating new ones, providing immediate feedback to users without waiting for ML calls.

- **Track existing drafts by recipient type**: Introduced `existing_by_type` dictionary to cache the most recent draft for each recipient type, allowing the generator to identify which recipients still need letter generation.

- **Generate only missing recipients**: Changed the generation task list from all recipients to only those without existing drafts (`needing_generation`), reducing unnecessary LLM invocations.

- **Fixed Django ORM query issue**: Removed `select_related("regulator", "insurance_company_obj")` from the denial query to avoid `ValidationError` on NULL values in `RegexField` columns during LEFT JOINs. Related object access now happens inside `sync_to_async` blocks as needed.

- **Comprehensive test coverage**: Added `EscalationStreamReusesExistingTest` class with four test cases:
  - `test_existing_letter_is_streamed_without_calling_llm`: Verifies existing letters are reused without LLM invocation
  - `test_missing_recipient_is_generated_existing_is_reused`: Tests mixed scenario where some recipients have drafts and others need generation
  - `test_fresh_run_generates_one_row_per_recipient`: Confirms fresh runs create exactly one row per recipient
  - `test_invalid_denial_yields_error` and `test_missing_parameters_yield_error`: Error handling validation

## Implementation Details

- Added helper function `_collect_stream()` to drive the async generator to completion and parse JSON records for testing.
- Updated imports to include `json`, `AsyncMock`, and `async_to_sync` for test infrastructure.
- Imported `EscalationPacketHelper` in test file to access the generator method.
- Status message now accurately reflects the count of letters still needing generation rather than total recipients.

https://claude.ai/code/session_01BQd4oRhzo7jE8EJ6EXQNka

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now draft regulator-facing escalation letters directly within the appeal process, with new option displayed on the appeals page.

* **Improvements**
  * Letter generation now reuses previously drafted escalation letters, avoiding unnecessary regeneration.
  * System only creates new letters for recipient types lacking existing drafts, improving efficiency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fighthealthinsurance/fighthealthinsurance/pull/812)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->