### PR TITLE
Add ClinicalTrials.gov prefetch to denial extraction workflow

### DIFF
--- a/fighthealthinsurance/chat/tools/base_tool.py
+++ b/fighthealthinsurance/chat/tools/base_tool.py
@@ -96,12 +96,16 @@ class BaseTool(ABC):
         Returns ``""`` if both are empty/None. Used to glue an LLM follow-up
         response onto the original response (or follow-up context onto the
         original context) so adjacent paragraphs don't run together.
+
+        Only newline characters are stripped at the join — leading spaces /
+        tabs are preserved so markdown indentation, nested-list alignment,
+        and code-block leading whitespace aren't accidentally clobbered.
         """
         if not existing:
-            return (addition or "").lstrip()
+            return (addition or "").lstrip("\n")
         if not addition:
             return existing
-        return f"{existing.rstrip()}\n\n{addition.lstrip()}"
+        return existing.rstrip("\n") + "\n\n" + addition.lstrip("\n")
 
     @abstractmethod
     async def execute(

--- a/fighthealthinsurance/chat/tools/base_tool.py
+++ b/fighthealthinsurance/chat/tools/base_tool.py
@@ -89,6 +89,20 @@ class BaseTool(ABC):
             cleaned = cleaned.replace(match.group(0), "")
         return cleaned.strip()
 
+    @staticmethod
+    def merge_strings(existing: Optional[str], addition: Optional[str]) -> str:
+        """Concatenate two strings with a blank-line separator.
+
+        Returns ``""`` if both are empty/None. Used to glue an LLM follow-up
+        response onto the original response (or follow-up context onto the
+        original context) so adjacent paragraphs don't run together.
+        """
+        if not existing:
+            return (addition or "").lstrip()
+        if not addition:
+            return existing
+        return f"{existing.rstrip()}\n\n{addition.lstrip()}"
+
     @abstractmethod
     async def execute(
         self, match: re.Match[str], response_text: str, context: str, **kwargs

--- a/fighthealthinsurance/chat/tools/clinical_trials_tool.py
+++ b/fighthealthinsurance/chat/tools/clinical_trials_tool.py
@@ -124,17 +124,10 @@ class ClinicalTrialsTool(BaseTool):
                 fallback_backends=kwargs.get("fallback_backends"),
                 full_history=kwargs.get("full_history"),
             )
-            if cleaned_response and additional_response:
-                cleaned_response += additional_response
-            elif additional_response:
-                cleaned_response = additional_response
+            cleaned_response = self.merge_strings(cleaned_response, additional_response)
+            context = self.merge_strings(context, additional_context)
 
-            if context and additional_context:
-                context = context + additional_context
-            elif additional_context:
-                context = additional_context
-
-        updated_context = context + trial_context if context else trial_context
+        updated_context = self.merge_strings(context, trial_context)
         return cleaned_response, updated_context
 
     def _build_trials_context(self, trials) -> str:

--- a/fighthealthinsurance/chat/tools/pubmed_tool.py
+++ b/fighthealthinsurance/chat/tools/pubmed_tool.py
@@ -152,18 +152,11 @@ class PubMedTool(BaseTool):
                 is_professional=is_professional,
             )
 
-            if cleaned_response and additional_response:
-                cleaned_response += additional_response
-            elif additional_response:
-                cleaned_response = additional_response
-
-            if context and additional_context:
-                context = context + additional_context
-            elif additional_context:
-                context = additional_context
+            cleaned_response = self.merge_strings(cleaned_response, additional_response)
+            context = self.merge_strings(context, additional_context)
 
         # Append PubMed context
-        updated_context = context + pubmed_context if context else pubmed_context
+        updated_context = self.merge_strings(context, pubmed_context)
 
         return cleaned_response, updated_context
 

--- a/fighthealthinsurance/chat/tools/rxnorm_tool.py
+++ b/fighthealthinsurance/chat/tools/rxnorm_tool.py
@@ -78,24 +78,11 @@ class RxNormLookupTool(BaseTool):
                 is_professional=is_professional,
             )
 
-            cleaned_response = self._merge(cleaned_response, additional_response)
-            context = self._merge(context, additional_context)
+            cleaned_response = self.merge_strings(cleaned_response, additional_response)
+            context = self.merge_strings(context, additional_context)
 
-        updated_context = self._merge(context, rx_context)
+        updated_context = self.merge_strings(context, rx_context)
         return cleaned_response, updated_context
-
-    @staticmethod
-    def _merge(existing: Optional[str], addition: Optional[str]) -> str:
-        """Concatenate two strings with a blank-line separator.
-
-        Returns ``""`` if both are empty/None. Avoids running text
-        together when the recursive callback returns plain prose.
-        """
-        if not existing:
-            return (addition or "").lstrip()
-        if not addition:
-            return existing
-        return f"{existing.rstrip()}\n\n{addition.lstrip()}"
 
     @classmethod
     def _format_context(cls, query: str, info: dict[str, Any]) -> str:

--- a/fighthealthinsurance/clinicaltrials_tools.py
+++ b/fighthealthinsurance/clinicaltrials_tools.py
@@ -431,6 +431,70 @@ class ClinicalTrialsTools(object):
             )
         return []
 
+    async def get_context_for_denial(
+        self,
+        denial: Denial,
+        max_trials: int = DEFAULT_MAX_TRIALS,
+    ) -> Optional[str]:
+        """Render the cached trials for this denial as an appeal-ready block.
+
+        DB-only — never makes a live API call. The fire-and-forget prefetch
+        in ``DenialCreatorHelper.extract_set_denial_and_diagnosis`` is what
+        populates the audit row + ``ClinicalTrial`` rows this reads from.
+        Returns ``None`` on cache-miss (prefetch hasn't completed, or the
+        registry had zero matches), so the appeal-gen gather can tell the
+        difference between "nothing to cite" and "live network from inside
+        the appeal hot path" — the latter is exactly what we wanted to
+        avoid by going through the prefetch in the first place.
+
+        Header text is self-contained: callers can bake the returned string
+        directly into the prompt with no extra section label, matching the
+        ``uspstf_context`` / ``pa_context`` pattern in ``make_open_prompt``.
+        """
+        try:
+            audit = (
+                await ClinicalTrialQueryData.objects.filter(denial_id=denial.denial_id)
+                .order_by("-created")
+                .afirst()
+            )
+            if audit is None or not audit.nct_ids:
+                return None
+            try:
+                nct_ids: List[str] = json.loads(audit.nct_ids.replace("\x00", ""))
+            except json.JSONDecodeError:
+                logger.debug("Corrupt nct_ids JSON in audit row; skipping context")
+                return None
+            if not nct_ids:
+                return None
+            wanted = nct_ids[:max_trials]
+            by_id: Dict[str, ClinicalTrial] = {
+                t.nct_id: t
+                async for t in ClinicalTrial.objects.filter(nct_id__in=wanted)
+            }
+            # Preserve the order the prefetch surfaced them in (relevance-
+            # ranked by the registry), and skip IDs we don't have details
+            # for rather than emitting a row with just an NCT and no body.
+            ordered = [by_id[n] for n in wanted if n in by_id]
+            rendered = [r for r in (self.format_trial_short(t) for t in ordered) if r]
+            if not rendered:
+                return None
+            return (
+                "CLINICAL TRIAL EVIDENCE (relevant when the denial cites "
+                '"experimental" or "investigational" grounds):\n\n'
+                + "\n\n".join(rendered)
+                + "\n\nWhen citing a trial, include the NCT ID and the URL. "
+                "The existence of a trial does not by itself establish "
+                "coverage; use it to argue that the therapy is being "
+                "actively studied or used clinically — so the relevant "
+                "question is whether the therapy is medically appropriate "
+                "for THIS patient, not whether the therapy is hypothetical."
+            )
+        except Exception as e:
+            logger.opt(exception=True).debug(
+                f"get_context_for_denial failed: {type(e).__name__}"
+            )
+            return None
+
     @staticmethod
     def format_trial_short(trial: ClinicalTrial) -> str:
         """Compact one-line-per-field rendering for LLM context."""

--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -2757,6 +2757,7 @@ class AppealsBackendHelper:
         imr_context: Optional[str] = None
         pa_context: Optional[str] = None
         uspstf_context: Optional[str] = None
+        clinical_trials_context: Optional[str] = None
 
         # Get PubMed context
         logger.debug("Looking up the pubmed context")
@@ -2900,6 +2901,20 @@ class AppealsBackendHelper:
                 done_msg="USPSTF preventive-services lookup complete",
             )
 
+            # Look up cached ClinicalTrials.gov matches for this denial.
+            # DB-only read — the live registry call already happened in the
+            # ``find_clinical_trials`` prefetch fired from
+            # ``extract_set_denial_and_diagnosis``. A short timeout is enough
+            # because the worst case here is a couple of indexed ORM queries.
+            clinical_trials_context_awaitable = tracked_awaitable(
+                asyncio.wait_for(
+                    ClinicalTrialsTools().get_context_for_denial(denial),
+                    timeout=10,
+                ),
+                substep="clinical_trials",
+                done_msg="ClinicalTrials.gov lookup complete",
+            )
+
             # Skip the NICE task entirely when no key is configured: avoids a
             # misleading "NICE guidance lookup complete" status and the wait_for
             # overhead in environments without syndication access.
@@ -2910,6 +2925,7 @@ class AppealsBackendHelper:
                 imr_context_awaitable,
                 pa_context_awaitable,
                 uspstf_context_awaitable,
+                clinical_trials_context_awaitable,
             ]
             if cls.nice.api_key:
                 gather_awaitables.append(
@@ -2966,8 +2982,11 @@ class AppealsBackendHelper:
                 if isinstance(results[5], str) and results[5]:
                     uspstf_context = results[5]
                     logger.info("USPSTF preventive-services context retrieved")
-                if len(results) > 6 and isinstance(results[6], str):
-                    nice_context = results[6]
+                if isinstance(results[6], str) and results[6]:
+                    clinical_trials_context = results[6]
+                    logger.info("ClinicalTrials.gov context retrieved")
+                if len(results) > 7 and isinstance(results[7], str):
+                    nice_context = results[7]
                 else:
                     # No fresh NICE result (skipped task or non-string error). Fall
                     # back to whatever is already persisted on the denial so cached
@@ -3005,6 +3024,22 @@ class AppealsBackendHelper:
                 uspstf_context = await _refresh_sync_denial_context(
                     denial, _uspstf_context_getter_factory, "USPSTF"
                 )
+                # ClinicalTrials context isn't persisted either; re-render from
+                # the prefetched cache so the fallback path doesn't silently
+                # lose trial evidence. The reader is already async (DB-only — no
+                # live registry call), so it can't go through
+                # _refresh_sync_denial_context (which wraps a sync getter in
+                # sync_to_async); use an inline guard with the same
+                # degrade-to-None behavior.
+                try:
+                    clinical_trials_context = (
+                        await ClinicalTrialsTools().get_context_for_denial(denial)
+                    )
+                except Exception as inner:
+                    logger.opt(exception=True).debug(
+                        f"ClinicalTrials context refresh during fallback failed: {inner}"
+                    )
+                    clinical_trials_context = None
                 logger.debug("Used saved contexts")
         else:
             logger.debug("Too many retries, skipping ML/pubmed/RAG ctx")
@@ -3022,6 +3057,19 @@ class AppealsBackendHelper:
             uspstf_context = await _refresh_sync_denial_context(
                 denial, _uspstf_context_getter_factory, "USPSTF"
             )
+            # ClinicalTrials lookup is also DB-only against the prefetched
+            # cache, so re-render it on retries. The reader is async, so it
+            # uses an inline guard rather than _refresh_sync_denial_context
+            # (which wraps a sync getter in sync_to_async).
+            try:
+                clinical_trials_context = (
+                    await ClinicalTrialsTools().get_context_for_denial(denial)
+                )
+            except Exception as e:
+                logger.opt(exception=True).debug(
+                    f"ClinicalTrials context refresh on retry failed: {e}"
+                )
+                clinical_trials_context = None
             yield json.dumps(
                 {
                     "type": "status",
@@ -3108,6 +3156,7 @@ class AppealsBackendHelper:
             specialized_templates=specialized_templates,
             pa_context=pa_context,
             uspstf_context=uspstf_context,
+            clinical_trials_context=clinical_trials_context,
         )
         # Drop None / empty / whitespace / runt outputs. Track runts so the
         # zero-appeal diagnostic can distinguish "models silent" from

--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -79,6 +79,7 @@ from fighthealthinsurance.utils import (
     MIN_APPEAL_CHARS,
     sync_iterator_to_async,
 )
+from .clinicaltrials_tools import ClinicalTrialsTools
 from .pubmed_tools import PubMedTools
 from .nice_tools import NICETools
 from .email_utils import is_sendable_email
@@ -1491,7 +1492,7 @@ class DenialCreatorHelper:
         """
         Asynchronously extracts procedure and diagnosis from a denial's text and updates the denial record.
 
-        Attempts to extract the procedure and diagnosis fields using the appeal generator. Updates the denial with the extracted values and marks extraction as finished, regardless of success. If extraction is successful or existing values are present, triggers background tasks to search for related PubMed articles and build speculative context. Handles timeouts and cancellation during PubMed search gracefully.
+        Attempts to extract the procedure and diagnosis fields using the appeal generator. Updates the denial with the extracted values and marks extraction as finished, regardless of success. If extraction is successful or existing values are present, triggers background tasks to search for related PubMed articles, prefetch ClinicalTrials.gov matches, and build speculative context. All background searches are fire-and-forget with their own timeouts and never block the caller.
         """
         denial = await Denial.objects.filter(denial_id=denial_id).aget()
         procedure = None
@@ -1559,14 +1560,52 @@ class DenialCreatorHelper:
                             f"Failed to find PubMed articles for denial {denial_id}: {e}"
                         )
 
+                async def find_clinical_trials():
+                    """
+                    Prefetch ClinicalTrials.gov matches for this denial into the
+                    DB cache, so the chat assistant (and any future appeal-side
+                    consumer) gets an instant hit instead of a live API roundtrip.
+
+                    Intentionally fire-and-forget: trial data is supplementary
+                    evidence, and the appeal flow must never stall on it. Any
+                    timeout, cancellation, or unexpected error is swallowed here
+                    so it can't propagate out of the daemon thread.
+                    """
+                    try:
+                        ct_tools = ClinicalTrialsTools()
+                        # find_trials_for_denial enforces its own end-to-end
+                        # budget; wait_for is a belt-and-suspenders cap in case
+                        # something deeper hangs past the internal timeout.
+                        await asyncio.wait_for(
+                            ct_tools.find_trials_for_denial(denial, timeout=40.0),
+                            timeout=50.0,
+                        )
+                    except asyncio.TimeoutError:
+                        logger.debug(
+                            f"ClinicalTrials search timed out for denial {denial_id}"
+                        )
+                    except asyncio.exceptions.CancelledError:
+                        logger.debug(
+                            f"Cancelled ClinicalTrials search for denial {denial_id}"
+                        )
+                    except Exception as e:
+                        logger.opt(exception=True).debug(
+                            f"ClinicalTrials prefetch failed for denial {denial_id}: "
+                            f"{type(e).__name__}"
+                        )
+
                 # Fire and forget the PubMed search task
                 await fire_and_forget_in_new_threadpool(find_pubmed_articles())
+                # Fire and forget the ClinicalTrials.gov prefetch. Supplementary
+                # evidence for "experimental/investigational" denials; non-blocking.
+                await fire_and_forget_in_new_threadpool(find_clinical_trials())
                 # Fire and forget the building the speculative context
                 await fire_and_forget_in_new_threadpool(
                     cls.build_speculative_context(denial_id)
                 )
                 logger.debug(
-                    f"Fired pubmed search & speculative context for denial {denial_id}"
+                    f"Fired pubmed + clinical-trials search & speculative context "
+                    f"for denial {denial_id}"
                 )
 
         except Exception as e:

--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -2360,6 +2360,7 @@ class AppealsBackendHelper:
     regex_denial_processor = ProcessDenialRegex()
     pmt = PubMedTools()
     nice = NICETools()
+    clinical_trials = ClinicalTrialsTools()
 
     @classmethod
     async def generate_appeals(cls, parameters) -> AsyncIterator[str]:
@@ -2908,7 +2909,7 @@ class AppealsBackendHelper:
             # because the worst case here is a couple of indexed ORM queries.
             clinical_trials_context_awaitable = tracked_awaitable(
                 asyncio.wait_for(
-                    ClinicalTrialsTools().get_context_for_denial(denial),
+                    cls.clinical_trials.get_context_for_denial(denial),
                     timeout=10,
                 ),
                 substep="clinical_trials",
@@ -3033,7 +3034,7 @@ class AppealsBackendHelper:
                 # degrade-to-None behavior.
                 try:
                     clinical_trials_context = (
-                        await ClinicalTrialsTools().get_context_for_denial(denial)
+                        await cls.clinical_trials.get_context_for_denial(denial)
                     )
                 except Exception as inner:
                     logger.opt(exception=True).debug(
@@ -3063,7 +3064,7 @@ class AppealsBackendHelper:
             # (which wraps a sync getter in sync_to_async).
             try:
                 clinical_trials_context = (
-                    await ClinicalTrialsTools().get_context_for_denial(denial)
+                    await cls.clinical_trials.get_context_for_denial(denial)
                 )
             except Exception as e:
                 logger.opt(exception=True).debug(

--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -3031,10 +3031,14 @@ class AppealsBackendHelper:
                 # live registry call), so it can't go through
                 # _refresh_sync_denial_context (which wraps a sync getter in
                 # sync_to_async); use an inline guard with the same
-                # degrade-to-None behavior.
+                # degrade-to-None behavior. wait_for bounds the DB read with
+                # the same 10s budget the gather path uses so a stalled query
+                # can't hang this resilience path (TimeoutError is an
+                # Exception subclass, so the except below catches it too).
                 try:
-                    clinical_trials_context = (
-                        await cls.clinical_trials.get_context_for_denial(denial)
+                    clinical_trials_context = await asyncio.wait_for(
+                        cls.clinical_trials.get_context_for_denial(denial),
+                        timeout=10,
                     )
                 except Exception as inner:
                     logger.opt(exception=True).debug(
@@ -3061,10 +3065,12 @@ class AppealsBackendHelper:
             # ClinicalTrials lookup is also DB-only against the prefetched
             # cache, so re-render it on retries. The reader is async, so it
             # uses an inline guard rather than _refresh_sync_denial_context
-            # (which wraps a sync getter in sync_to_async).
+            # (which wraps a sync getter in sync_to_async). wait_for bounds
+            # the DB read with the same 10s budget as the gather path.
             try:
-                clinical_trials_context = (
-                    await cls.clinical_trials.get_context_for_denial(denial)
+                clinical_trials_context = await asyncio.wait_for(
+                    cls.clinical_trials.get_context_for_denial(denial),
+                    timeout=10,
                 )
             except Exception as e:
                 logger.opt(exception=True).debug(

--- a/fighthealthinsurance/generate_appeal.py
+++ b/fighthealthinsurance/generate_appeal.py
@@ -642,10 +642,10 @@ def identifier_found_in_text(identifier: str, text: str) -> bool:
 
 # Context shed on retry when zero-result failures may stem from
 # context-window overflow. Only the call-dict keys can be shed here —
-# uspstf/pa/nice/rag contexts are already baked into the prompt string
-# by make_open_prompt, so they're out of reach without re-rendering.
-# TODO: a future improvement could re-call make_open_prompt with those
-# contexts nulled to get true tier-1-style enrichment shedding.
+# uspstf/pa/nice/rag/clinical_trials contexts are already baked into the
+# prompt string by make_open_prompt, so they're out of reach without
+# re-rendering. TODO: a future improvement could re-call make_open_prompt
+# with those contexts nulled to get true tier-1-style enrichment shedding.
 _SHEDDABLE_TIER1 = ("pubmed_context", "ml_citations_context")
 _TIER2_TRUNCATIONS = (("plan_context", 4000), ("patient_context", 6000))
 
@@ -1337,6 +1337,7 @@ class AppealGenerator(object):
         payer_policy_context=None,
         pa_context=None,
         uspstf_context=None,
+        clinical_trials_context=None,
         medication_context=None,
     ) -> Optional[str]:
         """
@@ -1427,9 +1428,10 @@ class AppealGenerator(object):
             or (rag_context is not None and rag_context != "")
             or (nice_context is not None and nice_context != "")
             or (uspstf_context is not None and uspstf_context != "")
+            or (clinical_trials_context is not None and clinical_trials_context != "")
         )
         if has_citations:
-            base = f"{base}\n\nCITATION INSTRUCTIONS: You may ONLY cite medical literature, studies, or references that are explicitly provided below. Do NOT invent, fabricate, or hallucinate any citations, PMIDs, journal names, author names, or study details. If you want to make a medical claim, either cite from the provided references or state it as general medical knowledge without a specific citation."
+            base = f"{base}\n\nCITATION INSTRUCTIONS: You may ONLY cite medical literature, studies, or references that are explicitly provided below. Do NOT invent, fabricate, or hallucinate any citations, PMIDs, NCT IDs, journal names, author names, or study details. If you want to make a medical claim, either cite from the provided references or state it as general medical knowledge without a specific citation."
             if rag_context is not None and rag_context != "":
                 base = f"{base}\n\nEvidence from medical guidelines and regulations:\n{rag_context}"
             if ml_context is not None and ml_context != "":
@@ -1446,9 +1448,15 @@ class AppealGenerator(object):
                 # ACA cost-sharing angle and the A/B-only caveat, so no extra
                 # section label is needed here.
                 base = f"{base}\n\n{uspstf_context}"
+            if clinical_trials_context is not None and clinical_trials_context != "":
+                # The header inside ``clinical_trials_context`` already
+                # explains the "experimental/investigational" angle and
+                # the "trial != coverage" caveat, so no extra section
+                # label is needed here.
+                base = f"{base}\n\n{clinical_trials_context}"
         else:
             # No citations provided - explicitly tell the model not to make any up
-            base = f"{base}\n\nIMPORTANT: No specific medical citations have been provided. Do NOT invent or hallucinate any citations, PMIDs, journal names, or study references. You may state general medical knowledge without citations, but do not fabricate specific study references."
+            base = f"{base}\n\nIMPORTANT: No specific medical citations have been provided. Do NOT invent or hallucinate any citations, PMIDs, NCT IDs, journal names, or study references. You may state general medical knowledge without citations, but do not fabricate specific study references."
         if ucr_context:
             # The block carries an independent rate benchmark for this
             # procedure + area; the model decides whether the evidence is
@@ -1612,6 +1620,7 @@ class AppealGenerator(object):
         specialized_templates: Optional[List[type[SpecializedDenialTemplate]]] = None,
         pa_context=None,
         uspstf_context=None,
+        clinical_trials_context=None,
     ) -> Iterator[str]:
         """
         Generates an iterator of appeal texts for a given insurance denial using templates, non-AI sources, and AI models.
@@ -1703,6 +1712,7 @@ class AppealGenerator(object):
             payer_policy_context=payer_policy_context,
             pa_context=pa_context,
             uspstf_context=uspstf_context,
+            clinical_trials_context=clinical_trials_context,
             medication_context=medication_context,
         )
         open_medically_necessary_prompt = self.make_open_med_prompt(

--- a/fighthealthinsurance/migrations/0181_alter_clinicaltrialquerydata_query.py
+++ b/fighthealthinsurance/migrations/0181_alter_clinicaltrialquerydata_query.py
@@ -1,0 +1,26 @@
+"""Drop the (misleading) ``max_length=300`` on ``ClinicalTrialQueryData.query``.
+
+``find_trials_for_denial`` builds the cache key by concatenating
+``Denial.procedure`` and ``Denial.diagnosis`` (each up to 300 chars on
+``Denial``), so the combined query can legitimately exceed 300 characters.
+PostgreSQL doesn't enforce ``max_length`` on ``TextField`` at the database
+level, but the cap still trips form/admin validators. Matches the existing
+fix on ``NICEQueryData.query``.
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("fighthealthinsurance", "0180_insurancecompany_pa_requirement_list_url"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="clinicaltrialquerydata",
+            name="query",
+            field=models.TextField(),
+        ),
+    ]

--- a/fighthealthinsurance/models.py
+++ b/fighthealthinsurance/models.py
@@ -1440,7 +1440,9 @@ class ClinicalTrialQueryData(models.Model):
     """
 
     internal_id = models.AutoField(primary_key=True)
-    query = models.TextField(null=False, max_length=300)
+    # TextField (not CharField) because procedure and diagnosis are each up to
+    # 300 chars on Denial, so the combined query can exceed 300.
+    query = models.TextField(null=False)
     condition = models.TextField(null=True, blank=True)
     intervention = models.TextField(null=True, blank=True)
     nct_ids = models.TextField(null=True)  # JSON array

--- a/tests/async-unit/test_appeals_backend_citations.py
+++ b/tests/async-unit/test_appeals_backend_citations.py
@@ -483,6 +483,102 @@ class TestAppealsBackendHelperWithCitations:
             call_kwargs = mock_make_appeals_wrapper.call_args[1]
             assert call_kwargs["uspstf_context"] == uspstf_payload
 
+    @pytest.mark.asyncio
+    async def test_clinical_trials_context_passed_to_make_appeals(self):
+        """ClinicalTrials context from the gather block is threaded into
+        make_appeals.
+
+        Mirrors the USPSTF/PA routing pattern, but the trials reader is an
+        async method on the shared ``clinical_trials`` helper (DB-only — the
+        live registry call happened earlier in the prefetch), so it's patched
+        directly rather than through the ``sync_to_async`` router.
+        """
+        mock_denial = _make_mock_denial()
+        mock_denial_query = _make_mock_denial_query(mock_denial)
+
+        parameters = {
+            "denial_id": "12345",
+            "email": "test@example.com",
+            "semi_sekret": "test-secret",
+        }
+
+        ct_payload = (
+            "CLINICAL TRIAL EVIDENCE (relevant when the denial cites "
+            '"experimental" or "investigational" grounds):\n\n'
+            "NCT: NCT12345678; Title: Pembrolizumab in Melanoma"
+        )
+
+        with (
+            patch(
+                "fighthealthinsurance.common_view_logic.Denial.objects.filter",
+                return_value=mock_denial_query,
+            ),
+            patch(
+                "fighthealthinsurance.common_view_logic.Denial.get_hashed_email",
+                return_value="hashed",
+            ),
+            patch.object(
+                AppealsBackendHelper,
+                "regex_denial_processor",
+            ) as mock_regex_processor,
+            patch(
+                "fighthealthinsurance.common_view_logic.MLCitationsHelper.generate_citations_for_denial",
+                new_callable=AsyncMock,
+                return_value="ML Citation 1",
+            ),
+            patch.object(
+                AppealsBackendHelper.pmt,
+                "find_context_for_denial",
+                new_callable=AsyncMock,
+                return_value="PubMed context data",
+            ),
+            patch.object(
+                AppealsBackendHelper.clinical_trials,
+                "get_context_for_denial",
+                new_callable=AsyncMock,
+                return_value=ct_payload,
+            ) as mock_get_ct_context,
+            patch(
+                "fighthealthinsurance.common_view_logic.sync_to_async",
+            ) as mock_sync_to_async,
+            patch(
+                "fighthealthinsurance.common_view_logic.interleave_iterator_for_keep_alive",
+            ) as mock_interleave,
+            patch(
+                "fighthealthinsurance.common_view_logic.ProposedAppeal",
+            ) as mock_proposed_appeal_cls,
+        ):
+            mock_regex_processor.get_appeal_templates = AsyncMock(return_value=[])
+
+            mock_make_appeals_wrapper = AsyncMock(
+                return_value=["Appeal with clinical trials context"]
+            )
+            mock_pa_wrapper = AsyncMock(return_value="")
+            mock_sync_to_async.side_effect = _sync_to_async_router(
+                mock_pa_wrapper, mock_make_appeals_wrapper
+            )
+
+            mock_pa_instance = MagicMock()
+            mock_pa_instance.id = 1
+            mock_pa_instance.asave = AsyncMock()
+            mock_proposed_appeal_cls.return_value = mock_pa_instance
+
+            mock_proposed_appeal_cls.objects.filter.return_value = (
+                _make_empty_proposed_appeal_query()
+            )
+
+            mock_interleave.side_effect = passthrough_interleave
+
+            async for _ in AppealsBackendHelper.generate_appeals(parameters):
+                pass
+
+            # The reader was consulted (DB-only cache read), and its output
+            # reached make_appeals as the clinical_trials_context kwarg.
+            mock_get_ct_context.assert_awaited()
+            mock_make_appeals_wrapper.assert_called_once()
+            call_kwargs = mock_make_appeals_wrapper.call_args[1]
+            assert call_kwargs["clinical_trials_context"] == ct_payload
+
 
 @pytest.mark.parametrize(
     "saved_texts,synthesis_should_run",
@@ -649,6 +745,6 @@ async def test_synthesis_skips_verbatim_duplicate():
     assert done_frames[0]["new_appeals"] == len(saved_texts)
     # And no chunk should carry the "synthesized": "true" marker.
     for c in chunks:
-        assert '"synthesized": "true"' not in c, (
-            f"verbatim-duplicate synthesis should have been skipped, got chunk: {c}"
-        )
+        assert (
+            '"synthesized": "true"' not in c
+        ), f"verbatim-duplicate synthesis should have been skipped, got chunk: {c}"

--- a/tests/async-unit/test_common_view_logic.py
+++ b/tests/async-unit/test_common_view_logic.py
@@ -562,6 +562,119 @@ class TestCommonViewLogic(TestCase):
 
         async_to_sync(test)()
 
+    @pytest.mark.django_db
+    @patch(
+        "fighthealthinsurance.common_view_logic.fire_and_forget_in_new_threadpool",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "fighthealthinsurance.common_view_logic.appealGenerator.get_procedure_and_diagnosis",
+        new_callable=AsyncMock,
+        return_value=("pembrolizumab", "melanoma"),
+    )
+    def test_extract_schedules_clinical_trials_prefetch(
+        self, _mock_get_proc_diag, mock_fire_forget
+    ):
+        """``extract_set_denial_and_diagnosis`` must fire the ClinicalTrials
+        prefetch alongside the existing PubMed and speculative-context tasks
+        once procedure/diagnosis are populated."""
+        email = "test@example.com"
+        denial = Denial.objects.create(
+            denial_id=15,
+            semi_sekret="sekret",
+            hashed_email=Denial.get_hashed_email(email),
+            denial_text="Insurer denied pembrolizumab for melanoma as experimental.",
+        )
+
+        async def test():
+            try:
+                await DenialCreatorHelper.extract_set_denial_and_diagnosis(
+                    denial.denial_id
+                )
+
+                # All three background tasks must have been scheduled.
+                assert mock_fire_forget.await_count == 3, (
+                    f"Expected 3 fire-and-forget tasks (pubmed, clinical "
+                    f"trials, speculative context); saw "
+                    f"{mock_fire_forget.await_count}"
+                )
+                scheduled_names = [
+                    call.args[0].cr_code.co_name
+                    for call in mock_fire_forget.await_args_list
+                ]
+                assert "find_clinical_trials" in scheduled_names, (
+                    f"ClinicalTrials prefetch coroutine not scheduled; "
+                    f"saw {scheduled_names}"
+                )
+                # Close the captured coroutines so pytest doesn't warn about
+                # un-awaited coros from the mocked-out fire_and_forget.
+                for call in mock_fire_forget.await_args_list:
+                    call.args[0].close()
+            finally:
+                await Denial.objects.filter(denial_id=15).adelete()
+
+        async_to_sync(test)()
+
+    @pytest.mark.django_db
+    @patch(
+        "fighthealthinsurance.common_view_logic.fire_and_forget_in_new_threadpool",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "fighthealthinsurance.common_view_logic.ClinicalTrialsTools.find_trials_for_denial",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("simulated upstream failure"),
+    )
+    @patch(
+        "fighthealthinsurance.common_view_logic.appealGenerator.get_procedure_and_diagnosis",
+        new_callable=AsyncMock,
+        return_value=("pembrolizumab", "melanoma"),
+    )
+    def test_clinical_trials_prefetch_swallows_failures(
+        self, _mock_get_proc_diag, _mock_find_trials, mock_fire_forget
+    ):
+        """The ``find_clinical_trials`` inner coroutine must swallow every
+        exception so the daemon thread that ``fire_and_forget_in_new_threadpool``
+        spawns can never re-raise into the appeal flow."""
+        email = "test@example.com"
+        denial = Denial.objects.create(
+            denial_id=16,
+            semi_sekret="sekret",
+            hashed_email=Denial.get_hashed_email(email),
+            denial_text="Insurer denied pembrolizumab for melanoma as experimental.",
+        )
+
+        async def test():
+            try:
+                await DenialCreatorHelper.extract_set_denial_and_diagnosis(
+                    denial.denial_id
+                )
+
+                # Locate the captured clinical-trials coroutine and run it
+                # directly. If the inner try/except is correct, awaiting it
+                # must not raise even though find_trials_for_denial throws.
+                ct_coros = [
+                    call.args[0]
+                    for call in mock_fire_forget.await_args_list
+                    if call.args[0].cr_code.co_name == "find_clinical_trials"
+                ]
+                assert len(ct_coros) == 1, (
+                    f"Expected exactly one find_clinical_trials coro; "
+                    f"got {len(ct_coros)}"
+                )
+                # Should complete cleanly despite the upstream RuntimeError.
+                await ct_coros[0]
+
+                # Close any remaining captured coros to avoid pytest warnings.
+                for call in mock_fire_forget.await_args_list:
+                    coro = call.args[0]
+                    if coro.cr_code.co_name != "find_clinical_trials":
+                        coro.close()
+            finally:
+                await Denial.objects.filter(denial_id=16).adelete()
+
+        async_to_sync(test)()
+
 
 @pytest.mark.parametrize(
     "value,expected",

--- a/tests/async-unit/test_rxnorm_tools.py
+++ b/tests/async-unit/test_rxnorm_tools.py
@@ -392,7 +392,7 @@ class TestPubMedSingleDrugHeuristic:
 
 
 class TestRxNormLookupToolFormatting:
-    """Cover RxNormLookupTool._format_context (score gating, _merge)."""
+    """Cover RxNormLookupTool._format_context (score gating, merge_strings)."""
 
     def test_low_score_treated_as_miss(self):
         from fighthealthinsurance.chat.tools.rxnorm_tool import RxNormLookupTool
@@ -429,18 +429,18 @@ class TestRxNormLookupToolFormatting:
         assert "Lipitor" in out
 
     def test_merge_inserts_separator(self):
-        from fighthealthinsurance.chat.tools.rxnorm_tool import RxNormLookupTool
+        from fighthealthinsurance.chat.tools.base_tool import BaseTool
 
-        merged = RxNormLookupTool._merge("first sentence.", "second sentence.")
+        merged = BaseTool.merge_strings("first sentence.", "second sentence.")
         assert merged == "first sentence.\n\nsecond sentence."
 
     def test_merge_handles_empties(self):
-        from fighthealthinsurance.chat.tools.rxnorm_tool import RxNormLookupTool
+        from fighthealthinsurance.chat.tools.base_tool import BaseTool
 
-        assert RxNormLookupTool._merge("", "") == ""
-        assert RxNormLookupTool._merge(None, None) == ""
-        assert RxNormLookupTool._merge("only", "") == "only"
-        assert RxNormLookupTool._merge("", "only") == "only"
+        assert BaseTool.merge_strings("", "") == ""
+        assert BaseTool.merge_strings(None, None) == ""
+        assert BaseTool.merge_strings("only", "") == "only"
+        assert BaseTool.merge_strings("", "only") == "only"
 
 
 class TestRxNormLookupToolHandle:

--- a/tests/async-unit/test_rxnorm_tools.py
+++ b/tests/async-unit/test_rxnorm_tools.py
@@ -442,6 +442,24 @@ class TestRxNormLookupToolFormatting:
         assert BaseTool.merge_strings("only", "") == "only"
         assert BaseTool.merge_strings("", "only") == "only"
 
+    def test_merge_preserves_leading_spaces_and_indentation(self):
+        """Markdown list bullets and code-block indentation must survive the
+        merge — the join only strips newlines, not spaces/tabs."""
+        from fighthealthinsurance.chat.tools.base_tool import BaseTool
+
+        # Bullet list continuation: leading spaces in the addition matter.
+        merged = BaseTool.merge_strings("Steps:", "  - first step\n  - second step")
+        assert merged == "Steps:\n\n  - first step\n  - second step"
+
+        # Code-block style indentation in addition.
+        assert BaseTool.merge_strings("", "    indented line") == "    indented line"
+
+        # Trailing spaces on existing must be preserved (could be a markdown
+        # hard line break — two trailing spaces).
+        assert BaseTool.merge_strings("hard break  ", "next") == (
+            "hard break  \n\nnext"
+        )
+
 
 class TestRxNormLookupToolHandle:
     """End-to-end coverage of RxNormLookupTool.handle()/execute().

--- a/tests/async/test_clinicaltrials_integration.py
+++ b/tests/async/test_clinicaltrials_integration.py
@@ -234,3 +234,87 @@ class TestFindTrialsForQuery:
         assert trial is not None
         assert trial.study_url == "https://clinicaltrials.gov/study/NCT44444444"
         assert trial.brief_title == "Cached title"
+
+    async def test_get_context_for_denial_returns_none_when_no_prefetch(self):
+        """No audit row from the prefetch means no context — appeal-gen must
+        not turn the cache miss into a live API call."""
+        tools = ClinicalTrialsTools()
+        denial = await Denial.objects.acreate(
+            procedure="pembrolizumab",
+            diagnosis="melanoma",
+        )
+        # Force an explosion if anything tries to hit the network from this path.
+        with patch(
+            "fighthealthinsurance.clinicaltrials_tools.aiohttp.ClientSession",
+            side_effect=AssertionError("should not hit network"),
+        ):
+            ctx = await tools.get_context_for_denial(denial)
+        assert ctx is None
+
+    async def test_get_context_for_denial_returns_none_for_empty_match_audit(self):
+        """An audit row with ``nct_ids == "[]"`` (registry returned zero
+        matches) must surface as no-context, not as an empty section in
+        the appeal prompt."""
+        tools = ClinicalTrialsTools()
+        denial = await Denial.objects.acreate(
+            procedure="exotic_thing",
+            diagnosis="rare_condition",
+        )
+        await ClinicalTrialQueryData.objects.acreate(
+            denial_id=denial,
+            query="exotic_thing rare_condition",
+            condition="rare_condition",
+            intervention="exotic_thing",
+            nct_ids="[]",
+        )
+        ctx = await tools.get_context_for_denial(denial)
+        assert ctx is None
+
+    async def test_get_context_for_denial_renders_cached_trials(self):
+        """When the prefetch has populated the audit row + trial rows, the
+        context block must include each NCT ID and the self-contained header
+        that the appeal prompt bakes verbatim."""
+        tools = ClinicalTrialsTools()
+        denial = await Denial.objects.acreate(
+            procedure="pembrolizumab",
+            diagnosis="melanoma",
+        )
+        await ClinicalTrial.objects.acreate(
+            nct_id="NCT77777777",
+            brief_title="Pembrolizumab in advanced melanoma",
+            overall_status="RECRUITING",
+            phases="PHASE3",
+            study_type="INTERVENTIONAL",
+            conditions="Melanoma",
+            interventions="DRUG: Pembrolizumab",
+            brief_summary="Evaluates pembrolizumab in stage IV melanoma.",
+        )
+        await ClinicalTrial.objects.acreate(
+            nct_id="NCT88888888",
+            brief_title="Combination therapy for melanoma",
+            overall_status="ACTIVE_NOT_RECRUITING",
+        )
+        await ClinicalTrialQueryData.objects.acreate(
+            denial_id=denial,
+            query="pembrolizumab melanoma",
+            condition="melanoma",
+            intervention="pembrolizumab",
+            nct_ids='["NCT77777777", "NCT88888888"]',
+        )
+
+        # Belt-and-suspenders: this must be a pure DB read, no network.
+        with patch(
+            "fighthealthinsurance.clinicaltrials_tools.aiohttp.ClientSession",
+            side_effect=AssertionError("should not hit network"),
+        ):
+            ctx = await tools.get_context_for_denial(denial)
+
+        assert ctx is not None
+        # Self-contained header: callers bake it verbatim with no extra label.
+        assert "CLINICAL TRIAL EVIDENCE" in ctx
+        assert "experimental" in ctx.lower()
+        # Both NCT IDs surface, in registry-ranked order (the JSON order).
+        assert ctx.index("NCT77777777") < ctx.index("NCT88888888")
+        # The "trial != coverage" caveat from the chat tool must also live
+        # here so appeal letters carry the same framing.
+        assert "does not by itself establish coverage" in ctx

--- a/tests/sync/test_clinical_trials_prompt.py
+++ b/tests/sync/test_clinical_trials_prompt.py
@@ -7,86 +7,87 @@ Parallel to ``test_uspstf_api.MakeOpenPromptIncludesUSPSTFContextTests`` and
 from django.test import TestCase
 
 
-class MakeOpenPromptIncludesClinicalTrialsContextTests(TestCase):
-    """Verify the appeal-generation prompt picks up clinical_trials_context."""
+# A realistic rendered block (what ``get_context_for_denial`` would return):
+# self-contained header + one trial row carrying an NCT id.
+SAMPLE_TRIALS_CONTEXT = (
+    "CLINICAL TRIAL EVIDENCE (relevant when the denial cites "
+    '"experimental" or "investigational" grounds):\n\n'
+    "NCT: NCT12345678; Title: Pembrolizumab in Melanoma; "
+    "Status: RECRUITING; Phase: PHASE3"
+)
 
-    def test_make_open_prompt_includes_clinical_trials_block(self):
+# Minimal trials block used by the "trials are the only evidence" cases.
+TRIALS_ONLY_CONTEXT = "CLINICAL TRIAL EVIDENCE …\n\nNCT: NCT99999999"
+
+# The exact sentence make_open_prompt emits when no citation evidence at all
+# was supplied; its presence/absence is how we tell the two prompt branches
+# apart.
+NO_CITATIONS_WARNING = "No specific medical citations have been provided"
+
+
+class MakeOpenPromptIncludesClinicalTrialsContextTests(TestCase):
+    """Verify the appeal-generation prompt picks up clinical_trials_context.
+
+    Each test asserts a single behavior; shared setup (generator construction +
+    make_open_prompt call with sensible defaults) lives in ``_prompt``.
+    """
+
+    def _prompt(self, **overrides) -> str:
+        """Build an appeal prompt, assert it rendered, and return it.
+
+        ``denial_text`` and ``insurance_company`` default to non-empty values
+        so callers only pass the kwarg under test (e.g.
+        ``clinical_trials_context``).
+        """
         from fighthealthinsurance.generate_appeal import AppealGenerator
 
-        generator = AppealGenerator()
-        prompt = generator.make_open_prompt(
-            denial_text=(
-                "Insurer denied pembrolizumab as experimental/investigational."
-            ),
-            procedure="Pembrolizumab",
-            diagnosis="Melanoma",
-            insurance_company="ExamplePayer",
-            clinical_trials_context=(
-                "CLINICAL TRIAL EVIDENCE (relevant when the denial cites "
-                '"experimental" or "investigational" grounds):\n\n'
-                "NCT: NCT12345678; Title: Pembrolizumab in Melanoma; "
-                "Status: RECRUITING; Phase: PHASE3"
-            ),
-        )
+        kwargs = {
+            "denial_text": "Insurer denied pembrolizumab as experimental.",
+            "insurance_company": "ExamplePayer",
+        }
+        kwargs.update(overrides)
+        prompt = AppealGenerator().make_open_prompt(**kwargs)
         self.assertIsNotNone(prompt)
-        assert prompt is not None
-        # The self-contained header survives unchanged into the prompt.
+        assert prompt is not None  # narrow Optional[str] for mypy
+        return prompt
+
+    def test_clinical_trials_block_included_when_provided(self):
+        """The self-contained header + NCT id survive unchanged into the prompt."""
+        prompt = self._prompt(clinical_trials_context=SAMPLE_TRIALS_CONTEXT)
         self.assertIn("CLINICAL TRIAL EVIDENCE", prompt)
         self.assertIn("NCT12345678", prompt)
-        # Citation instructions block kicks in because trials count as
-        # citation evidence; NCT IDs must be in the no-fabricate list.
+
+    def test_clinical_trials_adds_nct_to_citation_no_fabricate_list(self):
+        """Trials count as citation evidence: the citation-instructions block
+        fires and NCT IDs join the no-fabricate list."""
+        prompt = self._prompt(clinical_trials_context=SAMPLE_TRIALS_CONTEXT)
         self.assertIn("CITATION INSTRUCTIONS", prompt)
         self.assertIn("NCT IDs", prompt)
 
-    def test_make_open_prompt_omits_clinical_trials_block_when_empty(self):
-        from fighthealthinsurance.generate_appeal import AppealGenerator
-
-        generator = AppealGenerator()
-        prompt = generator.make_open_prompt(
-            denial_text="Insurer denied pembrolizumab.",
-            insurance_company="ExamplePayer",
-            clinical_trials_context="",
-        )
-        self.assertIsNotNone(prompt)
-        assert prompt is not None
+    def test_clinical_trials_block_omitted_when_empty(self):
+        """An empty-string context must not emit a trial section."""
+        prompt = self._prompt(clinical_trials_context="")
         self.assertNotIn("CLINICAL TRIAL EVIDENCE", prompt)
 
-    def test_make_open_prompt_omits_clinical_trials_block_when_none(self):
-        """Default (no clinical_trials_context kwarg) must not emit a stub
-        trial section or otherwise pollute the prompt."""
-        from fighthealthinsurance.generate_appeal import AppealGenerator
-
-        generator = AppealGenerator()
-        prompt = generator.make_open_prompt(
-            denial_text="Insurer denied pembrolizumab.",
-            insurance_company="ExamplePayer",
-        )
-        self.assertIsNotNone(prompt)
-        assert prompt is not None
+    def test_clinical_trials_block_omitted_when_none(self):
+        """Default call (no clinical_trials_context kwarg) emits no trial section."""
+        prompt = self._prompt()
         self.assertNotIn("CLINICAL TRIAL EVIDENCE", prompt)
 
-    def test_clinical_trials_context_alone_triggers_citation_instructions(self):
-        """When the only evidence we have is trial data, the model must still
-        get the "ONLY cite what's provided" block instead of the fallback
-        "no citations available, don't invent any" block."""
-        from fighthealthinsurance.generate_appeal import AppealGenerator
+    def test_trials_only_triggers_citation_instructions(self):
+        """When trial data is the sole evidence, the "ONLY cite what's
+        provided" block must still fire."""
+        prompt = self._prompt(clinical_trials_context=TRIALS_ONLY_CONTEXT)
+        self.assertIn("CITATION INSTRUCTIONS", prompt)
 
-        generator = AppealGenerator()
-        trials_only_prompt = generator.make_open_prompt(
-            denial_text="Insurer denied X as experimental.",
-            insurance_company="ExamplePayer",
-            clinical_trials_context="CLINICAL TRIAL EVIDENCE …\n\nNCT: NCT99999999",
-        )
-        no_evidence_prompt = generator.make_open_prompt(
-            denial_text="Insurer denied X as experimental.",
-            insurance_company="ExamplePayer",
-        )
-        assert trials_only_prompt is not None and no_evidence_prompt is not None
-        self.assertIn("CITATION INSTRUCTIONS", trials_only_prompt)
-        self.assertNotIn(
-            "No specific medical citations have been provided",
-            trials_only_prompt,
-        )
-        self.assertIn(
-            "No specific medical citations have been provided", no_evidence_prompt
-        )
+    def test_trials_only_suppresses_no_citations_warning(self):
+        """Trial-only evidence must NOT fall through to the "no citations
+        available" guard."""
+        prompt = self._prompt(clinical_trials_context=TRIALS_ONLY_CONTEXT)
+        self.assertNotIn(NO_CITATIONS_WARNING, prompt)
+
+    def test_no_evidence_emits_no_citations_warning(self):
+        """With no citation context of any kind, the explicit no-citations
+        guard is emitted."""
+        prompt = self._prompt()
+        self.assertIn(NO_CITATIONS_WARNING, prompt)

--- a/tests/sync/test_clinical_trials_prompt.py
+++ b/tests/sync/test_clinical_trials_prompt.py
@@ -1,0 +1,92 @@
+"""Tests that the appeal-generation prompt picks up clinical_trials_context.
+
+Parallel to ``test_uspstf_api.MakeOpenPromptIncludesUSPSTFContextTests`` and
+``test_nice_context_prompt`` — the same shape, for the trial-evidence path.
+"""
+
+from django.test import TestCase
+
+
+class MakeOpenPromptIncludesClinicalTrialsContextTests(TestCase):
+    """Verify the appeal-generation prompt picks up clinical_trials_context."""
+
+    def test_make_open_prompt_includes_clinical_trials_block(self):
+        from fighthealthinsurance.generate_appeal import AppealGenerator
+
+        generator = AppealGenerator()
+        prompt = generator.make_open_prompt(
+            denial_text=(
+                "Insurer denied pembrolizumab as experimental/investigational."
+            ),
+            procedure="Pembrolizumab",
+            diagnosis="Melanoma",
+            insurance_company="ExamplePayer",
+            clinical_trials_context=(
+                "CLINICAL TRIAL EVIDENCE (relevant when the denial cites "
+                '"experimental" or "investigational" grounds):\n\n'
+                "NCT: NCT12345678; Title: Pembrolizumab in Melanoma; "
+                "Status: RECRUITING; Phase: PHASE3"
+            ),
+        )
+        self.assertIsNotNone(prompt)
+        assert prompt is not None
+        # The self-contained header survives unchanged into the prompt.
+        self.assertIn("CLINICAL TRIAL EVIDENCE", prompt)
+        self.assertIn("NCT12345678", prompt)
+        # Citation instructions block kicks in because trials count as
+        # citation evidence; NCT IDs must be in the no-fabricate list.
+        self.assertIn("CITATION INSTRUCTIONS", prompt)
+        self.assertIn("NCT IDs", prompt)
+
+    def test_make_open_prompt_omits_clinical_trials_block_when_empty(self):
+        from fighthealthinsurance.generate_appeal import AppealGenerator
+
+        generator = AppealGenerator()
+        prompt = generator.make_open_prompt(
+            denial_text="Insurer denied pembrolizumab.",
+            insurance_company="ExamplePayer",
+            clinical_trials_context="",
+        )
+        self.assertIsNotNone(prompt)
+        assert prompt is not None
+        self.assertNotIn("CLINICAL TRIAL EVIDENCE", prompt)
+
+    def test_make_open_prompt_omits_clinical_trials_block_when_none(self):
+        """Default (no clinical_trials_context kwarg) must not emit a stub
+        trial section or otherwise pollute the prompt."""
+        from fighthealthinsurance.generate_appeal import AppealGenerator
+
+        generator = AppealGenerator()
+        prompt = generator.make_open_prompt(
+            denial_text="Insurer denied pembrolizumab.",
+            insurance_company="ExamplePayer",
+        )
+        self.assertIsNotNone(prompt)
+        assert prompt is not None
+        self.assertNotIn("CLINICAL TRIAL EVIDENCE", prompt)
+
+    def test_clinical_trials_context_alone_triggers_citation_instructions(self):
+        """When the only evidence we have is trial data, the model must still
+        get the "ONLY cite what's provided" block instead of the fallback
+        "no citations available, don't invent any" block."""
+        from fighthealthinsurance.generate_appeal import AppealGenerator
+
+        generator = AppealGenerator()
+        trials_only_prompt = generator.make_open_prompt(
+            denial_text="Insurer denied X as experimental.",
+            insurance_company="ExamplePayer",
+            clinical_trials_context="CLINICAL TRIAL EVIDENCE …\n\nNCT: NCT99999999",
+        )
+        no_evidence_prompt = generator.make_open_prompt(
+            denial_text="Insurer denied X as experimental.",
+            insurance_company="ExamplePayer",
+        )
+        assert trials_only_prompt is not None and no_evidence_prompt is not None
+        self.assertIn("CITATION INSTRUCTIONS", trials_only_prompt)
+        self.assertNotIn(
+            "No specific medical citations have been provided",
+            trials_only_prompt,
+        )
+        self.assertIn(
+            "No specific medical citations have been provided", no_evidence_prompt
+        )


### PR DESCRIPTION
## Summary
Integrates ClinicalTrials.gov search into the background task pipeline that runs after denial extraction. This allows the chat assistant to serve trial matches instantly from the database cache instead of making live API calls, improving response latency for denials involving experimental or investigational treatments.

## Key Changes

- **New background task for clinical trials prefetch**: Added `find_clinical_trials()` coroutine in `extract_set_denial_and_diagnosis()` that prefetches ClinicalTrials.gov matches into the database cache. The task is fire-and-forget with its own timeout (40s internal + 50s belt-and-suspenders cap) and gracefully handles timeouts, cancellations, and errors without blocking the caller.

- **Refactored string merging to base class**: Extracted the `_merge()` method from `RxNormLookupTool` into `BaseTool.merge_strings()` as a reusable utility. Updated `RxNormLookupTool`, `ClinicalTrialsTool`, and `PubMedTool` to use the shared implementation, eliminating duplicate string concatenation logic.

- **Fixed ClinicalTrialQueryData model**: Removed the misleading `max_length=300` constraint from the `query` TextField. Since the query is built by concatenating `Denial.procedure` and `Denial.diagnosis` (each up to 300 chars), the combined query can legitimately exceed 300 characters. Added a migration (0181) and clarifying comment matching the existing fix on `NICEQueryData.query`.

- **Updated docstring and logging**: Enhanced the `extract_set_denial_and_diagnosis()` docstring to document the new clinical trials prefetch task and clarified that all background searches are fire-and-forget with their own timeouts. Updated log message to reflect the expanded background task pipeline.

## Implementation Details

- The `find_clinical_trials()` task uses `ClinicalTrialsTools.find_trials_for_denial()` with a 40-second internal timeout and a 50-second outer `asyncio.wait_for()` cap for defense-in-depth.
- All exceptions (timeout, cancellation, unexpected errors) are caught and logged at debug level to prevent propagation into the daemon thread.
- The clinical trials prefetch is supplementary evidence and intentionally non-blocking—the appeal flow never stalls waiting for trial data.
- String merging now uses a single, tested implementation in `BaseTool`, reducing code duplication across tool classes.

https://claude.ai/code/session_01KcjabJ12JBENNWp37uanMD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Appeals now leverage clinical trials evidence and citations to strengthen reimbursement arguments
  * System automatically prefetches and caches relevant clinical trial data during denial processing and appeal generation

* **Tests**
  * Added comprehensive test coverage for clinical trials evidence integration and citation handling in appeals

<!-- end of auto-generated comment: release notes by coderabbit.ai -->