### PR TITLE
Add staff system-status dashboard for on-call health monitoring

### DIFF
--- a/fighthealthinsurance/fax_health_status.py
+++ b/fighthealthinsurance/fax_health_status.py
@@ -1,0 +1,122 @@
+"""
+Health checks for the outbound fax backends.
+
+This module reports which fax sending backends are currently registered on the
+global ``flexible_fax_magic`` router and whether the Sonic fax backend can
+authenticate. It is consumed by the staff system-status dashboard so on-call
+can tell at a glance whether faxing (and Sonic in particular) is working.
+
+The Sonic check makes a network login round-trip, so it is run under a timeout;
+other backends are reported as configured without an active probe (they do not
+expose a cheap liveness check).
+"""
+
+import concurrent.futures
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from loguru import logger
+
+
+@dataclass
+class FaxBackendHealthDetail:
+    name: str
+    ok: bool
+    professional: bool = False
+    probed: bool = False
+    error: Optional[str] = None
+
+
+def _probe_backend(backend: Any, timeout: float) -> tuple[bool, Optional[str]]:
+    """Run ``backend.check_health()`` under a timeout.
+
+    Returns ``(ok, error)``. A timeout or any raised exception is reported as
+    not-ok with a descriptive error rather than propagating, so one slow/broken
+    backend never takes down the whole status page.
+    """
+    try:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+            future = ex.submit(backend.check_health)
+            ok = bool(future.result(timeout=timeout))
+            return (ok, None if ok else "health check returned False")
+    except concurrent.futures.TimeoutError:
+        return (False, f"timeout>{timeout}s")
+    except Exception as e:
+        return (False, str(e))
+
+
+def check_fax_backends_health(probe_timeout: float = 10.0) -> Dict[str, Any]:
+    """Check the health of all registered fax backends.
+
+    Returns a dict with:
+    - ``backends``: list of per-backend details (name, ok, professional,
+      probed, error).
+    - ``total_backends``: number of registered backends.
+    - ``sonic``: summary of the Sonic backend specifically
+      (``configured``, ``active``, ``ok``, ``error``) since it is the backend
+      most worth surfacing on the status page.
+    """
+    from fighthealthinsurance.fax_utils import SonicFax, flexible_fax_magic
+
+    details: List[FaxBackendHealthDetail] = []
+    sonic_active = False
+    sonic_ok = False
+    sonic_error: Optional[str] = None
+
+    for backend in flexible_fax_magic.backends:
+        name = type(backend).__name__
+        professional = bool(getattr(backend, "professional", False))
+        is_sonic = isinstance(backend, SonicFax)
+        ok = True
+        error: Optional[str] = None
+        probed = False
+
+        if is_sonic:
+            sonic_active = True
+            probed = True
+            ok, error = _probe_backend(backend, probe_timeout)
+            sonic_ok = ok
+            sonic_error = error
+
+        details.append(
+            FaxBackendHealthDetail(
+                name=name,
+                ok=ok,
+                professional=professional,
+                probed=probed,
+                error=error,
+            )
+        )
+
+    # If Sonic isn't registered, figure out whether that's because it's not
+    # configured (missing env vars) so the dashboard can say why.
+    sonic_configured = sonic_active
+    if not sonic_active:
+        try:
+            SonicFax()
+            # Constructed fine but wasn't registered — unusual, surface it.
+            sonic_configured = True
+            sonic_error = "configured but not registered as a backend"
+        except Exception as e:
+            sonic_configured = False
+            sonic_error = str(e)
+
+    return {
+        "backends": [
+            {
+                "name": d.name,
+                "ok": d.ok,
+                "professional": d.professional,
+                "probed": d.probed,
+                "error": d.error,
+            }
+            for d in details
+        ],
+        "total_backends": len(details),
+        "sonic": {
+            "configured": sonic_configured,
+            "active": sonic_active,
+            "ok": sonic_ok,
+            "error": sonic_error,
+        },
+    }

--- a/fighthealthinsurance/fax_health_status.py
+++ b/fighthealthinsurance/fax_health_status.py
@@ -36,7 +36,10 @@ def _probe_backend(backend: Any, timeout: float) -> tuple[bool, Optional[str]]:
     """
     ex = concurrent.futures.ThreadPoolExecutor(max_workers=1)
     try:
-        future = ex.submit(backend.check_health)
+        # Pass the probe budget through so a backend's own per-request default
+        # (e.g. SonicFax's 3s) doesn't report it down under latency well within
+        # `timeout`.
+        future = ex.submit(backend.check_health, timeout=timeout)
         ok = bool(future.result(timeout=timeout))
         return (ok, None if ok else "health check returned False")
     except concurrent.futures.TimeoutError:

--- a/fighthealthinsurance/fax_health_status.py
+++ b/fighthealthinsurance/fax_health_status.py
@@ -34,15 +34,19 @@ def _probe_backend(backend: Any, timeout: float) -> tuple[bool, Optional[str]]:
     not-ok with a descriptive error rather than propagating, so one slow/broken
     backend never takes down the whole status page.
     """
+    ex = concurrent.futures.ThreadPoolExecutor(max_workers=1)
     try:
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
-            future = ex.submit(backend.check_health)
-            ok = bool(future.result(timeout=timeout))
-            return (ok, None if ok else "health check returned False")
+        future = ex.submit(backend.check_health)
+        ok = bool(future.result(timeout=timeout))
+        return (ok, None if ok else "health check returned False")
     except concurrent.futures.TimeoutError:
         return (False, f"timeout>{timeout}s")
     except Exception as e:
         return (False, str(e))
+    finally:
+        # Don't let exiting the executor block on a hung probe (a `with` block
+        # would shutdown(wait=True) and join it); make `timeout` a real cap.
+        ex.shutdown(wait=False, cancel_futures=True)
 
 
 def check_fax_backends_health(probe_timeout: float = 10.0) -> Dict[str, Any]:

--- a/fighthealthinsurance/fax_utils.py
+++ b/fighthealthinsurance/fax_utils.py
@@ -120,18 +120,33 @@ class SonicFax(FaxSenderBase):
             "SONIC_NOTIFICATION_EMAIL", "support42@fighthealthinsurance.com"
         )
 
-    def check_health(self, timeout: float = 4.0) -> bool:
+    def check_health(self, timeout: float = 3.0) -> bool:
         """Verify we can authenticate against the Sonic fax service.
 
-        Performs a login round-trip (network call) and returns ``True`` when it
-        succeeds. ``_login`` raises if credentials are rejected or Sonic is
-        unreachable, so any failure surfaces as an exception to the caller.
+        Logs in and then confirms the session can actually reach a
+        members-only page. ``_login`` alone only rejects a response that
+        contains the literal ``"Member Login"`` text, so a 4xx/5xx or
+        maintenance page would otherwise be treated as a successful login.
+        Here we additionally require the fax page to return HTTP 2xx
+        (``raise_for_status``) and not be the login form, so the dashboard
+        only reports Sonic healthy when it genuinely is.
 
-        ``timeout`` is applied per HTTP request so a hung/slow Sonic can't stall
-        the caller (e.g. the staff status page) indefinitely.
+        ``timeout`` is applied per HTTP request so a hung/slow Sonic can't
+        stall the caller (e.g. the staff status page) indefinitely.
         """
         with requests.Session() as s:
-            self._login(s, timeout=timeout)
+            cookies = self._login(s, timeout=timeout)
+            r = s.get(
+                "https://members.sonic.net/labs/fax/?a=history",
+                headers=self.headers,
+                cookies=cookies,
+                timeout=timeout,
+            )
+            # 4xx/5xx (incl. 403/500/maintenance) -> not healthy.
+            r.raise_for_status()
+            # A bounced/expired session renders the login form instead.
+            if "Member Login" in r.text:
+                raise Exception("Sonic session not authenticated (got login page)")
             return True
 
     async def send_fax_blocking(

--- a/fighthealthinsurance/fax_utils.py
+++ b/fighthealthinsurance/fax_utils.py
@@ -75,6 +75,16 @@ class FaxSenderBase(object):
     ) -> bool:
         return True
 
+    def check_health(self) -> bool:
+        """Return whether this backend is healthy.
+
+        Base backends are assumed healthy once configured; only backends that
+        support a cheap liveness probe (e.g. :class:`SonicFax`, which can do a
+        login round-trip) override this. Callers should wrap this in a timeout
+        since an override may make a network call.
+        """
+        return True
+
 
 class SonicFax(FaxSenderBase):
     base_cost = 10
@@ -110,6 +120,20 @@ class SonicFax(FaxSenderBase):
             "SONIC_NOTIFICATION_EMAIL", "support42@fighthealthinsurance.com"
         )
 
+    def check_health(self, timeout: float = 4.0) -> bool:
+        """Verify we can authenticate against the Sonic fax service.
+
+        Performs a login round-trip (network call) and returns ``True`` when it
+        succeeds. ``_login`` raises if credentials are rejected or Sonic is
+        unreachable, so any failure surfaces as an exception to the caller.
+
+        ``timeout`` is applied per HTTP request so a hung/slow Sonic can't stall
+        the caller (e.g. the staff status page) indefinitely.
+        """
+        with requests.Session() as s:
+            self._login(s, timeout=timeout)
+            return True
+
     async def send_fax_blocking(
         self, destination: str, path: str, dest_name: Optional[str] = None
     ) -> bool:
@@ -130,14 +154,20 @@ class SonicFax(FaxSenderBase):
                 dest_name=dest_name,
             )
 
-    def _login(self, s: Session) -> dict[str, str]:
+    def _login(self, s: Session, timeout: Optional[float] = None) -> dict[str, str]:
         cookies = {"mt2FAToken": self.token}
-        r = s.get("https://members.sonic.net/", headers=self.headers, cookies=cookies)
+        r = s.get(
+            "https://members.sonic.net/",
+            headers=self.headers,
+            cookies=cookies,
+            timeout=timeout,
+        )
         r = s.post(
             "https://members.sonic.net/",
             data={"login": "login", "user": self.username, "pw": self.password},
             headers=self.headers,
             cookies=cookies,
+            timeout=timeout,
         )
         if "Member Login" in r.text:
             raise Exception(f"Error logging into sonic got back {r.text}")

--- a/fighthealthinsurance/fax_utils.py
+++ b/fighthealthinsurance/fax_utils.py
@@ -75,13 +75,13 @@ class FaxSenderBase(object):
     ) -> bool:
         return True
 
-    def check_health(self) -> bool:
+    def check_health(self, timeout: Optional[float] = None) -> bool:
         """Return whether this backend is healthy.
 
         Base backends are assumed healthy once configured; only backends that
         support a cheap liveness probe (e.g. :class:`SonicFax`, which can do a
-        login round-trip) override this. Callers should wrap this in a timeout
-        since an override may make a network call.
+        login round-trip) override this. ``timeout`` is accepted (and ignored
+        here) so callers can pass a probe budget uniformly to any backend.
         """
         return True
 

--- a/fighthealthinsurance/fax_utils.py
+++ b/fighthealthinsurance/fax_utils.py
@@ -120,7 +120,7 @@ class SonicFax(FaxSenderBase):
             "SONIC_NOTIFICATION_EMAIL", "support42@fighthealthinsurance.com"
         )
 
-    def check_health(self, timeout: float = 3.0) -> bool:
+    def check_health(self, timeout: Optional[float] = None) -> bool:
         """Verify we can authenticate against the Sonic fax service.
 
         Logs in and then confirms the session can actually reach a
@@ -132,8 +132,13 @@ class SonicFax(FaxSenderBase):
         only reports Sonic healthy when it genuinely is.
 
         ``timeout`` is applied per HTTP request so a hung/slow Sonic can't
-        stall the caller (e.g. the staff status page) indefinitely.
+        stall the caller (e.g. the staff status page) indefinitely; it
+        defaults to 3s when not supplied. The signature matches
+        ``FaxSenderBase.check_health`` (``Optional[float]``) so the probe can
+        pass its budget uniformly to any backend.
         """
+        if timeout is None:
+            timeout = 3.0
         with requests.Session() as s:
             cookies = self._login(s, timeout=timeout)
             r = s.get(

--- a/fighthealthinsurance/ml/health_status.py
+++ b/fighthealthinsurance/ml/health_status.py
@@ -304,5 +304,59 @@ class _HealthStatus:
         self._schedule_refresh()
 
 
+def compute_model_health_details(timeout_seconds: int = 8) -> List[Dict[str, Any]]:
+    """Run a fresh, uncached health check across every known model backend.
+
+    Unlike :meth:`_HealthStatus.get_snapshot`, which returns a cached summary
+    (used by the public ``live_models_status`` endpoint and deliberately keeps
+    internal failures out of ``details``), this returns a full per-backend
+    breakdown — ``{"name", "ok", "external", "error"}`` — for the staff-only
+    system status dashboard. It does not send alerts or mutate the cached
+    snapshot.
+
+    Checks run in parallel with a shared deadline; a backend whose check has
+    not finished by ``timeout_seconds`` is reported as not-ok with a timeout
+    error. Results are sorted problems-first (down before up, internal before
+    external, then by name) so on-call sees failures at the top.
+    """
+    try:
+        candidates = list(ml_router_module.ml_router.all_models_by_cost)
+    except Exception as e:
+        logger.warning(f"compute_model_health_details could not enumerate models: {e}")
+        return []
+
+    results: List[Dict[str, Any]] = []
+    if not candidates:
+        return results
+
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=min(8, len(candidates))
+    ) as ex:
+        future_map = {ex.submit(m.model_is_ok): m for m in candidates}
+        concurrent.futures.wait(future_map, timeout=timeout_seconds)
+        for future, m in future_map.items():
+            name = str(
+                getattr(m, "model", None) or getattr(m, "__class__", type(m)).__name__
+            )
+            is_external = bool(getattr(m, "external", True))
+            ok = False
+            err: Optional[str] = None
+            if future.done():
+                try:
+                    ok = bool(future.result(timeout=0))
+                    if not ok:
+                        err = "not ok"
+                except Exception as e:
+                    err = str(e)
+            else:
+                err = f"timeout>{timeout_seconds}s"
+            results.append(
+                {"name": name, "ok": ok, "external": is_external, "error": err}
+            )
+
+    results.sort(key=lambda r: (r["ok"], r["external"], r["name"]))
+    return results
+
+
 # Singleton used by views
 health_status = _HealthStatus()

--- a/fighthealthinsurance/ml/health_status.py
+++ b/fighthealthinsurance/ml/health_status.py
@@ -321,9 +321,14 @@ def compute_model_health_details(timeout_seconds: int = 8) -> List[Dict[str, Any
     """
     try:
         candidates = list(ml_router_module.ml_router.all_models_by_cost)
-    except Exception as e:
-        logger.warning(f"compute_model_health_details could not enumerate models: {e}")
-        return []
+    except Exception:
+        # Propagate rather than returning [] — an empty list is indistinguishable
+        # from "no models registered" and would let the caller (_model_status)
+        # report a broken router as a healthy "0 backends" instead of an error.
+        logger.opt(exception=True).warning(
+            "compute_model_health_details could not enumerate models"
+        )
+        raise
 
     results: List[Dict[str, Any]] = []
     if not candidates:

--- a/fighthealthinsurance/ml/health_status.py
+++ b/fighthealthinsurance/ml/health_status.py
@@ -329,9 +329,8 @@ def compute_model_health_details(timeout_seconds: int = 8) -> List[Dict[str, Any
     if not candidates:
         return results
 
-    with concurrent.futures.ThreadPoolExecutor(
-        max_workers=min(8, len(candidates))
-    ) as ex:
+    ex = concurrent.futures.ThreadPoolExecutor(max_workers=min(8, len(candidates)))
+    try:
         future_map = {ex.submit(m.model_is_ok): m for m in candidates}
         concurrent.futures.wait(future_map, timeout=timeout_seconds)
         for future, m in future_map.items():
@@ -353,6 +352,14 @@ def compute_model_health_details(timeout_seconds: int = 8) -> List[Dict[str, Any
             results.append(
                 {"name": name, "ok": ok, "external": is_external, "error": err}
             )
+    finally:
+        # Return at the deadline rather than blocking on stragglers. Exiting a
+        # `with ThreadPoolExecutor()` calls shutdown(wait=True), which joins
+        # every submitted probe — so a single hung/slow model_is_ok() would
+        # stall the staff status request well past timeout_seconds, defeating
+        # the bounded live check. Cancel queued probes and let any in-flight
+        # ones finish in the background instead.
+        ex.shutdown(wait=False, cancel_futures=True)
 
     results.sort(key=lambda r: (r["ok"], r["external"], r["name"]))
     return results

--- a/fighthealthinsurance/staff_views.py
+++ b/fighthealthinsurance/staff_views.py
@@ -116,12 +116,18 @@ class AdminStatusView(generic.TemplateView):
 
     @staticmethod
     def _model_status() -> Dict[str, Any]:
-        """ML model backend health (fresh, per-backend) plus router summary."""
+        """ML model backend health: a fresh, per-backend probe plus router summary.
+
+        Uses ``compute_model_health_details`` (a standalone check) rather than
+        ``health_status.get_snapshot``. The latter, on first access, runs its
+        own full refresh *and* can fire an alert email / start a background
+        timer — surprising side effects to attach to rendering a status page,
+        and a redundant second check pass. ``generated_at`` conveys freshness.
+        """
         out: Dict[str, Any] = {"ok": True, "error": None, "details": []}
         try:
             from fighthealthinsurance.ml.health_status import (
                 compute_model_health_details,
-                health_status,
             )
             from fighthealthinsurance.ml.ml_router import ml_router
 
@@ -134,14 +140,6 @@ class AdminStatusView(generic.TemplateView):
             )
             out["internal_total"] = sum(1 for d in details if not d["external"])
             out["working"] = ml_router.working()
-
-            snapshot = health_status.get_snapshot()
-            last_checked = snapshot.get("last_checked")
-            out["last_background_check"] = (
-                datetime.datetime.fromtimestamp(last_checked, tz=datetime.timezone.utc)
-                if last_checked
-                else None
-            )
         except Exception as e:
             logger.opt(exception=True).error("Error computing model status")
             out["ok"] = False

--- a/fighthealthinsurance/staff_views.py
+++ b/fighthealthinsurance/staff_views.py
@@ -87,6 +87,168 @@ class StaffDashboardView(generic.TemplateView):
     template_name = "staff_dashboard.html"
 
 
+class AdminStatusView(generic.TemplateView):
+    """Staff system-status dashboard.
+
+    A one-stop live health view for on-call: which ML model backends are up,
+    Ray polling-actor health, whether the Sonic fax backend can authenticate,
+    queued/pending fax counts, and external storage reachability.
+
+    Each subsystem is gathered independently and wrapped in its own error
+    handling so a single failing check degrades to an error row instead of
+    breaking the whole page. The model and Sonic checks make live network
+    calls (bounded by timeouts), so this page is intentionally staff-only and
+    a little slower than a cached endpoint.
+    """
+
+    template_name = "admin_status.html"
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx["title"] = "System Status"
+        ctx["generated_at"] = timezone.now()
+        ctx["models"] = self._model_status()
+        ctx["actors"] = self._actor_status()
+        ctx["fax"] = self._fax_backend_status()
+        ctx["fax_queue"] = self._fax_queue_status()
+        ctx["storage"] = self._storage_status()
+        return ctx
+
+    @staticmethod
+    def _model_status() -> Dict[str, Any]:
+        """ML model backend health (fresh, per-backend) plus router summary."""
+        out: Dict[str, Any] = {"ok": True, "error": None, "details": []}
+        try:
+            from fighthealthinsurance.ml.health_status import (
+                compute_model_health_details,
+                health_status,
+            )
+            from fighthealthinsurance.ml.ml_router import ml_router
+
+            details = compute_model_health_details()
+            out["details"] = details
+            out["alive"] = sum(1 for d in details if d["ok"])
+            out["total"] = len(details)
+            out["internal_alive"] = sum(
+                1 for d in details if d["ok"] and not d["external"]
+            )
+            out["internal_total"] = sum(1 for d in details if not d["external"])
+            out["working"] = ml_router.working()
+
+            snapshot = health_status.get_snapshot()
+            last_checked = snapshot.get("last_checked")
+            out["last_background_check"] = (
+                datetime.datetime.fromtimestamp(last_checked, tz=datetime.timezone.utc)
+                if last_checked
+                else None
+            )
+        except Exception as e:
+            logger.opt(exception=True).error("Error computing model status")
+            out["ok"] = False
+            out["error"] = str(e)
+        return out
+
+    @staticmethod
+    def _actor_status() -> Dict[str, Any]:
+        """Ray polling-actor health via the shared check_actor_health helper."""
+        out: Dict[str, Any] = {
+            "ok": True,
+            "error": None,
+            "details": [],
+            "alive_actors": 0,
+            "total_actors": 0,
+        }
+        try:
+            from fighthealthinsurance.actor_health_status import check_actor_health
+
+            out.update(check_actor_health())
+        except Exception as e:
+            logger.opt(exception=True).error("Error checking actor health")
+            out["ok"] = False
+            out["error"] = str(e)
+        return out
+
+    @staticmethod
+    def _fax_backend_status() -> Dict[str, Any]:
+        """Fax backend health, including a live Sonic login probe."""
+        out: Dict[str, Any] = {
+            "ok": True,
+            "error": None,
+            "backends": [],
+            "sonic": {"configured": False, "active": False, "ok": False, "error": None},
+        }
+        try:
+            from fighthealthinsurance.fax_health_status import (
+                check_fax_backends_health,
+            )
+
+            out.update(check_fax_backends_health())
+        except Exception as e:
+            logger.opt(exception=True).error("Error checking fax backends")
+            out["ok"] = False
+            out["error"] = str(e)
+            out["sonic"] = {
+                "configured": False,
+                "active": False,
+                "ok": False,
+                "error": str(e),
+            }
+        return out
+
+    @staticmethod
+    def _fax_queue_status() -> Dict[str, Any]:
+        """Counts of queued / pending / failed faxes from FaxesToSend.
+
+        Mirrors what the fax actor acts on: it sends faxes that are
+        ``should_send=True, sent=False`` and at least an hour old.
+        """
+        out: Dict[str, Any] = {"ok": True, "error": None}
+        try:
+            from fighthealthinsurance.models import FaxesToSend
+
+            now = timezone.now()
+            one_hour_ago = now - datetime.timedelta(hours=1)
+            week_ago = now - datetime.timedelta(days=7)
+
+            unsent = FaxesToSend.objects.filter(sent=False)
+            out["unsent_total"] = unsent.count()
+            out["ready_queued"] = unsent.filter(should_send=True).count()
+            out["due_now"] = unsent.filter(
+                should_send=True, date__lt=one_hour_ago
+            ).count()
+            out["awaiting_confirmation"] = unsent.filter(should_send=False).count()
+            out["in_flight"] = unsent.filter(
+                attempting_to_send_as_of__isnull=False
+            ).count()
+            out["failures_recent"] = FaxesToSend.objects.filter(
+                sent=True, fax_success=False, date__gte=week_ago
+            ).count()
+        except Exception as e:
+            logger.opt(exception=True).error("Error computing fax queue status")
+            out["ok"] = False
+            out["error"] = str(e)
+        return out
+
+    @staticmethod
+    def _storage_status() -> Dict[str, Any]:
+        """Whether the external (encrypted) storage backend is reachable."""
+        out: Dict[str, Any] = {"ok": False, "error": None}
+        try:
+            from django.conf import settings
+            from stopit import ThreadingTimeout as Timeout
+
+            es = settings.EXTERNAL_STORAGE
+            with Timeout(3.0):
+                es.listdir("./")
+                out["ok"] = True
+                return out
+            out["error"] = "timeout"
+        except Exception as e:
+            logger.opt(exception=True).warning("External storage health check failed")
+            out["error"] = str(e)
+        return out
+
+
 class ScheduleFollowUps(View):
     """A view to go through and schedule any missing follow ups.
 

--- a/fighthealthinsurance/templates/admin_status.html
+++ b/fighthealthinsurance/templates/admin_status.html
@@ -1,4 +1,3 @@
-{% load static %}
 <!DOCTYPE html>
 <html>
 <head>

--- a/fighthealthinsurance/templates/admin_status.html
+++ b/fighthealthinsurance/templates/admin_status.html
@@ -1,0 +1,202 @@
+{% load static %}
+<!DOCTYPE html>
+<html>
+<head>
+  <title>{{ title }}</title>
+  <style>
+    body { font-family: Arial, sans-serif; max-width: 1100px; margin: 0 auto; padding: 20px; background: #f5f5f5; color: #222; }
+    h1 { color: #333; border-bottom: 2px solid #007bff; padding-bottom: 10px; }
+    h2 { color: #555; margin-top: 0; border-left: 4px solid #007bff; padding-left: 10px; }
+    .status-section { background: white; padding: 20px; border-radius: 8px; margin-bottom: 20px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+    .nav-back { display: inline-block; margin-bottom: 14px; color: #007bff; text-decoration: none; }
+    .nav-back:hover { text-decoration: underline; }
+    .meta { color: #666; font-size: 0.9em; margin-bottom: 18px; }
+    .meta a { color: #007bff; }
+    .summary-line { font-size: 1.05em; margin: 6px 0 12px 0; }
+    table.status { width: 100%; border-collapse: collapse; margin-top: 8px; }
+    table.status th, table.status td { padding: 6px 10px; text-align: left; border-bottom: 1px solid #eee; }
+    table.status th { background: #f0f4f8; }
+    table.status td.num, table.status th.num { text-align: right; }
+    .badge { display: inline-block; padding: 2px 10px; border-radius: 12px; font-size: 0.82em; font-weight: bold; color: white; }
+    .badge.ok { background: #28a745; }
+    .badge.bad { background: #dc3545; }
+    .badge.warn { background: #f0ad4e; color: #333; }
+    .badge.unknown { background: #adb5bd; }
+    .error-text { color: #dc3545; font-size: 0.85em; }
+    .pill { display: inline-block; padding: 1px 8px; border-radius: 10px; font-size: 0.78em; background: #e9ecef; color: #555; }
+    .stat-grid { display: flex; flex-wrap: wrap; gap: 14px; margin-top: 8px; }
+    .stat-card { flex: 1 1 140px; background: #f8f9fa; border: 1px solid #dee2e6; border-radius: 6px; padding: 12px 14px; }
+    .stat-card .value { font-size: 1.8em; font-weight: bold; color: #333; }
+    .stat-card .label { font-size: 0.85em; color: #666; margin-top: 2px; }
+    .stat-card.alert .value { color: #dc3545; }
+  </style>
+</head>
+<body>
+  <a class="nav-back" href="{% url 'staff_dashboard' %}">&laquo; Back to Staff Dashboard</a>
+  <h1>{{ title }}</h1>
+  <p class="meta">
+    Generated {{ generated_at }} &middot;
+    <a href="">Refresh</a> &middot;
+    Model and Sonic checks run live (bounded by timeouts), so this page may take a few seconds.
+  </p>
+
+  {# ---------------- ML Models ---------------- #}
+  <div class="status-section">
+    <h2>🧠 ML Model Backends</h2>
+    {% if models.error %}
+      <p><span class="badge bad">ERROR</span> <span class="error-text">{{ models.error }}</span></p>
+    {% else %}
+      <p class="summary-line">
+        {% if models.working and models.internal_alive %}
+          <span class="badge ok">UP</span>
+        {% elif models.alive %}
+          <span class="badge warn">DEGRADED</span>
+        {% else %}
+          <span class="badge bad">DOWN</span>
+        {% endif %}
+        &nbsp;{{ models.alive }} / {{ models.total }} backends responding
+        ({{ models.internal_alive }} / {{ models.internal_total }} internal)
+        &middot; router working: {{ models.working|yesno:"yes,no" }}
+      </p>
+      {% if models.last_background_check %}
+        <p class="meta">Last background snapshot: {{ models.last_background_check }} ({{ models.last_background_check|timesince }} ago)</p>
+      {% endif %}
+      {% if models.details %}
+      <table class="status">
+        <thead><tr><th>Model</th><th>Type</th><th>Status</th><th>Error</th></tr></thead>
+        <tbody>
+        {% for d in models.details %}
+          <tr>
+            <td>{{ d.name }}</td>
+            <td><span class="pill">{% if d.external %}external{% else %}internal{% endif %}</span></td>
+            <td>{% if d.ok %}<span class="badge ok">up</span>{% else %}<span class="badge bad">down</span>{% endif %}</td>
+            <td class="error-text">{{ d.error|default:"" }}</td>
+          </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+      {% else %}
+        <p class="meta">No model backends registered.</p>
+      {% endif %}
+    {% endif %}
+  </div>
+
+  {# ---------------- Ray Actors ---------------- #}
+  <div class="status-section">
+    <h2>⚙️ Ray Polling Actors</h2>
+    {% if actors.error %}
+      <p><span class="badge bad">ERROR</span> <span class="error-text">{{ actors.error }}</span></p>
+    {% else %}
+      <p class="summary-line">
+        {% if actors.alive_actors == actors.total_actors %}
+          <span class="badge ok">ALL UP</span>
+        {% elif actors.alive_actors %}
+          <span class="badge warn">DEGRADED</span>
+        {% else %}
+          <span class="badge bad">DOWN</span>
+        {% endif %}
+        &nbsp;{{ actors.alive_actors }} / {{ actors.total_actors }} actors alive
+      </p>
+      <table class="status">
+        <thead><tr><th>Actor</th><th>Status</th><th>Error</th></tr></thead>
+        <tbody>
+        {% for d in actors.details %}
+          <tr>
+            <td>{{ d.name }}</td>
+            <td>{% if d.alive %}<span class="badge ok">alive</span>{% else %}<span class="badge bad">down</span>{% endif %}</td>
+            <td class="error-text">{{ d.error|default:"" }}</td>
+          </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+    {% endif %}
+  </div>
+
+  {# ---------------- Fax Backends / Sonic ---------------- #}
+  <div class="status-section">
+    <h2>📠 Fax Backends</h2>
+    <p class="summary-line">
+      Sonic:
+      {% if not fax.sonic.configured %}
+        <span class="badge unknown">NOT CONFIGURED</span>
+      {% elif fax.sonic.ok %}
+        <span class="badge ok">WORKING</span>
+      {% else %}
+        <span class="badge bad">NOT WORKING</span>
+      {% endif %}
+      {% if fax.sonic.error %}<span class="error-text">&nbsp;{{ fax.sonic.error }}</span>{% endif %}
+    </p>
+    {% if fax.error %}
+      <p><span class="badge bad">ERROR</span> <span class="error-text">{{ fax.error }}</span></p>
+    {% endif %}
+    {% if fax.backends %}
+    <table class="status">
+      <thead><tr><th>Backend</th><th>Professional</th><th>Status</th><th>Error</th></tr></thead>
+      <tbody>
+      {% for b in fax.backends %}
+        <tr>
+          <td>{{ b.name }}</td>
+          <td>{{ b.professional|yesno:"yes,no" }}</td>
+          <td>
+            {% if b.ok %}<span class="badge ok">ok</span>{% else %}<span class="badge bad">down</span>{% endif %}
+            {% if not b.probed %}<span class="pill">not probed</span>{% endif %}
+          </td>
+          <td class="error-text">{{ b.error|default:"" }}</td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+    {% else %}
+      <p class="meta">No fax backends registered.</p>
+    {% endif %}
+  </div>
+
+  {# ---------------- Fax Queue ---------------- #}
+  <div class="status-section">
+    <h2>🗂️ Fax Queue</h2>
+    {% if fax_queue.error %}
+      <p><span class="badge bad">ERROR</span> <span class="error-text">{{ fax_queue.error }}</span></p>
+    {% else %}
+      <div class="stat-grid">
+        <div class="stat-card">
+          <div class="value">{{ fax_queue.unsent_total }}</div>
+          <div class="label">Unsent (total)</div>
+        </div>
+        <div class="stat-card">
+          <div class="value">{{ fax_queue.ready_queued }}</div>
+          <div class="label">Queued (should send)</div>
+        </div>
+        <div class="stat-card">
+          <div class="value">{{ fax_queue.due_now }}</div>
+          <div class="label">Due now (&gt;1h old)</div>
+        </div>
+        <div class="stat-card">
+          <div class="value">{{ fax_queue.awaiting_confirmation }}</div>
+          <div class="label">Awaiting confirmation</div>
+        </div>
+        <div class="stat-card {% if fax_queue.in_flight %}alert{% endif %}">
+          <div class="value">{{ fax_queue.in_flight }}</div>
+          <div class="label">In-flight / attempting</div>
+        </div>
+        <div class="stat-card {% if fax_queue.failures_recent %}alert{% endif %}">
+          <div class="value">{{ fax_queue.failures_recent }}</div>
+          <div class="label">Failures (last 7 days)</div>
+        </div>
+      </div>
+    {% endif %}
+  </div>
+
+  {# ---------------- Storage ---------------- #}
+  <div class="status-section">
+    <h2>💾 External Storage</h2>
+    <p class="summary-line">
+      {% if storage.ok %}
+        <span class="badge ok">REACHABLE</span>
+      {% else %}
+        <span class="badge bad">UNREACHABLE</span>
+      {% endif %}
+      {% if storage.error %}<span class="error-text">&nbsp;{{ storage.error }}</span>{% endif %}
+    </p>
+  </div>
+</body>
+</html>

--- a/fighthealthinsurance/templates/admin_status.html
+++ b/fighthealthinsurance/templates/admin_status.html
@@ -36,7 +36,7 @@
   <h1>{{ title }}</h1>
   <p class="meta">
     Generated {{ generated_at }} &middot;
-    <a href="">Refresh</a> &middot;
+    <a href="{% url 'admin_status' %}">Refresh</a> &middot;
     Model and Sonic checks run live (bounded by timeouts), so this page may take a few seconds.
   </p>
 
@@ -58,9 +58,6 @@
         ({{ models.internal_alive }} / {{ models.internal_total }} internal)
         &middot; router working: {{ models.working|yesno:"yes,no" }}
       </p>
-      {% if models.last_background_check %}
-        <p class="meta">Last background snapshot: {{ models.last_background_check }} ({{ models.last_background_check|timesince }} ago)</p>
-      {% endif %}
       {% if models.details %}
       <table class="status">
         <thead><tr><th>Model</th><th>Type</th><th>Status</th><th>Error</th></tr></thead>

--- a/fighthealthinsurance/templates/staff_dashboard.html
+++ b/fighthealthinsurance/templates/staff_dashboard.html
@@ -74,7 +74,19 @@
 </head>
 <body>
   <h1>Staff Dashboard</h1>
-  
+
+  <div class="dashboard-section">
+    <h2>🩺 System Status</h2>
+    <ul class="link-list">
+      <li>
+        <a href="{% url 'admin_status' %}">
+          <strong>System Status</strong>
+          <div class="link-description">Live health: ML models up, Ray actors, Sonic fax, queued faxes, and storage</div>
+        </a>
+      </li>
+    </ul>
+  </div>
+
   <div class="dashboard-section">
     <h2>📧 Email &amp; Communication</h2>
     <ul class="link-list">

--- a/fighthealthinsurance/urls.py
+++ b/fighthealthinsurance/urls.py
@@ -73,6 +73,11 @@ urlpatterns: List[Union[URLPattern, URLResolver]] = [
         name="staff_dashboard",
     ),
     path(
+        "timbit/help/status",
+        staff_member_required(staff_views.AdminStatusView.as_view()),
+        name="admin_status",
+    ),
+    path(
         "timbit/help/followup_sched",
         staff_member_required(staff_views.ScheduleFollowUps.as_view()),
     ),

--- a/tests/sync/test_admin_status.py
+++ b/tests/sync/test_admin_status.py
@@ -3,8 +3,11 @@ fax/model health helpers it relies on."""
 
 import datetime
 import os
+import threading
+import time
 from unittest import mock
 
+import requests
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls import reverse
@@ -129,9 +132,7 @@ class AdminStatusFaxQueueTest(TestCase):
         # C: awaiting confirmation (not marked should_send).
         self._make_fax(should_send=False, sent=False)
         # D: in-flight / attempting to send.
-        self._make_fax(
-            should_send=True, sent=False, attempting_to_send_as_of=now
-        )
+        self._make_fax(should_send=True, sent=False, attempting_to_send_as_of=now)
         # E: a recent failure.
         self._make_fax(should_send=True, sent=True, fax_success=False)
         # F: a success (must be ignored everywhere).
@@ -187,6 +188,51 @@ class ComputeModelHealthDetailsTest(TestCase):
         fake_router.all_models_by_cost = []
         with mock.patch("fighthealthinsurance.ml.ml_router.ml_router", fake_router):
             self.assertEqual(compute_model_health_details(), [])
+
+    def test_returns_at_deadline_without_blocking_on_hung_probe(self):
+        """A hung model_is_ok() must not stall the call past the deadline.
+
+        Regression for the executor shutdown(wait=True) gap: the call must
+        return ~timeout_seconds with the slow backend marked as a timeout,
+        not block until the hung probe finishes.
+        """
+        from fighthealthinsurance.ml.health_status import compute_model_health_details
+
+        release = threading.Event()
+
+        class Slow:
+            model = "slow-internal"
+            external = False
+
+            def model_is_ok(self):
+                # Blocks well past the deadline unless released.
+                release.wait(timeout=10)
+                return True
+
+        class Fast:
+            model = "fast-internal"
+            external = False
+
+            def model_is_ok(self):
+                return True
+
+        fake_router = mock.MagicMock()
+        fake_router.all_models_by_cost = [Slow(), Fast()]
+        try:
+            with mock.patch("fighthealthinsurance.ml.ml_router.ml_router", fake_router):
+                start = time.monotonic()
+                details = compute_model_health_details(timeout_seconds=1)
+                elapsed = time.monotonic() - start
+
+            # Returned promptly at the deadline, not after the 10s hung probe.
+            self.assertLess(elapsed, 5)
+            by_name = {d["name"]: d for d in details}
+            self.assertTrue(by_name["fast-internal"]["ok"])
+            self.assertFalse(by_name["slow-internal"]["ok"])
+            self.assertIn("timeout", by_name["slow-internal"]["error"] or "")
+        finally:
+            # Let the orphaned probe thread finish so it doesn't linger.
+            release.set()
 
 
 class FaxBackendsHealthTest(TestCase):
@@ -250,29 +296,60 @@ class FaxBackendsHealthTest(TestCase):
         self.assertFalse(result["backends"][0]["probed"])
 
 
+_LOGIN = "fighthealthinsurance.fax_utils.SonicFax._login"
+_SESSION_GET = "requests.Session.get"
+_SONIC_ENV = {"SONIC_USERNAME": "u", "SONIC_PASSWORD": "p", "SONIC_TOKEN": "t"}
+
+
+def _members_response(text="Fax Console", http_error=False):
+    """Fake members-page response for the post-login verification GET."""
+    resp = mock.Mock()
+    resp.text = text
+    resp.raise_for_status = mock.Mock(
+        side_effect=requests.HTTPError("500") if http_error else None
+    )
+    return resp
+
+
 class SonicCheckHealthTest(TestCase):
-    @mock.patch.dict(
-        os.environ,
-        {"SONIC_USERNAME": "u", "SONIC_PASSWORD": "p", "SONIC_TOKEN": "t"},
-    )
-    def test_check_health_true_on_successful_login(self):
+    @mock.patch.dict(os.environ, _SONIC_ENV)
+    @mock.patch(_SESSION_GET)
+    @mock.patch(_LOGIN, return_value={"c": "v"})
+    def test_check_health_true_when_login_and_members_page_ok(
+        self, mock_login, mock_get
+    ):
         from fighthealthinsurance.fax_utils import SonicFax
 
-        sonic = SonicFax()
-        with mock.patch.object(SonicFax, "_login", return_value={"c": "v"}) as m:
-            self.assertTrue(sonic.check_health())
-        m.assert_called_once()
+        mock_get.return_value = _members_response()
+        self.assertTrue(SonicFax().check_health())
+        mock_login.assert_called_once()
 
-    @mock.patch.dict(
-        os.environ,
-        {"SONIC_USERNAME": "u", "SONIC_PASSWORD": "p", "SONIC_TOKEN": "t"},
-    )
-    def test_check_health_propagates_login_failure(self):
+    @mock.patch.dict(os.environ, _SONIC_ENV)
+    @mock.patch(_LOGIN, side_effect=Exception("login rejected"))
+    def test_check_health_propagates_login_failure(self, mock_login):
         from fighthealthinsurance.fax_utils import SonicFax
 
-        sonic = SonicFax()
-        with mock.patch.object(
-            SonicFax, "_login", side_effect=Exception("login rejected")
-        ):
-            with self.assertRaises(Exception):
-                sonic.check_health()
+        with self.assertRaises(Exception):
+            SonicFax().check_health()
+
+    @mock.patch.dict(os.environ, _SONIC_ENV)
+    @mock.patch(_SESSION_GET)
+    @mock.patch(_LOGIN, return_value={"c": "v"})
+    def test_check_health_raises_on_http_error(self, mock_login, mock_get):
+        """A 4xx/5xx members page (e.g. 500/maintenance) is not healthy."""
+        from fighthealthinsurance.fax_utils import SonicFax
+
+        mock_get.return_value = _members_response(http_error=True)
+        with self.assertRaises(requests.HTTPError):
+            SonicFax().check_health()
+
+    @mock.patch.dict(os.environ, _SONIC_ENV)
+    @mock.patch(_SESSION_GET)
+    @mock.patch(_LOGIN, return_value={"c": "v"})
+    def test_check_health_raises_when_bounced_to_login(self, mock_login, mock_get):
+        """A 200 that is really the login form must not count as healthy."""
+        from fighthealthinsurance.fax_utils import SonicFax
+
+        mock_get.return_value = _members_response(text="Please Member Login")
+        with self.assertRaises(Exception):
+            SonicFax().check_health()

--- a/tests/sync/test_admin_status.py
+++ b/tests/sync/test_admin_status.py
@@ -26,7 +26,6 @@ class _FakeBackend:
 
 # Patch targets for the lazily-imported subsystem checks the view calls.
 _MODELS = "fighthealthinsurance.ml.health_status.compute_model_health_details"
-_SNAPSHOT = "fighthealthinsurance.ml.health_status.health_status.get_snapshot"
 _ACTORS = "fighthealthinsurance.actor_health_status.check_actor_health"
 _FAX = "fighthealthinsurance.fax_health_status.check_fax_backends_health"
 
@@ -55,19 +54,13 @@ class AdminStatusAccessTest(TestCase):
 
     @mock.patch(_FAX)
     @mock.patch(_ACTORS)
-    @mock.patch(_SNAPSHOT)
     @mock.patch(_MODELS)
     def test_staff_user_gets_200_and_renders_sections(
-        self, mock_models, mock_snap, mock_actors, mock_fax
+        self, mock_models, mock_actors, mock_fax
     ):
         mock_models.return_value = [
             {"name": "fhi-2025", "ok": True, "external": False, "error": None}
         ]
-        mock_snap.return_value = {
-            "alive_models": 1,
-            "last_checked": None,
-            "details": [],
-        }
         mock_actors.return_value = {
             "alive_actors": 6,
             "total_actors": 6,
@@ -116,15 +109,9 @@ class AdminStatusFaxQueueTest(TestCase):
 
     @mock.patch(_FAX)
     @mock.patch(_ACTORS)
-    @mock.patch(_SNAPSHOT)
     @mock.patch(_MODELS)
-    def test_fax_queue_counts(self, mock_models, mock_snap, mock_actors, mock_fax):
+    def test_fax_queue_counts(self, mock_models, mock_actors, mock_fax):
         mock_models.return_value = []
-        mock_snap.return_value = {
-            "alive_models": 0,
-            "last_checked": None,
-            "details": [],
-        }
         mock_actors.return_value = {
             "alive_actors": 0,
             "total_actors": 6,

--- a/tests/sync/test_admin_status.py
+++ b/tests/sync/test_admin_status.py
@@ -50,8 +50,15 @@ def _ok_fax_backends():
 
 
 class AdminStatusAccessTest(TestCase):
-    def test_non_staff_redirected(self):
+    def test_anonymous_user_redirected(self):
         # staff_member_required redirects anonymous users to the admin login.
+        response = self.client.get(reverse("admin_status"))
+        self.assertEqual(response.status_code, 302)
+
+    def test_authenticated_non_staff_user_redirected(self):
+        # An authenticated but non-staff user is also bounced (not just anon).
+        User.objects.create_user(username="plain", password="pw123", is_staff=False)
+        self.client.login(username="plain", password="pw123")
         response = self.client.get(reverse("admin_status"))
         self.assertEqual(response.status_code, 302)
 
@@ -189,6 +196,19 @@ class ComputeModelHealthDetailsTest(TestCase):
         with mock.patch("fighthealthinsurance.ml.ml_router.ml_router", fake_router):
             self.assertEqual(compute_model_health_details(), [])
 
+    def test_enumeration_failure_propagates(self):
+        """A broken router must raise, not mask the failure as 0 backends."""
+        from fighthealthinsurance.ml.health_status import compute_model_health_details
+
+        class BrokenRouter:
+            @property
+            def all_models_by_cost(self):
+                raise RuntimeError("router not ready")
+
+        with mock.patch("fighthealthinsurance.ml.ml_router.ml_router", BrokenRouter()):
+            with self.assertRaisesRegex(RuntimeError, "router not ready"):
+                compute_model_health_details()
+
     def test_returns_at_deadline_without_blocking_on_hung_probe(self):
         """A hung model_is_ok() must not stall the call past the deadline.
 
@@ -325,11 +345,11 @@ class SonicCheckHealthTest(TestCase):
         mock_login.assert_called_once()
 
     @mock.patch.dict(os.environ, _SONIC_ENV)
-    @mock.patch(_LOGIN, side_effect=Exception("login rejected"))
+    @mock.patch(_LOGIN, side_effect=RuntimeError("login rejected"))
     def test_check_health_propagates_login_failure(self, mock_login):
         from fighthealthinsurance.fax_utils import SonicFax
 
-        with self.assertRaises(Exception):
+        with self.assertRaisesRegex(RuntimeError, "login rejected"):
             SonicFax().check_health()
 
     @mock.patch.dict(os.environ, _SONIC_ENV)
@@ -351,5 +371,5 @@ class SonicCheckHealthTest(TestCase):
         from fighthealthinsurance.fax_utils import SonicFax
 
         mock_get.return_value = _members_response(text="Please Member Login")
-        with self.assertRaises(Exception):
+        with self.assertRaisesRegex(Exception, "not authenticated"):
             SonicFax().check_health()

--- a/tests/sync/test_admin_status.py
+++ b/tests/sync/test_admin_status.py
@@ -1,0 +1,291 @@
+"""Tests for the staff system-status dashboard (AdminStatusView) and the
+fax/model health helpers it relies on."""
+
+import datetime
+import os
+from unittest import mock
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from fighthealthinsurance.models import FaxesToSend
+
+User = get_user_model()
+
+
+class _FakeBackend:
+    """A non-Sonic fax backend stand-in (never actively probed)."""
+
+    professional = False
+
+    def check_health(self) -> bool:  # pragma: no cover - should not be called
+        return True
+
+
+# Patch targets for the lazily-imported subsystem checks the view calls.
+_MODELS = "fighthealthinsurance.ml.health_status.compute_model_health_details"
+_SNAPSHOT = "fighthealthinsurance.ml.health_status.health_status.get_snapshot"
+_ACTORS = "fighthealthinsurance.actor_health_status.check_actor_health"
+_FAX = "fighthealthinsurance.fax_health_status.check_fax_backends_health"
+
+
+def _ok_fax_backends():
+    return {
+        "backends": [
+            {
+                "name": "SonicFax",
+                "ok": True,
+                "professional": False,
+                "probed": True,
+                "error": None,
+            }
+        ],
+        "total_backends": 1,
+        "sonic": {"configured": True, "active": True, "ok": True, "error": None},
+    }
+
+
+class AdminStatusAccessTest(TestCase):
+    def test_non_staff_redirected(self):
+        # staff_member_required redirects anonymous users to the admin login.
+        response = self.client.get(reverse("admin_status"))
+        self.assertEqual(response.status_code, 302)
+
+    @mock.patch(_FAX)
+    @mock.patch(_ACTORS)
+    @mock.patch(_SNAPSHOT)
+    @mock.patch(_MODELS)
+    def test_staff_user_gets_200_and_renders_sections(
+        self, mock_models, mock_snap, mock_actors, mock_fax
+    ):
+        mock_models.return_value = [
+            {"name": "fhi-2025", "ok": True, "external": False, "error": None}
+        ]
+        mock_snap.return_value = {
+            "alive_models": 1,
+            "last_checked": None,
+            "details": [],
+        }
+        mock_actors.return_value = {
+            "alive_actors": 6,
+            "total_actors": 6,
+            "details": [
+                {"name": "fax_polling_actor", "alive": True, "error": None},
+            ],
+        }
+        mock_fax.return_value = _ok_fax_backends()
+
+        User.objects.create_user(username="staff", password="pw123", is_staff=True)
+        self.client.login(username="staff", password="pw123")
+
+        response = self.client.get(reverse("admin_status"))
+        self.assertEqual(response.status_code, 200)
+        # All major sections present.
+        self.assertContains(response, "System Status")
+        self.assertContains(response, "ML Model Backends")
+        self.assertContains(response, "Ray Polling Actors")
+        self.assertContains(response, "Fax Backends")
+        self.assertContains(response, "Fax Queue")
+        self.assertContains(response, "External Storage")
+        # Surfaced details from the mocked subsystems.
+        self.assertContains(response, "fhi-2025")
+        self.assertContains(response, "fax_polling_actor")
+        # Sonic working badge.
+        self.assertContains(response, "WORKING")
+
+
+class AdminStatusFaxQueueTest(TestCase):
+    def setUp(self):
+        self.staff = User.objects.create_user(
+            username="staff", password="pw123", is_staff=True
+        )
+        self.client.login(username="staff", password="pw123")
+
+    def _make_fax(self, date=None, **kwargs):
+        defaults = dict(
+            hashed_email="h", paid=True, email="a@b.com", appeal_text="x", name="Test"
+        )
+        defaults.update(kwargs)
+        fax = FaxesToSend.objects.create(**defaults)
+        if date is not None:
+            # date is auto_now_add, so backdate via update() to bypass it.
+            FaxesToSend.objects.filter(pk=fax.pk).update(date=date)
+        return fax
+
+    @mock.patch(_FAX)
+    @mock.patch(_ACTORS)
+    @mock.patch(_SNAPSHOT)
+    @mock.patch(_MODELS)
+    def test_fax_queue_counts(self, mock_models, mock_snap, mock_actors, mock_fax):
+        mock_models.return_value = []
+        mock_snap.return_value = {
+            "alive_models": 0,
+            "last_checked": None,
+            "details": [],
+        }
+        mock_actors.return_value = {
+            "alive_actors": 0,
+            "total_actors": 6,
+            "details": [],
+        }
+        mock_fax.return_value = _ok_fax_backends()
+
+        now = timezone.now()
+        two_hours_ago = now - datetime.timedelta(hours=2)
+
+        # A: queued and due (older than 1h).
+        self._make_fax(should_send=True, sent=False, date=two_hours_ago)
+        # B: queued but recent (not yet due).
+        self._make_fax(should_send=True, sent=False)
+        # C: awaiting confirmation (not marked should_send).
+        self._make_fax(should_send=False, sent=False)
+        # D: in-flight / attempting to send.
+        self._make_fax(
+            should_send=True, sent=False, attempting_to_send_as_of=now
+        )
+        # E: a recent failure.
+        self._make_fax(should_send=True, sent=True, fax_success=False)
+        # F: a success (must be ignored everywhere).
+        self._make_fax(should_send=True, sent=True, fax_success=True)
+
+        response = self.client.get(reverse("admin_status"))
+        self.assertEqual(response.status_code, 200)
+        q = response.context["fax_queue"]
+        self.assertTrue(q["ok"])
+        self.assertEqual(q["unsent_total"], 4)  # A, B, C, D
+        self.assertEqual(q["ready_queued"], 3)  # A, B, D
+        self.assertEqual(q["due_now"], 1)  # A only
+        self.assertEqual(q["awaiting_confirmation"], 1)  # C
+        self.assertEqual(q["in_flight"], 1)  # D
+        self.assertEqual(q["failures_recent"], 1)  # E
+
+
+class ComputeModelHealthDetailsTest(TestCase):
+    def test_classifies_and_sorts_problems_first(self):
+        from fighthealthinsurance.ml.health_status import compute_model_health_details
+
+        class Good:
+            model = "good-internal"
+            external = False
+
+            def model_is_ok(self):
+                return True
+
+        class Bad:
+            model = "bad-external"
+            external = True
+
+            def model_is_ok(self):
+                return False
+
+        fake_router = mock.MagicMock()
+        fake_router.all_models_by_cost = [Good(), Bad()]
+        with mock.patch("fighthealthinsurance.ml.ml_router.ml_router", fake_router):
+            details = compute_model_health_details(timeout_seconds=2)
+
+        by_name = {d["name"]: d for d in details}
+        self.assertTrue(by_name["good-internal"]["ok"])
+        self.assertFalse(by_name["good-internal"]["external"])
+        self.assertFalse(by_name["bad-external"]["ok"])
+        self.assertTrue(by_name["bad-external"]["external"])
+        # Down backends sort first so on-call sees problems at the top.
+        self.assertFalse(details[0]["ok"])
+
+    def test_empty_router_returns_empty_list(self):
+        from fighthealthinsurance.ml.health_status import compute_model_health_details
+
+        fake_router = mock.MagicMock()
+        fake_router.all_models_by_cost = []
+        with mock.patch("fighthealthinsurance.ml.ml_router.ml_router", fake_router):
+            self.assertEqual(compute_model_health_details(), [])
+
+
+class FaxBackendsHealthTest(TestCase):
+    @mock.patch.dict(
+        os.environ,
+        {"SONIC_USERNAME": "u", "SONIC_PASSWORD": "p", "SONIC_TOKEN": "t"},
+    )
+    def test_sonic_probe_reports_working(self):
+        from fighthealthinsurance import fax_utils
+        from fighthealthinsurance.fax_health_status import check_fax_backends_health
+        from fighthealthinsurance.fax_utils import SonicFax
+
+        sonic = SonicFax()
+        sonic.check_health = mock.Mock(return_value=True)
+        with mock.patch.object(fax_utils.flexible_fax_magic, "backends", [sonic]):
+            result = check_fax_backends_health(probe_timeout=2.0)
+
+        self.assertTrue(result["sonic"]["active"])
+        self.assertTrue(result["sonic"]["configured"])
+        self.assertTrue(result["sonic"]["ok"])
+        self.assertEqual(result["total_backends"], 1)
+        self.assertEqual(result["backends"][0]["name"], "SonicFax")
+        self.assertTrue(result["backends"][0]["probed"])
+
+    @mock.patch.dict(
+        os.environ,
+        {"SONIC_USERNAME": "u", "SONIC_PASSWORD": "p", "SONIC_TOKEN": "t"},
+    )
+    def test_sonic_probe_reports_failure(self):
+        from fighthealthinsurance import fax_utils
+        from fighthealthinsurance.fax_health_status import check_fax_backends_health
+        from fighthealthinsurance.fax_utils import SonicFax
+
+        sonic = SonicFax()
+        sonic.check_health = mock.Mock(side_effect=Exception("bad login"))
+        with mock.patch.object(fax_utils.flexible_fax_magic, "backends", [sonic]):
+            result = check_fax_backends_health(probe_timeout=2.0)
+
+        self.assertTrue(result["sonic"]["active"])
+        self.assertFalse(result["sonic"]["ok"])
+        self.assertIn("bad login", result["sonic"]["error"])
+        self.assertFalse(result["backends"][0]["ok"])
+
+    def test_sonic_not_configured_reports_reason(self):
+        from fighthealthinsurance import fax_utils
+        from fighthealthinsurance.fax_health_status import check_fax_backends_health
+
+        with mock.patch.object(
+            fax_utils.flexible_fax_magic, "backends", [_FakeBackend()]
+        ):
+            with mock.patch.dict(os.environ, {}, clear=False):
+                for k in ("SONIC_USERNAME", "SONIC_PASSWORD", "SONIC_TOKEN"):
+                    os.environ.pop(k, None)
+                result = check_fax_backends_health()
+
+        self.assertFalse(result["sonic"]["configured"])
+        self.assertFalse(result["sonic"]["active"])
+        self.assertFalse(result["sonic"]["ok"])
+        self.assertEqual(result["total_backends"], 1)
+        self.assertEqual(result["backends"][0]["name"], "_FakeBackend")
+        self.assertFalse(result["backends"][0]["probed"])
+
+
+class SonicCheckHealthTest(TestCase):
+    @mock.patch.dict(
+        os.environ,
+        {"SONIC_USERNAME": "u", "SONIC_PASSWORD": "p", "SONIC_TOKEN": "t"},
+    )
+    def test_check_health_true_on_successful_login(self):
+        from fighthealthinsurance.fax_utils import SonicFax
+
+        sonic = SonicFax()
+        with mock.patch.object(SonicFax, "_login", return_value={"c": "v"}) as m:
+            self.assertTrue(sonic.check_health())
+        m.assert_called_once()
+
+    @mock.patch.dict(
+        os.environ,
+        {"SONIC_USERNAME": "u", "SONIC_PASSWORD": "p", "SONIC_TOKEN": "t"},
+    )
+    def test_check_health_propagates_login_failure(self):
+        from fighthealthinsurance.fax_utils import SonicFax
+
+        sonic = SonicFax()
+        with mock.patch.object(
+            SonicFax, "_login", side_effect=Exception("login rejected")
+        ):
+            with self.assertRaises(Exception):
+                sonic.check_health()


### PR DESCRIPTION
## Summary

Adds a new staff-only system-status dashboard (`AdminStatusView`) that provides a live, at-a-glance health view of critical subsystems: ML model backends, Ray polling actors, Sonic fax authentication, queued/pending faxes, and external storage reachability. This enables on-call staff to quickly diagnose system issues without needing to check multiple monitoring tools.

## Key Changes

- **New `AdminStatusView` (staff_views.py)**: A staff-only dashboard that gathers health status from five independent subsystems, each wrapped in error handling so a single failing check degrades gracefully rather than breaking the page.
  - ML model backends: fresh per-backend probe via new `compute_model_health_details()` helper
  - Ray polling actors: via existing `check_actor_health()` helper
  - Fax backends: via new `check_fax_backends_health()` helper with live Sonic login probe
  - Fax queue: counts of queued, due, in-flight, and failed faxes from `FaxesToSend`
  - External storage: reachability check with 3-second timeout

- **New `compute_model_health_details()` (ml/health_status.py)**: Runs a fresh, uncached health check across all known ML model backends in parallel with a shared deadline. Returns full per-backend breakdown sorted problems-first (down before up) so on-call sees failures at the top. Does not send alerts or mutate cached snapshots (unlike the existing `_HealthStatus.get_snapshot()`).

- **New `check_fax_backends_health()` (fax_health_status.py)**: Reports all registered fax backends and whether Sonic can authenticate. Probes Sonic with a live login round-trip under a timeout; other backends are reported as configured without active probes.

- **New `check_health()` method (fax_utils.py)**: Added to `FaxSenderBase` (returns `True` by default) and overridden in `SonicFax` to perform a login round-trip with configurable timeout. Enables cheap liveness checks for backends that support them.

- **New `admin_status.html` template**: Clean, responsive dashboard with sections for each subsystem, status badges (UP/DOWN/DEGRADED), per-item tables, and stat cards for fax queue metrics. Includes navigation back to staff dashboard and refresh link.

- **Updated staff dashboard**: Added "System Status" section with link to the new admin status view.

- **Updated URL routing**: Added `/timbit/help/status` route (staff-only via `@staff_member_required`) pointing to `AdminStatusView`.

## Implementation Details

- Each subsystem check is independent and wrapped in try/except to prevent cascading failures
- Model and Sonic checks make live network calls bounded by timeouts (8s and 10s respectively)
- Fax queue logic mirrors what the fax actor acts on: sends faxes that are `should_send=True, sent=False` and at least 1 hour old
- Results are sorted problems-first so critical issues appear at the top of the page
- Uses `concurrent.futures` for parallel health checks with deadline enforcement
- Comprehensive test coverage (278 lines) including access control, subsystem integration, and edge cases

https://claude.ai/code/session_01RAWz7a2s5Ea3pG8N2ZtQLY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a staff-only system status dashboard displaying real-time health information for ML model backends, Ray polling actors, fax backend connectivity (including login checks), message queue metrics, and external storage accessibility.

* **Tests**
  * Added comprehensive test coverage for the system status dashboard and underlying health-check functionality, including timeout handling and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->