### PR TITLE
Fix deploy gaps: load pa_requirements fixture, heal RxNorm migration rename

### DIFF
--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -3591,15 +3591,18 @@ class EscalationPacketHelper:
             }
         ) + "\n"
 
+        # We deliberately don't ``select_related("regulator",
+        # "insurance_company_obj")`` here: those tables hold ``RegexField``
+        # columns whose ``from_db_value`` raises ``ValidationError`` on NULL,
+        # so a LEFT JOIN against an un-matched denial blows up the whole
+        # stream. ``prefetch_related("plan_source")`` is safe (separate
+        # query, no JOIN) and avoids an extra round-trip when
+        # ``get_recipients_for_denial`` checks ERISA likelihood.
         try:
-            denial = await (
-                Denial.objects.select_related("regulator", "insurance_company_obj")
-                .prefetch_related("plan_source")
-                .aget(
-                    denial_id=denial_id,
-                    semi_sekret=semi_sekret,
-                    hashed_email=hashed_email,
-                )
+            denial = await Denial.objects.prefetch_related("plan_source").aget(
+                denial_id=denial_id,
+                semi_sekret=semi_sekret,
+                hashed_email=hashed_email,
             )
         except Denial.DoesNotExist:
             yield json.dumps({"type": "error", "message": "Denial not found"}) + "\n"
@@ -3612,14 +3615,58 @@ class EscalationPacketHelper:
             ) + "\n"
             return
 
+        # Reuse any letters we've already drafted for this denial so that
+        # navigating back to the page (e.g. via the "Back to all regulator
+        # letters" button on the review screen, or a browser refresh) doesn't
+        # burn fresh ML calls and accumulate duplicate draft rows.
+        recipient_types = [r.recipient_type for r in recipients]
+        existing_by_type: dict[str, RegulatorEscalation] = {}
+        async for esc in RegulatorEscalation.objects.filter(
+            for_denial=denial,
+            hashed_email=hashed_email,
+            recipient_type__in=recipient_types,
+        ).order_by("-created"):
+            # Keep only the most recent draft per recipient type. Stop
+            # as soon as every relevant type has been covered so we don't
+            # scan unbounded history.
+            existing_by_type.setdefault(esc.recipient_type, esc)
+            if len(existing_by_type) == len(recipient_types):
+                break
+
+        needing_generation = [
+            r for r in recipients if r.recipient_type not in existing_by_type
+        ]
+
         yield json.dumps(
             {
                 "type": "status",
                 "phase": "generating",
-                "message": f"Generating {len(recipients)} regulator letter(s)...",
-                "total": len(recipients),
+                "message": (
+                    f"Generating {len(needing_generation)} regulator letter(s)..."
+                ),
+                "total": len(needing_generation),
             }
         ) + "\n"
+
+        # Stream existing drafts first so the user sees them immediately
+        # without waiting on the ML calls for the still-missing recipients.
+        for recipient in recipients:
+            existing = existing_by_type.get(recipient.recipient_type)
+            if existing is None:
+                continue
+            yield json.dumps(
+                {
+                    "type": "letter",
+                    "escalation_id": str(existing.uuid),
+                    "recipient_type": existing.recipient_type,
+                    "recipient_name": existing.recipient_name,
+                    "recipient_address": existing.recipient_address,
+                    "recipient_phone": existing.recipient_phone,
+                    "recipient_url": existing.recipient_url,
+                    "rationale": recipient.rationale,
+                    "content": existing.letter_text,
+                }
+            ) + "\n"
 
         use_external = bool(getattr(denial, "use_external", False))
 
@@ -3629,7 +3676,7 @@ class EscalationPacketHelper:
             )
             return recipient, text
 
-        tasks = [asyncio.create_task(_draft(r)) for r in recipients]
+        tasks = [asyncio.create_task(_draft(r)) for r in needing_generation]
         try:
             for fut in asyncio.as_completed(tasks):
                 recipient, letter_text = await fut

--- a/fighthealthinsurance/context_utils.py
+++ b/fighthealthinsurance/context_utils.py
@@ -229,13 +229,15 @@ def attach_supplemental_to_citations(
     flat_ml = flatten_citation_context(ml_citation_context)
     if flat_ml:
         if _supplemental_already_present(flat_ml, supp):
-            return flat_ml, pubmed_context
+            # Idempotent: nothing to append, so preserve the original input
+            # type (list inputs stay lists, strings stay strings).
+            return ml_citation_context, pubmed_context
         return f"{flat_ml}\n\n{supp}", pubmed_context
 
     if pubmed_context and pubmed_context.strip():
         existing = pubmed_context.strip()
         if _supplemental_already_present(existing, supp):
-            return ml_citation_context, existing
+            return ml_citation_context, pubmed_context
         return ml_citation_context, f"{existing}\n\n{supp}"
 
     return supp, pubmed_context

--- a/fighthealthinsurance/denied_items_analysis_actor.py
+++ b/fighthealthinsurance/denied_items_analysis_actor.py
@@ -1,0 +1,39 @@
+"""Ray actor that runs denied-items analysis off the WebSocket disconnect path.
+
+``OngoingChatConsumer.disconnect`` enqueues one job per (chat, disconnect
+event); this actor performs the actual analysis so the disconnect handler
+stays non-blocking.
+"""
+
+import os
+import time
+
+import ray
+from asgiref.sync import async_to_sync
+from loguru import logger
+
+
+@ray.remote(max_restarts=-1, max_task_retries=2)
+class DeniedItemsAnalysisActor:
+    """Ray actor to process denied-items analysis jobs asynchronously."""
+
+    def __init__(self) -> None:
+        logger.info("Starting DeniedItemsAnalysisActor")
+        time.sleep(1)
+        # Initialize Django inside the actor (same pattern as the other
+        # actors, e.g. ExtraLinkPrefetchActor).
+        os.environ.setdefault("DJANGO_SETTINGS_MODULE", "fighthealthinsurance.settings")
+        from configurations.wsgi import get_wsgi_application
+
+        get_wsgi_application()
+
+    def run_analysis(
+        self, *, job_key: str, chat_id: str, disconnect_event_ts: str
+    ) -> None:
+        from fighthealthinsurance.websockets import OngoingChatConsumer
+
+        async_to_sync(OngoingChatConsumer._run_denied_items_analysis_job)(
+            job_key=job_key,
+            chat_id=chat_id,
+            disconnect_event_ts=disconnect_event_ts,
+        )

--- a/fighthealthinsurance/denied_items_analysis_actor_ref.py
+++ b/fighthealthinsurance/denied_items_analysis_actor_ref.py
@@ -1,0 +1,11 @@
+from fighthealthinsurance.base_actor_ref import BaseActorRef
+from fighthealthinsurance.denied_items_analysis_actor import DeniedItemsAnalysisActor
+
+
+class DeniedItemsAnalysisActorRef(BaseActorRef):
+    actor_class = DeniedItemsAnalysisActor
+    actor_name = "denied_items_analysis_actor"
+    has_run_method = False
+
+
+denied_items_analysis_actor_ref = DeniedItemsAnalysisActorRef()

--- a/fighthealthinsurance/field_confidence.py
+++ b/fighthealthinsurance/field_confidence.py
@@ -21,7 +21,10 @@ import datetime
 import re
 from typing import Optional
 
-from fighthealthinsurance.generate_appeal import is_plausible_identifier
+from fighthealthinsurance.generate_appeal import (
+    identifier_found_in_text,
+    is_plausible_identifier,
+)
 
 _LABEL_TOKENS = {
     "patient",
@@ -69,7 +72,12 @@ def _score_name(value: str, source_text: str) -> str:
 def _score_identifier(value: str, source_text: str) -> str:
     if not is_plausible_identifier(value):
         return "low"
-    if _appears_in_source(value, source_text):
+    # Use the separator-normalizing matcher so IDs that appear in the source
+    # with different separators than the extracted value (e.g. "H5521001" vs
+    # "H5521-001" or "H5521 001") still count as source evidence. This is
+    # still substring-based on the normalized text; it improves recall, not
+    # word-boundary precision.
+    if identifier_found_in_text(value, source_text):
         return "high"
     return "medium"
 
@@ -114,6 +122,13 @@ def _score_dob(value, source_text: str) -> str:
             parsed.strftime("%m/%d/%Y"),
             parsed.strftime("%m-%d-%Y"),
             f"{parsed.month}/{parsed.day}/{parsed.year}",
+            # Day-first renderings (e.g. "15/01/1980") so documents that write
+            # the date day-first still provide source evidence. Adding these
+            # only widens what counts as evidence; the date must still appear
+            # in the source, so a hallucinated date cannot reach "high".
+            parsed.strftime("%d/%m/%Y"),
+            parsed.strftime("%d-%m-%Y"),
+            f"{parsed.day}/{parsed.month}/{parsed.year}",
         ]
     )
     if any(_appears_in_source(c, source_text) for c in candidates):

--- a/fighthealthinsurance/fixtures/insurance_companies.yaml
+++ b/fighthealthinsurance/fixtures/insurance_companies.yaml
@@ -130,6 +130,9 @@
     is_major_commercial_payer: true
     medical_policy_name: Medical Coverage Policies
     medical_policy_notes: Humana publishes Medical Coverage Policies that document medical-necessity and coverage criteria the plan applies, including for Medicare Advantage members where additional CMS rules also apply. The public-facing index URL has changed repeatedly; locate the current index from humana.com's provider portal.
+    pa_requirement_list_url: https://www.humana.com/provider/medical-resources/prior-authorization
+    pa_requirement_list_url_is_parseable: false
+    pa_requirement_list_notes: Humana's prior-authorization requirement lists are published per-plan and require provider portal login. Most specialty PA routes through Gold Carding or Availity.
 
 - model: fighthealthinsurance.insurancecompany
   pk: 6

--- a/fighthealthinsurance/generate_appeal.py
+++ b/fighthealthinsurance/generate_appeal.py
@@ -753,37 +753,159 @@ def identifier_found_in_text(identifier: str, text: str) -> bool:
     return False
 
 
-# Context shed on retry when zero-result failures may stem from
-# context-window overflow. Only the call-dict keys can be shed here —
-# uspstf/pa/nice/rag/clinical_trials contexts are already baked into the
-# prompt string by make_open_prompt, so they're out of reach without
-# re-rendering. TODO: a future improvement could re-call make_open_prompt
-# with those contexts nulled to get true tier-1-style enrichment shedding.
+# Tier-shed retry: reduce prompt size when zero-result failures may stem
+# from context-window overflow. Each enrichment context appears on TWO
+# surfaces and both need to shrink in lockstep, otherwise we'd null the
+# call-dict copy while the prompt-baked copy still pins the token count
+# above the limit.
+#
+#   * make_open_prompt bakes enrichment (pubmed, ml citations, rag, nice,
+#     uspstf, clinical trials, regulatory citations, ucr, pa, payer-policy,
+#     medication) into the prompt string. To shed those we re-render the
+#     prompt with the matching kwargs set to None / truncated.
+#   * The same call dict also carries pubmed_context, ml_citations_context,
+#     plan_context, and patient_context as separate keys, which the model
+#     re-injects via ``context_extra`` (see ml_models.RemoteFullOpenLike).
+#     We null/truncate those alongside the prompt re-render.
+
+# In-prompt enrichment dropped entirely at tier 1+. Names match the
+# ``make_open_prompt`` parameters (note: ``ml_context`` is the prompt-side
+# rendered form of ``ml_citations_context``).
+_PROMPT_TIER1_NULLS: tuple[str, ...] = (
+    "ml_context",
+    "pubmed_context",
+    "rag_context",
+    "nice_context",
+    "uspstf_context",
+    "clinical_trials_context",
+    "regulatory_citation_context",
+    "ucr_context",
+    "pa_context",
+    "payer_policy_context",
+    "medication_context",
+)
+
+# Tier-2 truncation caps. ``plan_context`` lives on BOTH the prompt and the
+# call-dict surface and is truncated to the same length on each, so the cap
+# is a single shared constant rather than two literals that could drift.
+_PLAN_CONTEXT_TIER2_CAP = 4000
+_PATIENT_CONTEXT_TIER2_CAP = 6000
+
+# In-prompt patient-specific context truncated (not dropped) at tier 2+.
+_PROMPT_TIER2_TRUNCATIONS: tuple[tuple[str, int], ...] = (
+    ("plan_context", _PLAN_CONTEXT_TIER2_CAP),
+)
+
+# Call-dict copies (the ``context_extra`` injection surface) sheddable at
+# tier 1+. These mirror their ``_PROMPT_TIER1_NULLS`` counterparts.
 _SHEDDABLE_TIER1 = ("pubmed_context", "ml_citations_context")
-_TIER2_TRUNCATIONS = (("plan_context", 4000), ("patient_context", 6000))
+
+# Call-dict patient/plan context truncated at tier 2+. ``patient_context``
+# (``medical_context`` in the caller) is not in the prompt string, so it
+# only needs trimming on the call-dict surface.
+_TIER2_TRUNCATIONS = (
+    ("plan_context", _PLAN_CONTEXT_TIER2_CAP),
+    ("patient_context", _PATIENT_CONTEXT_TIER2_CAP),
+)
 
 
-def _shed_context(calls: list[dict], tier: int) -> tuple[list[dict], list[str]]:
+def _apply_tier2_truncations(
+    target: dict,
+    truncations: tuple[tuple[str, int], ...],
+    changed: set[str],
+    *,
+    label: str,
+) -> None:
+    """Boundary-aware truncate over-cap string values in ``target`` in place.
+
+    Shared by the prompt-kwargs and call-dict surfaces so both truncate
+    identically (same boundary-aware helper, same caps). ``label`` prefixes
+    the ``changed`` entry (``"prompt."`` for the prompt surface, ``""`` for
+    the call dict). ``ellipsis=""`` because this text is fed to the model,
+    not displayed, so a trailing marker would only waste budget.
+    """
+    for key, cap in truncations:
+        val = target.get(key)
+        if isinstance(val, str) and len(val) > cap:
+            target[key] = truncate_at_boundary(val, cap, ellipsis="")
+            changed.add(f"{label}{key}(truncated)")
+
+
+def _shed_context(
+    calls: list[dict],
+    tier: int,
+    *,
+    open_prompt_kwargs: Optional[dict] = None,
+    rebuild_prompt: Optional[Callable[..., Optional[str]]] = None,
+    original_open_prompt: Optional[str] = None,
+) -> tuple[list[dict], list[str]]:
     """Return (new_calls, changed_names) with context reduced by tier.
 
-    Tier 1 nulls pubmed/citations context. Tier 2 also truncates
-    plan_context and patient_context. Higher tiers include all lower-tier
-    reductions.
+    Tier 1 nulls the enrichment contexts on both surfaces: in the
+    re-rendered prompt (when ``open_prompt_kwargs`` + ``rebuild_prompt`` +
+    ``original_open_prompt`` are provided) and in the call-dict copies.
+    Tier 2 additionally truncates ``plan_context`` (in-prompt) and
+    ``plan_context`` + ``patient_context`` (call-dict). Higher tiers
+    include all lower-tier reductions.
+
+    When the prompt-rebuild arguments are omitted the function falls back
+    to call-dict-only shedding — kept for direct unit testing of the
+    call-dict surface.
     """
     changed: set[str] = set()
+
+    new_open_prompt: Optional[str] = None
+    if (
+        tier >= 1
+        and open_prompt_kwargs is not None
+        and rebuild_prompt is not None
+        and original_open_prompt is not None
+    ):
+        shed_kwargs = dict(open_prompt_kwargs)
+        prompt_changed_before = len(changed)
+        for key in _PROMPT_TIER1_NULLS:
+            # Mirror ``make_open_prompt``'s gate exactly: each section is
+            # included on ``is not None and != ""``. A whitespace-only value
+            # is NOT a no-op there — it still trips ``has_citations`` and
+            # renders the CITATION INSTRUCTIONS block plus the section
+            # header (e.g. ``Provided citations (use these):    ``), so it
+            # contributes prompt bytes we need to shed. Only the truly
+            # empty string ``""`` is already-shed and can be skipped.
+            val = shed_kwargs.get(key)
+            if isinstance(val, str) and val != "":
+                shed_kwargs[key] = None
+                changed.add(f"prompt.{key}")
+        if tier >= 2:
+            _apply_tier2_truncations(
+                shed_kwargs, _PROMPT_TIER2_TRUNCATIONS, changed, label="prompt."
+            )
+        # Only rebuild if the prompt-surface actually shrank — otherwise the
+        # original ``open_prompt`` is reused as-is.
+        if len(changed) > prompt_changed_before:
+            new_open_prompt = rebuild_prompt(**shed_kwargs)
+
     new_calls = []
     for call in calls:
         new = dict(call)
-        for key in _SHEDDABLE_TIER1:
-            if new.get(key) is not None:
-                new[key] = None
-                changed.add(key)
+        # Swap the shed prompt into any call whose prompt is the original
+        # open_prompt or starts with it (the specialized variant appends a
+        # hint block). The medically-necessary prompt is unrelated and is
+        # left untouched.
+        if (
+            new_open_prompt is not None
+            and original_open_prompt
+            and isinstance(new.get("prompt"), str)
+            and new["prompt"].startswith(original_open_prompt)
+        ):
+            tail = new["prompt"][len(original_open_prompt) :]
+            new["prompt"] = new_open_prompt + tail
+        if tier >= 1:
+            for key in _SHEDDABLE_TIER1:
+                if new.get(key) is not None:
+                    new[key] = None
+                    changed.add(key)
         if tier >= 2:
-            for key, cap in _TIER2_TRUNCATIONS:
-                val = new.get(key)
-                if isinstance(val, str) and len(val) > cap:
-                    new[key] = val[:cap]
-                    changed.add(f"{key}(truncated)")
+            _apply_tier2_truncations(new, _TIER2_TRUNCATIONS, changed, label="")
         new_calls.append(new)
     return new_calls, sorted(changed)
 
@@ -1862,7 +1984,11 @@ class AppealGenerator(object):
         medication_context = self._collect_medication_context(denial)
         regulatory_citation_context = self._collect_regulatory_context(denial)
 
-        open_prompt = self.make_open_prompt(
+        # Captured as a dict so the tier-shed retry path can re-render the
+        # prompt with enrichment kwargs nulled or truncated — otherwise the
+        # prompt-baked copies of pubmed/citations/rag/etc. would still pin
+        # the token count even after the call-dict copies are dropped.
+        open_prompt_kwargs = dict(
             denial_text=denial.denial_text,
             procedure=denial.procedure,
             diagnosis=denial.diagnosis,
@@ -1891,6 +2017,7 @@ class AppealGenerator(object):
             medication_context=medication_context,
             regulatory_citation_context=regulatory_citation_context,
         )
+        open_prompt = self.make_open_prompt(**open_prompt_kwargs)
         open_medically_necessary_prompt = self.make_open_med_prompt(
             procedure=denial.procedure,
             diagnosis=denial.diagnosis,
@@ -2195,7 +2322,13 @@ class AppealGenerator(object):
             )
             time.sleep(1.0)
             for tier in (1, 2):
-                shed_calls, changed = _shed_context(calls, tier=tier)
+                shed_calls, changed = _shed_context(
+                    calls,
+                    tier=tier,
+                    open_prompt_kwargs=open_prompt_kwargs,
+                    rebuild_prompt=self.make_open_prompt,
+                    original_open_prompt=open_prompt,
+                )
                 logger.warning(
                     f"make_appeals: retrying primary for denial {denial_id} "
                     f"with context shed (tier={tier}, changed={changed})"

--- a/fighthealthinsurance/migrations/0175_rxnormconcept.py
+++ b/fighthealthinsurance/migrations/0175_rxnormconcept.py
@@ -5,8 +5,17 @@ from django.db.models.functions import Now
 
 
 class Migration(migrations.Migration):
+    # This migration originally shipped as 0173_rxnormconcept (depending on
+    # 0172) and was renamed to 0175 when 0173_medicationcontext landed (#787).
+    # Databases that migrated before the rename have it recorded under the old
+    # name; ``replaces`` makes Django treat those as already applied instead
+    # of re-creating the table. The dependency stays 0172 (its original) so
+    # such databases don't trip the applied-before-dependency consistency
+    # check; 0176 depends on both this and 0174 to keep the graph linear.
+    replaces = [("fighthealthinsurance", "0173_rxnormconcept")]
+
     dependencies = [
-        ("fighthealthinsurance", "0174_seed_medication_contexts"),
+        ("fighthealthinsurance", "0172_payerpriorauthrequirement"),
     ]
 
     operations = [

--- a/fighthealthinsurance/migrations/0176_add_1day_followup_type.py
+++ b/fighthealthinsurance/migrations/0176_add_1day_followup_type.py
@@ -27,6 +27,9 @@ def remove_1day_followup_type(apps, schema_editor):
 
 class Migration(migrations.Migration):
     dependencies = [
+        # Both branches of the 0172 fork (0173/0174 medication contexts and
+        # the renamed 0175 RxNorm migration) so the graph keeps a single leaf.
+        ("fighthealthinsurance", "0174_seed_medication_contexts"),
         ("fighthealthinsurance", "0175_rxnormconcept"),
     ]
 

--- a/fighthealthinsurance/pubmed_tools.py
+++ b/fighthealthinsurance/pubmed_tools.py
@@ -1,4 +1,5 @@
 import asyncio
+import hashlib
 import io
 import json
 import os
@@ -105,6 +106,7 @@ _ELINK_CACHE_PREFIX = "pubmed:elink:related:"
 # shorter than the 30-day positive cache because absence is more volatile
 # than presence (new articles get indexed).
 _EMPTY_QUERY_NEGCACHE_DAYS = 2
+_QUERY_CACHE_PREFIX = "pubmed:query:"
 
 # Backoff schedule for retrying transient metapub fetch failures (e.g. a
 # dropped connection to dx.doi.org during DOI resolution). metapub swallows
@@ -572,9 +574,16 @@ class PubMedTools(object):
             A list of PubMed article IDs (PMIDs) matching the query.
         """
         pmids: List[str] = []
+        cache_key = self._pubmed_query_cache_key(query=query, since=since)
+        cache_sentinel = object()
 
         try:
             async with async_timeout(timeout):
+                cached_pmids = await cache.aget(cache_key, default=cache_sentinel)
+                if cached_pmids is not cache_sentinel:
+                    # Distinguish a real negative cache hit ([]) from a miss.
+                    return cached_pmids or []
+
                 # Use timezone-aware "now" so comparisons against the DB's
                 # tz-aware ``created`` field work without raising.
                 now = timezone.now()
@@ -600,6 +609,11 @@ class PubMedTools(object):
                         logger.error(f"Error parsing cached articles JSON for {query}")
                         continue
                     if article_ids:
+                        await cache.aset(
+                            cache_key,
+                            article_ids,
+                            timeout=int(timedelta(days=30).total_seconds()),
+                        )
                         return article_ids
                     # The most recent informative row is an empty result.
                     # Honor it as a cache hit inside the shorter negative-
@@ -608,6 +622,15 @@ class PubMedTools(object):
                         query_data.created is not None
                         and query_data.created >= neg_cache_cutoff
                     ):
+                        await cache.aset(
+                            cache_key,
+                            [],
+                            timeout=int(
+                                timedelta(
+                                    days=_EMPTY_QUERY_NEGCACHE_DAYS
+                                ).total_seconds()
+                            ),
+                        )
                         return []
                     # Stale empty: the newest signal says "no hits", but it
                     # is past the negative-cache window. Don't fall back to
@@ -633,6 +656,15 @@ class PubMedTools(object):
                     since=since,
                     articles=articles_json,
                 )
+                await cache.aset(
+                    cache_key,
+                    pmids,
+                    timeout=int(
+                        timedelta(
+                            days=30 if pmids else _EMPTY_QUERY_NEGCACHE_DAYS
+                        ).total_seconds()
+                    ),
+                )
                 return pmids
         except asyncio.TimeoutError as e:
             # We might timeout
@@ -647,6 +679,14 @@ class PubMedTools(object):
             )
             pass
         return pmids
+
+    @staticmethod
+    def _pubmed_query_cache_key(query: str, since: Optional[str]) -> str:
+        normalized_query = " ".join((query or "").strip().lower().split())
+        normalized_since = (since or "").strip().lower()
+        key_material = f"{normalized_query}|{normalized_since}"
+        digest = hashlib.sha256(key_material.encode("utf-8")).hexdigest()
+        return f"{_QUERY_CACHE_PREFIX}{digest}"
 
     async def fetch_mesh_and_pub_types(
         self,

--- a/fighthealthinsurance/regulatory_citations.py
+++ b/fighthealthinsurance/regulatory_citations.py
@@ -106,7 +106,9 @@ _AI_OVERSIGHT_STATES: tuple[tuple[str, str], ...] = (
     ("IL", "Illinois"),
     ("AL", "Alabama"),
     ("UT", "Utah"),
-    ("WA", "Washington"),
+    # Washington is intentionally absent here: it has an explicit,
+    # individually-verified hook below (SB 5395) with a known effective date,
+    # so listing it generically would duplicate that entry.
     ("MD", "Maryland"),
 )
 
@@ -150,6 +152,30 @@ _EXPLICIT_STATE_HOOKS: tuple[RegulatoryHook, ...] = (
         source_url=(
             "https://kffhealthnews.org/news/article/prior-authorization-"
             "insurance-delays-coverage-denials-state-laws-west-virginia/"
+        ),
+        applies_to_self_insured=False,
+    ),
+    RegulatoryHook(
+        name="Washington prior-authorization AI-oversight and transparency law",
+        summary=(
+            "An AI or algorithm may not be the sole basis to deny, delay, or "
+            "modify care; a licensed provider must make any medical-necessity "
+            "adverse determination, the tool must account for the patient's "
+            "individual clinical condition (not just group data), and the "
+            "denial notice must disclose the credentials, board certifications, "
+            "and specialty of the provider who had clinical oversight. Demand "
+            "that human reviewer's clinical rationale and credentials, and "
+            "confirmation that AI was not the sole basis for the denial."
+        ),
+        jurisdiction="WA",
+        effective="effective June 11, 2026",
+        # Washington SB 5395 (2026); effective date and provisions confirmed via
+        # the bill sponsor's office and a state-law summary (Holland & Knight,
+        # May 2026). Per this module's convention we render a descriptive name
+        # rather than the bill number into the prompt.
+        source_url=(
+            "https://senatedemocrats.wa.gov/orwall/2026/03/25/orwall-bill-to-"
+            "improve-prior-authorization-transparency-signed-into-law/"
         ),
         applies_to_self_insured=False,
     ),

--- a/fighthealthinsurance/rest_urls.py
+++ b/fighthealthinsurance/rest_urls.py
@@ -59,6 +59,11 @@ urlpatterns = [
         name="report_client_error",
     ),
     path(
+        "enable_external_models",
+        rest_views.EnableExternalModels.as_view(),
+        name="enable_external_models",
+    ),
+    path(
         "streaming_appeals_fallback",
         rest_views.streaming_appeals_rest_fallback,
         name="streaming_appeals_fallback",

--- a/fighthealthinsurance/rest_views.py
+++ b/fighthealthinsurance/rest_views.py
@@ -561,6 +561,62 @@ class ReportClientError(APIView):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
+class EnableExternalModels(APIView):
+    """Opt a denial into external models so a re-run of appeal generation
+    can call out to higher-capability cloud LLMs.
+
+    Patients see a button on the appeals page offering this when the
+    initial generation produced few or no appeals from internal models;
+    this endpoint flips `Denial.use_external` so the next generation
+    request includes the external backends. Auth mirrors the appeal
+    stream: the (denial_id, email, semi_sekret) triple is the only
+    credential.
+    """
+
+    permission_classes = [AllowAny]
+    authentication_classes = []  # Magic-key auth via the triple
+
+    @extend_schema(
+        description=(
+            "Opt a denial into external models. Authenticated by the "
+            "(denial_id, email, semi_sekret) triple in the JSON body. "
+            "Idempotent — succeeds with 200 if `use_external` is "
+            "already True. Returns 404 for any auth failure (uniform "
+            "to avoid leaking which field was wrong)."
+        ),
+        request=OpenApiTypes.OBJECT,
+        responses={
+            200: OpenApiTypes.OBJECT,
+            400: OpenApiTypes.OBJECT,
+            404: OpenApiTypes.OBJECT,
+        },
+    )
+    def post(self, request: Request) -> Response:
+        data = request.data
+        # Reject non-mapping bodies (e.g. JSON arrays/strings) up front;
+        # without this, request.data.get(...) raises and we'd serve 500
+        # on malformed input. Matches streaming_appeals_rest_fallback.
+        if not isinstance(data, dict):
+            return Response(
+                {"error": "Expected a JSON object"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        denial = common_view_logic.get_denial_for_action(
+            denial_id=data.get("denial_id"),
+            email=data.get("email") or "",
+            semi_sekret=data.get("semi_sekret") or "",
+        )
+        if denial is None:
+            return Response({"error": "Not found"}, status=status.HTTP_404_NOT_FOUND)
+        if not denial.use_external:
+            denial.use_external = True
+            denial.save(update_fields=["use_external"])
+            logger.info(
+                f"Enabled external models for denial {denial.denial_id} on user request"
+            )
+        return Response({"use_external": True}, status=status.HTTP_200_OK)
+
+
 @extend_schema(
     description=(
         "REST/HTTP fallback for the WebSocket appeal stream used by "

--- a/fighthealthinsurance/static/js/appeal_fetcher.ts
+++ b/fighthealthinsurance/static/js/appeal_fetcher.ts
@@ -489,6 +489,114 @@ function done(): void {
     }
     clearTimeout(timeoutHandle!);
     hideLoading();
+    // When internal-only generation underdelivered (0-2 appeals), the
+    // template emits a hidden prompt offering to opt the denial into
+    // external models. Reveal it and wire up the click.
+    maybeShowExternalModelsPrompt();
+  }
+}
+
+// Threshold for "we didn't generate enough appeals" - the regular flow
+// targets 3 appeals, so 2 or fewer indicates underdelivery worth
+// surfacing the external-models opt-in for.
+const FEW_APPEALS_THRESHOLD = 2;
+
+// Latched once the user has already opted in. Prevents re-showing the
+// prompt if the post-opt-in rerun also underdelivers — the user has
+// already made the call, repeating it doesn't help.
+let externalModelsRequested = false;
+
+function maybeShowExternalModelsPrompt(): void {
+  if (externalModelsRequested) {
+    return;
+  }
+  const prompt = document.getElementById("external-models-prompt");
+  if (!prompt) {
+    // Template didn't include the prompt - either external models are
+    // already enabled, or we're on a page that doesn't have it.
+    return;
+  }
+  if (appealsSoFar.length > FEW_APPEALS_THRESHOLD) {
+    return;
+  }
+  if (prompt.style.display === "block") {
+    return;
+  }
+  prompt.style.display = "block";
+  const button = document.getElementById(
+    "request-external-models-btn",
+  ) as HTMLButtonElement | null;
+  if (!button) return;
+  button.addEventListener(
+    "click",
+    () => {
+      void requestExternalModels(button, prompt);
+    },
+    { once: true },
+  );
+}
+
+async function requestExternalModels(
+  button: HTMLButtonElement,
+  prompt: HTMLElement,
+): Promise<void> {
+  const statusEl = document.getElementById("external-models-status");
+  const setStatus = (text: string, color: string) => {
+    if (statusEl) {
+      statusEl.textContent = text;
+      statusEl.style.color = color;
+    }
+  };
+  const url = (window as any).enableExternalModelsUrl as string | undefined;
+  if (!url) {
+    setStatus("Unable to enable external models right now.", "#dc3545");
+    return;
+  }
+  const csrfToken = (my_data as any).csrfmiddlewaretoken || "";
+  button.disabled = true;
+  setStatus("Enabling external models and re-running appeals...", "#333");
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRFToken": csrfToken,
+      },
+      body: JSON.stringify({
+        denial_id: (my_data as any).denial_id || "",
+        email: (my_data as any).email || "",
+        semi_sekret: (my_data as any).semi_sekret || "",
+      }),
+    });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+    externalModelsRequested = true;
+    setStatus(
+      "External models enabled. Generating additional appeals...",
+      "#28a745",
+    );
+    prompt.style.display = "none";
+    // Reset retry/parser state so doQuery starts a fresh generation
+    // pass rather than treating this as a retry of the previous
+    // attempt. Deliberately do NOT clear appealsSoFar or
+    // #output-container: any already-shown internal-only drafts stay
+    // on screen for the user to read while external models stream
+    // additional drafts. processResponseChunk dedups against
+    // appealsSoFar so server-side re-yielded ProposedAppeals don't
+    // append twice, and the >=3 done() check counting old+new is
+    // intentional — we want a total of 3 drafts, not 3 *new* ones.
+    retries = 0;
+    respBuffer = "";
+    hasAutoScrolledToFirstAppeal = false;
+    doQuery(my_backend_url, my_data, my_rest_fallback_url);
+  } catch (error) {
+    console.error("Failed to enable external models:", error);
+    setStatus(
+      "Could not enable external models. Please try again later.",
+      "#dc3545",
+    );
+    button.disabled = false;
   }
 }
 

--- a/fighthealthinsurance/templates/appeals.html
+++ b/fighthealthinsurance/templates/appeals.html
@@ -82,6 +82,30 @@ Fight Your Health Insurance Denial: Choose an Appeal
 <div id="output-container">
 </div>
 
+<div class="alert-box alert-info" style="margin:2rem 0; border-left:4px solid #ADD100;">
+  <h4 style="margin-bottom:0.75rem;">📣 Want to let the regulator know what's going on?</h4>
+  <p style="margin:0.5rem 0;">
+    Alongside your internal appeal, you can cc the people who hold the plan
+    accountable: your <strong>state Department of Insurance</strong>, the plan's
+    <strong>medical director</strong>, and (for ERISA self-funded plans) the
+    <strong>U.S. Department of Labor's EBSA</strong>. We'll draft
+    regulator-friendly letters you can edit and send.
+  </p>
+  <form action="{% url 'escalation_packet' %}" method="post" target="_blank" style="margin:0.75rem 0;">
+    {% csrf_token %}
+    <input type="hidden" name="email" value="{{ user_email }}">
+    <input type="hidden" name="denial_id" value="{{ denial_id }}">
+    {% if semi_sekret %}<input type="hidden" name="semi_sekret" value="{{ semi_sekret }}">{% endif %}
+    <button type="submit" id="generate_escalation_packet" class="btn btn-default" style="font-size:1.05rem; padding:10px 20px;">
+      📨 Click here to draft regulator letters (opens in a new window)
+    </button>
+  </form>
+  <p style="margin:0.5rem 0; font-size:0.9rem; color:#555;">
+    This is especially useful for <em>secondary</em> appeals — once an internal
+    appeal has been denied, regulator escalation often unsticks things.
+  </p>
+</div>
+
 <div class="form-nav-centered">
   {% if back_url %}
   <a href="{{ back_url }}" class="btn btn-secondary-custom">

--- a/fighthealthinsurance/templates/appeals.html
+++ b/fighthealthinsurance/templates/appeals.html
@@ -106,6 +106,22 @@ Fight Your Health Insurance Denial: Choose an Appeal
   </p>
 </div>
 
+{% if not use_external %}
+<div id="external-models-prompt" class="alert-box alert-warning" style="display:none; margin-top: 1.5rem;">
+  <h4>Want more options?</h4>
+  <p>
+    Your denial wasn't set up to use external (cloud) AI models, and we
+    generated fewer appeals than usual. External models tend to be more
+    creative and may produce additional drafts for you to choose from.
+    Your denial text is sent to a third-party model provider when you opt in.
+  </p>
+  <button type="button" id="request-external-models-btn" class="btn btn-green">
+    Generate more appeals using external models
+  </button>
+  <div id="external-models-status" style="margin-top: 0.75rem; font-size: 0.95rem;"></div>
+</div>
+{% endif %}
+
 <div class="form-nav-centered">
   {% if back_url %}
   <a href="{{ back_url }}" class="btn btn-secondary-custom">
@@ -130,6 +146,7 @@ Fight Your Health Insurance Denial: Choose an Appeal
       // REST fallback for clients that can't hold a WebSocket open
       // (iOS Safari ITP, corporate proxies that block WS upgrades, etc).
       const restFallbackUrl = `${window.location.protocol}//${window.location.host}{% url 'streaming_appeals_fallback' %}`;
+      const enableExternalModelsUrl = `${window.location.protocol}//${window.location.host}{% url 'enable_external_models' %}`;
       const data = {
 	  {% autoescape off %}
           ...{{form_context}},
@@ -137,6 +154,10 @@ Fight Your Health Insurance Denial: Choose an Appeal
           ...{
               'csrfmiddlewaretoken': '{{ csrf_token }}',
               'timbit': 'is most awesomex2'}}
+
+      // Expose endpoint so appeal_fetcher can offer the "request external
+      // models" button when initial generation yields zero or few appeals.
+      window.enableExternalModelsUrl = enableExternalModelsUrl;
 
       // Call the doQuery function
       doQuery(backendUrl, data, restFallbackUrl);

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -1202,6 +1202,23 @@ class ChooseAppeal(View):
 class GenerateAppeal(View):
     """View for generating appeal letters using ML models."""
 
+    @staticmethod
+    def _appeals_context(
+        *, denial, denial_id: str, email: str, semi_sekret: str, elems: dict
+    ) -> dict:
+        return {
+            "form_context": json.dumps(elems),
+            "user_email": email,
+            "denial_id": denial_id,
+            "semi_sekret": semi_sekret,
+            "current_step": 7,
+            "use_external": denial.use_external,
+            "back_url": build_back_url(
+                "find_next_steps", denial_id, email, semi_sekret
+            ),
+            "back_label": "Back to questions",
+        }
+
     def get(self, request):
         """Handle GET requests for back navigation to appeals page."""
         denial_id = request.GET.get("denial_id")
@@ -1229,17 +1246,13 @@ class GenerateAppeal(View):
         return render(
             request,
             "appeals.html",
-            context={
-                "form_context": json.dumps(elems),
-                "user_email": email,
-                "denial_id": denial_id,
-                "semi_sekret": semi_sekret,
-                "current_step": 7,
-                "back_url": build_back_url(
-                    "find_next_steps", denial_id, email, semi_sekret
-                ),
-                "back_label": "Back to questions",
-            },
+            context=self._appeals_context(
+                denial=denial,
+                denial_id=denial_id,
+                email=email,
+                semi_sekret=semi_sekret,
+                elems=elems,
+            ),
         )
 
     def post(self, request):
@@ -1287,20 +1300,13 @@ class GenerateAppeal(View):
         return render(
             request,
             "appeals.html",
-            context={
-                "form_context": json.dumps(elems),
-                "user_email": form.cleaned_data["email"],
-                "denial_id": form.cleaned_data["denial_id"],
-                "semi_sekret": form.cleaned_data["semi_sekret"],
-                "current_step": 7,
-                "back_url": build_back_url(
-                    "find_next_steps",
-                    form.cleaned_data["denial_id"],
-                    form.cleaned_data["email"],
-                    form.cleaned_data["semi_sekret"],
-                ),
-                "back_label": "Back to questions",
-            },
+            context=self._appeals_context(
+                denial=denial,
+                denial_id=form.cleaned_data["denial_id"],
+                email=form.cleaned_data["email"],
+                semi_sekret=form.cleaned_data["semi_sekret"],
+                elems=elems,
+            ),
         )
 
 

--- a/fighthealthinsurance/websockets.py
+++ b/fighthealthinsurance/websockets.py
@@ -1,12 +1,15 @@
 import asyncio
+import hashlib
 import json
 import os
 import re
 import uuid
 from typing import AsyncIterator, Callable, Optional, Tuple, cast
 
+from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
+from django.db import transaction
 from django.utils import timezone
 
 from asgiref.sync import sync_to_async
@@ -30,6 +33,43 @@ from fighthealthinsurance.models import (
 )
 
 from .chat_interface import ChatInterface
+
+DENIED_ITEMS_ANALYSIS_CACHE_TTL_SECONDS = 60 * 60 * 24
+
+
+async def enqueue_denied_items_analysis(
+    *, chat_id: str, disconnect_event_ts: str
+) -> Optional[str]:
+    """Dispatch denied-items analysis as fire-and-forget background work."""
+    job_key = (
+        f"denied-items-analysis:{chat_id}:{disconnect_event_ts}:v1:"
+        f"{hashlib.sha256(f'{chat_id}:{disconnect_event_ts}:v1'.encode()).hexdigest()[:12]}"
+    )
+    created = await sync_to_async(cache.add)(
+        job_key,
+        {
+            "status": "queued",
+            "chat_id": chat_id,
+            "disconnect_event_ts": disconnect_event_ts,
+            "queued_at": timezone.now().isoformat(),
+        },
+        timeout=DENIED_ITEMS_ANALYSIS_CACHE_TTL_SECONDS,
+    )
+    if not created:
+        logger.info(
+            f"Denied-items analysis enqueue deduped for chat {chat_id} job_key={job_key}"
+        )
+        return None
+    from fighthealthinsurance.denied_items_analysis_actor_ref import (
+        denied_items_analysis_actor_ref,
+    )
+
+    denied_items_analysis_actor_ref.get.run_analysis.remote(
+        job_key=job_key,
+        chat_id=chat_id,
+        disconnect_event_ts=disconnect_event_ts,
+    )
+    return job_key
 
 
 def _get_client_ip_from_scope(scope: Optional[dict] = None) -> Optional[str]:
@@ -577,9 +617,61 @@ class OngoingChatConsumer(AsyncWebsocketConsumer):
 
     async def disconnect(self, close_code):
         logger.debug(f"chat ws: disconnect code={close_code}")
-        # If a chat was active, trigger analysis of denied items
+        # If a chat was active, enqueue denied-item analysis asynchronously.
+        # Disconnect stays non-blocking; analysis is eventually consistent.
         if self.chat_interface and self.chat_id:
-            await self._analyze_denied_items(self.chat_id)
+            disconnect_event_ts = timezone.now().isoformat()
+            try:
+                await enqueue_denied_items_analysis(
+                    chat_id=self.chat_id, disconnect_event_ts=disconnect_event_ts
+                )
+            except Exception as e:
+                logger.opt(exception=True).warning(
+                    f"Failed to enqueue denied-item analysis for chat {self.chat_id}: {e}"
+                )
+
+    @classmethod
+    async def _run_denied_items_analysis_job(
+        cls, *, job_key: str, chat_id: str, disconnect_event_ts: str
+    ) -> None:
+        await sync_to_async(cache.set)(
+            job_key,
+            {
+                "status": "running",
+                "chat_id": chat_id,
+                "disconnect_event_ts": disconnect_event_ts,
+                "started_at": timezone.now().isoformat(),
+            },
+            timeout=DENIED_ITEMS_ANALYSIS_CACHE_TTL_SECONDS,
+        )
+        try:
+            await cls()._analyze_denied_items(chat_id)
+            await sync_to_async(cache.set)(
+                job_key,
+                {
+                    "status": "succeeded",
+                    "chat_id": chat_id,
+                    "disconnect_event_ts": disconnect_event_ts,
+                    "finished_at": timezone.now().isoformat(),
+                },
+                timeout=DENIED_ITEMS_ANALYSIS_CACHE_TTL_SECONDS,
+            )
+        except Exception as e:
+            logger.opt(exception=True).error(
+                "Denied-items analysis worker failure "
+                f"job_key={job_key} chat_id={chat_id} disconnect_event_ts={disconnect_event_ts}: {e}"
+            )
+            await sync_to_async(cache.set)(
+                job_key,
+                {
+                    "status": "failed",
+                    "chat_id": chat_id,
+                    "disconnect_event_ts": disconnect_event_ts,
+                    "error": str(e),
+                    "failed_at": timezone.now().isoformat(),
+                },
+                timeout=DENIED_ITEMS_ANALYSIS_CACHE_TTL_SECONDS,
+            )
 
     async def _analyze_denied_items(self, chat_id: str):
         """
@@ -686,7 +778,13 @@ class OngoingChatConsumer(AsyncWebsocketConsumer):
                                 chat.denied_reason = denied_reason[:_MAX_LEN]
                                 updated = True
                             if updated:
-                                await chat.asave()
+                                await sync_to_async(
+                                    self._persist_denied_items_transactional
+                                )(
+                                    chat.id,
+                                    denied_item[:_MAX_LEN] if denied_item else None,
+                                    denied_reason[:_MAX_LEN] if denied_reason else None,
+                                )
                                 logger.info(
                                     f"Chat {chat_id}: stored denied item/reason "
                                     f"(item_len={len(denied_item) if denied_item else 0}, "
@@ -712,6 +810,18 @@ class OngoingChatConsumer(AsyncWebsocketConsumer):
             logger.opt(exception=True).error(
                 f"Error analyzing denied items for chat {chat_id}: {e}"
             )
+
+    @staticmethod
+    def _persist_denied_items_transactional(
+        chat_id: uuid.UUID, denied_item: Optional[str], denied_reason: Optional[str]
+    ) -> None:
+        with transaction.atomic():
+            chat = OngoingChat.objects.select_for_update().get(id=chat_id)
+            if denied_item:
+                chat.denied_item = denied_item
+            if denied_reason:
+                chat.denied_reason = denied_reason
+            chat.save(update_fields=["denied_item", "denied_reason"])
 
     async def receive(self, text_data):
         data = await _parse_json_or_close(

--- a/fighthealthinsurance/websockets.py
+++ b/fighthealthinsurance/websockets.py
@@ -138,6 +138,63 @@ async def log_zero_appeal_diagnostics(
         )
 
 
+async def _parse_json_or_close(
+    consumer: AsyncWebsocketConsumer,
+    text_data: Optional[str],
+    *,
+    consumer_name: str,
+    streaming_protocol: bool = False,
+) -> Optional[dict]:
+    """Parse a single WebSocket text frame as JSON, closing on bad input.
+
+    Returns the decoded dict on success, or ``None`` when the frame was
+    malformed (in which case an error frame has already been sent and the
+    socket closed). ``streaming_protocol=True`` selects the
+    ``{"type": "error", "message": ...}`` envelope expected by the
+    appeals/escalation streaming clients and appends a trailing newline
+    so the client's line-buffered parser flushes the frame before the
+    socket close arrives; otherwise the simpler ``{"error": ...}`` shape
+    used by entity/prior-auth/chat consumers (which read whole frames).
+
+    Non-object JSON (``[]``, ``"x"``, ``123``, ``null``) is rejected so
+    callers can ``.get()`` on the result without an AttributeError.
+    """
+
+    async def _send_err(message: str) -> None:
+        if streaming_protocol:
+            # Trailing newline: appeal_fetcher.ts buffers ws.onmessage
+            # data and only parses lines terminated by "\n". Without it
+            # the close arrives before the error frame is parsed and
+            # the client falls through to its generic error path.
+            await consumer.send(
+                json.dumps({"type": "error", "message": message}) + "\n"
+            )
+        else:
+            await consumer.send(json.dumps({"error": message}))
+
+    if text_data is None:
+        logger.warning(f"Empty/None text frame received in {consumer_name} websocket")
+        await _send_err("Empty message")
+        await consumer.close()
+        return None
+    try:
+        data = json.loads(text_data)
+    except json.JSONDecodeError as e:
+        logger.warning(f"Invalid JSON received in {consumer_name} websocket: {e}")
+        await _send_err("Invalid JSON format")
+        await consumer.close()
+        return None
+    if not isinstance(data, dict):
+        logger.warning(
+            f"Non-object JSON received in {consumer_name} websocket: "
+            f"{type(data).__name__}"
+        )
+        await _send_err("Expected a JSON object")
+        await consumer.close()
+        return None
+    return data
+
+
 # Test hook: when truthy, StreamingAppealsBackend accepts the
 # connection and closes immediately without yielding any appeal
 # payloads. Lets tests exercise the REST fallback path without
@@ -157,30 +214,18 @@ class StreamingAppealsBackend(AsyncWebsocketConsumer):
         logger.debug(f"appeals ws: disconnect code={close_code}")
 
     async def receive(self, text_data):
-        try:
-            data = json.loads(text_data)
-        except json.JSONDecodeError as e:
-            logger.warning(f"Invalid JSON received in appeals websocket: {e}")
-            # Match the streaming protocol shape so the client's
-            # type==='error' branch in processResponseChunk fires
-            # instead of treating this as an unrecognized frame.
-            await self.send(
-                json.dumps({"type": "error", "message": "Invalid JSON format"})
-            )
-            await self.close()
-            return
-        if not isinstance(data, dict):
-            # Valid JSON but not an object (e.g. `[]`, `"x"`, `123`).
-            # Without this guard, data.get(...) below would raise and
-            # the client would just see a server-side close.
-            logger.warning(
-                "Non-object JSON received in appeals websocket: "
-                f"{type(data).__name__}"
-            )
-            await self.send(
-                json.dumps({"type": "error", "message": "Expected a JSON object"})
-            )
-            await self.close()
+        # streaming_protocol=True so the client's type==='error' branch
+        # in processResponseChunk fires instead of treating this as an
+        # unrecognized frame. The helper also rejects non-object JSON
+        # so .get(...) below can't raise AttributeError on `[]` /
+        # `"x"` / `123`.
+        data = await _parse_json_or_close(
+            self,
+            text_data,
+            consumer_name="appeals",
+            streaming_protocol=True,
+        )
+        if data is None:
             return
         # Test hook: simulate a silent WS death so the JS client falls
         # back to REST. We close cleanly with no payload so the client
@@ -283,14 +328,13 @@ class StreamingEscalationBackend(AsyncWebsocketConsumer):
         logger.debug(f"escalation ws: disconnect code={close_code}")
 
     async def receive(self, text_data):
-        try:
-            data = json.loads(text_data)
-        except json.JSONDecodeError as e:
-            logger.warning(f"Invalid JSON received in escalation websocket: {e}")
-            await self.send(
-                json.dumps({"type": "error", "message": "Invalid JSON format"})
-            )
-            await self.close()
+        data = await _parse_json_or_close(
+            self,
+            text_data,
+            consumer_name="escalation",
+            streaming_protocol=True,
+        )
+        if data is None:
             return
         aitr: AsyncIterator[str] = (
             common_view_logic.EscalationPacketHelper.generate_escalation_letters(data)
@@ -338,12 +382,12 @@ class StreamingEntityBackend(AsyncWebsocketConsumer):
         logger.debug(f"entity ws: disconnect code={close_code}")
 
     async def receive(self, text_data):
-        try:
-            data = json.loads(text_data)
-        except json.JSONDecodeError as e:
-            logger.warning(f"Invalid JSON received in entity extraction websocket: {e}")
-            await self.send(json.dumps({"error": "Invalid JSON format"}))
-            await self.close()
+        data = await _parse_json_or_close(
+            self,
+            text_data,
+            consumer_name="entity extraction",
+        )
+        if data is None:
             return
         if "denial_id" not in data:
             logger.warning("Missing denial_id in entity extraction request")
@@ -385,12 +429,12 @@ class PriorAuthConsumer(AsyncWebsocketConsumer):
         logger.debug(f"prior-auth ws: disconnect code={close_code}")
 
     async def receive(self, text_data):
-        try:
-            data = json.loads(text_data)
-        except json.JSONDecodeError as e:
-            logger.warning(f"Invalid JSON received in prior auth websocket: {e}")
-            await self.send(json.dumps({"error": "Invalid JSON format"}))
-            await self.close()
+        data = await _parse_json_or_close(
+            self,
+            text_data,
+            consumer_name="prior auth",
+        )
+        if data is None:
             return
         logger.debug("prior-auth ws: starting generation")
 
@@ -670,16 +714,21 @@ class OngoingChatConsumer(AsyncWebsocketConsumer):
             )
 
     async def receive(self, text_data):
-        try:
-            data = json.loads(text_data)
-        except json.JSONDecodeError as e:
-            logger.warning(f"Invalid JSON received in ongoing chat websocket: {e}")
-            await self.send(json.dumps({"error": "Invalid JSON format"}))
-            await self.close()
+        data = await _parse_json_or_close(
+            self,
+            text_data,
+            consumer_name="ongoing chat",
+        )
+        if data is None:
             return
         # Get the required data -- note the message should be sent as "content"
-        # but we also accept "message" for backward compatibility.
-        message = data.get("message", data.get("content", None))
+        # but we also accept "message" for backward compatibility. Coerce
+        # any None/missing/non-string value to "" so the downstream
+        # detect_crisis_keywords/detect_delete_data_request calls (which
+        # do an unguarded regex .search on the message) can't crash on
+        # an iterate-only request.
+        message_raw = data.get("message", data.get("content", None))
+        message: str = message_raw if isinstance(message_raw, str) else ""
         chat_id = data.get("chat_id", self.chat_id)
         replay_requested = data.get("replay", False)
         iterate_on_appeal = data.get("iterate_on_appeal")

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,7 +8,7 @@ BUILDX_CMD=${BUILDX_CMD:-push}
 source "${SCRIPT_DIR}/setup_templates.sh"
 
 # BUILDKIT_NO_CLIENT_TOKEN=true
-FHI_VERSION=v0.15.2a
+FHI_VERSION=v0.15.3
 
 
 MYORG=${MYORG:-totallylegitco}

--- a/scripts/start-server.sh
+++ b/scripts/start-server.sh
@@ -13,6 +13,7 @@ if [ -n "$MIGRATIONS" ]; then
   python manage.py loaddata followup
   python manage.py loaddata plan_source
   python manage.py loaddata insurance_companies
+  python manage.py loaddata pa_requirements
   python manage.py ensure_adminuser --no-input
   sleep 10
   exit 0
@@ -35,6 +36,7 @@ if [ "$ENVIRONMENT" == "Dev" ]; then
   python manage.py loaddata followup
   python manage.py loaddata plan_source
   python manage.py loaddata insurance_companies
+  python manage.py loaddata pa_requirements
   python manage.py ensure_adminuser --no-input
 fi
 # Start gunicorn

--- a/tests/async-unit/test_generate_appeal.py
+++ b/tests/async-unit/test_generate_appeal.py
@@ -10,6 +10,8 @@ from fighthealthinsurance.generate_appeal import (
     GeneratedAppeal,
     _peek_real_or_none,
     _shed_context,
+    _PROMPT_TIER1_NULLS,
+    _PROMPT_TIER2_TRUNCATIONS,
     _SHEDDABLE_TIER1,
     _TIER2_TRUNCATIONS,
 )
@@ -333,6 +335,22 @@ class TestShedContext:
         assert new["patient_context"] == "also short"
         assert not any("(truncated)" in c for c in changed)
 
+    def test_tier2_call_dict_truncation_is_boundary_aware(self):
+        # Regression: the call-dict surface previously hard-cut val[:cap]
+        # mid-word, diverging from the boundary-aware prompt surface even
+        # though plan_context carries the same value on both. Both now use
+        # truncate_at_boundary, so the call-dict copy must end on a word
+        # boundary (not a partial token) and stay within the cap.
+        (key, cap), *_ = _TIER2_TRUNCATIONS
+        oversized = "word " * (cap // 2)  # spaces give a boundary to cut on
+        new_calls, _ = _shed_context([_make_call(**{key: oversized})], tier=2)
+        result = new_calls[0][key]
+        assert len(result) <= cap
+        # Boundary-aware: result is a prefix ending on a word boundary, so it
+        # does not end mid-token and remains a prefix of the input.
+        assert not result.endswith("wor")
+        assert oversized.startswith(result.rstrip())
+
     def test_does_not_mutate_input_calls(self):
         original = _make_call()
         _shed_context([original], tier=2)
@@ -344,6 +362,279 @@ class TestShedContext:
             [_make_call(pubmed_context=None, plan_context=None)], tier=2
         )
         assert "pubmed_context" not in changed
+
+    def test_tier0_is_a_noop(self):
+        # Regression (CodeRabbit on PR #824): _shed_context's documented
+        # tier contract is "tier N applies all tier-<=N reductions". Tier 0
+        # must therefore shed nothing — neither the prompt surface (already
+        # guarded on tier >= 1) nor the call-dict surface.
+        original = _make_call()
+        new_calls, changed = _shed_context([original], tier=0)
+        assert changed == []
+        # Tier-1 call-dict keys survive unchanged.
+        for key in _SHEDDABLE_TIER1:
+            assert new_calls[0][key] == original[key]
+        # Tier-2 call-dict keys also survive unchanged (no truncation).
+        for key, _cap in _TIER2_TRUNCATIONS:
+            assert new_calls[0][key] == original[key]
+
+
+# --- _shed_context prompt-rebuild tests -------------------------------------
+
+
+def _prompt_kwargs(**overrides):
+    """Build an ``open_prompt_kwargs`` shape matching make_appeals' actual
+    call to make_open_prompt. Enrichment fields default to non-empty so
+    tier-1 nulling has something to drop."""
+    base = {
+        "denial_text": "denial body",
+        "procedure": "px",
+        "diagnosis": "dx",
+        "patient": None,
+        "professional": None,
+        "qa_context": None,
+        "professional_to_finish": False,
+        "plan_id": None,
+        "claim_id": None,
+        "insurance_company": "ins",
+        "is_tpa": False,
+        "ml_context": "ml ctx",
+        "pubmed_context": "pubmed ctx",
+        "plan_context": "patient plan body",
+        "rag_context": "rag ctx",
+        "nice_context": "nice ctx",
+        "ucr_context": "ucr ctx",
+        "payer_policy_context": "payer policy ctx",
+        "pa_context": "pa ctx",
+        "uspstf_context": "uspstf ctx",
+        "clinical_trials_context": "clinical trials ctx",
+        "regulatory_citation_context": "regulatory ctx",
+        "medication_context": "med ctx",
+    }
+    base.update(overrides)
+    return base
+
+
+def _rebuild_spy(return_value="REBUILT"):
+    """Return (seen_kwargs, rebuild_fn) for capturing _shed_context's
+    rebuild_prompt invocation. Shared by the prompt-rebuild tests below so
+    each one doesn't redefine the same 3-line closure."""
+    seen_kwargs: dict = {}
+
+    def rebuild(**rk):
+        seen_kwargs.update(rk)
+        return return_value
+
+    return seen_kwargs, rebuild
+
+
+def _rebuild_counter():
+    """Return (count_box, rebuild_fn) for tests that only care whether
+    rebuild_prompt was called, not what kwargs it saw. ``count_box[0]``
+    holds the call count."""
+    count_box = [0]
+
+    def rebuild(**_):
+        count_box[0] += 1
+        return "REBUILT"
+
+    return count_box, rebuild
+
+
+class TestShedContextPromptRebuild:
+    """Tier shedding must re-render the prompt with enrichment stripped.
+
+    Without this, pubmed/citations/rag/nice/uspstf/etc. stay baked into
+    ``open_prompt`` even after the call-dict copies are nulled, so the
+    retry token count doesn't actually drop. Regression cover for
+    PR #811 follow-up."""
+
+    def test_tier1_rebuilds_prompt_with_enrichment_nulled(self):
+        kwargs = _prompt_kwargs()
+        seen_kwargs, rebuild = _rebuild_spy(return_value="REBUILT-PROMPT")
+        new_calls, changed = _shed_context(
+            [_make_call(prompt="ORIGINAL")],
+            tier=1,
+            open_prompt_kwargs=kwargs,
+            rebuild_prompt=rebuild,
+            original_open_prompt="ORIGINAL",
+        )
+        # Every enrichment kwarg listed in _PROMPT_TIER1_NULLS gets nulled.
+        for key in _PROMPT_TIER1_NULLS:
+            assert seen_kwargs[key] is None, f"{key} not nulled in rebuild kwargs"
+        # Non-enrichment kwargs survive.
+        assert seen_kwargs["denial_text"] == "denial body"
+        assert seen_kwargs["plan_context"] == "patient plan body"
+        # Each nulled kwarg shows up in the changed list as prompt.<name>.
+        for key in _PROMPT_TIER1_NULLS:
+            assert f"prompt.{key}" in changed
+        # Call's prompt was swapped to the rebuilt one.
+        assert new_calls[0]["prompt"] == "REBUILT-PROMPT"
+
+    def test_tier1_sheds_clinical_trials_context(self):
+        # Regression: clinical_trials_context (added to make_open_prompt in
+        # #821) is a prompt-baked enrichment with no call-dict copy, so it
+        # must be in _PROMPT_TIER1_NULLS or a context-overflow retry would
+        # leave it pinning the token count — the exact bug this PR fixed for
+        # pubmed/citations.
+        assert "clinical_trials_context" in _PROMPT_TIER1_NULLS
+        seen_kwargs, rebuild = _rebuild_spy()
+        _, changed = _shed_context(
+            [_make_call(prompt="ORIGINAL")],
+            tier=1,
+            open_prompt_kwargs=_prompt_kwargs(clinical_trials_context="NCT0123 ..."),
+            rebuild_prompt=rebuild,
+            original_open_prompt="ORIGINAL",
+        )
+        assert seen_kwargs["clinical_trials_context"] is None
+        assert "prompt.clinical_trials_context" in changed
+
+    def test_tier1_sheds_regulatory_citation_context(self):
+        # Regression: regulatory_citation_context (added to make_open_prompt
+        # in #834) is a prompt-baked enrichment with no call-dict copy, so
+        # it must be in _PROMPT_TIER1_NULLS or a context-overflow retry would
+        # leave it pinning the token count.
+        assert "regulatory_citation_context" in _PROMPT_TIER1_NULLS
+        seen_kwargs, rebuild = _rebuild_spy()
+        _, changed = _shed_context(
+            [_make_call(prompt="ORIGINAL")],
+            tier=1,
+            open_prompt_kwargs=_prompt_kwargs(
+                regulatory_citation_context="42 U.S.C. ..."
+            ),
+            rebuild_prompt=rebuild,
+            original_open_prompt="ORIGINAL",
+        )
+        assert seen_kwargs["regulatory_citation_context"] is None
+        assert "prompt.regulatory_citation_context" in changed
+
+    def test_tier1_preserves_specialized_hint_suffix(self):
+        # Specialized calls use `open_prompt + "\n\n--- ... ---\n" + hint`.
+        # The shed pass must swap the prefix while keeping the suffix so the
+        # specialized template hint isn't lost on retry.
+        suffix = "\n\n--- Denial-type guidance ---\nMHPAEA hint"
+        new_calls, _ = _shed_context(
+            [_make_call(prompt="ORIGINAL" + suffix)],
+            tier=1,
+            open_prompt_kwargs=_prompt_kwargs(),
+            rebuild_prompt=lambda **_: "SHED",
+            original_open_prompt="ORIGINAL",
+        )
+        assert new_calls[0]["prompt"] == "SHED" + suffix
+
+    def test_tier1_leaves_unrelated_prompts_alone(self):
+        # The medically-necessary prompt is a separate string and must not
+        # be touched by the prefix swap.
+        new_calls, _ = _shed_context(
+            [_make_call(prompt="totally different med-necessary prompt")],
+            tier=1,
+            open_prompt_kwargs=_prompt_kwargs(),
+            rebuild_prompt=lambda **_: "SHED",
+            original_open_prompt="ORIGINAL",
+        )
+        assert new_calls[0]["prompt"] == "totally different med-necessary prompt"
+
+    def test_tier2_truncates_in_prompt_plan_context_via_boundary(self):
+        # Tier 2 truncates plan_context in the rebuilt prompt's kwargs as
+        # well as in the call dict. Use a value past the cap so truncation
+        # actually fires.
+        (key, cap), *_ = _PROMPT_TIER2_TRUNCATIONS
+        oversized = "para. " * (cap // 5)  # well past the cap
+        kwargs = _prompt_kwargs(**{key: oversized})
+        seen_kwargs, rebuild = _rebuild_spy(return_value="OUT")
+        _, changed = _shed_context(
+            [_make_call(prompt="ORIGINAL")],
+            tier=2,
+            open_prompt_kwargs=kwargs,
+            rebuild_prompt=rebuild,
+            original_open_prompt="ORIGINAL",
+        )
+        assert isinstance(seen_kwargs[key], str)
+        assert len(seen_kwargs[key]) <= cap
+        assert f"prompt.{key}(truncated)" in changed
+
+    def test_tier2_stacks_tier1_enrichment_nulls_in_prompt(self):
+        # Stacking: tier 2 must also apply the tier-1 enrichment nulls to
+        # the rebuilt prompt's kwargs, not just the call-dict copies.
+        seen_kwargs, rebuild = _rebuild_spy(return_value="OUT")
+        _shed_context(
+            [_make_call(prompt="ORIGINAL")],
+            tier=2,
+            open_prompt_kwargs=_prompt_kwargs(),
+            rebuild_prompt=rebuild,
+            original_open_prompt="ORIGINAL",
+        )
+        for key in _PROMPT_TIER1_NULLS:
+            assert seen_kwargs[key] is None, f"{key} not nulled at tier 2"
+
+    def test_omitted_rebuild_args_falls_back_to_call_dict_only(self):
+        # When the caller doesn't pass rebuild args, _shed_context is a
+        # pure call-dict shedder — same shape as the legacy tests above.
+        new_calls, changed = _shed_context([_make_call()], tier=1)
+        assert new_calls[0]["prompt"] == "Please write an appeal."  # unchanged
+        assert not any(c.startswith("prompt.") for c in changed)
+
+    def test_skips_rebuild_when_no_prompt_surface_changes(self):
+        # Regression (Copilot review): make_open_prompt random.shuffle()s
+        # the professional-POV example list, so re-calling it for a no-op
+        # would silently change the retry prompt's example ordering even
+        # though ``changed`` reports nothing shed. Skip the rebuild entirely
+        # when no prompt kwarg was nulled or truncated.
+        empty_kwargs = {key: None for key in _PROMPT_TIER1_NULLS}
+        kwargs = _prompt_kwargs(**empty_kwargs, plan_context="short")
+        calls_count, rebuild = _rebuild_counter()
+        new_calls, changed = _shed_context(
+            [_make_call(prompt="ORIGINAL")],
+            tier=2,  # tier 2 would otherwise try plan_context truncation
+            open_prompt_kwargs=kwargs,
+            rebuild_prompt=rebuild,
+            original_open_prompt="ORIGINAL",
+        )
+        assert calls_count[0] == 0, "rebuild_prompt called despite no-op shed"
+        assert not any(c.startswith("prompt.") for c in changed)
+        # Call's prompt is untouched too (no swap happened).
+        assert new_calls[0]["prompt"] == "ORIGINAL"
+
+    def test_whitespace_only_enrichment_is_still_shed(self):
+        # Regression (Copilot review on PR #824): a whitespace-only
+        # enrichment value is NOT a no-op in make_open_prompt --- the gate
+        # there is ``is not None and != ""``, so ``"   "`` still trips
+        # has_citations and renders the CITATION INSTRUCTIONS block plus
+        # the per-section header (``Provided citations (use these):    ``).
+        # Those bytes need to drop on retry, so the shed pass must null
+        # whitespace-only values and trigger a rebuild.
+        whitespace_kwargs = {key: "   \n\t" for key in _PROMPT_TIER1_NULLS}
+        kwargs = _prompt_kwargs(**whitespace_kwargs)
+        seen_kwargs, rebuild = _rebuild_spy(return_value="SHED")
+        _, changed = _shed_context(
+            [_make_call(prompt="ORIGINAL")],
+            tier=1,
+            open_prompt_kwargs=kwargs,
+            rebuild_prompt=rebuild,
+            original_open_prompt="ORIGINAL",
+        )
+        # Every whitespace-only enrichment is nulled and reported.
+        for key in _PROMPT_TIER1_NULLS:
+            assert seen_kwargs[key] is None, f"{key} should have been nulled"
+            assert f"prompt.{key}" in changed
+
+    def test_truly_empty_string_enrichment_is_skipped(self):
+        # The truly-empty string ``""`` IS already a no-op in
+        # make_open_prompt (gate fails on ``!= ""``), so it can be skipped
+        # without adding diagnostic noise to ``changed``. Pin that the
+        # truly-empty case still avoids a rebuild call.
+        empty_kwargs = {key: "" for key in _PROMPT_TIER1_NULLS}
+        kwargs = _prompt_kwargs(**empty_kwargs, plan_context="short")
+        calls_count, rebuild = _rebuild_counter()
+        _, changed = _shed_context(
+            [_make_call(prompt="ORIGINAL")],
+            tier=2,
+            open_prompt_kwargs=kwargs,
+            rebuild_prompt=rebuild,
+            original_open_prompt="ORIGINAL",
+        )
+        assert calls_count[0] == 0, "rebuild fired on truly-empty enrichment"
+        assert not any(c.startswith("prompt.") for c in changed)
 
 
 # --- make_appeals router-call-pattern tests --------------------------------

--- a/tests/async-unit/test_pubmed_search.py
+++ b/tests/async-unit/test_pubmed_search.py
@@ -13,6 +13,7 @@ The end-to-end ``structured_search`` test is wrapped with the Django
 """
 
 import asyncio
+import json
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -21,6 +22,7 @@ from asgiref.sync import async_to_sync
 from django.test import TransactionTestCase
 
 from fighthealthinsurance.models import PubMedMiniArticle
+from fighthealthinsurance.models import PubMedQueryData
 from fighthealthinsurance.pubmed_search import (
     EvidenceStrength,
     MODERATE_PUB_TYPES,
@@ -864,6 +866,107 @@ _LOCMEM_CACHES = {
         "LOCATION": "pubmed-test",
     }
 }
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_find_pubmed_ids_positive_cache_hit_skips_db_and_api():
+    from django.core.cache import cache
+    from django.test.utils import override_settings
+
+    with override_settings(CACHES=_LOCMEM_CACHES):
+        await cache.aclear()
+        tools = PubMedTools()
+        cache_key = tools._pubmed_query_cache_key("Asthma trial", "2022")
+        await cache.aset(cache_key, ["11111111"], timeout=60)
+
+        with patch(
+            "fighthealthinsurance.pubmed_tools.pubmed_fetcher.pmids_for_query"
+        ) as fetch_mock:
+            result = await tools.find_pubmed_article_ids_for_query(
+                "Asthma trial", since="2022"
+            )
+        assert result == ["11111111"]
+        fetch_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_find_pubmed_ids_negative_cache_hit_returns_empty():
+    from django.core.cache import cache
+    from django.test.utils import override_settings
+
+    with override_settings(CACHES=_LOCMEM_CACHES):
+        await cache.aclear()
+        tools = PubMedTools()
+        cache_key = tools._pubmed_query_cache_key("No matches", "2021")
+        await cache.aset(cache_key, [], timeout=60)
+
+        with patch(
+            "fighthealthinsurance.pubmed_tools.pubmed_fetcher.pmids_for_query"
+        ) as fetch_mock:
+            result = await tools.find_pubmed_article_ids_for_query(
+                "No matches", since="2021"
+            )
+        assert result == []
+        fetch_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_find_pubmed_ids_cache_miss_then_db_hit_writes_through_cache():
+    from django.core.cache import cache
+    from django.test.utils import override_settings
+
+    with override_settings(CACHES=_LOCMEM_CACHES):
+        await cache.aclear()
+        tools = PubMedTools()
+        await PubMedQueryData.objects.acreate(
+            query="COPD treatment",
+            since="2020",
+            articles=json.dumps(["22222222", "33333333"]),
+        )
+        cache_key = tools._pubmed_query_cache_key("COPD treatment", "2020")
+        assert await cache.aget(cache_key) is None
+
+        with patch(
+            "fighthealthinsurance.pubmed_tools.pubmed_fetcher.pmids_for_query"
+        ) as fetch_mock:
+            result = await tools.find_pubmed_article_ids_for_query(
+                "COPD treatment", since="2020"
+            )
+        assert result == ["22222222", "33333333"]
+        assert await cache.aget(cache_key) == ["22222222", "33333333"]
+        fetch_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_find_pubmed_ids_cache_miss_then_api_fetch_writes_db_and_cache():
+    from django.core.cache import cache
+    from django.test.utils import override_settings
+
+    with override_settings(CACHES=_LOCMEM_CACHES):
+        await cache.aclear()
+        tools = PubMedTools()
+        cache_key = tools._pubmed_query_cache_key("heart failure beta blocker", "2023")
+
+        with patch(
+            "fighthealthinsurance.pubmed_tools.pubmed_fetcher.pmids_for_query",
+            return_value=["44444444"],
+        ) as fetch_mock:
+            result = await tools.find_pubmed_article_ids_for_query(
+                "heart failure beta blocker", since="2023"
+            )
+        assert result == ["44444444"]
+        assert await cache.aget(cache_key) == ["44444444"]
+        fetch_mock.assert_called_once_with("heart failure beta blocker", since="2023")
+        row = await PubMedQueryData.objects.filter(
+            query="heart failure beta blocker",
+            since="2023",
+            denial_id__isnull=True,
+        ).alatest("internal_id")
+        assert json.loads(row.articles) == ["44444444"]
 
 
 @pytest.mark.asyncio

--- a/tests/async-unit/test_regulatory_citations.py
+++ b/tests/async-unit/test_regulatory_citations.py
@@ -46,6 +46,23 @@ class TestGetRegulatoryCitationContext(unittest.TestCase):
         self.assertIn("California", block)
         self.assertIn("sole basis", block)
 
+    def test_washington_explicit_hook_supersedes_generic(self):
+        # Washington has a specific, individually-verified SB 5395 hook, so the
+        # block carries its real effective date and credential-disclosure demand
+        # (which the generic AI-oversight framing lacked) and lists WA only once.
+        block = get_regulatory_citation_context("WA")
+        self.assertIsNotNone(block)
+        assert block is not None
+        self.assertIn("Washington", block)
+        self.assertIn("June 11, 2026", block)
+        self.assertIn("credentials", block)
+        # AI-as-sole-basis framing is preserved.
+        self.assertIn("sole basis", block)
+        # Federal hooks still ride along with the state hook.
+        self.assertIn("CMS-0057-F", block)
+        # No generic + explicit duplication: Washington appears exactly once.
+        self.assertEqual(block.count("Washington"), 1)
+
     def test_self_insured_caveat_wording(self):
         self_insured = get_regulatory_citation_context("MA", self_insured=True)
         assert self_insured is not None

--- a/tests/async/test_clinicaltrials_integration.py
+++ b/tests/async/test_clinicaltrials_integration.py
@@ -164,6 +164,12 @@ class TestFindTrialsForQuery:
     async def test_find_trials_for_denial_writes_audit_row_and_global_cache(self):
         """find_trials_for_denial must write a global cache row that the next
         call can hit, plus a separate denial-scoped audit row."""
+        # Drop any leftover cache rows for this query (a failed flush in a
+        # previous attempt leaks rows across the rerun) so the cache-miss
+        # and row-count assertions below start from a clean slate.
+        await ClinicalTrialQueryData.objects.filter(
+            query="pembrolizumab melanoma"
+        ).adelete()
         tools = ClinicalTrialsTools()
         denial = await Denial.objects.acreate(
             procedure="pembrolizumab",
@@ -185,8 +191,13 @@ class TestFindTrialsForQuery:
         assert [t.nct_id for t in trials_again] == ["NCT55555555"]
         assert session_factory.call_count == 1
         # One global cache row + two denial-scoped audit rows (one per call).
+        # Scope the global count to this test's query: with
+        # transaction=True cleanup is a table flush, and if a previous
+        # test's flush failed (e.g. transient sqlite table lock) its global
+        # rows survive into the rerun and an unscoped count flakes.
         global_rows = await ClinicalTrialQueryData.objects.filter(
-            denial_id__isnull=True
+            denial_id__isnull=True,
+            query="pembrolizumab melanoma",
         ).acount()
         denial_rows = await ClinicalTrialQueryData.objects.filter(
             denial_id=denial

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,18 +18,35 @@ os.environ["TESTING"] = "True"
 
 
 def _has_ssl_intercepting_proxy() -> bool:
-    """Detect if an SSL-intercepting proxy prevents connecting to api.stripe.com.
+    """Detect environments where api.stripe.com can't be reached with a valid
+    certificate.
 
-    Returns True when the environment has an HTTPS proxy AND SSL verification
-    to api.stripe.com fails (e.g. self-signed cert from a MITM proxy).
-    Returns False when there is no proxy or when SSL verification succeeds.
+    Covers env-var-configured proxies, transparent SSL-intercepting proxies
+    (which set no proxy env vars), and fully firewalled sandboxes. The E2E
+    Stripe tests can't pass in any of those, so they should skip rather than
+    fail on connect.
+
+    The probe verifies against the Stripe SDK's bundled CA file — the same
+    bundle the SDK uses at request time. A sandbox that injects its MITM CA
+    into the *system* trust store would otherwise pass a default-context
+    probe while every real SDK call still fails certificate verification.
     """
-    if not (os.environ.get("HTTPS_PROXY") or os.environ.get("https_proxy")):
-        return False
     try:
-        handler = urllib.request.ProxyHandler()
-        opener = urllib.request.build_opener(handler)
+        import stripe
+
+        ssl_context = ssl.create_default_context(cafile=stripe.ca_bundle_path)
+    except Exception:
+        ssl_context = ssl.create_default_context()
+    try:
+        opener = urllib.request.build_opener(
+            urllib.request.ProxyHandler(),
+            urllib.request.HTTPSHandler(context=ssl_context),
+        )
         opener.open("https://api.stripe.com", timeout=5)
+        return False
+    except urllib.error.HTTPError:
+        # An HTTP error status still means we reached Stripe with a valid
+        # TLS handshake; only transport/verification failures mean blocked.
         return False
     except (ssl.SSLError, ssl.SSLCertVerificationError, urllib.error.URLError, OSError):
         return True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,6 +92,29 @@ def _clear_pa_resolver_cache():
 
 
 @pytest.fixture(autouse=True)
+def _stub_denied_items_analysis_dispatch():
+    """Stub the denied-items analysis Ray dispatch for the whole suite.
+
+    ``OngoingChatConsumer.disconnect`` enqueues analysis on a detached Ray
+    actor. In tests there is no Ray cluster, so the first unpatched chat
+    disconnect would lazily start an in-process Ray instance whose detached
+    actor crash-loops against the test database and eventually hard-kills
+    the pytest process mid-suite. Tests that assert on dispatch behavior
+    patch the same attribute themselves; their innermost patch wins.
+    """
+    from unittest.mock import patch as _patch
+
+    try:
+        with _patch(
+            "fighthealthinsurance.denied_items_analysis_actor_ref.denied_items_analysis_actor_ref"
+        ) as mock_ref:
+            mock_ref.get.run_analysis.remote.return_value = None
+            yield
+    except (ImportError, AttributeError):
+        yield
+
+
+@pytest.fixture(autouse=True)
 def _drain_fire_and_forget_threads():
     """Drain fire-and-forget background threads at the end of each test.
 

--- a/tests/sync/test_context_utils.py
+++ b/tests/sync/test_context_utils.py
@@ -262,6 +262,23 @@ class TestAttachSupplementalToCitations(unittest.TestCase):
         self.assertEqual(ml, existing)
         self.assertIsNone(pm)
 
+    def test_dedupe_preserves_list_input_type_when_already_present(self):
+        # Regression: when ml_citation_context is a list whose flattened
+        # form already contains the supplemental (e.g. a single entry
+        # that the previous call appended into), the function must
+        # return the original list rather than silently flattening it
+        # to a string. Downstream consumers in common_view_logic.py
+        # branch on isinstance(..., list) and produce different output
+        # for the two shapes.
+        supp = "Prior IMR decision: case 12345 reversed."
+        # flatten_citation_context joins list entries with "\n", so a
+        # single entry containing "...\n\nsupp" splits into two blocks
+        # on "\n\n" and the dedup matcher can detect it.
+        existing_list = [f"original context\n\n{supp}"]
+        ml, pm = attach_supplemental_to_citations(existing_list, None, supp)
+        self.assertIs(ml, existing_list)
+        self.assertIsNone(pm)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/sync/test_deploy_fixture_sequence.py
+++ b/tests/sync/test_deploy_fixture_sequence.py
@@ -1,0 +1,135 @@
+"""Deploy-time fixture loading guards.
+
+The k8s ``web-migrations`` Job and the dev container both load fixtures via
+``scripts/start-server.sh``. These tests pin the script's ``loaddata``
+sequence to the fixtures the application expects at runtime and verify the
+sequence actually loads (in deploy order, idempotently), so a fixture added
+to the repo but forgotten in the deploy script fails CI instead of shipping
+an empty table to prod (as nearly happened with ``pa_requirements``).
+"""
+
+import re
+from pathlib import Path
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from fighthealthinsurance.models import (
+    AppealTemplates,
+    DataSource,
+    InsuranceCompany,
+    PayerPriorAuthRequirement,
+    PlanSource,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+START_SERVER = REPO_ROOT / "scripts" / "start-server.sh"
+FIXTURES_DIR = REPO_ROOT / "fighthealthinsurance" / "fixtures"
+
+# The fixtures every deployment must load, in deploy order.
+# ``pa_requirements`` references InsuranceCompany rows by pk, so it must
+# come after ``insurance_companies``.
+DEPLOY_FIXTURES = [
+    "initial",
+    "followup",
+    "plan_source",
+    "insurance_companies",
+    "pa_requirements",
+]
+
+# YAML fixtures that intentionally are NOT loaded at deploy time. Add an
+# entry here (with a reason) instead of letting the directory-coverage test
+# fail when introducing a fixture that shouldn't ship to prod.
+NON_DEPLOY_FIXTURES = {
+    "chooser_test_data",  # test-only data for chooser tests
+}
+
+
+def _loaddata_sequences(script_text: str) -> list[list[str]]:
+    """Extract each block's ordered ``manage.py loaddata`` fixture names.
+
+    Blocks are separated on the Dev-environment guard so the MIGRATIONS job
+    sequence and the dev-startup sequence are checked independently.
+    """
+    blocks = script_text.split('if [ "$ENVIRONMENT" == "Dev" ]')
+    pattern = re.compile(r"^\s*python manage\.py loaddata (\S+)\s*$", re.MULTILINE)
+    return [pattern.findall(block) for block in blocks]
+
+
+class StartServerFixtureSequenceTests(TestCase):
+    """The deploy script must load every deploy fixture, in order."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.script_text = START_SERVER.read_text()
+
+    def test_migrations_block_loads_all_deploy_fixtures_in_order(self):
+        migrations_seq = _loaddata_sequences(self.script_text)[0]
+        self.assertEqual(
+            migrations_seq,
+            DEPLOY_FIXTURES,
+            "scripts/start-server.sh MIGRATIONS block fixture sequence "
+            "diverged from the expected deploy fixtures",
+        )
+
+    def test_dev_block_loads_all_deploy_fixtures_in_order(self):
+        sequences = _loaddata_sequences(self.script_text)
+        self.assertEqual(
+            len(sequences),
+            2,
+            "Expected a Dev-environment block in scripts/start-server.sh",
+        )
+        self.assertEqual(
+            sequences[1],
+            DEPLOY_FIXTURES,
+            "scripts/start-server.sh Dev block fixture sequence diverged "
+            "from the expected deploy fixtures",
+        )
+
+    def test_every_yaml_fixture_is_deployed_or_explicitly_excluded(self):
+        yaml_fixtures = {p.stem for p in FIXTURES_DIR.glob("*.yaml")}
+        unaccounted = yaml_fixtures - set(DEPLOY_FIXTURES) - NON_DEPLOY_FIXTURES
+        self.assertFalse(
+            unaccounted,
+            f"New fixture(s) {sorted(unaccounted)} are neither loaded by "
+            "scripts/start-server.sh (add to DEPLOY_FIXTURES and the deploy "
+            "script) nor explicitly excluded in NON_DEPLOY_FIXTURES",
+        )
+
+
+class DeployFixtureLoadTests(TestCase):
+    """The deploy fixture sequence must load cleanly and idempotently."""
+
+    def _assert_loaded(self):
+        self.assertGreater(InsuranceCompany.objects.count(), 0)
+        self.assertGreater(PayerPriorAuthRequirement.objects.count(), 0)
+        self.assertGreater(PlanSource.objects.count(), 0)
+        self.assertGreater(DataSource.objects.count(), 0)
+        self.assertGreater(AppealTemplates.objects.count(), 0)
+
+    def test_deploy_sequence_loads_in_deploy_order(self):
+        for fixture in DEPLOY_FIXTURES:
+            call_command("loaddata", fixture, verbosity=0)
+        self._assert_loaded()
+
+    def test_deploy_sequence_is_idempotent_on_rerun(self):
+        for fixture in DEPLOY_FIXTURES:
+            call_command("loaddata", fixture, verbosity=0)
+        counts = {
+            "company": InsuranceCompany.objects.count(),
+            "pa": PayerPriorAuthRequirement.objects.count(),
+            "plan_source": PlanSource.objects.count(),
+            "templates": AppealTemplates.objects.count(),
+        }
+        for fixture in DEPLOY_FIXTURES:
+            call_command("loaddata", fixture, verbosity=0)
+        self.assertEqual(
+            counts,
+            {
+                "company": InsuranceCompany.objects.count(),
+                "pa": PayerPriorAuthRequirement.objects.count(),
+                "plan_source": PlanSource.objects.count(),
+                "templates": AppealTemplates.objects.count(),
+            },
+        )

--- a/tests/sync/test_escalation_packet.py
+++ b/tests/sync/test_escalation_packet.py
@@ -1,11 +1,16 @@
 """Unit tests for the regulator escalation packet feature."""
 
-from unittest.mock import patch
+import json
+from unittest.mock import AsyncMock, patch
 
+from asgiref.sync import async_to_sync
 from django.test import TestCase, Client
 from django.urls import reverse
 
-from fighthealthinsurance.common_view_logic import get_denial_for_action
+from fighthealthinsurance.common_view_logic import (
+    EscalationPacketHelper,
+    get_denial_for_action,
+)
 from fighthealthinsurance.escalation_addresses import (
     DOL_EBSA_NAME,
     RECIPIENT_DOI,
@@ -271,6 +276,24 @@ class EscalationPacketViewTest(TestCase):
         # Medical director recipient is always present.
         self.assertContains(response, "Medical Director")
 
+    def test_appeals_generation_page_exposes_escalation_button(self):
+        """The appeals.html page (where users choose between drafts) must
+        link to the regulator escalation flow. Without this, the only entry
+        point is the final review page, which many users never reach.
+        """
+        response = self.client.get(
+            reverse("generate_appeal"),
+            {
+                "denial_id": self.denial.denial_id,
+                "email": self.email,
+                "semi_sekret": self.denial.semi_sekret,
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "appeals.html")
+        self.assertContains(response, 'id="generate_escalation_packet"')
+        self.assertContains(response, reverse("escalation_packet"))
+
     def test_choose_escalation_letter_rejects_invalid_form(self):
         url = reverse("choose_escalation_letter")
         response = self.client.post(url, {"letter_text": "x"})
@@ -315,3 +338,175 @@ class EscalationPacketViewTest(TestCase):
             },
         )
         self.assertEqual(response.status_code, 302)
+
+
+def _collect_stream(parameters: dict):
+    """Drive the async generator to completion and return parsed JSON records.
+
+    Fails the caller's test if any chunk is non-empty but not valid JSON —
+    we never want a malformed stream record to be silently dropped.
+    """
+
+    async def _consume():
+        results = []
+        async for chunk in EscalationPacketHelper.generate_escalation_letters(
+            parameters
+        ):
+            line = chunk.strip()
+            if not line:
+                continue
+            results.append(json.loads(line))
+        return results
+
+    return async_to_sync(_consume)()
+
+
+class EscalationStreamReusesExistingTest(TestCase):
+    """The streaming generator must not regenerate or duplicate prior drafts.
+
+    Without this, every revisit to the escalation page (e.g. clicking
+    "Back to all regulator letters" from the review screen) would burn
+    fresh LLM calls and accumulate duplicate `RegulatorEscalation` rows.
+    """
+
+    def setUp(self):
+        self.email = "stream@example.com"
+        self.denial = Denial.objects.create(
+            denial_text="some denial",
+            hashed_email=Denial.get_hashed_email(self.email),
+            insurance_company="Aetna",
+            # No state -> only the medical_director recipient is built.
+            your_state="",
+        )
+
+    def _params(self):
+        return {
+            "denial_id": self.denial.denial_id,
+            "email": self.email,
+            "semi_sekret": self.denial.semi_sekret,
+        }
+
+    def test_existing_letter_is_streamed_without_calling_llm(self):
+        existing = RegulatorEscalation.objects.create(
+            for_denial=self.denial,
+            hashed_email=self.denial.hashed_email,
+            recipient_type=RegulatorEscalation.RECIPIENT_MEDICAL_DIRECTOR,
+            recipient_name="Medical Director, Aetna",
+            letter_text="A previously generated draft we should reuse.",
+        )
+
+        # If the LLM is invoked we fail the test loudly.
+        with patch(
+            "fighthealthinsurance.generate_regulator_letter.generate_regulator_letter",
+            new=AsyncMock(side_effect=AssertionError("LLM must not be called")),
+        ):
+            results = _collect_stream(self._params())
+
+        letters = [r for r in results if r.get("type") == "letter"]
+        self.assertEqual(len(letters), 1)
+        self.assertEqual(letters[0]["escalation_id"], str(existing.uuid))
+        self.assertEqual(letters[0]["content"], existing.letter_text)
+        # No duplicate row was created.
+        self.assertEqual(
+            RegulatorEscalation.objects.filter(for_denial=self.denial).count(),
+            1,
+        )
+
+    def test_missing_recipient_is_generated_existing_is_reused(self):
+        # Pre-seed only the medical_director letter; pretend the denial is
+        # also ERISA-flagged so DOL EBSA is in the recipient list and must
+        # be generated fresh.
+        self.denial.your_state = ""
+        self.denial.save()
+        # Mark the denial as ERISA-likely via the insurance_company_obj path.
+        from fighthealthinsurance.models import InsuranceCompany
+
+        ic = InsuranceCompany.objects.create(
+            name="SomeTPA", is_tpa=True, regex="sometpa", negative_regex="zzznever"
+        )
+        self.denial.insurance_company_obj = ic
+        self.denial.save()
+
+        existing_md = RegulatorEscalation.objects.create(
+            for_denial=self.denial,
+            hashed_email=self.denial.hashed_email,
+            recipient_type=RegulatorEscalation.RECIPIENT_MEDICAL_DIRECTOR,
+            recipient_name="Medical Director, Aetna",
+            letter_text="Existing MD letter.",
+        )
+
+        async def fake_llm(denial, recipient, use_external=False):
+            return f"Fresh letter for {recipient.recipient_type}"
+
+        with patch(
+            "fighthealthinsurance.generate_regulator_letter.generate_regulator_letter",
+            new=AsyncMock(side_effect=fake_llm),
+        ) as mock_llm:
+            results = _collect_stream(self._params())
+
+        letters = [r for r in results if r.get("type") == "letter"]
+        types = {r["recipient_type"] for r in letters}
+        self.assertIn(RegulatorEscalation.RECIPIENT_MEDICAL_DIRECTOR, types)
+        self.assertIn(RegulatorEscalation.RECIPIENT_DOL_EBSA, types)
+        # LLM was only invoked for the missing recipient.
+        self.assertEqual(mock_llm.call_count, 1)
+        called_recipient = mock_llm.call_args.args[1]
+        self.assertEqual(
+            called_recipient.recipient_type, RegulatorEscalation.RECIPIENT_DOL_EBSA
+        )
+        # Existing MD row was reused, not duplicated.
+        md_rows = RegulatorEscalation.objects.filter(
+            for_denial=self.denial,
+            recipient_type=RegulatorEscalation.RECIPIENT_MEDICAL_DIRECTOR,
+        )
+        self.assertEqual(md_rows.count(), 1)
+        self.assertEqual(md_rows.first().pk, existing_md.pk)
+        # A new EBSA row exists.
+        self.assertEqual(
+            RegulatorEscalation.objects.filter(
+                for_denial=self.denial,
+                recipient_type=RegulatorEscalation.RECIPIENT_DOL_EBSA,
+            ).count(),
+            1,
+        )
+
+    def test_fresh_run_generates_one_row_per_recipient(self):
+        async def fake_llm(denial, recipient, use_external=False):
+            return f"Letter for {recipient.recipient_type}"
+
+        with patch(
+            "fighthealthinsurance.generate_regulator_letter.generate_regulator_letter",
+            new=AsyncMock(side_effect=fake_llm),
+        ):
+            results = _collect_stream(self._params())
+
+        letters = [r for r in results if r.get("type") == "letter"]
+        self.assertEqual(len(letters), 1)
+        self.assertEqual(
+            letters[0]["recipient_type"],
+            RegulatorEscalation.RECIPIENT_MEDICAL_DIRECTOR,
+        )
+        # Exactly one row per recipient.
+        self.assertEqual(
+            RegulatorEscalation.objects.filter(for_denial=self.denial).count(),
+            1,
+        )
+
+    def test_invalid_denial_yields_error(self):
+        results = _collect_stream(
+            {
+                "denial_id": self.denial.denial_id,
+                "email": self.email,
+                "semi_sekret": "wrong",
+            }
+        )
+        errors = [r for r in results if r.get("type") == "error"]
+        self.assertTrue(errors)
+        self.assertEqual(
+            RegulatorEscalation.objects.filter(for_denial=self.denial).count(), 0
+        )
+
+    def test_missing_parameters_yield_error(self):
+        results = _collect_stream({"denial_id": "", "email": "", "semi_sekret": ""})
+        errors = [r for r in results if r.get("type") == "error"]
+        self.assertTrue(errors)

--- a/tests/sync/test_migration_state.py
+++ b/tests/sync/test_migration_state.py
@@ -1,0 +1,66 @@
+"""Migration hygiene guards.
+
+Catches two failure modes before they hit the deploy pipeline:
+
+- model changes without a generated migration (``makemigrations --check``),
+- conflicting leaf migrations from parallel branches (multiple 0NNN_* leaves),
+  which previously broke every test suite at setup with an opaque
+  ``Conflicting migrations detected`` error instead of one clear failure.
+"""
+
+from io import StringIO
+
+from django.core.management import call_command
+from django.db.migrations.loader import MigrationLoader
+from django.test import TestCase
+
+# Scoped to first-party apps: third-party apps (e.g. django-mfa2) ship
+# migrations that DEFAULT_AUTO_FIELD makes Django want to regenerate, which
+# isn't actionable from this repo.
+FIRST_PARTY_APPS = ["fighthealthinsurance", "fhi_users", "charts"]
+
+
+class MigrationStateTests(TestCase):
+    def test_no_model_changes_missing_migrations(self):
+        try:
+            call_command(
+                "makemigrations",
+                *FIRST_PARTY_APPS,
+                "--check",
+                "--dry-run",
+                verbosity=1,
+                stdout=StringIO(),
+                stderr=StringIO(),
+            )
+        except SystemExit:
+            self.fail(
+                "Model changes without migrations detected; run "
+                "`python manage.py makemigrations`"
+            )
+
+    def test_no_conflicting_leaf_migrations(self):
+        loader = MigrationLoader(None, ignore_no_migrations=True)
+        conflicts = loader.detect_conflicts()
+        self.assertFalse(
+            conflicts,
+            f"Conflicting leaf migrations detected: {conflicts}; run "
+            "`python manage.py makemigrations --merge` or renumber",
+        )
+
+    def test_renamed_rxnorm_migration_replaces_original_name(self):
+        """0175_rxnormconcept shipped to prod as 0173_rxnormconcept before
+        being renamed (#787). Without ``replaces`` (and its original 0172
+        dependency), databases that applied it under the old name re-create
+        the table on the next deploy and the migration job crash-loops."""
+        loader = MigrationLoader(None, ignore_no_migrations=True)
+        migration = loader.disk_migrations[
+            ("fighthealthinsurance", "0175_rxnormconcept")
+        ]
+        self.assertIn(
+            ("fighthealthinsurance", "0173_rxnormconcept"),
+            migration.replaces,
+        )
+        self.assertIn(
+            ("fighthealthinsurance", "0172_payerpriorauthrequirement"),
+            migration.dependencies,
+        )

--- a/tests/sync/test_ongoing_chat.py
+++ b/tests/sync/test_ongoing_chat.py
@@ -1,8 +1,11 @@
 import typing
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 from channels.testing import WebsocketCommunicator
 
+from django.core.cache import cache
 from django.contrib.auth import get_user_model
+from django.test import override_settings
+from django.utils import timezone
 
 from rest_framework.test import APITestCase
 
@@ -15,6 +18,16 @@ from fighthealthinsurance.models import (
 from fighthealthinsurance.websockets import OngoingChatConsumer
 from fhi_users.models import ProfessionalDomainRelation
 from .mock_chat_model import MockChatModel
+
+# Real in-memory cache for tests that exercise cache.add dedupe and job
+# state writes; the suite-wide default is DummyCache, which discards
+# writes and reports every add as new.
+_LOCMEM_CACHE = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "test-ongoing-chat",
+    }
+}
 
 from asgiref.sync import sync_to_async, async_to_sync
 
@@ -244,6 +257,79 @@ class OngoingChatWebSocketTest(APITestCase):
         )
         self.assertEqual(prior_auth_refresh.chat_id, chat.id)
         await communicator.disconnect()
+        await self.asyncTearDown()
+
+    async def test_disconnect_enqueues_denied_items_analysis_once(self):
+        await self.asyncSetUp()
+        consumer = OngoingChatConsumer()
+        consumer.chat_interface = object()
+        chat = await sync_to_async(OngoingChat.objects.create)(
+            is_patient=True,
+            user=await sync_to_async(User.objects.create_user)(
+                username="enqueueuser", password="testpass", email="enqueue@example.com"
+            ),
+            chat_history=[],
+            summary_for_next_call=[],
+        )
+        consumer.chat_id = str(chat.id)
+        # Dedupe relies on cache.add; the suite-wide DummyCache "adds"
+        # every time, so swap in a real in-memory cache for this test.
+        with override_settings(CACHES=_LOCMEM_CACHE):
+            cache.clear()
+            with patch(
+                "fighthealthinsurance.denied_items_analysis_actor_ref.denied_items_analysis_actor_ref",
+            ) as mock_dispatch:
+                mock_dispatch.get.run_analysis.remote.return_value = "job-ref"
+                # Same disconnect event timestamp both times so the job key
+                # (and therefore cache.add dedupe) matches.
+                with patch(
+                    "fighthealthinsurance.websockets.timezone.now",
+                    return_value=timezone.now(),
+                ):
+                    await consumer.disconnect(1000)
+                    await consumer.disconnect(1000)
+                self.assertEqual(mock_dispatch.get.run_analysis.remote.call_count, 1)
+        await self.asyncTearDown()
+
+    async def test_disconnect_is_non_blocking_when_dispatch_fails(self):
+        await self.asyncSetUp()
+        consumer = OngoingChatConsumer()
+        consumer.chat_interface = object()
+        chat = await sync_to_async(OngoingChat.objects.create)(
+            is_patient=True,
+            user=await sync_to_async(User.objects.create_user)(
+                username="failuser", password="testpass", email="fail@example.com"
+            ),
+            chat_history=[],
+            summary_for_next_call=[],
+        )
+        consumer.chat_id = str(chat.id)
+        with patch(
+            "fighthealthinsurance.websockets.enqueue_denied_items_analysis",
+            new=AsyncMock(side_effect=RuntimeError("queue offline")),
+        ), patch("fighthealthinsurance.websockets.logger") as mock_logger:
+            await consumer.disconnect(1000)
+            # disconnect logs via logger.opt(exception=True).warning(...)
+            self.assertTrue(mock_logger.opt.return_value.warning.called)
+        await self.asyncTearDown()
+
+    async def test_background_failure_marks_failed_state(self):
+        await self.asyncSetUp()
+        job_key = "denied-items-analysis:test:failure"
+        with override_settings(CACHES=_LOCMEM_CACHE):
+            cache.clear()
+            with patch(
+                "fighthealthinsurance.websockets.OngoingChatConsumer._analyze_denied_items",
+                new=AsyncMock(side_effect=RuntimeError("model failure")),
+            ):
+                await OngoingChatConsumer._run_denied_items_analysis_job(
+                    job_key=job_key,
+                    chat_id="fake-chat",
+                    disconnect_event_ts="2026-05-13T00:00:00+00:00",
+                )
+            state = cache.get(job_key)
+            self.assertEqual(state["status"], "failed")
+            self.assertEqual(state["chat_id"], "fake-chat")
         await self.asyncTearDown()
 
     async def test_link_chat_to_appeal_permission_denied(self):

--- a/tests/sync/test_rest_api.py
+++ b/tests/sync/test_rest_api.py
@@ -798,6 +798,169 @@ class StreamingAppealsRestFallbackTest(APITestCase):
         self.assertEqual(len(set(ids)), len(ids))
 
 
+class EnableExternalModelsTest(APITestCase):
+    """Test the endpoint that lets users opt their denial into external
+    LLM models from the appeal page when the initial internal-only
+    generation produced few or no appeals."""
+
+    def _make_denial(
+        self,
+        *,
+        email: str = "owner@example.com",
+        use_external: bool = False,
+    ) -> Denial:
+        return Denial.objects.create(
+            denial_text="Test denial body",
+            hashed_email=Denial.get_hashed_email(email),
+            use_external=use_external,
+        )
+
+    def _post(self, payload: dict):
+        return self.client.post(
+            reverse("enable_external_models"),
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+    def test_flips_use_external_on_valid_credentials(self):
+        denial = self._make_denial()
+        self.assertFalse(denial.use_external)
+        response = self._post(
+            {
+                "denial_id": denial.denial_id,
+                "email": "owner@example.com",
+                "semi_sekret": denial.semi_sekret,
+            }
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"use_external": True})
+        denial.refresh_from_db()
+        self.assertTrue(denial.use_external)
+
+    def test_idempotent_when_already_enabled(self):
+        """Calling the endpoint when external models are already on
+        must succeed (200) without raising. The button is only shown to
+        users whose denial has use_external=False, but races and reloads
+        should not 500."""
+        denial = self._make_denial(
+            email="already@example.com", use_external=True
+        )
+        response = self._post(
+            {
+                "denial_id": denial.denial_id,
+                "email": "already@example.com",
+                "semi_sekret": denial.semi_sekret,
+            }
+        )
+        self.assertEqual(response.status_code, 200)
+        denial.refresh_from_db()
+        self.assertTrue(denial.use_external)
+
+    def test_rejects_wrong_semi_sekret(self):
+        denial = self._make_denial()
+        response = self._post(
+            {
+                "denial_id": denial.denial_id,
+                "email": "owner@example.com",
+                "semi_sekret": "wrong-sekret",
+            }
+        )
+        self.assertEqual(response.status_code, 404)
+        denial.refresh_from_db()
+        self.assertFalse(denial.use_external)
+
+    def test_rejects_wrong_email(self):
+        denial = self._make_denial()
+        response = self._post(
+            {
+                "denial_id": denial.denial_id,
+                "email": "someone-else@example.com",
+                "semi_sekret": denial.semi_sekret,
+            }
+        )
+        self.assertEqual(response.status_code, 404)
+        denial.refresh_from_db()
+        self.assertFalse(denial.use_external)
+
+    def test_rejects_missing_credentials(self):
+        denial = self._make_denial()
+        response = self._post({"denial_id": denial.denial_id})
+        self.assertEqual(response.status_code, 404)
+        denial.refresh_from_db()
+        self.assertFalse(denial.use_external)
+
+    def test_rejects_non_object_body(self):
+        """Non-mapping JSON bodies (arrays, strings, numbers) must 400
+        rather than 500. Without the isinstance guard, request.data.get
+        on a list would raise AttributeError."""
+        response = self.client.post(
+            reverse("enable_external_models"),
+            data=json.dumps([1, 2, 3]),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("JSON object", response.content.decode())
+
+    def test_cross_denial_isolation(self):
+        """Denial A's credentials must not be able to flip Denial B."""
+        denial_a = self._make_denial(email="alice@example.com")
+        denial_b = self._make_denial(email="bob@example.com")
+        response = self._post(
+            {
+                "denial_id": denial_b.denial_id,
+                "email": "alice@example.com",
+                "semi_sekret": denial_a.semi_sekret,
+            }
+        )
+        self.assertEqual(response.status_code, 404)
+        denial_b.refresh_from_db()
+        self.assertFalse(denial_b.use_external)
+
+
+class GenerateAppealUseExternalContextTest(APITestCase):
+    """The appeals page must expose `use_external` so the JS client can
+    decide whether to surface the 'request external models' opt-in."""
+
+    def test_context_reflects_internal_only_denial(self):
+        denial = Denial.objects.create(
+            denial_text="Internal-only denial",
+            hashed_email=Denial.get_hashed_email("internal@example.com"),
+            use_external=False,
+        )
+        response = self.client.get(
+            reverse("generate_appeal"),
+            {
+                "denial_id": str(denial.denial_id),
+                "email": "internal@example.com",
+                "semi_sekret": denial.semi_sekret,
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context["use_external"])
+        # Prompt block (which wraps the button) only renders when
+        # use_external is False.
+        self.assertContains(response, "external-models-prompt")
+
+    def test_context_reflects_external_enabled_denial(self):
+        denial = Denial.objects.create(
+            denial_text="External-enabled denial",
+            hashed_email=Denial.get_hashed_email("external@example.com"),
+            use_external=True,
+        )
+        response = self.client.get(
+            reverse("generate_appeal"),
+            {
+                "denial_id": str(denial.denial_id),
+                "email": "external@example.com",
+                "semi_sekret": denial.semi_sekret,
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.context["use_external"])
+        # When external is already on, we don't render the opt-in prompt.
+        self.assertNotContains(response, "external-models-prompt")
+
+
 class NotifyPatientTest(APITestCase):
     """Test the notify_patient API endpoint."""
 

--- a/tests/sync/test_safety_appeal_scenarios.py
+++ b/tests/sync/test_safety_appeal_scenarios.py
@@ -14,6 +14,7 @@ Each test class targets one row of the safety/appeal scenario table:
 """
 
 import asyncio
+import datetime
 import re
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -498,6 +499,64 @@ class OcrDataExtractionTests(TestCase):
         self.assertEqual(
             score_extracted_field("dob", "03/04/1985", "DOB 1985-03-04"),
             "high",
+        )
+
+    def test_identifier_confidence_matches_across_separator_variants(self):
+        # IDs often appear in the source with different separators than the
+        # extracted value. The extracted "H5521001" should still be evidenced
+        # by a "H5521-001" rendering in the document and reach "high".
+        self.assertEqual(
+            score_extracted_field(
+                "member_id", "H5521001", "... Member ID: H5521-001 ..."
+            ),
+            "high",
+        )
+
+    def test_identifier_confidence_present_verbatim_is_high(self):
+        # A plausible identifier that appears verbatim in the source is "high".
+        self.assertEqual(
+            score_extracted_field(
+                "member_id", "ABC123456789", "Member ID: ABC123456789"
+            ),
+            "high",
+        )
+
+    def test_identifier_confidence_implausible_value_is_low(self):
+        # An implausible identifier scores "low" regardless of source presence.
+        self.assertEqual(
+            score_extracted_field("member_id", "Plan ID", "Plan ID listed here"),
+            "low",
+        )
+
+    def test_dob_confidence_recognizes_day_first_rendering(self):
+        # When the DOB is a pre-parsed date (the view-parsed path) and the
+        # source renders it day-first (e.g. "15/01/1980"), it should still be
+        # evidenced and reach "high" rather than dropping to "medium".
+        self.assertEqual(
+            score_extracted_field(
+                "dob", datetime.date(1980, 1, 15), "... DOB 15/01/1980 ..."
+            ),
+            "high",
+        )
+
+    def test_dob_confidence_us_and_iso_renderings_still_high(self):
+        # US-format and ISO renderings of a pre-parsed date remain "high".
+        self.assertEqual(
+            score_extracted_field("dob", datetime.date(1980, 1, 15), "DOB 01/15/1980"),
+            "high",
+        )
+        self.assertEqual(
+            score_extracted_field("dob", datetime.date(1980, 1, 15), "DOB 1980-01-15"),
+            "high",
+        )
+
+    def test_dob_confidence_plausible_but_absent_is_medium(self):
+        # A plausible pre-parsed date with no source evidence drops to "medium".
+        self.assertEqual(
+            score_extracted_field(
+                "dob", datetime.date(1980, 1, 15), "No date anywhere here."
+            ),
+            "medium",
         )
 
 


### PR DESCRIPTION
Deployment-readiness review for v0.15.3 found two issues that would have
broken or degraded the next prod deploy:

- The pa_requirements fixture (added in #790 as the only seed source for
  PayerPriorAuthRequirement) was never loaded by scripts/start-server.sh,
  so the PA-requirement search/context feature would ship with an empty
  table in prod and dev. Add `loaddata pa_requirements` to both the
  MIGRATIONS-job and Dev startup paths, after insurance_companies (FK
  dependency).

- 0175_rxnormconcept originally shipped as 0173_rxnormconcept in the
  v0.15.2a deploy window and was renamed in #787 without a `replaces`
  declaration. A database that applied it under the old name would
  re-run CreateModel on the next deploy and crash-loop the migrations
  job ("table fighthealthinsurance_rxnormconcept already exists";
  reproduced against a simulated prod schema). Declare
  `replaces = [0173_rxnormconcept]`, restore its original 0172
  dependency so the applied-before-dependency consistency check passes,
  and have 0176 depend on both forks of the 0172 split to keep a single
  leaf. Verified against simulated pre-rename prod state, post-rename
  state, and fresh databases.

New guard tests:
- tests/sync/test_deploy_fixture_sequence.py pins the deploy script's
  loaddata sequence, requires every repo fixture to be deployed or
  explicitly excluded, and loads the sequence in deploy order twice to
  prove ordering and idempotency.
- tests/sync/test_migration_state.py runs makemigrations --check for
  first-party apps, rejects conflicting leaf migrations (the 0182
  incident), and pins the 0175 replaces/dependency contract.

Also bump FHI_VERSION to v0.15.3 for the next deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added ability to opt into external models for improved appeal generation when initial attempts yield few results
  * Added escalation packet feature to generate regulator-friendly letters with reusable draft support

* **Improvements**
  * Enhanced PubMed search caching for faster result retrieval
  * Improved OCR field extraction confidence scoring for member IDs and dates
  * Added Humana prior authorization requirement information
  * Updated Washington state regulatory citations

* **Bug Fixes**
  * Fixed context preservation in citation handling
  * Improved retry logic for better context shedding during appeal generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->