### PR TITLE
Clean up the professional interest (pro_version) page layout

### DIFF
--- a/fighthealthinsurance/static/css/custom.css
+++ b/fighthealthinsurance/static/css/custom.css
@@ -718,9 +718,6 @@ a.link:hover::after {
     border: 1px solid #ced4da;
 }
 
-#id_address, #id_business_name{
-    width: 30em;
-}
 /* Featured In Section */
 .featured-section {
     padding: 3rem 0;
@@ -1670,5 +1667,140 @@ section:not(.slider) .share-subcopy {
         flex: 0 0 auto;
         scroll-snap-align: start;
         min-width: 120px;
+    }
+}
+
+/* ===== Professional interest ("pro version") signup page ===== */
+.pro-interest-section {
+    padding: 3rem 0 4rem;
+}
+
+.pro-interest-card {
+    max-width: 780px;
+    margin: 0 auto;
+    background: #fff;
+    border: 1px solid #e8e8e8;
+    border-radius: 14px;
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.07);
+    padding: 2.75rem 3rem;
+}
+
+.pro-interest-title {
+    text-align: center;
+    font-size: 1.9rem;
+    font-weight: 700;
+    color: #2e7d32;
+    margin: 0 0 1.25rem;
+    padding-bottom: 1rem;
+    border-bottom: 2px solid #4caf50;
+}
+
+.pro-interest-lead,
+.pro-interest-note {
+    color: #555;
+    line-height: 1.65;
+    margin-bottom: 1rem;
+}
+
+.pro-interest-note {
+    margin-bottom: 2rem;
+}
+
+.pro-interest-form {
+    width: 100%;
+}
+
+/* Two fields side-by-side on desktop, stacked on mobile. Uses its own row
+   helper (rather than the shared .together-form-group) so the de-jank here
+   doesn't affect the appeal-generator forms that also use that class. */
+.pro-interest-form .pro-row {
+    display: flex;
+    gap: 1.25rem;
+}
+
+.pro-interest-form .pro-row > .pro-field {
+    flex: 1;
+    min-width: 0;
+}
+
+.pro-interest-form .pro-field {
+    margin-bottom: 1.25rem;
+}
+
+.pro-interest-form label {
+    display: block;
+    font-weight: 600;
+    color: #333;
+    margin-bottom: 0.4rem;
+}
+
+.pro-interest-form input[type="text"],
+.pro-interest-form input[type="email"],
+.pro-interest-form input[type="tel"],
+.pro-interest-form textarea {
+    width: 100%;
+    font-size: inherit;
+    font-family: inherit;
+    box-sizing: border-box;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.pro-interest-form input:focus,
+.pro-interest-form textarea:focus {
+    outline: none;
+    border-color: #a5c422;
+    box-shadow: 0 0 0 3px rgba(165, 196, 34, 0.18);
+}
+
+.pro-interest-form textarea {
+    resize: vertical;
+}
+
+/* Keep the legacy fixed-width textareas inside the card (these classes are
+   only used by this form). */
+.pro-interest-form .form-textarea-medium,
+.pro-interest-form .most_common_denial {
+    width: 100%;
+    height: 5em;
+}
+
+.pro-interest-form .form-textarea-wide,
+.pro-interest-form .comments {
+    width: 100%;
+    height: 8em;
+}
+
+.pro-interest-form .errorlist {
+    list-style: none;
+    padding: 0;
+    margin: 0.35rem 0 0;
+    color: #c0392b;
+    font-size: 1.3rem;
+}
+
+.pro-interest-actions {
+    margin-top: 1.75rem;
+}
+
+.pro-interest-form .pro-submit-btn {
+    width: 100%;
+    margin: 0;
+    padding: 0.8rem 1.5rem;
+    font-size: 1.6rem;
+    font-weight: 600;
+}
+
+@media (max-width: 768px) {
+    .pro-interest-card {
+        padding: 1.75rem 1.25rem;
+    }
+
+    .pro-interest-title {
+        font-size: 1.5rem;
+    }
+
+    .pro-interest-form .pro-row {
+        flex-direction: column;
+        gap: 0;
     }
 }

--- a/fighthealthinsurance/static/css/custom.css
+++ b/fighthealthinsurance/static/css/custom.css
@@ -1756,8 +1756,9 @@ section:not(.slider) .share-subcopy {
     resize: vertical;
 }
 
-/* Keep the legacy fixed-width textareas inside the card (these classes are
-   only used by this form). */
+/* These textarea classes carry fixed em widths elsewhere in this file
+   (e.g. .form-textarea-wide is 50em, .comments is 80em); override them to
+   100% here so the fields stay inside the card. Used only by this form. */
 .pro-interest-form .form-textarea-medium,
 .pro-interest-form .most_common_denial {
     width: 100%;

--- a/fighthealthinsurance/templates/professional.html
+++ b/fighthealthinsurance/templates/professional.html
@@ -5,68 +5,79 @@ Fight Health Insurance Professional Version
 {% load static %}
 {% load absolute %}
 {% block content %}
-<section id="contact">
+<section id="contact" class="pro-interest-section">
     <div class="container">
-      <div class="section-header text-align-center">
-	<h3 class="pro-version-header" style="text-align: center; padding: 15px; margin-top: 10vh;">New Updated Professional Version Available</h3>
-      </div>
-      <p>
-	We have an exciting new option for professionals (providers, revenue cycle management, pharma, etc.) and we'd love to tell you more! Let us know a little bit about you, your common denials, and we'll be in touch to see how we can best help.
-      </p>
-      <p>
-	Not a professional (e.g. providers office, appeal specialist, lawyer, etc.) but still ended up here? Don't worry!
-      <a href="{% url 'scan' %}">You can try the regular appeal generator here.</a>
-      </p>
-      <p>
-	<div class="main-form">
-	<form method="post">
-	  {% csrf_token %}
-          <div class="together-form-group">
-	    <div>
-              <label for="id_name">Name:</label>
+      <div class="pro-interest-card">
+        <h1 class="pro-interest-title">New Updated Professional Version Available</h1>
+        <p class="pro-interest-lead">
+          We have an exciting new option for professionals (providers, revenue cycle management, pharma, etc.) and we'd love to tell you more! Let us know a little bit about you, your common denials, and we'll be in touch to see how we can best help.
+        </p>
+        <p class="pro-interest-note">
+          Not a professional (e.g. provider's office, appeal specialist, lawyer, etc.) but still ended up here? Don't worry!
+          <a href="{% url 'scan' %}">You can try the regular appeal generator here.</a>
+        </p>
+
+        <form method="post" class="pro-interest-form">
+          {% csrf_token %}
+          {% if form.non_field_errors %}
+          <div class="alert alert-danger" role="alert">{{ form.non_field_errors }}</div>
+          {% endif %}
+
+          <div class="pro-row">
+            <div class="pro-field">
+              <label for="id_name">Name</label>
               {{ form.name }}
-	    </div>
-	    <div>
-              <label for="id_job_title_or_provider_type">Job title or Provider type:</label>
-              {{ form.job_title_or_provider_type}}
-	    </div>
+              {{ form.name.errors }}
+            </div>
+            <div class="pro-field">
+              <label for="id_job_title_or_provider_type">Job title or provider type</label>
+              {{ form.job_title_or_provider_type }}
+              {{ form.job_title_or_provider_type.errors }}
+            </div>
           </div>
-          <div class="together-form-group">
-	    <div>
-              <label for="id_email">Email:</label>
+
+          <div class="pro-row">
+            <div class="pro-field">
+              <label for="id_email">Email</label>
               {{ form.email }}
-	    </div>
-	    <div>
-              <label for="id_phone">Phone number:</label>
+              {{ form.email.errors }}
+            </div>
+            <div class="pro-field">
+              <label for="id_phone_number">Phone number</label>
               {{ form.phone_number }}
-	    </div>
+              {{ form.phone_number.errors }}
+            </div>
           </div>
-          <div class="form-group business_name">
-            <label for="id_business_name" style="display: block;">Business name:</label>
+
+          <div class="pro-field">
+            <label for="id_business_name">Business name</label>
             {{ form.business_name }}
-          </div><br>
-
-          <div class="form-group address">
-            <label for="id_address" style="display: block;">Address:</label>
-            {{ form.address}}
-          </div><br>
-
-          <div class="form-group most_common_denial">
-            <label for="id_most_common_denial">Most common denial:</label>
-            {{ form.most_common_denial}}
+            {{ form.business_name.errors }}
           </div>
 
-          <div class="form-group">
-            <label for="id_comments">Comments:</label>
-            {{ form.comments}}
+          <div class="pro-field">
+            <label for="id_address">Address</label>
+            {{ form.address }}
+            {{ form.address.errors }}
           </div>
 
-          <div class="form-group">
-	    <input class="pro-submit-btn" type="submit" value="Submit">
+          <div class="pro-field">
+            <label for="id_most_common_denial">Most common denial</label>
+            {{ form.most_common_denial }}
+            {{ form.most_common_denial.errors }}
           </div>
-	</form>
-	</div>
-      </p>
+
+          <div class="pro-field">
+            <label for="id_comments">Comments</label>
+            {{ form.comments }}
+            {{ form.comments.errors }}
+          </div>
+
+          <div class="pro-interest-actions">
+            <input class="pro-submit-btn" type="submit" value="Submit">
+          </div>
+        </form>
+      </div>
     </div>
 </section>
 {% endblock content %}

--- a/tests/sync/test_pro_version_signup.py
+++ b/tests/sync/test_pro_version_signup.py
@@ -75,6 +75,37 @@ class ProVersionSignupSuccessTest(TestCase):
         )
 
 
+class ProVersionSignupInvalidSubmissionTest(TestCase):
+    """A submission missing the required email is rejected, not saved.
+
+    Email is the only required field on the interest form, so an otherwise
+    empty POST exercises the form_invalid path -- which must re-render the
+    page (with the per-field error markup the template emits) instead of
+    redirecting, creating a record, or sending any mail.
+    """
+
+    def setUp(self):
+        self.response = self.client.post(
+            reverse("pro_version"), {"name": "No Email", "email": ""}
+        )
+
+    def test_does_not_redirect(self):
+        # form_invalid re-renders in place rather than redirecting to thankyou.
+        self.assertEqual(self.response.status_code, 200)
+
+    def test_rerenders_form_with_field_error(self):
+        # Confirms the template surfaces validation errors to the user.
+        self.assertContains(self.response, "This field is required.")
+
+    def test_creates_no_record(self):
+        self.assertFalse(InterestedProfessional.objects.exists())
+
+    def test_sends_no_email(self):
+        # Neither the team notification nor the thank-you fire on a rejected
+        # submission (both live on the form_valid path).
+        self.assertEqual(mail.outbox, [])
+
+
 class ProVersionSignupEdgeCaseTest(TestCase):
     """Rendering, failure-mode, and security guards for the signup form."""
 

--- a/tests/sync/test_pro_version_signup.py
+++ b/tests/sync/test_pro_version_signup.py
@@ -81,7 +81,7 @@ class ProVersionSignupEdgeCaseTest(TestCase):
     def test_get_renders_signup_form(self):
         response = self.client.get(reverse("pro_version"))
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "New Updated Professional Version Coming Soon")
+        self.assertContains(response, "New Updated Professional Version Available")
         self.assertContains(response, 'method="post"')
         # Pay-to-express-interest has been dropped.
         self.assertNotContains(response, "Pay $10")


### PR DESCRIPTION
The /pro_version interest form looked janky: a large 10vh top margin, text inputs at three different widths (default-width paired fields, 30em business_name/address, and full-width textareas), the form nested inside a <p>, <br>-based spacing, and mobile fields that centered inconsistently.

- Rewrite professional.html as a centered card with a responsive two-up field grid (its own .pro-row helper, so the shared .together-form-group used by the appeal-generator forms is untouched), consistent full-width inputs, proper labels, and a clear full-width submit button. Also fixes the phone-number label's stale for="id_phone".
- Add scoped .pro-interest-* styles in custom.css and drop the form-specific '#id_address, #id_business_name { width: 30em }' rule that forced those two inputs to overflow the container.
- Update the pro-version signup test, which still asserted the old "Coming Soon" heading after the copy changed to "Available".


Claude-Session: https://claude.ai/code/session_01SczPcSo7AbfeWCwWowFpmt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned the professional interest signup form with improved layout and responsive design.
  * Enhanced form validation with clearer error messaging for required fields.

* **Style**
  * Adjusted form field widths and reorganized field grouping for better visual hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->