### PR TITLE
Add appeal-page opt-in to retry with external models

### DIFF
--- a/fighthealthinsurance/rest_urls.py
+++ b/fighthealthinsurance/rest_urls.py
@@ -59,6 +59,11 @@ urlpatterns = [
         name="report_client_error",
     ),
     path(
+        "enable_external_models",
+        rest_views.EnableExternalModels.as_view(),
+        name="enable_external_models",
+    ),
+    path(
         "streaming_appeals_fallback",
         rest_views.streaming_appeals_rest_fallback,
         name="streaming_appeals_fallback",

--- a/fighthealthinsurance/rest_views.py
+++ b/fighthealthinsurance/rest_views.py
@@ -574,12 +574,35 @@ class EnableExternalModels(APIView):
     permission_classes = [AllowAny]
     authentication_classes = []  # Magic-key auth via the triple
 
+    @extend_schema(
+        description=(
+            "Opt a denial into external models. Authenticated by the "
+            "(denial_id, email, semi_sekret) triple in the JSON body. "
+            "Idempotent — succeeds with 200 if `use_external` is "
+            "already True. Returns 404 for any auth failure (uniform "
+            "to avoid leaking which field was wrong)."
+        ),
+        request=OpenApiTypes.OBJECT,
+        responses={
+            200: OpenApiTypes.OBJECT,
+            400: OpenApiTypes.OBJECT,
+            404: OpenApiTypes.OBJECT,
+        },
+    )
     def post(self, request: Request) -> Response:
-        denial_id = request.data.get("denial_id")
-        email = request.data.get("email") or ""
-        semi_sekret = request.data.get("semi_sekret") or ""
+        data = request.data
+        # Reject non-mapping bodies (e.g. JSON arrays/strings) up front;
+        # without this, request.data.get(...) raises and we'd serve 500
+        # on malformed input. Matches streaming_appeals_rest_fallback.
+        if not isinstance(data, dict):
+            return Response(
+                {"error": "Expected a JSON object"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         denial = common_view_logic.get_denial_for_action(
-            denial_id=denial_id, email=email, semi_sekret=semi_sekret
+            denial_id=data.get("denial_id"),
+            email=data.get("email") or "",
+            semi_sekret=data.get("semi_sekret") or "",
         )
         if denial is None:
             return Response({"error": "Not found"}, status=status.HTTP_404_NOT_FOUND)

--- a/fighthealthinsurance/rest_views.py
+++ b/fighthealthinsurance/rest_views.py
@@ -559,6 +559,39 @@ class ReportClientError(APIView):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
+class EnableExternalModels(APIView):
+    """Opt a denial into external models so a re-run of appeal generation
+    can call out to higher-capability cloud LLMs.
+
+    Patients see a button on the appeals page offering this when the
+    initial generation produced few or no appeals from internal models;
+    this endpoint flips `Denial.use_external` so the next generation
+    request includes the external backends. Auth mirrors the appeal
+    stream: the (denial_id, email, semi_sekret) triple is the only
+    credential.
+    """
+
+    permission_classes = [AllowAny]
+    authentication_classes = []  # Magic-key auth via the triple
+
+    def post(self, request: Request) -> Response:
+        denial_id = request.data.get("denial_id")
+        email = request.data.get("email") or ""
+        semi_sekret = request.data.get("semi_sekret") or ""
+        denial = common_view_logic.get_denial_for_action(
+            denial_id=denial_id, email=email, semi_sekret=semi_sekret
+        )
+        if denial is None:
+            return Response({"error": "Not found"}, status=status.HTTP_404_NOT_FOUND)
+        if not denial.use_external:
+            denial.use_external = True
+            denial.save(update_fields=["use_external"])
+            logger.info(
+                f"Enabled external models for denial {denial.denial_id} on user request"
+            )
+        return Response({"use_external": True}, status=status.HTTP_200_OK)
+
+
 @extend_schema(
     description=(
         "REST/HTTP fallback for the WebSocket appeal stream used by "

--- a/fighthealthinsurance/static/js/appeal_fetcher.ts
+++ b/fighthealthinsurance/static/js/appeal_fetcher.ts
@@ -571,8 +571,15 @@ async function requestExternalModels(
       "#28a745",
     );
     prompt.style.display = "none";
-    // Reset client state so doQuery starts a fresh generation pass
-    // rather than treating this as a retry of the previous attempt.
+    // Reset retry/parser state so doQuery starts a fresh generation
+    // pass rather than treating this as a retry of the previous
+    // attempt. Deliberately do NOT clear appealsSoFar or
+    // #output-container: any already-shown internal-only drafts stay
+    // on screen for the user to read while external models stream
+    // additional drafts. processResponseChunk dedups against
+    // appealsSoFar so server-side re-yielded ProposedAppeals don't
+    // append twice, and the >=3 done() check counting old+new is
+    // intentional — we want a total of 3 drafts, not 3 *new* ones.
     retries = 0;
     respBuffer = "";
     hasAutoScrolledToFirstAppeal = false;

--- a/fighthealthinsurance/static/js/appeal_fetcher.ts
+++ b/fighthealthinsurance/static/js/appeal_fetcher.ts
@@ -505,40 +505,42 @@ function maybeShowExternalModelsPrompt(): void {
   if (appealsSoFar.length > FEW_APPEALS_THRESHOLD) {
     return;
   }
+  if (prompt.style.display === "block") {
+    return;
+  }
   prompt.style.display = "block";
   const button = document.getElementById(
     "request-external-models-btn",
   ) as HTMLButtonElement | null;
-  if (!button || (button as any)._fhiWired) {
-    return;
-  }
-  (button as any)._fhiWired = true;
-  button.addEventListener("click", () => {
-    void requestExternalModels(button);
-  });
+  if (!button) return;
+  button.addEventListener(
+    "click",
+    () => {
+      void requestExternalModels(button, prompt);
+    },
+    { once: true },
+  );
 }
 
 async function requestExternalModels(
   button: HTMLButtonElement,
+  prompt: HTMLElement,
 ): Promise<void> {
   const statusEl = document.getElementById("external-models-status");
+  const setStatus = (text: string, color: string) => {
+    if (statusEl) {
+      statusEl.textContent = text;
+      statusEl.style.color = color;
+    }
+  };
   const url = (window as any).enableExternalModelsUrl as string | undefined;
   if (!url) {
-    if (statusEl) {
-      statusEl.textContent = "Unable to enable external models right now.";
-      statusEl.style.color = "#dc3545";
-    }
+    setStatus("Unable to enable external models right now.", "#dc3545");
     return;
   }
-  const denialId = (my_data as any).denial_id || "";
-  const email = (my_data as any).email || "";
-  const semiSekret = (my_data as any).semi_sekret || "";
   const csrfToken = (my_data as any).csrfmiddlewaretoken || "";
   button.disabled = true;
-  if (statusEl) {
-    statusEl.textContent = "Enabling external models and re-running appeals...";
-    statusEl.style.color = "#333";
-  }
+  setStatus("Enabling external models and re-running appeals...", "#333");
   try {
     const response = await fetch(url, {
       method: "POST",
@@ -547,21 +549,19 @@ async function requestExternalModels(
         "X-CSRFToken": csrfToken,
       },
       body: JSON.stringify({
-        denial_id: denialId,
-        email,
-        semi_sekret: semiSekret,
+        denial_id: (my_data as any).denial_id || "",
+        email: (my_data as any).email || "",
+        semi_sekret: (my_data as any).semi_sekret || "",
       }),
     });
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}: ${response.statusText}`);
     }
-    if (statusEl) {
-      statusEl.textContent =
-        "External models enabled. Re-generating appeals now...";
-      statusEl.style.color = "#28a745";
-    }
-    const prompt = document.getElementById("external-models-prompt");
-    if (prompt) prompt.style.display = "none";
+    setStatus(
+      "External models enabled. Re-generating appeals now...",
+      "#28a745",
+    );
+    prompt.style.display = "none";
     // Reset client state so doQuery starts a fresh generation pass
     // rather than treating this as a retry of the previous attempt.
     retries = 0;
@@ -570,11 +570,10 @@ async function requestExternalModels(
     doQuery(my_backend_url, my_data, my_rest_fallback_url);
   } catch (error) {
     console.error("Failed to enable external models:", error);
-    if (statusEl) {
-      statusEl.textContent =
-        "Could not enable external models. Please try again later.";
-      statusEl.style.color = "#dc3545";
-    }
+    setStatus(
+      "Could not enable external models. Please try again later.",
+      "#dc3545",
+    );
     button.disabled = false;
   }
 }

--- a/fighthealthinsurance/static/js/appeal_fetcher.ts
+++ b/fighthealthinsurance/static/js/appeal_fetcher.ts
@@ -495,7 +495,15 @@ function done(): void {
 // surfacing the external-models opt-in for.
 const FEW_APPEALS_THRESHOLD = 2;
 
+// Latched once the user has already opted in. Prevents re-showing the
+// prompt if the post-opt-in rerun also underdelivers — the user has
+// already made the call, repeating it doesn't help.
+let externalModelsRequested = false;
+
 function maybeShowExternalModelsPrompt(): void {
+  if (externalModelsRequested) {
+    return;
+  }
   const prompt = document.getElementById("external-models-prompt");
   if (!prompt) {
     // Template didn't include the prompt - either external models are
@@ -557,8 +565,9 @@ async function requestExternalModels(
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}: ${response.statusText}`);
     }
+    externalModelsRequested = true;
     setStatus(
-      "External models enabled. Re-generating appeals now...",
+      "External models enabled. Generating additional appeals...",
       "#28a745",
     );
     prompt.style.display = "none";

--- a/fighthealthinsurance/static/js/appeal_fetcher.ts
+++ b/fighthealthinsurance/static/js/appeal_fetcher.ts
@@ -483,6 +483,99 @@ function done(): void {
     }
     clearTimeout(timeoutHandle!);
     hideLoading();
+    // When internal-only generation underdelivered (0-2 appeals), the
+    // template emits a hidden prompt offering to opt the denial into
+    // external models. Reveal it and wire up the click.
+    maybeShowExternalModelsPrompt();
+  }
+}
+
+// Threshold for "we didn't generate enough appeals" - the regular flow
+// targets 3 appeals, so 2 or fewer indicates underdelivery worth
+// surfacing the external-models opt-in for.
+const FEW_APPEALS_THRESHOLD = 2;
+
+function maybeShowExternalModelsPrompt(): void {
+  const prompt = document.getElementById("external-models-prompt");
+  if (!prompt) {
+    // Template didn't include the prompt - either external models are
+    // already enabled, or we're on a page that doesn't have it.
+    return;
+  }
+  if (appealsSoFar.length > FEW_APPEALS_THRESHOLD) {
+    return;
+  }
+  prompt.style.display = "block";
+  const button = document.getElementById(
+    "request-external-models-btn",
+  ) as HTMLButtonElement | null;
+  if (!button || (button as any)._fhiWired) {
+    return;
+  }
+  (button as any)._fhiWired = true;
+  button.addEventListener("click", () => {
+    void requestExternalModels(button);
+  });
+}
+
+async function requestExternalModels(
+  button: HTMLButtonElement,
+): Promise<void> {
+  const statusEl = document.getElementById("external-models-status");
+  const url = (window as any).enableExternalModelsUrl as string | undefined;
+  if (!url) {
+    if (statusEl) {
+      statusEl.textContent = "Unable to enable external models right now.";
+      statusEl.style.color = "#dc3545";
+    }
+    return;
+  }
+  const denialId = (my_data as any).denial_id || "";
+  const email = (my_data as any).email || "";
+  const semiSekret = (my_data as any).semi_sekret || "";
+  const csrfToken = (my_data as any).csrfmiddlewaretoken || "";
+  button.disabled = true;
+  if (statusEl) {
+    statusEl.textContent = "Enabling external models and re-running appeals...";
+    statusEl.style.color = "#333";
+  }
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRFToken": csrfToken,
+      },
+      body: JSON.stringify({
+        denial_id: denialId,
+        email,
+        semi_sekret: semiSekret,
+      }),
+    });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+    if (statusEl) {
+      statusEl.textContent =
+        "External models enabled. Re-generating appeals now...";
+      statusEl.style.color = "#28a745";
+    }
+    const prompt = document.getElementById("external-models-prompt");
+    if (prompt) prompt.style.display = "none";
+    // Reset client state so doQuery starts a fresh generation pass
+    // rather than treating this as a retry of the previous attempt.
+    retries = 0;
+    respBuffer = "";
+    hasAutoScrolledToFirstAppeal = false;
+    doQuery(my_backend_url, my_data, my_rest_fallback_url);
+  } catch (error) {
+    console.error("Failed to enable external models:", error);
+    if (statusEl) {
+      statusEl.textContent =
+        "Could not enable external models. Please try again later.";
+      statusEl.style.color = "#dc3545";
+    }
+    button.disabled = false;
   }
 }
 

--- a/fighthealthinsurance/templates/appeals.html
+++ b/fighthealthinsurance/templates/appeals.html
@@ -81,6 +81,22 @@ Fight Your Health Insurance Denial: Choose an Appeal
 <div id="output-container">
 </div>
 
+{% if not use_external %}
+<div id="external-models-prompt" class="alert-box alert-warning" style="display:none; margin-top: 1.5rem;">
+  <h4>Want more options?</h4>
+  <p>
+    Your denial wasn't set up to use external (cloud) AI models, and we
+    generated fewer appeals than usual. External models tend to be more
+    creative and may produce additional drafts for you to choose from.
+    Your denial text is sent to a third-party model provider when you opt in.
+  </p>
+  <button type="button" id="request-external-models-btn" class="btn btn-green">
+    Generate more appeals using external models
+  </button>
+  <div id="external-models-status" style="margin-top: 0.75rem; font-size: 0.95rem;"></div>
+</div>
+{% endif %}
+
 <div class="form-nav-centered">
   {% if back_url %}
   <a href="{{ back_url }}" class="btn btn-secondary-custom">
@@ -105,6 +121,7 @@ Fight Your Health Insurance Denial: Choose an Appeal
       // REST fallback for clients that can't hold a WebSocket open
       // (iOS Safari ITP, corporate proxies that block WS upgrades, etc).
       const restFallbackUrl = `${window.location.protocol}//${window.location.host}{% url 'streaming_appeals_fallback' %}`;
+      const enableExternalModelsUrl = `${window.location.protocol}//${window.location.host}{% url 'enable_external_models' %}`;
       const data = {
 	  {% autoescape off %}
           ...{{form_context}},
@@ -112,6 +129,10 @@ Fight Your Health Insurance Denial: Choose an Appeal
           ...{
               'csrfmiddlewaretoken': '{{ csrf_token }}',
               'timbit': 'is most awesomex2'}}
+
+      // Expose endpoint so appeal_fetcher can offer the "request external
+      // models" button when initial generation yields zero or few appeals.
+      window.enableExternalModelsUrl = enableExternalModelsUrl;
 
       // Call the doQuery function
       doQuery(backendUrl, data, restFallbackUrl);

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -1237,6 +1237,7 @@ class GenerateAppeal(View):
                 "denial_id": denial_id,
                 "semi_sekret": semi_sekret,
                 "current_step": 7,
+                "use_external": bool(denial.use_external),
                 "back_url": build_back_url(
                     "find_next_steps", denial_id, email, semi_sekret
                 ),
@@ -1296,6 +1297,7 @@ class GenerateAppeal(View):
                 "denial_id": form.cleaned_data["denial_id"],
                 "semi_sekret": form.cleaned_data["semi_sekret"],
                 "current_step": 7,
+                "use_external": bool(denial.use_external),
                 "back_url": build_back_url(
                     "find_next_steps",
                     form.cleaned_data["denial_id"],

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -1204,6 +1204,23 @@ class ChooseAppeal(View):
 class GenerateAppeal(View):
     """View for generating appeal letters using ML models."""
 
+    @staticmethod
+    def _appeals_context(
+        *, denial, denial_id: str, email: str, semi_sekret: str, elems: dict
+    ) -> dict:
+        return {
+            "form_context": json.dumps(elems),
+            "user_email": email,
+            "denial_id": denial_id,
+            "semi_sekret": semi_sekret,
+            "current_step": 7,
+            "use_external": denial.use_external,
+            "back_url": build_back_url(
+                "find_next_steps", denial_id, email, semi_sekret
+            ),
+            "back_label": "Back to questions",
+        }
+
     def get(self, request):
         """Handle GET requests for back navigation to appeals page."""
         denial_id = request.GET.get("denial_id")
@@ -1231,18 +1248,13 @@ class GenerateAppeal(View):
         return render(
             request,
             "appeals.html",
-            context={
-                "form_context": json.dumps(elems),
-                "user_email": email,
-                "denial_id": denial_id,
-                "semi_sekret": semi_sekret,
-                "current_step": 7,
-                "use_external": bool(denial.use_external),
-                "back_url": build_back_url(
-                    "find_next_steps", denial_id, email, semi_sekret
-                ),
-                "back_label": "Back to questions",
-            },
+            context=self._appeals_context(
+                denial=denial,
+                denial_id=denial_id,
+                email=email,
+                semi_sekret=semi_sekret,
+                elems=elems,
+            ),
         )
 
     def post(self, request):
@@ -1291,21 +1303,13 @@ class GenerateAppeal(View):
         return render(
             request,
             "appeals.html",
-            context={
-                "form_context": json.dumps(elems),
-                "user_email": form.cleaned_data["email"],
-                "denial_id": form.cleaned_data["denial_id"],
-                "semi_sekret": form.cleaned_data["semi_sekret"],
-                "current_step": 7,
-                "use_external": bool(denial.use_external),
-                "back_url": build_back_url(
-                    "find_next_steps",
-                    form.cleaned_data["denial_id"],
-                    form.cleaned_data["email"],
-                    form.cleaned_data["semi_sekret"],
-                ),
-                "back_label": "Back to questions",
-            },
+            context=self._appeals_context(
+                denial=denial,
+                denial_id=form.cleaned_data["denial_id"],
+                email=form.cleaned_data["email"],
+                semi_sekret=form.cleaned_data["semi_sekret"],
+                elems=elems,
+            ),
         )
 
 

--- a/tests/sync/test_rest_api.py
+++ b/tests/sync/test_rest_api.py
@@ -798,6 +798,160 @@ class StreamingAppealsRestFallbackTest(APITestCase):
         self.assertEqual(len(set(ids)), len(ids))
 
 
+class EnableExternalModelsTest(APITestCase):
+    """Test the endpoint that lets users opt their denial into external
+    LLM models from the appeal page when the initial internal-only
+    generation produced few or no appeals."""
+
+    fixtures = ["./fighthealthinsurance/fixtures/initial.yaml"]
+
+    def _make_internal_only_denial(
+        self, email: str = "owner@example.com"
+    ) -> Denial:
+        return Denial.objects.create(
+            denial_text="Test denial body",
+            hashed_email=Denial.get_hashed_email(email),
+            use_external=False,
+        )
+
+    def _post(self, payload: dict):
+        return self.client.post(
+            reverse("enable_external_models"),
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+    def test_flips_use_external_on_valid_credentials(self):
+        denial = self._make_internal_only_denial()
+        self.assertFalse(denial.use_external)
+        response = self._post(
+            {
+                "denial_id": denial.denial_id,
+                "email": "owner@example.com",
+                "semi_sekret": denial.semi_sekret,
+            }
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"use_external": True})
+        denial.refresh_from_db()
+        self.assertTrue(denial.use_external)
+
+    def test_idempotent_when_already_enabled(self):
+        """Calling the endpoint when external models are already on
+        must succeed (200) without raising. The button is only shown to
+        users whose denial has use_external=False, but races and reloads
+        should not 500."""
+        denial = Denial.objects.create(
+            denial_text="Already-external denial",
+            hashed_email=Denial.get_hashed_email("already@example.com"),
+            use_external=True,
+        )
+        response = self._post(
+            {
+                "denial_id": denial.denial_id,
+                "email": "already@example.com",
+                "semi_sekret": denial.semi_sekret,
+            }
+        )
+        self.assertEqual(response.status_code, 200)
+        denial.refresh_from_db()
+        self.assertTrue(denial.use_external)
+
+    def test_rejects_wrong_semi_sekret(self):
+        denial = self._make_internal_only_denial()
+        response = self._post(
+            {
+                "denial_id": denial.denial_id,
+                "email": "owner@example.com",
+                "semi_sekret": "wrong-sekret",
+            }
+        )
+        self.assertEqual(response.status_code, 404)
+        denial.refresh_from_db()
+        self.assertFalse(denial.use_external)
+
+    def test_rejects_wrong_email(self):
+        denial = self._make_internal_only_denial()
+        response = self._post(
+            {
+                "denial_id": denial.denial_id,
+                "email": "someone-else@example.com",
+                "semi_sekret": denial.semi_sekret,
+            }
+        )
+        self.assertEqual(response.status_code, 404)
+        denial.refresh_from_db()
+        self.assertFalse(denial.use_external)
+
+    def test_rejects_missing_credentials(self):
+        denial = self._make_internal_only_denial()
+        response = self._post({"denial_id": denial.denial_id})
+        self.assertEqual(response.status_code, 404)
+        denial.refresh_from_db()
+        self.assertFalse(denial.use_external)
+
+    def test_cross_denial_isolation(self):
+        """Denial A's credentials must not be able to flip Denial B."""
+        denial_a = self._make_internal_only_denial(email="alice@example.com")
+        denial_b = self._make_internal_only_denial(email="bob@example.com")
+        response = self._post(
+            {
+                "denial_id": denial_b.denial_id,
+                "email": "alice@example.com",
+                "semi_sekret": denial_a.semi_sekret,
+            }
+        )
+        self.assertEqual(response.status_code, 404)
+        denial_b.refresh_from_db()
+        self.assertFalse(denial_b.use_external)
+
+
+class GenerateAppealUseExternalContextTest(APITestCase):
+    """The appeals page must expose `use_external` so the JS client can
+    decide whether to surface the 'request external models' opt-in."""
+
+    fixtures = ["./fighthealthinsurance/fixtures/initial.yaml"]
+
+    def test_context_reflects_internal_only_denial(self):
+        denial = Denial.objects.create(
+            denial_text="Internal-only denial",
+            hashed_email=Denial.get_hashed_email("internal@example.com"),
+            use_external=False,
+        )
+        response = self.client.get(
+            reverse("generate_appeal"),
+            {
+                "denial_id": str(denial.denial_id),
+                "email": "internal@example.com",
+                "semi_sekret": denial.semi_sekret,
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context["use_external"])
+        # Prompt block is only rendered when use_external is False.
+        self.assertContains(response, "external-models-prompt")
+        self.assertContains(response, "request-external-models-btn")
+
+    def test_context_reflects_external_enabled_denial(self):
+        denial = Denial.objects.create(
+            denial_text="External-enabled denial",
+            hashed_email=Denial.get_hashed_email("external@example.com"),
+            use_external=True,
+        )
+        response = self.client.get(
+            reverse("generate_appeal"),
+            {
+                "denial_id": str(denial.denial_id),
+                "email": "external@example.com",
+                "semi_sekret": denial.semi_sekret,
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.context["use_external"])
+        # When external is already on, we don't render the opt-in prompt.
+        self.assertNotContains(response, "external-models-prompt")
+
+
 class NotifyPatientTest(APITestCase):
     """Test the notify_patient API endpoint."""
 

--- a/tests/sync/test_rest_api.py
+++ b/tests/sync/test_rest_api.py
@@ -803,15 +803,16 @@ class EnableExternalModelsTest(APITestCase):
     LLM models from the appeal page when the initial internal-only
     generation produced few or no appeals."""
 
-    fixtures = ["./fighthealthinsurance/fixtures/initial.yaml"]
-
-    def _make_internal_only_denial(
-        self, email: str = "owner@example.com"
+    def _make_denial(
+        self,
+        *,
+        email: str = "owner@example.com",
+        use_external: bool = False,
     ) -> Denial:
         return Denial.objects.create(
             denial_text="Test denial body",
             hashed_email=Denial.get_hashed_email(email),
-            use_external=False,
+            use_external=use_external,
         )
 
     def _post(self, payload: dict):
@@ -822,7 +823,7 @@ class EnableExternalModelsTest(APITestCase):
         )
 
     def test_flips_use_external_on_valid_credentials(self):
-        denial = self._make_internal_only_denial()
+        denial = self._make_denial()
         self.assertFalse(denial.use_external)
         response = self._post(
             {
@@ -841,10 +842,8 @@ class EnableExternalModelsTest(APITestCase):
         must succeed (200) without raising. The button is only shown to
         users whose denial has use_external=False, but races and reloads
         should not 500."""
-        denial = Denial.objects.create(
-            denial_text="Already-external denial",
-            hashed_email=Denial.get_hashed_email("already@example.com"),
-            use_external=True,
+        denial = self._make_denial(
+            email="already@example.com", use_external=True
         )
         response = self._post(
             {
@@ -858,7 +857,7 @@ class EnableExternalModelsTest(APITestCase):
         self.assertTrue(denial.use_external)
 
     def test_rejects_wrong_semi_sekret(self):
-        denial = self._make_internal_only_denial()
+        denial = self._make_denial()
         response = self._post(
             {
                 "denial_id": denial.denial_id,
@@ -871,7 +870,7 @@ class EnableExternalModelsTest(APITestCase):
         self.assertFalse(denial.use_external)
 
     def test_rejects_wrong_email(self):
-        denial = self._make_internal_only_denial()
+        denial = self._make_denial()
         response = self._post(
             {
                 "denial_id": denial.denial_id,
@@ -884,7 +883,7 @@ class EnableExternalModelsTest(APITestCase):
         self.assertFalse(denial.use_external)
 
     def test_rejects_missing_credentials(self):
-        denial = self._make_internal_only_denial()
+        denial = self._make_denial()
         response = self._post({"denial_id": denial.denial_id})
         self.assertEqual(response.status_code, 404)
         denial.refresh_from_db()
@@ -892,8 +891,8 @@ class EnableExternalModelsTest(APITestCase):
 
     def test_cross_denial_isolation(self):
         """Denial A's credentials must not be able to flip Denial B."""
-        denial_a = self._make_internal_only_denial(email="alice@example.com")
-        denial_b = self._make_internal_only_denial(email="bob@example.com")
+        denial_a = self._make_denial(email="alice@example.com")
+        denial_b = self._make_denial(email="bob@example.com")
         response = self._post(
             {
                 "denial_id": denial_b.denial_id,
@@ -909,8 +908,6 @@ class EnableExternalModelsTest(APITestCase):
 class GenerateAppealUseExternalContextTest(APITestCase):
     """The appeals page must expose `use_external` so the JS client can
     decide whether to surface the 'request external models' opt-in."""
-
-    fixtures = ["./fighthealthinsurance/fixtures/initial.yaml"]
 
     def test_context_reflects_internal_only_denial(self):
         denial = Denial.objects.create(
@@ -928,9 +925,9 @@ class GenerateAppealUseExternalContextTest(APITestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertFalse(response.context["use_external"])
-        # Prompt block is only rendered when use_external is False.
+        # Prompt block (which wraps the button) only renders when
+        # use_external is False.
         self.assertContains(response, "external-models-prompt")
-        self.assertContains(response, "request-external-models-btn")
 
     def test_context_reflects_external_enabled_denial(self):
         denial = Denial.objects.create(

--- a/tests/sync/test_rest_api.py
+++ b/tests/sync/test_rest_api.py
@@ -889,6 +889,18 @@ class EnableExternalModelsTest(APITestCase):
         denial.refresh_from_db()
         self.assertFalse(denial.use_external)
 
+    def test_rejects_non_object_body(self):
+        """Non-mapping JSON bodies (arrays, strings, numbers) must 400
+        rather than 500. Without the isinstance guard, request.data.get
+        on a list would raise AttributeError."""
+        response = self.client.post(
+            reverse("enable_external_models"),
+            data=json.dumps([1, 2, 3]),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("JSON object", response.content.decode())
+
     def test_cross_denial_isolation(self):
         """Denial A's credentials must not be able to flip Denial B."""
         denial_a = self._make_denial(email="alice@example.com")


### PR DESCRIPTION
When initial appeal generation under-delivers (0-2 drafts) for a denial
that has use_external=False, surface a button letting the user opt in
to external/cloud LLMs and re-run generation. A new
/ziggy/rest/enable_external_models endpoint (magic-key auth via the
denial_id/email/semi_sekret triple) flips the flag, and the JS client
reuses the existing streaming pipeline for the rerun.

https://claude.ai/code/session_01KaUVs2KoUQM3Bt6U85M23x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in feature for users to generate additional appeals using external models.
  * External models prompt appears when initial appeal generation returns fewer than 3 options.
  * Users can now request additional appeals directly from the interface.

* **Tests**
  * Added comprehensive test coverage for external models opt-in functionality and related workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->