### PR TITLE
Add explicit Washington SB 5395 prior-auth AI-oversight regulatory hook

### DIFF
--- a/fighthealthinsurance/regulatory_citations.py
+++ b/fighthealthinsurance/regulatory_citations.py
@@ -106,7 +106,9 @@ _AI_OVERSIGHT_STATES: tuple[tuple[str, str], ...] = (
     ("IL", "Illinois"),
     ("AL", "Alabama"),
     ("UT", "Utah"),
-    ("WA", "Washington"),
+    # Washington is intentionally absent here: it has an explicit,
+    # individually-verified hook below (SB 5395) with a known effective date,
+    # so listing it generically would duplicate that entry.
     ("MD", "Maryland"),
 )
 
@@ -150,6 +152,30 @@ _EXPLICIT_STATE_HOOKS: tuple[RegulatoryHook, ...] = (
         source_url=(
             "https://kffhealthnews.org/news/article/prior-authorization-"
             "insurance-delays-coverage-denials-state-laws-west-virginia/"
+        ),
+        applies_to_self_insured=False,
+    ),
+    RegulatoryHook(
+        name="Washington prior-authorization AI-oversight and transparency law",
+        summary=(
+            "An AI or algorithm may not be the sole basis to deny, delay, or "
+            "modify care; a licensed provider must make any medical-necessity "
+            "adverse determination, the tool must account for the patient's "
+            "individual clinical condition (not just group data), and the "
+            "denial notice must disclose the credentials, board certifications, "
+            "and specialty of the provider who had clinical oversight. Demand "
+            "that human reviewer's clinical rationale and credentials, and "
+            "confirmation that AI was not the sole basis for the denial."
+        ),
+        jurisdiction="WA",
+        effective="effective June 11, 2026",
+        # Washington SB 5395 (2026); effective date and provisions confirmed via
+        # the bill sponsor's office and a state-law summary (Holland & Knight,
+        # May 2026). Per this module's convention we render a descriptive name
+        # rather than the bill number into the prompt.
+        source_url=(
+            "https://senatedemocrats.wa.gov/orwall/2026/03/25/orwall-bill-to-"
+            "improve-prior-authorization-transparency-signed-into-law/"
         ),
         applies_to_self_insured=False,
     ),

--- a/tests/async-unit/test_regulatory_citations.py
+++ b/tests/async-unit/test_regulatory_citations.py
@@ -46,6 +46,23 @@ class TestGetRegulatoryCitationContext(unittest.TestCase):
         self.assertIn("California", block)
         self.assertIn("sole basis", block)
 
+    def test_washington_explicit_hook_supersedes_generic(self):
+        # Washington has a specific, individually-verified SB 5395 hook, so the
+        # block carries its real effective date and credential-disclosure demand
+        # (which the generic AI-oversight framing lacked) and lists WA only once.
+        block = get_regulatory_citation_context("WA")
+        self.assertIsNotNone(block)
+        assert block is not None
+        self.assertIn("Washington", block)
+        self.assertIn("June 11, 2026", block)
+        self.assertIn("credentials", block)
+        # AI-as-sole-basis framing is preserved.
+        self.assertIn("sole basis", block)
+        # Federal hooks still ride along with the state hook.
+        self.assertIn("CMS-0057-F", block)
+        # No generic + explicit duplication: Washington appears exactly once.
+        self.assertEqual(block.count("Washington"), 1)
+
     def test_self_insured_caveat_wording(self):
         self_insured = get_regulatory_citation_context("MA", self_insured=True)
         assert self_insured is not None


### PR DESCRIPTION
**Draft — opened from the daily competitive/regulatory brief (2026-06-07) for review. Please do not auto-merge.**

## What & why
Washington's **SB 5395** takes effect **June 11, 2026**. It establishes that an AI/algorithm may not be the **sole basis** to deny, delay, or modify care; a **licensed provider** must make any medical-necessity adverse determination; the tool must account for the patient's individual clinical condition (not just group data); and a denial notice must **disclose the reviewing provider's credentials, board certifications, and specialty**.

Today `regulatory_citations.py` only listed Washington in the *generic* `_AI_OVERSIGHT_STATES` tracker bucket ("enacted as of 2025-2026 (see KFF tracker)"), with no effective date and none of the WA-specific, citable demands. This PR replaces that generic entry with an **explicit, individually-sourced hook** — mirroring the existing Massachusetts and West Virginia explicit hooks — so a Washington appellant gets the concrete, verifiable hook (effective date + credential-disclosure demand) starting June 11.

## Changes
- `fighthealthinsurance/regulatory_citations.py`
  - Add an explicit `RegulatoryHook` for Washington (descriptive name + `effective June 11, 2026`, `applies_to_self_insured=False`).
  - Remove `("WA", "Washington")` from `_AI_OVERSIGHT_STATES` so WA is not double-listed (explicit + generic).
- `tests/async-unit/test_regulatory_citations.py`
  - Add `test_washington_explicit_hook_supersedes_generic`: asserts the verified effective date, the credential-disclosure demand, preserved "sole basis" framing, that federal hooks still ride along (CMS-0057-F), and that Washington appears exactly once (no duplication).

## Convention notes
- Follows the module's existing philosophy: render a **descriptive name** (not the bill number) into the prompt; keep `source_url` for documentation/tests only; bill number cited only in a code comment. No statute section numbers, quotations, or dates are invented.
- Plan-type handling is unchanged: as a state insurance mandate it is correctly dropped for self-insured (ERISA) plans by the existing `self_insured` filter.

## Sourcing (effective date + provisions dual-confirmed)
- Bill sponsor's office — Sen. Tina Orwall, "Orwall bill to improve prior authorization transparency signed into law" (states "goes into effect June 11"): https://senatedemocrats.wa.gov/orwall/2026/03/25/orwall-bill-to-improve-prior-authorization-transparency-signed-into-law/
- Holland & Knight, "States Continue Efforts to Regulate AI in Healthcare" (May 2026): https://www.hklaw.com/en/insights/publications/2026/05/states-continue-efforts-to-regulate-ai-in-healthcare

## Verification (sandbox limitations disclosed)
- `black` — both files already correctly formatted (`--check` clean on `regulatory_citations.py`).
- Standalone logic validation of `get_regulatory_citation_context` (the module imports only `dataclasses`/`typing`, so it runs without Django): 14/14 checks pass — WA effective date + credentials present, no duplication, full-name normalization, self-insured filtering, CA generic unaffected, NV→None.
- Both files byte-compile.
- ⚠️ `tox -e py313-django52-async-unit` could **not** run in this ephemeral environment (no `tox`; Django not installed; network is a restricted git proxy). Please let CI run the formal `async-unit` suite — the new test only adds assertions on the standalone-validated function and uses the same imports as the existing passing tests.

## Scope / risk
Additive and bounded: only affects appeals where the patient's state is Washington (which already received a generic hook). Touches the appeal-prompt path, which is why it's a **draft for human review** rather than an autonomous merge.

https://claude.ai/code/session_01BoZirkTtfZDetSDKTrLaZg

---
_Generated by [Claude Code](https://claude.ai/code/session_01BoZirkTtfZDetSDKTrLaZg)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Washington state AI-oversight regulatory information with specific requirements for AI prior-authorization and transparency. Effective June 11, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->