### PR TITLE
Add Azure OpenAI and Claude support with model tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -131,6 +131,7 @@ ANTHROPIC_API_KEY=your-anthropic-api-key
 # Restrict which REMOTE models are loaded (optional). Comma-separated list of
 # model names (the friendly names shown in the "All loaded models" startup log,
 # e.g. azure-openai/gpt-5, anthropic/claude-opus-4-8). When unset, ALL configured
-# models are enabled. When set, ONLY the listed remote models are enabled --
-# local/internal models (e.g. fhi-legacy) are always enabled regardless.
+# models are enabled. When set, ONLY the listed remote generation models are
+# enabled -- local/internal models (e.g. fhi-legacy) and context-only models
+# (e.g. Perplexity sonar for citations) are always enabled regardless.
 # ENABLED_REMOTE_MODELS=azure-anthropic/claude-opus-4-8,azure-openai/gpt-5

--- a/.env.example
+++ b/.env.example
@@ -109,3 +109,27 @@ GROQ_API_KEY=your-groq-api-key
 # Anthropic Claude API (optional)
 # Used for high-quality chat and letter generation when use_external=True
 ANTHROPIC_API_KEY=your-anthropic-api-key
+
+# Azure OpenAI Service (optional) - OpenAI GPT models hosted on Azure
+# Endpoint must be the OpenAI-compatible v1 base URL (no trailing
+# /chat/completions). Registers models as azure-openai/<deployment>.
+# AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com/openai/v1
+# AZURE_OPENAI_API_KEY=your-azure-openai-key
+# Optional: override the default latest-model deployments (comma-separated).
+# Defaults to: gpt-4.1-mini, gpt-5-mini, gpt-5
+# AZURE_OPENAI_MODELS=gpt-5,gpt-5-mini
+
+# Azure AI Foundry - Anthropic Claude on Azure (optional)
+# Endpoint must be the OpenAI-compatible base URL (no trailing
+# /chat/completions). Registers models as azure-anthropic/<deployment>.
+# AZURE_ANTHROPIC_ENDPOINT=https://your-resource.services.ai.azure.com/openai/v1
+# AZURE_ANTHROPIC_API_KEY=your-azure-foundry-key
+# Optional: override the default latest-model deployments (comma-separated).
+# Defaults to: claude-haiku-4-5, claude-sonnet-4-6, claude-opus-4-8
+# AZURE_ANTHROPIC_MODELS=claude-opus-4-8,claude-sonnet-4-6
+
+# Restrict which models are loaded (optional). Comma-separated list of model
+# names (the friendly names shown in the "All loaded models" startup log, e.g.
+# azure-openai/gpt-5, anthropic/claude-opus-4-7, fhi-legacy). When unset, ALL
+# configured models are enabled. When set, ONLY the listed models are enabled.
+# ENABLED_REMOTE_MODELS=azure-anthropic/claude-opus-4-8,azure-openai/gpt-5

--- a/.env.example
+++ b/.env.example
@@ -128,8 +128,9 @@ ANTHROPIC_API_KEY=your-anthropic-api-key
 # Defaults to: claude-haiku-4-5, claude-sonnet-4-6, claude-opus-4-8
 # AZURE_ANTHROPIC_MODELS=claude-opus-4-8,claude-sonnet-4-6
 
-# Restrict which models are loaded (optional). Comma-separated list of model
-# names (the friendly names shown in the "All loaded models" startup log, e.g.
-# azure-openai/gpt-5, anthropic/claude-opus-4-7, fhi-legacy). When unset, ALL
-# configured models are enabled. When set, ONLY the listed models are enabled.
+# Restrict which REMOTE models are loaded (optional). Comma-separated list of
+# model names (the friendly names shown in the "All loaded models" startup log,
+# e.g. azure-openai/gpt-5, anthropic/claude-opus-4-8). When unset, ALL configured
+# models are enabled. When set, ONLY the listed remote models are enabled --
+# local/internal models (e.g. fhi-legacy) are always enabled regardless.
 # ENABLED_REMOTE_MODELS=azure-anthropic/claude-opus-4-8,azure-openai/gpt-5

--- a/.env.example
+++ b/.env.example
@@ -120,9 +120,11 @@ ANTHROPIC_API_KEY=your-anthropic-api-key
 # AZURE_OPENAI_MODELS=gpt-5,gpt-5-mini
 
 # Azure AI Foundry - Anthropic Claude on Azure (optional)
-# Endpoint must be the OpenAI-compatible base URL (no trailing
-# /chat/completions). Registers models as azure-anthropic/<deployment>.
-# AZURE_ANTHROPIC_ENDPOINT=https://your-resource.services.ai.azure.com/openai/v1
+# Foundry's Claude deployments use the native Anthropic Messages API (NOT an
+# OpenAI-compatible surface). Endpoint is the Anthropic base URL ending in
+# /anthropic; the /v1/messages path is appended automatically. Registers models
+# as azure-anthropic/<deployment>.
+# AZURE_ANTHROPIC_ENDPOINT=https://your-resource.services.ai.azure.com/anthropic
 # AZURE_ANTHROPIC_API_KEY=your-azure-foundry-key
 # Optional: override the default latest-model deployments (comma-separated).
 # Defaults to: claude-haiku-4-5, claude-sonnet-4-6, claude-opus-4-8

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The router auto-discovers any external backend whose API key (and, for Azure,
 endpoint) is configured. Each model is registered under a friendly name that is
 recorded for usage tracking in both the regular appeal workflow and the chooser
 (e.g. `azure-openai/gpt-5`, `azure-anthropic/claude-opus-4-8`,
-`anthropic/claude-opus-4-7`). Configured names are printed in the
+`anthropic/claude-opus-4-8`). Configured names are printed in the
 `All loaded models` line at startup.
 
 | Provider | Required env vars | Friendly name prefix |
@@ -115,11 +115,14 @@ recorded for usage tracking in both the regular appeal workflow and the chooser
    ids, list them explicitly with `AZURE_OPENAI_MODELS` /
    `AZURE_ANTHROPIC_MODELS` (comma-separated).
 
-**Restricting which models load:** Set `ENABLED_REMOTE_MODELS` to a
-comma-separated list of friendly names to enable *only* those models. When the
-variable is unset (the default), every configured model is enabled.
+**Restricting which remote models load:** Set `ENABLED_REMOTE_MODELS` to a
+comma-separated list of friendly names to enable *only* those **remote**
+(external) models. Local/internal models (e.g. `fhi-legacy`, the self-hosted
+backends) are **always enabled** regardless of this setting. When the variable
+is unset (the default), every configured model is enabled.
 ```bash
-# Only load Azure Opus and Azure GPT-5, nothing else:
+# Of the remote providers, load only Azure Opus and Azure GPT-5
+# (local models still load):
 export ENABLED_REMOTE_MODELS="azure-anthropic/claude-opus-4-8,azure-openai/gpt-5"
 ```
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,62 @@ The app needs an ML backend to generate appeals. Options:
    ```
    Note: Requires a GPU (3090 or equivalent).
 
+3. **Hosted generative models (Azure, Anthropic, Groq, …)**: Set the relevant
+   API keys (see below). These external models are used when `use_external=True`
+   (e.g. premium/chooser workflows).
+
+### External & Azure Generative Models
+
+The router auto-discovers any external backend whose API key (and, for Azure,
+endpoint) is configured. Each model is registered under a friendly name that is
+recorded for usage tracking in both the regular appeal workflow and the chooser
+(e.g. `azure-openai/gpt-5`, `azure-anthropic/claude-opus-4-8`,
+`anthropic/claude-opus-4-7`). Configured names are printed in the
+`All loaded models` line at startup.
+
+| Provider | Required env vars | Friendly name prefix |
+| --- | --- | --- |
+| Azure OpenAI (GPT) | `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_ENDPOINT` | `azure-openai/` |
+| Azure AI Foundry (Claude) | `AZURE_ANTHROPIC_API_KEY`, `AZURE_ANTHROPIC_ENDPOINT` | `azure-anthropic/` |
+| Anthropic (direct) | `ANTHROPIC_API_KEY` | `anthropic/` |
+| Groq | `GROQ_API_KEY` | `groq/` |
+| DeepInfra | `DEEPINFRA_API` | (model id) |
+| Perplexity (citations) | `PERPLEXITY_API` | `sonar` |
+
+**Set up Azure-hosted models (Claude & OpenAI):**
+
+1. In the [Azure AI Foundry](https://ai.azure.com/) / Azure OpenAI portal, create
+   a resource and **deploy** the model(s) you want (e.g. `gpt-5`,
+   `claude-opus-4-8`). Note the *deployment name* — that is the model id sent on
+   the wire.
+2. Copy the resource's **API key** and its **OpenAI-compatible v1 endpoint**.
+   The endpoint is the base URL *without* a trailing `/chat/completions`, e.g.
+   `https://my-resource.openai.azure.com/openai/v1` (Azure OpenAI) or
+   `https://my-resource.services.ai.azure.com/openai/v1` (Foundry/Claude).
+3. Export the variables (or add them to `.env`):
+   ```bash
+   # Azure OpenAI (GPT family)
+   export AZURE_OPENAI_API_KEY=...
+   export AZURE_OPENAI_ENDPOINT=https://my-resource.openai.azure.com/openai/v1
+
+   # Azure AI Foundry (Claude family)
+   export AZURE_ANTHROPIC_API_KEY=...
+   export AZURE_ANTHROPIC_ENDPOINT=https://my-resource.services.ai.azure.com/openai/v1
+   ```
+4. By default the latest models are exposed (Azure OpenAI: `gpt-4.1-mini`,
+   `gpt-5-mini`, `gpt-5`; Azure Claude: `claude-haiku-4-5`, `claude-sonnet-4-6`,
+   `claude-opus-4-8`). If your Azure *deployment names* differ from these model
+   ids, list them explicitly with `AZURE_OPENAI_MODELS` /
+   `AZURE_ANTHROPIC_MODELS` (comma-separated).
+
+**Restricting which models load:** Set `ENABLED_REMOTE_MODELS` to a
+comma-separated list of friendly names to enable *only* those models. When the
+variable is unset (the default), every configured model is enabled.
+```bash
+# Only load Azure Opus and Azure GPT-5, nothing else:
+export ENABLED_REMOTE_MODELS="azure-anthropic/claude-opus-4-8,azure-openai/gpt-5"
+```
+
 ### Troubleshooting
 
 If you see `django.core.exceptions.AppRegistryNotReady`, make sure you're using Python 3.10+.

--- a/README.md
+++ b/README.md
@@ -95,10 +95,15 @@ recorded for usage tracking in both the regular appeal workflow and the chooser
    a resource and **deploy** the model(s) you want (e.g. `gpt-5`,
    `claude-opus-4-8`). Note the *deployment name* — that is the model id sent on
    the wire.
-2. Copy the resource's **API key** and its **OpenAI-compatible v1 endpoint**.
-   The endpoint is the base URL *without* a trailing `/chat/completions`, e.g.
-   `https://my-resource.openai.azure.com/openai/v1` (Azure OpenAI) or
-   `https://my-resource.services.ai.azure.com/openai/v1` (Foundry/Claude).
+2. Copy the resource's **API key** and endpoint. The two providers use different
+   API surfaces:
+   - **Azure OpenAI (GPT)** is OpenAI-compatible — use the v1 base URL *without*
+     a trailing `/chat/completions`, e.g.
+     `https://my-resource.openai.azure.com/openai/v1`.
+   - **Azure AI Foundry (Claude)** uses the native Anthropic **Messages API** —
+     use the base URL ending in `/anthropic`, e.g.
+     `https://my-resource.services.ai.azure.com/anthropic` (the `/v1/messages`
+     path is appended automatically).
 3. Export the variables (or add them to `.env`):
    ```bash
    # Azure OpenAI (GPT family)
@@ -107,7 +112,7 @@ recorded for usage tracking in both the regular appeal workflow and the chooser
 
    # Azure AI Foundry (Claude family)
    export AZURE_ANTHROPIC_API_KEY=...
-   export AZURE_ANTHROPIC_ENDPOINT=https://my-resource.services.ai.azure.com/openai/v1
+   export AZURE_ANTHROPIC_ENDPOINT=https://my-resource.services.ai.azure.com/anthropic
    ```
 4. By default the latest models are exposed (Azure OpenAI: `gpt-4.1-mini`,
    `gpt-5-mini`, `gpt-5`; Azure Claude: `claude-haiku-4-5`, `claude-sonnet-4-6`,

--- a/README.md
+++ b/README.md
@@ -117,9 +117,10 @@ recorded for usage tracking in both the regular appeal workflow and the chooser
 
 **Restricting which remote models load:** Set `ENABLED_REMOTE_MODELS` to a
 comma-separated list of friendly names to enable *only* those **remote**
-(external) models. Local/internal models (e.g. `fhi-legacy`, the self-hosted
-backends) are **always enabled** regardless of this setting. When the variable
-is unset (the default), every configured model is enabled.
+generation models. **Always enabled** regardless of this setting: local/internal
+models (e.g. `fhi-legacy`, the self-hosted backends) and context-only models
+(e.g. Perplexity `sonar` used for citations). When the variable is unset (the
+default), every configured model is enabled.
 ```bash
 # Of the remote providers, load only Azure Opus and Azure GPT-5
 # (local models still load):

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -377,6 +377,13 @@ def repetition_penalty(text: str, min_block_size: int = 3) -> float:
 class RemoteModelLike(DenialBase):
     """Base class for remote ML model backends used for chat and appeal generation."""
 
+    # Friendly tracking name, stamped by MLRouter during model registration so
+    # that consumers holding a model *instance* (e.g. the chooser in
+    # chooser_tasks.py) can record the same human-readable name the router uses
+    # (matches ModelDescription.name / ml_router.models_by_name keys) instead of
+    # an opaque ``<...object at 0x...>`` repr. ``None`` until the router stamps it.
+    name: Optional[str] = None
+
     # Keywords that indicate Medicaid/Medicare-related conversation
     # Note: All keywords should be lowercase for case-insensitive matching
     MEDICAID_KEYWORDS: ClassVar[List[str]] = [
@@ -460,6 +467,21 @@ class RemoteModelLike(DenialBase):
         "government health",
         "public health insurance",
     ]
+
+    def __str__(self) -> str:
+        # Prefer the friendly tracking name (stamped by MLRouter). Fall back to
+        # a class+model descriptor so logs and any consumer that calls
+        # ``str(model)`` never surface an opaque ``<...object at 0x...>`` repr.
+        name = getattr(self, "name", None)
+        if name:
+            return str(name)
+        model = getattr(self, "model", None)
+        if isinstance(model, str) and model:
+            return f"{type(self).__name__}({model})"
+        return type(self).__name__
+
+    def __repr__(self) -> str:
+        return self.__str__()
 
     def quality(self) -> int:
         return 100
@@ -3277,6 +3299,323 @@ class RemoteAnthropic(RemoteFullOpenLike):
         if not os.getenv("ANTHROPIC_API_KEY"):
             return False
         return self.rate_limiter.can_request()
+
+
+class RemoteAzureOpenLike(RemoteFullOpenLike):
+    """
+    Shared base for Azure-hosted, OpenAI-compatible generative backends.
+
+    Microsoft Azure serves both Azure OpenAI Service (GPT-family models) and,
+    via Azure AI Foundry, Anthropic Claude models through an OpenAI-compatible
+    ``/chat/completions`` surface that accepts Bearer-token authentication —
+    the same wire format ``RemoteOpenLike`` already speaks, so no SDK is
+    required.
+
+    Two things differ from the fixed public Anthropic/Groq endpoints:
+
+    * Azure resources are tenant-specific, so the endpoint *and* the API key
+      are read from environment variables rather than hard-coded.
+    * The set of available models is operator-specific (Azure "deployments"
+      are named by whoever provisions the resource), so each provider ships a
+      latest-models default that can be overridden with an environment
+      variable listing the deployment names to expose.
+
+    Subclasses configure a provider by setting the ``*_ENV`` names, the
+    friendly-name ``NAME_PREFIX`` (used for tracking, e.g. ``azure-openai``),
+    the ``MAX_LEN`` context window, and the ``DEFAULT_MODELS`` spec. Each
+    concrete subclass MUST also declare its own ``_rate_limiters`` /
+    ``_rate_limiter_lock`` so providers don't share rate-limit state.
+
+    Environment variables (names are subclass-specific):
+    - <API_KEY_ENV>:  API key for the Azure resource (required to enable)
+    - <ENDPOINT_ENV>: Base URL up to and including the OpenAI-compatible
+        version segment, e.g.
+        ``https://my-resource.openai.azure.com/openai/v1`` (required)
+    - <MODELS_ENV>:   Optional comma-separated list of deployment names to
+        expose instead of the latest-models default.
+    """
+
+    # --- Subclass configuration (overridden by concrete providers) --------
+    API_KEY_ENV: ClassVar[str] = ""
+    ENDPOINT_ENV: ClassVar[str] = ""
+    MODELS_ENV: ClassVar[str] = ""
+    NAME_PREFIX: ClassVar[str] = "azure"
+    PROVIDER_LABEL: ClassVar[str] = "Azure"
+    MAX_LEN: ClassVar[int] = 128000
+    # Ordered cheapest -> most expensive: (deployment_name, cost, tier).
+    DEFAULT_MODELS: ClassVar[List[Tuple[str, int, str]]] = []
+
+    # Per-provider rate-limit state. Declared here for type-safety; each
+    # concrete subclass overrides these with its own dict/lock so providers do
+    # not share rate-limit state.
+    _rate_limiters: ClassVar[dict[str, RateLimiter]] = {}
+    _rate_limiter_lock: ClassVar[threading.Lock] = threading.Lock()
+
+    # Re-raise ClientResponseError from the parent _infer so we can detect 429.
+    _propagate_http_errors: ClassVar[bool] = True
+
+    def __init__(self, model: str, dual_mode: bool = False):
+        api_key = os.getenv(self.API_KEY_ENV) if self.API_KEY_ENV else None
+        endpoint = os.getenv(self.ENDPOINT_ENV) if self.ENDPOINT_ENV else None
+        if not api_key:
+            raise EnvironmentError(
+                f"No API key found for {self.PROVIDER_LABEL}. Please set the "
+                f"{self.API_KEY_ENV} environment variable in your environment "
+                f"or .env file."
+            )
+        if not endpoint:
+            raise EnvironmentError(
+                f"No endpoint found for {self.PROVIDER_LABEL}. Please set the "
+                f"{self.ENDPOINT_ENV} environment variable (e.g. "
+                f"https://my-resource.openai.azure.com/openai/v1)."
+            )
+
+        api_base = self._normalize_endpoint(endpoint)
+        super().__init__(
+            api_base, api_key, model=model, dual_mode=dual_mode, max_len=self.MAX_LEN
+        )
+
+        self._ensure_rate_limiter(model)
+
+        tier = self.get_tier()
+        logger.debug(
+            f"{type(self).__name__} initialized: model={model}, tier={tier}, "
+            f"endpoint={api_base}"
+        )
+
+    @staticmethod
+    def _normalize_endpoint(endpoint: str) -> str:
+        """Trim trailing slashes and a trailing ``/chat/completions`` so the
+        operator can paste either the base URL or the full completions URL.
+
+        ``__infer`` appends ``/chat/completions`` to ``api_base``; stripping it
+        here keeps both forms working.
+        """
+        e = endpoint.strip().rstrip("/")
+        suffix = "/chat/completions"
+        if e.endswith(suffix):
+            e = e[: -len(suffix)]
+        return e
+
+    @classmethod
+    def _configured_deployments(cls) -> List[Tuple[str, int, str]]:
+        """Resolve the (deployment, cost, tier) list, honoring the optional
+        ``MODELS_ENV`` override. Overridden deployments inherit incrementing
+        costs from the cheapest default and a ``custom`` tier."""
+        override = os.getenv(cls.MODELS_ENV) if cls.MODELS_ENV else None
+        if override and override.strip():
+            names = [n.strip() for n in override.split(",") if n.strip()]
+            base_cost = cls.DEFAULT_MODELS[0][1] if cls.DEFAULT_MODELS else 60
+            return [(n, base_cost + i * 10, "custom") for i, n in enumerate(names)]
+        return list(cls.DEFAULT_MODELS)
+
+    @classmethod
+    def _ensure_rate_limiter(cls, model: str) -> None:
+        """Ensure a rate limiter exists for the given model (thread-safe)."""
+        if model not in cls._rate_limiters:
+            with cls._rate_limiter_lock:
+                if model not in cls._rate_limiters:
+                    cls._rate_limiters[model] = RateLimiter(
+                        name=f"{cls.NAME_PREFIX}-{model}",
+                    )
+                    logger.info(f"Created rate limiter for {cls.NAME_PREFIX}-{model}")
+
+    @property
+    def rate_limiter(self) -> RateLimiter:
+        """Get the rate limiter for this model instance."""
+        return self._rate_limiters[self.model]
+
+    @property
+    def supports_system(self):
+        return True
+
+    @property
+    def external(self):
+        return True
+
+    def get_tier(self) -> str:
+        """Get the tier (speed/quality/premium/custom) for this model."""
+        for deployment, _cost, tier in self._configured_deployments():
+            if deployment == self.model:
+                return tier
+        return "unknown"
+
+    async def _infer(
+        self,
+        system_prompts: list[str],
+        prompt: str,
+        patient_context: Optional[str] = None,
+        plan_context: Optional[str] = None,
+        pubmed_context: Optional[str] = None,
+        ml_citations_context: Optional[List[str]] = None,
+        history: Optional[List[dict[str, str]]] = None,
+        temperature: float = 0.7,
+    ) -> Optional[Tuple[Optional[str], Optional[List[str]]]]:
+        """Perform inference with rate-limit checking and 429 handling.
+
+        Mirrors the public Anthropic/Groq backends: skip when backing off, and
+        on a 429 mark the limiter exhausted (honoring Retry-After) so other
+        backends can take over.
+        """
+        if not self.rate_limiter.can_request():
+            logger.debug(
+                f"{type(self).__name__}._infer: Skipping {self.model} - backing off"
+            )
+            return None
+
+        try:
+            return await super()._infer(
+                system_prompts=system_prompts,
+                prompt=prompt,
+                patient_context=patient_context,
+                plan_context=plan_context,
+                pubmed_context=pubmed_context,
+                ml_citations_context=ml_citations_context,
+                history=history,
+                temperature=temperature,
+            )
+        except aiohttp.ClientResponseError as e:
+            if e.status == 429:
+                retry_after = 60.0
+                if hasattr(e, "headers") and e.headers:
+                    retry_header = e.headers.get("Retry-After", "")
+                    if retry_header:
+                        try:
+                            retry_after = float(retry_header)
+                        except ValueError:
+                            logger.debug(
+                                f"{type(self).__name__}._infer: Non-numeric "
+                                f"Retry-After header '{retry_header}' for "
+                                f"{self.model}; using default {retry_after}s"
+                            )
+
+                retry_after = max(1.0, min(retry_after, 600.0))
+
+                self.rate_limiter.mark_exhausted(retry_after)
+                logger.warning(
+                    f"{type(self).__name__}._infer: 429 from {self.PROVIDER_LABEL} "
+                    f"for {self.model}, backing off for {retry_after}s"
+                )
+                return None
+            else:
+                raise
+        except Exception as e:
+            logger.warning(f"{type(self).__name__}._infer error for {self.model}: {e}")
+            return None
+
+    @classmethod
+    def models(cls) -> List[ModelDescription]:
+        """Return the configured Azure deployments as ModelDescriptions.
+
+        Returns an empty list (the backend is effectively disabled) unless both
+        the API key and endpoint environment variables are set.
+        """
+        # The shared base carries no configuration of its own.
+        if not cls.API_KEY_ENV or not cls.ENDPOINT_ENV:
+            return []
+        if not os.getenv(cls.API_KEY_ENV):
+            logger.debug(f"{cls.__name__}.models: {cls.API_KEY_ENV} not set, skipping")
+            return []
+        if not os.getenv(cls.ENDPOINT_ENV):
+            logger.debug(
+                f"{cls.__name__}.models: {cls.API_KEY_ENV} set but "
+                f"{cls.ENDPOINT_ENV} missing; skipping"
+            )
+            return []
+
+        return [
+            ModelDescription(
+                cost=cost,
+                name=f"{cls.NAME_PREFIX}/{deployment}",
+                internal_name=deployment,
+            )
+            for deployment, cost, _tier in cls._configured_deployments()
+        ]
+
+    def model_is_ok(self) -> bool:
+        """Check the model is available (env configured and not rate limited).
+
+        We don't query the ``/models`` endpoint: Azure's OpenAI-compatible
+        layer support varies, and we'd rather fail fast on actual inference
+        than block startup.
+        """
+        if self.API_KEY_ENV and not os.getenv(self.API_KEY_ENV):
+            return False
+        if self.ENDPOINT_ENV and not os.getenv(self.ENDPOINT_ENV):
+            return False
+        return self.rate_limiter.can_request()
+
+
+class RemoteAzureOpenAI(RemoteAzureOpenLike):
+    """
+    Azure OpenAI Service backend (OpenAI GPT-family models hosted on Azure).
+
+    Uses the Azure OpenAI v1 (OpenAI-compatible) endpoint, e.g.
+    ``https://<resource>.openai.azure.com/openai/v1/chat/completions`` with
+    Bearer-token auth. The ``model`` sent on the wire is the Azure *deployment*
+    name; by default we assume deployments are named after the model id, but
+    that can be overridden with ``AZURE_OPENAI_MODELS``.
+
+    Environment variables:
+    - AZURE_OPENAI_API_KEY:  API key for the Azure OpenAI resource (required)
+    - AZURE_OPENAI_ENDPOINT: Base URL incl. ``/openai/v1`` (required)
+    - AZURE_OPENAI_MODELS:   Optional comma-separated deployment names
+    """
+
+    API_KEY_ENV: ClassVar[str] = "AZURE_OPENAI_API_KEY"
+    ENDPOINT_ENV: ClassVar[str] = "AZURE_OPENAI_ENDPOINT"
+    MODELS_ENV: ClassVar[str] = "AZURE_OPENAI_MODELS"
+    NAME_PREFIX: ClassVar[str] = "azure-openai"
+    PROVIDER_LABEL: ClassVar[str] = "Azure OpenAI"
+    MAX_LEN: ClassVar[int] = 128000
+
+    # Latest broadly-available Azure OpenAI deployments (cheapest -> premium).
+    DEFAULT_MODELS: ClassVar[List[Tuple[str, int, str]]] = [
+        ("gpt-4.1-mini", 55, "speed"),
+        ("gpt-5-mini", 75, "quality"),
+        ("gpt-5", 135, "premium"),
+    ]
+
+    # Per-subclass rate-limit state (do not share across providers).
+    _rate_limiters: ClassVar[dict[str, RateLimiter]] = {}
+    _rate_limiter_lock: ClassVar[threading.Lock] = threading.Lock()
+
+
+class RemoteAzureClaude(RemoteAzureOpenLike):
+    """
+    Anthropic Claude models hosted on Azure AI Foundry (Microsoft Foundry).
+
+    Uses Foundry's OpenAI-compatible chat-completions surface with Bearer-token
+    auth. Friendly names are prefixed ``azure-anthropic/`` so usage tracking in
+    the chooser and regular workflows clearly distinguishes Azure-hosted Claude
+    from the direct Anthropic API (``anthropic/...``).
+
+    Environment variables:
+    - AZURE_ANTHROPIC_API_KEY:  API key for the Foundry resource (required)
+    - AZURE_ANTHROPIC_ENDPOINT: Base URL for the OpenAI-compatible endpoint
+        (required), e.g. ``https://<resource>.services.ai.azure.com/openai/v1``
+    - AZURE_ANTHROPIC_MODELS:   Optional comma-separated deployment names
+    """
+
+    API_KEY_ENV: ClassVar[str] = "AZURE_ANTHROPIC_API_KEY"
+    ENDPOINT_ENV: ClassVar[str] = "AZURE_ANTHROPIC_ENDPOINT"
+    MODELS_ENV: ClassVar[str] = "AZURE_ANTHROPIC_MODELS"
+    NAME_PREFIX: ClassVar[str] = "azure-anthropic"
+    PROVIDER_LABEL: ClassVar[str] = "Azure AI Foundry (Claude)"
+    MAX_LEN: ClassVar[int] = 200000
+
+    # Latest Claude models (cheapest -> premium). Deployment names default to
+    # the canonical model ids; override with AZURE_ANTHROPIC_MODELS if your
+    # Foundry deployments use different names.
+    DEFAULT_MODELS: ClassVar[List[Tuple[str, int, str]]] = [
+        ("claude-haiku-4-5", 55, "speed"),
+        ("claude-sonnet-4-6", 95, "quality"),
+        ("claude-opus-4-8", 135, "premium"),
+    ]
+
+    # Per-subclass rate-limit state (do not share across providers).
+    _rate_limiters: ClassVar[dict[str, RateLimiter]] = {}
+    _rate_limiter_lock: ClassVar[threading.Lock] = threading.Lock()
 
 
 class TailscaleModelBackend(RemoteFullOpenLike):

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -3238,6 +3238,9 @@ class RemoteAzureOpenLike(RateLimitedRemoteOpenLike):
     MODELS_ENV: ClassVar[str] = ""
     NAME_PREFIX: ClassVar[str] = "azure"
     PROVIDER_LABEL: ClassVar[str] = "Azure"
+    # Example endpoint shown in the "missing endpoint" error; each provider
+    # overrides this since Azure OpenAI and Azure AI Foundry use different hosts.
+    ENDPOINT_EXAMPLE: ClassVar[str] = "https://my-resource.services.ai.azure.com"
     MAX_LEN: ClassVar[int] = 128000
     # Ordered cheapest -> most expensive: (deployment_name, cost, tier).
     DEFAULT_MODELS: ClassVar[List[Tuple[str, int, str]]] = []
@@ -3258,7 +3261,7 @@ class RemoteAzureOpenLike(RateLimitedRemoteOpenLike):
             raise EnvironmentError(
                 f"No endpoint found for {self.PROVIDER_LABEL}. Please set the "
                 f"{self.ENDPOINT_ENV} environment variable (e.g. "
-                f"https://my-resource.openai.azure.com/openai/v1)."
+                f"{self.ENDPOINT_EXAMPLE})."
             )
 
         api_base = self._normalize_endpoint(endpoint)
@@ -3277,7 +3280,7 @@ class RemoteAzureOpenLike(RateLimitedRemoteOpenLike):
     @staticmethod
     def _normalize_endpoint(endpoint: str) -> str:
         """Strip trailing slashes and a trailing ``/chat/completions`` (which
-        ``__infer`` re-appends) so either form of the URL works."""
+        ``_infer`` re-appends) so either form of the URL works."""
         e = endpoint.strip().rstrip("/")
         suffix = "/chat/completions"
         if e.endswith(suffix):
@@ -3291,6 +3294,16 @@ class RemoteAzureOpenLike(RateLimitedRemoteOpenLike):
         override = os.getenv(cls.MODELS_ENV) if cls.MODELS_ENV else None
         if override and override.strip():
             names = [n.strip() for n in override.split(",") if n.strip()]
+            if not names:
+                # e.g. AZURE_*_MODELS="," — separators only, no real names.
+                # Fall back to defaults rather than silently disabling the
+                # provider with an empty deployment list.
+                logger.warning(
+                    f"{cls.__name__}._configured_deployments: {cls.MODELS_ENV} is "
+                    f"set but contains no valid deployment names; falling back to "
+                    f"defaults"
+                )
+                return list(cls.DEFAULT_MODELS)
             base_cost = cls.DEFAULT_MODELS[0][1] if cls.DEFAULT_MODELS else 60
             return [(n, base_cost + i * 10, "custom") for i, n in enumerate(names)]
         return list(cls.DEFAULT_MODELS)
@@ -3357,6 +3370,7 @@ class RemoteAzureOpenAI(RemoteAzureOpenLike):
     MODELS_ENV: ClassVar[str] = "AZURE_OPENAI_MODELS"
     NAME_PREFIX: ClassVar[str] = "azure-openai"
     PROVIDER_LABEL: ClassVar[str] = "Azure OpenAI"
+    ENDPOINT_EXAMPLE: ClassVar[str] = "https://my-resource.openai.azure.com/openai/v1"
     MAX_LEN: ClassVar[int] = 128000
 
     # Latest broadly-available Azure OpenAI deployments (cheapest -> premium).

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -2817,7 +2817,109 @@ class DeepInfra(RemoteFullOpenLike):
         ]
 
 
-class RemoteGroq(RemoteFullOpenLike):
+class RateLimitedRemoteOpenLike(RemoteFullOpenLike):
+    """``RemoteFullOpenLike`` with shared per-model rate limiting and 429
+    back-off, used by the external paid backends (Groq, Anthropic, Azure).
+
+    Concrete subclasses declare their own ``_rate_limiters`` dict and
+    ``_rate_limiter_lock`` (so providers keep separate rate-limit state) and set
+    ``PROVIDER_LABEL`` for rate-limiter names and 429 log messages.
+    """
+
+    # Subclasses override these with their own instances.
+    _rate_limiters: ClassVar[dict[str, RateLimiter]] = {}
+    _rate_limiter_lock: ClassVar[threading.Lock] = threading.Lock()
+    PROVIDER_LABEL: ClassVar[str] = "remote"
+
+    # Re-raise ClientResponseError from the parent _infer so we can detect 429.
+    _propagate_http_errors: ClassVar[bool] = True
+
+    @classmethod
+    def _ensure_rate_limiter(cls, model: str) -> None:
+        """Lazily create a per-model rate limiter (thread-safe)."""
+        if model not in cls._rate_limiters:
+            with cls._rate_limiter_lock:
+                if model not in cls._rate_limiters:
+                    cls._rate_limiters[model] = RateLimiter(
+                        name=f"{cls.PROVIDER_LABEL}-{model}",
+                    )
+                    logger.info(
+                        f"Created rate limiter for {cls.PROVIDER_LABEL}-{model}"
+                    )
+
+    @property
+    def rate_limiter(self) -> RateLimiter:
+        """Get the rate limiter for this model instance."""
+        return self._rate_limiters[self.model]
+
+    def _retry_after_seconds(
+        self, e: aiohttp.ClientResponseError, default: float = 60.0
+    ) -> float:
+        """Parse and clamp (1-600s) a Retry-After header from a 429 response."""
+        retry_after = default
+        headers = getattr(e, "headers", None)
+        if headers:
+            retry_header = headers.get("Retry-After", "")
+            if retry_header:
+                try:
+                    retry_after = float(retry_header)
+                except ValueError:
+                    logger.debug(
+                        f"{type(self).__name__}._infer: Non-numeric Retry-After "
+                        f"header '{retry_header}' for {self.model}; using default "
+                        f"{retry_after}s"
+                    )
+        return max(1.0, min(retry_after, 600.0))
+
+    async def _infer(
+        self,
+        system_prompts: list[str],
+        prompt: str,
+        patient_context: Optional[str] = None,
+        plan_context: Optional[str] = None,
+        pubmed_context: Optional[str] = None,
+        ml_citations_context: Optional[List[str]] = None,
+        history: Optional[List[dict[str, str]]] = None,
+        temperature: float = 0.7,
+    ) -> Optional[Tuple[Optional[str], Optional[List[str]]]]:
+        """Inference with rate-limit gating and 429 back-off.
+
+        Skips (returns None) when backing off; on a 429 marks the limiter
+        exhausted honoring Retry-After so other backends can take over; other
+        HTTP errors propagate.
+        """
+        if not self.rate_limiter.can_request():
+            logger.debug(
+                f"{type(self).__name__}._infer: Skipping {self.model} - backing off"
+            )
+            return None
+        try:
+            return await super()._infer(
+                system_prompts=system_prompts,
+                prompt=prompt,
+                patient_context=patient_context,
+                plan_context=plan_context,
+                pubmed_context=pubmed_context,
+                ml_citations_context=ml_citations_context,
+                history=history,
+                temperature=temperature,
+            )
+        except aiohttp.ClientResponseError as e:
+            if e.status == 429:
+                retry_after = self._retry_after_seconds(e)
+                self.rate_limiter.mark_exhausted(retry_after)
+                logger.warning(
+                    f"{type(self).__name__}._infer: 429 from {self.PROVIDER_LABEL} "
+                    f"for {self.model}, backing off for {retry_after}s"
+                )
+                return None
+            raise
+        except Exception as e:
+            logger.warning(f"{type(self).__name__}._infer error for {self.model}: {e}")
+            return None
+
+
+class RemoteGroq(RateLimitedRemoteOpenLike):
     """
     Groq API backend for ultra-fast LLM inference.
 
@@ -2853,12 +2955,11 @@ class RemoteGroq(RemoteFullOpenLike):
         },
     }
 
-    # Shared rate limiters per model (class-level, initialized lazily)
+    # Per-provider rate-limit state (separate from other providers); the
+    # limiter logic and 429 back-off live in RateLimitedRemoteOpenLike.
     _rate_limiters: ClassVar[dict[str, RateLimiter]] = {}
     _rate_limiter_lock: ClassVar[threading.Lock] = threading.Lock()
-
-    # Re-raise ClientResponseError from the parent _infer so we can detect 429.
-    _propagate_http_errors: ClassVar[bool] = True
+    PROVIDER_LABEL: ClassVar[str] = "Groq"
 
     def __init__(self, model: str, dual_mode: bool = False):
         """
@@ -2889,26 +2990,6 @@ class RemoteGroq(RemoteFullOpenLike):
             f"RemoteGroq initialized: model={model}, "
             f"tier={model_spec.get('tier', 'unknown')}"
         )
-
-    @classmethod
-    def _ensure_rate_limiter(cls, model: str) -> None:
-        """
-        Ensure a rate limiter exists for the given model.
-        Creates one if it doesn't exist (thread-safe).
-        """
-        if model not in cls._rate_limiters:
-            with cls._rate_limiter_lock:
-                # Double-check after acquiring lock
-                if model not in cls._rate_limiters:
-                    cls._rate_limiters[model] = RateLimiter(
-                        name=f"groq-{model}",
-                    )
-                    logger.info(f"Created rate limiter for groq-{model}")
-
-    @property
-    def rate_limiter(self) -> RateLimiter:
-        """Get the rate limiter for this model instance."""
-        return self._rate_limiters[self.model]
 
     @property
     def supports_system(self):
@@ -2975,88 +3056,6 @@ class RemoteGroq(RemoteFullOpenLike):
         logger.warning("Groq model selection: No models available (all rate limited)")
         return None
 
-    async def _infer(
-        self,
-        system_prompts: list[str],
-        prompt: str,
-        patient_context: Optional[str] = None,
-        plan_context: Optional[str] = None,
-        pubmed_context: Optional[str] = None,
-        ml_citations_context: Optional[List[str]] = None,
-        history: Optional[List[dict[str, str]]] = None,
-        temperature: float = 0.7,
-    ) -> Optional[Tuple[Optional[str], Optional[List[str]]]]:
-        """
-        Perform inference with rate limit checking and 429 handling.
-
-        Checks the rate limiter before making the API call. If rate limited,
-        returns None immediately to allow fallback to other backends.
-        On 429 response, marks the limiter as exhausted and returns None.
-
-        Args:
-            system_prompts: System prompts for the model
-            prompt: User prompt
-            patient_context: Optional patient health context
-            plan_context: Optional insurance plan context
-            pubmed_context: Optional PubMed citations context
-            ml_citations_context: Optional ML-generated citations
-            history: Optional conversation history
-            temperature: Optional temperature override
-
-        Returns:
-            Tuple of (response_text, context_parts) or None if rate limited/failed
-        """
-        # Check if we're backing off from a previous 429
-        if not self.rate_limiter.can_request():
-            logger.debug(f"RemoteGroq._infer: Skipping {self.model} - backing off")
-            return None
-
-        try:
-            # Call parent implementation
-            result = await super()._infer(
-                system_prompts=system_prompts,
-                prompt=prompt,
-                patient_context=patient_context,
-                plan_context=plan_context,
-                pubmed_context=pubmed_context,
-                ml_citations_context=ml_citations_context,
-                history=history,
-                temperature=temperature,
-            )
-            return result
-
-        except aiohttp.ClientResponseError as e:
-            if e.status == 429:
-                # Rate limited by Groq - parse Retry-After if available
-                retry_after = 60.0  # Default fallback
-                if hasattr(e, "headers") and e.headers:
-                    retry_header = e.headers.get("Retry-After", "")
-                    if retry_header:
-                        try:
-                            # Most APIs send delay-seconds (e.g., "30")
-                            retry_after = float(retry_header)
-                        except ValueError:
-                            # If not a number, use default (HTTP-date format is rare)
-                            logger.debug(
-                                f"RemoteGroq._infer: Non-numeric Retry-After header "
-                                f"'{retry_header}' for {self.model}; using default {retry_after}s"
-                            )
-
-                retry_after = max(1.0, min(retry_after, 600.0))
-
-                self.rate_limiter.mark_exhausted(retry_after)
-                logger.warning(
-                    f"RemoteGroq._infer: 429 from Groq for {self.model}, "
-                    f"backing off for {retry_after}s"
-                )
-                return None
-            else:
-                # Re-raise other HTTP errors
-                raise
-        except Exception as e:
-            logger.warning(f"RemoteGroq._infer error for {self.model}: {e}")
-            return None
-
     @classmethod
     def models(cls) -> List[ModelDescription]:
         """
@@ -3095,7 +3094,7 @@ class RemoteGroq(RemoteFullOpenLike):
         return self.rate_limiter.can_request()
 
 
-class RemoteAnthropic(RemoteFullOpenLike):
+class RemoteAnthropic(RateLimitedRemoteOpenLike):
     """
     Anthropic Claude API backend.
 
@@ -3128,12 +3127,11 @@ class RemoteAnthropic(RemoteFullOpenLike):
         },
     }
 
-    # Shared rate limiters per model (class-level, initialized lazily)
+    # Per-provider rate-limit state (separate from other providers); the
+    # limiter logic and 429 back-off live in RateLimitedRemoteOpenLike.
     _rate_limiters: ClassVar[dict[str, RateLimiter]] = {}
     _rate_limiter_lock: ClassVar[threading.Lock] = threading.Lock()
-
-    # Re-raise ClientResponseError from the parent _infer so we can detect 429.
-    _propagate_http_errors: ClassVar[bool] = True
+    PROVIDER_LABEL: ClassVar[str] = "Anthropic"
 
     def __init__(self, model: str, dual_mode: bool = False):
         """
@@ -3164,25 +3162,6 @@ class RemoteAnthropic(RemoteFullOpenLike):
             f"tier={model_spec.get('tier', 'unknown')}"
         )
 
-    @classmethod
-    def _ensure_rate_limiter(cls, model: str) -> None:
-        """
-        Ensure a rate limiter exists for the given model.
-        Creates one if it doesn't exist (thread-safe).
-        """
-        if model not in cls._rate_limiters:
-            with cls._rate_limiter_lock:
-                if model not in cls._rate_limiters:
-                    cls._rate_limiters[model] = RateLimiter(
-                        name=f"anthropic-{model}",
-                    )
-                    logger.info(f"Created rate limiter for anthropic-{model}")
-
-    @property
-    def rate_limiter(self) -> RateLimiter:
-        """Get the rate limiter for this model instance."""
-        return self._rate_limiters[self.model]
-
     @property
     def supports_system(self):
         return True
@@ -3194,67 +3173,6 @@ class RemoteAnthropic(RemoteFullOpenLike):
     def get_tier(self) -> str:
         """Get the tier (speed/quality/premium) for this model."""
         return self.MODEL_SPECS.get(self.model, {}).get("tier", "unknown")
-
-    async def _infer(
-        self,
-        system_prompts: list[str],
-        prompt: str,
-        patient_context: Optional[str] = None,
-        plan_context: Optional[str] = None,
-        pubmed_context: Optional[str] = None,
-        ml_citations_context: Optional[List[str]] = None,
-        history: Optional[List[dict[str, str]]] = None,
-        temperature: float = 0.7,
-    ) -> Optional[Tuple[Optional[str], Optional[List[str]]]]:
-        """
-        Perform inference with rate limit checking and 429 handling.
-
-        Checks the rate limiter before making the API call. If rate limited,
-        returns None immediately to allow fallback to other backends.
-        On 429 response, marks the limiter as exhausted and returns None.
-        """
-        if not self.rate_limiter.can_request():
-            logger.debug(f"RemoteAnthropic._infer: Skipping {self.model} - backing off")
-            return None
-
-        try:
-            return await super()._infer(
-                system_prompts=system_prompts,
-                prompt=prompt,
-                patient_context=patient_context,
-                plan_context=plan_context,
-                pubmed_context=pubmed_context,
-                ml_citations_context=ml_citations_context,
-                history=history,
-                temperature=temperature,
-            )
-        except aiohttp.ClientResponseError as e:
-            if e.status == 429:
-                retry_after = 60.0
-                if hasattr(e, "headers") and e.headers:
-                    retry_header = e.headers.get("Retry-After", "")
-                    if retry_header:
-                        try:
-                            retry_after = float(retry_header)
-                        except ValueError:
-                            logger.debug(
-                                f"RemoteAnthropic._infer: Non-numeric Retry-After header "
-                                f"'{retry_header}' for {self.model}; using default {retry_after}s"
-                            )
-
-                retry_after = max(1.0, min(retry_after, 600.0))
-
-                self.rate_limiter.mark_exhausted(retry_after)
-                logger.warning(
-                    f"RemoteAnthropic._infer: 429 from Anthropic for {self.model}, "
-                    f"backing off for {retry_after}s"
-                )
-                return None
-            else:
-                raise
-        except Exception as e:
-            logger.warning(f"RemoteAnthropic._infer error for {self.model}: {e}")
-            return None
 
     @classmethod
     def models(cls) -> List[ModelDescription]:
@@ -3301,7 +3219,7 @@ class RemoteAnthropic(RemoteFullOpenLike):
         return self.rate_limiter.can_request()
 
 
-class RemoteAzureOpenLike(RemoteFullOpenLike):
+class RemoteAzureOpenLike(RateLimitedRemoteOpenLike):
     """Shared base for Azure-hosted, OpenAI-compatible backends.
 
     Azure serves both Azure OpenAI (GPT) and, via Azure AI Foundry, Claude
@@ -3322,15 +3240,6 @@ class RemoteAzureOpenLike(RemoteFullOpenLike):
     MAX_LEN: ClassVar[int] = 128000
     # Ordered cheapest -> most expensive: (deployment_name, cost, tier).
     DEFAULT_MODELS: ClassVar[List[Tuple[str, int, str]]] = []
-
-    # Per-provider rate-limit state. Declared here for type-safety; each
-    # concrete subclass overrides these with its own dict/lock so providers do
-    # not share rate-limit state.
-    _rate_limiters: ClassVar[dict[str, RateLimiter]] = {}
-    _rate_limiter_lock: ClassVar[threading.Lock] = threading.Lock()
-
-    # Re-raise ClientResponseError from the parent _infer so we can detect 429.
-    _propagate_http_errors: ClassVar[bool] = True
 
     def __init__(self, model: str, dual_mode: bool = False):
         api_key = os.getenv(self.API_KEY_ENV) if self.API_KEY_ENV else None
@@ -3382,22 +3291,6 @@ class RemoteAzureOpenLike(RemoteFullOpenLike):
             return [(n, base_cost + i * 10, "custom") for i, n in enumerate(names)]
         return list(cls.DEFAULT_MODELS)
 
-    @classmethod
-    def _ensure_rate_limiter(cls, model: str) -> None:
-        """Ensure a rate limiter exists for the given model (thread-safe)."""
-        if model not in cls._rate_limiters:
-            with cls._rate_limiter_lock:
-                if model not in cls._rate_limiters:
-                    cls._rate_limiters[model] = RateLimiter(
-                        name=f"{cls.NAME_PREFIX}-{model}",
-                    )
-                    logger.info(f"Created rate limiter for {cls.NAME_PREFIX}-{model}")
-
-    @property
-    def rate_limiter(self) -> RateLimiter:
-        """Get the rate limiter for this model instance."""
-        return self._rate_limiters[self.model]
-
     @property
     def supports_system(self):
         return True
@@ -3412,65 +3305,6 @@ class RemoteAzureOpenLike(RemoteFullOpenLike):
             if deployment == self.model:
                 return tier
         return "unknown"
-
-    async def _infer(
-        self,
-        system_prompts: list[str],
-        prompt: str,
-        patient_context: Optional[str] = None,
-        plan_context: Optional[str] = None,
-        pubmed_context: Optional[str] = None,
-        ml_citations_context: Optional[List[str]] = None,
-        history: Optional[List[dict[str, str]]] = None,
-        temperature: float = 0.7,
-    ) -> Optional[Tuple[Optional[str], Optional[List[str]]]]:
-        """Inference with rate-limit/429 handling (mirrors Anthropic/Groq:
-        skip when backing off; on 429 back off honoring Retry-After)."""
-        if not self.rate_limiter.can_request():
-            logger.debug(
-                f"{type(self).__name__}._infer: Skipping {self.model} - backing off"
-            )
-            return None
-
-        try:
-            return await super()._infer(
-                system_prompts=system_prompts,
-                prompt=prompt,
-                patient_context=patient_context,
-                plan_context=plan_context,
-                pubmed_context=pubmed_context,
-                ml_citations_context=ml_citations_context,
-                history=history,
-                temperature=temperature,
-            )
-        except aiohttp.ClientResponseError as e:
-            if e.status == 429:
-                retry_after = 60.0
-                if hasattr(e, "headers") and e.headers:
-                    retry_header = e.headers.get("Retry-After", "")
-                    if retry_header:
-                        try:
-                            retry_after = float(retry_header)
-                        except ValueError:
-                            logger.debug(
-                                f"{type(self).__name__}._infer: Non-numeric "
-                                f"Retry-After header '{retry_header}' for "
-                                f"{self.model}; using default {retry_after}s"
-                            )
-
-                retry_after = max(1.0, min(retry_after, 600.0))
-
-                self.rate_limiter.mark_exhausted(retry_after)
-                logger.warning(
-                    f"{type(self).__name__}._infer: 429 from {self.PROVIDER_LABEL} "
-                    f"for {self.model}, backing off for {retry_after}s"
-                )
-                return None
-            else:
-                raise
-        except Exception as e:
-            logger.warning(f"{type(self).__name__}._infer error for {self.model}: {e}")
-            return None
 
     @classmethod
     def models(cls) -> List[ModelDescription]:

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -3519,6 +3519,10 @@ class RemoteAzureClaude(RemoteAzureOpenLike):
         if prompt is None:
             logger.debug("No prompt supplied; skipping inference")
             return None
+        # The native Anthropic Messages API caps temperature at 1.0 (vs the
+        # OpenAI surface's 2.0); clamp so a shared router temperature that's
+        # valid for other providers can't trigger a 400 here.
+        temperature = max(0.0, min(temperature, 1.0))
         context_extra = self._build_context_extra(
             patient_context,
             pubmed_context,
@@ -3552,12 +3556,12 @@ class RemoteAzureClaude(RemoteAzureOpenLike):
                 "messages": cleaned_messages,
                 "temperature": temperature,
             }
-            result = await self.__messages_request(url, headers, body)
+            result = await self._messages_request(url, headers, body)
             if result and result[0]:
                 return result
         return None
 
-    async def __messages_request(
+    async def _messages_request(
         self, url: str, headers: dict, body: dict
     ) -> Optional[Tuple[Optional[str], Optional[List[str]]]]:
         """POST a single Messages API request (honoring ``self._timeout``) and

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -1995,21 +1995,12 @@ class RemoteOpenLike(RemoteModel):
         json_result = {}
         try:
             async with aiohttp.ClientSession() as s:
-                context_extra = ""
-                if patient_context is not None and len(patient_context) > 3:
-                    patient_context_max = int(self.max_len / 2)
-                    max_len = self.max_len - min(
-                        len(patient_context), patient_context_max
-                    )
-                    context_extra = f"When answering the following question you can use the patient context {patient_context[0:patient_context_max]}."
-                if pubmed_context is not None:
-                    context_extra += f"You can also use this context from pubmed: {pubmed_context} and you can include the DOI number in the appeal."
-                if plan_context is not None and len(plan_context) > 3:
-                    context_extra += f"For answering the question you can use this context about the plan {plan_context}"
-                if ml_citations_context is not None:
-                    context_extra += f"You can also use this context from citations: {ml_citations_context}."
-                if len(context_extra) > 0:
-                    context_extra = f"System context: {context_extra}\n\n"
+                context_extra = self._build_context_extra(
+                    patient_context,
+                    pubmed_context,
+                    plan_context,
+                    ml_citations_context,
+                )
 
                 # Detect if backend supports system messages
                 # Some backends (e.g., Mistral VLLM) do not support the system role; in those cases, embed the system prompt in the user message.
@@ -2179,6 +2170,33 @@ class RemoteOpenLike(RemoteModel):
             formatted_citations.append(str(citation))
 
         return formatted_citations
+
+    def _build_context_extra(
+        self,
+        patient_context: Optional[str] = None,
+        pubmed_context: Optional[str] = None,
+        plan_context: Optional[str] = None,
+        ml_citations_context: Optional[List[str]] = None,
+    ) -> str:
+        """Assemble the optional ``System context: …`` preamble injected into the
+        user turn. Shared by the OpenAI-compatible path and the Anthropic
+        Messages path (``RemoteAzureClaude``) so context handling stays in one
+        place."""
+        context_extra = ""
+        if patient_context is not None and len(patient_context) > 3:
+            patient_context_max = int(self.max_len / 2)
+            context_extra = f"When answering the following question you can use the patient context {patient_context[0:patient_context_max]}."
+        if pubmed_context is not None:
+            context_extra += f"You can also use this context from pubmed: {pubmed_context} and you can include the DOI number in the appeal."
+        if plan_context is not None and len(plan_context) > 3:
+            context_extra += f"For answering the question you can use this context about the plan {plan_context}"
+        if ml_citations_context is not None:
+            context_extra += (
+                f"You can also use this context from citations: {ml_citations_context}."
+            )
+        if len(context_extra) > 0:
+            context_extra = f"System context: {context_extra}\n\n"
+        return context_extra
 
 
 class RemoteFullOpenLike(RemoteOpenLike):
@@ -2895,7 +2913,7 @@ class RateLimitedRemoteOpenLike(RemoteFullOpenLike):
             )
             return None
         try:
-            return await super()._infer(
+            return await self._do_infer(
                 system_prompts=system_prompts,
                 prompt=prompt,
                 patient_context=patient_context,
@@ -2918,6 +2936,37 @@ class RateLimitedRemoteOpenLike(RemoteFullOpenLike):
         except Exception as e:
             logger.warning(f"{type(self).__name__}._infer error for {self.model}: {e}")
             return None
+
+    async def _do_infer(
+        self,
+        system_prompts: list[str],
+        prompt: str,
+        patient_context: Optional[str] = None,
+        plan_context: Optional[str] = None,
+        pubmed_context: Optional[str] = None,
+        ml_citations_context: Optional[List[str]] = None,
+        history: Optional[List[dict[str, str]]] = None,
+        temperature: float = 0.7,
+    ) -> Optional[Tuple[Optional[str], Optional[List[str]]]]:
+        """The actual transport call wrapped by ``_infer``'s rate-limit gating
+        and 429 back-off.
+
+        Defaults to the OpenAI-compatible path (``RemoteOpenLike._infer``).
+        Subclasses whose provider speaks a different wire format (e.g.
+        ``RemoteAzureClaude`` with the Anthropic Messages API) override this and
+        raise ``aiohttp.ClientResponseError`` on HTTP errors so the shared 429
+        handling in ``_infer`` still applies.
+        """
+        return await super()._infer(
+            system_prompts=system_prompts,
+            prompt=prompt,
+            patient_context=patient_context,
+            plan_context=plan_context,
+            pubmed_context=pubmed_context,
+            ml_citations_context=ml_citations_context,
+            history=history,
+            temperature=temperature,
+        )
 
 
 class RemoteGroq(RateLimitedRemoteOpenLike):
@@ -3221,15 +3270,19 @@ class RemoteAnthropic(RateLimitedRemoteOpenLike):
 
 
 class RemoteAzureOpenLike(RateLimitedRemoteOpenLike):
-    """Shared base for Azure-hosted, OpenAI-compatible backends.
+    """Shared base for Azure-hosted backends configured from environment vars.
 
-    Azure serves both Azure OpenAI (GPT) and, via Azure AI Foundry, Claude
-    through an OpenAI-compatible ``/chat/completions`` surface with Bearer auth
-    — the wire format ``RemoteOpenLike`` already speaks. Azure resources and
-    deployments are tenant-specific, so the endpoint, key, and (latest-default)
-    model list come from environment variables. Concrete subclasses set the
-    ``*_ENV`` names, ``NAME_PREFIX``, ``MAX_LEN`` and ``DEFAULT_MODELS``, and
-    each declares its own ``_rate_limiters``/``_rate_limiter_lock``.
+    Azure OpenAI (GPT) deployments speak an OpenAI-compatible
+    ``/chat/completions`` surface with Bearer auth — the wire format
+    ``RemoteOpenLike`` already speaks — so ``RemoteAzureOpenAI`` uses this base
+    as-is. Claude on Azure AI Foundry instead answers only the native Anthropic
+    Messages API, so ``RemoteAzureClaude`` reuses the shared configuration and
+    rate limiting here but overrides the transport (``_do_infer``). Azure
+    resources and deployments are tenant-specific, so the endpoint, key, and
+    (latest-default) model list come from environment variables. Concrete
+    subclasses set the ``*_ENV`` names, ``NAME_PREFIX``, ``MAX_LEN`` and
+    ``DEFAULT_MODELS``, and each declares its own
+    ``_rate_limiters``/``_rate_limiter_lock``.
     """
 
     # --- Subclass configuration (overridden by concrete providers) --------
@@ -3310,7 +3363,9 @@ class RemoteAzureOpenLike(RateLimitedRemoteOpenLike):
 
     @property
     def supports_system(self):
-        """Azure GPT/Claude deployments accept the OpenAI ``system`` role."""
+        """Azure OpenAI (GPT) deployments accept the OpenAI ``system`` role.
+        (``RemoteAzureClaude`` overrides the transport and passes the system
+        prompt as a top-level Messages field instead.)"""
         return True
 
     @property
@@ -3390,6 +3445,16 @@ class RemoteAzureClaude(RemoteAzureOpenLike):
     (distinct from the direct ``anthropic/`` API so usage tracking can tell them
     apart). Configure AZURE_ANTHROPIC_API_KEY + AZURE_ANTHROPIC_ENDPOINT;
     optionally override the deployment list with AZURE_ANTHROPIC_MODELS.
+
+    Unlike Azure OpenAI, Foundry's Claude deployments are **not** exposed over an
+    OpenAI ``/chat/completions`` surface — they answer only the native Anthropic
+    Messages API at ``{endpoint}/v1/messages`` (``x-api-key`` +
+    ``anthropic-version`` auth), per Microsoft's docs. So this subclass keeps the
+    shared config/model-list/rate-limit machinery but overrides the transport
+    (:meth:`_do_infer`) to speak the Messages wire format (system prompt as a
+    top-level field; text returned in ``content`` blocks). HTTP errors still
+    surface as ``aiohttp.ClientResponseError`` so the inherited 429 back-off
+    applies unchanged.
     """
 
     API_KEY_ENV: ClassVar[str] = "AZURE_ANTHROPIC_API_KEY"
@@ -3397,7 +3462,15 @@ class RemoteAzureClaude(RemoteAzureOpenLike):
     MODELS_ENV: ClassVar[str] = "AZURE_ANTHROPIC_MODELS"
     NAME_PREFIX: ClassVar[str] = "azure-anthropic"
     PROVIDER_LABEL: ClassVar[str] = "Azure AI Foundry (Claude)"
+    ENDPOINT_EXAMPLE: ClassVar[str] = (
+        "https://my-resource.services.ai.azure.com/anthropic"
+    )
     MAX_LEN: ClassVar[int] = 200000
+
+    # Anthropic Messages API wire constants.
+    ANTHROPIC_VERSION: ClassVar[str] = "2023-06-01"
+    # The Messages API requires an explicit max output token budget.
+    MAX_OUTPUT_TOKENS: ClassVar[int] = 8192
 
     # Latest Claude models (cheapest -> premium). Deployment names default to
     # the canonical model ids; override with AZURE_ANTHROPIC_MODELS if your
@@ -3411,6 +3484,125 @@ class RemoteAzureClaude(RemoteAzureOpenLike):
     # Per-subclass rate-limit state (do not share across providers).
     _rate_limiters: ClassVar[dict[str, RateLimiter]] = {}
     _rate_limiter_lock: ClassVar[threading.Lock] = threading.Lock()
+
+    @staticmethod
+    def _normalize_endpoint(endpoint: str) -> str:
+        """Normalize to the Foundry Anthropic base (``…/anthropic``); the
+        Messages path ``/v1/messages`` is appended at request time. Accepts the
+        endpoint with or without a trailing ``/v1/messages``, and appends the
+        ``/anthropic`` segment when only the bare resource host was supplied."""
+        e = endpoint.strip().rstrip("/")
+        suffix = "/v1/messages"
+        if e.endswith(suffix):
+            e = e[: -len(suffix)].rstrip("/")
+        if not e.endswith("/anthropic"):
+            e = f"{e}/anthropic"
+        return e
+
+    async def _do_infer(
+        self,
+        system_prompts: list[str],
+        prompt: str,
+        patient_context: Optional[str] = None,
+        plan_context: Optional[str] = None,
+        pubmed_context: Optional[str] = None,
+        ml_citations_context: Optional[List[str]] = None,
+        history: Optional[List[dict[str, str]]] = None,
+        temperature: float = 0.7,
+    ) -> Optional[Tuple[Optional[str], Optional[List[str]]]]:
+        """Inference via the Anthropic Messages API exposed by Azure AI Foundry.
+
+        Returns the first non-empty completion across ``system_prompts``. HTTP
+        error statuses raise ``aiohttp.ClientResponseError`` (so the caller's
+        429 back-off applies); transport/parse failures return ``None``.
+        """
+        if prompt is None:
+            logger.debug("No prompt supplied; skipping inference")
+            return None
+        context_extra = self._build_context_extra(
+            patient_context,
+            pubmed_context,
+            plan_context,
+            ml_citations_context,
+        )
+        url = f"{self.api_base}/v1/messages"
+        headers = {
+            "x-api-key": self.token or "",
+            "anthropic-version": self.ANTHROPIC_VERSION,
+            "content-type": "application/json",
+        }
+        for system_prompt in system_prompts:
+            messages: List[dict[str, str]] = []
+            if history:
+                messages.extend(history)
+            messages.append(
+                {
+                    "role": "user",
+                    "content": f"{context_extra}\n\n User prompt: {prompt}",
+                }
+            )
+            messages = ensure_message_alternation(messages)
+            cleaned_messages = [
+                {"role": m.get("role"), "content": m.get("content")} for m in messages
+            ]
+            body = {
+                "model": self.model,
+                "max_tokens": self.MAX_OUTPUT_TOKENS,
+                "system": system_prompt,
+                "messages": cleaned_messages,
+                "temperature": temperature,
+            }
+            result = await self.__messages_request(url, headers, body)
+            if result and result[0]:
+                return result
+        return None
+
+    async def __messages_request(
+        self, url: str, headers: dict, body: dict
+    ) -> Optional[Tuple[Optional[str], Optional[List[str]]]]:
+        """POST a single Messages API request (honoring ``self._timeout``) and
+        parse the response. ``raise_for_status`` surfaces HTTP errors as
+        ``aiohttp.ClientResponseError`` so 429s reach the shared back-off."""
+
+        async def _post() -> Optional[Tuple[Optional[str], Optional[List[str]]]]:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(url, headers=headers, json=body) as response:
+                    response.raise_for_status()
+                    json_result = await response.json()
+            return self._parse_messages_response(json_result)
+
+        if self._timeout is not None:
+            try:
+                async with async_timeout(self._timeout):
+                    return await _post()
+            except asyncio.TimeoutError:
+                logger.warning(f"Timed out querying {self}")
+                return None
+        return await _post()
+
+    def _parse_messages_response(
+        self, json_result: dict
+    ) -> Optional[Tuple[Optional[str], Optional[List[str]]]]:
+        """Extract text from a Messages API response by concatenating its
+        ``text`` content blocks, then apply the same validity check and
+        reasoning-answer extraction as the OpenAI path."""
+        blocks = json_result.get("content") or []
+        text = "".join(
+            block.get("text", "")
+            for block in blocks
+            if isinstance(block, dict) and block.get("type") == "text"
+        )
+        if not text:
+            logger.debug(f"Messages response from {self.model} had no text content")
+            return None
+        if not LLMResponseUtils.is_valid_text(text):
+            logger.error(f"Received non-text response from {self.model}")
+            return None
+        if LLMResponseUtils.is_well_formatted_for_reasoning(text):
+            extracted = LLMResponseUtils.extract_answer(text)
+            if extracted:
+                text = extracted.strip()
+        return (text, [])
 
 
 class TailscaleModelBackend(RemoteFullOpenLike):

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -3302,37 +3302,15 @@ class RemoteAnthropic(RemoteFullOpenLike):
 
 
 class RemoteAzureOpenLike(RemoteFullOpenLike):
-    """
-    Shared base for Azure-hosted, OpenAI-compatible generative backends.
+    """Shared base for Azure-hosted, OpenAI-compatible backends.
 
-    Microsoft Azure serves both Azure OpenAI Service (GPT-family models) and,
-    via Azure AI Foundry, Anthropic Claude models through an OpenAI-compatible
-    ``/chat/completions`` surface that accepts Bearer-token authentication —
-    the same wire format ``RemoteOpenLike`` already speaks, so no SDK is
-    required.
-
-    Two things differ from the fixed public Anthropic/Groq endpoints:
-
-    * Azure resources are tenant-specific, so the endpoint *and* the API key
-      are read from environment variables rather than hard-coded.
-    * The set of available models is operator-specific (Azure "deployments"
-      are named by whoever provisions the resource), so each provider ships a
-      latest-models default that can be overridden with an environment
-      variable listing the deployment names to expose.
-
-    Subclasses configure a provider by setting the ``*_ENV`` names, the
-    friendly-name ``NAME_PREFIX`` (used for tracking, e.g. ``azure-openai``),
-    the ``MAX_LEN`` context window, and the ``DEFAULT_MODELS`` spec. Each
-    concrete subclass MUST also declare its own ``_rate_limiters`` /
-    ``_rate_limiter_lock`` so providers don't share rate-limit state.
-
-    Environment variables (names are subclass-specific):
-    - <API_KEY_ENV>:  API key for the Azure resource (required to enable)
-    - <ENDPOINT_ENV>: Base URL up to and including the OpenAI-compatible
-        version segment, e.g.
-        ``https://my-resource.openai.azure.com/openai/v1`` (required)
-    - <MODELS_ENV>:   Optional comma-separated list of deployment names to
-        expose instead of the latest-models default.
+    Azure serves both Azure OpenAI (GPT) and, via Azure AI Foundry, Claude
+    through an OpenAI-compatible ``/chat/completions`` surface with Bearer auth
+    — the wire format ``RemoteOpenLike`` already speaks. Azure resources and
+    deployments are tenant-specific, so the endpoint, key, and (latest-default)
+    model list come from environment variables. Concrete subclasses set the
+    ``*_ENV`` names, ``NAME_PREFIX``, ``MAX_LEN`` and ``DEFAULT_MODELS``, and
+    each declares its own ``_rate_limiters``/``_rate_limiter_lock``.
     """
 
     # --- Subclass configuration (overridden by concrete providers) --------
@@ -3385,12 +3363,8 @@ class RemoteAzureOpenLike(RemoteFullOpenLike):
 
     @staticmethod
     def _normalize_endpoint(endpoint: str) -> str:
-        """Trim trailing slashes and a trailing ``/chat/completions`` so the
-        operator can paste either the base URL or the full completions URL.
-
-        ``__infer`` appends ``/chat/completions`` to ``api_base``; stripping it
-        here keeps both forms working.
-        """
+        """Strip trailing slashes and a trailing ``/chat/completions`` (which
+        ``__infer`` re-appends) so either form of the URL works."""
         e = endpoint.strip().rstrip("/")
         suffix = "/chat/completions"
         if e.endswith(suffix):
@@ -3399,9 +3373,8 @@ class RemoteAzureOpenLike(RemoteFullOpenLike):
 
     @classmethod
     def _configured_deployments(cls) -> List[Tuple[str, int, str]]:
-        """Resolve the (deployment, cost, tier) list, honoring the optional
-        ``MODELS_ENV`` override. Overridden deployments inherit incrementing
-        costs from the cheapest default and a ``custom`` tier."""
+        """(deployment, cost, tier) list, honoring the optional ``MODELS_ENV``
+        override (overrides inherit incrementing costs and a ``custom`` tier)."""
         override = os.getenv(cls.MODELS_ENV) if cls.MODELS_ENV else None
         if override and override.strip():
             names = [n.strip() for n in override.split(",") if n.strip()]
@@ -3451,12 +3424,8 @@ class RemoteAzureOpenLike(RemoteFullOpenLike):
         history: Optional[List[dict[str, str]]] = None,
         temperature: float = 0.7,
     ) -> Optional[Tuple[Optional[str], Optional[List[str]]]]:
-        """Perform inference with rate-limit checking and 429 handling.
-
-        Mirrors the public Anthropic/Groq backends: skip when backing off, and
-        on a 429 mark the limiter exhausted (honoring Retry-After) so other
-        backends can take over.
-        """
+        """Inference with rate-limit/429 handling (mirrors Anthropic/Groq:
+        skip when backing off; on 429 back off honoring Retry-After)."""
         if not self.rate_limiter.can_request():
             logger.debug(
                 f"{type(self).__name__}._infer: Skipping {self.model} - backing off"
@@ -3505,21 +3474,14 @@ class RemoteAzureOpenLike(RemoteFullOpenLike):
 
     @classmethod
     def models(cls) -> List[ModelDescription]:
-        """Return the configured Azure deployments as ModelDescriptions.
-
-        Returns an empty list (the backend is effectively disabled) unless both
-        the API key and endpoint environment variables are set.
-        """
-        # The shared base carries no configuration of its own.
+        """Configured Azure deployments; empty (disabled) unless the base class
+        is subclassed and both the key and endpoint env vars are set."""
         if not cls.API_KEY_ENV or not cls.ENDPOINT_ENV:
-            return []
-        if not os.getenv(cls.API_KEY_ENV):
-            logger.debug(f"{cls.__name__}.models: {cls.API_KEY_ENV} not set, skipping")
-            return []
-        if not os.getenv(cls.ENDPOINT_ENV):
+            return []  # the shared base carries no configuration of its own
+        if not os.getenv(cls.API_KEY_ENV) or not os.getenv(cls.ENDPOINT_ENV):
             logger.debug(
-                f"{cls.__name__}.models: {cls.API_KEY_ENV} set but "
-                f"{cls.ENDPOINT_ENV} missing; skipping"
+                f"{cls.__name__}.models: {cls.API_KEY_ENV}/{cls.ENDPOINT_ENV} "
+                f"not both set, skipping"
             )
             return []
 
@@ -3533,12 +3495,8 @@ class RemoteAzureOpenLike(RemoteFullOpenLike):
         ]
 
     def model_is_ok(self) -> bool:
-        """Check the model is available (env configured and not rate limited).
-
-        We don't query the ``/models`` endpoint: Azure's OpenAI-compatible
-        layer support varies, and we'd rather fail fast on actual inference
-        than block startup.
-        """
+        """Available if env is configured and not rate limited. (No ``/models``
+        query — Azure's compat-layer support varies; fail fast on inference.)"""
         if self.API_KEY_ENV and not os.getenv(self.API_KEY_ENV):
             return False
         if self.ENDPOINT_ENV and not os.getenv(self.ENDPOINT_ENV):
@@ -3547,19 +3505,11 @@ class RemoteAzureOpenLike(RemoteFullOpenLike):
 
 
 class RemoteAzureOpenAI(RemoteAzureOpenLike):
-    """
-    Azure OpenAI Service backend (OpenAI GPT-family models hosted on Azure).
+    """Azure OpenAI Service (GPT family). Registers as ``azure-openai/<deploy>``.
 
-    Uses the Azure OpenAI v1 (OpenAI-compatible) endpoint, e.g.
-    ``https://<resource>.openai.azure.com/openai/v1/chat/completions`` with
-    Bearer-token auth. The ``model`` sent on the wire is the Azure *deployment*
-    name; by default we assume deployments are named after the model id, but
-    that can be overridden with ``AZURE_OPENAI_MODELS``.
-
-    Environment variables:
-    - AZURE_OPENAI_API_KEY:  API key for the Azure OpenAI resource (required)
-    - AZURE_OPENAI_ENDPOINT: Base URL incl. ``/openai/v1`` (required)
-    - AZURE_OPENAI_MODELS:   Optional comma-separated deployment names
+    Configure AZURE_OPENAI_API_KEY + AZURE_OPENAI_ENDPOINT (the ``/openai/v1``
+    base URL); optionally override the deployment list with AZURE_OPENAI_MODELS.
+    The wire ``model`` is the Azure deployment name. See README / .env.example.
     """
 
     API_KEY_ENV: ClassVar[str] = "AZURE_OPENAI_API_KEY"
@@ -3582,19 +3532,10 @@ class RemoteAzureOpenAI(RemoteAzureOpenLike):
 
 
 class RemoteAzureClaude(RemoteAzureOpenLike):
-    """
-    Anthropic Claude models hosted on Azure AI Foundry (Microsoft Foundry).
-
-    Uses Foundry's OpenAI-compatible chat-completions surface with Bearer-token
-    auth. Friendly names are prefixed ``azure-anthropic/`` so usage tracking in
-    the chooser and regular workflows clearly distinguishes Azure-hosted Claude
-    from the direct Anthropic API (``anthropic/...``).
-
-    Environment variables:
-    - AZURE_ANTHROPIC_API_KEY:  API key for the Foundry resource (required)
-    - AZURE_ANTHROPIC_ENDPOINT: Base URL for the OpenAI-compatible endpoint
-        (required), e.g. ``https://<resource>.services.ai.azure.com/openai/v1``
-    - AZURE_ANTHROPIC_MODELS:   Optional comma-separated deployment names
+    """Claude on Azure AI Foundry. Registers as ``azure-anthropic/<deploy>``
+    (distinct from the direct ``anthropic/`` API so usage tracking can tell them
+    apart). Configure AZURE_ANTHROPIC_API_KEY + AZURE_ANTHROPIC_ENDPOINT;
+    optionally override the deployment list with AZURE_ANTHROPIC_MODELS.
     """
 
     API_KEY_ENV: ClassVar[str] = "AZURE_ANTHROPIC_API_KEY"

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -3122,9 +3122,9 @@ class RemoteAnthropic(RemoteFullOpenLike):
             "tier": "quality",
             "description": "Claude Sonnet 4.6 - balanced quality and speed",
         },
-        "claude-opus-4-7": {
+        "claude-opus-4-8": {
             "tier": "premium",
-            "description": "Claude Opus 4.7 - highest quality, most capable",
+            "description": "Claude Opus 4.8 - highest quality, most capable",
         },
     }
 
@@ -3283,8 +3283,8 @@ class RemoteAnthropic(RemoteFullOpenLike):
             ),
             ModelDescription(
                 cost=130,
-                name="anthropic/claude-opus-4-7",
-                internal_name="claude-opus-4-7",
+                name="anthropic/claude-opus-4-8",
+                internal_name="claude-opus-4-8",
             ),
         ]
 

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -469,9 +469,9 @@ class RemoteModelLike(DenialBase):
     ]
 
     def __str__(self) -> str:
-        # Prefer the friendly tracking name (stamped by MLRouter). Fall back to
-        # a class+model descriptor so logs and any consumer that calls
-        # ``str(model)`` never surface an opaque ``<...object at 0x...>`` repr.
+        """Render as the friendly tracking name (stamped by MLRouter), falling
+        back to a ``Class(model)`` descriptor so logs and any ``str(model)``
+        consumer never surface an opaque ``<...object at 0x...>`` repr."""
         name = getattr(self, "name", None)
         if name:
             return str(name)
@@ -481,6 +481,7 @@ class RemoteModelLike(DenialBase):
         return type(self).__name__
 
     def __repr__(self) -> str:
+        """Same as ``__str__`` (friendly name / descriptor, never an object id)."""
         return self.__str__()
 
     def quality(self) -> int:
@@ -3242,6 +3243,9 @@ class RemoteAzureOpenLike(RateLimitedRemoteOpenLike):
     DEFAULT_MODELS: ClassVar[List[Tuple[str, int, str]]] = []
 
     def __init__(self, model: str, dual_mode: bool = False):
+        """Configure the backend from the subclass's env vars (API key +
+        endpoint), normalize the endpoint, and create the rate limiter.
+        Raises EnvironmentError if the key or endpoint is missing."""
         api_key = os.getenv(self.API_KEY_ENV) if self.API_KEY_ENV else None
         endpoint = os.getenv(self.ENDPOINT_ENV) if self.ENDPOINT_ENV else None
         if not api_key:
@@ -3293,10 +3297,12 @@ class RemoteAzureOpenLike(RateLimitedRemoteOpenLike):
 
     @property
     def supports_system(self):
+        """Azure GPT/Claude deployments accept the OpenAI ``system`` role."""
         return True
 
     @property
     def external(self):
+        """Azure-hosted models are external (paid) backends."""
         return True
 
     def get_tier(self) -> str:

--- a/fighthealthinsurance/ml/ml_router.py
+++ b/fighthealthinsurance/ml/ml_router.py
@@ -46,13 +46,16 @@ class MLRouter(object):
                     if m.model is None:
                         m.model = backend(model=m.internal_name)
                     # Honor the ENABLED_REMOTE_MODELS allow-list (if set): only
-                    # register a *remote* (external) model whose friendly name
-                    # (or internal name) is listed. Local/internal models are
-                    # always enabled regardless of the allow-list, and when the
-                    # variable is unset every model is enabled.
+                    # register a *remote* generation model whose friendly name
+                    # (or internal name) is listed. Always-enabled regardless of
+                    # the allow-list: local/internal models, and context-only
+                    # models (e.g. Perplexity citations) which are a separate
+                    # special-purpose pool. When the variable is unset, every
+                    # model is enabled.
                     if (
                         enabled_models is not None
                         and m.model.external
+                        and not m.model.context_only
                         and m.name not in enabled_models
                         and m.internal_name not in enabled_models
                     ):
@@ -135,8 +138,9 @@ class MLRouter(object):
         restriction" (the default when the variable is absent/blank). Entries
         are comma-separated; surrounding whitespace is ignored.
 
-        The allow-list only gates remote (external) models — local/internal
-        models are always enabled regardless of this setting.
+        The allow-list only gates remote (external) generation models.
+        Local/internal models and context-only models (e.g. Perplexity
+        citations) are always enabled regardless of this setting.
         """
         raw = os.getenv("ENABLED_REMOTE_MODELS")
         if not raw or not raw.strip():

--- a/fighthealthinsurance/ml/ml_router.py
+++ b/fighthealthinsurance/ml/ml_router.py
@@ -43,19 +43,24 @@ class MLRouter(object):
                 models = backend.models()
                 logger.debug(f"MLRouter: {backend} provided {len(models)} models")
                 for m in models:
+                    if m.model is None:
+                        m.model = backend(model=m.internal_name)
                     # Honor the ENABLED_REMOTE_MODELS allow-list (if set): only
-                    # register models whose friendly name (or internal name) is
-                    # listed. When unset, every model is enabled.
-                    if enabled_models is not None and not (
-                        m.name in enabled_models or m.internal_name in enabled_models
+                    # register a *remote* (external) model whose friendly name
+                    # (or internal name) is listed. Local/internal models are
+                    # always enabled regardless of the allow-list, and when the
+                    # variable is unset every model is enabled.
+                    if (
+                        enabled_models is not None
+                        and m.model.external
+                        and m.name not in enabled_models
+                        and m.internal_name not in enabled_models
                     ):
                         logger.debug(
-                            f"MLRouter: skipping disabled model {m.name} "
+                            f"MLRouter: skipping disabled remote model {m.name} "
                             f"(not in ENABLED_REMOTE_MODELS)"
                         )
                         continue
-                    if m.model is None:
-                        m.model = backend(model=m.internal_name)
                     # Stamp the friendly tracking name onto the instance so
                     # consumers that hold a model *instance* (e.g. the chooser
                     # in chooser_tasks.py) record this stable, human-readable
@@ -124,11 +129,14 @@ class MLRouter(object):
     def _enabled_model_names() -> Optional[set[str]]:
         """Parse the ``ENABLED_REMOTE_MODELS`` allow-list.
 
-        Returns a set of enabled model names (friendly names as shown in the
-        "All loaded models" log, and/or internal names) when the environment
-        variable is set and non-empty, or ``None`` to mean "enable all models"
-        (the default when the variable is absent/blank). Entries are
-        comma-separated; surrounding whitespace is ignored.
+        Returns a set of enabled *remote* model names (friendly names as shown
+        in the "All loaded models" log, and/or internal names) when the
+        environment variable is set and non-empty, or ``None`` to mean "no
+        restriction" (the default when the variable is absent/blank). Entries
+        are comma-separated; surrounding whitespace is ignored.
+
+        The allow-list only gates remote (external) models — local/internal
+        models are always enabled regardless of this setting.
         """
         raw = os.getenv("ENABLED_REMOTE_MODELS")
         if not raw or not raw.strip():

--- a/fighthealthinsurance/ml/ml_router.py
+++ b/fighthealthinsurance/ml/ml_router.py
@@ -72,9 +72,10 @@ class MLRouter(object):
                     if getattr(m.model, "name", None) is None:
                         try:
                             m.model.name = m.name
-                        except Exception:
+                        except Exception as e:
                             logger.debug(
-                                f"MLRouter: could not stamp name on {m.internal_name}"
+                                f"MLRouter: could not stamp name on "
+                                f"{m.internal_name}: {e}"
                             )
                     # Context-only models (e.g. Perplexity) are reserved for
                     # building context such as citations and must never appear

--- a/fighthealthinsurance/ml/ml_router.py
+++ b/fighthealthinsurance/ml/ml_router.py
@@ -27,6 +27,12 @@ class MLRouter(object):
         self.external_models_by_cost = []
         self.context_only_models_by_cost = []
         logger.debug("MLRouter: starting model registration")
+        enabled_models = self._enabled_model_names()
+        if enabled_models is not None:
+            logger.info(
+                f"MLRouter: ENABLED_REMOTE_MODELS set; only enabling "
+                f"{sorted(enabled_models)}"
+            )
         building_internal_models_by_cost = []
         building_external_models_by_cost = []
         building_all_models_by_cost = []
@@ -37,8 +43,31 @@ class MLRouter(object):
                 models = backend.models()
                 logger.debug(f"MLRouter: {backend} provided {len(models)} models")
                 for m in models:
+                    # Honor the ENABLED_REMOTE_MODELS allow-list (if set): only
+                    # register models whose friendly name (or internal name) is
+                    # listed. When unset, every model is enabled.
+                    if enabled_models is not None and not (
+                        m.name in enabled_models or m.internal_name in enabled_models
+                    ):
+                        logger.debug(
+                            f"MLRouter: skipping disabled model {m.name} "
+                            f"(not in ENABLED_REMOTE_MODELS)"
+                        )
+                        continue
                     if m.model is None:
                         m.model = backend(model=m.internal_name)
+                    # Stamp the friendly tracking name onto the instance so
+                    # consumers that hold a model *instance* (e.g. the chooser
+                    # in chooser_tasks.py) record this stable, human-readable
+                    # name instead of a raw object repr. The name also matches
+                    # the models_by_name keys used by the regular workflow.
+                    if getattr(m.model, "name", None) is None:
+                        try:
+                            m.model.name = m.name
+                        except Exception:
+                            logger.debug(
+                                f"MLRouter: could not stamp name on {m.internal_name}"
+                            )
                     # Context-only models (e.g. Perplexity) are reserved for
                     # building context such as citations and must never appear
                     # in the general generation pools. They remain reachable by
@@ -90,6 +119,22 @@ class MLRouter(object):
         logger.debug(
             f"Built {self} with i:{self.internal_models_by_cost} a:{self.all_models_by_cost}"
         )
+
+    @staticmethod
+    def _enabled_model_names() -> Optional[set[str]]:
+        """Parse the ``ENABLED_REMOTE_MODELS`` allow-list.
+
+        Returns a set of enabled model names (friendly names as shown in the
+        "All loaded models" log, and/or internal names) when the environment
+        variable is set and non-empty, or ``None`` to mean "enable all models"
+        (the default when the variable is absent/blank). Entries are
+        comma-separated; surrounding whitespace is ignored.
+        """
+        raw = os.getenv("ENABLED_REMOTE_MODELS")
+        if not raw or not raw.strip():
+            return None
+        names = {n.strip() for n in raw.split(",") if n.strip()}
+        return names or None
 
     @staticmethod
     def _keep_single_groq(models: Sequence[RemoteModelLike]) -> list[RemoteModelLike]:

--- a/tests/async-unit/test_anthropic_models.py
+++ b/tests/async-unit/test_anthropic_models.py
@@ -19,7 +19,7 @@ import aiohttp
 # Set up environment before importing RemoteAnthropic
 os.environ.setdefault("ANTHROPIC_API_KEY", "test-api-key")
 
-from fighthealthinsurance.ml.ml_models import RemoteAnthropic
+from fighthealthinsurance.ml.ml_models import RemoteAnthropic, RemoteFullOpenLike
 from fighthealthinsurance.utils import RateLimiter
 
 
@@ -186,7 +186,7 @@ class TestRemoteAnthropicInfer(unittest.TestCase):
         )
 
         with patch.object(
-            RemoteAnthropic.__bases__[0],
+            RemoteFullOpenLike,
             "_infer",
             new_callable=AsyncMock,
             side_effect=error,
@@ -218,7 +218,7 @@ class TestRemoteAnthropicInfer(unittest.TestCase):
         )
 
         with patch.object(
-            RemoteAnthropic.__bases__[0],
+            RemoteFullOpenLike,
             "_infer",
             new_callable=AsyncMock,
             side_effect=error,
@@ -252,7 +252,7 @@ class TestRemoteAnthropicInfer(unittest.TestCase):
         )
 
         with patch.object(
-            RemoteAnthropic.__bases__[0],
+            RemoteFullOpenLike,
             "_infer",
             new_callable=AsyncMock,
             side_effect=error,

--- a/tests/async-unit/test_anthropic_models.py
+++ b/tests/async-unit/test_anthropic_models.py
@@ -103,7 +103,7 @@ class TestRemoteAnthropicModels(unittest.TestCase):
 
         haiku_cost = models_by_name["anthropic/claude-haiku-4-5"].cost
         sonnet_cost = models_by_name["anthropic/claude-sonnet-4-6"].cost
-        opus_cost = models_by_name["anthropic/claude-opus-4-7"].cost
+        opus_cost = models_by_name["anthropic/claude-opus-4-8"].cost
 
         self.assertLess(haiku_cost, sonnet_cost)
         self.assertLess(sonnet_cost, opus_cost)
@@ -143,7 +143,7 @@ class TestRemoteAnthropicTiers(unittest.TestCase):
     @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"})
     def test_opus_is_premium_tier(self):
         """Test Opus is in premium tier."""
-        model = RemoteAnthropic(model="claude-opus-4-7")
+        model = RemoteAnthropic(model="claude-opus-4-8")
 
         self.assertEqual(model.get_tier(), "premium")
 

--- a/tests/async-unit/test_azure_models.py
+++ b/tests/async-unit/test_azure_models.py
@@ -29,7 +29,7 @@ AZURE_OPENAI_ENV = {
 }
 AZURE_CLAUDE_ENV = {
     "AZURE_ANTHROPIC_API_KEY": "test-key",
-    "AZURE_ANTHROPIC_ENDPOINT": "https://res.services.ai.azure.com/openai/v1",
+    "AZURE_ANTHROPIC_ENDPOINT": "https://res.services.ai.azure.com/anthropic",
 }
 
 
@@ -45,6 +45,63 @@ def _clear_azure_env():
         "ENABLED_REMOTE_MODELS",
     ):
         os.environ.pop(k, None)
+
+
+class _FakeAiohttpResponse:
+    """Minimal async-context-manager stand-in for an aiohttp response."""
+
+    def __init__(self, json_data=None, status=200, headers=None):
+        """Capture the canned JSON body, HTTP status, and response headers."""
+        self._json_data = json_data or {}
+        self.status = status
+        self._headers = headers or {}
+
+    async def __aenter__(self):
+        """Enter the ``async with`` response context."""
+        return self
+
+    async def __aexit__(self, *exc):
+        """Exit the response context without suppressing exceptions."""
+        return False
+
+    async def json(self):
+        """Return the canned JSON body."""
+        return self._json_data
+
+    def raise_for_status(self):
+        """Raise ClientResponseError for >=400 statuses (like aiohttp)."""
+        if self.status >= 400:
+            raise aiohttp.ClientResponseError(
+                request_info=MagicMock(),
+                history=(),
+                status=self.status,
+                message="error",
+                headers=self._headers,
+            )
+
+
+class _FakeAiohttpSession:
+    """Stand-in for aiohttp.ClientSession that records the POST arguments."""
+
+    def __init__(self, response, capture=None):
+        """Wrap the response to return and an optional dict to record args in."""
+        self._response = response
+        self._capture = capture if capture is not None else {}
+
+    async def __aenter__(self):
+        """Enter the ``async with`` session context."""
+        return self
+
+    async def __aexit__(self, *exc):
+        """Exit the session context without suppressing exceptions."""
+        return False
+
+    def post(self, url, headers=None, json=None):
+        """Record the request and return the canned response context manager."""
+        self._capture["url"] = url
+        self._capture["headers"] = headers
+        self._capture["json"] = json
+        return self._response
 
 
 class TestAzureBackends(unittest.TestCase):
@@ -238,6 +295,99 @@ class TestAzureInfer(unittest.TestCase):
             with patch.object(
                 RemoteFullOpenLike, "_infer", new_callable=AsyncMock, side_effect=error
             ):
+                with self.assertRaises(aiohttp.ClientResponseError):
+                    await m._infer(system_prompts=["x"], prompt="y")
+
+        asyncio.run(run())
+
+
+class TestAzureClaudeMessages(unittest.TestCase):
+    """RemoteAzureClaude's Anthropic Messages API transport (Foundry)."""
+
+    def setUp(self):
+        """Reset Claude rate-limiter state and Azure env before each test."""
+        RemoteAzureClaude._rate_limiters.clear()
+        _clear_azure_env()
+
+    def tearDown(self):
+        """Clear Azure env vars set during the test."""
+        _clear_azure_env()
+
+    def test_normalize_endpoint_variants(self):
+        """Endpoint normalization yields the …/anthropic base for every form."""
+        norm = RemoteAzureClaude._normalize_endpoint
+        base = "https://res.services.ai.azure.com/anthropic"
+        self.assertEqual(norm(base), base)
+        self.assertEqual(norm(base + "/"), base)
+        # A pasted full target URI is trimmed back to the base.
+        self.assertEqual(norm(base + "/v1/messages"), base)
+        # A bare resource host gets the /anthropic segment appended.
+        self.assertEqual(norm("https://res.services.ai.azure.com"), base)
+
+    @patch.dict(os.environ, AZURE_CLAUDE_ENV)
+    def test_messages_api_success(self):
+        """_infer posts the Messages wire format to /anthropic/v1/messages and
+        concatenates text content blocks from the response."""
+
+        async def run():
+            """Drive _infer against a fake 200 response and inspect the request."""
+            m = RemoteAzureClaude(model="claude-sonnet-4-6")
+            capture: dict = {}
+            response = _FakeAiohttpResponse(
+                {
+                    "content": [
+                        {"type": "text", "text": "Dear "},
+                        {"type": "text", "text": "insurer"},
+                    ]
+                }
+            )
+            session = _FakeAiohttpSession(response, capture)
+            with patch.object(aiohttp, "ClientSession", return_value=session):
+                result = await m._infer(
+                    system_prompts=["be helpful"], prompt="write an appeal"
+                )
+            self.assertEqual(result, ("Dear insurer", []))
+            self.assertEqual(
+                capture["url"],
+                "https://res.services.ai.azure.com/anthropic/v1/messages",
+            )
+            self.assertEqual(capture["headers"]["x-api-key"], "test-key")
+            self.assertEqual(capture["headers"]["anthropic-version"], "2023-06-01")
+            self.assertEqual(capture["json"]["model"], "claude-sonnet-4-6")
+            # System prompt is a top-level field, not a system-role message.
+            self.assertEqual(capture["json"]["system"], "be helpful")
+            self.assertIn("max_tokens", capture["json"])
+            self.assertTrue(
+                all(msg["role"] != "system" for msg in capture["json"]["messages"])
+            )
+
+        asyncio.run(run())
+
+    @patch.dict(os.environ, AZURE_CLAUDE_ENV)
+    def test_messages_api_429_backs_off(self):
+        """A 429 from the Messages endpoint marks the limiter exhausted."""
+
+        async def run():
+            """Force a 429 response and assert back-off + None result."""
+            m = RemoteAzureClaude(model="claude-sonnet-4-6")
+            response = _FakeAiohttpResponse(status=429, headers={"Retry-After": "90"})
+            session = _FakeAiohttpSession(response)
+            with patch.object(aiohttp, "ClientSession", return_value=session):
+                self.assertIsNone(await m._infer(system_prompts=["x"], prompt="y"))
+            self.assertTrue(m.rate_limiter.get_status()["exhausted"])
+
+        asyncio.run(run())
+
+    @patch.dict(os.environ, AZURE_CLAUDE_ENV)
+    def test_messages_api_non_429_propagates(self):
+        """Non-429 HTTP errors propagate rather than being swallowed."""
+
+        async def run():
+            """Force a 500 response and assert it raises ClientResponseError."""
+            m = RemoteAzureClaude(model="claude-sonnet-4-6")
+            response = _FakeAiohttpResponse(status=500, headers={})
+            session = _FakeAiohttpSession(response)
+            with patch.object(aiohttp, "ClientSession", return_value=session):
                 with self.assertRaises(aiohttp.ClientResponseError):
                     await m._infer(system_prompts=["x"], prompt="y")
 

--- a/tests/async-unit/test_azure_models.py
+++ b/tests/async-unit/test_azure_models.py
@@ -152,6 +152,19 @@ class TestAzureBackends(unittest.TestCase):
         # An overridden (non-default) deployment reports the "custom" tier.
         self.assertEqual(RemoteAzureOpenAI(model="my-deploy").get_tier(), "custom")
 
+    @patch.dict(
+        os.environ,
+        {**AZURE_OPENAI_ENV, "AZURE_OPENAI_MODELS": " , , "},
+    )
+    def test_models_env_override_blank_falls_back_to_defaults(self):
+        """A separators-only AZURE_OPENAI_MODELS (no real names) falls back to
+        the defaults instead of silently disabling the provider."""
+        models = RemoteAzureOpenAI.models()
+        self.assertEqual(
+            [m.internal_name for m in models],
+            ["gpt-4.1-mini", "gpt-5-mini", "gpt-5"],
+        )
+
     @patch.dict(os.environ, AZURE_OPENAI_ENV)
     def test_model_is_ok(self):
         """model_is_ok() is True when configured, False once rate limited."""

--- a/tests/async-unit/test_azure_models.py
+++ b/tests/async-unit/test_azure_models.py
@@ -251,9 +251,9 @@ class TestAzureInfer(unittest.TestCase):
                 message="Rate limited",
                 headers={"Retry-After": "120"},
             )
-            # super()._infer resolves to RemoteFullOpenLike (the base's parent).
+            # super()._infer resolves through RemoteFullOpenLike (the base's parent).
             with patch.object(
-                RemoteAzureOpenLike.__bases__[0],
+                RemoteFullOpenLike,
                 "_infer",
                 new_callable=AsyncMock,
                 side_effect=error,
@@ -278,7 +278,7 @@ class TestAzureInfer(unittest.TestCase):
                 headers={},
             )
             with patch.object(
-                RemoteAzureOpenLike.__bases__[0],
+                RemoteFullOpenLike,
                 "_infer",
                 new_callable=AsyncMock,
                 side_effect=error,

--- a/tests/async-unit/test_azure_models.py
+++ b/tests/async-unit/test_azure_models.py
@@ -364,6 +364,25 @@ class TestAzureClaudeMessages(unittest.TestCase):
         asyncio.run(run())
 
     @patch.dict(os.environ, AZURE_CLAUDE_ENV)
+    def test_messages_api_clamps_temperature(self):
+        """Temperature is clamped to the Messages API's [0, 1] range so a shared
+        router value that's valid on the OpenAI surface (up to 2.0) can't 400."""
+
+        async def run():
+            """Pass an out-of-range temperature and inspect the request body."""
+            m = RemoteAzureClaude(model="claude-sonnet-4-6")
+            capture: dict = {}
+            response = _FakeAiohttpResponse(
+                {"content": [{"type": "text", "text": "ok"}]}
+            )
+            session = _FakeAiohttpSession(response, capture)
+            with patch.object(aiohttp, "ClientSession", return_value=session):
+                await m._infer(system_prompts=["x"], prompt="y", temperature=1.8)
+            self.assertEqual(capture["json"]["temperature"], 1.0)
+
+        asyncio.run(run())
+
+    @patch.dict(os.environ, AZURE_CLAUDE_ENV)
     def test_messages_api_429_backs_off(self):
         """A 429 from the Messages endpoint marks the limiter exhausted."""
 

--- a/tests/async-unit/test_azure_models.py
+++ b/tests/async-unit/test_azure_models.py
@@ -1,13 +1,9 @@
 """
 Tests for the Azure-hosted generative backends and model-name tracking.
 
-Covers:
-- RemoteAzureOpenAI / RemoteAzureClaude initialization and configuration
-- Endpoint normalization, default + overridable model lists, cost tiers
-- Rate-limit checking and 429 handling
-- MLRouter stamping friendly names onto model instances (so the chooser
-  workflow records readable names instead of object reprs)
-- The ENABLED_REMOTE_MODELS allow-list
+Covers the Azure OpenAI / Claude backends (config, model lists, endpoint
+normalization, 429 handling), the MLRouter name-stamping that lets the chooser
+record readable model names, and the ENABLED_REMOTE_MODELS allow-list.
 """
 
 import asyncio
@@ -26,7 +22,6 @@ from fighthealthinsurance.ml.ml_models import (
     RemoteModelLike,
 )
 from fighthealthinsurance.ml.ml_router import MLRouter
-from fighthealthinsurance.utils import RateLimiter
 
 AZURE_OPENAI_ENV = {
     "AZURE_OPENAI_API_KEY": "test-key",
@@ -51,45 +46,47 @@ def _clear_azure_env():
         os.environ.pop(k, None)
 
 
-class TestRemoteAzureOpenAIInit(unittest.TestCase):
-    """Initialization of the Azure OpenAI backend."""
+class TestAzureBackends(unittest.TestCase):
+    """Config, model registration, and endpoint handling for both providers."""
 
     def setUp(self):
         RemoteAzureOpenAI._rate_limiters.clear()
+        RemoteAzureClaude._rate_limiters.clear()
         _clear_azure_env()
 
     def tearDown(self):
         _clear_azure_env()
 
     @patch.dict(os.environ, AZURE_OPENAI_ENV)
-    def test_init_with_valid_config(self):
-        model = RemoteAzureOpenAI(model="gpt-5")
-        self.assertEqual(model.model, "gpt-5")
-        self.assertTrue(model.supports_system)
-        self.assertTrue(model.external)
-        self.assertEqual(model.get_max_context(), 128000)
+    def test_openai_init(self):
+        m = RemoteAzureOpenAI(model="gpt-5")
+        self.assertEqual(m.model, "gpt-5")
+        self.assertTrue(m.external)
+        self.assertTrue(m.supports_system)
+        self.assertEqual(m.get_max_context(), 128000)
+        self.assertEqual(m.get_tier(), "premium")
 
-    @patch.dict(os.environ, AZURE_OPENAI_ENV)
-    def test_init_creates_rate_limiter(self):
-        model = RemoteAzureOpenAI(model="gpt-5")
-        self.assertIn("gpt-5", RemoteAzureOpenAI._rate_limiters)
-        self.assertIsInstance(model.rate_limiter, RateLimiter)
+    @patch.dict(os.environ, AZURE_CLAUDE_ENV)
+    def test_claude_init(self):
+        m = RemoteAzureClaude(model="claude-opus-4-8")
+        self.assertTrue(m.external)
+        self.assertEqual(m.get_max_context(), 200000)
 
     @patch.dict(
         os.environ,
         {"AZURE_OPENAI_ENDPOINT": AZURE_OPENAI_ENV["AZURE_OPENAI_ENDPOINT"]},
         clear=True,
     )
-    def test_init_without_api_key_raises(self):
+    def test_missing_key_raises(self):
         with self.assertRaises(EnvironmentError) as ctx:
             RemoteAzureOpenAI(model="gpt-5")
         self.assertIn("AZURE_OPENAI_API_KEY", str(ctx.exception))
 
-    @patch.dict(os.environ, {"AZURE_OPENAI_API_KEY": "test-key"}, clear=True)
-    def test_init_without_endpoint_raises(self):
+    @patch.dict(os.environ, {"AZURE_ANTHROPIC_API_KEY": "k"}, clear=True)
+    def test_missing_endpoint_raises(self):
         with self.assertRaises(EnvironmentError) as ctx:
-            RemoteAzureOpenAI(model="gpt-5")
-        self.assertIn("AZURE_OPENAI_ENDPOINT", str(ctx.exception))
+            RemoteAzureClaude(model="claude-opus-4-8")
+        self.assertIn("AZURE_ANTHROPIC_ENDPOINT", str(ctx.exception))
 
     @patch.dict(
         os.environ,
@@ -99,123 +96,56 @@ class TestRemoteAzureOpenAIInit(unittest.TestCase):
             "AZURE_OPENAI_ENDPOINT": "https://res.openai.azure.com/openai/v1/chat/completions/",
         },
     )
-    def test_endpoint_normalization_strips_completions_suffix(self):
-        model = RemoteAzureOpenAI(model="gpt-5")
-        self.assertEqual(model.api_base, "https://res.openai.azure.com/openai/v1")
-
-
-class TestRemoteAzureClaudeInit(unittest.TestCase):
-    """Initialization of the Azure AI Foundry (Claude) backend."""
-
-    def setUp(self):
-        RemoteAzureClaude._rate_limiters.clear()
-        _clear_azure_env()
-
-    def tearDown(self):
-        _clear_azure_env()
-
-    @patch.dict(os.environ, AZURE_CLAUDE_ENV)
-    def test_init_with_valid_config(self):
-        model = RemoteAzureClaude(model="claude-opus-4-8")
-        self.assertEqual(model.model, "claude-opus-4-8")
-        self.assertTrue(model.external)
-        self.assertEqual(model.get_max_context(), 200000)
-
-    @patch.dict(os.environ, {"AZURE_ANTHROPIC_API_KEY": "k"}, clear=True)
-    def test_init_without_endpoint_raises(self):
-        with self.assertRaises(EnvironmentError) as ctx:
-            RemoteAzureClaude(model="claude-opus-4-8")
-        self.assertIn("AZURE_ANTHROPIC_ENDPOINT", str(ctx.exception))
-
-    def test_providers_use_separate_rate_limiter_state(self):
-        """Each concrete provider must own its rate-limiter dict."""
-        self.assertIsNot(
-            RemoteAzureOpenAI._rate_limiters, RemoteAzureClaude._rate_limiters
-        )
-
-
-class TestAzureModels(unittest.TestCase):
-    """models() class method behavior for both Azure providers."""
-
-    def setUp(self):
-        _clear_azure_env()
-
-    def tearDown(self):
-        _clear_azure_env()
+    def test_endpoint_normalized(self):
+        m = RemoteAzureOpenAI(model="gpt-5")
+        self.assertEqual(m.api_base, "https://res.openai.azure.com/openai/v1")
 
     @patch.dict(os.environ, AZURE_OPENAI_ENV)
-    def test_openai_models_have_prefix(self):
+    def test_openai_models_prefixed_and_cost_ordered(self):
         models = RemoteAzureOpenAI.models()
         self.assertEqual(len(models), 3)
-        for m in models:
-            self.assertTrue(
-                m.name.startswith("azure-openai/"),
-                f"{m.name} should start with azure-openai/",
-            )
+        self.assertTrue(all(m.name.startswith("azure-openai/") for m in models))
+        costs = [m.cost for m in models]
+        self.assertEqual(costs, sorted(costs))  # cheapest -> premium
 
     @patch.dict(os.environ, AZURE_CLAUDE_ENV)
-    def test_claude_models_have_prefix_and_latest_ids(self):
-        models = RemoteAzureClaude.models()
-        names = {m.name for m in models}
-        self.assertIn("azure-anthropic/claude-opus-4-8", names)
-        self.assertIn("azure-anthropic/claude-sonnet-4-6", names)
-        self.assertIn("azure-anthropic/claude-haiku-4-5", names)
-
-    @patch.dict(os.environ, AZURE_OPENAI_ENV)
-    def test_openai_models_cost_ordering(self):
-        models = {m.name: m for m in RemoteAzureOpenAI.models()}
-        self.assertLess(
-            models["azure-openai/gpt-4.1-mini"].cost,
-            models["azure-openai/gpt-5-mini"].cost,
-        )
-        self.assertLess(
-            models["azure-openai/gpt-5-mini"].cost,
-            models["azure-openai/gpt-5"].cost,
+    def test_claude_models_use_latest_ids(self):
+        names = {m.name for m in RemoteAzureClaude.models()}
+        self.assertEqual(
+            names,
+            {
+                "azure-anthropic/claude-haiku-4-5",
+                "azure-anthropic/claude-sonnet-4-6",
+                "azure-anthropic/claude-opus-4-8",
+            },
         )
 
-    def test_models_empty_without_env(self):
-        # Neither key nor endpoint set.
+    def test_models_disabled_without_env(self):
+        # No key/endpoint -> providers register nothing; base never registers.
         self.assertEqual(RemoteAzureOpenAI.models(), [])
         self.assertEqual(RemoteAzureClaude.models(), [])
-
-    @patch.dict(os.environ, {"AZURE_OPENAI_API_KEY": "k"}, clear=True)
-    def test_models_empty_with_key_but_no_endpoint(self):
-        self.assertEqual(RemoteAzureOpenAI.models(), [])
+        self.assertEqual(RemoteAzureOpenLike.models(), [])
 
     @patch.dict(
         os.environ,
-        {**AZURE_OPENAI_ENV, "AZURE_OPENAI_MODELS": "gpt-5, my-custom-deploy "},
+        {**AZURE_OPENAI_ENV, "AZURE_OPENAI_MODELS": "gpt-5, my-deploy "},
     )
-    def test_models_override_via_env(self):
+    def test_models_env_override(self):
         models = RemoteAzureOpenAI.models()
-        names = [m.name for m in models]
-        self.assertEqual(names, ["azure-openai/gpt-5", "azure-openai/my-custom-deploy"])
-        # Internal (deployment) name is the bare override entry, trimmed.
-        internal = {m.internal_name for m in models}
-        self.assertEqual(internal, {"gpt-5", "my-custom-deploy"})
-
-    def test_base_class_yields_no_models(self):
-        """The shared base carries no configuration and registers nothing."""
-        self.assertEqual(RemoteAzureOpenLike.models(), [])
-
-
-class TestAzureTiers(unittest.TestCase):
-    def setUp(self):
-        RemoteAzureOpenAI._rate_limiters.clear()
-        RemoteAzureClaude._rate_limiters.clear()
-        _clear_azure_env()
-
-    def tearDown(self):
-        _clear_azure_env()
+        self.assertEqual([m.internal_name for m in models], ["gpt-5", "my-deploy"])
+        self.assertEqual(
+            [m.name for m in models],
+            ["azure-openai/gpt-5", "azure-openai/my-deploy"],
+        )
+        # An overridden (non-default) deployment reports the "custom" tier.
+        self.assertEqual(RemoteAzureOpenAI(model="my-deploy").get_tier(), "custom")
 
     @patch.dict(os.environ, AZURE_OPENAI_ENV)
-    def test_default_tier(self):
-        self.assertEqual(RemoteAzureOpenAI(model="gpt-5").get_tier(), "premium")
-        self.assertEqual(RemoteAzureOpenAI(model="gpt-4.1-mini").get_tier(), "speed")
-
-    @patch.dict(os.environ, {**AZURE_OPENAI_ENV, "AZURE_OPENAI_MODELS": "foo-deploy"})
-    def test_override_tier_is_custom(self):
-        self.assertEqual(RemoteAzureOpenAI(model="foo-deploy").get_tier(), "custom")
+    def test_model_is_ok(self):
+        m = RemoteAzureOpenAI(model="gpt-5")
+        self.assertTrue(m.model_is_ok())
+        m.rate_limiter.mark_exhausted(60.0)
+        self.assertFalse(m.model_is_ok())
 
 
 class TestAzureInfer(unittest.TestCase):
@@ -229,21 +159,18 @@ class TestAzureInfer(unittest.TestCase):
         _clear_azure_env()
 
     @patch.dict(os.environ, AZURE_OPENAI_ENV)
-    def test_infer_checks_rate_limit(self):
+    def test_skips_when_rate_limited(self):
         async def run():
-            model = RemoteAzureOpenAI(model="gpt-5")
-            model.rate_limiter.mark_exhausted(60.0)
-            result = await model._infer(
-                system_prompts=["You are helpful."], prompt="Test"
-            )
-            self.assertIsNone(result)
+            m = RemoteAzureOpenAI(model="gpt-5")
+            m.rate_limiter.mark_exhausted(60.0)
+            self.assertIsNone(await m._infer(system_prompts=["x"], prompt="y"))
 
         asyncio.run(run())
 
     @patch.dict(os.environ, AZURE_OPENAI_ENV)
-    def test_infer_handles_429(self):
+    def test_429_backs_off(self):
         async def run():
-            model = RemoteAzureOpenAI(model="gpt-5")
+            m = RemoteAzureOpenAI(model="gpt-5")
             error = aiohttp.ClientResponseError(
                 request_info=MagicMock(),
                 history=(),
@@ -251,25 +178,19 @@ class TestAzureInfer(unittest.TestCase):
                 message="Rate limited",
                 headers={"Retry-After": "120"},
             )
-            # super()._infer resolves through RemoteFullOpenLike (the base's parent).
+            # super()._infer resolves through RemoteFullOpenLike.
             with patch.object(
-                RemoteFullOpenLike,
-                "_infer",
-                new_callable=AsyncMock,
-                side_effect=error,
+                RemoteFullOpenLike, "_infer", new_callable=AsyncMock, side_effect=error
             ):
-                result = await model._infer(
-                    system_prompts=["You are helpful."], prompt="Test"
-                )
-            self.assertIsNone(result)
-            self.assertTrue(model.rate_limiter.get_status()["exhausted"])
+                self.assertIsNone(await m._infer(system_prompts=["x"], prompt="y"))
+            self.assertTrue(m.rate_limiter.get_status()["exhausted"])
 
         asyncio.run(run())
 
     @patch.dict(os.environ, AZURE_OPENAI_ENV)
-    def test_infer_other_http_errors_propagate(self):
+    def test_non_429_propagates(self):
         async def run():
-            model = RemoteAzureOpenAI(model="gpt-5")
+            m = RemoteAzureOpenAI(model="gpt-5")
             error = aiohttp.ClientResponseError(
                 request_info=MagicMock(),
                 history=(),
@@ -278,24 +199,12 @@ class TestAzureInfer(unittest.TestCase):
                 headers={},
             )
             with patch.object(
-                RemoteFullOpenLike,
-                "_infer",
-                new_callable=AsyncMock,
-                side_effect=error,
+                RemoteFullOpenLike, "_infer", new_callable=AsyncMock, side_effect=error
             ):
                 with self.assertRaises(aiohttp.ClientResponseError):
-                    await model._infer(
-                        system_prompts=["You are helpful."], prompt="Test"
-                    )
+                    await m._infer(system_prompts=["x"], prompt="y")
 
         asyncio.run(run())
-
-    @patch.dict(os.environ, AZURE_OPENAI_ENV)
-    def test_model_is_ok(self):
-        model = RemoteAzureOpenAI(model="gpt-5")
-        self.assertTrue(model.model_is_ok())
-        model.rate_limiter.mark_exhausted(60.0)
-        self.assertFalse(model.model_is_ok())
 
 
 # ---------------------------------------------------------------------------

--- a/tests/async-unit/test_azure_models.py
+++ b/tests/async-unit/test_azure_models.py
@@ -215,9 +215,10 @@ class TestAzureInfer(unittest.TestCase):
 class _FakeModel(RemoteModelLike):
     """Minimal concrete model used to drive MLRouter in tests."""
 
-    def __init__(self, model, external=False):
+    def __init__(self, model, external=False, context_only=False):
         self.model = model
         self._external = external
+        self._context_only = context_only
 
     @property
     def external(self):
@@ -225,7 +226,7 @@ class _FakeModel(RemoteModelLike):
 
     @property
     def context_only(self):
-        return False
+        return self._context_only
 
     async def _infer(self, *args, **kwargs):
         return None
@@ -253,8 +254,9 @@ class _FakeBackend:
 
 
 class _FakeMixedBackend:
-    """Backend stub with two remote (external) models plus one local model,
-    used to verify ENABLED_REMOTE_MODELS gates remote models only."""
+    """Backend stub with remote (external) generation models, a local model,
+    and a context-only model -- to verify ENABLED_REMOTE_MODELS gates only
+    remote generation models."""
 
     @classmethod
     def models(cls):
@@ -276,6 +278,12 @@ class _FakeMixedBackend:
                 name="local/keep",
                 internal_name="lkeep-int",
                 model=_FakeModel("lkeep-int", external=False),
+            ),
+            ModelDescription(
+                cost=5,
+                name="ctx/cite",
+                internal_name="ctx-int",
+                model=_FakeModel("ctx-int", external=True, context_only=True),
             ),
         ]
 
@@ -372,11 +380,12 @@ class TestEnabledRemoteModels(unittest.TestCase):
         self.assertIn("local/keep", router.models_by_name)
 
     @patch.dict(os.environ, {"ENABLED_REMOTE_MODELS": "nonexistent/model"})
-    def test_local_models_always_enabled_even_when_not_listed(self):
-        """A local model loads even though it is not in the allow-list, while
-        unlisted remote models are dropped."""
+    def test_local_and_context_only_always_enabled_when_not_listed(self):
+        """Local and context-only (citation) models load even though they are
+        not in the allow-list, while unlisted remote models are dropped."""
         router = self._build()
         self.assertIn("local/keep", router.models_by_name)
+        self.assertIn("ctx/cite", router.models_by_name)  # context-only, always on
         self.assertNotIn("remote/alpha", router.models_by_name)
         self.assertNotIn("remote/beta", router.models_by_name)
 

--- a/tests/async-unit/test_azure_models.py
+++ b/tests/async-unit/test_azure_models.py
@@ -306,12 +306,13 @@ class TestAzureInfer(unittest.TestCase):
 class _FakeModel(RemoteModelLike):
     """Minimal concrete model used to drive MLRouter in tests."""
 
-    def __init__(self, model):
+    def __init__(self, model, external=False):
         self.model = model
+        self._external = external
 
     @property
     def external(self):
-        return False
+        return self._external
 
     @property
     def context_only(self):
@@ -322,7 +323,7 @@ class _FakeModel(RemoteModelLike):
 
 
 class _FakeBackend:
-    """Backend stub whose models() returns pre-built _FakeModel instances."""
+    """Backend stub of local/internal models (for name-tracking tests)."""
 
     @classmethod
     def models(cls):
@@ -331,13 +332,41 @@ class _FakeBackend:
                 cost=10,
                 name="fake/alpha",
                 internal_name="alpha-int",
-                model=_FakeModel("alpha-int"),
+                model=_FakeModel("alpha-int", external=False),
             ),
             ModelDescription(
                 cost=20,
                 name="fake/beta",
                 internal_name="beta-int",
-                model=_FakeModel("beta-int"),
+                model=_FakeModel("beta-int", external=False),
+            ),
+        ]
+
+
+class _FakeMixedBackend:
+    """Backend stub with two remote (external) models plus one local model,
+    used to verify ENABLED_REMOTE_MODELS gates remote models only."""
+
+    @classmethod
+    def models(cls):
+        return [
+            ModelDescription(
+                cost=10,
+                name="remote/alpha",
+                internal_name="ralpha-int",
+                model=_FakeModel("ralpha-int", external=True),
+            ),
+            ModelDescription(
+                cost=20,
+                name="remote/beta",
+                internal_name="rbeta-int",
+                model=_FakeModel("rbeta-int", external=True),
+            ),
+            ModelDescription(
+                cost=5,
+                name="local/keep",
+                internal_name="lkeep-int",
+                model=_FakeModel("lkeep-int", external=False),
             ),
         ]
 
@@ -395,7 +424,8 @@ class TestModelNameTracking(unittest.TestCase):
 
 
 class TestEnabledRemoteModels(unittest.TestCase):
-    """ENABLED_REMOTE_MODELS restricts which models load."""
+    """ENABLED_REMOTE_MODELS restricts which *remote* models load; local
+    models are always enabled."""
 
     def setUp(self):
         os.environ.pop("ENABLED_REMOTE_MODELS", None)
@@ -403,35 +433,43 @@ class TestEnabledRemoteModels(unittest.TestCase):
     def tearDown(self):
         os.environ.pop("ENABLED_REMOTE_MODELS", None)
 
+    def _build(self):
+        with patch(
+            "fighthealthinsurance.ml.ml_router.candidate_model_backends",
+            [_FakeMixedBackend],
+        ):
+            return MLRouter()
+
     def test_unset_enables_all(self):
         self.assertIsNone(MLRouter._enabled_model_names())
-        with patch(
-            "fighthealthinsurance.ml.ml_router.candidate_model_backends",
-            [_FakeBackend],
-        ):
-            router = MLRouter()
-        self.assertIn("fake/alpha", router.models_by_name)
-        self.assertIn("fake/beta", router.models_by_name)
+        router = self._build()
+        self.assertIn("remote/alpha", router.models_by_name)
+        self.assertIn("remote/beta", router.models_by_name)
+        self.assertIn("local/keep", router.models_by_name)
 
-    @patch.dict(os.environ, {"ENABLED_REMOTE_MODELS": "fake/alpha"})
-    def test_allow_list_filters_by_friendly_name(self):
-        with patch(
-            "fighthealthinsurance.ml.ml_router.candidate_model_backends",
-            [_FakeBackend],
-        ):
-            router = MLRouter()
-        self.assertIn("fake/alpha", router.models_by_name)
-        self.assertNotIn("fake/beta", router.models_by_name)
+    @patch.dict(os.environ, {"ENABLED_REMOTE_MODELS": "remote/alpha"})
+    def test_allow_list_filters_remote_by_friendly_name(self):
+        router = self._build()
+        self.assertIn("remote/alpha", router.models_by_name)
+        self.assertNotIn("remote/beta", router.models_by_name)
+        # Local models load regardless of the allow-list.
+        self.assertIn("local/keep", router.models_by_name)
 
-    @patch.dict(os.environ, {"ENABLED_REMOTE_MODELS": "beta-int"})
+    @patch.dict(os.environ, {"ENABLED_REMOTE_MODELS": "rbeta-int"})
     def test_allow_list_also_matches_internal_name(self):
-        with patch(
-            "fighthealthinsurance.ml.ml_router.candidate_model_backends",
-            [_FakeBackend],
-        ):
-            router = MLRouter()
-        self.assertIn("fake/beta", router.models_by_name)
-        self.assertNotIn("fake/alpha", router.models_by_name)
+        router = self._build()
+        self.assertIn("remote/beta", router.models_by_name)
+        self.assertNotIn("remote/alpha", router.models_by_name)
+        self.assertIn("local/keep", router.models_by_name)
+
+    @patch.dict(os.environ, {"ENABLED_REMOTE_MODELS": "nonexistent/model"})
+    def test_local_models_always_enabled_even_when_not_listed(self):
+        """A local model loads even though it is not in the allow-list, while
+        unlisted remote models are dropped."""
+        router = self._build()
+        self.assertIn("local/keep", router.models_by_name)
+        self.assertNotIn("remote/alpha", router.models_by_name)
+        self.assertNotIn("remote/beta", router.models_by_name)
 
     @patch.dict(os.environ, {"ENABLED_REMOTE_MODELS": "  "})
     def test_blank_value_enables_all(self):

--- a/tests/async-unit/test_azure_models.py
+++ b/tests/async-unit/test_azure_models.py
@@ -34,6 +34,7 @@ AZURE_CLAUDE_ENV = {
 
 
 def _clear_azure_env():
+    """Remove all Azure/allow-list env vars so tests start from a clean slate."""
     for k in (
         "AZURE_OPENAI_API_KEY",
         "AZURE_OPENAI_ENDPOINT",
@@ -50,15 +51,18 @@ class TestAzureBackends(unittest.TestCase):
     """Config, model registration, and endpoint handling for both providers."""
 
     def setUp(self):
+        """Reset rate-limiter state and Azure env vars before each test."""
         RemoteAzureOpenAI._rate_limiters.clear()
         RemoteAzureClaude._rate_limiters.clear()
         _clear_azure_env()
 
     def tearDown(self):
+        """Clear Azure env vars set during the test."""
         _clear_azure_env()
 
     @patch.dict(os.environ, AZURE_OPENAI_ENV)
     def test_openai_init(self):
+        """Azure OpenAI init wires model, external/system flags, context, tier."""
         m = RemoteAzureOpenAI(model="gpt-5")
         self.assertEqual(m.model, "gpt-5")
         self.assertTrue(m.external)
@@ -68,6 +72,7 @@ class TestAzureBackends(unittest.TestCase):
 
     @patch.dict(os.environ, AZURE_CLAUDE_ENV)
     def test_claude_init(self):
+        """Azure Claude init is external and uses the 200K context window."""
         m = RemoteAzureClaude(model="claude-opus-4-8")
         self.assertTrue(m.external)
         self.assertEqual(m.get_max_context(), 200000)
@@ -78,12 +83,14 @@ class TestAzureBackends(unittest.TestCase):
         clear=True,
     )
     def test_missing_key_raises(self):
+        """Missing API key raises EnvironmentError naming the key env var."""
         with self.assertRaises(EnvironmentError) as ctx:
             RemoteAzureOpenAI(model="gpt-5")
         self.assertIn("AZURE_OPENAI_API_KEY", str(ctx.exception))
 
     @patch.dict(os.environ, {"AZURE_ANTHROPIC_API_KEY": "k"}, clear=True)
     def test_missing_endpoint_raises(self):
+        """Missing endpoint raises EnvironmentError naming the endpoint env var."""
         with self.assertRaises(EnvironmentError) as ctx:
             RemoteAzureClaude(model="claude-opus-4-8")
         self.assertIn("AZURE_ANTHROPIC_ENDPOINT", str(ctx.exception))
@@ -97,11 +104,13 @@ class TestAzureBackends(unittest.TestCase):
         },
     )
     def test_endpoint_normalized(self):
+        """A pasted /chat/completions URL is normalized back to the base."""
         m = RemoteAzureOpenAI(model="gpt-5")
         self.assertEqual(m.api_base, "https://res.openai.azure.com/openai/v1")
 
     @patch.dict(os.environ, AZURE_OPENAI_ENV)
     def test_openai_models_prefixed_and_cost_ordered(self):
+        """models() yields azure-openai/-prefixed entries, cheapest first."""
         models = RemoteAzureOpenAI.models()
         self.assertEqual(len(models), 3)
         self.assertTrue(all(m.name.startswith("azure-openai/") for m in models))
@@ -110,6 +119,7 @@ class TestAzureBackends(unittest.TestCase):
 
     @patch.dict(os.environ, AZURE_CLAUDE_ENV)
     def test_claude_models_use_latest_ids(self):
+        """Azure Claude exposes the latest Haiku/Sonnet/Opus-4.8 deployments."""
         names = {m.name for m in RemoteAzureClaude.models()}
         self.assertEqual(
             names,
@@ -121,6 +131,7 @@ class TestAzureBackends(unittest.TestCase):
         )
 
     def test_models_disabled_without_env(self):
+        """Without env config, providers (and the base) register no models."""
         # No key/endpoint -> providers register nothing; base never registers.
         self.assertEqual(RemoteAzureOpenAI.models(), [])
         self.assertEqual(RemoteAzureClaude.models(), [])
@@ -131,6 +142,7 @@ class TestAzureBackends(unittest.TestCase):
         {**AZURE_OPENAI_ENV, "AZURE_OPENAI_MODELS": "gpt-5, my-deploy "},
     )
     def test_models_env_override(self):
+        """AZURE_OPENAI_MODELS overrides the deployment list (tier=custom)."""
         models = RemoteAzureOpenAI.models()
         self.assertEqual([m.internal_name for m in models], ["gpt-5", "my-deploy"])
         self.assertEqual(
@@ -142,6 +154,7 @@ class TestAzureBackends(unittest.TestCase):
 
     @patch.dict(os.environ, AZURE_OPENAI_ENV)
     def test_model_is_ok(self):
+        """model_is_ok() is True when configured, False once rate limited."""
         m = RemoteAzureOpenAI(model="gpt-5")
         self.assertTrue(m.model_is_ok())
         m.rate_limiter.mark_exhausted(60.0)
@@ -152,15 +165,20 @@ class TestAzureInfer(unittest.TestCase):
     """Rate-limit and 429 handling for Azure backends."""
 
     def setUp(self):
+        """Reset rate-limiter state and Azure env vars before each test."""
         RemoteAzureOpenAI._rate_limiters.clear()
         _clear_azure_env()
 
     def tearDown(self):
+        """Clear Azure env vars set during the test."""
         _clear_azure_env()
 
     @patch.dict(os.environ, AZURE_OPENAI_ENV)
     def test_skips_when_rate_limited(self):
+        """_infer short-circuits to None while the limiter is backing off."""
+
         async def run():
+            """Exhaust the limiter, then assert _infer returns None."""
             m = RemoteAzureOpenAI(model="gpt-5")
             m.rate_limiter.mark_exhausted(60.0)
             self.assertIsNone(await m._infer(system_prompts=["x"], prompt="y"))
@@ -169,7 +187,10 @@ class TestAzureInfer(unittest.TestCase):
 
     @patch.dict(os.environ, AZURE_OPENAI_ENV)
     def test_429_backs_off(self):
+        """A 429 marks the limiter exhausted (honoring Retry-After)."""
+
         async def run():
+            """Force a 429 from the parent _infer and assert back-off."""
             m = RemoteAzureOpenAI(model="gpt-5")
             error = aiohttp.ClientResponseError(
                 request_info=MagicMock(),
@@ -189,7 +210,10 @@ class TestAzureInfer(unittest.TestCase):
 
     @patch.dict(os.environ, AZURE_OPENAI_ENV)
     def test_non_429_propagates(self):
+        """Non-429 HTTP errors propagate rather than being swallowed."""
+
         async def run():
+            """Force a 500 from the parent _infer and assert it raises."""
             m = RemoteAzureOpenAI(model="gpt-5")
             error = aiohttp.ClientResponseError(
                 request_info=MagicMock(),
@@ -216,19 +240,23 @@ class _FakeModel(RemoteModelLike):
     """Minimal concrete model used to drive MLRouter in tests."""
 
     def __init__(self, model, external=False, context_only=False):
+        """Build a fake model with configurable external/context_only flags."""
         self.model = model
         self._external = external
         self._context_only = context_only
 
     @property
     def external(self):
+        """Whether this fake is treated as an external (remote) model."""
         return self._external
 
     @property
     def context_only(self):
+        """Whether this fake is a context-only (citation) model."""
         return self._context_only
 
     async def _infer(self, *args, **kwargs):
+        """No-op inference; the router tests never call it."""
         return None
 
 
@@ -237,6 +265,7 @@ class _FakeBackend:
 
     @classmethod
     def models(cls):
+        """Return two local (internal) fake models."""
         return [
             ModelDescription(
                 cost=10,
@@ -260,6 +289,7 @@ class _FakeMixedBackend:
 
     @classmethod
     def models(cls):
+        """Return two remote, one local, and one context-only fake model."""
         return [
             ModelDescription(
                 cost=10,
@@ -292,12 +322,15 @@ class TestModelNameTracking(unittest.TestCase):
     """The router must stamp friendly names so the chooser records them."""
 
     def setUp(self):
+        """Clear ENABLED_REMOTE_MODELS before each test."""
         os.environ.pop("ENABLED_REMOTE_MODELS", None)
 
     def tearDown(self):
+        """Clear ENABLED_REMOTE_MODELS set during the test."""
         os.environ.pop("ENABLED_REMOTE_MODELS", None)
 
     def test_router_stamps_friendly_name_on_instances(self):
+        """The router stamps each model instance with its friendly name."""
         with patch(
             "fighthealthinsurance.ml.ml_router.candidate_model_backends",
             [_FakeBackend],
@@ -329,11 +362,13 @@ class TestModelNameTracking(unittest.TestCase):
         self.assertNotIn("object at 0x", recorded)
 
     def test_str_returns_friendly_name_when_stamped(self):
+        """str(model) returns the stamped friendly name."""
         stamped = _FakeModel("alpha-int")
         stamped.name = "fake/alpha"
         self.assertEqual(str(stamped), "fake/alpha")
 
     def test_str_descriptive_when_unstamped(self):
+        """An unstamped model still renders a descriptive (non-repr) string."""
         unstamped = _FakeModel("alpha-int")
         rendered = str(unstamped)
         self.assertNotIn("object at 0x", rendered)
@@ -345,12 +380,15 @@ class TestEnabledRemoteModels(unittest.TestCase):
     models are always enabled."""
 
     def setUp(self):
+        """Clear ENABLED_REMOTE_MODELS before each test."""
         os.environ.pop("ENABLED_REMOTE_MODELS", None)
 
     def tearDown(self):
+        """Clear ENABLED_REMOTE_MODELS set during the test."""
         os.environ.pop("ENABLED_REMOTE_MODELS", None)
 
     def _build(self):
+        """Build an MLRouter backed only by the mixed fake backend."""
         with patch(
             "fighthealthinsurance.ml.ml_router.candidate_model_backends",
             [_FakeMixedBackend],
@@ -358,6 +396,7 @@ class TestEnabledRemoteModels(unittest.TestCase):
             return MLRouter()
 
     def test_unset_enables_all(self):
+        """With the var unset, every model (remote and local) is enabled."""
         self.assertIsNone(MLRouter._enabled_model_names())
         router = self._build()
         self.assertIn("remote/alpha", router.models_by_name)
@@ -366,6 +405,7 @@ class TestEnabledRemoteModels(unittest.TestCase):
 
     @patch.dict(os.environ, {"ENABLED_REMOTE_MODELS": "remote/alpha"})
     def test_allow_list_filters_remote_by_friendly_name(self):
+        """The allow-list drops unlisted remote models but keeps locals."""
         router = self._build()
         self.assertIn("remote/alpha", router.models_by_name)
         self.assertNotIn("remote/beta", router.models_by_name)
@@ -374,6 +414,7 @@ class TestEnabledRemoteModels(unittest.TestCase):
 
     @patch.dict(os.environ, {"ENABLED_REMOTE_MODELS": "rbeta-int"})
     def test_allow_list_also_matches_internal_name(self):
+        """The allow-list matches a model's internal name too, not just friendly."""
         router = self._build()
         self.assertIn("remote/beta", router.models_by_name)
         self.assertNotIn("remote/alpha", router.models_by_name)
@@ -391,6 +432,7 @@ class TestEnabledRemoteModels(unittest.TestCase):
 
     @patch.dict(os.environ, {"ENABLED_REMOTE_MODELS": "  "})
     def test_blank_value_enables_all(self):
+        """A blank/whitespace value is treated as 'no restriction' (None)."""
         self.assertIsNone(MLRouter._enabled_model_names())
 
 

--- a/tests/async-unit/test_azure_models.py
+++ b/tests/async-unit/test_azure_models.py
@@ -1,0 +1,442 @@
+"""
+Tests for the Azure-hosted generative backends and model-name tracking.
+
+Covers:
+- RemoteAzureOpenAI / RemoteAzureClaude initialization and configuration
+- Endpoint normalization, default + overridable model lists, cost tiers
+- Rate-limit checking and 429 handling
+- MLRouter stamping friendly names onto model instances (so the chooser
+  workflow records readable names instead of object reprs)
+- The ENABLED_REMOTE_MODELS allow-list
+"""
+
+import asyncio
+import os
+import unittest
+from unittest.mock import patch, MagicMock, AsyncMock
+
+import aiohttp
+
+from fighthealthinsurance.ml.ml_models import (
+    ModelDescription,
+    RemoteAzureClaude,
+    RemoteAzureOpenAI,
+    RemoteAzureOpenLike,
+    RemoteFullOpenLike,
+    RemoteModelLike,
+)
+from fighthealthinsurance.ml.ml_router import MLRouter
+from fighthealthinsurance.utils import RateLimiter
+
+AZURE_OPENAI_ENV = {
+    "AZURE_OPENAI_API_KEY": "test-key",
+    "AZURE_OPENAI_ENDPOINT": "https://res.openai.azure.com/openai/v1",
+}
+AZURE_CLAUDE_ENV = {
+    "AZURE_ANTHROPIC_API_KEY": "test-key",
+    "AZURE_ANTHROPIC_ENDPOINT": "https://res.services.ai.azure.com/openai/v1",
+}
+
+
+def _clear_azure_env():
+    for k in (
+        "AZURE_OPENAI_API_KEY",
+        "AZURE_OPENAI_ENDPOINT",
+        "AZURE_OPENAI_MODELS",
+        "AZURE_ANTHROPIC_API_KEY",
+        "AZURE_ANTHROPIC_ENDPOINT",
+        "AZURE_ANTHROPIC_MODELS",
+        "ENABLED_REMOTE_MODELS",
+    ):
+        os.environ.pop(k, None)
+
+
+class TestRemoteAzureOpenAIInit(unittest.TestCase):
+    """Initialization of the Azure OpenAI backend."""
+
+    def setUp(self):
+        RemoteAzureOpenAI._rate_limiters.clear()
+        _clear_azure_env()
+
+    def tearDown(self):
+        _clear_azure_env()
+
+    @patch.dict(os.environ, AZURE_OPENAI_ENV)
+    def test_init_with_valid_config(self):
+        model = RemoteAzureOpenAI(model="gpt-5")
+        self.assertEqual(model.model, "gpt-5")
+        self.assertTrue(model.supports_system)
+        self.assertTrue(model.external)
+        self.assertEqual(model.get_max_context(), 128000)
+
+    @patch.dict(os.environ, AZURE_OPENAI_ENV)
+    def test_init_creates_rate_limiter(self):
+        model = RemoteAzureOpenAI(model="gpt-5")
+        self.assertIn("gpt-5", RemoteAzureOpenAI._rate_limiters)
+        self.assertIsInstance(model.rate_limiter, RateLimiter)
+
+    @patch.dict(
+        os.environ,
+        {"AZURE_OPENAI_ENDPOINT": AZURE_OPENAI_ENV["AZURE_OPENAI_ENDPOINT"]},
+        clear=True,
+    )
+    def test_init_without_api_key_raises(self):
+        with self.assertRaises(EnvironmentError) as ctx:
+            RemoteAzureOpenAI(model="gpt-5")
+        self.assertIn("AZURE_OPENAI_API_KEY", str(ctx.exception))
+
+    @patch.dict(os.environ, {"AZURE_OPENAI_API_KEY": "test-key"}, clear=True)
+    def test_init_without_endpoint_raises(self):
+        with self.assertRaises(EnvironmentError) as ctx:
+            RemoteAzureOpenAI(model="gpt-5")
+        self.assertIn("AZURE_OPENAI_ENDPOINT", str(ctx.exception))
+
+    @patch.dict(
+        os.environ,
+        {
+            "AZURE_OPENAI_API_KEY": "test-key",
+            # Operator pasted the full completions URL with a trailing slash.
+            "AZURE_OPENAI_ENDPOINT": "https://res.openai.azure.com/openai/v1/chat/completions/",
+        },
+    )
+    def test_endpoint_normalization_strips_completions_suffix(self):
+        model = RemoteAzureOpenAI(model="gpt-5")
+        self.assertEqual(model.api_base, "https://res.openai.azure.com/openai/v1")
+
+
+class TestRemoteAzureClaudeInit(unittest.TestCase):
+    """Initialization of the Azure AI Foundry (Claude) backend."""
+
+    def setUp(self):
+        RemoteAzureClaude._rate_limiters.clear()
+        _clear_azure_env()
+
+    def tearDown(self):
+        _clear_azure_env()
+
+    @patch.dict(os.environ, AZURE_CLAUDE_ENV)
+    def test_init_with_valid_config(self):
+        model = RemoteAzureClaude(model="claude-opus-4-8")
+        self.assertEqual(model.model, "claude-opus-4-8")
+        self.assertTrue(model.external)
+        self.assertEqual(model.get_max_context(), 200000)
+
+    @patch.dict(os.environ, {"AZURE_ANTHROPIC_API_KEY": "k"}, clear=True)
+    def test_init_without_endpoint_raises(self):
+        with self.assertRaises(EnvironmentError) as ctx:
+            RemoteAzureClaude(model="claude-opus-4-8")
+        self.assertIn("AZURE_ANTHROPIC_ENDPOINT", str(ctx.exception))
+
+    def test_providers_use_separate_rate_limiter_state(self):
+        """Each concrete provider must own its rate-limiter dict."""
+        self.assertIsNot(
+            RemoteAzureOpenAI._rate_limiters, RemoteAzureClaude._rate_limiters
+        )
+
+
+class TestAzureModels(unittest.TestCase):
+    """models() class method behavior for both Azure providers."""
+
+    def setUp(self):
+        _clear_azure_env()
+
+    def tearDown(self):
+        _clear_azure_env()
+
+    @patch.dict(os.environ, AZURE_OPENAI_ENV)
+    def test_openai_models_have_prefix(self):
+        models = RemoteAzureOpenAI.models()
+        self.assertEqual(len(models), 3)
+        for m in models:
+            self.assertTrue(
+                m.name.startswith("azure-openai/"),
+                f"{m.name} should start with azure-openai/",
+            )
+
+    @patch.dict(os.environ, AZURE_CLAUDE_ENV)
+    def test_claude_models_have_prefix_and_latest_ids(self):
+        models = RemoteAzureClaude.models()
+        names = {m.name for m in models}
+        self.assertIn("azure-anthropic/claude-opus-4-8", names)
+        self.assertIn("azure-anthropic/claude-sonnet-4-6", names)
+        self.assertIn("azure-anthropic/claude-haiku-4-5", names)
+
+    @patch.dict(os.environ, AZURE_OPENAI_ENV)
+    def test_openai_models_cost_ordering(self):
+        models = {m.name: m for m in RemoteAzureOpenAI.models()}
+        self.assertLess(
+            models["azure-openai/gpt-4.1-mini"].cost,
+            models["azure-openai/gpt-5-mini"].cost,
+        )
+        self.assertLess(
+            models["azure-openai/gpt-5-mini"].cost,
+            models["azure-openai/gpt-5"].cost,
+        )
+
+    def test_models_empty_without_env(self):
+        # Neither key nor endpoint set.
+        self.assertEqual(RemoteAzureOpenAI.models(), [])
+        self.assertEqual(RemoteAzureClaude.models(), [])
+
+    @patch.dict(os.environ, {"AZURE_OPENAI_API_KEY": "k"}, clear=True)
+    def test_models_empty_with_key_but_no_endpoint(self):
+        self.assertEqual(RemoteAzureOpenAI.models(), [])
+
+    @patch.dict(
+        os.environ,
+        {**AZURE_OPENAI_ENV, "AZURE_OPENAI_MODELS": "gpt-5, my-custom-deploy "},
+    )
+    def test_models_override_via_env(self):
+        models = RemoteAzureOpenAI.models()
+        names = [m.name for m in models]
+        self.assertEqual(names, ["azure-openai/gpt-5", "azure-openai/my-custom-deploy"])
+        # Internal (deployment) name is the bare override entry, trimmed.
+        internal = {m.internal_name for m in models}
+        self.assertEqual(internal, {"gpt-5", "my-custom-deploy"})
+
+    def test_base_class_yields_no_models(self):
+        """The shared base carries no configuration and registers nothing."""
+        self.assertEqual(RemoteAzureOpenLike.models(), [])
+
+
+class TestAzureTiers(unittest.TestCase):
+    def setUp(self):
+        RemoteAzureOpenAI._rate_limiters.clear()
+        RemoteAzureClaude._rate_limiters.clear()
+        _clear_azure_env()
+
+    def tearDown(self):
+        _clear_azure_env()
+
+    @patch.dict(os.environ, AZURE_OPENAI_ENV)
+    def test_default_tier(self):
+        self.assertEqual(RemoteAzureOpenAI(model="gpt-5").get_tier(), "premium")
+        self.assertEqual(RemoteAzureOpenAI(model="gpt-4.1-mini").get_tier(), "speed")
+
+    @patch.dict(os.environ, {**AZURE_OPENAI_ENV, "AZURE_OPENAI_MODELS": "foo-deploy"})
+    def test_override_tier_is_custom(self):
+        self.assertEqual(RemoteAzureOpenAI(model="foo-deploy").get_tier(), "custom")
+
+
+class TestAzureInfer(unittest.TestCase):
+    """Rate-limit and 429 handling for Azure backends."""
+
+    def setUp(self):
+        RemoteAzureOpenAI._rate_limiters.clear()
+        _clear_azure_env()
+
+    def tearDown(self):
+        _clear_azure_env()
+
+    @patch.dict(os.environ, AZURE_OPENAI_ENV)
+    def test_infer_checks_rate_limit(self):
+        async def run():
+            model = RemoteAzureOpenAI(model="gpt-5")
+            model.rate_limiter.mark_exhausted(60.0)
+            result = await model._infer(
+                system_prompts=["You are helpful."], prompt="Test"
+            )
+            self.assertIsNone(result)
+
+        asyncio.run(run())
+
+    @patch.dict(os.environ, AZURE_OPENAI_ENV)
+    def test_infer_handles_429(self):
+        async def run():
+            model = RemoteAzureOpenAI(model="gpt-5")
+            error = aiohttp.ClientResponseError(
+                request_info=MagicMock(),
+                history=(),
+                status=429,
+                message="Rate limited",
+                headers={"Retry-After": "120"},
+            )
+            # super()._infer resolves to RemoteFullOpenLike (the base's parent).
+            with patch.object(
+                RemoteAzureOpenLike.__bases__[0],
+                "_infer",
+                new_callable=AsyncMock,
+                side_effect=error,
+            ):
+                result = await model._infer(
+                    system_prompts=["You are helpful."], prompt="Test"
+                )
+            self.assertIsNone(result)
+            self.assertTrue(model.rate_limiter.get_status()["exhausted"])
+
+        asyncio.run(run())
+
+    @patch.dict(os.environ, AZURE_OPENAI_ENV)
+    def test_infer_other_http_errors_propagate(self):
+        async def run():
+            model = RemoteAzureOpenAI(model="gpt-5")
+            error = aiohttp.ClientResponseError(
+                request_info=MagicMock(),
+                history=(),
+                status=500,
+                message="Server error",
+                headers={},
+            )
+            with patch.object(
+                RemoteAzureOpenLike.__bases__[0],
+                "_infer",
+                new_callable=AsyncMock,
+                side_effect=error,
+            ):
+                with self.assertRaises(aiohttp.ClientResponseError):
+                    await model._infer(
+                        system_prompts=["You are helpful."], prompt="Test"
+                    )
+
+        asyncio.run(run())
+
+    @patch.dict(os.environ, AZURE_OPENAI_ENV)
+    def test_model_is_ok(self):
+        model = RemoteAzureOpenAI(model="gpt-5")
+        self.assertTrue(model.model_is_ok())
+        model.rate_limiter.mark_exhausted(60.0)
+        self.assertFalse(model.model_is_ok())
+
+
+# ---------------------------------------------------------------------------
+# Model-name tracking: router stamping, __str__, ENABLED_REMOTE_MODELS
+# ---------------------------------------------------------------------------
+
+
+class _FakeModel(RemoteModelLike):
+    """Minimal concrete model used to drive MLRouter in tests."""
+
+    def __init__(self, model):
+        self.model = model
+
+    @property
+    def external(self):
+        return False
+
+    @property
+    def context_only(self):
+        return False
+
+    async def _infer(self, *args, **kwargs):
+        return None
+
+
+class _FakeBackend:
+    """Backend stub whose models() returns pre-built _FakeModel instances."""
+
+    @classmethod
+    def models(cls):
+        return [
+            ModelDescription(
+                cost=10,
+                name="fake/alpha",
+                internal_name="alpha-int",
+                model=_FakeModel("alpha-int"),
+            ),
+            ModelDescription(
+                cost=20,
+                name="fake/beta",
+                internal_name="beta-int",
+                model=_FakeModel("beta-int"),
+            ),
+        ]
+
+
+class TestModelNameTracking(unittest.TestCase):
+    """The router must stamp friendly names so the chooser records them."""
+
+    def setUp(self):
+        os.environ.pop("ENABLED_REMOTE_MODELS", None)
+
+    def tearDown(self):
+        os.environ.pop("ENABLED_REMOTE_MODELS", None)
+
+    def test_router_stamps_friendly_name_on_instances(self):
+        with patch(
+            "fighthealthinsurance.ml.ml_router.candidate_model_backends",
+            [_FakeBackend],
+        ):
+            router = MLRouter()
+
+        # Both friendly names registered.
+        self.assertIn("fake/alpha", router.models_by_name)
+        self.assertIn("fake/beta", router.models_by_name)
+
+        # Each instance now carries its friendly name (what the chooser records
+        # via getattr(model, "name", str(model))).
+        for name, instances in router.models_by_name.items():
+            for inst in instances:
+                self.assertEqual(getattr(inst, "name", None), name)
+
+    def test_chooser_style_lookup_returns_friendly_name(self):
+        """Reproduce chooser_tasks.py's getattr(model, "name", str(model))."""
+        with patch(
+            "fighthealthinsurance.ml.ml_router.candidate_model_backends",
+            [_FakeBackend],
+        ):
+            router = MLRouter()
+
+        model = router.internal_models_by_cost[0]
+        recorded = getattr(model, "name", str(model))
+        self.assertEqual(recorded, "fake/alpha")
+        # Must not be an opaque object repr.
+        self.assertNotIn("object at 0x", recorded)
+
+    def test_str_returns_friendly_name_when_stamped(self):
+        stamped = _FakeModel("alpha-int")
+        stamped.name = "fake/alpha"
+        self.assertEqual(str(stamped), "fake/alpha")
+
+    def test_str_descriptive_when_unstamped(self):
+        unstamped = _FakeModel("alpha-int")
+        rendered = str(unstamped)
+        self.assertNotIn("object at 0x", rendered)
+        self.assertIn("alpha-int", rendered)
+
+
+class TestEnabledRemoteModels(unittest.TestCase):
+    """ENABLED_REMOTE_MODELS restricts which models load."""
+
+    def setUp(self):
+        os.environ.pop("ENABLED_REMOTE_MODELS", None)
+
+    def tearDown(self):
+        os.environ.pop("ENABLED_REMOTE_MODELS", None)
+
+    def test_unset_enables_all(self):
+        self.assertIsNone(MLRouter._enabled_model_names())
+        with patch(
+            "fighthealthinsurance.ml.ml_router.candidate_model_backends",
+            [_FakeBackend],
+        ):
+            router = MLRouter()
+        self.assertIn("fake/alpha", router.models_by_name)
+        self.assertIn("fake/beta", router.models_by_name)
+
+    @patch.dict(os.environ, {"ENABLED_REMOTE_MODELS": "fake/alpha"})
+    def test_allow_list_filters_by_friendly_name(self):
+        with patch(
+            "fighthealthinsurance.ml.ml_router.candidate_model_backends",
+            [_FakeBackend],
+        ):
+            router = MLRouter()
+        self.assertIn("fake/alpha", router.models_by_name)
+        self.assertNotIn("fake/beta", router.models_by_name)
+
+    @patch.dict(os.environ, {"ENABLED_REMOTE_MODELS": "beta-int"})
+    def test_allow_list_also_matches_internal_name(self):
+        with patch(
+            "fighthealthinsurance.ml.ml_router.candidate_model_backends",
+            [_FakeBackend],
+        ):
+            router = MLRouter()
+        self.assertIn("fake/beta", router.models_by_name)
+        self.assertNotIn("fake/alpha", router.models_by_name)
+
+    @patch.dict(os.environ, {"ENABLED_REMOTE_MODELS": "  "})
+    def test_blank_value_enables_all(self):
+        self.assertIsNone(MLRouter._enabled_model_names())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/async-unit/test_groq_models.py
+++ b/tests/async-unit/test_groq_models.py
@@ -20,7 +20,7 @@ import aiohttp
 # Set up environment before importing RemoteGroq
 os.environ.setdefault("GROQ_API_KEY", "test-api-key")
 
-from fighthealthinsurance.ml.ml_models import RemoteGroq
+from fighthealthinsurance.ml.ml_models import RemoteGroq, RemoteFullOpenLike
 from fighthealthinsurance.utils import RateLimiter
 
 
@@ -269,7 +269,7 @@ class TestRemoteGroqInfer(unittest.TestCase):
 
         # Mock parent _infer to raise 429
         with patch.object(
-            RemoteGroq.__bases__[0], "_infer", new_callable=AsyncMock, side_effect=error
+            RemoteFullOpenLike, "_infer", new_callable=AsyncMock, side_effect=error
         ):
             result = await model._infer(
                 system_prompts=["You are helpful."], prompt="Test prompt"
@@ -303,7 +303,7 @@ class TestRemoteGroqInfer(unittest.TestCase):
 
         # Mock parent _infer to raise 429
         with patch.object(
-            RemoteGroq.__bases__[0], "_infer", new_callable=AsyncMock, side_effect=error
+            RemoteFullOpenLike, "_infer", new_callable=AsyncMock, side_effect=error
         ):
             result = await model._infer(
                 system_prompts=["You are helpful."], prompt="Test prompt"
@@ -339,7 +339,7 @@ class TestRemoteGroqInfer(unittest.TestCase):
 
         # Mock parent _infer to raise 429
         with patch.object(
-            RemoteGroq.__bases__[0], "_infer", new_callable=AsyncMock, side_effect=error
+            RemoteFullOpenLike, "_infer", new_callable=AsyncMock, side_effect=error
         ):
             result = await model._infer(
                 system_prompts=["You are helpful."], prompt="Test prompt"


### PR DESCRIPTION
## Summary

Adds support for Azure-hosted generative models (both Azure OpenAI Service for GPT models and Azure AI Foundry for Claude) alongside improved model-name tracking across all backends. The router now stamps friendly names onto model instances so consumers (like the chooser workflow) record human-readable names instead of opaque object reprs. Introduces `ENABLED_REMOTE_MODELS` allow-list to restrict which remote models load while always enabling local/internal models.

## Key Changes

**Azure Backend Support:**
- New `RemoteAzureOpenLike` base class for Azure-hosted, OpenAI-compatible endpoints
- `RemoteAzureOpenAI` for Azure OpenAI Service (GPT family): `gpt-4.1-mini`, `gpt-5-mini`, `gpt-5`
- `RemoteAzureClaude` for Azure AI Foundry (Claude family): `claude-haiku-4-5`, `claude-sonnet-4-6`, `claude-opus-4-8`
- Environment-driven configuration: `AZURE_OPENAI_API_KEY`/`ENDPOINT`, `AZURE_ANTHROPIC_API_KEY`/`ENDPOINT`
- Optional model override via `AZURE_OPENAI_MODELS` / `AZURE_ANTHROPIC_MODELS` (comma-separated deployment names)
- Per-provider rate-limit state (separate from other backends)
- Endpoint normalization to handle both base URLs and full `/chat/completions` URLs
- 429 handling with `Retry-After` header parsing

**Model-Name Tracking:**
- `RemoteModelLike` now has a `name` attribute (stamped by MLRouter during registration)
- `__str__()` and `__repr__()` methods return friendly name when stamped, or a descriptive fallback
- MLRouter stamps `m.name` onto each model instance so the chooser and other consumers can call `getattr(model, "name", str(model))` to get readable names instead of object reprs

**Remote Model Allow-List:**
- New `MLRouter._enabled_model_names()` class method reads `ENABLED_REMOTE_MODELS` env var
- Filters *remote* (external) models by friendly name or internal name
- Local/internal models are always enabled regardless of the allow-list
- When unset, all configured models are enabled

**Documentation & Configuration:**
- Updated `.env.example` with Azure setup instructions and `ENABLED_REMOTE_MODELS` example
- Updated README with Azure setup steps, provider table, and allow-list usage
- Updated Anthropic model version from `claude-opus-4-7` to `claude-opus-4-8`

## Implementation Details

- Azure backends inherit from `RemoteFullOpenLike` (OpenAI-compatible wire format) and add Azure-specific initialization, endpoint normalization, and rate-limiting
- Each Azure provider declares its own `_rate_limiters` dict and `_rate_limiter_lock` to avoid sharing rate-limit state across providers
- `_configured_deployments()` resolves the model list, honoring optional env var overrides with auto-incrementing costs and `custom` tier
- Rate-limit checking in `_infer()` skips when backing off; 429 responses mark the limiter exhausted with configurable backoff
- Comprehensive test suite (`test_azure_models.py`) covers initialization, configuration, endpoint normalization, rate-limiting, 429 handling, and model-name tracking

https://claude.ai/code/session_01HYeqYMMMHX2QTfaBy8XEYw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Azure-hosted LLM provider support for Azure OpenAI and Azure AI Foundry (Claude)
  * Added `ENABLED_REMOTE_MODELS` to control which remote models auto-load (local/internal and context-only models still remain available)
  * Improved remote model identification with stable friendly names for routing/logging
* **Bug Fixes**
  * Centralized rate-limit handling with robust HTTP 429 + `Retry-After` parsing/clamping
* **Documentation**
  * Expanded README and updated `.env.example` with Azure/provider setup and remote model auto-discovery guidance
* **Tests**
  * Added/updated async unit tests for Azure configuration, 429 behavior, router name stamping, and provider-specific model updates
* **Chores**
  * Updated Claude Opus model references to 4.8
<!-- end of auto-generated comment: release notes by coderabbit.ai -->