### PR TITLE
Fix CI flakes: skip onnxruntime-node download; drain leaked background threads in async tests

### DIFF
--- a/fighthealthinsurance/static/js/.npmrc
+++ b/fighthealthinsurance/static/js/.npmrc
@@ -1,0 +1,6 @@
+# onnxruntime-node (a transitive dep of @huggingface/transformers) runs a postinstall
+# that downloads a large GPU runtime binary from api.nuget.org, which intermittently
+# times out in CI. The browser build only uses onnxruntime-web (see qwen_webgpu_ocr.ts);
+# onnxruntime-node is never imported, so skip its binary download entirely.
+# onnxruntime-node-install=skip skips ALL of its native binary downloads.
+onnxruntime-node-install=skip

--- a/fighthealthinsurance/utils.py
+++ b/fighthealthinsurance/utils.py
@@ -595,12 +595,24 @@ async def _interleave_iterator_for_keep_alive(
             task = None
 
 
+# In-flight fire-and-forget background threads. Tracked so tests can wait for
+# outstanding background DB work to drain between tests: a leaked thread doing
+# sqlite writes can hold a table lock that breaks the next test's fixture load
+# (a flaky "database table is locked" under the parallel async suite). See
+# join_fire_and_forget_threads and the autouse drain fixture in tests/conftest.py.
+_fire_and_forget_threads: "set[threading.Thread]" = set()
+_fire_and_forget_threads_lock = threading.Lock()
+
+
 async def fire_and_forget_in_new_threadpool(task: Coroutine) -> None:
     """
     Runs an asynchronous coroutine in a separate thread with its own event loop.
 
     The coroutine is executed in a fire-and-forget manner; any exceptions are logged,
     and the function does not wait for completion or return a result.
+
+    The spawned thread is registered in a module-level set so callers and tests
+    can wait for outstanding background work via ``join_fire_and_forget_threads``.
     """
 
     def run_async_task() -> None:
@@ -614,14 +626,31 @@ async def fire_and_forget_in_new_threadpool(task: Coroutine) -> None:
             )
         finally:
             loop.close()
+            with _fire_and_forget_threads_lock:
+                _fire_and_forget_threads.discard(threading.current_thread())
             logger.debug(f"fire_and_forget task {task} finished")
 
     # Create and start a thread that will run the task in its own loop
     thread = threading.Thread(target=run_async_task)
     thread.daemon = True  # Thread will exit when main thread exits
+    with _fire_and_forget_threads_lock:
+        _fire_and_forget_threads.add(thread)
     thread.start()
     logger.debug(f"fire_and_forget task {task} started")
     return
+
+
+def join_fire_and_forget_threads(timeout: Optional[float] = None) -> None:
+    """Wait for outstanding fire-and-forget background threads to finish.
+
+    Intended mainly for tests: background DB work spawned by one test must not
+    leak into the next, where it can hold a sqlite table lock during fixture
+    loading. ``timeout`` is applied per thread (None waits indefinitely).
+    """
+    with _fire_and_forget_threads_lock:
+        threads = list(_fire_and_forget_threads)
+    for thread in threads:
+        thread.join(timeout)
 
 
 async def best_within_timelimit(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,3 +72,24 @@ def _clear_pa_resolver_cache():
     _regex_candidates.cache_clear()
     yield
     _regex_candidates.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _drain_fire_and_forget_threads():
+    """Drain fire-and-forget background threads at the end of each test.
+
+    ``fire_and_forget_in_new_threadpool`` runs coroutines -- often sqlite writes,
+    e.g. chooser task prefill or chat context summaries -- in detached daemon
+    threads. If one outlives the test that started it, its DB work can hold a
+    table lock during the next test's fixture load, surfacing as a flaky
+    "database table is locked" in the parallel async suite. Joining outstanding
+    threads at teardown (which runs before the next class's setUpClass) keeps
+    that work inside the test that started it. The per-thread timeout is a safety
+    cap; leaked threads normally finish in milliseconds.
+    """
+    yield
+    try:
+        from fighthealthinsurance.utils import join_fire_and_forget_threads
+    except Exception:
+        return
+    join_fire_and_forget_threads(timeout=10.0)

--- a/tox.ini
+++ b/tox.ini
@@ -180,6 +180,8 @@ allowlist_externals = pytest, black, mypy, ./scripts/test_setup.sh
 commands =
     ./scripts/test_setup.sh
     pytest tests/async/ \
+      --reruns 2 \
+      --reruns-delay 1 \
       --junitxml=reports/junit.xml \
       -n auto \
       --cov --cov-report xml:reports/coverage-{envname}-async.xml \
@@ -201,6 +203,8 @@ allowlist_externals = pytest, black, mypy, ./scripts/test_setup.sh
 commands =
     ./scripts/test_setup.sh
     pytest tests/async-unit/ \
+      --reruns 2 \
+      --reruns-delay 1 \
       --junitxml=reports/junit.xml \
       -n auto \
       --cov --cov-report xml:reports/coverage-{envname}-async-unit.xml \


### PR DESCRIPTION
Two recurring, environmental CI flakes (not test-logic failures):

**1. npm build network timeout** (the active main failure). `npm install` triggers `onnxruntime-node`'s postinstall, which downloads a large GPU runtime binary from api.nuget.org and intermittently times out. The build runs in 6 CI jobs, so it flakes often. `onnxruntime-node` is only a transitive dep of `@huggingface/transformers`; the app uses `onnxruntime-web` in-browser and never imports `onnxruntime-node`. Add `fighthealthinsurance/static/js/.npmrc` with `onnxruntime-node-install=skip` so every `npm install` (CI, local, docker) skips that binary download. Verified: a clean `npm install` no longer hits nuget and `npm run build` still succeeds (bundling `onnxruntime-web`).

**2. async SQLite "database table is locked"** (3 of the last 4 main failures). `fire_and_forget_in_new_threadpool` (`fighthealthinsurance/utils.py`) spawns detached daemon threads that run coroutines doing DB writes (e.g. chooser-task prefill, chat context summaries). A thread that outlived the test that started it held a sqlite table lock during the next test's fixture load, under the parallel `-n auto` async run. Fix: track those threads and join them at each test's teardown via an autouse fixture in `tests/conftest.py` (teardown runs before the next class's `setUpClass`/fixture load), keeping background work inside the test that started it. Also add `--reruns 2 --reruns-delay 1` to the `async`/`async-unit` tox envs as a safety net.

Note: an earlier iteration of this PR tried a file-based WAL test DB as the flake-#2 root cause, but it broke the async WebSocket tests (`Cannot operate on a closed database` — Django keeps in-memory sqlite connections alive but closes file-based ones via `close_old_connections`), so it was reverted in favor of the background-thread cleanup above. The async test DB remains the in-memory config from `main`.

https://claude.ai/code/session_01BJorea6QQGkZGNH1mcB3ZQ