### PR TITLE
Gate free-text PA code scan on PA/CPT context to stop false requirements

### DIFF
--- a/fighthealthinsurance/pa_requirement_parsers.py
+++ b/fighthealthinsurance/pa_requirement_parsers.py
@@ -80,23 +80,27 @@ _INLINE_CODE = re.compile(
 # ``_INLINE_CODE`` regex matches any bare 5-digit number (ZIP codes, dollar
 # amounts, member/group IDs, fax/phone fragments) and would fabricate
 # "requires prior authorization" rows. Compared lowercase against ``ctx_lower``.
-_PA_CONTEXT_CUES: frozenset = frozenset(
+# Cues are kept specific on purpose: a bare ``"authorization"`` matches
+# incidental fragments like ``"Authorization # 12345"`` and a bare
+# ``"procedure"`` matches ``"Procedure date: 90210"`` — both would re-introduce
+# false PA rows from incidental 5-digit numbers. ``"procedure code"`` already
+# covers ``"procedure codes"`` via substring.
+_PA_CONTEXT_CUES: frozenset[str] = frozenset(
     {
         "prior auth",
         "prior authorization",
+        "authorization required",
         "preauth",
         "pre-auth",
         "precert",
         "pre-cert",
         "precertification",
-        "authorization",
         "auth required",
         "requires pa",
         "pa required",
         "cpt",
         "hcpcs",
         "procedure code",
-        "procedure",
     }
 )
 

--- a/fighthealthinsurance/pa_requirement_parsers.py
+++ b/fighthealthinsurance/pa_requirement_parsers.py
@@ -74,6 +74,32 @@ _INLINE_CODE = re.compile(
     r"\b(\d{5}|[ABCDEGHJKLPQRSTV]\d{4})(?:[-\s][A-Z0-9]{2})?\b", re.IGNORECASE
 )
 
+# Positive context cues that mark a free-text token as a CPT/HCPCS code inside a
+# prior-authorization listing. ``_scan_text_for_codes`` only emits a record when
+# one of these appears in the surrounding context window; without this gate the
+# ``_INLINE_CODE`` regex matches any bare 5-digit number (ZIP codes, dollar
+# amounts, member/group IDs, fax/phone fragments) and would fabricate
+# "requires prior authorization" rows. Compared lowercase against ``ctx_lower``.
+_PA_CONTEXT_CUES: frozenset = frozenset(
+    {
+        "prior auth",
+        "prior authorization",
+        "preauth",
+        "pre-auth",
+        "precert",
+        "pre-cert",
+        "precertification",
+        "authorization",
+        "auth required",
+        "requires pa",
+        "pa required",
+        "cpt",
+        "hcpcs",
+        "procedure code",
+        "procedure",
+    }
+)
+
 # Column header keywords → canonical field names. Headers are normalised
 # (lowercased, whitespace squashed) before lookup.
 _COLUMN_ALIASES: Dict[str, str] = {
@@ -374,6 +400,12 @@ def _scan_text_for_codes(
             code = m.group(1).upper()
             context = " ".join(lines[max(0, i - 1) : i + 3])
             ctx_lower = context.lower()
+            # Require positive PA/CPT context before treating the token as a
+            # code. Without a cue nearby it is almost certainly an incidental
+            # 5-digit number (ZIP, dollar amount, member/group ID, fax/phone),
+            # not a procedure code that requires prior authorization.
+            if not any(cue in ctx_lower for cue in _PA_CONTEXT_CUES):
+                continue
             requires_pa = True
             notification_only = False
             if any(

--- a/tests/sync/test_pa_requirement_parsers.py
+++ b/tests/sync/test_pa_requirement_parsers.py
@@ -382,3 +382,16 @@ class ScanTextForCodesTests(TestCase):
         reqs = _scan_text_for_codes(text, source_document="payer.pdf")
         self.assertTrue(reqs)
         self.assertTrue(all(r.source_document == "payer.pdf" for r in reqs))
+
+    def test_authorization_number_fragment_yields_nothing(self):
+        # A bare "Authorization # 12345" fragment is an incidental reference
+        # number, not a PA code listing. With the broad "authorization" cue
+        # removed, the lone 5-digit token must no longer be emitted.
+        reqs = _scan_text_for_codes("Authorization # 12345")
+        self.assertEqual(reqs, [])
+
+    def test_procedure_date_fragment_yields_nothing(self):
+        # "Procedure date: 90210" carries the word "procedure" but no
+        # "procedure code" cue; the bare 5-digit date token must be ignored.
+        reqs = _scan_text_for_codes("Procedure date: 90210")
+        self.assertEqual(reqs, [])

--- a/tests/sync/test_pa_requirement_parsers.py
+++ b/tests/sync/test_pa_requirement_parsers.py
@@ -15,6 +15,7 @@ from fighthealthinsurance.pa_requirement_parsers import (
     _dedupe,
     _map_columns,
     _rows_to_requirements,
+    _scan_text_for_codes,
     apply_enrichment,
     enrichment_for_host,
     parse_csv_pa_list,
@@ -310,3 +311,74 @@ class CSVParserTests(TestCase):
         )
         reqs = parse_csv_pa_list(csv_data)
         self.assertEqual(len(reqs), 1)
+
+
+class ScanTextForCodesTests(TestCase):
+    """Free-text fallback scanning (used for PDF pages with no detectable table).
+
+    The scanner must only emit requirements when surrounding text carries a
+    positive PA/CPT cue; otherwise incidental 5-digit numbers (ZIPs, dollar
+    amounts, member/group IDs) would become false "requires prior auth" rows.
+    """
+
+    def test_bare_non_code_numbers_without_pa_context_yield_nothing(self):
+        # Member/group IDs and a ZIP code all match the 5-digit _INLINE_CODE
+        # regex but appear with no PA/CPT context — none should be emitted.
+        text = "Member ID: 12345\n" "Group Number: 67890\n" "ZIP: 90210"
+        reqs = _scan_text_for_codes(text)
+        self.assertEqual(reqs, [])
+
+    def test_dollar_amount_without_pa_context_yields_nothing(self):
+        # "$10,000" extracts a bare "10000"; without PA context it must be
+        # ignored rather than treated as a procedure code.
+        text = "Estimated out-of-pocket maximum is $10,000 per plan year."
+        reqs = _scan_text_for_codes(text)
+        self.assertEqual(reqs, [])
+
+    def test_code_with_pa_context_is_extracted(self):
+        text = (
+            "The following CPT codes require prior authorization:\n"
+            "72148 MRI lumbar spine"
+        )
+        reqs = _scan_text_for_codes(text)
+        self.assertEqual(len(reqs), 1)
+        self.assertEqual(reqs[0].cpt_hcpcs_code, "72148")
+        self.assertTrue(reqs[0].requires_pa)
+
+    def test_negative_phrase_with_context_sets_requires_pa_false(self):
+        text = "CPT 72148 does not require prior authorization."
+        reqs = _scan_text_for_codes(text)
+        self.assertEqual(len(reqs), 1)
+        self.assertEqual(reqs[0].cpt_hcpcs_code, "72148")
+        self.assertFalse(reqs[0].requires_pa)
+
+    def test_notification_only_context_sets_flag(self):
+        # Advance-notification language carries a "procedure code" cue but no
+        # "authorization", so the record is flagged notification-only.
+        text = (
+            "Advance notification is required for the following procedure codes:\n"
+            "27447 Total knee arthroplasty"
+        )
+        reqs = _scan_text_for_codes(text)
+        self.assertEqual(len(reqs), 1)
+        self.assertEqual(reqs[0].cpt_hcpcs_code, "27447")
+        self.assertTrue(reqs[0].notification_only)
+        self.assertTrue(reqs[0].requires_pa)
+
+    def test_hcpcs_code_with_pa_context_is_extracted(self):
+        text = (
+            "HCPCS codes requiring prior authorization:\n" "J0490 Belimumab injection"
+        )
+        reqs = _scan_text_for_codes(text)
+        self.assertEqual(len(reqs), 1)
+        self.assertEqual(reqs[0].cpt_hcpcs_code, "J0490")
+        self.assertTrue(reqs[0].requires_pa)
+
+    def test_source_document_is_propagated(self):
+        text = (
+            "Prior authorization is required for procedure code 72148.\n"
+            "72148 MRI lumbar spine"
+        )
+        reqs = _scan_text_for_codes(text, source_document="payer.pdf")
+        self.assertTrue(reqs)
+        self.assertTrue(all(r.source_document == "payer.pdf" for r in reqs))


### PR DESCRIPTION
## Problem

`pa_requirement_parsers._scan_text_for_codes` is the free-text fallback used by `parse_pdf_pa_list` whenever a PDF page has no detectable table. For **every** `_INLINE_CODE` match on every line it appended a `ParsedPARequirement(requires_pa=True, ...)`, with no check that the surrounding text was actually a CPT/HCPCS prior-authorization listing — despite the function's own docstring promising "CPT/HCPCS codes **with PA-keyword context**".

Because `_INLINE_CODE` matches any standalone 5-digit run, free-text PA PDFs turned **ZIP codes, dollar amounts (`$10,000` → `10000`), member/group IDs, and fax/phone fragments into bogus "requires prior authorization" rows.** These flow through `pa_requirements_fetcher._upsert_rows` and are persisted as authoritative `auto:`-sourced `PayerPriorAuthRequirement` records, then read by `lookup_pa_requirements` and surfaced in appeal / prior-auth context — i.e. **false "prior authorization required for code XXXXX" claims in patient appeal letters.**

## Fix

Add the context gate the docstring already promised. `_scan_text_for_codes` now only emits a requirement when a positive PA/CPT cue (new module-level `_PA_CONTEXT_CUES` frozenset: `prior auth`, `prior authorization`, `preauth`, `precert`, `authorization`, `cpt`, `hcpcs`, `procedure code`, etc.) appears in the existing context window. The negative-phrase handling (`requires_pa = False`) and notification-only handling are preserved; the structured-table path (`_rows_to_requirements`) is untouched.

This trades a little recall in the unstructured **fallback** path for precision — well-formed PA lists are parsed via the table path, while the free-text fallback no longer fabricates data.

## Tests

7 new tests in `tests/sync/test_pa_requirement_parsers.py` (`ScanTextForCodesTests`): bare ZIP/dollar/member-ID text yields nothing; a real code with CPT/PA context is extracted; negative-phrase sets `requires_pa=False`; notification-only is detected; HCPCS code with context; source-document propagation.

## Verification

- `black` ✓ · `tox -e mypy` ✓ ("no issues found in 414 source files")
- `tox -e py313-django52-sync`: **1202 passed** (37 for the parser file, incl. the 7 new tests)

https://claude.ai/code/session_01PMbjda5sJvbEVzmnahSBZU

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMbjda5sJvbEVzmnahSBZU)_