### PR TITLE
Consolidate insurance company resolution to share regex fallback

### DIFF
--- a/fighthealthinsurance/pa_requirement_parsers.py
+++ b/fighthealthinsurance/pa_requirement_parsers.py
@@ -143,7 +143,12 @@ def _bool_cell(cell: str) -> Optional[bool]:
 
 
 def _normalize_header(raw: str) -> str:
-    return raw.strip().lower().replace("\n", " ").replace("  ", " ")
+    # Collapse every whitespace run (tabs, newlines, multi-space runs from
+    # PDF/Excel column extraction) into a single space so aliases like
+    # ``"procedure code"`` match headers like ``"Procedure   Code"`` or
+    # ``"Procedure\tCode"`` that the simpler ``.replace("  ", " ")`` would
+    # leave un-normalised.
+    return re.sub(r"\s+", " ", raw.strip().lower())
 
 
 def _map_columns(headers: List[str]) -> Dict[int, str]:

--- a/fighthealthinsurance/pa_requirements.py
+++ b/fighthealthinsurance/pa_requirements.py
@@ -552,8 +552,13 @@ def _denial_lookup(
             on_date=on_date,
         )
     except Exception as e:
+        # Return empty codes too so the caller emits no context block at all.
+        # Keeping ``codes`` here would make ``format_pa_context`` emit the
+        # "no published PA rule found in this payer's indexed list" line,
+        # which implies the DB was queried and returned nothing — but the
+        # query failed, so we don't actually know.
         logger.opt(exception=True).debug(f"PA requirement lookup failed: {e}")
-        return [], codes
+        return [], []
 
     return requirements, codes
 

--- a/fighthealthinsurance/payer_policy_helper.py
+++ b/fighthealthinsurance/payer_policy_helper.py
@@ -78,10 +78,16 @@ def resolve_company_from_text(name_text: Optional[str]) -> Optional[InsuranceCom
     leak into the comparative-evidence block.
     """
     # Local import to avoid an import-time dependency cycle between the two
-    # sibling helper modules.
-    from fighthealthinsurance.pa_requirements import resolve_insurance_company_by_name
-
+    # sibling helper modules. The import sits inside the ``try`` so an
+    # ``ImportError`` (e.g. a future refactor reintroducing a cycle) flows
+    # through the same best-effort ``None`` fallback as a DB-level failure
+    # rather than propagating out of a function the callers expect to be
+    # safe to call from appeal-generation paths.
     try:
+        from fighthealthinsurance.pa_requirements import (
+            resolve_insurance_company_by_name,
+        )
+
         return resolve_insurance_company_by_name(name_text)
     except Exception:
         logger.exception("Error resolving InsuranceCompany from text")

--- a/fighthealthinsurance/payer_policy_helper.py
+++ b/fighthealthinsurance/payer_policy_helper.py
@@ -68,25 +68,24 @@ def resolve_company_from_text(name_text: Optional[str]) -> Optional[InsuranceCom
     this, the denying payer can show up in the comparative-evidence section
     as an "other major payer", which is wrong.
 
-    Tries case-insensitive exact match first, then a case-insensitive search
-    of the ``alt_names`` lines. Returns None if no confident match.
+    Delegates to ``pa_requirements.resolve_insurance_company_by_name`` so
+    payer-policy and PA-requirement lookups share the same three-stage
+    resolution (iexact name → alt-name line → cached regex with negative
+    guard) and the same cache. Without the regex fallback, denials whose
+    free-text insurer field is a near-miss for the canonical name
+    (e.g. ``"United Health Care of Texas"``) would fail to resolve here
+    even though they resolve everywhere else, and the denying payer would
+    leak into the comparative-evidence block.
     """
-    if not name_text:
-        return None
-    text = name_text.strip()
-    if not text:
-        return None
+    # Local import to avoid an import-time dependency cycle between the two
+    # sibling helper modules.
+    from fighthealthinsurance.pa_requirements import resolve_insurance_company_by_name
+
     try:
-        match = InsuranceCompany.objects.filter(name__iexact=text).first()
-        if match is not None:
-            return match
-        for company in InsuranceCompany.objects.filter(alt_names__icontains=text):
-            for alt in (company.alt_names or "").splitlines():
-                if alt.strip().lower() == text.lower():
-                    return company
+        return resolve_insurance_company_by_name(name_text)
     except Exception:
         logger.exception("Error resolving InsuranceCompany from text")
-    return None
+        return None
 
 
 # --- query helpers ---------------------------------------------------------

--- a/tests/sync/test_pa_requirement_parsers.py
+++ b/tests/sync/test_pa_requirement_parsers.py
@@ -83,6 +83,21 @@ class ColumnMappingTests(TestCase):
         mapping = _map_columns(["Claim Number", "Member ID", "Date of Service"])
         self.assertEqual(mapping, {})
 
+    def test_collapses_multiple_whitespace_runs(self):
+        # PDF-extracted headers often carry runs of 3+ spaces or interleaved
+        # tabs / newlines. The normaliser must collapse them all to a single
+        # space so the alias map still matches.
+        mapping = _map_columns(
+            [
+                "Procedure   Code",  # 3-space run
+                "Procedure\tDescription",  # tab
+                "Prior  Authorization\n  Required",  # mixed run
+            ]
+        )
+        self.assertEqual(mapping.get(0), "code")
+        self.assertEqual(mapping.get(1), "description")
+        self.assertEqual(mapping.get(2), "requires_pa")
+
 
 class RowsToRequirementsTests(TestCase):
     def _make_col_map(self):

--- a/tests/sync/test_pa_requirements.py
+++ b/tests/sync/test_pa_requirements.py
@@ -476,6 +476,26 @@ class GetPaContextForDenialTests(TestCase):
         context = get_pa_context_for_denial(denial)
         self.assertIn("95810", context)
 
+    def test_returns_empty_string_when_lookup_raises(self):
+        # If the DB query itself fails, ``format_pa_context`` would otherwise
+        # emit "no published PA rule was found in this payer's indexed list"
+        # — which implies the DB was queried and returned nothing. The real
+        # state is unknown, so the context block must be suppressed entirely
+        # rather than misleading the LLM.
+        from unittest.mock import patch
+
+        denial = Denial.objects.create(
+            hashed_email="x" * 64,
+            denial_text="UnitedHealthcare denied 95810 polysomnography.",
+            insurance_company_obj=self.uhc,
+        )
+        with patch(
+            "fighthealthinsurance.pa_requirements.lookup_pa_requirements",
+            side_effect=RuntimeError("simulated DB error"),
+        ):
+            context = get_pa_context_for_denial(denial)
+        self.assertEqual(context, "")
+
 
 class MakeOpenPromptIncludesPaContextTests(TestCase):
     """Verify the appeal-generation prompt picks up pa_context."""

--- a/tests/sync/test_payer_policy_helper.py
+++ b/tests/sync/test_payer_policy_helper.py
@@ -322,11 +322,23 @@ class PayerPolicyContextTests(TestCase):
 
 class ResolveCompanyFromTextTests(TestCase):
     def setUp(self):
+        # Clear the resolver cache so a regex registered by a prior test
+        # (run inside the same 5-minute bucket) can't leak in and resolve
+        # an unrelated payer string.
+        from fighthealthinsurance.pa_requirements import _regex_candidates
+
+        _regex_candidates.cache_clear()
+
         self.aetna = InsuranceCompany.objects.create(
             name="Aetna",
             alt_names="Aetna Inc\nCVS Health Aetna",
             regex=r"aetna",
         )
+
+    def tearDown(self):
+        from fighthealthinsurance.pa_requirements import _regex_candidates
+
+        _regex_candidates.cache_clear()
 
     def test_returns_none_for_blank(self):
         self.assertIsNone(resolve_company_from_text(None))
@@ -343,6 +355,15 @@ class ResolveCompanyFromTextTests(TestCase):
 
     def test_no_match_returns_none(self):
         self.assertIsNone(resolve_company_from_text("Some Made-up Insurer"))
+
+    def test_resolves_via_regex_fallback(self):
+        # Regression after consolidating onto ``resolve_insurance_company_by_name``:
+        # a denial's free-text insurer field that misses iexact/alt-name
+        # but matches the carrier's regex must resolve, so the denying
+        # payer is correctly excluded from the comparative-evidence block.
+        # Without this, free-text variations like "Aetna of California"
+        # would leave the denying payer in the comparative section.
+        self.assertEqual(resolve_company_from_text("Aetna of California"), self.aetna)
 
 
 class FetcherIngestTests(TransactionTestCase):


### PR DESCRIPTION
## Summary
Refactors `resolve_company_from_text()` in the payer-policy helper to delegate to the PA-requirements module's `resolve_insurance_company_by_name()`, ensuring both code paths use the same three-stage resolution strategy (iexact name → alt-name line → cached regex with negative guard). This prevents denials with near-miss insurer names (e.g., "United Health Care of Texas") from leaking into the comparative-evidence block.

## Key Changes

- **Consolidate resolution logic**: `payer_policy_helper.resolve_company_from_text()` now delegates to `pa_requirements.resolve_insurance_company_by_name()` instead of duplicating the lookup logic. Uses a local import to avoid circular dependencies between sibling modules.

- **Improve header normalization**: `_normalize_header()` in `pa_requirement_parsers.py` now uses `re.sub(r"\s+", " ")` to collapse all whitespace runs (tabs, newlines, multi-space sequences) into single spaces, fixing cases where PDF/Excel extraction produces irregular spacing that the simpler `.replace("  ", " ")` would miss.

- **Fix error handling in PA lookups**: When `_denial_lookup()` encounters an exception, it now returns empty codes (not the original codes) so `format_pa_context()` emits no context block at all. This prevents misleading the LLM with "no published PA rule found" when the actual state is unknown due to a query failure.

- **Add cache clearing in tests**: `ResolveCompanyFromTextTests` now clears the `_regex_candidates` cache in `setUp()` and `tearDown()` to prevent regex registrations from prior tests (within the same 5-minute bucket) from leaking into unrelated test cases. Adds a new regression test (`test_resolves_via_regex_fallback`) to verify that free-text variations like "Aetna of California" resolve via the regex fallback.

- **Add DB error test**: New test in `test_pa_requirements.py` verifies that when `lookup_pa_requirements()` raises an exception, `get_pa_context_for_denial()` returns an empty string rather than a misleading "no rule found" message.

## Implementation Details

The consolidation ensures that both payer-policy and PA-requirement lookups benefit from the same regex fallback mechanism, which is critical for handling real-world insurer name variations in denial free-text fields. The local import pattern avoids circular dependencies while keeping the shared logic in the PA-requirements module where it's already cached and tested.

https://claude.ai/code/session_015Vrv6nF6dwqCD43c7pq9SW