### PR TITLE
Deterministic PubMed query cache key and Django cache write-through

### DIFF
--- a/fighthealthinsurance/pubmed_tools.py
+++ b/fighthealthinsurance/pubmed_tools.py
@@ -1,4 +1,5 @@
 import asyncio
+import hashlib
 import io
 import json
 import os
@@ -91,6 +92,7 @@ _ELINK_CACHE_PREFIX = "pubmed:elink:related:"
 # shorter than the 30-day positive cache because absence is more volatile
 # than presence (new articles get indexed).
 _EMPTY_QUERY_NEGCACHE_DAYS = 2
+_QUERY_CACHE_PREFIX = "pubmed:query:"
 
 
 @asynccontextmanager
@@ -448,9 +450,16 @@ class PubMedTools(object):
             A list of PubMed article IDs (PMIDs) matching the query.
         """
         pmids: List[str] = []
+        cache_key = self._pubmed_query_cache_key(query=query, since=since)
+        cache_sentinel = object()
 
         try:
             async with async_timeout(timeout):
+                cached_pmids = await cache.aget(cache_key, default=cache_sentinel)
+                if cached_pmids is not cache_sentinel:
+                    # Distinguish a real negative cache hit ([]) from a miss.
+                    return cached_pmids or []
+
                 # Use timezone-aware "now" so comparisons against the DB's
                 # tz-aware ``created`` field work without raising.
                 now = timezone.now()
@@ -476,6 +485,11 @@ class PubMedTools(object):
                         logger.error(f"Error parsing cached articles JSON for {query}")
                         continue
                     if article_ids:
+                        await cache.aset(
+                            cache_key,
+                            article_ids,
+                            timeout=int(timedelta(days=30).total_seconds()),
+                        )
                         return article_ids
                     # The most recent informative row is an empty result.
                     # Honor it as a cache hit inside the shorter negative-
@@ -484,6 +498,15 @@ class PubMedTools(object):
                         query_data.created is not None
                         and query_data.created >= neg_cache_cutoff
                     ):
+                        await cache.aset(
+                            cache_key,
+                            [],
+                            timeout=int(
+                                timedelta(
+                                    days=_EMPTY_QUERY_NEGCACHE_DAYS
+                                ).total_seconds()
+                            ),
+                        )
                         return []
                     # Stale empty: the newest signal says "no hits", but it
                     # is past the negative-cache window. Don't fall back to
@@ -509,6 +532,15 @@ class PubMedTools(object):
                     since=since,
                     articles=articles_json,
                 )
+                await cache.aset(
+                    cache_key,
+                    pmids,
+                    timeout=int(
+                        timedelta(
+                            days=30 if pmids else _EMPTY_QUERY_NEGCACHE_DAYS
+                        ).total_seconds()
+                    ),
+                )
                 return pmids
         except asyncio.TimeoutError as e:
             # We might timeout
@@ -523,6 +555,14 @@ class PubMedTools(object):
             )
             pass
         return pmids
+
+    @staticmethod
+    def _pubmed_query_cache_key(query: str, since: Optional[str]) -> str:
+        normalized_query = " ".join((query or "").strip().lower().split())
+        normalized_since = (since or "").strip().lower()
+        key_material = f"{normalized_query}|{normalized_since}"
+        digest = hashlib.sha256(key_material.encode("utf-8")).hexdigest()
+        return f"{_QUERY_CACHE_PREFIX}{digest}"
 
     async def fetch_mesh_and_pub_types(
         self,

--- a/tests/async-unit/test_pubmed_search.py
+++ b/tests/async-unit/test_pubmed_search.py
@@ -13,6 +13,7 @@ The end-to-end ``structured_search`` test is wrapped with the Django
 """
 
 import asyncio
+import json
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -21,6 +22,7 @@ from asgiref.sync import async_to_sync
 from django.test import TransactionTestCase
 
 from fighthealthinsurance.models import PubMedMiniArticle
+from fighthealthinsurance.models import PubMedQueryData
 from fighthealthinsurance.pubmed_search import (
     EvidenceStrength,
     MODERATE_PUB_TYPES,
@@ -864,6 +866,107 @@ _LOCMEM_CACHES = {
         "LOCATION": "pubmed-test",
     }
 }
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_find_pubmed_ids_positive_cache_hit_skips_db_and_api():
+    from django.core.cache import cache
+    from django.test.utils import override_settings
+
+    with override_settings(CACHES=_LOCMEM_CACHES):
+        await cache.aclear()
+        tools = PubMedTools()
+        cache_key = tools._pubmed_query_cache_key("Asthma trial", "2022")
+        await cache.aset(cache_key, ["11111111"], timeout=60)
+
+        with patch(
+            "fighthealthinsurance.pubmed_tools.pubmed_fetcher.pmids_for_query"
+        ) as fetch_mock:
+            result = await tools.find_pubmed_article_ids_for_query(
+                "Asthma trial", since="2022"
+            )
+        assert result == ["11111111"]
+        fetch_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_find_pubmed_ids_negative_cache_hit_returns_empty():
+    from django.core.cache import cache
+    from django.test.utils import override_settings
+
+    with override_settings(CACHES=_LOCMEM_CACHES):
+        await cache.aclear()
+        tools = PubMedTools()
+        cache_key = tools._pubmed_query_cache_key("No matches", "2021")
+        await cache.aset(cache_key, [], timeout=60)
+
+        with patch(
+            "fighthealthinsurance.pubmed_tools.pubmed_fetcher.pmids_for_query"
+        ) as fetch_mock:
+            result = await tools.find_pubmed_article_ids_for_query(
+                "No matches", since="2021"
+            )
+        assert result == []
+        fetch_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_find_pubmed_ids_cache_miss_then_db_hit_writes_through_cache():
+    from django.core.cache import cache
+    from django.test.utils import override_settings
+
+    with override_settings(CACHES=_LOCMEM_CACHES):
+        await cache.aclear()
+        tools = PubMedTools()
+        await PubMedQueryData.objects.acreate(
+            query="COPD treatment",
+            since="2020",
+            articles=json.dumps(["22222222", "33333333"]),
+        )
+        cache_key = tools._pubmed_query_cache_key("COPD treatment", "2020")
+        assert await cache.aget(cache_key) is None
+
+        with patch(
+            "fighthealthinsurance.pubmed_tools.pubmed_fetcher.pmids_for_query"
+        ) as fetch_mock:
+            result = await tools.find_pubmed_article_ids_for_query(
+                "COPD treatment", since="2020"
+            )
+        assert result == ["22222222", "33333333"]
+        assert await cache.aget(cache_key) == ["22222222", "33333333"]
+        fetch_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_find_pubmed_ids_cache_miss_then_api_fetch_writes_db_and_cache():
+    from django.core.cache import cache
+    from django.test.utils import override_settings
+
+    with override_settings(CACHES=_LOCMEM_CACHES):
+        await cache.aclear()
+        tools = PubMedTools()
+        cache_key = tools._pubmed_query_cache_key("heart failure beta blocker", "2023")
+
+        with patch(
+            "fighthealthinsurance.pubmed_tools.pubmed_fetcher.pmids_for_query",
+            return_value=["44444444"],
+        ) as fetch_mock:
+            result = await tools.find_pubmed_article_ids_for_query(
+                "heart failure beta blocker", since="2023"
+            )
+        assert result == ["44444444"]
+        assert await cache.aget(cache_key) == ["44444444"]
+        fetch_mock.assert_called_once_with("heart failure beta blocker", since="2023")
+        row = await PubMedQueryData.objects.filter(
+            query="heart failure beta blocker",
+            since="2023",
+            denial_id__isnull=True,
+        ).alatest("internal_id")
+        assert json.loads(row.articles) == ["44444444"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- Ensure cache lookups for PubMed queries are deterministic and avoid redundant DB/API calls by normalizing the `(query, since)` tuple into a stable key. 
- Provide a fast-path Django-cache layer so common positive and negative results are served without hitting the DB or PubMed API. 

### Description
- Add a stable cache-key helper `PubMedTools._pubmed_query_cache_key()` that normalizes `(query, since)` and produces a SHA-256 digest with the `pubmed:query:` prefix. 
- Check Django cache first using `cache.aget()` with a sentinel to distinguish cache-miss vs cached-empty-list, and short-circuit on hits. 
- Write-through DB→cache on DB hits with TTLs: positive results cached ~30 days and negative (empty) results cached for `_EMPTY_QUERY_NEGCACHE_DAYS`. 
- On successful API fetch, persist to `PubMedQueryData` and write-through to Django cache with matching TTLs, while preserving existing timeout/cancellation behavior so transport failures are not cached. 

### Testing
- Added async unit tests in `tests/async-unit/test_pubmed_search.py` covering positive cache hit, negative cache hit, cache miss then DB hit (cache write-through), and cache miss then API fetch (DB+cache write-through). 
- Ran `pytest -q tests/async-unit/test_pubmed_search.py -k 'find_pubmed_ids_'` which failed during collection in this environment due to missing Django settings (`ImproperlyConfigured: Requested setting DEFF_SALT`), so the new tests were not executed to completion here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a040a8a743c8322baec95de5a61c8d0)