### PR TITLE
Add context_only model flag for context-building-only models

### DIFF
--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -1112,6 +1112,15 @@ Remember in the last three sentences GLP-1 is just an _example_ check what the u
         """Whether this is an external model"""
         return True
 
+    @property
+    def context_only(self):
+        """
+        Whether this model should only be used for building context (e.g.
+        gathering citations / web-informed research) and never for general
+        text generation such as appeals, chat, or prior auth.
+        """
+        return False
+
 
 @dataclass(kw_only=True)
 class ModelDescription:
@@ -2688,6 +2697,12 @@ class RemotePerplexity(RemoteFullOpenLike):
 
     @property
     def supports_system(self):
+        return True
+
+    @property
+    def context_only(self):
+        # Perplexity is only used for building context (web-informed
+        # citations / research), never for generating appeals or chat.
         return True
 
     @classmethod

--- a/fighthealthinsurance/ml/ml_router.py
+++ b/fighthealthinsurance/ml/ml_router.py
@@ -17,6 +17,7 @@ class MLRouter(object):
     internal_models_by_cost: List[RemoteModelLike]
     all_models_by_cost: List[RemoteModelLike]
     external_models_by_cost: List[RemoteModelLike]
+    context_only_models_by_cost: List[RemoteModelLike]
 
     def __init__(self):
         # Initialize instance attributes to avoid mutable class-level state
@@ -24,10 +25,12 @@ class MLRouter(object):
         self.internal_models_by_cost = []
         self.all_models_by_cost = []
         self.external_models_by_cost = []
+        self.context_only_models_by_cost = []
         logger.debug("MLRouter: starting model registration")
         building_internal_models_by_cost = []
         building_external_models_by_cost = []
         building_all_models_by_cost = []
+        building_context_only_models_by_cost = []
         building_models_by_name: dict[str, List[ModelDescription]] = {}
         for backend in candidate_model_backends:
             try:
@@ -36,11 +39,18 @@ class MLRouter(object):
                 for m in models:
                     if m.model is None:
                         m.model = backend(model=m.internal_name)
-                    if not m.model.external:
-                        building_internal_models_by_cost.append(m)
+                    # Context-only models (e.g. Perplexity) are reserved for
+                    # building context such as citations and must never appear
+                    # in the general generation pools. They remain reachable by
+                    # name via models_by_name for the context-building methods.
+                    if m.model.context_only:
+                        building_context_only_models_by_cost.append(m)
                     else:
-                        building_external_models_by_cost.append(m)
-                    building_all_models_by_cost.append(m)
+                        if not m.model.external:
+                            building_internal_models_by_cost.append(m)
+                        else:
+                            building_external_models_by_cost.append(m)
+                        building_all_models_by_cost.append(m)
                     same_models: list[ModelDescription] = []
                     if m.name in building_models_by_name:
                         same_models = building_models_by_name[m.name]
@@ -66,9 +76,15 @@ class MLRouter(object):
             for x in sorted(building_external_models_by_cost)
             if x.model is not None
         ]
+        self.context_only_models_by_cost = [
+            x.model
+            for x in sorted(building_context_only_models_by_cost)
+            if x.model is not None
+        ]
         logger.info(
             f"MLRouter initialized with {len(self.all_models_by_cost)} total models, "
-            f"{len(self.internal_models_by_cost)} internal, {len(self.external_models_by_cost)} external"
+            f"{len(self.internal_models_by_cost)} internal, {len(self.external_models_by_cost)} external, "
+            f"{len(self.context_only_models_by_cost)} context-only"
         )
         logger.info(f"All loaded models: {[str(m) for m in self.all_models_by_cost]}")
         logger.debug(

--- a/tests/async-unit/test_ml_router.py
+++ b/tests/async-unit/test_ml_router.py
@@ -4,7 +4,12 @@ import asyncio
 from typing import Optional
 
 from fighthealthinsurance.ml.ml_router import MLRouter
-from fighthealthinsurance.ml.ml_models import RemoteModelLike
+from fighthealthinsurance.ml.ml_models import (
+    ModelDescription,
+    RemoteHealthInsurance,
+    RemoteModelLike,
+    RemotePerplexity,
+)
 
 
 class TestMLRouterGenerateTextBackendNames(unittest.TestCase):
@@ -220,6 +225,108 @@ class TestMLRouterChatBackends(unittest.TestCase):
             # Verify get_chat_backends was called with use_external=False
             mock_get_chat.assert_called_once_with(use_external=False)
             self.assertEqual(primary_models, ["mock_model"])
+
+
+class TestContextOnlyModelFlag(unittest.TestCase):
+    """Tests for the context_only flag and how the router handles it."""
+
+    def test_default_model_is_not_context_only(self):
+        """Models default to not being context-only."""
+        with patch.dict(
+            "os.environ",
+            {"HEALTH_BACKEND_HOST": "localhost", "HEALTH_BACKEND_PORT": "80"},
+        ):
+            model = RemoteHealthInsurance(model="test")
+        self.assertFalse(model.context_only)
+
+    def test_perplexity_is_context_only(self):
+        """Perplexity is flagged as context-only (citations / research only)."""
+        with patch.dict("os.environ", {"PERPLEXITY_API": "test-token"}):
+            model = RemotePerplexity(model="sonar")
+        self.assertTrue(model.context_only)
+
+    def _make_backend(self, descriptions):
+        class FakeBackend:
+            @classmethod
+            def models(cls):
+                return descriptions
+
+        return FakeBackend
+
+    def test_context_only_model_kept_out_of_generation_pools(self):
+        """Context-only models must not appear in the general generation pools
+        but should remain reachable by name for context-building tasks."""
+        internal_model = MagicMock(spec=RemoteModelLike)
+        internal_model.external = False
+        internal_model.context_only = False
+
+        external_model = MagicMock(spec=RemoteModelLike)
+        external_model.external = True
+        external_model.context_only = False
+
+        context_model = MagicMock(spec=RemoteModelLike)
+        context_model.external = True
+        context_model.context_only = True
+
+        descriptions = [
+            ModelDescription(
+                cost=2, name="fhi", internal_name="fhi", model=internal_model
+            ),
+            ModelDescription(
+                cost=8, name="ext", internal_name="ext", model=external_model
+            ),
+            ModelDescription(
+                cost=100, name="sonar", internal_name="sonar", model=context_model
+            ),
+        ]
+        fake_backend = self._make_backend(descriptions)
+
+        with patch(
+            "fighthealthinsurance.ml.ml_router.candidate_model_backends",
+            [fake_backend],
+        ):
+            router = MLRouter()
+
+        # Tracked in the dedicated context-only pool.
+        self.assertIn(context_model, router.context_only_models_by_cost)
+        # Excluded from every general generation pool.
+        self.assertNotIn(context_model, router.all_models_by_cost)
+        self.assertNotIn(context_model, router.external_models_by_cost)
+        self.assertNotIn(context_model, router.internal_models_by_cost)
+        # Regular models still populate the generation pools.
+        self.assertIn(internal_model, router.internal_models_by_cost)
+        self.assertIn(external_model, router.external_models_by_cost)
+        # Still reachable by name so citation/context methods can use it.
+        self.assertIn(context_model, router.models_by_name["sonar"])
+
+    def test_context_only_model_not_used_for_text_generation(self):
+        """The text generation backend list excludes context-only models."""
+        external_model = MagicMock(spec=RemoteModelLike)
+        external_model.external = True
+        external_model.context_only = False
+
+        context_model = MagicMock(spec=RemoteModelLike)
+        context_model.external = True
+        context_model.context_only = True
+
+        descriptions = [
+            ModelDescription(
+                cost=8, name="ext", internal_name="ext", model=external_model
+            ),
+            ModelDescription(
+                cost=100, name="sonar", internal_name="sonar", model=context_model
+            ),
+        ]
+        fake_backend = self._make_backend(descriptions)
+
+        with patch(
+            "fighthealthinsurance.ml.ml_router.candidate_model_backends",
+            [fake_backend],
+        ):
+            router = MLRouter()
+
+        backends = router.generate_text_backends(use_external=True)
+        self.assertNotIn(context_model, backends)
 
 
 class TestMLRouterSummarizeChatHistory(unittest.TestCase):


### PR DESCRIPTION
Introduce a context_only flag on model backends to mark models that
should only be used for building context (e.g. gathering citations /
web-informed research) and never for general text generation such as
appeals, chat, or prior auth.

- Add context_only property (default False) to RemoteModelLike
- Flag RemotePerplexity as context_only
- MLRouter routes context_only models into a dedicated
  context_only_models_by_cost pool and excludes them from the
  internal/external/all generation pools, while keeping them reachable
  by name for the citation/context-building methods
- Add tests covering the flag and router behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Models can now be classified as context-only for exclusive use in research and citation generation, ensuring they do not interfere with general text generation models used for appeals and prior authorization requests.

* **Chores**
  * Updated model routing to properly separate context-only models from general-purpose models during initialization.

* **Tests**
  * Added comprehensive test suite for context-only model classification and routing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->