### PR TITLE
Use rolling lower-bound year for PubMed recent searches

### DIFF
--- a/fighthealthinsurance/chat/tools/pubmed_tool.py
+++ b/fighthealthinsurance/chat/tools/pubmed_tool.py
@@ -6,7 +6,9 @@ relevant medical literature.
 """
 
 import asyncio
+import os
 import re
+from datetime import datetime, timezone
 from typing import Any, Awaitable, Callable, Optional, Tuple, Union
 
 from loguru import logger
@@ -195,7 +197,7 @@ class PubMedTool(BaseTool):
         """
         Search PubMed for articles matching the query.
 
-        Searches both recent (since 2024) and all-time articles,
+        Searches both recent and all-time articles,
         then combines the results.
 
         Args:
@@ -204,8 +206,9 @@ class PubMedTool(BaseTool):
         Returns:
             List of unique article IDs
         """
+        recent_since_year = self._recent_since_year()
         recent_awaitable = self.pubmed_tools.find_pubmed_article_ids_for_query(
-            query=query, since="2024", timeout=30.0
+            query=query, since=recent_since_year, timeout=30.0
         )
         all_awaitable = self.pubmed_tools.find_pubmed_article_ids_for_query(
             query=query, timeout=30.0
@@ -243,6 +246,16 @@ class PubMedTool(BaseTool):
         )
 
         return article_ids
+
+    def _recent_since_year(self) -> str:
+        """Compute rolling lower bound year for the "recent" PubMed query."""
+        raw_window = os.getenv("PUBMED_RECENT_WINDOW_YEARS", "2")
+        try:
+            window_years = max(0, int(raw_window))
+        except ValueError:
+            window_years = 2
+        current_year = datetime.now(timezone.utc).year
+        return str(current_year - window_years)
 
     async def _build_article_context(self, article_ids: list[str]) -> str:
         """

--- a/tests/sync/test_chat_tools.py
+++ b/tests/sync/test_chat_tools.py
@@ -205,6 +205,40 @@ class TestPubMedTool(TestCase):
 
         self.assertIsNone(match)
 
+    def test_recent_search_uses_dynamic_year(self):
+        """Recent search should use a rolling lower-bound year string."""
+        mock_status = AsyncMock()
+        mock_pubmed_tools = MagicMock()
+        mock_pubmed_tools.find_pubmed_article_ids_for_query = AsyncMock(
+            side_effect=[["1", "2"], ["2", "3"]]
+        )
+        tool = PubMedTool(mock_status, pubmed_tools=mock_pubmed_tools)
+
+        with patch.object(tool, "_recent_since_year", return_value="2024"):
+            article_ids = asyncio.run(tool._search_articles("test query"))
+
+        self.assertTrue(set(article_ids).issuperset({"1", "2", "3"}))
+        recent_call = mock_pubmed_tools.find_pubmed_article_ids_for_query.call_args_list[
+            0
+        ]
+        self.assertEqual(recent_call.kwargs["since"], "2024")
+
+    def test_recent_since_year_uses_configurable_window(self):
+        mock_status = AsyncMock()
+        tool = PubMedTool(mock_status)
+
+        with patch("fighthealthinsurance.chat.tools.pubmed_tool.datetime") as mock_dt:
+            mock_now = MagicMock()
+            mock_now.year = 2030
+            mock_dt.now.return_value = mock_now
+
+            with patch.dict(
+                "os.environ",
+                {"PUBMED_RECENT_WINDOW_YEARS": "3"},
+                clear=False,
+            ):
+                self.assertEqual(tool._recent_since_year(), "2027")
+
 
 class TestClinicalTrialsTool(TestCase):
     """Test ClinicalTrialsTool detection and helper rendering."""


### PR DESCRIPTION
### Motivation
- Remove a brittle hardcoded `since="2024"` in PubMed searches and compute a rolling recent-year lower bound instead. 
- Allow a small configurable window so the definition of “recent” can be tuned without changing code. 
- Prevent status messages or behavior from implying a fixed calendar year.

### Description
- Replaced the fixed `since="2024"` in `PubMedTool._search_articles()` with a computed value from a new helper `PubMedTool._recent_since_year()` that returns a string year. 
- Added imports for `os` and `datetime` and implemented `_recent_since_year()` which uses `PUBMED_RECENT_WINDOW_YEARS` (default `2`) and falls back to `2` on invalid values. 
- Updated the `_search_articles()` docstring to remove the fixed-year wording and kept status messages year-agnostic. 
- Added two unit tests in `tests/sync/test_chat_tools.py` to assert the recent path receives a dynamic `since` string and that the computed year honors the configurable window.

### Testing
- Ran `pytest -q tests/sync/test_chat_tools.py -k 'recent_search_uses_dynamic_year or recent_since_year_uses_configurable_window'`, which failed during collection due to Django settings not being configured in the pytest environment. 
- Ran the Django test runner for the two new tests with `python manage.py test tests.sync.test_chat_tools.TestPubMedTool.test_recent_search_uses_dynamic_year tests.sync.test_chat_tools.TestPubMedTool.test_recent_since_year_uses_configurable_window`, and both tests passed (2 tests OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a040a8f84848322acafd1c103760a36)