### PR TITLE
Fix abandoned-cart resume link pointing to wrong domain

### DIFF
--- a/fighthealthinsurance/helpers/stripe_helpers.py
+++ b/fighthealthinsurance/helpers/stripe_helpers.py
@@ -118,15 +118,27 @@ class StripeWebhookHelper:
           error: that SPA has no ``/stripe/finish`` route, so its router
           treated ``stripe`` as a demo-type path segment.
 
+        Returns ``None`` when we can't build a link the target app could
+        actually act on, so the caller skips emailing a dead resume link.
+
         Hosts are read from settings so non-prod environments don't email
         users production links.
         """
         if payment_type == "professional_domain_subscription":
-            # Completed in the Fight Paperwork SPA.
+            # Completed in the Fight Paperwork SPA. Without both ids the SPA
+            # can't resume the subscription, so skip rather than email a dead
+            # link.
+            domain_id = metadata.get("domain_id")
+            professional_id = metadata.get("professional_id")
+            if not domain_id or not professional_id:
+                logger.warning(
+                    "Skipping professional recovery link: missing domain_id/professional_id"
+                )
+                return None
             params = urlencode(
                 {
-                    "domain_id": metadata.get("domain_id"),
-                    "professional_id": metadata.get("professional_id"),
+                    "domain_id": domain_id,
+                    "professional_id": professional_id,
                 }
             )
             return (
@@ -134,8 +146,18 @@ class StripeWebhookHelper:
                 f"/stripe/finish-checkout?{params}"
             )
         # Completed by the Django `complete_payment` view on the Fight Health
-        # Insurance domain. Use the unguessable secure_token rather than the
-        # row id so the recovery URL can't be brute-forced by enumerating ids.
+        # Insurance domain. That view rebuilds the checkout from either a
+        # `recovery_info_id` or serialized `line_items` in the metadata; if
+        # neither is present (e.g. pay-what-you-want donations) it can't
+        # recreate the session, so skip emailing a link that would only error.
+        if not metadata.get("recovery_info_id") and not metadata.get("line_items"):
+            logger.warning(
+                f"Skipping recovery link for payment_type={payment_type}: "
+                "no recovery_info_id or line_items in metadata"
+            )
+            return None
+        # Use the unguessable secure_token rather than the row id so the
+        # recovery URL can't be brute-forced by enumerating ids.
         params = urlencode({"token": lost_session.secure_token})
         return (
             f"https://{settings.FIGHT_HEALTH_INSURANCE_DOMAIN}"

--- a/fighthealthinsurance/helpers/stripe_helpers.py
+++ b/fighthealthinsurance/helpers/stripe_helpers.py
@@ -101,6 +101,48 @@ class StripeWebhookHelper:
             raise e
 
     @staticmethod
+    def _build_recovery_link(
+        payment_type: Optional[str], metadata: Any, lost_session: LostStripeSession
+    ) -> Optional[str]:
+        """Build the abandoned-cart recovery link for an expired checkout.
+
+        The link has to point at whichever app actually serves the resume
+        route, otherwise the customer lands on a 404 / SPA catch-all:
+
+        * Professional domain subscriptions are completed in the Fight
+          Paperwork SPA at ``/stripe/finish-checkout``.
+        * Everything else (patient appeals, fax, pay-what-you-want, ...) is
+          completed by this Django backend's ``complete_payment`` view, which
+          is served on the Fight Health Insurance domain. Pointing these at
+          the Fight Paperwork SPA is what produced the "Invalid Demo Type"
+          error: that SPA has no ``/stripe/finish`` route, so its router
+          treated ``stripe`` as a demo-type path segment.
+
+        Hosts are read from settings so non-prod environments don't email
+        users production links.
+        """
+        if payment_type == "professional_domain_subscription":
+            # Completed in the Fight Paperwork SPA.
+            params = urlencode(
+                {
+                    "domain_id": metadata.get("domain_id"),
+                    "professional_id": metadata.get("professional_id"),
+                }
+            )
+            return (
+                f"https://{settings.FIGHT_PAPERWORK_DOMAIN}"
+                f"/stripe/finish-checkout?{params}"
+            )
+        # Completed by the Django `complete_payment` view on the Fight Health
+        # Insurance domain. Use the unguessable secure_token rather than the
+        # row id so the recovery URL can't be brute-forced by enumerating ids.
+        params = urlencode({"token": lost_session.secure_token})
+        return (
+            f"https://{settings.FIGHT_HEALTH_INSURANCE_DOMAIN}"
+            f"{reverse('complete_payment')}?{params}"
+        )
+
+    @staticmethod
     def handle_checkout_session_expired(request: Any, session: Any) -> None:
         """
         Handle an expired Stripe checkout session.
@@ -121,7 +163,6 @@ class StripeWebhookHelper:
                 metadata = session["metadata"]
             payment_type = metadata.get("payment_type")
             item = "Fight Health Insurance / Fight paperwork"
-            finish_link = None
 
             if payment_type == "fax":
                 item = "Fight Health Insurance Fax"
@@ -141,18 +182,6 @@ class StripeWebhookHelper:
                         logger.info(
                             f"Domain {domain_id} no longer exists, might have been recreated"
                         )
-
-                # Temporary until the FPW UI is ready
-                finish_base_link = (
-                    "https://www.fightpaperwork.com/stripe/finish-checkout"
-                )
-                params = urlencode(
-                    {
-                        "domain_id": domain_id,
-                        "professional_id": metadata.get("professional_id"),
-                    }
-                )
-                finish_link = f"{finish_base_link}?{params}"
 
             # Try to extract email from various session locations
             email: Optional[str] = None
@@ -232,16 +261,9 @@ class StripeWebhookHelper:
                 session_id=session_id,
                 metadata=metadata,
             )
-            if finish_link is None:
-                # Use the unguessable secure_token rather than the row id so the
-                # recovery URL can't be brute-forced by enumerating ids. Build
-                # the host from settings so non-prod environments don't email
-                # users a production link.
-                params = urlencode({"token": lost_session.secure_token})
-                finish_link = (
-                    f"https://{settings.FIGHT_PAPERWORK_DOMAIN}"
-                    f"{reverse('complete_payment')}?{params}"
-                )
+            finish_link = StripeWebhookHelper._build_recovery_link(
+                payment_type, metadata, lost_session
+            )
             if finish_link:
                 fhi_emails.send_checkout_session_expired(
                     request,

--- a/fighthealthinsurance/templates/stripe_finish_error.html
+++ b/fighthealthinsurance/templates/stripe_finish_error.html
@@ -1,0 +1,26 @@
+{% extends 'base.html' %}
+{% block title %}
+Checkout Link Problem
+{% endblock title %}
+{% block content %}
+
+<!-- HOME -->
+<section id="stripe-finish-error" data-stellar-background-ratio="0.5">
+    <div class="row mt-5 mb-5">
+        <div class="caption d-flex flex-column align-items-center justify-content-center">
+            <div class="col-md-offset-1 col-md-10 text-align-center d-flex flex-column align-items-center justify-content-center" style="margin-top: 10vh;">
+                <h2>We couldn't resume your checkout</h2>
+                <p>Sorry, something went wrong while trying to continue your payment.</p>
+                {% if error_message %}
+                <div class="alert alert-warning mt-3 text-start" role="alert" style="max-width: 640px;">
+                    {{ error_message }}
+                </div>
+                {% endif %}
+                <p class="mt-3">The recovery link may have expired or already been used. You can start a new checkout, or contact us if you need a hand.</p>
+                <p class="mt-3"><strong>Need help?</strong> Reach out to <a href="mailto:{{ support_email }}">{{ support_email }}</a> and we'll get you sorted.</p>
+            </div>
+        </div>
+    </div>
+</section>
+
+{% endblock content %}

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -2367,22 +2367,30 @@ def create_pwyw_checkout(request: HttpRequest) -> HttpResponse:
             success_url = request.build_absolute_uri("/") + "?donation=success"
             cancel_url = request.build_absolute_uri("/")
 
+        # Persist the line items so an expired/abandoned donation checkout can
+        # be rebuilt by CompletePaymentView via the recovery email link. PWYW
+        # uses inline price_data (the amount is dynamic), so we store the items
+        # in a StripeRecoveryInfo and reference it by id in the metadata,
+        # mirroring the fax flow.
+        line_items = [
+            {
+                "price_data": {
+                    "currency": "usd",
+                    "unit_amount": amount * 100,  # Convert dollars to cents
+                    "product_data": {
+                        "name": "Fight Health Insurance - Pay What You Want",
+                        "description": "Support our mission to help people fight health insurance denials",
+                    },
+                },
+                "quantity": 1,
+            }
+        ]
+        recovery_info = StripeRecoveryInfo.objects.create(items=line_items)
+
         # Create a checkout session with the specified amount
         checkout_session = stripe.checkout.Session.create(
             payment_method_types=["card"],
-            line_items=[
-                {
-                    "price_data": {
-                        "currency": "usd",
-                        "unit_amount": amount * 100,  # Convert dollars to cents
-                        "product_data": {
-                            "name": "Fight Health Insurance - Pay What You Want",
-                            "description": "Support our mission to help people fight health insurance denials",
-                        },
-                    },
-                    "quantity": 1,
-                }
-            ],
+            line_items=line_items,  # type: ignore
             mode="payment",
             success_url=success_url,
             cancel_url=cancel_url,
@@ -2390,6 +2398,7 @@ def create_pwyw_checkout(request: HttpRequest) -> HttpResponse:
                 "payment_type": "donation",
                 "donation_type": "pwyw",
                 "source": "checkout",
+                "recovery_info_id": str(recovery_info.id),
             },
         )
 

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -2010,6 +2010,11 @@ class CompletePaymentView(View):
     """
 
     def get(self, request):
+        """Resume an abandoned checkout from the emailed recovery link.
+
+        Browsers are 302-redirected to Stripe; ``?format=json`` callers and
+        error cases get JSON, and other errors render a friendly HTML page.
+        """
         # Computed up front so the exception handler below can honor the JSON
         # contract even when an unexpected error escapes _resolve_next_url.
         wants_json = request.GET.get("format") == "json"
@@ -2038,6 +2043,7 @@ class CompletePaymentView(View):
             return self._render_error_page(request, "An internal error occurred", 500)
 
     def post(self, request):
+        """Resolve an abandoned checkout from a JSON body and return next_url."""
         try:
             try:
                 data = json.loads(request.body)

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -2012,8 +2012,9 @@ class CompletePaymentView(View):
     def get(self, request):
         """Resume an abandoned checkout from the emailed recovery link.
 
-        Browsers are 302-redirected to Stripe; ``?format=json`` callers and
-        error cases get JSON, and other errors render a friendly HTML page.
+        Browsers are 302-redirected to Stripe. ``?format=json`` callers get
+        JSON (the next URL on success, an error object on failure); every
+        other client gets a friendly HTML error page when something fails.
         """
         # Computed up front so the exception handler below can honor the JSON
         # contract even when an unexpected error escapes _resolve_next_url.

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -1999,7 +1999,15 @@ class StripeWebhookView(View):
 
 
 class CompletePaymentView(View):
-    """View for completing payment after Stripe checkout redirect."""
+    """View for completing payment after a Stripe checkout redirect.
+
+    This backs the abandoned-cart recovery link (``/stripe/finish``) that is
+    emailed to patients/Fight Health Insurance customers. The link is opened
+    directly in a browser, so a GET redirects the visitor straight to a fresh
+    Stripe checkout session (302). Programmatic callers can opt into the JSON
+    payload via ``?format=json`` or by POSTing, which keeps returning
+    ``{"next_url": ...}`` for the front-end checkout flows.
+    """
 
     def get(self, request):
         try:
@@ -2007,31 +2015,62 @@ class CompletePaymentView(View):
                 "token": request.GET.get("token"),
                 "session_id": request.GET.get("session_id"),
             }
-
-            return self.process_payment(data)
+            next_url, error = self._resolve_next_url(data)
+            wants_json = request.GET.get("format") == "json"
+            if error is not None or next_url is None:
+                message, status_code = error or ("An internal error occurred", 500)
+                if wants_json:
+                    return self._json_error_response(message, status_code)
+                return self._render_error_page(request, message, status_code)
+            if wants_json:
+                return JsonResponse({"next_url": next_url})
+            # Browser navigation from the recovery email: send the visitor
+            # straight to Stripe rather than showing them raw JSON.
+            return HttpResponseRedirect(next_url)
         except Exception as e:
             logger.opt(exception=True).error(
                 "Error processing payment completion from GET"
             )
-            return HttpResponse(status=500)
+            return self._render_error_page(request, "An internal error occurred", 500)
 
     def post(self, request):
         try:
-            return self.do_post(request)
+            data = json.loads(request.body)
+            next_url, error = self._resolve_next_url(data)
+            if error is not None or next_url is None:
+                message, status_code = error or ("An internal error occurred", 500)
+                return self._json_error_response(message, status_code)
+            return JsonResponse({"next_url": next_url})
         except Exception as e:
             logger.opt(exception=True).error("Error processing payment completion")
             return HttpResponse(status=500)
-
-    def do_post(self, request):
-        data = json.loads(request.body)
-        return self.process_payment(data)
 
     @staticmethod
     def _json_error_response(error: str, status_code: int) -> JsonResponse:
         """Return a standardized JSON error response for payment completion."""
         return JsonResponse({"error": error}, status=status_code)
 
-    def process_payment(self, data):
+    @staticmethod
+    def _render_error_page(request, message: str, status_code: int) -> HttpResponse:
+        """Render a friendly HTML page for browser visitors hitting an error."""
+        return render(
+            request,
+            "stripe_finish_error.html",
+            {
+                "error_message": message,
+                "support_email": "support42@fighthealthinsurance.com",
+            },
+            status=status_code,
+        )
+
+    def _resolve_next_url(
+        self, data
+    ) -> typing.Tuple[typing.Optional[str], typing.Optional[typing.Tuple[str, int]]]:
+        """Resolve the Stripe checkout URL to resume an abandoned session.
+
+        Returns ``(next_url, None)`` on success or ``(None, (message, status))``
+        on failure so callers can render either JSON or an HTML page.
+        """
         token = data.get("token")
         session_id = data.get("session_id")
 
@@ -2049,7 +2088,7 @@ class CompletePaymentView(View):
                 except (TypeError, ValueError):
                     pass
                 if legacy_id is None or legacy_id <= 0:
-                    return self._json_error_response("Invalid or expired link", 400)
+                    return None, ("Invalid or expired link", 400)
                 rollout_at = getattr(settings, "SECURE_TOKEN_ROLLOUT_AT", None)
                 legacy_max_id = int(
                     getattr(settings, "SECURE_TOKEN_LEGACY_MAX_ID", 1000)
@@ -2066,10 +2105,10 @@ class CompletePaymentView(View):
                         id=legacy_id
                     ).first()
                 if lost_session_opt is None:
-                    return self._json_error_response("Invalid or expired link", 400)
+                    return None, ("Invalid or expired link", 400)
                 lost_session = lost_session_opt
             else:
-                return self._json_error_response("Missing token", 400)
+                return None, ("Missing token", 400)
             continue_url = lost_session.success_url
             cancel_url = lost_session.cancel_url
             payment_type = lost_session.payment_type
@@ -2080,9 +2119,7 @@ class CompletePaymentView(View):
                 line_items_json = metadata.get("line_items")
                 if not line_items_json:
                     logger.error(f"No recovery info found in metadata {metadata}")
-                    return self._json_error_response(
-                        "No recovery info found in metadata", 400
-                    )
+                    return None, ("No recovery info found in metadata", 400)
                 line_items = json.loads(line_items_json)
             else:
                 line_items = StripeRecoveryInfo.objects.get(id=recovery_info_id).items
@@ -2095,16 +2132,12 @@ class CompletePaymentView(View):
                 metadata=metadata,
             )
 
-            return HttpResponse(
-                json.dumps({"next_url": checkout_session.url}),
-                status=200,
-                content_type="application/json",
-            )
+            return checkout_session.url, None
         except models.LostStripeSession.DoesNotExist:
-            return self._json_error_response("Session not found", 400)
+            return None, ("Session not found", 400)
         except Exception as e:
             logger.opt(exception=e).error("Error in finishing payment")
-            return self._json_error_response("An internal error occurred", 500)
+            return None, ("An internal error occurred", 500)
 
 
 @ensure_csrf_cookie

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -2010,13 +2010,15 @@ class CompletePaymentView(View):
     """
 
     def get(self, request):
+        # Computed up front so the exception handler below can honor the JSON
+        # contract even when an unexpected error escapes _resolve_next_url.
+        wants_json = request.GET.get("format") == "json"
         try:
             data = {
                 "token": request.GET.get("token"),
                 "session_id": request.GET.get("session_id"),
             }
             next_url, error = self._resolve_next_url(data)
-            wants_json = request.GET.get("format") == "json"
             if error is not None or next_url is None:
                 message, status_code = error or ("An internal error occurred", 500)
                 if wants_json:
@@ -2031,11 +2033,18 @@ class CompletePaymentView(View):
             logger.opt(exception=True).error(
                 "Error processing payment completion from GET"
             )
+            if wants_json:
+                return self._json_error_response("An internal error occurred", 500)
             return self._render_error_page(request, "An internal error occurred", 500)
 
     def post(self, request):
         try:
-            data = json.loads(request.body)
+            try:
+                data = json.loads(request.body)
+            except json.JSONDecodeError:
+                return self._json_error_response("Invalid JSON body", 400)
+            if not isinstance(data, dict):
+                return self._json_error_response("Invalid request body", 400)
             next_url, error = self._resolve_next_url(data)
             if error is not None or next_url is None:
                 message, status_code = error or ("An internal error occurred", 500)
@@ -2043,7 +2052,7 @@ class CompletePaymentView(View):
             return JsonResponse({"next_url": next_url})
         except Exception as e:
             logger.opt(exception=True).error("Error processing payment completion")
-            return HttpResponse(status=500)
+            return self._json_error_response("An internal error occurred", 500)
 
     @staticmethod
     def _json_error_response(error: str, status_code: int) -> JsonResponse:

--- a/tests/async/test_non_professional_abandoned_cart.py
+++ b/tests/async/test_non_professional_abandoned_cart.py
@@ -47,16 +47,28 @@ def test_non_professional_abandoned_cart():
         assert "next_url" in response.json()
         assert response.json()["next_url"] == "https://checkout.stripe.com/test"
 
-    # Test GET method (token-based)
+    # Test GET method (token-based) with explicit JSON opt-in for API callers
+    with patch("stripe.checkout.Session.create") as mock_create:
+        mock_create.return_value.url = "https://checkout.stripe.com/test"
+
+        query_params = urlencode({"token": token, "format": "json"})
+        response = client.get(f"{reverse('complete_payment')}?{query_params}")
+
+        assert response.status_code == 200
+        assert "next_url" in response.json()
+        assert response.json()["next_url"] == "https://checkout.stripe.com/test"
+
+    # Test GET method (token-based) from a browser: the recovery email link is
+    # opened directly, so it should redirect the visitor straight to Stripe
+    # rather than dumping raw JSON.
     with patch("stripe.checkout.Session.create") as mock_create:
         mock_create.return_value.url = "https://checkout.stripe.com/test"
 
         query_params = urlencode({"token": token})
         response = client.get(f"{reverse('complete_payment')}?{query_params}")
 
-        assert response.status_code == 200
-        assert "next_url" in response.json()
-        assert response.json()["next_url"] == "https://checkout.stripe.com/test"
+        assert response.status_code == 302
+        assert response["Location"] == "https://checkout.stripe.com/test"
 
     # Brute-forcing a post-rollout row id (>= the legacy cutoff) must not work —
     # only the secure_token grants access for new sessions.
@@ -101,9 +113,8 @@ def test_non_professional_abandoned_cart():
     )
     with patch("stripe.checkout.Session.create") as mock_create:
         mock_create.return_value.url = "https://checkout.stripe.com/legacy"
-        response = client.get(
-            f"{reverse('complete_payment')}?session_id={legacy_session.pk}"
-        )
+        query_params = urlencode({"session_id": legacy_session.pk, "format": "json"})
+        response = client.get(f"{reverse('complete_payment')}?{query_params}")
         assert response.status_code == 200
         assert response.json()["next_url"] == "https://checkout.stripe.com/legacy"
 

--- a/tests/async/test_non_professional_abandoned_cart.py
+++ b/tests/async/test_non_professional_abandoned_cart.py
@@ -5,141 +5,137 @@ from urllib.parse import urlencode
 from unittest.mock import patch
 from django.urls import reverse
 from django.test import Client
-from django.utils import timezone
-from fighthealthinsurance.models import LostStripeSession, StripeRecoveryInfo
+from fighthealthinsurance.models import LostStripeSession
 from fighthealthinsurance.helpers.stripe_helpers import StripeWebhookHelper
+
+EMAIL = "test@example.com"
+LINE_ITEMS_METADATA = {
+    "line_items": json.dumps([{"price": "price_123", "quantity": 1}])
+}
+
+
+def _make_lost_session(**overrides) -> LostStripeSession:
+    """Create a non-professional LostStripeSession with rebuildable metadata."""
+    defaults = dict(
+        session_id="test_session_id",
+        payment_type="non_professional_item",
+        email=EMAIL,
+        metadata=dict(LINE_ITEMS_METADATA),
+    )
+    defaults.update(overrides)
+    return LostStripeSession.objects.create(**defaults)
 
 
 @pytest.mark.django_db
-def test_non_professional_abandoned_cart():
-    client = Client()
-    session_id = "test_session_id"
-    email = "test@example.com"
-    line_items = [{"price": "price_123", "quantity": 1}]
-    metadata = {"line_items": json.dumps(line_items)}
-
-    # Create a LostStripeSession
-    lost_session = LostStripeSession.objects.create(
-        session_id=session_id,
-        payment_type="non_professional_item",
-        email=email,
-        metadata=metadata,
-    )
-    token = lost_session.secure_token
-
-    # Test POST method (token-based)
+def test_post_token_returns_stripe_url():
+    """POST with a valid token returns the fresh Stripe checkout URL as JSON."""
+    lost_session = _make_lost_session()
     with patch("stripe.checkout.Session.create") as mock_create:
         mock_create.return_value.url = "https://checkout.stripe.com/test"
-
-        response = client.post(
+        response = Client().post(
             reverse("complete_payment"),
-            data=json.dumps(
-                {
-                    "token": token,
-                    "continue_url": "https://example.com/success",
-                    "cancel_url": "https://example.com/cancel",
-                }
-            ),
+            data=json.dumps({"token": lost_session.secure_token}),
             content_type="application/json",
         )
+    assert response.status_code == 200
+    assert response.json()["next_url"] == "https://checkout.stripe.com/test"
 
-        assert response.status_code == 200
-        assert "next_url" in response.json()
-        assert response.json()["next_url"] == "https://checkout.stripe.com/test"
 
-    # Test GET method (token-based) with explicit JSON opt-in for API callers
+@pytest.mark.django_db
+def test_get_token_with_format_json_returns_stripe_url():
+    """GET ?format=json lets API callers opt into the JSON payload."""
+    lost_session = _make_lost_session()
     with patch("stripe.checkout.Session.create") as mock_create:
         mock_create.return_value.url = "https://checkout.stripe.com/test"
+        query = urlencode({"token": lost_session.secure_token, "format": "json"})
+        response = Client().get(f"{reverse('complete_payment')}?{query}")
+    assert response.status_code == 200
+    assert response.json()["next_url"] == "https://checkout.stripe.com/test"
 
-        query_params = urlencode({"token": token, "format": "json"})
-        response = client.get(f"{reverse('complete_payment')}?{query_params}")
 
-        assert response.status_code == 200
-        assert "next_url" in response.json()
-        assert response.json()["next_url"] == "https://checkout.stripe.com/test"
-
-    # Test GET method (token-based) from a browser: the recovery email link is
-    # opened directly, so it should redirect the visitor straight to Stripe
-    # rather than dumping raw JSON.
+@pytest.mark.django_db
+def test_get_token_from_browser_redirects_to_stripe():
+    """A browser opening the recovery email link is 302-redirected to Stripe."""
+    lost_session = _make_lost_session()
     with patch("stripe.checkout.Session.create") as mock_create:
         mock_create.return_value.url = "https://checkout.stripe.com/test"
+        query = urlencode({"token": lost_session.secure_token})
+        response = Client().get(f"{reverse('complete_payment')}?{query}")
+    assert response.status_code == 302
+    assert response["Location"] == "https://checkout.stripe.com/test"
 
-        query_params = urlencode({"token": token})
-        response = client.get(f"{reverse('complete_payment')}?{query_params}")
 
-        assert response.status_code == 302
-        assert response["Location"] == "https://checkout.stripe.com/test"
-
-    # Brute-forcing a post-rollout row id (>= the legacy cutoff) must not work —
-    # only the secure_token grants access for new sessions.
-    high_id_session = LostStripeSession(
-        pk=9999,
-        session_id="high_id_stripe_session",
-        payment_type="non_professional_item",
-        email=email,
-        metadata=metadata,
+@pytest.mark.django_db
+def test_post_invalid_json_body_returns_400_json():
+    """A malformed POST body still gets a JSON error, not an empty 500."""
+    response = Client().post(
+        reverse("complete_payment"),
+        data="not-json",
+        content_type="application/json",
     )
-    high_id_session.save()
-    response = client.get(
+    assert response.status_code == 400
+    assert "error" in response.json()
+
+
+@pytest.mark.django_db
+def test_high_id_session_id_lookup_rejected():
+    """Post-rollout row ids can't be used for lookup; only the token grants access."""
+    high_id_session = _make_lost_session(pk=9999, session_id="high_id_stripe_session")
+    response = Client().get(
         f"{reverse('complete_payment')}?session_id={high_id_session.pk}"
     )
     assert response.status_code == 400
 
-    # An unknown / forged token must be rejected.
-    response = client.get(f"{reverse('complete_payment')}?token=not-a-real-token")
+
+@pytest.mark.django_db
+def test_forged_token_rejected():
+    """An unknown / forged token is rejected."""
+    response = Client().get(f"{reverse('complete_payment')}?token=not-a-real-token")
     assert response.status_code == 400
 
-    # Passing the raw Stripe session_id string is no longer a valid lookup —
-    # post-cutoff sessions must use the token.
-    response = client.get(
+
+@pytest.mark.django_db
+def test_raw_stripe_session_id_string_rejected():
+    """The raw Stripe session_id string is not a valid post-cutoff lookup."""
+    high_id_session = _make_lost_session(pk=9999, session_id="high_id_stripe_session")
+    response = Client().get(
         f"{reverse('complete_payment')}?session_id={high_id_session.session_id}"
     )
     assert response.status_code == 400
 
-    # Legacy support: rows created before secure token rollout were emailed
-    # with ?session_id=<row_id>; honor those old links.
-    legacy_session = LostStripeSession.objects.create(
-        pk=42,
-        session_id="legacy_stripe_session",
-        payment_type="non_professional_item",
-        email=email,
-        metadata=metadata,
-    )
-    # Bypass auto_now_add to backdate created_at into the pre-rollout window.
-    # `auto_now_add` ignores values passed to the constructor, so a plain
-    # save() always stamps "now"; an UPDATE goes through unmolested.
+
+@pytest.mark.django_db
+def test_legacy_session_id_link_still_works():
+    """Pre-rollout emails used ?session_id=<row_id>; those old links still work."""
+    legacy_session = _make_lost_session(pk=42, session_id="legacy_stripe_session")
+    # auto_now_add ignores constructor values, so backdate created_at via UPDATE
+    # into the pre-rollout window.
     LostStripeSession.objects.filter(pk=legacy_session.pk).update(
         created_at=datetime.datetime(2026, 5, 3, tzinfo=datetime.UTC)
     )
     with patch("stripe.checkout.Session.create") as mock_create:
         mock_create.return_value.url = "https://checkout.stripe.com/legacy"
-        query_params = urlencode({"session_id": legacy_session.pk, "format": "json"})
-        response = client.get(f"{reverse('complete_payment')}?{query_params}")
-        assert response.status_code == 200
-        assert response.json()["next_url"] == "https://checkout.stripe.com/legacy"
+        query = urlencode({"session_id": legacy_session.pk, "format": "json"})
+        response = Client().get(f"{reverse('complete_payment')}?{query}")
+    assert response.status_code == 200
+    assert response.json()["next_url"] == "https://checkout.stripe.com/legacy"
 
-    # Simulate Stripe webhook call to trigger the email
-    stripe_event = {
-        "type": "checkout.session.expired",
-        "data": {
-            "object": {
-                "metadata": {
-                    "payment_type": "non_professional_item",
-                    "session_id": session_id,
-                },
-                "customer_details": {
-                    "email": email,
-                },
-            }
+
+@pytest.mark.django_db
+@patch(
+    "fighthealthinsurance.helpers.stripe_helpers.fhi_emails.send_checkout_session_expired"
+)
+def test_expired_checkout_webhook_persists_lost_session(mock_send_email):
+    """An expired non-professional checkout webhook records a LostStripeSession."""
+    session = {
+        "metadata": {
+            "payment_type": "non_professional_item",
+            "line_items": LINE_ITEMS_METADATA["line_items"],
         },
+        "customer_details": {"email": EMAIL},
     }
-    StripeWebhookHelper.handle_checkout_session_expired(
-        None, stripe_event["data"]["object"]
-    )
+    StripeWebhookHelper.handle_checkout_session_expired(None, session)
 
-    # Check that the LostStripeSession was created
-    assert LostStripeSession.objects.filter(session_id=session_id).exists()
-    lost_session = LostStripeSession.objects.get(session_id=session_id)
-    assert lost_session.email == email
+    lost_session = LostStripeSession.objects.get(email=EMAIL)
     assert lost_session.payment_type == "non_professional_item"
-    assert lost_session.metadata == metadata
+    mock_send_email.assert_called_once()

--- a/tests/async/test_non_professional_abandoned_cart.py
+++ b/tests/async/test_non_professional_abandoned_cart.py
@@ -5,7 +5,7 @@ from urllib.parse import urlencode
 from unittest.mock import patch
 from django.urls import reverse
 from django.test import Client
-from fighthealthinsurance.models import LostStripeSession
+from fighthealthinsurance.models import LostStripeSession, StripeRecoveryInfo
 from fighthealthinsurance.helpers.stripe_helpers import StripeWebhookHelper
 
 EMAIL = "test@example.com"
@@ -119,6 +119,44 @@ def test_legacy_session_id_link_still_works():
         response = Client().get(f"{reverse('complete_payment')}?{query}")
     assert response.status_code == 200
     assert response.json()["next_url"] == "https://checkout.stripe.com/legacy"
+
+
+@pytest.mark.django_db
+def test_donation_recovery_link_redirects_to_stripe():
+    """A browser opening an expired-donation recovery link is redirected to Stripe.
+
+    PWYW donations persist their line items in a StripeRecoveryInfo referenced
+    by recovery_info_id, so complete_payment can rebuild the checkout.
+    """
+    recovery_info = StripeRecoveryInfo.objects.create(
+        items=[{"price_data": {"currency": "usd", "unit_amount": 500}, "quantity": 1}]
+    )
+    lost_session = LostStripeSession.objects.create(
+        session_id="donation_session",
+        payment_type="donation",
+        email=EMAIL,
+        metadata={
+            "payment_type": "donation",
+            "donation_type": "pwyw",
+            "source": "checkout",
+            "recovery_info_id": str(recovery_info.id),
+        },
+    )
+    with patch("stripe.checkout.Session.create") as mock_create:
+        mock_create.return_value.url = "https://checkout.stripe.com/donation"
+        query = urlencode({"token": lost_session.secure_token})
+        response = Client().get(f"{reverse('complete_payment')}?{query}")
+    assert response.status_code == 302
+    assert response["Location"] == "https://checkout.stripe.com/donation"
+
+
+@pytest.mark.django_db
+def test_browser_error_renders_html_error_page():
+    """A forged token opened in a browser renders the friendly HTML error page."""
+    response = Client().get(f"{reverse('complete_payment')}?token=not-a-real-token")
+    assert response.status_code == 400
+    assert response["Content-Type"].startswith("text/html")
+    assert b"resume your checkout" in response.content
 
 
 @pytest.mark.django_db

--- a/tests/async/test_stripe_webhooks.py
+++ b/tests/async/test_stripe_webhooks.py
@@ -141,10 +141,41 @@ class StripeWebhookTests(TestCase):
         link = mock_send_email.call_args.kwargs["link"]
 
         lost_session = LostStripeSession.objects.get(session_id=mock_session.id)
-        # Link must be absolute, target the configured host (so non-prod
-        # environments don't email production links), and carry the
-        # unguessable token rather than the row id.
-        self.assertTrue(link.startswith(f"https://{settings.FIGHT_PAPERWORK_DOMAIN}/"))
+        # Non-professional recovery is completed by the Django `complete_payment`
+        # view, which is served on the Fight Health Insurance domain. The link
+        # must be absolute, target that host (so non-prod environments don't
+        # email production links and so customers don't hit the Fight Paperwork
+        # SPA's "Invalid Demo Type" catch-all), and carry the unguessable token
+        # rather than the row id.
+        self.assertTrue(
+            link.startswith(f"https://{settings.FIGHT_HEALTH_INSURANCE_DOMAIN}/")
+        )
+        self.assertIn("/stripe/finish?", link)
         self.assertIn(f"token={lost_session.secure_token}", link)
         self.assertNotIn(f"session_id={lost_session.id}", link)
         self.assertNotIn(f"session_id={lost_session.pk}", link)
+
+    @patch(
+        "fighthealthinsurance.helpers.stripe_helpers.fhi_emails.send_checkout_session_expired"
+    )
+    def test_professional_subscription_recovery_link_targets_fpw_spa(
+        self, mock_send_email
+    ):
+        """Professional domain subscriptions resume in the Fight Paperwork SPA."""
+        mock_session = MagicMock()
+        mock_session.id = "cs_unique_for_pro_test"
+        mock_session.metadata = {
+            "payment_type": "professional_domain_subscription",
+            "domain_id": "123",
+            "professional_id": "456",
+        }
+        mock_session.customer_email = "pro@example.com"
+
+        StripeWebhookHelper.handle_checkout_session_expired(self.client, mock_session)
+
+        mock_send_email.assert_called_once()
+        link = mock_send_email.call_args.kwargs["link"]
+        self.assertTrue(link.startswith(f"https://{settings.FIGHT_PAPERWORK_DOMAIN}/"))
+        self.assertIn("/stripe/finish-checkout?", link)
+        self.assertIn("domain_id=123", link)
+        self.assertIn("professional_id=456", link)

--- a/tests/async/test_stripe_webhooks.py
+++ b/tests/async/test_stripe_webhooks.py
@@ -6,7 +6,11 @@ from django.test import TestCase
 from django.urls import reverse
 from django.contrib.auth import get_user_model
 
-from fighthealthinsurance.models import StripeWebhookEvents, LostStripeSession
+from fighthealthinsurance.models import (
+    StripeWebhookEvents,
+    LostStripeSession,
+    StripeRecoveryInfo,
+)
 from fighthealthinsurance.helpers.stripe_helpers import StripeWebhookHelper
 
 User = get_user_model()
@@ -186,9 +190,10 @@ class StripeWebhookTests(TestCase):
     def test_no_recovery_email_for_unrebuildable_payment(self, mock_send_email):
         """Payment types with no line_items/recovery_info don't get a dead link.
 
-        Pay-what-you-want donations only store payment_type/source metadata, so
-        the complete_payment view can't recreate the checkout. We must skip the
-        recovery email rather than send a link that would only error.
+        Legacy donation sessions (created before recovery_info was persisted)
+        only store payment_type/source metadata, so the complete_payment view
+        can't recreate the checkout. We must skip the recovery email rather
+        than send a link that would only error.
         """
         mock_session = MagicMock()
         mock_session.id = "cs_unique_for_donation_test"
@@ -202,6 +207,42 @@ class StripeWebhookTests(TestCase):
         StripeWebhookHelper.handle_checkout_session_expired(self.client, mock_session)
 
         mock_send_email.assert_not_called()
+
+    @patch(
+        "fighthealthinsurance.helpers.stripe_helpers.fhi_emails.send_checkout_session_expired"
+    )
+    def test_donation_with_recovery_info_gets_fhi_recovery_link(self, mock_send_email):
+        """A PWYW donation carrying recovery_info_id gets a working FHI link.
+
+        New donation checkouts persist their line items and reference them via
+        recovery_info_id, so the recovery email points at the Django
+        complete_payment view (which can rebuild the session).
+        """
+        recovery_info = StripeRecoveryInfo.objects.create(
+            items=[
+                {"price_data": {"currency": "usd", "unit_amount": 500}, "quantity": 1}
+            ]
+        )
+        mock_session = MagicMock()
+        mock_session.id = "cs_unique_for_donation_recovery"
+        mock_session.metadata = {
+            "payment_type": "donation",
+            "donation_type": "pwyw",
+            "source": "checkout",
+            "recovery_info_id": str(recovery_info.id),
+        }
+        mock_session.customer_email = "donor@example.com"
+
+        StripeWebhookHelper.handle_checkout_session_expired(self.client, mock_session)
+
+        mock_send_email.assert_called_once()
+        link = mock_send_email.call_args.kwargs["link"]
+        self.assertTrue(
+            link.startswith(f"https://{settings.FIGHT_HEALTH_INSURANCE_DOMAIN}/")
+        )
+        self.assertIn("/stripe/finish?", link)
+        lost_session = LostStripeSession.objects.get(session_id=mock_session.id)
+        self.assertIn(f"token={lost_session.secure_token}", link)
 
     @patch(
         "fighthealthinsurance.helpers.stripe_helpers.fhi_emails.send_checkout_session_expired"

--- a/tests/async/test_stripe_webhooks.py
+++ b/tests/async/test_stripe_webhooks.py
@@ -179,3 +179,42 @@ class StripeWebhookTests(TestCase):
         self.assertIn("/stripe/finish-checkout?", link)
         self.assertIn("domain_id=123", link)
         self.assertIn("professional_id=456", link)
+
+    @patch(
+        "fighthealthinsurance.helpers.stripe_helpers.fhi_emails.send_checkout_session_expired"
+    )
+    def test_no_recovery_email_for_unrebuildable_payment(self, mock_send_email):
+        """Payment types with no line_items/recovery_info don't get a dead link.
+
+        Pay-what-you-want donations only store payment_type/source metadata, so
+        the complete_payment view can't recreate the checkout. We must skip the
+        recovery email rather than send a link that would only error.
+        """
+        mock_session = MagicMock()
+        mock_session.id = "cs_unique_for_donation_test"
+        mock_session.metadata = {
+            "payment_type": "donation",
+            "donation_type": "pwyw",
+            "source": "checkout",
+        }
+        mock_session.customer_email = "donor@example.com"
+
+        StripeWebhookHelper.handle_checkout_session_expired(self.client, mock_session)
+
+        mock_send_email.assert_not_called()
+
+    @patch(
+        "fighthealthinsurance.helpers.stripe_helpers.fhi_emails.send_checkout_session_expired"
+    )
+    def test_no_recovery_email_when_professional_ids_missing(self, mock_send_email):
+        """A professional subscription without domain/professional ids is skipped."""
+        mock_session = MagicMock()
+        mock_session.id = "cs_unique_for_pro_missing_ids"
+        mock_session.metadata = {
+            "payment_type": "professional_domain_subscription",
+        }
+        mock_session.customer_email = "pro@example.com"
+
+        StripeWebhookHelper.handle_checkout_session_expired(self.client, mock_session)
+
+        mock_send_email.assert_not_called()

--- a/tests/sync/test_pwyw_checkout.py
+++ b/tests/sync/test_pwyw_checkout.py
@@ -2,6 +2,8 @@ import json
 from django.test import TestCase, Client
 from unittest.mock import patch, MagicMock
 
+from fighthealthinsurance.models import StripeRecoveryInfo
+
 
 class PWYWCheckoutTest(TestCase):
     def setUp(self):
@@ -116,6 +118,29 @@ class PWYWCheckoutTest(TestCase):
             call_kwargs = mock_stripe_create.call_args[1]
             self.assertTrue(call_kwargs["success_url"].endswith("/?donation=success"))
             self.assertFalse("evil.com" in call_kwargs["success_url"])
+
+    @patch("stripe.checkout.Session.create")
+    def test_pwyw_checkout_persists_recovery_info(self, mock_stripe_create):
+        """The donation checkout stores recovery info so an expired link can rebuild it."""
+        mock_session = MagicMock()
+        mock_session.url = "https://checkout.stripe.com/test"
+        mock_stripe_create.return_value = mock_session
+
+        response = self.client.post(
+            "/v0/pwyw/checkout",
+            data=json.dumps({"amount": 30}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        call_kwargs = mock_stripe_create.call_args[1]
+        # A StripeRecoveryInfo holding the line items must be created and
+        # referenced in the metadata so CompletePaymentView can rebuild the
+        # session from the recovery email link.
+        recovery_info_id = call_kwargs["metadata"]["recovery_info_id"]
+        recovery_info = StripeRecoveryInfo.objects.get(id=recovery_info_id)
+        self.assertEqual(recovery_info.items, call_kwargs["line_items"])
+        self.assertEqual(recovery_info.items[0]["price_data"]["unit_amount"], 30 * 100)
 
     @patch("stripe.checkout.Session.create")
     def test_pwyw_checkout_stripe_error(self, mock_stripe_create):


### PR DESCRIPTION
The Stripe checkout recovery email built its "finish" link against
FIGHT_PAPERWORK_DOMAIN for every payment type. That domain serves the
Fight Paperwork React SPA, which has no /stripe/finish route, so its
router treated "stripe" as a demo-type path segment and rendered
"Invalid Demo Type. Demo type must be either pharma or dme." The Django
complete_payment view that actually handles /stripe/finish is served on
the Fight Health Insurance domain.

Split the two recovery flows in a new _build_recovery_link helper:
- professional domain subscriptions resume in the Fight Paperwork SPA
  (/stripe/finish-checkout), built from settings instead of a hardcoded
  production URL
- all other payment types (patient appeals, fax, pay-what-you-want)
  resume via the Django complete_payment view on the Fight Health
  Insurance domain, carrying the unguessable secure_token

Also improve the patient resume experience: CompletePaymentView GET now
302-redirects browser visitors straight to Stripe instead of dumping raw
JSON, renders a friendly HTML error page on failure, and keeps the JSON
API contract for POST and ?format=json callers.

https://claude.ai/code/session_01Ch6Zc5fKjzxoqsTFWLDc41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JSON response support for payment completion requests via `?format=json` parameter
  * New error page for handling expired or reused Stripe checkout recovery links

* **Bug Fixes**
  * Enhanced abandoned cart recovery for professional subscriptions with improved link generation
  * Improved error handling and user messaging for payment recovery failures

* **Tests**
  * Expanded test coverage for JSON and redirect response paths
  * Added validation tests for professional subscription recovery links

<!-- end of auto-generated comment: release notes by coderabbit.ai -->