### PR TITLE
Extract reCAPTCHA mixin to support multiple forms

### DIFF
--- a/fighthealthinsurance/forms/__init__.py
+++ b/fighthealthinsurance/forms/__init__.py
@@ -1,10 +1,19 @@
 import os
+from typing import TYPE_CHECKING
 
 from django import forms
 from django.conf import settings
 from django.forms import CheckboxInput, ModelForm, Textarea
 
 from django_recaptcha.fields import ReCaptchaField, ReCaptchaV2Checkbox
+
+if TYPE_CHECKING:
+    # Typing-only base so mypy knows ``self.fields`` exists. At runtime the
+    # mixin stays a plain ``object`` so it doesn't interfere with the form
+    # metaclass or MRO of the concrete forms that use it.
+    from django.forms import BaseForm as _ReCaptchaMixinBase
+else:
+    _ReCaptchaMixinBase = object
 
 from fighthealthinsurance.form_utils import *
 from fighthealthinsurance.models import (
@@ -30,7 +39,7 @@ REFERRAL_SOURCE_CHOICES = [
 ]
 
 
-class ReCaptchaOptionalMixin:
+class ReCaptchaOptionalMixin(_ReCaptchaMixinBase):
     """Adds an optionally-enforced reCAPTCHA field to a form.
 
     Forms using this mixin must declare a placeholder ``captcha`` field so the

--- a/fighthealthinsurance/forms/__init__.py
+++ b/fighthealthinsurance/forms/__init__.py
@@ -30,8 +30,45 @@ REFERRAL_SOURCE_CHOICES = [
 ]
 
 
+class ReCaptchaOptionalMixin:
+    """Adds an optionally-enforced reCAPTCHA field to a form.
+
+    Forms using this mixin must declare a placeholder ``captcha`` field so the
+    form metaclass collects it::
+
+        captcha = forms.CharField(required=False, widget=forms.HiddenInput())
+
+    The placeholder is a hidden no-op CharField and is swapped to a real
+    ReCaptchaField at instance construction time when Django settings have both
+    RECAPTCHA_PUBLIC_KEY and RECAPTCHA_PRIVATE_KEY configured and
+    RECAPTCHA_TESTING is not enabled. Gating on django.conf.settings (rather
+    than os.environ at import time) keeps a single source of truth and makes
+    the behavior testable via override_settings.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self._is_recaptcha_enabled():
+            self.fields["captcha"] = ReCaptchaField(widget=ReCaptchaV2Checkbox())
+
+    @staticmethod
+    def _is_recaptcha_enabled() -> bool:
+        """Return True when reCAPTCHA should be enforced.
+
+        Requires both RECAPTCHA_PUBLIC_KEY and RECAPTCHA_PRIVATE_KEY to be
+        set (non-empty) and RECAPTCHA_TESTING to not be enabled.
+        """
+        if getattr(settings, "RECAPTCHA_TESTING", False):
+            return False
+        return bool(
+            getattr(settings, "RECAPTCHA_PUBLIC_KEY", "")
+            and getattr(settings, "RECAPTCHA_PRIVATE_KEY", "")
+        )
+
+
 # Actual forms
-class InterestedProfessionalForm(forms.ModelForm):
+class InterestedProfessionalForm(ReCaptchaOptionalMixin, forms.ModelForm):
+    captcha = forms.CharField(required=False, widget=forms.HiddenInput())
     business_name = forms.CharField(required=False)
     address = forms.CharField(
         required=False,
@@ -80,39 +117,15 @@ class DeleteDataForm(forms.Form):
     email = forms.EmailField(required=True)
 
 
-class PublicDeleteDataForm(DeleteDataForm):
+class PublicDeleteDataForm(ReCaptchaOptionalMixin, DeleteDataForm):
     """Public-facing delete data form with reCAPTCHA protection.
 
     Used by the unauthenticated public deletion request flow to prevent
-    bots from spamming deletion request emails. The captcha field defaults
-    to a hidden CharField and is swapped to a real ReCaptchaField at
-    instance construction time when Django settings have both
-    RECAPTCHA_PUBLIC_KEY and RECAPTCHA_PRIVATE_KEY configured and
-    RECAPTCHA_TESTING is not enabled. Gating on django.conf.settings
-    (rather than os.environ at import time) keeps a single source of
-    truth and makes the behavior testable via override_settings.
+    bots from spamming deletion request emails. See ReCaptchaOptionalMixin
+    for how the captcha field is conditionally enforced.
     """
 
     captcha = forms.CharField(required=False, widget=forms.HiddenInput())
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        if self._is_recaptcha_enabled():
-            self.fields["captcha"] = ReCaptchaField(widget=ReCaptchaV2Checkbox())
-
-    @staticmethod
-    def _is_recaptcha_enabled() -> bool:
-        """Return True when reCAPTCHA should be enforced.
-
-        Requires both RECAPTCHA_PUBLIC_KEY and RECAPTCHA_PRIVATE_KEY to be
-        set (non-empty) and RECAPTCHA_TESTING to not be enabled.
-        """
-        if getattr(settings, "RECAPTCHA_TESTING", False):
-            return False
-        return bool(
-            getattr(settings, "RECAPTCHA_PUBLIC_KEY", "")
-            and getattr(settings, "RECAPTCHA_PRIVATE_KEY", "")
-        )
 
 
 class ShareAppealForm(forms.Form):

--- a/fighthealthinsurance/forms/__init__.py
+++ b/fighthealthinsurance/forms/__init__.py
@@ -42,10 +42,18 @@ REFERRAL_SOURCE_CHOICES = [
 class ReCaptchaOptionalMixin(_ReCaptchaMixinBase):
     """Adds an optionally-enforced reCAPTCHA field to a form.
 
-    Forms using this mixin must declare a placeholder ``captcha`` field so the
-    form metaclass collects it::
+    Order matters: list this mixin **before** ``forms.Form`` /
+    ``forms.ModelForm`` in the base classes, and declare a placeholder
+    ``captcha`` field so the form metaclass collects it::
 
-        captcha = forms.CharField(required=False, widget=forms.HiddenInput())
+        class MyForm(ReCaptchaOptionalMixin, forms.ModelForm):
+            captcha = forms.CharField(required=False, widget=forms.HiddenInput())
+
+    The real ReCaptchaField is swapped in by this mixin's ``__init__``. Django's
+    ``BaseForm.__init__`` does not call ``super().__init__()``, so the mixin
+    must precede the form base in the MRO for its ``__init__`` to run at all;
+    listing it *after* the form base silently leaves the hidden no-op field in
+    place and disables the captcha.
 
     The placeholder is a hidden no-op CharField and is swapped to a real
     ReCaptchaField at instance construction time when Django settings have both

--- a/fighthealthinsurance/templates/professional.html
+++ b/fighthealthinsurance/templates/professional.html
@@ -73,6 +73,11 @@ Fight Health Insurance Professional Version
             {{ form.comments.errors }}
           </div>
 
+          <div class="pro-field">
+            {{ form.captcha }}
+            {{ form.captcha.errors }}
+          </div>
+
           <div class="pro-interest-actions">
             <input class="pro-submit-btn" type="submit" value="Submit">
           </div>

--- a/tests/sync/test_form_validation.py
+++ b/tests/sync/test_form_validation.py
@@ -7,6 +7,7 @@ from django_recaptcha.fields import ReCaptchaField
 from fighthealthinsurance.forms import (
     DeleteDataForm,
     PublicDeleteDataForm,
+    InterestedProfessionalForm,
     ShareAppealForm,
     BaseDenialForm,
     DenialForm,
@@ -102,6 +103,58 @@ class TestPublicDeleteDataFormReCaptchaEnabled(TestCase):
     def test_form_without_captcha_fails(self):
         """Without a captcha token, validation should fail."""
         form = PublicDeleteDataForm(data={"email": "test@test-fhi.com"})
+        self.assertFalse(form.is_valid())
+        self.assertIn("captcha", form.errors)
+
+
+class TestInterestedProfessionalFormTestingMode(TestCase):
+    """In testing/dev mode the captcha is a hidden no-op CharField."""
+
+    @override_settings(RECAPTCHA_TESTING=True)
+    def test_captcha_is_hidden_char_field(self):
+        form = InterestedProfessionalForm()
+        captcha_field = form.fields["captcha"]
+        self.assertIsInstance(captcha_field, django_forms.CharField)
+        self.assertNotIsInstance(captcha_field, ReCaptchaField)
+        self.assertIsInstance(captcha_field.widget, django_forms.HiddenInput)
+
+    @override_settings(RECAPTCHA_TESTING=True)
+    def test_form_validates_without_captcha(self):
+        """Without reCAPTCHA, an email-only signup should validate."""
+        form = InterestedProfessionalForm(data={"email": "pro@clinic.example"})
+        self.assertTrue(form.is_valid(), form.errors)
+
+    @override_settings(
+        RECAPTCHA_TESTING=False,
+        RECAPTCHA_PUBLIC_KEY="",
+        RECAPTCHA_PRIVATE_KEY="",
+    )
+    def test_captcha_hidden_when_keys_empty(self):
+        """Empty keys should NOT enable the ReCaptchaField."""
+        form = InterestedProfessionalForm()
+        self.assertNotIsInstance(form.fields["captcha"], ReCaptchaField)
+
+
+class TestInterestedProfessionalFormReCaptchaEnabled(TestCase):
+    """When both reCAPTCHA keys are set and testing is off, use ReCaptchaField."""
+
+    @override_settings(
+        RECAPTCHA_TESTING=False,
+        RECAPTCHA_PUBLIC_KEY="test-public-key",
+        RECAPTCHA_PRIVATE_KEY="test-private-key",
+    )
+    def test_captcha_is_recaptcha_field(self):
+        form = InterestedProfessionalForm()
+        self.assertIsInstance(form.fields["captcha"], ReCaptchaField)
+
+    @override_settings(
+        RECAPTCHA_TESTING=False,
+        RECAPTCHA_PUBLIC_KEY="test-public-key",
+        RECAPTCHA_PRIVATE_KEY="test-private-key",
+    )
+    def test_form_without_captcha_fails(self):
+        """Without a captcha token, an otherwise-valid signup should fail."""
+        form = InterestedProfessionalForm(data={"email": "pro@clinic.example"})
         self.assertFalse(form.is_valid())
         self.assertIn("captcha", form.errors)
 


### PR DESCRIPTION
## Summary
Refactors reCAPTCHA handling by extracting the conditional captcha logic into a reusable `ReCaptchaOptionalMixin` class. This allows multiple forms to share the same reCAPTCHA enforcement behavior without code duplication.

## Key Changes
- **New `ReCaptchaOptionalMixin` class**: Encapsulates the logic for conditionally enabling reCAPTCHA based on Django settings (`RECAPTCHA_PUBLIC_KEY`, `RECAPTCHA_PRIVATE_KEY`, and `RECAPTCHA_TESTING`)
  - Uses a `TYPE_CHECKING` guard to provide proper type hints for `self.fields` without interfering with Django's form metaclass at runtime
  - Implements `_is_recaptcha_enabled()` static method to centralize the configuration check
  - Swaps the placeholder `captcha` field with a real `ReCaptchaField` during `__init__` when reCAPTCHA is enabled

- **Updated `PublicDeleteDataForm`**: Now inherits from `ReCaptchaOptionalMixin` instead of duplicating the reCAPTCHA logic
  - Removed `__init__` and `_is_recaptcha_enabled()` methods (now provided by mixin)
  - Updated docstring to reference the mixin for implementation details

- **Updated `InterestedProfessionalForm`**: Now inherits from `ReCaptchaOptionalMixin` to add reCAPTCHA protection to the professional signup form
  - Added placeholder `captcha` field declaration

- **Template update**: Added captcha field rendering to `professional.html` template

- **Test coverage**: Added comprehensive tests for `InterestedProfessionalForm` covering both testing mode (captcha disabled) and production mode (captcha enabled)

## Implementation Details
- The mixin uses a conditional base class pattern (`_ReCaptchaMixinBase`) to satisfy type checkers while keeping the runtime behavior clean
- Forms using the mixin must declare a placeholder `captcha = forms.CharField(required=False, widget=forms.HiddenInput())` field so Django's form metaclass collects it
- The actual reCAPTCHA field replacement happens at instance construction time, allowing settings to be overridden in tests via `@override_settings`

https://claude.ai/code/session_019xxSkZayPxT5jJE9erzYph