### PR TITLE
Refine primary procedure-code selection in UCR helper

### DIFF
--- a/fighthealthinsurance/ucr_helper.py
+++ b/fighthealthinsurance/ucr_helper.py
@@ -257,22 +257,74 @@ class UCREnrichmentHelper:
 
     @classmethod
     def resolve_procedure_code(cls, denial: Denial) -> str:
-        """Pull a CPT/HCPCS code from `denial`'s free-text fields.
+        """Resolve the primary CPT/HCPCS code from structured + free-text fields.
 
-        Delegates extraction to the project's centralized
-        `medical_code_extractor` so we don't drift from the canonical regex.
+        Selection priority is deterministic and intentionally *not* lexical:
+          1. Prefer explicit structured values first (e.g. `verified_procedure`).
+          2. For free text, prefer the earliest textual occurrence in
+             `denial.procedure` before `denial.denial_text`.
+          3. As a soft tiebreaker for free-text candidates, boost codes that
+             appear near context words like "denied", "allowed", or "service".
+
+        Backward-compatibility guard: when a field yields only one code, return
+        it directly (equivalent to prior behavior for single-code inputs).
+
+        Extraction itself delegates to the centralized
+        `medical_code_extractor` regex set.
         """
-        for explicit in (
-            getattr(denial, "verified_procedure", "") or "",
+        structured_fields = (getattr(denial, "verified_procedure", "") or "",)
+        free_text_fields = (
             denial.procedure or "",
             denial.denial_text or "",
-        ):
+        )
+
+        for explicit in structured_fields:
             if not explicit:
                 continue
-            codes = sorted(extract_procedure_codes(explicit))
-            if codes:
+            codes = list(extract_procedure_codes(explicit))
+            if len(codes) == 1:
                 return codes[0]
+            if len(codes) > 1:
+                ranked = cls._rank_codes_from_text(explicit, codes)
+                if ranked:
+                    return ranked[0]
+
+        for text in free_text_fields:
+            if not text:
+                continue
+            codes = list(extract_procedure_codes(text))
+            if len(codes) == 1:
+                return codes[0]
+            if len(codes) > 1:
+                ranked = cls._rank_codes_from_text(text, codes)
+                if ranked:
+                    return ranked[0]
         return ""
+
+    @staticmethod
+    def _rank_codes_from_text(text: str, codes: Sequence[str]) -> list[str]:
+        keyword_re = re.compile(r"\b(?:denied|allowed|service)\b", re.IGNORECASE)
+
+        scored: list[tuple[int, int, str]] = []
+        for code in sorted(set(codes)):
+            match = re.search(rf"\b{re.escape(code)}\b", text)
+            if match is None:
+                continue
+            first_index = match.start()
+
+            # Soft boost when the code appears in the same short clause as a
+            # claim-adjudication keyword.
+            start = max(0, first_index - 40)
+            end = min(len(text), match.end() + 40)
+            nearby = text[start:end]
+            keyword_boost = 1 if keyword_re.search(nearby) else 0
+
+            # Higher keyword_boost wins; then earliest appearance; then lexical
+            # for deterministic total ordering.
+            scored.append((-keyword_boost, first_index, code))
+
+        scored.sort()
+        return [code for _boost, _idx, code in scored]
 
     @classmethod
     def resolve_geographic_area(cls, denial: Denial) -> Optional[UCRGeographicArea]:

--- a/tests/sync/test_ucr_helper.py
+++ b/tests/sync/test_ucr_helper.py
@@ -60,6 +60,26 @@ class ProcedureCodeExtractionTests(TestCase):
         denial = Denial(procedure="No structured code here")
         self.assertEqual(UCREnrichmentHelper.resolve_procedure_code(denial), "")
 
+    def test_verified_procedure_preferred_over_free_text(self):
+        denial = Denial(
+            verified_procedure="Primary denied code 99213; secondary 99354",
+            procedure="Procedure mentions 99354 first then 99213",
+            denial_text="Allowed amount for 99354.",
+        )
+        self.assertEqual(UCREnrichmentHelper.resolve_procedure_code(denial), "99213")
+
+    def test_uses_textual_order_not_lexical_order(self):
+        denial = Denial(procedure="Service billed under 99213 and then 90837")
+        # Lexical order would prefer 90837, but textual order should prefer 99213.
+        self.assertEqual(UCREnrichmentHelper.resolve_procedure_code(denial), "99213")
+
+    def test_procedure_text_preferred_before_denial_text(self):
+        denial = Denial(
+            procedure="Service code 99213 documented.",
+            denial_text="Denied as billed under 90837.",
+        )
+        self.assertEqual(UCREnrichmentHelper.resolve_procedure_code(denial), "99213")
+
 
 class AreaResolutionTests(TestCase):
     def test_zip3_preferred(self):


### PR DESCRIPTION
### Motivation
- Avoid returning the lexically-first extracted code from free text because that can surface a secondary/less relevant code when multiple codes appear. 
- Prefer explicit structured inputs and textual/semantic cues so the UCR comparison uses the most relevant procedure for appeal text. 
- Preserve backward compatibility so single-code inputs behave as before and callers see no behavioral regressions. 

### Description
- Replaced lexical-first logic in `UCREnrichmentHelper.resolve_procedure_code` with a deterministic relevance ordering that prefers structured `verified_procedure` first, then `denial.procedure` before `denial.denial_text`. 
- When multiple codes are present in a single field, added `UCREnrichmentHelper._rank_codes_from_text` which ranks codes by earliest textual occurrence and soft-boosts codes appearing near keywords like `denied`, `allowed`, or `service`. 
- Kept a compatibility guard that returns a field's single extracted code immediately to match prior behavior for single-code inputs. 
- Documented the selection rule in the method docstring and added tests in `tests/sync/test_ucr_helper.py` for structured preference, textual-order vs lexical-order disagreement, and `procedure` vs `denial_text` precedence. 

### Testing
- Ran `python manage.py test tests.sync.test_ucr_helper` and the test suite passed (26 tests run, OK). 
- Ran `pytest -q tests/sync/test_ucr_helper.py` which failed during collection in this environment due to Django settings not being initialized for plain `pytest` (error: requested setting but settings not configured). 
- New unit tests in `tests/sync/test_ucr_helper.py` exercise the multi-code selection behavior and succeeded under the Django test runner.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a040a7c69dc8322b23482b39b1b5db7)