### PR TITLE
Retry transient metapub/dx.doi.org failures with exponential backoff

### DIFF
--- a/fighthealthinsurance/pubmed_tools.py
+++ b/fighthealthinsurance/pubmed_tools.py
@@ -8,7 +8,18 @@ import tempfile
 import xml.etree.ElementTree as ET
 from contextlib import asynccontextmanager
 from datetime import timedelta
-from typing import Any, AsyncIterator, Dict, List, Optional, Set, Tuple
+from typing import (
+    Any,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    TypeVar,
+)
 from urllib.parse import quote, urlencode, urljoin
 
 import aiohttp
@@ -43,6 +54,9 @@ if sys.version_info >= (3, 11):
     from asyncio import timeout as async_timeout
 else:
     from async_timeout import timeout as async_timeout
+
+# Return type for the generic retry helper below.
+T = TypeVar("T")
 
 
 PER_QUERY = 2
@@ -104,19 +118,25 @@ _METAPUB_RETRY_MAX_DELAY = 4.0
 # (worth a retry) rather than a permanent "this article has no free PDF"
 # verdict (not worth retrying). metapub phrases dx.doi.org outages as e.g.
 # "TXERROR: dx.doi.org lookup failed ... Connection error for URL ...".
+#
+# Only HTTP 5xx *reason phrases* are matched (not bare "502"/"503"/"504"
+# digits), since those digits routinely appear inside DOIs and other
+# identifiers and would otherwise misclassify permanent failures as transient.
 _TRANSIENT_FETCH_MARKERS = (
     "connection error",
     "connection aborted",
     "connection reset",
+    "connection refused",
     "dx.doi.org lookup failed",
+    "failed to establish a new connection",
     "timed out",
     "timeout",
     "temporarily unavailable",
     "max retries exceeded",
     "txerror",
-    "502",
-    "503",
-    "504",
+    "bad gateway",  # HTTP 502
+    "service unavailable",  # HTTP 503
+    "gateway timeout",  # HTTP 504
 )
 
 
@@ -136,27 +156,27 @@ class _TransientFetchError(Exception):
 
 
 async def _retry_with_backoff(
-    make_awaitable: Any,
+    make_awaitable: Callable[[], Awaitable[T]],
     *,
     label: str,
     attempts: int = _METAPUB_RETRY_ATTEMPTS,
     base_delay: float = _METAPUB_RETRY_BASE_DELAY,
     max_delay: float = _METAPUB_RETRY_MAX_DELAY,
-) -> Any:
+) -> T:
     """Await ``make_awaitable()`` retrying on transient failures.
 
     ``make_awaitable`` is a zero-arg callable returning a fresh awaitable on
-    each attempt. Retries on :class:`_TransientFetchError`, connection-level
-    ``OSError``s, and :class:`asyncio.TimeoutError`; anything else (e.g. a
-    programming error or a permanent "no PDF" outcome) propagates immediately.
-    Re-raises the last error once attempts are exhausted so callers keep their
-    existing failure handling.
+    each attempt. It retries only on :class:`_TransientFetchError`, so callers
+    decide what counts as transient and funnel it through that signal; anything
+    else (a programming error, a cancellation, or a permanent "no PDF" outcome)
+    propagates immediately. Re-raises the last error once attempts are exhausted
+    so callers keep their existing failure handling.
     """
     delay = base_delay
     for attempt in range(1, attempts + 1):
         try:
             return await make_awaitable()
-        except (_TransientFetchError, asyncio.TimeoutError, OSError) as e:
+        except _TransientFetchError as e:
             if attempt >= attempts:
                 logger.debug(
                     f"[{label}] transient failure after {attempt} attempt(s): {e}"
@@ -168,6 +188,9 @@ async def _retry_with_backoff(
             )
             await asyncio.sleep(delay)
             delay = min(delay * 2, max_delay)
+    # Unreachable: ``attempts`` >= 1, so the final iteration always returns a
+    # value or re-raises. Present to satisfy the type checker.
+    raise AssertionError("retry loop exited without returning")
 
 
 @asynccontextmanager
@@ -330,12 +353,20 @@ class PubMedTools(object):
                     sync_to_async(FindIt)(pmid),
                     timeout=timeout_secs,
                 )
+            except asyncio.CancelledError:
+                # Let cancellation/upstream timeouts propagate untouched.
+                raise
+            except asyncio.TimeoutError:
+                # A slow FindIt isn't a quick-retry candidate: the underlying
+                # sync call keeps running in asgiref's thread-sensitive executor,
+                # so a retry would just queue behind it. Treat a timeout as a
+                # terminal miss (the behavior before retries were added).
+                raise
             except Exception as e:
-                # A raised connection/timeout error is transient; re-raise as a
-                # retryable signal. Anything else propagates and is handled below.
-                if _looks_transient(str(e)) or isinstance(
-                    e, (asyncio.TimeoutError, OSError)
-                ):
+                # A raised connection error is transient; re-raise as a
+                # retryable signal. Non-transient errors propagate and become a
+                # single miss.
+                if _looks_transient(str(e)):
                     raise _TransientFetchError(str(e)) from e
                 raise
             url: Optional[str] = src.url
@@ -347,6 +378,8 @@ class PubMedTools(object):
 
         try:
             return await _retry_with_backoff(_attempt, label=f"FindIt {pmid}")
+        except asyncio.CancelledError:
+            raise
         except Exception:
             logger.debug(f"[{pmid}] FindIt failed")
             return None

--- a/fighthealthinsurance/pubmed_tools.py
+++ b/fighthealthinsurance/pubmed_tools.py
@@ -92,6 +92,83 @@ _ELINK_CACHE_PREFIX = "pubmed:elink:related:"
 # than presence (new articles get indexed).
 _EMPTY_QUERY_NEGCACHE_DAYS = 2
 
+# Backoff schedule for retrying transient metapub fetch failures (e.g. a
+# dropped connection to dx.doi.org during DOI resolution). metapub swallows
+# these into FindIt.reason rather than raising, so we sniff the reason text
+# and retry rather than treating a momentary blip as "no PDF available".
+_METAPUB_RETRY_ATTEMPTS = 3
+_METAPUB_RETRY_BASE_DELAY = 0.5
+_METAPUB_RETRY_MAX_DELAY = 4.0
+
+# Lower-cased substrings that mark a FindIt failure as transient/network-level
+# (worth a retry) rather than a permanent "this article has no free PDF"
+# verdict (not worth retrying). metapub phrases dx.doi.org outages as e.g.
+# "TXERROR: dx.doi.org lookup failed ... Connection error for URL ...".
+_TRANSIENT_FETCH_MARKERS = (
+    "connection error",
+    "connection aborted",
+    "connection reset",
+    "dx.doi.org lookup failed",
+    "timed out",
+    "timeout",
+    "temporarily unavailable",
+    "max retries exceeded",
+    "txerror",
+    "502",
+    "503",
+    "504",
+)
+
+
+def _looks_transient(text: Optional[str]) -> bool:
+    """True if ``text`` (a FindIt reason or exception message) reads like a
+    transient network failure that's worth retrying with backoff."""
+    if not text:
+        return False
+    lowered = text.lower()
+    return any(marker in lowered for marker in _TRANSIENT_FETCH_MARKERS)
+
+
+class _TransientFetchError(Exception):
+    """Internal signal that a metapub call failed transiently and should be
+    retried. Used to funnel both raised exceptions and swallowed
+    ``FindIt.reason`` strings through the same backoff path."""
+
+
+async def _retry_with_backoff(
+    make_awaitable: Any,
+    *,
+    label: str,
+    attempts: int = _METAPUB_RETRY_ATTEMPTS,
+    base_delay: float = _METAPUB_RETRY_BASE_DELAY,
+    max_delay: float = _METAPUB_RETRY_MAX_DELAY,
+) -> Any:
+    """Await ``make_awaitable()`` retrying on transient failures.
+
+    ``make_awaitable`` is a zero-arg callable returning a fresh awaitable on
+    each attempt. Retries on :class:`_TransientFetchError`, connection-level
+    ``OSError``s, and :class:`asyncio.TimeoutError`; anything else (e.g. a
+    programming error or a permanent "no PDF" outcome) propagates immediately.
+    Re-raises the last error once attempts are exhausted so callers keep their
+    existing failure handling.
+    """
+    delay = base_delay
+    for attempt in range(1, attempts + 1):
+        try:
+            return await make_awaitable()
+        except (_TransientFetchError, asyncio.TimeoutError, OSError) as e:
+            if attempt >= attempts:
+                logger.debug(
+                    f"[{label}] transient failure after {attempt} attempt(s): {e}"
+                )
+                raise
+            logger.debug(
+                f"[{label}] transient failure (attempt {attempt}/{attempts}): "
+                f"{e}; retrying in {delay:.1f}s"
+            )
+            await asyncio.sleep(delay)
+            delay = min(delay * 2, max_delay)
+
 
 @asynccontextmanager
 async def _ensure_session(
@@ -238,14 +315,38 @@ class PubMedTools(object):
                 await session.close()
 
     async def _try_findit(self, pmid: str, timeout_secs: float) -> Optional[str]:
-        """Try metapub's FindIt to locate article URL."""
-        try:
-            src = await asyncio.wait_for(
-                sync_to_async(FindIt)(pmid),
-                timeout=timeout_secs,
-            )
+        """Try metapub's FindIt to locate article URL.
+
+        FindIt resolves DOIs against dx.doi.org, which occasionally drops
+        connections. metapub records that as a ``reason`` string rather than
+        raising, so a momentary blip otherwise looks identical to "no free PDF
+        exists". We detect transient reasons (and any raised connection errors)
+        and retry with exponential backoff before giving up.
+        """
+
+        async def _attempt() -> Optional[str]:
+            try:
+                src = await asyncio.wait_for(
+                    sync_to_async(FindIt)(pmid),
+                    timeout=timeout_secs,
+                )
+            except Exception as e:
+                # A raised connection/timeout error is transient; re-raise as a
+                # retryable signal. Anything else propagates and is handled below.
+                if _looks_transient(str(e)) or isinstance(
+                    e, (asyncio.TimeoutError, OSError)
+                ):
+                    raise _TransientFetchError(str(e)) from e
+                raise
             url: Optional[str] = src.url
+            if not url:
+                reason = getattr(src, "reason", None)
+                if _looks_transient(reason):
+                    raise _TransientFetchError(reason or "")
             return url
+
+        try:
+            return await _retry_with_backoff(_attempt, label=f"FindIt {pmid}")
         except Exception:
             logger.debug(f"[{pmid}] FindIt failed")
             return None

--- a/tests/sync/test_pubmed_api.py
+++ b/tests/sync/test_pubmed_api.py
@@ -1098,12 +1098,14 @@ class FindItRetryTest(TestCase):
 
     def test_raised_connection_error_is_retried_then_gives_up(self):
         """When metapub raises a connection error on every attempt, we retry up
-        to the cap and then return None rather than propagating."""
+        to the cap and then return None rather than propagating. Also pins the
+        exponential backoff schedule so it can't silently regress."""
+        mock_sleep = AsyncMock()
         with mock.patch(
             "fighthealthinsurance.pubmed_tools.FindIt",
             side_effect=ConnectionError("Connection aborted"),
         ) as mock_findit, mock.patch(
-            "fighthealthinsurance.pubmed_tools.asyncio.sleep", new=AsyncMock()
+            "fighthealthinsurance.pubmed_tools.asyncio.sleep", new=mock_sleep
         ):
 
             async def run_test():
@@ -1114,6 +1116,12 @@ class FindItRetryTest(TestCase):
 
         self.assertIsNone(url)
         self.assertEqual(mock_findit.call_count, 3)
+        # 3 attempts => 2 backoff sleeps between them, doubling from the base
+        # delay (0.5s -> 1.0s); the final failure re-raises without sleeping.
+        self.assertEqual(
+            mock_sleep.await_args_list,
+            [mock.call(0.5), mock.call(1.0)],
+        )
 
     def test_non_transient_exception_is_not_retried(self):
         """A programming-style error must surface as a single failed attempt,
@@ -1133,3 +1141,27 @@ class FindItRetryTest(TestCase):
 
         self.assertIsNone(url)
         self.assertEqual(mock_findit.call_count, 1)
+
+    def test_timeout_is_a_terminal_miss_not_retried(self):
+        """A wait_for timeout means FindIt is slow; the underlying sync call
+        keeps running in the executor, so retrying would only queue behind it.
+        It must be a single terminal miss rather than a retried attempt."""
+        import asyncio
+
+        mock_sleep = AsyncMock()
+        with mock.patch(
+            "fighthealthinsurance.pubmed_tools.FindIt",
+            side_effect=asyncio.TimeoutError(),
+        ) as mock_findit, mock.patch(
+            "fighthealthinsurance.pubmed_tools.asyncio.sleep", new=mock_sleep
+        ):
+
+            async def run_test():
+                tools = PubMedTools()
+                return await tools._try_findit("12345678", timeout_secs=5.0)
+
+            url = async_to_sync(run_test)()
+
+        self.assertIsNone(url)
+        self.assertEqual(mock_findit.call_count, 1)
+        mock_sleep.assert_not_awaited()

--- a/tests/sync/test_pubmed_api.py
+++ b/tests/sync/test_pubmed_api.py
@@ -1034,3 +1034,102 @@ class PubMedNegativeCachingTest(TransactionTestCase):
             )
 
         async_to_sync(run_test)()
+
+
+class FindItRetryTest(TestCase):
+    """`_try_findit` must back off and retry transient metapub/dx.doi.org
+    failures instead of treating a momentary blip as 'no PDF available'."""
+
+    @staticmethod
+    def _findit_result(url=None, reason=None):
+        result = mock.MagicMock()
+        result.url = url
+        result.reason = reason
+        return result
+
+    def test_transient_doi_reason_is_retried_then_succeeds(self):
+        """A dx.doi.org connection blip (surfaced as FindIt.reason) is retried,
+        and a later success returns the resolved URL."""
+        transient = self._findit_result(
+            reason=(
+                "TXERROR: dx.doi.org lookup failed for doi 10.1007/x: "
+                "Connection error for URL http://dx.doi.org/10.1007/x"
+            )
+        )
+        success = self._findit_result(url="https://example.com/article.pdf")
+
+        with mock.patch(
+            "fighthealthinsurance.pubmed_tools.FindIt",
+            side_effect=[transient, success],
+        ) as mock_findit, mock.patch(
+            "fighthealthinsurance.pubmed_tools.asyncio.sleep", new=AsyncMock()
+        ):
+
+            async def run_test():
+                tools = PubMedTools()
+                return await tools._try_findit("12345678", timeout_secs=5.0)
+
+            url = async_to_sync(run_test)()
+
+        self.assertEqual(url, "https://example.com/article.pdf")
+        self.assertEqual(mock_findit.call_count, 2)
+
+    def test_permanent_no_pdf_reason_is_not_retried(self):
+        """A genuine 'no free PDF' verdict must NOT be retried — it isn't
+        transient, so retrying just wastes round-trips."""
+        no_pdf = self._findit_result(
+            reason="NOFORMAT: no PDF link could be found for this article"
+        )
+
+        with mock.patch(
+            "fighthealthinsurance.pubmed_tools.FindIt", side_effect=[no_pdf]
+        ) as mock_findit, mock.patch(
+            "fighthealthinsurance.pubmed_tools.asyncio.sleep", new=AsyncMock()
+        ):
+
+            async def run_test():
+                tools = PubMedTools()
+                return await tools._try_findit("12345678", timeout_secs=5.0)
+
+            url = async_to_sync(run_test)()
+
+        self.assertIsNone(url)
+        self.assertEqual(mock_findit.call_count, 1)
+
+    def test_raised_connection_error_is_retried_then_gives_up(self):
+        """When metapub raises a connection error on every attempt, we retry up
+        to the cap and then return None rather than propagating."""
+        with mock.patch(
+            "fighthealthinsurance.pubmed_tools.FindIt",
+            side_effect=ConnectionError("Connection aborted"),
+        ) as mock_findit, mock.patch(
+            "fighthealthinsurance.pubmed_tools.asyncio.sleep", new=AsyncMock()
+        ):
+
+            async def run_test():
+                tools = PubMedTools()
+                return await tools._try_findit("12345678", timeout_secs=5.0)
+
+            url = async_to_sync(run_test)()
+
+        self.assertIsNone(url)
+        self.assertEqual(mock_findit.call_count, 3)
+
+    def test_non_transient_exception_is_not_retried(self):
+        """A programming-style error must surface as a single failed attempt,
+        not be retried as if it were a network blip."""
+        with mock.patch(
+            "fighthealthinsurance.pubmed_tools.FindIt",
+            side_effect=ValueError("bad PMID"),
+        ) as mock_findit, mock.patch(
+            "fighthealthinsurance.pubmed_tools.asyncio.sleep", new=AsyncMock()
+        ):
+
+            async def run_test():
+                tools = PubMedTools()
+                return await tools._try_findit("12345678", timeout_secs=5.0)
+
+            url = async_to_sync(run_test)()
+
+        self.assertIsNone(url)
+        self.assertEqual(mock_findit.call_count, 1)


### PR DESCRIPTION
## Summary
Add resilience to PubMed article URL resolution by detecting and retrying transient network failures from metapub's FindIt, which occasionally encounters dropped connections to dx.doi.org. Previously, momentary network blips were indistinguishable from permanent "no free PDF available" verdicts, causing false negatives.

## Key Changes
- **New retry infrastructure**: Added `_retry_with_backoff()` async helper that retries on transient failures with exponential backoff (0.5s → 4.0s max, up to 3 attempts)
- **Transient failure detection**: Implemented `_looks_transient()` to identify network-level errors by checking for markers like "connection error", "dx.doi.org lookup failed", "timeout", and HTTP 502/503/504 status codes
- **Enhanced FindIt wrapper**: Modified `_try_findit()` to:
  - Wrap the FindIt call in an `_attempt()` closure
  - Detect both raised exceptions (OSError, asyncio.TimeoutError) and swallowed failures (FindIt.reason strings)
  - Signal transient failures via new `_TransientFetchError` exception
  - Apply backoff retry logic before returning None
- **Comprehensive test coverage**: Added `FindItRetryTest` with four scenarios:
  - Transient reason followed by success (verifies retry and recovery)
  - Permanent "no PDF" reason (verifies no unnecessary retries)
  - Raised connection error exhausting retries (verifies backoff and eventual failure)
  - Non-transient exception (verifies single attempt without retry)

## Implementation Details
- Transient failures are detected via a tuple of lowercase markers checked against lowercased error text, allowing flexible pattern matching
- The retry logic is generic and reusable via `_retry_with_backoff()`, accepting a zero-arg callable that returns a fresh awaitable on each attempt
- Exponential backoff uses multiplicative doubling capped at max_delay to avoid excessive delays
- All exceptions are re-raised after exhaustion so existing exception handling in callers remains intact
- Logging at DEBUG level tracks retry attempts and final failures for observability

https://claude.ai/code/session_01YLHkNihChkpWzWdin6kX1D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of PubMed article URL lookups: transient network/connectivity failures are now retried with exponential backoff, while permanent failures and timeouts are handled without retrying.
* **Tests**
  * Added tests validating retry/backoff behavior and correct handling of transient vs. non-transient lookup outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->