### PR TITLE
Extract IMRRefreshActor boilerplate into BaseRefreshActor

### DIFF
--- a/fighthealthinsurance/imr_refresh_actor.py
+++ b/fighthealthinsurance/imr_refresh_actor.py
@@ -3,75 +3,26 @@
 Pulls the CA DMHC and (optionally) NY DFS CSV exports on the
 ``IMR_REFRESH_INTERVAL_HOURS`` cadence and upserts rows via the shared
 ``load_csv_text`` loader. Sources whose URL setting is unset are skipped.
+
+The run-loop / health-check / backoff scaffolding lives in
+``BaseRefreshActor``.
 """
 
-import asyncio
-import datetime
-import os
-import time
-from typing import Optional, Tuple
+from typing import Tuple
 
 import ray
 from asgiref.sync import sync_to_async
 
-from fighthealthinsurance.utils import get_env_variable
+from fighthealthinsurance.base_refresh_actor import BaseRefreshActor
 
 name = "IMRRefreshActor"
 
 
-# Backoff between attempts after an unexpected error.
-ERROR_BACKOFF_SECONDS = 600
-
-
 @ray.remote(max_restarts=-1, max_task_retries=-1)
-class IMRRefreshActor:
-    def __init__(self) -> None:
-        time.sleep(1)
-        os.environ.setdefault(
-            "DJANGO_SETTINGS_MODULE",
-            get_env_variable("DJANGO_SETTINGS_MODULE", "fighthealthinsurance.settings"),
-        )
-        from configurations.wsgi import get_wsgi_application
-
-        _application = get_wsgi_application()
-        from loguru import logger
-
-        self._logger = logger
-        self.running = False
-        self.last_refresh: Optional[datetime.datetime] = None
-        self._logger.info("IMRRefreshActor initialized")
-
-    async def health_check(self) -> bool:
-        return self.running
-
-    async def run(self) -> None:
-        self._logger.info("Starting IMRRefreshActor run")
-        self.running = True
-
-        while self.running:
-            try:
-                interval_hours = self._interval_hours()
-                await self._refresh_due_sources(interval_hours)
-                # Re-check hourly so config changes are picked up without restart.
-                await asyncio.sleep(3600)
-            except Exception:
-                self._logger.opt(exception=True).error(
-                    "Error in IMRRefreshActor refresh cycle"
-                )
-                await asyncio.sleep(ERROR_BACKOFF_SECONDS)
-
-        self._logger.warning("IMRRefreshActor stopped running")
-
-    def stop(self) -> None:
-        self.running = False
-
-    # --- Implementation -----------------------------------------------------
-
-    @staticmethod
-    def _interval_hours() -> int:
-        from django.conf import settings
-
-        return getattr(settings, "IMR_REFRESH_INTERVAL_HOURS", 168)
+class IMRRefreshActor(BaseRefreshActor):
+    actor_log_name = "IMRRefreshActor"
+    settings_interval_key = "IMR_REFRESH_INTERVAL_HOURS"
+    default_interval_hours = 168
 
     @staticmethod
     def _configured_sources() -> list[Tuple[str, str]]:
@@ -85,16 +36,18 @@ class IMRRefreshActor:
         ]
         return [(src, url) for src, url in candidates if url]
 
-    async def _refresh_due_sources(self, interval_hours: int) -> None:
+    @staticmethod
+    def _refresh_source(source: str, url: str) -> Tuple[int, int, int, int]:
+        from fighthealthinsurance.imr_ingest import fetch_csv, load_csv_text
+
+        csv_text = fetch_csv(url)
+        return load_csv_text(csv_text, source=source, source_url=url)
+
+    async def _refresh_due(self, interval_hours: int) -> bool:
         sources = self._configured_sources()
         if not sources:
             self._logger.debug("No IMR_*_CSV_URL settings configured; skipping refresh")
-            return
-
-        if self.last_refresh is not None:
-            elapsed = datetime.datetime.utcnow() - self.last_refresh
-            if elapsed < datetime.timedelta(hours=interval_hours):
-                return
+            return False
 
         any_success = False
         for source, url in sources:
@@ -112,16 +65,4 @@ class IMRRefreshActor:
                 self._logger.opt(exception=True).warning(
                     f"IMR refresh failed for source {source}: {e}"
                 )
-
-        # Only mark the cycle as complete if at least one source actually
-        # refreshed; otherwise the next loop iteration will retry instead of
-        # waiting another full IMR_REFRESH_INTERVAL_HOURS window.
-        if any_success:
-            self.last_refresh = datetime.datetime.utcnow()
-
-    @staticmethod
-    def _refresh_source(source: str, url: str) -> Tuple[int, int, int, int]:
-        from fighthealthinsurance.imr_ingest import fetch_csv, load_csv_text
-
-        csv_text = fetch_csv(url)
-        return load_csv_text(csv_text, source=source, source_url=url)
+        return any_success

--- a/tests/async-unit/test_imr_refresh_actor.py
+++ b/tests/async-unit/test_imr_refresh_actor.py
@@ -62,3 +62,11 @@ class TestIntervalHours:
         # actor instantiation (Django bootstrap + 1s sleep).
         assert _Underlying.settings_interval_key == "IMR_REFRESH_INTERVAL_HOURS"
         assert _Underlying.default_interval_hours == 168
+
+    @patch("django.conf.settings.IMR_REFRESH_INTERVAL_HOURS", 24, create=True)
+    def test_reads_interval_from_settings(self):
+        # __new__ bypasses BaseRefreshActor.__init__ (Django bootstrap +
+        # 1s sleep) so we can exercise the inherited settings lookup
+        # directly and catch regressions in the IMR-key wiring.
+        instance = _Underlying.__new__(_Underlying)
+        assert instance._interval_hours() == 24

--- a/tests/async-unit/test_imr_refresh_actor.py
+++ b/tests/async-unit/test_imr_refresh_actor.py
@@ -55,6 +55,10 @@ class TestRefreshSource:
 
 
 class TestIntervalHours:
-    @patch("django.conf.settings.IMR_REFRESH_INTERVAL_HOURS", 24, create=True)
-    def test_returns_configured_value(self):
-        assert _Underlying._interval_hours() == 24
+    def test_class_is_wired_to_imr_settings_key(self):
+        # _interval_hours is provided by BaseRefreshActor and reads from
+        # settings via these class attributes, so verifying the wiring is
+        # sufficient — exercising the inherited method would require a full
+        # actor instantiation (Django bootstrap + 1s sleep).
+        assert _Underlying.settings_interval_key == "IMR_REFRESH_INTERVAL_HOURS"
+        assert _Underlying.default_interval_hours == 168


### PR DESCRIPTION
## Summary
Refactors `IMRRefreshActor` to inherit from a new `BaseRefreshActor` class, eliminating duplicated run-loop, health-check, and backoff scaffolding. This reduces code duplication and establishes a reusable pattern for other refresh actors.

## Key Changes
- **Created `BaseRefreshActor`**: New base class that handles:
  - Async run-loop with configurable interval checking
  - Health-check endpoint
  - Error backoff and retry logic
  - Django initialization and logging setup
  
- **Simplified `IMRRefreshActor`**:
  - Now inherits from `BaseRefreshActor` with minimal boilerplate
  - Moved interval configuration to class attributes (`settings_interval_key`, `default_interval_hours`)
  - Renamed `_refresh_due_sources()` to `_refresh_due()` and changed return type to `bool` to indicate whether refresh occurred
  - Removed manual `last_refresh` tracking (now handled by base class)
  - Removed duplicate initialization, run-loop, and error handling code

- **Updated tests**:
  - Changed `TestIntervalHours` to verify class attribute wiring instead of testing the inherited `_interval_hours()` method directly
  - Avoids need for full actor instantiation (Django bootstrap + 1s sleep) in unit tests

## Implementation Details
- `BaseRefreshActor` manages the run-loop cadence and tracks `last_refresh` to prevent redundant refreshes within the interval window
- Subclasses implement `_refresh_due()` to return `True` if any refresh occurred, allowing the base class to update the refresh timestamp appropriately
- Configuration is declarative via class attributes, making it easy for future refresh actors to adopt the pattern

https://claude.ai/code/session_01LqVSzdtQzebfEErR6Mo3gw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * IMR refresh component refactored to consolidate shared scaffolding logic with inherited base class patterns, reducing code duplication across refresh actors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fighthealthinsurance/fighthealthinsurance/pull/825)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->