### PR TITLE
Fix tier-shed retry to re-render prompt with enrichment nulled

### DIFF
--- a/fighthealthinsurance/generate_appeal.py
+++ b/fighthealthinsurance/generate_appeal.py
@@ -760,9 +760,9 @@ def identifier_found_in_text(identifier: str, text: str) -> bool:
 # above the limit.
 #
 #   * make_open_prompt bakes enrichment (pubmed, ml citations, rag, nice,
-#     uspstf, clinical trials, ucr, pa, payer-policy, medication) into the
-#     prompt string. To shed those we re-render the prompt with the matching
-#     kwargs set to None / truncated.
+#     uspstf, clinical trials, regulatory citations, ucr, pa, payer-policy,
+#     medication) into the prompt string. To shed those we re-render the
+#     prompt with the matching kwargs set to None / truncated.
 #   * The same call dict also carries pubmed_context, ml_citations_context,
 #     plan_context, and patient_context as separate keys, which the model
 #     re-injects via ``context_extra`` (see ml_models.RemoteFullOpenLike).
@@ -778,6 +778,7 @@ _PROMPT_TIER1_NULLS: tuple[str, ...] = (
     "nice_context",
     "uspstf_context",
     "clinical_trials_context",
+    "regulatory_citation_context",
     "ucr_context",
     "pa_context",
     "payer_policy_context",

--- a/fighthealthinsurance/generate_appeal.py
+++ b/fighthealthinsurance/generate_appeal.py
@@ -828,6 +828,10 @@ def _shed_context(
     ):
         shed_kwargs = dict(open_prompt_kwargs)
         for key in _PROMPT_TIER1_NULLS:
+            # Truthy check (not ``is not None``): an empty-string enrichment
+            # is already a no-op inside ``make_open_prompt`` (each section is
+            # gated on ``!= ""``), so nulling it would add diagnostic noise
+            # to ``changed`` without changing the rebuilt prompt.
             if shed_kwargs.get(key):
                 shed_kwargs[key] = None
                 changed.add(f"prompt.{key}")

--- a/fighthealthinsurance/generate_appeal.py
+++ b/fighthealthinsurance/generate_appeal.py
@@ -860,19 +860,27 @@ def _shed_context(
         and original_open_prompt is not None
     ):
         shed_kwargs = dict(open_prompt_kwargs)
+        prompt_changed_before = len(changed)
         for key in _PROMPT_TIER1_NULLS:
-            # Truthy check (not ``is not None``): an empty-string enrichment
-            # is already a no-op inside ``make_open_prompt`` (each section is
-            # gated on ``!= ""``), so nulling it would add diagnostic noise
-            # to ``changed`` without changing the rebuilt prompt.
-            if shed_kwargs.get(key):
+            # Only null real content: ``make_open_prompt`` gates each section
+            # on ``!= ""`` and a whitespace-only value yields a no-op section
+            # body, so treat empty/whitespace as already-shed. Skipping these
+            # keeps ``changed`` honest and avoids a needless rebuild_prompt
+            # call below (``make_open_prompt`` random.shuffle()s the
+            # professional-POV examples — re-calling it for a no-op would
+            # silently change the retry prompt's example ordering).
+            val = shed_kwargs.get(key)
+            if isinstance(val, str) and val.strip():
                 shed_kwargs[key] = None
                 changed.add(f"prompt.{key}")
         if tier >= 2:
             _apply_tier2_truncations(
                 shed_kwargs, _PROMPT_TIER2_TRUNCATIONS, changed, label="prompt."
             )
-        new_open_prompt = rebuild_prompt(**shed_kwargs)
+        # Only rebuild if the prompt-surface actually shrank — otherwise the
+        # original ``open_prompt`` is reused as-is.
+        if len(changed) > prompt_changed_before:
+            new_open_prompt = rebuild_prompt(**shed_kwargs)
 
     new_calls = []
     for call in calls:

--- a/fighthealthinsurance/generate_appeal.py
+++ b/fighthealthinsurance/generate_appeal.py
@@ -753,27 +753,107 @@ def identifier_found_in_text(identifier: str, text: str) -> bool:
     return False
 
 
-# Context shed on retry when zero-result failures may stem from
-# context-window overflow. Only the call-dict keys can be shed here —
-# uspstf/pa/nice/rag/clinical_trials contexts are already baked into the
-# prompt string by make_open_prompt, so they're out of reach without
-# re-rendering. TODO: a future improvement could re-call make_open_prompt
-# with those contexts nulled to get true tier-1-style enrichment shedding.
+# Tier-shed retry: reduce prompt size when zero-result failures may stem
+# from context-window overflow. Each enrichment context appears on TWO
+# surfaces and both need to shrink in lockstep, otherwise we'd null the
+# call-dict copy while the prompt-baked copy still pins the token count
+# above the limit.
+#
+#   * make_open_prompt bakes enrichment (pubmed, ml citations, rag, nice,
+#     uspstf, ucr, pa, payer-policy, medication) into the prompt string.
+#     To shed those we re-render the prompt with the matching kwargs set
+#     to None / truncated.
+#   * The same call dict also carries pubmed_context, ml_citations_context,
+#     plan_context, and patient_context as separate keys, which the model
+#     re-injects via ``context_extra`` (see ml_models.RemoteFullOpenLike).
+#     We null/truncate those alongside the prompt re-render.
+
+# In-prompt enrichment dropped entirely at tier 1+. Names match the
+# ``make_open_prompt`` parameters (note: ``ml_context`` is the prompt-side
+# rendered form of ``ml_citations_context``).
+_PROMPT_TIER1_NULLS: tuple[str, ...] = (
+    "ml_context",
+    "pubmed_context",
+    "rag_context",
+    "nice_context",
+    "uspstf_context",
+    "ucr_context",
+    "pa_context",
+    "payer_policy_context",
+    "medication_context",
+)
+
+# In-prompt patient-specific context truncated (not dropped) at tier 2+.
+_PROMPT_TIER2_TRUNCATIONS: tuple[tuple[str, int], ...] = (("plan_context", 4000),)
+
+# Call-dict copies (the ``context_extra`` injection surface) sheddable at
+# tier 1+. These mirror their ``_PROMPT_TIER1_NULLS`` counterparts.
 _SHEDDABLE_TIER1 = ("pubmed_context", "ml_citations_context")
+
+# Call-dict patient/plan context truncated at tier 2+. ``patient_context``
+# (``medical_context`` in the caller) is not in the prompt string, so it
+# only needs trimming on the call-dict surface.
 _TIER2_TRUNCATIONS = (("plan_context", 4000), ("patient_context", 6000))
 
 
-def _shed_context(calls: list[dict], tier: int) -> tuple[list[dict], list[str]]:
+def _shed_context(
+    calls: list[dict],
+    tier: int,
+    *,
+    open_prompt_kwargs: Optional[dict] = None,
+    rebuild_prompt: Optional[Callable[..., Optional[str]]] = None,
+    original_open_prompt: Optional[str] = None,
+) -> tuple[list[dict], list[str]]:
     """Return (new_calls, changed_names) with context reduced by tier.
 
-    Tier 1 nulls pubmed/citations context. Tier 2 also truncates
-    plan_context and patient_context. Higher tiers include all lower-tier
-    reductions.
+    Tier 1 nulls the enrichment contexts on both surfaces: in the
+    re-rendered prompt (when ``open_prompt_kwargs`` + ``rebuild_prompt`` +
+    ``original_open_prompt`` are provided) and in the call-dict copies.
+    Tier 2 additionally truncates ``plan_context`` (in-prompt) and
+    ``plan_context`` + ``patient_context`` (call-dict). Higher tiers
+    include all lower-tier reductions.
+
+    When the prompt-rebuild arguments are omitted the function falls back
+    to call-dict-only shedding — kept for direct unit testing of the
+    call-dict surface.
     """
     changed: set[str] = set()
+
+    new_open_prompt: Optional[str] = None
+    if (
+        tier >= 1
+        and open_prompt_kwargs is not None
+        and rebuild_prompt is not None
+        and original_open_prompt is not None
+    ):
+        shed_kwargs = dict(open_prompt_kwargs)
+        for key in _PROMPT_TIER1_NULLS:
+            if shed_kwargs.get(key):
+                shed_kwargs[key] = None
+                changed.add(f"prompt.{key}")
+        if tier >= 2:
+            for key, cap in _PROMPT_TIER2_TRUNCATIONS:
+                val = shed_kwargs.get(key)
+                if isinstance(val, str) and len(val) > cap:
+                    shed_kwargs[key] = truncate_at_boundary(val, cap, ellipsis="")
+                    changed.add(f"prompt.{key}(truncated)")
+        new_open_prompt = rebuild_prompt(**shed_kwargs)
+
     new_calls = []
     for call in calls:
         new = dict(call)
+        # Swap the shed prompt into any call whose prompt is the original
+        # open_prompt or starts with it (the specialized variant appends a
+        # hint block). The medically-necessary prompt is unrelated and is
+        # left untouched.
+        if (
+            new_open_prompt is not None
+            and original_open_prompt
+            and isinstance(new.get("prompt"), str)
+            and new["prompt"].startswith(original_open_prompt)
+        ):
+            tail = new["prompt"][len(original_open_prompt) :]
+            new["prompt"] = new_open_prompt + tail
         for key in _SHEDDABLE_TIER1:
             if new.get(key) is not None:
                 new[key] = None
@@ -1862,7 +1942,11 @@ class AppealGenerator(object):
         medication_context = self._collect_medication_context(denial)
         regulatory_citation_context = self._collect_regulatory_context(denial)
 
-        open_prompt = self.make_open_prompt(
+        # Captured as a dict so the tier-shed retry path can re-render the
+        # prompt with enrichment kwargs nulled or truncated — otherwise the
+        # prompt-baked copies of pubmed/citations/rag/etc. would still pin
+        # the token count even after the call-dict copies are dropped.
+        open_prompt_kwargs = dict(
             denial_text=denial.denial_text,
             procedure=denial.procedure,
             diagnosis=denial.diagnosis,
@@ -1891,6 +1975,7 @@ class AppealGenerator(object):
             medication_context=medication_context,
             regulatory_citation_context=regulatory_citation_context,
         )
+        open_prompt = self.make_open_prompt(**open_prompt_kwargs)
         open_medically_necessary_prompt = self.make_open_med_prompt(
             procedure=denial.procedure,
             diagnosis=denial.diagnosis,
@@ -2195,7 +2280,13 @@ class AppealGenerator(object):
             )
             time.sleep(1.0)
             for tier in (1, 2):
-                shed_calls, changed = _shed_context(calls, tier=tier)
+                shed_calls, changed = _shed_context(
+                    calls,
+                    tier=tier,
+                    open_prompt_kwargs=open_prompt_kwargs,
+                    rebuild_prompt=self.make_open_prompt,
+                    original_open_prompt=open_prompt,
+                )
                 logger.warning(
                     f"make_appeals: retrying primary for denial {denial_id} "
                     f"with context shed (tier={tier}, changed={changed})"

--- a/fighthealthinsurance/generate_appeal.py
+++ b/fighthealthinsurance/generate_appeal.py
@@ -783,8 +783,16 @@ _PROMPT_TIER1_NULLS: tuple[str, ...] = (
     "medication_context",
 )
 
+# Tier-2 truncation caps. ``plan_context`` lives on BOTH the prompt and the
+# call-dict surface and is truncated to the same length on each, so the cap
+# is a single shared constant rather than two literals that could drift.
+_PLAN_CONTEXT_TIER2_CAP = 4000
+_PATIENT_CONTEXT_TIER2_CAP = 6000
+
 # In-prompt patient-specific context truncated (not dropped) at tier 2+.
-_PROMPT_TIER2_TRUNCATIONS: tuple[tuple[str, int], ...] = (("plan_context", 4000),)
+_PROMPT_TIER2_TRUNCATIONS: tuple[tuple[str, int], ...] = (
+    ("plan_context", _PLAN_CONTEXT_TIER2_CAP),
+)
 
 # Call-dict copies (the ``context_extra`` injection surface) sheddable at
 # tier 1+. These mirror their ``_PROMPT_TIER1_NULLS`` counterparts.
@@ -793,7 +801,32 @@ _SHEDDABLE_TIER1 = ("pubmed_context", "ml_citations_context")
 # Call-dict patient/plan context truncated at tier 2+. ``patient_context``
 # (``medical_context`` in the caller) is not in the prompt string, so it
 # only needs trimming on the call-dict surface.
-_TIER2_TRUNCATIONS = (("plan_context", 4000), ("patient_context", 6000))
+_TIER2_TRUNCATIONS = (
+    ("plan_context", _PLAN_CONTEXT_TIER2_CAP),
+    ("patient_context", _PATIENT_CONTEXT_TIER2_CAP),
+)
+
+
+def _apply_tier2_truncations(
+    target: dict,
+    truncations: tuple[tuple[str, int], ...],
+    changed: set[str],
+    *,
+    label: str,
+) -> None:
+    """Boundary-aware truncate over-cap string values in ``target`` in place.
+
+    Shared by the prompt-kwargs and call-dict surfaces so both truncate
+    identically (same boundary-aware helper, same caps). ``label`` prefixes
+    the ``changed`` entry (``"prompt."`` for the prompt surface, ``""`` for
+    the call dict). ``ellipsis=""`` because this text is fed to the model,
+    not displayed, so a trailing marker would only waste budget.
+    """
+    for key, cap in truncations:
+        val = target.get(key)
+        if isinstance(val, str) and len(val) > cap:
+            target[key] = truncate_at_boundary(val, cap, ellipsis="")
+            changed.add(f"{label}{key}(truncated)")
 
 
 def _shed_context(
@@ -836,11 +869,9 @@ def _shed_context(
                 shed_kwargs[key] = None
                 changed.add(f"prompt.{key}")
         if tier >= 2:
-            for key, cap in _PROMPT_TIER2_TRUNCATIONS:
-                val = shed_kwargs.get(key)
-                if isinstance(val, str) and len(val) > cap:
-                    shed_kwargs[key] = truncate_at_boundary(val, cap, ellipsis="")
-                    changed.add(f"prompt.{key}(truncated)")
+            _apply_tier2_truncations(
+                shed_kwargs, _PROMPT_TIER2_TRUNCATIONS, changed, label="prompt."
+            )
         new_open_prompt = rebuild_prompt(**shed_kwargs)
 
     new_calls = []
@@ -863,11 +894,7 @@ def _shed_context(
                 new[key] = None
                 changed.add(key)
         if tier >= 2:
-            for key, cap in _TIER2_TRUNCATIONS:
-                val = new.get(key)
-                if isinstance(val, str) and len(val) > cap:
-                    new[key] = val[:cap]
-                    changed.add(f"{key}(truncated)")
+            _apply_tier2_truncations(new, _TIER2_TRUNCATIONS, changed, label="")
         new_calls.append(new)
     return new_calls, sorted(changed)
 

--- a/fighthealthinsurance/generate_appeal.py
+++ b/fighthealthinsurance/generate_appeal.py
@@ -863,15 +863,15 @@ def _shed_context(
         shed_kwargs = dict(open_prompt_kwargs)
         prompt_changed_before = len(changed)
         for key in _PROMPT_TIER1_NULLS:
-            # Only null real content: ``make_open_prompt`` gates each section
-            # on ``!= ""`` and a whitespace-only value yields a no-op section
-            # body, so treat empty/whitespace as already-shed. Skipping these
-            # keeps ``changed`` honest and avoids a needless rebuild_prompt
-            # call below (``make_open_prompt`` random.shuffle()s the
-            # professional-POV examples — re-calling it for a no-op would
-            # silently change the retry prompt's example ordering).
+            # Mirror ``make_open_prompt``'s gate exactly: each section is
+            # included on ``is not None and != ""``. A whitespace-only value
+            # is NOT a no-op there — it still trips ``has_citations`` and
+            # renders the CITATION INSTRUCTIONS block plus the section
+            # header (e.g. ``Provided citations (use these):    ``), so it
+            # contributes prompt bytes we need to shed. Only the truly
+            # empty string ``""`` is already-shed and can be skipped.
             val = shed_kwargs.get(key)
-            if isinstance(val, str) and val.strip():
+            if isinstance(val, str) and val != "":
                 shed_kwargs[key] = None
                 changed.add(f"prompt.{key}")
         if tier >= 2:

--- a/fighthealthinsurance/generate_appeal.py
+++ b/fighthealthinsurance/generate_appeal.py
@@ -760,9 +760,9 @@ def identifier_found_in_text(identifier: str, text: str) -> bool:
 # above the limit.
 #
 #   * make_open_prompt bakes enrichment (pubmed, ml citations, rag, nice,
-#     uspstf, ucr, pa, payer-policy, medication) into the prompt string.
-#     To shed those we re-render the prompt with the matching kwargs set
-#     to None / truncated.
+#     uspstf, clinical trials, ucr, pa, payer-policy, medication) into the
+#     prompt string. To shed those we re-render the prompt with the matching
+#     kwargs set to None / truncated.
 #   * The same call dict also carries pubmed_context, ml_citations_context,
 #     plan_context, and patient_context as separate keys, which the model
 #     re-injects via ``context_extra`` (see ml_models.RemoteFullOpenLike).
@@ -777,6 +777,7 @@ _PROMPT_TIER1_NULLS: tuple[str, ...] = (
     "rag_context",
     "nice_context",
     "uspstf_context",
+    "clinical_trials_context",
     "ucr_context",
     "pa_context",
     "payer_policy_context",

--- a/fighthealthinsurance/generate_appeal.py
+++ b/fighthealthinsurance/generate_appeal.py
@@ -898,10 +898,11 @@ def _shed_context(
         ):
             tail = new["prompt"][len(original_open_prompt) :]
             new["prompt"] = new_open_prompt + tail
-        for key in _SHEDDABLE_TIER1:
-            if new.get(key) is not None:
-                new[key] = None
-                changed.add(key)
+        if tier >= 1:
+            for key in _SHEDDABLE_TIER1:
+                if new.get(key) is not None:
+                    new[key] = None
+                    changed.add(key)
         if tier >= 2:
             _apply_tier2_truncations(new, _TIER2_TRUNCATIONS, changed, label="")
         new_calls.append(new)

--- a/tests/async-unit/test_generate_appeal.py
+++ b/tests/async-unit/test_generate_appeal.py
@@ -509,6 +509,56 @@ class TestShedContextPromptRebuild:
         assert new_calls[0]["prompt"] == "Please write an appeal."  # unchanged
         assert not any(c.startswith("prompt.") for c in changed)
 
+    def test_skips_rebuild_when_no_prompt_surface_changes(self):
+        # Regression (Copilot review): make_open_prompt random.shuffle()s
+        # the professional-POV example list, so re-calling it for a no-op
+        # would silently change the retry prompt's example ordering even
+        # though ``changed`` reports nothing shed. Skip the rebuild entirely
+        # when no prompt kwarg was nulled or truncated.
+        empty_kwargs = {key: None for key in _PROMPT_TIER1_NULLS}
+        kwargs = _prompt_kwargs(**empty_kwargs, plan_context="short")
+        calls_count = [0]
+
+        def rebuild(**_):
+            calls_count[0] += 1
+            return "SHOULD-NOT-BE-USED"
+
+        new_calls, changed = _shed_context(
+            [_make_call(prompt="ORIGINAL")],
+            tier=2,  # tier 2 would otherwise try plan_context truncation
+            open_prompt_kwargs=kwargs,
+            rebuild_prompt=rebuild,
+            original_open_prompt="ORIGINAL",
+        )
+        assert calls_count[0] == 0, "rebuild_prompt called despite no-op shed"
+        assert not any(c.startswith("prompt.") for c in changed)
+        # Call's prompt is untouched too (no swap happened).
+        assert new_calls[0]["prompt"] == "ORIGINAL"
+
+    def test_whitespace_only_enrichment_treated_as_already_shed(self):
+        # Regression (Copilot review): a whitespace-only enrichment value
+        # is truthy in Python but is a no-op section in make_open_prompt
+        # (gated on ``!= ""``). Treat it as already-shed so we don't add
+        # diagnostic noise to ``changed`` for a string that wasn't
+        # contributing anything.
+        whitespace_kwargs = {key: "   \n\t" for key in _PROMPT_TIER1_NULLS}
+        kwargs = _prompt_kwargs(**whitespace_kwargs)
+        calls_count = [0]
+
+        def rebuild(**_):
+            calls_count[0] += 1
+            return "X"
+
+        _, changed = _shed_context(
+            [_make_call(prompt="ORIGINAL")],
+            tier=1,
+            open_prompt_kwargs=kwargs,
+            rebuild_prompt=rebuild,
+            original_open_prompt="ORIGINAL",
+        )
+        assert calls_count[0] == 0, "rebuild_prompt fired on whitespace-only enrichment"
+        assert not any(c.startswith("prompt.") for c in changed)
+
 
 # --- make_appeals router-call-pattern tests --------------------------------
 

--- a/tests/async-unit/test_generate_appeal.py
+++ b/tests/async-unit/test_generate_appeal.py
@@ -467,6 +467,25 @@ class TestShedContextPromptRebuild:
         assert len(seen_kwargs[key]) <= cap
         assert f"prompt.{key}(truncated)" in changed
 
+    def test_tier2_stacks_tier1_enrichment_nulls_in_prompt(self):
+        # Stacking: tier 2 must also apply the tier-1 enrichment nulls to
+        # the rebuilt prompt's kwargs, not just the call-dict copies.
+        seen_kwargs: dict = {}
+
+        def rebuild(**rk):
+            seen_kwargs.update(rk)
+            return "OUT"
+
+        _shed_context(
+            [_make_call(prompt="ORIGINAL")],
+            tier=2,
+            open_prompt_kwargs=_prompt_kwargs(),
+            rebuild_prompt=rebuild,
+            original_open_prompt="ORIGINAL",
+        )
+        for key in _PROMPT_TIER1_NULLS:
+            assert seen_kwargs[key] is None, f"{key} not nulled at tier 2"
+
     def test_omitted_rebuild_args_falls_back_to_call_dict_only(self):
         # When the caller doesn't pass rebuild args, _shed_context is a
         # pure call-dict shedder — same shape as the legacy tests above.

--- a/tests/async-unit/test_generate_appeal.py
+++ b/tests/async-unit/test_generate_appeal.py
@@ -335,6 +335,22 @@ class TestShedContext:
         assert new["patient_context"] == "also short"
         assert not any("(truncated)" in c for c in changed)
 
+    def test_tier2_call_dict_truncation_is_boundary_aware(self):
+        # Regression: the call-dict surface previously hard-cut val[:cap]
+        # mid-word, diverging from the boundary-aware prompt surface even
+        # though plan_context carries the same value on both. Both now use
+        # truncate_at_boundary, so the call-dict copy must end on a word
+        # boundary (not a partial token) and stay within the cap.
+        (key, cap), *_ = _TIER2_TRUNCATIONS
+        oversized = "word " * (cap // 2)  # spaces give a boundary to cut on
+        new_calls, _ = _shed_context([_make_call(**{key: oversized})], tier=2)
+        result = new_calls[0][key]
+        assert len(result) <= cap
+        # Boundary-aware: result is a prefix ending on a word boundary, so it
+        # does not end mid-token and remains a prefix of the input.
+        assert not result.endswith("wor")
+        assert oversized.startswith(result.rstrip())
+
     def test_does_not_mutate_input_calls(self):
         original = _make_call()
         _shed_context([original], tier=2)

--- a/tests/async-unit/test_generate_appeal.py
+++ b/tests/async-unit/test_generate_appeal.py
@@ -405,6 +405,7 @@ def _prompt_kwargs(**overrides):
         "pa_context": "pa ctx",
         "uspstf_context": "uspstf ctx",
         "clinical_trials_context": "clinical trials ctx",
+        "regulatory_citation_context": "regulatory ctx",
         "medication_context": "med ctx",
     }
     base.update(overrides)
@@ -468,6 +469,30 @@ class TestShedContextPromptRebuild:
         )
         assert seen_kwargs["clinical_trials_context"] is None
         assert "prompt.clinical_trials_context" in changed
+
+    def test_tier1_sheds_regulatory_citation_context(self):
+        # Regression: regulatory_citation_context (added to make_open_prompt
+        # in #834) is a prompt-baked enrichment with no call-dict copy, so
+        # it must be in _PROMPT_TIER1_NULLS or a context-overflow retry would
+        # leave it pinning the token count.
+        assert "regulatory_citation_context" in _PROMPT_TIER1_NULLS
+        seen_kwargs: dict = {}
+
+        def rebuild(**rk):
+            seen_kwargs.update(rk)
+            return "REBUILT"
+
+        _, changed = _shed_context(
+            [_make_call(prompt="ORIGINAL")],
+            tier=1,
+            open_prompt_kwargs=_prompt_kwargs(
+                regulatory_citation_context="42 U.S.C. ..."
+            ),
+            rebuild_prompt=rebuild,
+            original_open_prompt="ORIGINAL",
+        )
+        assert seen_kwargs["regulatory_citation_context"] is None
+        assert "prompt.regulatory_citation_context" in changed
 
     def test_tier1_preserves_specialized_hint_suffix(self):
         # Specialized calls use `open_prompt + "\n\n--- ... ---\n" + hint`.

--- a/tests/async-unit/test_generate_appeal.py
+++ b/tests/async-unit/test_generate_appeal.py
@@ -559,19 +559,21 @@ class TestShedContextPromptRebuild:
         # Call's prompt is untouched too (no swap happened).
         assert new_calls[0]["prompt"] == "ORIGINAL"
 
-    def test_whitespace_only_enrichment_treated_as_already_shed(self):
-        # Regression (Copilot review): a whitespace-only enrichment value
-        # is truthy in Python but is a no-op section in make_open_prompt
-        # (gated on ``!= ""``). Treat it as already-shed so we don't add
-        # diagnostic noise to ``changed`` for a string that wasn't
-        # contributing anything.
+    def test_whitespace_only_enrichment_is_still_shed(self):
+        # Regression (Copilot review on PR #824): a whitespace-only
+        # enrichment value is NOT a no-op in make_open_prompt --- the gate
+        # there is ``is not None and != ""``, so ``"   "`` still trips
+        # has_citations and renders the CITATION INSTRUCTIONS block plus
+        # the per-section header (``Provided citations (use these):    ``).
+        # Those bytes need to drop on retry, so the shed pass must null
+        # whitespace-only values and trigger a rebuild.
         whitespace_kwargs = {key: "   \n\t" for key in _PROMPT_TIER1_NULLS}
         kwargs = _prompt_kwargs(**whitespace_kwargs)
-        calls_count = [0]
+        seen_kwargs: dict = {}
 
-        def rebuild(**_):
-            calls_count[0] += 1
-            return "X"
+        def rebuild(**rk):
+            seen_kwargs.update(rk)
+            return "SHED"
 
         _, changed = _shed_context(
             [_make_call(prompt="ORIGINAL")],
@@ -580,7 +582,32 @@ class TestShedContextPromptRebuild:
             rebuild_prompt=rebuild,
             original_open_prompt="ORIGINAL",
         )
-        assert calls_count[0] == 0, "rebuild_prompt fired on whitespace-only enrichment"
+        # Every whitespace-only enrichment is nulled and reported.
+        for key in _PROMPT_TIER1_NULLS:
+            assert seen_kwargs[key] is None, f"{key} should have been nulled"
+            assert f"prompt.{key}" in changed
+
+    def test_truly_empty_string_enrichment_is_skipped(self):
+        # The truly-empty string ``""`` IS already a no-op in
+        # make_open_prompt (gate fails on ``!= ""``), so it can be skipped
+        # without adding diagnostic noise to ``changed``. Pin that the
+        # truly-empty case still avoids a rebuild call.
+        empty_kwargs = {key: "" for key in _PROMPT_TIER1_NULLS}
+        kwargs = _prompt_kwargs(**empty_kwargs, plan_context="short")
+        calls_count = [0]
+
+        def rebuild(**_):
+            calls_count[0] += 1
+            return "X"
+
+        _, changed = _shed_context(
+            [_make_call(prompt="ORIGINAL")],
+            tier=2,
+            open_prompt_kwargs=kwargs,
+            rebuild_prompt=rebuild,
+            original_open_prompt="ORIGINAL",
+        )
+        assert calls_count[0] == 0, "rebuild fired on truly-empty enrichment"
         assert not any(c.startswith("prompt.") for c in changed)
 
 

--- a/tests/async-unit/test_generate_appeal.py
+++ b/tests/async-unit/test_generate_appeal.py
@@ -374,6 +374,9 @@ class TestShedContext:
         # Tier-1 call-dict keys survive unchanged.
         for key in _SHEDDABLE_TIER1:
             assert new_calls[0][key] == original[key]
+        # Tier-2 call-dict keys also survive unchanged (no truncation).
+        for key, _cap in _TIER2_TRUNCATIONS:
+            assert new_calls[0][key] == original[key]
 
 
 # --- _shed_context prompt-rebuild tests -------------------------------------
@@ -412,6 +415,32 @@ def _prompt_kwargs(**overrides):
     return base
 
 
+def _rebuild_spy(return_value="REBUILT"):
+    """Return (seen_kwargs, rebuild_fn) for capturing _shed_context's
+    rebuild_prompt invocation. Shared by the prompt-rebuild tests below so
+    each one doesn't redefine the same 3-line closure."""
+    seen_kwargs: dict = {}
+
+    def rebuild(**rk):
+        seen_kwargs.update(rk)
+        return return_value
+
+    return seen_kwargs, rebuild
+
+
+def _rebuild_counter():
+    """Return (count_box, rebuild_fn) for tests that only care whether
+    rebuild_prompt was called, not what kwargs it saw. ``count_box[0]``
+    holds the call count."""
+    count_box = [0]
+
+    def rebuild(**_):
+        count_box[0] += 1
+        return "REBUILT"
+
+    return count_box, rebuild
+
+
 class TestShedContextPromptRebuild:
     """Tier shedding must re-render the prompt with enrichment stripped.
 
@@ -422,12 +451,7 @@ class TestShedContextPromptRebuild:
 
     def test_tier1_rebuilds_prompt_with_enrichment_nulled(self):
         kwargs = _prompt_kwargs()
-        seen_kwargs: dict = {}
-
-        def rebuild(**rk):
-            seen_kwargs.update(rk)
-            return "REBUILT-PROMPT"
-
+        seen_kwargs, rebuild = _rebuild_spy(return_value="REBUILT-PROMPT")
         new_calls, changed = _shed_context(
             [_make_call(prompt="ORIGINAL")],
             tier=1,
@@ -454,12 +478,7 @@ class TestShedContextPromptRebuild:
         # leave it pinning the token count — the exact bug this PR fixed for
         # pubmed/citations.
         assert "clinical_trials_context" in _PROMPT_TIER1_NULLS
-        seen_kwargs: dict = {}
-
-        def rebuild(**rk):
-            seen_kwargs.update(rk)
-            return "REBUILT"
-
+        seen_kwargs, rebuild = _rebuild_spy()
         _, changed = _shed_context(
             [_make_call(prompt="ORIGINAL")],
             tier=1,
@@ -476,12 +495,7 @@ class TestShedContextPromptRebuild:
         # it must be in _PROMPT_TIER1_NULLS or a context-overflow retry would
         # leave it pinning the token count.
         assert "regulatory_citation_context" in _PROMPT_TIER1_NULLS
-        seen_kwargs: dict = {}
-
-        def rebuild(**rk):
-            seen_kwargs.update(rk)
-            return "REBUILT"
-
+        seen_kwargs, rebuild = _rebuild_spy()
         _, changed = _shed_context(
             [_make_call(prompt="ORIGINAL")],
             tier=1,
@@ -527,12 +541,7 @@ class TestShedContextPromptRebuild:
         (key, cap), *_ = _PROMPT_TIER2_TRUNCATIONS
         oversized = "para. " * (cap // 5)  # well past the cap
         kwargs = _prompt_kwargs(**{key: oversized})
-        seen_kwargs: dict = {}
-
-        def rebuild(**rk):
-            seen_kwargs.update(rk)
-            return "OUT"
-
+        seen_kwargs, rebuild = _rebuild_spy(return_value="OUT")
         _, changed = _shed_context(
             [_make_call(prompt="ORIGINAL")],
             tier=2,
@@ -547,12 +556,7 @@ class TestShedContextPromptRebuild:
     def test_tier2_stacks_tier1_enrichment_nulls_in_prompt(self):
         # Stacking: tier 2 must also apply the tier-1 enrichment nulls to
         # the rebuilt prompt's kwargs, not just the call-dict copies.
-        seen_kwargs: dict = {}
-
-        def rebuild(**rk):
-            seen_kwargs.update(rk)
-            return "OUT"
-
+        seen_kwargs, rebuild = _rebuild_spy(return_value="OUT")
         _shed_context(
             [_make_call(prompt="ORIGINAL")],
             tier=2,
@@ -578,12 +582,7 @@ class TestShedContextPromptRebuild:
         # when no prompt kwarg was nulled or truncated.
         empty_kwargs = {key: None for key in _PROMPT_TIER1_NULLS}
         kwargs = _prompt_kwargs(**empty_kwargs, plan_context="short")
-        calls_count = [0]
-
-        def rebuild(**_):
-            calls_count[0] += 1
-            return "SHOULD-NOT-BE-USED"
-
+        calls_count, rebuild = _rebuild_counter()
         new_calls, changed = _shed_context(
             [_make_call(prompt="ORIGINAL")],
             tier=2,  # tier 2 would otherwise try plan_context truncation
@@ -606,12 +605,7 @@ class TestShedContextPromptRebuild:
         # whitespace-only values and trigger a rebuild.
         whitespace_kwargs = {key: "   \n\t" for key in _PROMPT_TIER1_NULLS}
         kwargs = _prompt_kwargs(**whitespace_kwargs)
-        seen_kwargs: dict = {}
-
-        def rebuild(**rk):
-            seen_kwargs.update(rk)
-            return "SHED"
-
+        seen_kwargs, rebuild = _rebuild_spy(return_value="SHED")
         _, changed = _shed_context(
             [_make_call(prompt="ORIGINAL")],
             tier=1,
@@ -631,12 +625,7 @@ class TestShedContextPromptRebuild:
         # truly-empty case still avoids a rebuild call.
         empty_kwargs = {key: "" for key in _PROMPT_TIER1_NULLS}
         kwargs = _prompt_kwargs(**empty_kwargs, plan_context="short")
-        calls_count = [0]
-
-        def rebuild(**_):
-            calls_count[0] += 1
-            return "X"
-
+        calls_count, rebuild = _rebuild_counter()
         _, changed = _shed_context(
             [_make_call(prompt="ORIGINAL")],
             tier=2,

--- a/tests/async-unit/test_generate_appeal.py
+++ b/tests/async-unit/test_generate_appeal.py
@@ -363,6 +363,18 @@ class TestShedContext:
         )
         assert "pubmed_context" not in changed
 
+    def test_tier0_is_a_noop(self):
+        # Regression (CodeRabbit on PR #824): _shed_context's documented
+        # tier contract is "tier N applies all tier-<=N reductions". Tier 0
+        # must therefore shed nothing — neither the prompt surface (already
+        # guarded on tier >= 1) nor the call-dict surface.
+        original = _make_call()
+        new_calls, changed = _shed_context([original], tier=0)
+        assert changed == []
+        # Tier-1 call-dict keys survive unchanged.
+        for key in _SHEDDABLE_TIER1:
+            assert new_calls[0][key] == original[key]
+
 
 # --- _shed_context prompt-rebuild tests -------------------------------------
 

--- a/tests/async-unit/test_generate_appeal.py
+++ b/tests/async-unit/test_generate_appeal.py
@@ -10,6 +10,8 @@ from fighthealthinsurance.generate_appeal import (
     GeneratedAppeal,
     _peek_real_or_none,
     _shed_context,
+    _PROMPT_TIER1_NULLS,
+    _PROMPT_TIER2_TRUNCATIONS,
     _SHEDDABLE_TIER1,
     _TIER2_TRUNCATIONS,
 )
@@ -344,6 +346,133 @@ class TestShedContext:
             [_make_call(pubmed_context=None, plan_context=None)], tier=2
         )
         assert "pubmed_context" not in changed
+
+
+# --- _shed_context prompt-rebuild tests -------------------------------------
+
+
+def _prompt_kwargs(**overrides):
+    """Build an ``open_prompt_kwargs`` shape matching make_appeals' actual
+    call to make_open_prompt. Enrichment fields default to non-empty so
+    tier-1 nulling has something to drop."""
+    base = {
+        "denial_text": "denial body",
+        "procedure": "px",
+        "diagnosis": "dx",
+        "patient": None,
+        "professional": None,
+        "qa_context": None,
+        "professional_to_finish": False,
+        "plan_id": None,
+        "claim_id": None,
+        "insurance_company": "ins",
+        "is_tpa": False,
+        "ml_context": "ml ctx",
+        "pubmed_context": "pubmed ctx",
+        "plan_context": "patient plan body",
+        "rag_context": "rag ctx",
+        "nice_context": "nice ctx",
+        "ucr_context": "ucr ctx",
+        "payer_policy_context": "payer policy ctx",
+        "pa_context": "pa ctx",
+        "uspstf_context": "uspstf ctx",
+        "medication_context": "med ctx",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestShedContextPromptRebuild:
+    """Tier shedding must re-render the prompt with enrichment stripped.
+
+    Without this, pubmed/citations/rag/nice/uspstf/etc. stay baked into
+    ``open_prompt`` even after the call-dict copies are nulled, so the
+    retry token count doesn't actually drop. Regression cover for
+    PR #811 follow-up."""
+
+    def test_tier1_rebuilds_prompt_with_enrichment_nulled(self):
+        kwargs = _prompt_kwargs()
+        seen_kwargs: dict = {}
+
+        def rebuild(**rk):
+            seen_kwargs.update(rk)
+            return "REBUILT-PROMPT"
+
+        new_calls, changed = _shed_context(
+            [_make_call(prompt="ORIGINAL")],
+            tier=1,
+            open_prompt_kwargs=kwargs,
+            rebuild_prompt=rebuild,
+            original_open_prompt="ORIGINAL",
+        )
+        # Every enrichment kwarg listed in _PROMPT_TIER1_NULLS gets nulled.
+        for key in _PROMPT_TIER1_NULLS:
+            assert seen_kwargs[key] is None, f"{key} not nulled in rebuild kwargs"
+        # Non-enrichment kwargs survive.
+        assert seen_kwargs["denial_text"] == "denial body"
+        assert seen_kwargs["plan_context"] == "patient plan body"
+        # Each nulled kwarg shows up in the changed list as prompt.<name>.
+        for key in _PROMPT_TIER1_NULLS:
+            assert f"prompt.{key}" in changed
+        # Call's prompt was swapped to the rebuilt one.
+        assert new_calls[0]["prompt"] == "REBUILT-PROMPT"
+
+    def test_tier1_preserves_specialized_hint_suffix(self):
+        # Specialized calls use `open_prompt + "\n\n--- ... ---\n" + hint`.
+        # The shed pass must swap the prefix while keeping the suffix so the
+        # specialized template hint isn't lost on retry.
+        suffix = "\n\n--- Denial-type guidance ---\nMHPAEA hint"
+        new_calls, _ = _shed_context(
+            [_make_call(prompt="ORIGINAL" + suffix)],
+            tier=1,
+            open_prompt_kwargs=_prompt_kwargs(),
+            rebuild_prompt=lambda **_: "SHED",
+            original_open_prompt="ORIGINAL",
+        )
+        assert new_calls[0]["prompt"] == "SHED" + suffix
+
+    def test_tier1_leaves_unrelated_prompts_alone(self):
+        # The medically-necessary prompt is a separate string and must not
+        # be touched by the prefix swap.
+        new_calls, _ = _shed_context(
+            [_make_call(prompt="totally different med-necessary prompt")],
+            tier=1,
+            open_prompt_kwargs=_prompt_kwargs(),
+            rebuild_prompt=lambda **_: "SHED",
+            original_open_prompt="ORIGINAL",
+        )
+        assert new_calls[0]["prompt"] == "totally different med-necessary prompt"
+
+    def test_tier2_truncates_in_prompt_plan_context_via_boundary(self):
+        # Tier 2 truncates plan_context in the rebuilt prompt's kwargs as
+        # well as in the call dict. Use a value past the cap so truncation
+        # actually fires.
+        (key, cap), *_ = _PROMPT_TIER2_TRUNCATIONS
+        oversized = "para. " * (cap // 5)  # well past the cap
+        kwargs = _prompt_kwargs(**{key: oversized})
+        seen_kwargs: dict = {}
+
+        def rebuild(**rk):
+            seen_kwargs.update(rk)
+            return "OUT"
+
+        _, changed = _shed_context(
+            [_make_call(prompt="ORIGINAL")],
+            tier=2,
+            open_prompt_kwargs=kwargs,
+            rebuild_prompt=rebuild,
+            original_open_prompt="ORIGINAL",
+        )
+        assert isinstance(seen_kwargs[key], str)
+        assert len(seen_kwargs[key]) <= cap
+        assert f"prompt.{key}(truncated)" in changed
+
+    def test_omitted_rebuild_args_falls_back_to_call_dict_only(self):
+        # When the caller doesn't pass rebuild args, _shed_context is a
+        # pure call-dict shedder — same shape as the legacy tests above.
+        new_calls, changed = _shed_context([_make_call()], tier=1)
+        assert new_calls[0]["prompt"] == "Please write an appeal."  # unchanged
+        assert not any(c.startswith("prompt.") for c in changed)
 
 
 # --- make_appeals router-call-pattern tests --------------------------------

--- a/tests/async-unit/test_generate_appeal.py
+++ b/tests/async-unit/test_generate_appeal.py
@@ -392,6 +392,7 @@ def _prompt_kwargs(**overrides):
         "payer_policy_context": "payer policy ctx",
         "pa_context": "pa ctx",
         "uspstf_context": "uspstf ctx",
+        "clinical_trials_context": "clinical trials ctx",
         "medication_context": "med ctx",
     }
     base.update(overrides)
@@ -432,6 +433,29 @@ class TestShedContextPromptRebuild:
             assert f"prompt.{key}" in changed
         # Call's prompt was swapped to the rebuilt one.
         assert new_calls[0]["prompt"] == "REBUILT-PROMPT"
+
+    def test_tier1_sheds_clinical_trials_context(self):
+        # Regression: clinical_trials_context (added to make_open_prompt in
+        # #821) is a prompt-baked enrichment with no call-dict copy, so it
+        # must be in _PROMPT_TIER1_NULLS or a context-overflow retry would
+        # leave it pinning the token count — the exact bug this PR fixed for
+        # pubmed/citations.
+        assert "clinical_trials_context" in _PROMPT_TIER1_NULLS
+        seen_kwargs: dict = {}
+
+        def rebuild(**rk):
+            seen_kwargs.update(rk)
+            return "REBUILT"
+
+        _, changed = _shed_context(
+            [_make_call(prompt="ORIGINAL")],
+            tier=1,
+            open_prompt_kwargs=_prompt_kwargs(clinical_trials_context="NCT0123 ..."),
+            rebuild_prompt=rebuild,
+            original_open_prompt="ORIGINAL",
+        )
+        assert seen_kwargs["clinical_trials_context"] is None
+        assert "prompt.clinical_trials_context" in changed
 
     def test_tier1_preserves_specialized_hint_suffix(self):
         # Specialized calls use `open_prompt + "\n\n--- ... ---\n" + hint`.


### PR DESCRIPTION
## Summary

When retrying appeal generation after zero-result failures due to context-window overflow, the tier-shedding logic was only nulling enrichment contexts in the call-dict copies (pubmed_context, ml_citations_context) but leaving them baked into the prompt string itself. This meant the token count didn't actually drop on retry, causing the same failure to repeat.

This fix ensures both surfaces are shed in lockstep: the prompt is re-rendered with enrichment kwargs nulled/truncated, and the call-dict copies are updated accordingly.

## Key Changes

- **Added prompt re-rendering to tier-shedding logic**: `_shed_context()` now accepts optional `open_prompt_kwargs`, `rebuild_prompt`, and `original_open_prompt` parameters to re-render the prompt with enrichment contexts stripped.

- **Defined enrichment context lists**:
  - `_PROMPT_TIER1_NULLS`: In-prompt enrichment dropped entirely at tier 1+ (ml_context, pubmed_context, rag_context, nice_context, uspstf_context, ucr_context, pa_context, payer_policy_context, medication_context)
  - `_PROMPT_TIER2_TRUNCATIONS`: In-prompt patient-specific context truncated at tier 2+ (plan_context)

- **Updated `make_appeals()` to capture prompt kwargs**: Changed from directly calling `make_open_prompt()` to capturing its arguments in `open_prompt_kwargs` dict, enabling the retry path to re-render with modified parameters.

- **Enhanced retry logic**: When tier-shedding on retry, now passes the captured kwargs and rebuild function to `_shed_context()` so it can re-render the prompt while swapping in the shed version.

- **Preserved specialized prompt hints**: When swapping the shed prompt into calls, the logic preserves any specialized template hint suffix (e.g., denial-type guidance) that was appended to the original prompt.

- **Maintained backward compatibility**: When prompt-rebuild arguments are omitted, `_shed_context()` falls back to call-dict-only shedding for direct unit testing.

## Implementation Details

The fix addresses a regression where enrichment contexts (pubmed, citations, rag, nice, uspstf, etc.) appear on two surfaces:
1. Baked into the prompt string by `make_open_prompt()`
2. As separate call-dict keys (pubmed_context, ml_citations_context, plan_context) injected via `context_extra`

Both must shrink in lockstep, otherwise the prompt-baked copies still pin the token count above the limit even after call-dict copies are nulled. The solution re-renders the prompt with matching kwargs set to None (tier 1) or truncated (tier 2), then swaps it into the retry calls while preserving any specialized template hints.

https://claude.ai/code/session_01911ihpAptvcj9HdpDPcisR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved appeal generation resilience with a staged context-reduction system that progressively trims and retries prompts when limits are hit, preserving original prompt lineage so retries produce consistent, reliable appeals for complex or lengthy cases.

* **Tests**
  * Added extensive tests covering staged context trimming, prompt regeneration, boundary-aware truncation, whitespace/empty-edge cases, and other behaviors to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->