### PR TITLE
Refactor session management in pubmed_tools and fix bioRxiv PDF URL validation

### DIFF
--- a/fighthealthinsurance/pubmed_tools.py
+++ b/fighthealthinsurance/pubmed_tools.py
@@ -218,24 +218,14 @@ class PubMedTools(object):
         per_source_timeout: float = 10.0,
     ) -> Optional[str]:
         """Try multiple sources in order to find a PDF/full-text URL for an article."""
-        owns_session = session is None
-        if owns_session:
-            session = aiohttp.ClientSession(headers=_FETCH_HEADERS)
-        assert session is not None
-
-        try:
-            for name, make_coro in self._url_sources(
-                pmid, doi, session, per_source_timeout
-            ):
+        async with _ensure_session(session) as s:
+            for name, make_coro in self._url_sources(pmid, doi, s, per_source_timeout):
                 url: Optional[str] = await make_coro()
                 if url:
                     logger.debug(f"[{pmid}] Found URL via {name}: {url}")
                     return url
-            logger.debug(f"[{pmid}] No PDF URL found from any source")
-            return None
-        finally:
-            if owns_session and session:
-                await session.close()
+        logger.debug(f"[{pmid}] No PDF URL found from any source")
+        return None
 
     async def _try_findit(self, pmid: str, timeout_secs: float) -> Optional[str]:
         """Try metapub's FindIt to locate article URL."""
@@ -342,7 +332,7 @@ class PubMedTools(object):
         last = results[-1]
         if endpoint == "details":
             jatsxml = last.get("jatsxml")
-            if jatsxml:
+            if jatsxml and ".source.xml" in str(jatsxml):
                 return str(jatsxml).replace(".source.xml", ".full.pdf")
             doi_val = last.get("doi") or ""
         else:

--- a/tests/async-unit/test_pubmed_pdf_resolution.py
+++ b/tests/async-unit/test_pubmed_pdf_resolution.py
@@ -349,6 +349,29 @@ class TestQueryBiorxiv:
             == "https://www.biorxiv.org/content/10.1101/2024.01.01.123456.full.pdf"
         )
 
+    async def test_details_ignores_jatsxml_without_source_xml_suffix(self, tools):
+        """Regression: a jatsxml URL that isn't the expected .source.xml form
+        must not be returned as-is (it would not be a PDF). We should fall
+        through to the DOI-derived .full.pdf URL instead."""
+        resp = _make_mock_response(
+            json_data={
+                "collection": [
+                    {
+                        "doi": "10.1101/2024.01.01.123456",
+                        "jatsxml": "https://www.medrxiv.org/content/10.1101/2024.01.01.123456v1.full.json",
+                    }
+                ]
+            }
+        )
+        session = _make_mock_session(responses=[resp])
+        result = await tools._query_biorxiv(
+            "medrxiv", "10.1101/2024.01.01.123456", "details", session, timeout_secs=5.0
+        )
+        assert (
+            result
+            == "https://www.medrxiv.org/content/10.1101/2024.01.01.123456.full.pdf"
+        )
+
     async def test_pubs_returns_preprint_pdf(self, tools):
         resp = _make_mock_response(
             json_data={"collection": [{"preprint_doi": "10.1101/2023.06.15.545100"}]}


### PR DESCRIPTION
## Summary
This PR improves session management in the PubMed tools module and adds validation for bioRxiv PDF URL extraction to prevent invalid URLs.

## Key Changes
- **Session management refactoring**: Replaced manual session lifecycle management (create/close) with a context manager pattern using `_ensure_session()` in `_find_article_url()`. This simplifies the code and reduces the risk of resource leaks.
- **bioRxiv PDF URL validation**: Added a check to ensure the jatsxml URL contains `.source.xml` before attempting to replace it with `.full.pdf`. This prevents returning invalid PDF URLs when the jatsxml field exists but doesn't have the expected format.

## Implementation Details
- The `_ensure_session()` context manager handles session creation and cleanup automatically, eliminating the need for explicit try/finally blocks and ownership tracking.
- The bioRxiv validation check (`if jatsxml and ".source.xml" in str(jatsxml)`) ensures we only attempt the string replacement when the URL has the expected structure, improving robustness of the PDF URL discovery process.

https://claude.ai/code/session_01X4gKGbKz6WRRedNJs97anR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined article URL resolution for bioRxiv/medRxiv sources with stricter JATS XML to PDF URL conversion logic.

* **Tests**
  * Added regression test for bioRxiv/medRxiv URL handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->