### PR TITLE
Stop generating spurious partial-delivery errors

### DIFF
--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -3130,7 +3130,11 @@ class AppealsBackendHelper:
             async for pa in ProposedAppeal.objects.filter(for_denial=denial)
             if is_real_appeal(pa.appeal_text)
         ]
-        if len(saved_appeal_texts) >= 1:
+        # Synthesis requires >=2 drafts to be meaningful: with a single
+        # input, models often regurgitate it verbatim. The client dedupes
+        # by content, so a verbatim copy gets silently dropped, which then
+        # trips the "partial delivery" error path in appeal_fetcher.ts.
+        if len(saved_appeal_texts) >= 2:
             yield json.dumps(
                 {
                     "type": "status",
@@ -3174,14 +3178,24 @@ class AppealsBackendHelper:
                 else:
                     synthesized = synthesis_task.result()
                     if synthesized:
-                        saved = await save_appeal(synthesized)
-                        subbed = await sub_in_appeals(saved)
-                        subbed["synthesized"] = "true"
-                        yield await format_response(subbed)
-                        new += 1
-                        logger.info(
-                            f"Synthesized appeal generated from {len(saved_appeal_texts)} drafts"
-                        )
+                        # Belt-and-suspenders: even with >=2 drafts a model
+                        # can still pick one verbatim. Skip the yield in
+                        # that case rather than ship a known duplicate.
+                        normalized = synthesized.strip()
+                        existing_normalized = {s.strip() for s in saved_appeal_texts}
+                        if normalized in existing_normalized:
+                            logger.info(
+                                "Synthesis returned a verbatim copy of an input draft; skipping yield"
+                            )
+                        else:
+                            saved = await save_appeal(synthesized)
+                            subbed = await sub_in_appeals(saved)
+                            subbed["synthesized"] = "true"
+                            yield await format_response(subbed)
+                            new += 1
+                            logger.info(
+                                f"Synthesized appeal generated from {len(saved_appeal_texts)} drafts"
+                            )
                     else:
                         logger.debug("Synthesis returned no result, skipping")
             except Exception:

--- a/fighthealthinsurance/static/js/appeal_fetcher.ts
+++ b/fighthealthinsurance/static/js/appeal_fetcher.ts
@@ -382,6 +382,11 @@ let lastWsCloseCode = -1;
 let lastWsCloseReason = '';
 let lastWsErrorMessage = '';
 let lastRestErrorMessage = '';
+// Count of appeals the client deduped against ones already shown. The
+// server counts these in total_appeals, so we offset the partial-delivery
+// check by this value — otherwise a legitimately-duplicated synthesis
+// would page Sentry every time.
+let duplicatesSkipped = 0;
 
 // Wait-time tracking so Sentry shows how long the user waited
 // before we gave up. `doQueryStartedAtMs` is the moment doQuery()
@@ -430,6 +435,7 @@ function reportClientError(error: string): void {
   // user-agent string in browser_info doesn't truncate them.
   const diagnostics = [
     `appeals_received=${appealsSoFar.length}`,
+    `dupes_skipped=${duplicatesSkipped}`,
     `retries=${retries}`,
     `status_msgs=${statusMessagesReceived}`,
     `last_phase=${lastPhaseReceived || 'none'}`,
@@ -590,12 +596,17 @@ function processResponseChunk(chunk: string): void {
             serverReportedTotalAppeals = total;
             serverReportedNewAppeals = newAppeals;
             serverReportedExistingAppeals = existing;
-            console.log(`Server stream complete: ${total} total appeals (${newAppeals} new, ${existing} existing), client has ${appealsSoFar.length}`);
-            if (total > 0 && appealsSoFar.length === 0) {
+            // The server counts attempted yields; the client counts
+            // distinct payloads. If we deduped some, account for them
+            // here so a benign duplicate (e.g. synthesis returning a
+            // verbatim draft) doesn't fire the partial-delivery alarm.
+            const accountedFor = appealsSoFar.length + duplicatesSkipped;
+            console.log(`Server stream complete: ${total} total appeals (${newAppeals} new, ${existing} existing), client has ${appealsSoFar.length} (+${duplicatesSkipped} deduped)`);
+            if (total > 0 && appealsSoFar.length === 0 && duplicatesSkipped === 0) {
               console.error(`BUG: Server sent ${total} appeals but client received none!`);
               reportClientError(`Server sent ${total} appeals but client received 0 (lost in transit)`);
-            } else if (total > appealsSoFar.length) {
-              console.warn(`Partial delivery: server reported ${total} appeals, client got ${appealsSoFar.length}`);
+            } else if (total > accountedFor) {
+              console.warn(`Partial delivery: server reported ${total} appeals, client got ${appealsSoFar.length} (+${duplicatesSkipped} deduped)`);
               reportClientError(`Partial delivery: server reported ${total} appeals, client got ${appealsSoFar.length}`);
             }
             markAllDone();
@@ -657,6 +668,7 @@ function processResponseChunk(chunk: string): void {
             (appeal) => JSON.stringify(appeal) === JSON.stringify(appealText),
           )
         ) {
+          duplicatesSkipped++;
           console.log("Duplicate appeal found. Skipping.");
           return;
         }

--- a/tests/async-unit/test_appeals_backend_citations.py
+++ b/tests/async-unit/test_appeals_backend_citations.py
@@ -1,6 +1,8 @@
 from unittest.mock import patch, AsyncMock, MagicMock
-import pytest
 import asyncio
+import json
+
+import pytest
 
 from fighthealthinsurance.common_view_logic import AppealsBackendHelper
 
@@ -485,14 +487,19 @@ class TestAppealsBackendHelperWithCitations:
 @pytest.mark.parametrize(
     "saved_texts,synthesis_should_run",
     [
-        (["single saved appeal text"], True),  # Step 5: >=1 triggers synthesis
+        # >=2 drafts: synthesis is meaningful (combines multiple inputs).
+        (["draft one text", "draft two text"], True),
+        # 1 draft: skipped — models tend to regurgitate a single input
+        # verbatim, which the client then dedupes and reports as a
+        # partial-delivery error.
+        (["single saved appeal text"], False),
         ([], False),  # 0 saved appeals -> synthesis skipped
     ],
-    ids=["one_saved_appeal", "zero_saved_appeals"],
+    ids=["two_saved_appeals", "one_saved_appeal", "zero_saved_appeals"],
 )
 @pytest.mark.asyncio
 async def test_synthesis_threshold(saved_texts, synthesis_should_run):
-    """Step 5: synthesis runs when >=1 saved appeal exists (was >=2)."""
+    """Synthesis runs only when >=2 saved appeals exist."""
     mock_denial = _make_mock_denial()
     parameters = {
         "denial_id": "12345",
@@ -557,3 +564,91 @@ async def test_synthesis_threshold(saved_texts, synthesis_should_run):
             )
         else:
             mock_appeal_gen.synthesize_appeals.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_synthesis_skips_verbatim_duplicate():
+    """If the synthesizer returns text matching a saved draft, it must not be
+    yielded — otherwise the client's content-based dedup silently drops it
+    and reports a spurious "partial delivery" error.
+    """
+    mock_denial = _make_mock_denial()
+    parameters = {
+        "denial_id": "12345",
+        "email": "test@example.com",
+        "semi_sekret": "test-secret",
+    }
+    saved_texts = ["draft one text body", "draft two text body"]
+
+    with (
+        patch(
+            "fighthealthinsurance.common_view_logic.Denial.objects.filter",
+            return_value=_make_mock_denial_query(mock_denial),
+        ),
+        patch(
+            "fighthealthinsurance.common_view_logic.Denial.get_hashed_email",
+            return_value="hashed",
+        ),
+        patch.object(AppealsBackendHelper, "regex_denial_processor") as mock_regex,
+        patch(
+            "fighthealthinsurance.common_view_logic.MLCitationsHelper.generate_citations_for_denial",
+            new_callable=AsyncMock,
+            return_value="",
+        ),
+        patch.object(
+            AppealsBackendHelper.pmt,
+            "find_context_for_denial",
+            new_callable=AsyncMock,
+            return_value="",
+        ),
+        patch(
+            "fighthealthinsurance.common_view_logic.sync_to_async",
+        ) as mock_sync_to_async,
+        patch(
+            "fighthealthinsurance.common_view_logic.interleave_iterator_for_keep_alive",
+            side_effect=passthrough_interleave,
+        ),
+        patch(
+            "fighthealthinsurance.common_view_logic.ProposedAppeal",
+        ) as mock_pa_cls,
+        patch(
+            "fighthealthinsurance.common_view_logic.appealGenerator"
+        ) as mock_appeal_gen,
+    ):
+        mock_regex.get_appeal_templates = AsyncMock(return_value=[])
+        mock_sync_to_async.side_effect = _sync_to_async_router(
+            AsyncMock(return_value=""),
+            AsyncMock(return_value=saved_texts),
+        )
+        mock_pa_cls.return_value = MagicMock(id=1, asave=AsyncMock())
+        mock_pa_cls.objects.filter.return_value = (
+            _make_proposed_appeal_query_with_texts(saved_texts)
+        )
+        # Synthesizer returns a verbatim copy of the first saved draft —
+        # the server must NOT yield it as a "new" appeal.
+        mock_appeal_gen.synthesize_appeals = AsyncMock(return_value=saved_texts[0])
+
+        chunks = []
+        async for chunk in AppealsBackendHelper.generate_appeals(parameters):
+            chunks.append(chunk)
+
+    # The "done" frame should report only the streamed drafts, not the
+    # deduped synthesis: new_appeals should equal len(saved_texts).
+    done_frames = []
+    for c in chunks:
+        stripped = c.strip()
+        if not stripped:
+            continue
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict) and parsed.get("phase") == "done":
+            done_frames.append(parsed)
+    assert len(done_frames) == 1, f"expected exactly one done frame, got {done_frames}"
+    assert done_frames[0]["new_appeals"] == len(saved_texts)
+    # And no chunk should carry the "synthesized": "true" marker.
+    for c in chunks:
+        assert '"synthesized": "true"' not in c, (
+            f"verbatim-duplicate synthesis should have been skipped, got chunk: {c}"
+        )


### PR DESCRIPTION
When the streaming pipeline produced only one valid draft, the final synthesis step would still run, and weaker internal models tended to return the input draft verbatim. After running through `sub_in_appeals`, the synthesized "new" appeal was byte-identical to the streamed one, so the client deduped it on content and the server's `total_appeals=2` then triggered the `Partial delivery: server reported 2 appeals, client got 1` report.

Three layered fixes so neither side relies on the other:

- Server: bump the synthesis threshold from `>=1` to `>=2` (one-draft synthesis has no real upside) and, even with >=2 inputs, skip the yield if the synthesizer returned a verbatim copy of any input.
- Client: count duplicates in `duplicatesSkipped`, offset the partial-delivery check by that count, and surface it in diagnostics so future regressions are easy to triage.
- Tests: update the threshold parametrization and add coverage for the verbatim-duplicate skip path.

https://claude.ai/code/session_016mXKTFYbqBCRtos5XYcrky

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced appeal synthesis to require at least 2 saved drafts before processing, reducing unnecessary duplicates.

* **Bug Fixes**
  * Improved duplicate appeal detection and deduplication tracking.
  * Fixed partial delivery status reporting to account for deduplicated appeals.
  * System now skips synthesized appeals that verbatim match existing drafts.

* **Tests**
  * Added coverage for synthesis threshold behavior and duplicate appeal detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fighthealthinsurance/fighthealthinsurance/pull/827?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->