### PR TITLE
Security: Hardcoded credentials in setup_local_db command

### DIFF
--- a/fighthealthinsurance/management/commands/setup_local_db.py
+++ b/fighthealthinsurance/management/commands/setup_local_db.py
@@ -4,8 +4,10 @@ Replaces separate invocations of migrate, loaddata, ensure_adminuser, and make_u
 with a single management command to avoid repeated Django startup overhead.
 """
 
+import os
 from typing import Any
 
+from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
 
@@ -14,6 +16,12 @@ class Command(BaseCommand):
     help = "Run all local dev DB setup: migrate, load fixtures, create test users."
 
     def handle(self, *args: str, **options: Any) -> None:
+        if not settings.DEBUG:
+            self.stderr.write(
+                self.style.ERROR("This command can only be run with DEBUG=True.")
+            )
+            return
+
         self.stdout.write("Running migrations...")
         call_command("migrate", verbosity=1)
 
@@ -28,14 +36,16 @@ class Command(BaseCommand):
         call_command("loaddata", "pa_requirements")
 
         self.stdout.write("Ensuring admin user...")
-        call_command("ensure_adminuser", username="admin", password="admin")
+        admin_password = os.environ.get("LOCAL_ADMIN_PASSWORD", "admin")
+        call_command("ensure_adminuser", username="admin", password=admin_password)
 
         self.stdout.write("Creating test users...")
+        test_password = os.environ.get("LOCAL_TEST_PASSWORD", "farts12345678")
         call_command(
             "make_user",
             username="test@test.com",
             domain="testfarts1",
-            password="farts12345678",
+            password=test_password,
             email="test@test.com",
             visible_phone_number="42",
             is_provider=True,
@@ -45,7 +55,7 @@ class Command(BaseCommand):
             "make_user",
             username="test-patient@test.com",
             domain="testfarts1",
-            password="farts12345678",
+            password=test_password,
             email="test-patient@test.com",
             visible_phone_number="42",
             is_provider=False,


### PR DESCRIPTION
## Summary

Security: Hardcoded credentials in setup_local_db command

## Problem

**Severity**: `High` | **File**: `fighthealthinsurance/management/commands/setup_local_db.py:L1`

The `setup_local_db` management command contains multiple hardcoded credentials including admin password 'admin' and test user password 'farts12345678'. While this is intended for local development, these credentials could accidentally be used in production or committed to version control, creating a significant security risk.

## Solution

Move all credentials to environment variables or a separate configuration file that is excluded from version control. Add warnings or guards to prevent this command from running in production environments. Consider using Django's `get_random_secret_key()` or similar for test passwords.

## Changes

- `fighthealthinsurance/management/commands/setup_local_db.py` (modified)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the local development environment setup process. Debug mode is now required to execute the setup command; if disabled, the command exits with an error message. Authentication credentials are now sourced from environment variables rather than hardcoded defaults, enhancing security for development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->