### PR TITLE
Notify professional inbox on FPW REST professional signup

### DIFF
--- a/fhi_users/auth/rest_auth_views.py
+++ b/fhi_users/auth/rest_auth_views.py
@@ -1083,6 +1083,21 @@ class ProfessionalUserViewSet(viewsets.ViewSet, CreateMixin):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
+        # Notify the professional-signup inbox (defaults to
+        # professional@fighthealthinsurance.com) for every FPW REST professional
+        # sign-up. Deferred via transaction.on_commit so the mail only goes out
+        # once this signup transaction commits and a mail failure can't roll the
+        # signup back.
+        self._notify_professional_signup(
+            email=email,
+            first_name=first_name,
+            last_name=last_name,
+            domain_name=domain_name,
+            visible_phone_number=visible_phone_number,
+            new_domain=new_domain,
+            professional_user=professional_user,
+        )
+
         # If the domain is not new we don't need billing info
         if not new_domain:
             return Response(
@@ -1139,6 +1154,42 @@ class ProfessionalUserViewSet(viewsets.ViewSet, CreateMixin):
                 ).data,
                 status=status.HTTP_201_CREATED,
             )
+
+    @staticmethod
+    def _notify_professional_signup(
+        *,
+        email: str,
+        first_name: str,
+        last_name: str,
+        domain_name: Optional[str],
+        visible_phone_number: Optional[str],
+        new_domain: bool,
+        professional_user: ProfessionalUser,
+    ) -> None:
+        """Queue a best-effort team notification for a professional signing up
+        via the Fight Paperwork REST API.
+
+        Deferred via transaction.on_commit so the notification only fires once
+        the signup transaction commits — no spurious mail if a later step (e.g.
+        Stripe checkout creation) rolls the signup back.
+        """
+        from fighthealthinsurance.utils import notify_professional_signup
+
+        full_name = f"{first_name} {last_name}".strip()
+        body = (
+            "A new professional signed up via the Fight Paperwork REST API.\n\n"
+            f"Name: {full_name or 'N/A'}\n"
+            f"Email: {email}\n"
+            f"Domain: {domain_name or 'N/A'}\n"
+            f"Phone: {visible_phone_number or 'N/A'}\n"
+            f"New domain: {'yes' if new_domain else 'no (joining existing domain)'}\n"
+            f"Professional user id: {professional_user.id}\n"
+        )
+        transaction.on_commit(
+            lambda: notify_professional_signup(
+                f"New professional signup: {email}", body
+            )
+        )
 
     @extend_schema(
         responses={

--- a/fhi_users/auth/rest_auth_views.py
+++ b/fhi_users/auth/rest_auth_views.py
@@ -1083,6 +1083,12 @@ class ProfessionalUserViewSet(viewsets.ViewSet, CreateMixin):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
+        # DEPRECATED: professional-interest notifications are consolidating on
+        # the dedicated `interested_professional` REST endpoint
+        # (InterestedProfessionalViewSet) and the web /pro_version form. This
+        # signup-flow notification is retained for backward compatibility but
+        # should not be extended -- prefer the dedicated endpoint for new work.
+        #
         # Notify the professional-signup inbox (defaults to
         # professional@fighthealthinsurance.com) for every FPW REST professional
         # sign-up. Deferred via transaction.on_commit so the mail only goes out
@@ -1168,6 +1174,11 @@ class ProfessionalUserViewSet(viewsets.ViewSet, CreateMixin):
     ) -> None:
         """Queue a best-effort team notification for a professional signing up
         via the Fight Paperwork REST API.
+
+        DEPRECATED: prefer the dedicated `interested_professional` REST endpoint
+        (InterestedProfessionalViewSet), which is the canonical channel for
+        professional-interest notifications. This signup-flow hook is retained
+        for backward compatibility and should not be extended.
 
         Deferred via transaction.on_commit so the notification only fires once
         the signup transaction commits — no spurious mail if a later step (e.g.

--- a/fighthealthinsurance/rest_serializers.py
+++ b/fighthealthinsurance/rest_serializers.py
@@ -16,6 +16,7 @@ from fighthealthinsurance.models import (
     ChatType,
     DemoRequests,
     Denial,
+    InterestedProfessional,
     MailingListSubscriber,
     OngoingChat,
     PriorAuthRequest,
@@ -467,6 +468,28 @@ class DemoRequestsSerializer(serializers.ModelSerializer):
     class Meta:
         model = DemoRequests
         fields = ["email", "name", "company", "role", "source", "phone"]
+
+
+class InterestedProfessionalSerializer(serializers.ModelSerializer):
+    """Serializer for Fight Paperwork professional-interest lead submissions.
+
+    Exposes the same lead fields collected by the web /pro_version interest
+    form. Internal fields (paid/clicked_for_paid/signup_date/mod_date/
+    thankyou_email_sent) are set server-side and are not client-writable.
+    """
+
+    class Meta:
+        model = InterestedProfessional
+        fields = [
+            "email",
+            "name",
+            "business_name",
+            "phone_number",
+            "address",
+            "comments",
+            "most_common_denial",
+            "job_title_or_provider_type",
+        ]
 
 
 class SendToUserSerializer(serializers.Serializer):

--- a/fighthealthinsurance/rest_urls.py
+++ b/fighthealthinsurance/rest_urls.py
@@ -42,6 +42,11 @@ router.register(
     rest_views.DemoRequestsViewSet,
     basename="demorequest",
 )
+router.register(
+    r"interested_professional",
+    rest_views.InterestedProfessionalViewSet,
+    basename="interested-professional",
+)
 router.register(r"prior-auth", rest_views.PriorAuthViewSet, basename="prior-auth")
 router.register(
     r"prior-auth/(?P<prior_auth_id>[^/.]+)/proposals",

--- a/fighthealthinsurance/rest_views.py
+++ b/fighthealthinsurance/rest_views.py
@@ -1577,7 +1577,7 @@ class DemoRequestsViewSet(viewsets.ViewSet, CreateMixin, DeleteMixin):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
-class InterestedProfessionalViewSet(viewsets.ViewSet, CreateMixin, DeleteMixin):
+class InterestedProfessionalViewSet(viewsets.ViewSet, CreateMixin):
     """
     ViewSet for professional-interest leads submitted via the Fight Paperwork
     REST API.
@@ -1585,8 +1585,10 @@ class InterestedProfessionalViewSet(viewsets.ViewSet, CreateMixin, DeleteMixin):
     Public counterpart to the web /pro_version interest form: it records an
     InterestedProfessional lead and notifies the professional-signup inbox
     (defaults to professional@fighthealthinsurance.com, extendable via
-    settings.PROFESSIONAL_SIGNUP_NOTIFICATION_EMAILS). Also supports removing a
-    lead by email for data-removal requests.
+    settings.PROFESSIONAL_SIGNUP_NOTIFICATION_EMAILS). Create-only: this is a
+    public, unauthenticated endpoint, so lead removal is intentionally not
+    exposed here (an email-only delete would let anyone erase a lead); data
+    removal is handled out of band.
     """
 
     serializer_class = serializers.InterestedProfessionalSerializer
@@ -1613,40 +1615,19 @@ class InterestedProfessionalViewSet(viewsets.ViewSet, CreateMixin, DeleteMixin):
     def _notify_interested_professional(
         interested_pro: InterestedProfessional,
     ) -> None:
-        """Email the professional-signup inbox about a new REST interest lead.
+        """Notify the professional-signup inbox about a new REST interest lead.
 
-        Best-effort: notify_professional_signup logs and swallows mail failures
-        so a mail error never fails the already-persisted lead. Mirrors the body
-        of the web /pro_version notification for a consistent inbox format."""
-        from django.urls import reverse
+        Delegates to the shared notify_interested_professional helper so the web
+        /pro_version form and this endpoint send an identical inbox format.
+        Best-effort: mail failures are logged, not raised, so they never fail
+        the already-persisted lead."""
+        from fighthealthinsurance.utils import notify_interested_professional
 
-        from fighthealthinsurance.utils import notify_professional_signup
-
-        admin_path = reverse(
-            "admin:fighthealthinsurance_interestedprofessional_change",
-            args=[interested_pro.id],
+        notify_interested_professional(
+            interested_pro,
+            source="the Fight Paperwork REST API",
+            subject=f"New pro REST signup #{interested_pro.id}",
         )
-        admin_url = f"https://{settings.FIGHT_HEALTH_INSURANCE_DOMAIN}{admin_path}"
-        body = (
-            "A new professional signed up via the Fight Paperwork REST API.\n\n"
-            f"Name: {interested_pro.name or 'N/A'}\n"
-            f"Email: {interested_pro.email}\n"
-            f"Job title / provider type: {interested_pro.job_title_or_provider_type or 'N/A'}\n"
-            f"Business: {interested_pro.business_name or 'N/A'}\n"
-            f"Phone: {interested_pro.phone_number or 'N/A'}\n"
-            f"Address: {interested_pro.address or 'N/A'}\n"
-            f"Most common denial: {interested_pro.most_common_denial or 'N/A'}\n"
-            f"Comments: {interested_pro.comments or 'N/A'}\n"
-            f"Admin: {admin_url}\n"
-        )
-        notify_professional_signup(f"New pro REST signup #{interested_pro.id}", body)
-
-    @extend_schema(responses=serializers.StatusResponseSerializer)
-    def perform_delete(self, request: Request, serializer):
-        """Remove a professional-interest lead by email."""
-        email = serializer.validated_data["email"]
-        InterestedProfessional.objects.filter(email=email).delete()
-        return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 class SendToUserViewSet(viewsets.ViewSet, SerializerMixin):

--- a/fighthealthinsurance/rest_views.py
+++ b/fighthealthinsurance/rest_views.py
@@ -1598,7 +1598,6 @@ class InterestedProfessionalViewSet(viewsets.ViewSet, CreateMixin):
         """Submit a new professional-interest lead."""
         return super().create(request)
 
-    @extend_schema(responses=serializers.StatusResponseSerializer)
     def perform_create(self, request: Request, serializer) -> Response:
         """Save the lead, then notify the professional-signup inbox."""
         # clicked_for_paid defaults to True on the model for legacy reasons; the

--- a/fighthealthinsurance/rest_views.py
+++ b/fighthealthinsurance/rest_views.py
@@ -55,6 +55,7 @@ from fighthealthinsurance.models import (
     DemoRequests,
     Denial,
     DenialQA,
+    InterestedProfessional,
     MailingListSubscriber,
     OngoingChat,
     PriorAuthRequest,
@@ -1573,6 +1574,78 @@ class DemoRequestsViewSet(viewsets.ViewSet, CreateMixin, DeleteMixin):
     def perform_delete(self, request: Request, serializer):
         email = serializer.validated_data["email"]
         DemoRequests.objects.filter(email=email).delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class InterestedProfessionalViewSet(viewsets.ViewSet, CreateMixin, DeleteMixin):
+    """
+    ViewSet for professional-interest leads submitted via the Fight Paperwork
+    REST API.
+
+    Public counterpart to the web /pro_version interest form: it records an
+    InterestedProfessional lead and notifies the professional-signup inbox
+    (defaults to professional@fighthealthinsurance.com, extendable via
+    settings.PROFESSIONAL_SIGNUP_NOTIFICATION_EMAILS). Also supports removing a
+    lead by email for data-removal requests.
+    """
+
+    serializer_class = serializers.InterestedProfessionalSerializer
+
+    @extend_schema(responses=serializers.StatusResponseSerializer)
+    def create(self, request: Request) -> Response:
+        """Submit a new professional-interest lead."""
+        return super().create(request)
+
+    @extend_schema(responses=serializers.StatusResponseSerializer)
+    def perform_create(self, request: Request, serializer) -> Response:
+        """Save the lead, then notify the professional-signup inbox."""
+        # clicked_for_paid defaults to True on the model for legacy reasons; the
+        # interest form no longer collects a pay-to-express-interest choice, so
+        # record leads as not-clicked (matches the web /pro_version form).
+        interested_pro = serializer.save(clicked_for_paid=False)
+        self._notify_interested_professional(interested_pro)
+        return Response(
+            serializers.StatusResponseSerializer({"status": "subscribed"}).data,
+            status=status.HTTP_201_CREATED,
+        )
+
+    @staticmethod
+    def _notify_interested_professional(
+        interested_pro: InterestedProfessional,
+    ) -> None:
+        """Email the professional-signup inbox about a new REST interest lead.
+
+        Best-effort: notify_professional_signup logs and swallows mail failures
+        so a mail error never fails the already-persisted lead. Mirrors the body
+        of the web /pro_version notification for a consistent inbox format."""
+        from django.urls import reverse
+
+        from fighthealthinsurance.utils import notify_professional_signup
+
+        admin_path = reverse(
+            "admin:fighthealthinsurance_interestedprofessional_change",
+            args=[interested_pro.id],
+        )
+        admin_url = f"https://{settings.FIGHT_HEALTH_INSURANCE_DOMAIN}{admin_path}"
+        body = (
+            "A new professional signed up via the Fight Paperwork REST API.\n\n"
+            f"Name: {interested_pro.name or 'N/A'}\n"
+            f"Email: {interested_pro.email}\n"
+            f"Job title / provider type: {interested_pro.job_title_or_provider_type or 'N/A'}\n"
+            f"Business: {interested_pro.business_name or 'N/A'}\n"
+            f"Phone: {interested_pro.phone_number or 'N/A'}\n"
+            f"Address: {interested_pro.address or 'N/A'}\n"
+            f"Most common denial: {interested_pro.most_common_denial or 'N/A'}\n"
+            f"Comments: {interested_pro.comments or 'N/A'}\n"
+            f"Admin: {admin_url}\n"
+        )
+        notify_professional_signup(f"New pro REST signup #{interested_pro.id}", body)
+
+    @extend_schema(responses=serializers.StatusResponseSerializer)
+    def perform_delete(self, request: Request, serializer):
+        """Remove a professional-interest lead by email."""
+        email = serializer.validated_data["email"]
+        InterestedProfessional.objects.filter(email=email).delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 

--- a/fighthealthinsurance/settings.py
+++ b/fighthealthinsurance/settings.py
@@ -126,6 +126,21 @@ class Base(Configuration):
         if e.strip()
     ]
 
+    # Professional-signup notifications — the web /pro_version interest form and
+    # the Fight Paperwork (FPW) REST professional sign-up endpoint — default to
+    # professional@fighthealthinsurance.com; additional recipients can be
+    # configured via the PROFESSIONAL_SIGNUP_EXTRA_NOTIFICATION_EMAILS env var
+    # (comma-separated).
+    PROFESSIONAL_SIGNUP_NOTIFICATION_EMAILS = [
+        "professional@fighthealthinsurance.com"
+    ] + [
+        e.strip()
+        for e in os.getenv("PROFESSIONAL_SIGNUP_EXTRA_NOTIFICATION_EMAILS", "").split(
+            ","
+        )
+        if e.strip()
+    ]
+
     # Session cookie configs
     SESSION_COOKIE_SECURE = True  # https only (up to the browser to enforce)
     SESSION_COOKIE_HTTPONLY = False  # allow js access

--- a/fighthealthinsurance/utils.py
+++ b/fighthealthinsurance/utils.py
@@ -409,8 +409,12 @@ def notify_professional_signup(subject: str, body: str) -> None:
     try:
         send_mail(subject, body, settings.DEFAULT_FROM_EMAIL, recipients)
     except Exception:
+        # Don't interpolate `subject`/`body`: for REST signups the subject
+        # embeds the professional's email and the body is full of PII. The
+        # recipients are configured internal inboxes, so they're safe to log,
+        # and logger.opt(exception=True) attaches the SMTP traceback.
         logger.opt(exception=True).error(
-            f"Error sending professional signup notification email: {subject}"
+            f"Error sending professional signup notification email to {recipients}"
         )
 
 

--- a/fighthealthinsurance/utils.py
+++ b/fighthealthinsurance/utils.py
@@ -23,6 +23,7 @@ from typing import (
     List,
     Optional,
     Sequence,
+    TYPE_CHECKING,
     Tuple,
     TypeVar,
     Union,
@@ -34,6 +35,9 @@ from uuid import UUID
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives, send_mail
 from django.template.loader import render_to_string
+
+if TYPE_CHECKING:
+    from fighthealthinsurance.models import InterestedProfessional
 
 # Shared by the generation-side filter (drop runt outputs before save) and
 # the streaming-side counter (so generation rejection and delivery counting
@@ -416,6 +420,39 @@ def notify_professional_signup(subject: str, body: str) -> None:
         logger.opt(exception=True).error(
             f"Error sending professional signup notification email to {recipients}"
         )
+
+
+def notify_interested_professional(
+    interested_pro: "InterestedProfessional", *, source: str, subject: str
+) -> None:
+    """Send the standard professional-interest team notification.
+
+    Shared by the web /pro_version interest form and the Fight Paperwork REST
+    interested-professional endpoint so both produce an identical inbox format
+    (the same field layout and admin deep-link). `source` names where the lead
+    came from (e.g. "/pro_version"); `subject` is the email subject. Best-effort
+    via notify_professional_signup -- mail failures are logged, not raised.
+    """
+    from django.urls import reverse
+
+    admin_path = reverse(
+        "admin:fighthealthinsurance_interestedprofessional_change",
+        args=[interested_pro.id],
+    )
+    admin_url = f"https://{settings.FIGHT_HEALTH_INSURANCE_DOMAIN}{admin_path}"
+    body = (
+        f"A new professional signed up via {source}.\n\n"
+        f"Name: {interested_pro.name or 'N/A'}\n"
+        f"Email: {interested_pro.email}\n"
+        f"Job title / provider type: {interested_pro.job_title_or_provider_type or 'N/A'}\n"
+        f"Business: {interested_pro.business_name or 'N/A'}\n"
+        f"Phone: {interested_pro.phone_number or 'N/A'}\n"
+        f"Address: {interested_pro.address or 'N/A'}\n"
+        f"Most common denial: {interested_pro.most_common_denial or 'N/A'}\n"
+        f"Comments: {interested_pro.comments or 'N/A'}\n"
+        f"Admin: {admin_url}\n"
+    )
+    notify_professional_signup(subject, body)
 
 
 def get_unsubscribe_url(email: str) -> Optional[str]:

--- a/fighthealthinsurance/utils.py
+++ b/fighthealthinsurance/utils.py
@@ -32,7 +32,7 @@ from email.utils import formataddr
 from uuid import UUID
 
 from django.conf import settings
-from django.core.mail import EmailMultiAlternatives
+from django.core.mail import EmailMultiAlternatives, send_mail
 from django.template.loader import render_to_string
 
 # Shared by the generation-side filter (drop runt outputs before save) and
@@ -386,6 +386,32 @@ def send_fallback_email(
     except Exception as e:
         logger.error(f"Error sending email to BCC: {e}")
         pass
+
+
+def notify_professional_signup(subject: str, body: str) -> None:
+    """Send a best-effort team notification about a new professional signup.
+
+    Shared by the web /pro_version interest form and the Fight Paperwork REST
+    professional sign-up endpoint. Recipients default to
+    professional@fighthealthinsurance.com and can be extended via
+    settings.PROFESSIONAL_SIGNUP_NOTIFICATION_EMAILS. A mail failure is logged
+    and swallowed so it never breaks the signup it is reporting on.
+    """
+    recipients = list(
+        getattr(
+            settings,
+            "PROFESSIONAL_SIGNUP_NOTIFICATION_EMAILS",
+            ["professional@fighthealthinsurance.com"],
+        )
+    )
+    if not recipients:
+        return
+    try:
+        send_mail(subject, body, settings.DEFAULT_FROM_EMAIL, recipients)
+    except Exception:
+        logger.opt(exception=True).error(
+            f"Error sending professional signup notification email: {subject}"
+        )
 
 
 def get_unsubscribe_url(email: str) -> Optional[str]:

--- a/fighthealthinsurance/utils.py
+++ b/fighthealthinsurance/utils.py
@@ -35,6 +35,7 @@ from uuid import UUID
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives, send_mail
 from django.template.loader import render_to_string
+from django.urls import reverse
 
 if TYPE_CHECKING:
     from fighthealthinsurance.models import InterestedProfessional
@@ -430,28 +431,34 @@ def notify_interested_professional(
     Shared by the web /pro_version interest form and the Fight Paperwork REST
     interested-professional endpoint so both produce an identical inbox format
     (the same field layout and admin deep-link). `source` names where the lead
-    came from (e.g. "/pro_version"); `subject` is the email subject. Best-effort
-    via notify_professional_signup -- mail failures are logged, not raised.
+    came from (e.g. "/pro_version"); `subject` is the email subject. Best-effort:
+    failures building (e.g. a missing admin URL) or sending the notification are
+    logged, not raised, so they never fail the already-persisted lead.
     """
-    from django.urls import reverse
-
-    admin_path = reverse(
-        "admin:fighthealthinsurance_interestedprofessional_change",
-        args=[interested_pro.id],
-    )
-    admin_url = f"https://{settings.FIGHT_HEALTH_INSURANCE_DOMAIN}{admin_path}"
-    body = (
-        f"A new professional signed up via {source}.\n\n"
-        f"Name: {interested_pro.name or 'N/A'}\n"
-        f"Email: {interested_pro.email}\n"
-        f"Job title / provider type: {interested_pro.job_title_or_provider_type or 'N/A'}\n"
-        f"Business: {interested_pro.business_name or 'N/A'}\n"
-        f"Phone: {interested_pro.phone_number or 'N/A'}\n"
-        f"Address: {interested_pro.address or 'N/A'}\n"
-        f"Most common denial: {interested_pro.most_common_denial or 'N/A'}\n"
-        f"Comments: {interested_pro.comments or 'N/A'}\n"
-        f"Admin: {admin_url}\n"
-    )
+    try:
+        admin_path = reverse(
+            "admin:fighthealthinsurance_interestedprofessional_change",
+            args=[interested_pro.id],
+        )
+        admin_url = f"https://{settings.FIGHT_HEALTH_INSURANCE_DOMAIN}{admin_path}"
+        body = (
+            f"A new professional signed up via {source}.\n\n"
+            f"Name: {interested_pro.name or 'N/A'}\n"
+            f"Email: {interested_pro.email}\n"
+            f"Job title / provider type: {interested_pro.job_title_or_provider_type or 'N/A'}\n"
+            f"Business: {interested_pro.business_name or 'N/A'}\n"
+            f"Phone: {interested_pro.phone_number or 'N/A'}\n"
+            f"Address: {interested_pro.address or 'N/A'}\n"
+            f"Most common denial: {interested_pro.most_common_denial or 'N/A'}\n"
+            f"Comments: {interested_pro.comments or 'N/A'}\n"
+            f"Admin: {admin_url}\n"
+        )
+    except Exception:
+        logger.opt(exception=True).error(
+            "Error building professional-interest notification "
+            f"(interested_pro_id={interested_pro.id})"
+        )
+        return
     notify_professional_signup(subject, body)
 
 

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -53,7 +53,7 @@ from fighthealthinsurance.models import (
 from fighthealthinsurance.type_utils import User
 from fighthealthinsurance.utils import (
     is_valid_denial_id,
-    notify_professional_signup,
+    notify_interested_professional,
     send_fallback_email,
 )
 
@@ -297,24 +297,11 @@ class ProVersionView(generic.FormView):
     def _notify_professional_signup(
         interested_pro: "models.InterestedProfessional",
     ) -> None:
-        admin_path = reverse(
-            "admin:fighthealthinsurance_interestedprofessional_change",
-            args=[interested_pro.id],
+        notify_interested_professional(
+            interested_pro,
+            source="/pro_version",
+            subject=f"New pro version signup #{interested_pro.id}",
         )
-        admin_url = f"https://{settings.FIGHT_HEALTH_INSURANCE_DOMAIN}{admin_path}"
-        body = (
-            f"A new professional signed up via /pro_version.\n\n"
-            f"Name: {interested_pro.name or 'N/A'}\n"
-            f"Email: {interested_pro.email}\n"
-            f"Job title / provider type: {interested_pro.job_title_or_provider_type or 'N/A'}\n"
-            f"Business: {interested_pro.business_name or 'N/A'}\n"
-            f"Phone: {interested_pro.phone_number or 'N/A'}\n"
-            f"Address: {interested_pro.address or 'N/A'}\n"
-            f"Most common denial: {interested_pro.most_common_denial or 'N/A'}\n"
-            f"Comments: {interested_pro.comments or 'N/A'}\n"
-            f"Admin: {admin_url}\n"
-        )
-        notify_professional_signup(f"New pro version signup #{interested_pro.id}", body)
 
 
 class PatientAccessView(generic.TemplateView):

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -280,7 +280,7 @@ class ProVersionView(generic.FormView):
         interested_pro = form.save(commit=False)
         interested_pro.clicked_for_paid = False
         interested_pro.save()
-        self._notify_support_of_signup(interested_pro)
+        self._notify_professional_signup(interested_pro)
         # Send the thank-you email synchronously so the signer gets it right
         # away. The batched ThankyouEmailSender will skip records where
         # thankyou_email_sent=True, which dosend() sets on success.
@@ -294,7 +294,7 @@ class ProVersionView(generic.FormView):
         return super().form_valid(form)
 
     @staticmethod
-    def _notify_support_of_signup(
+    def _notify_professional_signup(
         interested_pro: "models.InterestedProfessional",
     ) -> None:
         admin_path = reverse(

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -32,7 +32,6 @@ from django.views.decorators.http import require_http_methods
 from django.views.generic.base import TemplateView
 from django.utils import timezone
 from django.views.generic.edit import FormView
-from django.core.mail import send_mail
 
 import stripe
 from django_encrypted_filefield.crypt import Cryptographer
@@ -52,7 +51,11 @@ from fighthealthinsurance.models import (
     StripeRecoveryInfo,
 )
 from fighthealthinsurance.type_utils import User
-from fighthealthinsurance.utils import is_valid_denial_id, send_fallback_email
+from fighthealthinsurance.utils import (
+    is_valid_denial_id,
+    notify_professional_signup,
+    send_fallback_email,
+)
 
 
 def _handle_mailing_list_subscribe(form: forms.Form, source_page: str) -> None:
@@ -311,18 +314,7 @@ class ProVersionView(generic.FormView):
             f"Comments: {interested_pro.comments or 'N/A'}\n"
             f"Admin: {admin_url}\n"
         )
-        try:
-            send_mail(
-                f"New pro version signup #{interested_pro.id}",
-                body,
-                settings.DEFAULT_FROM_EMAIL,
-                ["support42@fighthealthinsurance.com"],
-            )
-        except Exception:
-            logger.opt(exception=True).error(
-                f"Error sending pro signup notification email "
-                f"(interested_professional_id={interested_pro.id})"
-            )
+        notify_professional_signup(f"New pro version signup #{interested_pro.id}", body)
 
 
 class PatientAccessView(generic.TemplateView):

--- a/tests/async/test_rest_auth_views.py
+++ b/tests/async/test_rest_auth_views.py
@@ -361,6 +361,40 @@ class RestAuthViewsTests(TestCase):
         response = self.client.post(url, data, format="json")
         self.assertIn(response.status_code, range(200, 300))
 
+    def test_professional_signup_notifies_professional_inbox(self) -> None:
+        """A successful FPW REST professional signup emails the professional
+        notification inbox (defaults to professional@fighthealthinsurance.com).
+
+        Uses the join-existing-domain path so no Stripe call is involved, and
+        captures on_commit callbacks since the notification is deferred until
+        the signup transaction commits.
+        """
+        url = reverse("professional_user-list")
+        data = {
+            "user_signup_info": {
+                "username": "notifypro",
+                "password": "newLongerPasswordMagicCheetoCheeto123",
+                "email": "notifypro@test-fhi.com",
+                "first_name": "Notify",
+                "last_name": "Pro",
+                "domain_name": "testdomain",
+                "visible_phone_number": "1234567892",
+                "continue_url": "http://example.com/continue",
+            },
+            "make_new_domain": False,
+        }
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(url, data, format="json")
+        self.assertIn(response.status_code, range(200, 300))
+        notification = next(
+            m
+            for m in mail.outbox
+            if m.subject == "New professional signup: notifypro@test-fhi.com"
+        )
+        self.assertEqual(notification.to, ["professional@fighthealthinsurance.com"])
+        self.assertIn("notifypro@test-fhi.com", notification.body)
+        self.assertIn("Notify Pro", notification.body)
+
     def test_create_professional_user_with_existing_visible_phone_number(self) -> None:
         url = reverse("professional_user-list")
         data = {

--- a/tests/sync/test_pro_version_signup.py
+++ b/tests/sync/test_pro_version_signup.py
@@ -49,8 +49,10 @@ class ProVersionSignupSuccessTest(TestCase):
         # Pay-to-express-interest is no longer collected.
         self.assertFalse(self.pro.clicked_for_paid)
 
-    def test_sends_team_notification_to_support(self):
-        self.assertEqual(self._team_email().to, ["support42@fighthealthinsurance.com"])
+    def test_sends_team_notification_to_professional_inbox(self):
+        self.assertEqual(
+            self._team_email().to, ["professional@fighthealthinsurance.com"]
+        )
 
     def test_team_notification_includes_captured_fields(self):
         body = self._team_email().body
@@ -120,7 +122,7 @@ class ProVersionSignupEdgeCaseTest(TestCase):
 
     def test_team_notification_failure_does_not_block_signup(self):
         with patch(
-            "fighthealthinsurance.views.send_mail", side_effect=Exception("smtp down")
+            "fighthealthinsurance.utils.send_mail", side_effect=Exception("smtp down")
         ):
             response = self.client.post(
                 reverse("pro_version"),

--- a/tests/sync/test_rest_api.py
+++ b/tests/sync/test_rest_api.py
@@ -2141,3 +2141,25 @@ class InterestedProfessionalEndpointTest(APITestCase):
             InterestedProfessional.objects.filter(name="No Email").exists()
         )
         mock_send.assert_not_called()
+
+    def test_notification_build_failure_does_not_fail_request(self):
+        # The notification body is built (including an admin reverse()) only
+        # after the lead is saved. A failure there must be logged and swallowed
+        # -- the lead is already persisted, so it must not surface as a 500.
+        from fighthealthinsurance.models import InterestedProfessional
+
+        with patch(
+            "fighthealthinsurance.utils.reverse",
+            side_effect=Exception("no reverse match"),
+        ), patch("fighthealthinsurance.utils.send_mail") as mock_send:
+            response = self.client.post(
+                reverse("interested-professional-list"),
+                data=json.dumps({"email": "pro4@example.com"}),
+                content_type="application/json",
+            )
+        self.assertEqual(response.status_code, 201)
+        self.assertTrue(
+            InterestedProfessional.objects.filter(email="pro4@example.com").exists()
+        )
+        # The build failed before the send, so no notification goes out.
+        mock_send.assert_not_called()

--- a/tests/sync/test_rest_api.py
+++ b/tests/sync/test_rest_api.py
@@ -2049,3 +2049,95 @@ class DemoRequestEndpointTest(APITestCase):
             )
         self.assertEqual(response.status_code, 201)
         self.assertTrue(DemoRequests.objects.filter(email="lead3@example.com").exists())
+
+
+class InterestedProfessionalEndpointTest(APITestCase):
+    """The interested_professional REST endpoint records a professional-interest
+    lead (the FPW counterpart to the web /pro_version form) and notifies the
+    professional-signup inbox (defaults to professional@fighthealthinsurance.com).
+    The notification flows through fighthealthinsurance.utils.notify_professional_signup,
+    so that is the send_mail patch target."""
+
+    def test_records_lead_and_emails_professional_inbox(self):
+        from fighthealthinsurance.models import InterestedProfessional
+
+        with patch("fighthealthinsurance.utils.send_mail") as mock_send:
+            response = self.client.post(
+                reverse("interested-professional-list"),
+                data=json.dumps(
+                    {
+                        "email": "pro@example.com",
+                        "name": "Dr. Pro",
+                        "business_name": "Acme Health",
+                        "job_title_or_provider_type": "Billing Manager",
+                    }
+                ),
+                content_type="application/json",
+            )
+        self.assertEqual(response.status_code, 201)
+        pro = InterestedProfessional.objects.get(email="pro@example.com")
+        self.assertEqual(pro.name, "Dr. Pro")
+        self.assertEqual(pro.business_name, "Acme Health")
+        # Legacy model default is clicked_for_paid=True; the endpoint records
+        # leads as not-clicked (matches the web /pro_version form).
+        self.assertFalse(pro.clicked_for_paid)
+        mock_send.assert_called_once()
+        # send_mail(subject, body, from_email, recipients)
+        subject, body, _from, recipients = mock_send.call_args.args
+        self.assertIn("professional@fighthealthinsurance.com", recipients)
+        self.assertIn("pro@example.com", body)
+        self.assertIn(str(pro.id), subject)
+
+    def test_extra_notification_recipient_is_configurable(self):
+        with patch(
+            "fighthealthinsurance.utils.send_mail"
+        ) as mock_send, self.settings(
+            PROFESSIONAL_SIGNUP_NOTIFICATION_EMAILS=[
+                "professional@fighthealthinsurance.com",
+                "sales@example.com",
+            ]
+        ):
+            response = self.client.post(
+                reverse("interested-professional-list"),
+                data=json.dumps({"email": "pro2@example.com"}),
+                content_type="application/json",
+            )
+        self.assertEqual(response.status_code, 201)
+        recipients = mock_send.call_args.args[3]
+        self.assertIn("sales@example.com", recipients)
+
+    def test_mail_failure_does_not_fail_request(self):
+        # The lead is persisted before the notification is attempted, so a mail
+        # backend error must not turn into a 500.
+        from fighthealthinsurance.models import InterestedProfessional
+
+        with patch(
+            "fighthealthinsurance.utils.send_mail",
+            side_effect=RuntimeError("smtp down"),
+        ):
+            response = self.client.post(
+                reverse("interested-professional-list"),
+                data=json.dumps({"email": "pro3@example.com"}),
+                content_type="application/json",
+            )
+        self.assertEqual(response.status_code, 201)
+        self.assertTrue(
+            InterestedProfessional.objects.filter(email="pro3@example.com").exists()
+        )
+
+    def test_email_is_required(self):
+        # email is the one required lead field; a payload without it is a 400
+        # and must not persist a row or send a notification.
+        from fighthealthinsurance.models import InterestedProfessional
+
+        with patch("fighthealthinsurance.utils.send_mail") as mock_send:
+            response = self.client.post(
+                reverse("interested-professional-list"),
+                data=json.dumps({"name": "No Email"}),
+                content_type="application/json",
+            )
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(
+            InterestedProfessional.objects.filter(name="No Email").exists()
+        )
+        mock_send.assert_not_called()

--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,13 @@ deps =
   -rrequirements.txt
   -rrequirements-dev.txt
 
-[testenv:mypy]
+[testenv:{mypy,py311-mypy,py312-mypy,py313-mypy}]
+# The py3XX-mypy envs derive their interpreter from the pyXY factor (like the
+# sync envs); the bare `mypy` env uses tox's default interpreter. All of them
+# share the config below so they actually run mypy. Previously the py3XX-mypy
+# sections only set basepython and inherited no commands (there is no base
+# [testenv]), so `tox -e py313-mypy` -- which CI runs via [gh-actions] -- was a
+# silent no-op that never type-checked anything.
 setenv =
     DJANGO_SETTINGS_MODULE=fighthealthinsurance.settings
     PYTHONPATH={toxinidir}
@@ -86,17 +92,7 @@ extras =
 deps = {[base_django_deps]deps}
 allowlist_externals = pytest, black, mypy
 commands =
-    mypy: mypy --config-file mypy.ini -p fighthealthinsurance -p fhi_users
-    pyright: pyright {posargs}
-
-[testenv:py311-mypy]
-basepython = python3.11
-
-[testenv:py312-mypy]
-basepython = python3.12
-
-[testenv:py313-mypy]
-basepython = python3.13
+    mypy --config-file mypy.ini -p fighthealthinsurance -p fhi_users
 
 # sync tests
 [testenv:{sync,py311-django52-sync,py312-django52-sync,py313-django52-sync,pyright,py312-pyright}]


### PR DESCRIPTION
## Summary
Adds email notifications to the professional signup inbox when new professionals sign up via the Fight Paperwork (FPW) REST API endpoint, mirroring the existing notification behavior for web-based professional signups.

## Key Changes

- **New notification method** (`_notify_professional_signup`): Added a static method to `RestAuthViews` that queues a best-effort email notification for professional signups via the REST API. The notification is deferred using `transaction.on_commit()` to ensure it only fires after the signup transaction commits, preventing spurious emails if later steps (e.g., Stripe checkout) roll back the transaction.

- **Shared notification utility** (`notify_professional_signup`): Extracted professional signup notification logic into a reusable utility function in `fighthealthinsurance/utils.py`. This function:
  - Sends to `professional@fighthealthinsurance.com` by default
  - Supports additional recipients via `PROFESSIONAL_SIGNUP_NOTIFICATION_EMAILS` setting
  - Logs and swallows mail failures so they never break the signup being reported

- **Settings configuration**: Added `PROFESSIONAL_SIGNUP_NOTIFICATION_EMAILS` setting in `fighthealthinsurance/settings.py` with support for extending recipients via the `PROFESSIONAL_SIGNUP_EXTRA_NOTIFICATION_EMAILS` environment variable.

- **Refactored web signup notifications**: Updated `fighthealthinsurance/views.py` to use the new shared `notify_professional_signup()` utility instead of inline `send_mail()` calls, reducing code duplication.

- **Test coverage**: Added `test_professional_signup_notifies_professional_inbox()` to verify that REST API professional signups trigger the notification email with correct recipient and content.

- **Fixed mypy configuration**: Updated `tox.ini` to properly configure mypy for Python version-specific environments (`py311-mypy`, `py312-mypy`, `py313-mypy`), fixing a silent no-op where type checking wasn't actually running in CI.

## Implementation Details

The notification is sent asynchronously via `transaction.on_commit()` callback, ensuring:
- The email only goes out once the signup transaction successfully commits
- A mail failure cannot roll back the signup transaction
- The notification includes signup details (name, email, domain, phone, professional user ID)

The shared utility pattern allows both the web form (`/pro_version`) and REST API endpoints to use consistent notification logic and recipient configuration.

https://claude.ai/code/session_01RuP4Y8Vjrtj8MHUMF8L9nP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new create-only REST endpoint for professional-interest signups to capture lead details and submit them for review.
  * Professional signup/inquiry notifications now send to a configurable inbox, with optional extra recipient emails.

* **Bug Fixes**
  * Signup notifications are now deferred until after the signup transaction successfully commits.
  * Email delivery remains best-effort: notification failures no longer block signup or lead creation.
  * Professional-interest submissions now require an email field (missing it is rejected).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->