### PR TITLE
Add .claude/worktrees/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,6 @@ memory
 
 # metapub auto-generated db
 default/
+
+# Claude Code agent worktrees (transient, created by background agents)
+.claude/worktrees/


### PR DESCRIPTION
## Summary
Updated `.gitignore` to exclude the `.claude/worktrees/` directory, which contains transient worktrees created by Claude Code background agents.

## Changes
- Added `.claude/worktrees/` to `.gitignore` with a descriptive comment explaining that these are transient directories created by background agents

## Details
This prevents temporary worktree directories created during Claude Code agent operations from being accidentally committed to the repository. These are ephemeral artifacts that should not be version controlled.

https://claude.ai/code/session_01PMbjda5sJvbEVzmnahSBZU