### PR TITLE
Enforce minimum appeal length with meaningful character counting

### DIFF
--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -80,6 +80,7 @@ from fighthealthinsurance.utils import (
     is_real_appeal,
     MIN_APPEAL_CHARS,
     sync_iterator_to_async,
+    warn_too_short_appeal,
 )
 from .clinicaltrials_tools import ClinicalTrialsTools
 from .pubmed_tools import PubMedTools
@@ -2667,13 +2668,22 @@ class AppealsBackendHelper:
         # Yield the existing appeals first
         old = 0
         async for appeal in existing_appeals:
-            if appeal.appeal_text is not None:
+            # Enforce the minimum-length rule on previously-saved appeals too:
+            # the DB may hold short drafts saved before this threshold existed
+            # (or by paths that skipped the filter), and we must not re-deliver
+            # them.
+            if is_real_appeal(appeal.appeal_text):
                 old = old + 1
                 logger.debug(f"Found existing appeal {appeal}, yielding")
                 existing_appeal_dict = await sub_in_appeals(
                     {"id": str(appeal.id), "content": appeal.appeal_text}
                 )
                 yield await format_response(existing_appeal_dict)
+            elif appeal.appeal_text is not None and str(appeal.appeal_text).strip():
+                warn_too_short_appeal(
+                    appeal.appeal_text,
+                    f"saved appeal id={appeal.id} for denial {denial_id}",
+                )
 
         # Yield status after any previously saved appeals have been sent
         yield json.dumps(
@@ -3370,6 +3380,10 @@ class AppealsBackendHelper:
                 return True
             if isinstance(text, str) and text.strip():
                 runts += 1
+                warn_too_short_appeal(
+                    text,
+                    f"model={item.model_name!r} for denial {denial_id}",
+                )
             return False
 
         filtered_appeals: Iterator[GeneratedAppeal] = filter(keep, appeals)
@@ -3470,7 +3484,15 @@ class AppealsBackendHelper:
                     logger.warning(f"Synthesis timed out after {SYNTHESIS_TIMEOUT}s")
                 else:
                     synthesized = synthesis_task.result()
-                    if synthesized:
+                    if synthesized and not is_real_appeal(synthesized):
+                        # Non-empty but below the deliverable threshold: filter
+                        # it out so synthesis can't bypass the minimum-length
+                        # rule that the streaming path enforces.
+                        warn_too_short_appeal(
+                            synthesized,
+                            f"synthesis output for denial {denial_id}",
+                        )
+                    elif synthesized:
                         # Belt-and-suspenders: even with >=2 drafts a model
                         # can still pick one verbatim. Skip the yield in
                         # that case rather than ship a known duplicate.

--- a/fighthealthinsurance/utils.py
+++ b/fighthealthinsurance/utils.py
@@ -6,6 +6,7 @@ import re
 import string
 import threading
 import time
+import unicodedata
 from concurrent.futures import Future, ThreadPoolExecutor
 from functools import reduce
 from inspect import isabstract
@@ -36,24 +37,44 @@ from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
 from django.template.loader import render_to_string
 
-# Minimum number of (stripped) characters an appeal must have to be
-# considered "real" and worth delivering/saving: appeals must be at least
-# MIN_APPEAL_CHARS characters long. Shared by the generation-side filter
-# (drop runt outputs before save) and the streaming-side counter (so
-# generation rejection and delivery counting agree). Also used by
-# make_appeals to decide when to trigger the fallback path — a runt first
-# item means the user gets nothing, so fall back.
+# Minimum number of meaningful characters an appeal must have to be
+# considered "real" and worth delivering/saving: appeals must contain at
+# least MIN_APPEAL_CHARS non-whitespace, non-control characters (see
+# meaningful_appeal_length). Shared by the generation-side filter (drop runt
+# outputs before save) and the streaming-side counter (so generation
+# rejection and delivery counting agree). Also used by make_appeals to
+# decide when to trigger the fallback path — a runt first item means the
+# user gets nothing, so fall back.
 MIN_APPEAL_CHARS = 15
 
 
+def meaningful_appeal_length(text: Optional[str]) -> int:
+    """Count the characters in ``text`` that actually carry content.
+
+    Whitespace and control characters are excluded so an appeal can't meet
+    the minimum-length requirement by padding with spaces, newlines, or
+    non-printing control characters. A non-string returns 0.
+    """
+    if not isinstance(text, str):
+        return 0
+    return sum(
+        1
+        for ch in text
+        # ``isspace`` covers spaces/tabs/newlines (incl. Unicode whitespace);
+        # the category check drops control/format/surrogate/private-use/
+        # unassigned characters (Unicode "Other", whose category starts "C").
+        if not ch.isspace() and unicodedata.category(ch)[0] != "C"
+    )
+
+
 def is_real_appeal(x: Optional[str]) -> TypeGuard[str]:
-    """True when ``x`` is a deliverable appeal: a string at least
-    ``MIN_APPEAL_CHARS`` characters long (after stripping whitespace).
+    """True when ``x`` is a deliverable appeal: a string with at least
+    ``MIN_APPEAL_CHARS`` non-whitespace, non-control characters.
 
     Typed as a ``TypeGuard[str]`` so callers narrow ``Optional[str]`` to
     ``str`` inside the truthy branch (e.g. when building the streamed
     appeal payload)."""
-    return isinstance(x, str) and len(x.strip()) >= MIN_APPEAL_CHARS
+    return isinstance(x, str) and meaningful_appeal_length(x) >= MIN_APPEAL_CHARS
 
 
 import asyncstdlib
@@ -81,9 +102,11 @@ def warn_too_short_appeal(text: Optional[str], context: str) -> None:
     Centralizes the message format shared by the generation, streaming, and
     synthesis drop sites so a runt appeal is reported consistently wherever
     it is dropped. ``context`` identifies the source (e.g. the model name,
-    a saved-appeal id, or "synthesis output") plus the denial id.
+    a saved-appeal id, or "synthesis output") plus the denial id. The logged
+    length is the meaningful (non-whitespace, non-control) count actually
+    used by the filter.
     """
-    length = len(text.strip()) if isinstance(text, str) else 0
+    length = meaningful_appeal_length(text)
     logger.warning(
         f"Filtering out too-short appeal "
         f"(len={length} < {MIN_APPEAL_CHARS} chars): {context}"

--- a/fighthealthinsurance/utils.py
+++ b/fighthealthinsurance/utils.py
@@ -24,6 +24,7 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
+    TypeGuard,
     TypeVar,
     Union,
     cast,
@@ -35,15 +36,24 @@ from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
 from django.template.loader import render_to_string
 
-# Shared by the generation-side filter (drop runt outputs before save) and
-# the streaming-side counter (so generation rejection and delivery counting
-# agree). Also used by make_appeals to decide when to trigger the fallback
-# path — a runt first item means the user gets nothing, so fall back.
-MIN_APPEAL_CHARS = 10
+# Minimum number of (stripped) characters an appeal must have to be
+# considered "real" and worth delivering/saving: appeals must be at least
+# MIN_APPEAL_CHARS characters long. Shared by the generation-side filter
+# (drop runt outputs before save) and the streaming-side counter (so
+# generation rejection and delivery counting agree). Also used by
+# make_appeals to decide when to trigger the fallback path — a runt first
+# item means the user gets nothing, so fall back.
+MIN_APPEAL_CHARS = 15
 
 
-def is_real_appeal(x: Optional[str]) -> bool:
-    return isinstance(x, str) and len(x.strip()) > MIN_APPEAL_CHARS
+def is_real_appeal(x: Optional[str]) -> TypeGuard[str]:
+    """True when ``x`` is a deliverable appeal: a string at least
+    ``MIN_APPEAL_CHARS`` characters long (after stripping whitespace).
+
+    Typed as a ``TypeGuard[str]`` so callers narrow ``Optional[str]`` to
+    ``str`` inside the truthy branch (e.g. when building the streamed
+    appeal payload)."""
+    return isinstance(x, str) and len(x.strip()) >= MIN_APPEAL_CHARS
 
 
 import asyncstdlib
@@ -63,6 +73,21 @@ _NCBI_API_KEY = os.environ.get("NCBI_API_KEY") or None
 pubmed_fetcher = (
     PubMedFetcher(api_key=_NCBI_API_KEY) if _NCBI_API_KEY else PubMedFetcher()
 )
+
+
+def warn_too_short_appeal(text: Optional[str], context: str) -> None:
+    """Log a warning that a too-short appeal is being filtered out.
+
+    Centralizes the message format shared by the generation, streaming, and
+    synthesis drop sites so a runt appeal is reported consistently wherever
+    it is dropped. ``context`` identifies the source (e.g. the model name,
+    a saved-appeal id, or "synthesis output") plus the denial id.
+    """
+    length = len(text.strip()) if isinstance(text, str) else 0
+    logger.warning(
+        f"Filtering out too-short appeal "
+        f"(len={length} < {MIN_APPEAL_CHARS} chars): {context}"
+    )
 
 
 class RateLimiter:

--- a/tests/async-unit/test_appeals_backend_citations.py
+++ b/tests/async-unit/test_appeals_backend_citations.py
@@ -1,16 +1,46 @@
 from unittest.mock import patch, AsyncMock, MagicMock
 import asyncio
+import io
 import json
+from contextlib import contextmanager
 
 import pytest
+from loguru import logger as loguru_logger
 
 from fighthealthinsurance.common_view_logic import AppealsBackendHelper
 from fighthealthinsurance.generate_appeal import GeneratedAppeal
 
 
+@contextmanager
+def _loguru_capture(level="WARNING"):
+    """Capture loguru records at or above ``level`` into a StringIO sink."""
+    sink = io.StringIO()
+    handler_id = loguru_logger.add(sink, level=level)
+    try:
+        yield sink
+    finally:
+        loguru_logger.remove(handler_id)
+
+
 def _ga(text: str, model_name: str = "test-model"):
     """Shorthand for the appeal-generation iterator's GeneratedAppeal items."""
     return GeneratedAppeal(text=text, model_name=model_name)
+
+
+def _collect_appeal_contents(chunks):
+    """Extract the ``content`` field from every appeal JSON chunk."""
+    contents = []
+    for c in chunks:
+        stripped = c.strip()
+        if not stripped:
+            continue
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict) and "content" in parsed:
+            contents.append(parsed["content"])
+    return contents
 
 
 async def passthrough_interleave(iterator):
@@ -590,7 +620,7 @@ class TestAppealsBackendHelperWithCitations:
     "saved_texts,synthesis_should_run",
     [
         # >=2 drafts: synthesis is meaningful (combines multiple inputs).
-        (["draft one text", "draft two text"], True),
+        (["draft one text body", "draft two text body"], True),
         # 1 draft: skipped — models tend to regurgitate a single input
         # verbatim, which the client then dedupes and reports as a
         # partial-delivery error.
@@ -655,7 +685,9 @@ async def test_synthesis_threshold(saved_texts, synthesis_should_run):
         mock_pa_cls.objects.filter.return_value = (
             _make_proposed_appeal_query_with_texts(saved_texts)
         )
-        mock_appeal_gen.synthesize_appeals = AsyncMock(return_value="synthesized")
+        mock_appeal_gen.synthesize_appeals = AsyncMock(
+            return_value="synthesized appeal letter text"
+        )
 
         async for _ in AppealsBackendHelper.generate_appeals(parameters):
             pass
@@ -756,3 +788,155 @@ async def test_synthesis_skips_verbatim_duplicate():
         assert (
             '"synthesized": "true"' not in c
         ), f"verbatim-duplicate synthesis should have been skipped, got chunk: {c}"
+
+
+@pytest.mark.asyncio
+async def test_synthesis_too_short_output_is_filtered():
+    """A synthesized appeal below MIN_APPEAL_CHARS must not be yielded — it
+    would otherwise bypass the minimum-length rule the streaming path
+    enforces — and the drop must be logged as a warning."""
+    mock_denial = _make_mock_denial()
+    parameters = {
+        "denial_id": "12345",
+        "email": "test@example.com",
+        "semi_sekret": "test-secret",
+    }
+    saved_texts = ["draft one text body", "draft two text body"]
+
+    with (
+        patch(
+            "fighthealthinsurance.common_view_logic.Denial.objects.filter",
+            return_value=_make_mock_denial_query(mock_denial),
+        ),
+        patch(
+            "fighthealthinsurance.common_view_logic.Denial.get_hashed_email",
+            return_value="hashed",
+        ),
+        patch.object(AppealsBackendHelper, "regex_denial_processor") as mock_regex,
+        patch(
+            "fighthealthinsurance.common_view_logic.MLCitationsHelper.generate_citations_for_denial",
+            new_callable=AsyncMock,
+            return_value="",
+        ),
+        patch.object(
+            AppealsBackendHelper.pmt,
+            "find_context_for_denial",
+            new_callable=AsyncMock,
+            return_value="",
+        ),
+        patch(
+            "fighthealthinsurance.common_view_logic.sync_to_async",
+        ) as mock_sync_to_async,
+        patch(
+            "fighthealthinsurance.common_view_logic.interleave_iterator_for_keep_alive",
+            side_effect=passthrough_interleave,
+        ),
+        patch(
+            "fighthealthinsurance.common_view_logic.ProposedAppeal",
+        ) as mock_pa_cls,
+        patch(
+            "fighthealthinsurance.common_view_logic.appealGenerator"
+        ) as mock_appeal_gen,
+    ):
+        mock_regex.get_appeal_templates = AsyncMock(return_value=[])
+        # make_appeals returns nothing new so the only synthesis candidate is
+        # the (too-short) synthesizer output under test.
+        mock_sync_to_async.side_effect = _sync_to_async_router(
+            AsyncMock(return_value=""),
+            AsyncMock(return_value=[]),
+        )
+        mock_pa_cls.return_value = MagicMock(id=1, asave=AsyncMock())
+        mock_pa_cls.objects.filter.return_value = (
+            _make_proposed_appeal_query_with_texts(saved_texts)
+        )
+        # Synthesizer returns a non-empty but too-short letter (< 15 chars).
+        mock_appeal_gen.synthesize_appeals = AsyncMock(return_value="too short")
+
+        with _loguru_capture() as sink:
+            chunks = []
+            async for chunk in AppealsBackendHelper.generate_appeals(parameters):
+                chunks.append(chunk)
+
+    # The too-short synthesis must never be delivered.
+    contents = _collect_appeal_contents(chunks)
+    assert "too short" not in contents
+    for c in chunks:
+        assert '"synthesized": "true"' not in c
+    # And the drop is logged as a warning naming the denial.
+    output = sink.getvalue()
+    assert "too-short appeal" in output
+    assert "synthesis output for denial 12345" in output
+
+
+@pytest.mark.asyncio
+async def test_existing_too_short_appeal_is_skipped():
+    """Previously-saved appeals below MIN_APPEAL_CHARS (e.g. saved before the
+    threshold existed) must not be re-delivered, and the skip is warned."""
+    mock_denial = _make_mock_denial()
+    parameters = {
+        "denial_id": "12345",
+        "email": "test@example.com",
+        "semi_sekret": "test-secret",
+    }
+    # One runt (4 chars) and one deliverable existing appeal.
+    existing_texts = ["tiny", "a valid existing appeal body"]
+
+    with (
+        patch(
+            "fighthealthinsurance.common_view_logic.Denial.objects.filter",
+            return_value=_make_mock_denial_query(mock_denial),
+        ),
+        patch(
+            "fighthealthinsurance.common_view_logic.Denial.get_hashed_email",
+            return_value="hashed",
+        ),
+        patch.object(AppealsBackendHelper, "regex_denial_processor") as mock_regex,
+        patch(
+            "fighthealthinsurance.common_view_logic.MLCitationsHelper.generate_citations_for_denial",
+            new_callable=AsyncMock,
+            return_value="",
+        ),
+        patch.object(
+            AppealsBackendHelper.pmt,
+            "find_context_for_denial",
+            new_callable=AsyncMock,
+            return_value="",
+        ),
+        patch(
+            "fighthealthinsurance.common_view_logic.sync_to_async",
+        ) as mock_sync_to_async,
+        patch(
+            "fighthealthinsurance.common_view_logic.interleave_iterator_for_keep_alive",
+            side_effect=passthrough_interleave,
+        ),
+        patch(
+            "fighthealthinsurance.common_view_logic.ProposedAppeal",
+        ) as mock_pa_cls,
+        patch(
+            "fighthealthinsurance.common_view_logic.appealGenerator"
+        ) as mock_appeal_gen,
+    ):
+        mock_regex.get_appeal_templates = AsyncMock(return_value=[])
+        mock_sync_to_async.side_effect = _sync_to_async_router(
+            AsyncMock(return_value=""),
+            AsyncMock(return_value=[]),  # no newly generated appeals
+        )
+        mock_pa_cls.return_value = MagicMock(id=1, asave=AsyncMock())
+        mock_pa_cls.objects.filter.return_value = (
+            _make_proposed_appeal_query_with_texts(existing_texts)
+        )
+        mock_appeal_gen.synthesize_appeals = AsyncMock(return_value=None)
+
+        with _loguru_capture() as sink:
+            chunks = []
+            async for chunk in AppealsBackendHelper.generate_appeals(parameters):
+                chunks.append(chunk)
+
+    contents = _collect_appeal_contents(chunks)
+    # The runt is dropped; the valid existing appeal is delivered.
+    assert "tiny" not in contents
+    assert "a valid existing appeal body" in contents
+    # The drop is logged as a warning identifying it as a saved appeal.
+    output = sink.getvalue()
+    assert "too-short appeal" in output
+    assert "saved appeal id=" in output

--- a/tests/async-unit/test_common_view_logic.py
+++ b/tests/async-unit/test_common_view_logic.py
@@ -10,7 +10,11 @@ from fighthealthinsurance.common_view_logic import (
     NextStepInfo,
     DenialCreatorHelper,
 )
-from fighthealthinsurance.utils import MIN_APPEAL_CHARS, is_real_appeal
+from fighthealthinsurance.utils import (
+    MIN_APPEAL_CHARS,
+    is_real_appeal,
+    warn_too_short_appeal,
+)
 from fighthealthinsurance.helpers import SendFaxHelper, RemoveDataHelper
 from fighthealthinsurance.models import Denial, DenialTypes, Appeal, FaxesToSend
 import pytest
@@ -683,7 +687,8 @@ class TestCommonViewLogic(TestCase):
         ("", False),
         ("   \t\n  ", False),  # whitespace-only
         ("ok", False),  # below threshold
-        ("a" * MIN_APPEAL_CHARS, False),  # at threshold (strict >)
+        ("a" * (MIN_APPEAL_CHARS - 1), False),  # just below threshold
+        ("a" * MIN_APPEAL_CHARS, True),  # at threshold (inclusive >=)
         (123, False),  # non-string
         (["a"] * 100, False),  # non-string
         ("          short          ", False),  # strip-then-measure
@@ -693,3 +698,35 @@ class TestCommonViewLogic(TestCase):
 )
 def test_is_real_appeal(value, expected):
     assert is_real_appeal(value) is expected
+
+
+def test_warn_too_short_appeal_logs_length_and_context():
+    """The shared drop-site warning reports the measured length, the
+    threshold, and the caller-supplied context."""
+    from loguru import logger as loguru_logger
+
+    sink = io.StringIO()
+    handler_id = loguru_logger.add(sink, level="WARNING")
+    try:
+        warn_too_short_appeal("abc", "model='m' for denial 7")
+    finally:
+        loguru_logger.remove(handler_id)
+    output = sink.getvalue()
+    assert "too-short appeal" in output
+    assert "len=3" in output
+    assert f"< {MIN_APPEAL_CHARS} chars" in output
+    assert "model='m' for denial 7" in output
+
+
+def test_warn_too_short_appeal_handles_non_string():
+    """A non-string (e.g. None) is reported as length 0 without raising."""
+    from loguru import logger as loguru_logger
+
+    sink = io.StringIO()
+    handler_id = loguru_logger.add(sink, level="WARNING")
+    try:
+        warn_too_short_appeal(None, "some context")
+    finally:
+        loguru_logger.remove(handler_id)
+    output = sink.getvalue()
+    assert "len=0" in output

--- a/tests/async-unit/test_common_view_logic.py
+++ b/tests/async-unit/test_common_view_logic.py
@@ -13,6 +13,7 @@ from fighthealthinsurance.common_view_logic import (
 from fighthealthinsurance.utils import (
     MIN_APPEAL_CHARS,
     is_real_appeal,
+    meaningful_appeal_length,
     warn_too_short_appeal,
 )
 from fighthealthinsurance.helpers import SendFaxHelper, RemoveDataHelper
@@ -694,26 +695,54 @@ class TestCommonViewLogic(TestCase):
         ("          short          ", False),  # strip-then-measure
         ("a" * (MIN_APPEAL_CHARS + 1), True),  # just over threshold
         ("this is a long enough appeal text for delivery", True),
+        # Internal whitespace doesn't count: 10 letters padded with spaces.
+        ("a " * 10, False),
+        # Control characters don't count: 10 letters + 50 NUL bytes.
+        ("a" * 10 + "\x00" * 50, False),
+        # Exactly MIN_APPEAL_CHARS letters with control padding stays valid.
+        ("a" * MIN_APPEAL_CHARS + "\x07" * 20, True),
+        # Tabs/newlines between letters are ignored (only 12 real letters).
+        ("a\tb\nc d e f g h i j k l", False),
     ],
 )
 def test_is_real_appeal(value, expected):
     assert is_real_appeal(value) is expected
 
 
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (None, 0),
+        (123, 0),
+        ("", 0),
+        ("   \t\n  ", 0),  # whitespace-only
+        ("abc", 3),
+        ("a b c", 3),  # internal spaces excluded
+        ("  hi  ", 2),  # surrounding spaces excluded
+        ("a\x00b\x07c", 3),  # control characters excluded
+        ("a" * 15, 15),
+        ("a" * 15 + "\n\n\n", 15),  # trailing whitespace excluded
+    ],
+)
+def test_meaningful_appeal_length(value, expected):
+    assert meaningful_appeal_length(value) == expected
+
+
 def test_warn_too_short_appeal_logs_length_and_context():
     """The shared drop-site warning reports the measured length, the
-    threshold, and the caller-supplied context."""
+    threshold, and the caller-supplied context. The reported length is the
+    meaningful (non-whitespace) count, so internal spaces are not counted."""
     from loguru import logger as loguru_logger
 
     sink = io.StringIO()
     handler_id = loguru_logger.add(sink, level="WARNING")
     try:
-        warn_too_short_appeal("abc", "model='m' for denial 7")
+        warn_too_short_appeal("a b c", "model='m' for denial 7")
     finally:
         loguru_logger.remove(handler_id)
     output = sink.getvalue()
     assert "too-short appeal" in output
-    assert "len=3" in output
+    assert "len=3" in output  # 3 letters, the 2 spaces are excluded
     assert f"< {MIN_APPEAL_CHARS} chars" in output
     assert "model='m' for denial 7" in output
 


### PR DESCRIPTION
## Summary
Implement stricter validation of appeal letter length by counting only meaningful characters (excluding whitespace and control characters) and enforce this threshold consistently across generation, streaming, and synthesis paths. This prevents appeals from meeting the minimum-length requirement through padding and ensures runt appeals are logged and filtered uniformly.

## Key Changes

- **New utility functions in `utils.py`:**
  - `meaningful_appeal_length()`: Counts non-whitespace, non-control characters in text, excluding spaces, tabs, newlines, and Unicode control/format characters
  - `warn_too_short_appeal()`: Centralized logging for filtered appeals with consistent message format including meaningful length, threshold, and context
  - Updated `is_real_appeal()` to use meaningful character counting and changed from strict `>` to inclusive `>=` comparison
  - Increased `MIN_APPEAL_CHARS` from 10 to 15 characters

- **Enhanced filtering in `common_view_logic.py`:**
  - Added minimum-length validation for previously-saved appeals (which may have been saved before this threshold existed)
  - Added warning logs when existing appeals are filtered out
  - Added filtering and logging for synthesized appeals that are non-empty but below the threshold
  - Ensured synthesis can't bypass the minimum-length rule enforced by the streaming path

- **Comprehensive test coverage:**
  - Added `test_synthesis_too_short_output_is_filtered()`: Verifies synthesized appeals below MIN_APPEAL_CHARS are dropped and logged
  - Added `test_existing_too_short_appeal_is_skipped()`: Verifies previously-saved short appeals are filtered with warnings
  - Added parametrized tests for `meaningful_appeal_length()` covering edge cases (whitespace, control characters, internal spacing)
  - Added parametrized tests for `is_real_appeal()` with updated threshold expectations
  - Added test for `warn_too_short_appeal()` logging format and non-string handling
  - Added test helper `_loguru_capture()` for capturing log output in tests
  - Added test helper `_collect_appeal_contents()` for extracting content from JSON chunks

## Notable Implementation Details

- Meaningful character counting uses `unicodedata.category()` to exclude Unicode control/format/surrogate/private-use/unassigned characters, preventing padding with non-printing characters
- `is_real_appeal()` is typed as `TypeGuard[str]` to enable type narrowing in callers
- Warning logs include the meaningful length (not raw length) so internal spaces don't inflate the reported count
- Filtering is applied at three drop sites: generation (model output), streaming (existing appeals), and synthesis (combined output)
- All three drop sites use the shared `warn_too_short_appeal()` function for consistent logging

https://claude.ai/code/session_01U2aR1HvJz1EAJZe39mcuMV