### PR TITLE
Route to best available external models instead of cheapest

### DIFF
--- a/fighthealthinsurance/ml/health_status.py
+++ b/fighthealthinsurance/ml/health_status.py
@@ -27,21 +27,21 @@ ALERT_THROTTLE_SECONDS = 60 * 60  # at most one alert email per hour
 
 
 def _model_key(model: Any) -> str:
-    """Stable identifier for a backend instance, shared by the health sweep
+    """Stable per-instance identifier for a backend, shared by the health sweep
     (which records per-model results) and the router (which looks them up).
 
-    Prefers the unique friendly ``name`` the router stamps onto each registered
-    model (so two providers exposing the same wire ``model`` id — e.g. the
-    direct Anthropic API vs Azure Claude — don't collide), then the wire
-    ``model`` id, then the class name.
+    Keyed by object identity so distinct backend instances never collide — e.g.
+    internal replicas of one model on several hosts, or two providers exposing
+    the same wire ``model`` id — even when they share a friendly ``name``. The
+    sweep and the router operate on the same registered singleton instances, so
+    the identity matches across them; an unregistered/foreign instance simply
+    isn't found (``model_ok`` returns ``None`` -> the router fails open). A
+    readable prefix (friendly name / wire id / class) is kept for debuggability.
     """
-    name = getattr(model, "name", None)
-    if name:
-        return str(name)
-    model_id = getattr(model, "model", None)
-    if model_id:
-        return str(model_id)
-    return type(model).__name__
+    prefix = getattr(model, "name", None) or getattr(model, "model", None)
+    if not prefix:
+        prefix = type(model).__name__
+    return f"{prefix}@{id(model):x}"
 
 
 @dataclass
@@ -68,6 +68,14 @@ class _HealthStatus:
         self._health_map: Dict[str, bool] = {}
         self._timer: Optional[threading.Timer] = None
         self._initialized = False
+        # Whether the recurring background sweep has been kicked off. Kept
+        # separate from ``_initialized`` (which get_snapshot owns for its first
+        # synchronous refresh) so ensure_started() can start the sweep without
+        # making get_snapshot's first call return a stale empty snapshot.
+        # Guarded by a short, dedicated lock that is never held during a sweep,
+        # so request-path callers (via model_ok) never block.
+        self._sweep_started = False
+        self._start_lock = threading.Lock()
         # Use RLock to allow reentrant locking and reduce deadlock chances
         self._lock = threading.RLock()
         # Fast mode for tests to avoid network stalls
@@ -84,8 +92,13 @@ class _HealthStatus:
         with self._lock:
             if not self._initialized:
                 pending_alert = self._refresh_unlocked()
-                self._schedule_refresh()
                 self._initialized = True
+
+        # Start the recurring sweep exactly once. Done outside _lock via a
+        # short, separate lock so it neither double-schedules with
+        # ensure_started() nor blocks. We just refreshed synchronously above
+        # (when first initializing), so only the timer chain needs starting.
+        self._ensure_sweep_scheduled(refresh_now=False)
 
         if pending_alert is not None:
             self._alert_if_all_internal_dead(*pending_alert)
@@ -112,23 +125,38 @@ class _HealthStatus:
         return self._health_map.get(_model_key(model))
 
     def ensure_started(self) -> None:
-        """Start the periodic health sweep exactly once, in the background, so
-        cached results get populated without any caller blocking on the initial
-        probe.
+        """Start the periodic health sweep once, in the background, so cached
+        results get populated without any caller blocking on the initial probe.
 
-        The common (already-started) path is a lock-free flag read, so callers
-        on the request path don't contend on the sweep lock. Shares the
-        ``_initialized`` guard with :meth:`get_snapshot`, so whichever runs
-        first does the one-time start and only a single refresh timer is ever
-        scheduled.
+        Lock-free fast path; the short ``_start_lock`` is never held during a
+        sweep, so request-path callers (via :meth:`model_ok`) don't contend.
+        Crucially this does *not* set ``_initialized`` — that flag is owned by
+        :meth:`get_snapshot`, so its first call still does a synchronous refresh
+        and never returns a stale empty snapshot just because a background sweep
+        was kicked off here first.
         """
-        if self._initialized:
+        self._ensure_sweep_scheduled(refresh_now=True)
+
+    def _ensure_sweep_scheduled(self, refresh_now: bool) -> None:
+        """Kick off the recurring sweep exactly once (idempotent, non-blocking).
+
+        ``refresh_now`` runs the first sweep immediately in a background thread
+        (used when the cached snapshot may still be cold); otherwise we only
+        start the timer chain, because the caller already refreshed
+        synchronously and the snapshot is warm.
+        """
+        if self._sweep_started:
             return
-        with self._lock:
-            if self._initialized:
+        with self._start_lock:
+            if self._sweep_started:
                 return
-            self._initialized = True
-        threading.Thread(target=self._refresh, daemon=True, name="health-init").start()
+            self._sweep_started = True
+        if refresh_now:
+            threading.Thread(
+                target=self._refresh, daemon=True, name="health-sweep"
+            ).start()
+        else:
+            self._schedule_refresh()
 
     def _schedule_refresh(self):
         """Schedule the next refresh."""

--- a/fighthealthinsurance/ml/health_status.py
+++ b/fighthealthinsurance/ml/health_status.py
@@ -26,6 +26,24 @@ REFRESH_INTERVAL_SECONDS = 60 * 60  # hourly
 ALERT_THROTTLE_SECONDS = 60 * 60  # at most one alert email per hour
 
 
+def _model_key(model: Any) -> str:
+    """Stable identifier for a backend instance, shared by the health sweep
+    (which records per-model results) and the router (which looks them up).
+
+    Prefers the unique friendly ``name`` the router stamps onto each registered
+    model (so two providers exposing the same wire ``model`` id — e.g. the
+    direct Anthropic API vs Azure Claude — don't collide), then the wire
+    ``model`` id, then the class name.
+    """
+    name = getattr(model, "name", None)
+    if name:
+        return str(name)
+    model_id = getattr(model, "model", None)
+    if model_id:
+        return str(model_id)
+    return type(model).__name__
+
+
 @dataclass
 class BackendHealthDetail:
     name: str
@@ -43,6 +61,11 @@ class HealthSnapshot:
 class _HealthStatus:
     def __init__(self):
         self._snapshot: HealthSnapshot = HealthSnapshot()
+        # Per-model result of the last sweep, keyed by ``_model_key``. Rebound
+        # atomically on each refresh and read lock-free by ``model_ok`` so the
+        # router can consult it on the request path without ever blocking on the
+        # sweep lock.
+        self._health_map: Dict[str, bool] = {}
         self._timer: Optional[threading.Timer] = None
         self._initialized = False
         # Use RLock to allow reentrant locking and reduce deadlock chances
@@ -75,6 +98,37 @@ class _HealthStatus:
                 for d in self._snapshot.details
             ],
         }
+
+    def model_ok(self, model: Any) -> Optional[bool]:
+        """Return the last sweep's result for ``model`` — ``True``/``False`` —
+        or ``None`` if it hasn't been checked yet.
+
+        Lock-free and non-blocking: it reads the atomically-rebound health map
+        and never triggers a probe, so the router can call it on the request
+        path. It does ensure the periodic sweep is running (in the background)
+        so the cache gets populated, but returns immediately regardless.
+        """
+        self.ensure_started()
+        return self._health_map.get(_model_key(model))
+
+    def ensure_started(self) -> None:
+        """Start the periodic health sweep exactly once, in the background, so
+        cached results get populated without any caller blocking on the initial
+        probe.
+
+        The common (already-started) path is a lock-free flag read, so callers
+        on the request path don't contend on the sweep lock. Shares the
+        ``_initialized`` guard with :meth:`get_snapshot`, so whichever runs
+        first does the one-time start and only a single refresh timer is ever
+        scheduled.
+        """
+        if self._initialized:
+            return
+        with self._lock:
+            if self._initialized:
+                return
+            self._initialized = True
+        threading.Thread(target=self._refresh, daemon=True, name="health-init").start()
 
     def _schedule_refresh(self):
         """Schedule the next refresh."""
@@ -127,6 +181,7 @@ class _HealthStatus:
         # dropped from both buckets, which could otherwise fire a false "all
         # internal models are dead" page for a slow-but-healthy backend.
         details: List[BackendHealthDetail] = []
+        new_health: Dict[str, bool] = {}
         timeout_seconds = 10
         if candidates:
             with concurrent.futures.ThreadPoolExecutor(
@@ -155,6 +210,7 @@ class _HealthStatus:
                         details.append(
                             BackendHealthDetail(name=name, ok=False, error=err)
                         )
+                    new_health[_model_key(m)] = bool(ok)
                     if ok:
                         alive_count += 1
                         if is_internal:
@@ -173,6 +229,11 @@ class _HealthStatus:
         )
 
         self._snapshot = snapshot
+        if candidates:
+            # Only replace the cached per-model health when we actually ran a
+            # sweep; on an enumeration failure (no candidates) keep the last
+            # known-good map rather than wiping it to "unknown".
+            self._health_map = new_health
 
         return internal_total, internal_alive, internal_failures, enumeration_error
 

--- a/fighthealthinsurance/ml/health_status.py
+++ b/fighthealthinsurance/ml/health_status.py
@@ -212,9 +212,10 @@ class _HealthStatus:
         new_health: Dict[str, bool] = {}
         timeout_seconds = 10
         if candidates:
-            with concurrent.futures.ThreadPoolExecutor(
+            ex = concurrent.futures.ThreadPoolExecutor(
                 max_workers=min(8, len(candidates))
-            ) as ex:
+            )
+            try:
                 future_map = {ex.submit(m.model_is_ok): m for m in candidates}
                 # Block until all checks finish or the deadline elapses.
                 concurrent.futures.wait(future_map, timeout=timeout_seconds)
@@ -249,6 +250,14 @@ class _HealthStatus:
                                 name=name, ok=False, error=err or "not ok"
                             )
                         )
+            finally:
+                # Return at the deadline rather than blocking on stragglers: a
+                # `with` block's shutdown(wait=True) would join every probe, so
+                # one hung model_is_ok() could stall the sweep (and the held
+                # _lock) past timeout_seconds and delay publishing _health_map.
+                # Cancel queued probes; let any in-flight ones finish in the
+                # background. Matches compute_model_health_details below.
+                ex.shutdown(wait=False, cancel_futures=True)
 
         snapshot = HealthSnapshot(
             alive_models=alive_count,

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -524,6 +524,22 @@ class RemoteModelLike(DenialBase):
         """
         return True
 
+    @property
+    def health_checked_live(self) -> bool:
+        """Whether ``is_available()`` is a complete, current health signal the
+        router can trust directly (cheap and in-memory), versus relying on the
+        periodic ``health_status`` sweep for reachability.
+
+        Defaults to ``False``: most backends have no cheap live probe, so the
+        router consults the last cached sweep result for them (e.g. DeepInfra,
+        which the sweep checks over the network). Backends that track their own
+        state in memory (rate-limited paid providers) override this to ``True``
+        so the router trusts ``is_available()`` and skips the sweep result —
+        whose hourly snapshot would otherwise pin a transient rate-limit for an
+        hour.
+        """
+        return False
+
     def infer(
         self,
         prompt,
@@ -3015,6 +3031,14 @@ class RateLimitedRemoteOpenLike(RemoteFullOpenLike):
         in-memory (API key/endpoint presence + rate-limit state) and never hits
         the network, so it is safe to consult on the request path."""
         return bool(self.model_is_ok())
+
+    @property
+    def health_checked_live(self) -> bool:
+        """Paid providers track availability live in memory (config + rate-limit
+        back-off), so the router trusts ``is_available()`` and skips the cached
+        sweep result for them (an hourly snapshot would otherwise pin a
+        transient 429 back-off for up to an hour)."""
+        return True
 
     @classmethod
     def _ensure_rate_limiter(cls, model: str) -> None:

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -511,6 +511,19 @@ class RemoteModelLike(DenialBase):
     def model_is_ok(self):
         return False
 
+    def is_available(self) -> bool:
+        """Cheap, non-blocking availability signal used when *selecting* which
+        backends to fan out to (see ``MLRouter.best_external_models``).
+
+        Defaults to ``True`` (fail-open). Unlike ``model_is_ok()`` this must not
+        perform network I/O: it runs on the request path, so a slow check would
+        add latency to every call. Subclasses with an in-memory health signal
+        (e.g. paid providers that track API-key presence and rate-limit
+        back-off) override this; deeper reachability checks remain the job of
+        the periodic ``health_status`` sweep and per-inference fallback.
+        """
+        return True
+
     def infer(
         self,
         prompt,
@@ -2863,6 +2876,20 @@ class DeepInfra(RemoteFullOpenLike):
         "deepseek-ai/DeepSeek-V4-Pro": 1048000,
     }
 
+    # Routing quality per model, kept below the internal models' range (>=101)
+    # so internal backends stay preferred. Used to rank the "best" external
+    # models for fan-out (MLRouter.best_external_models). Unknown models fall
+    # back to a mid value.
+    _MODEL_QUALITY: ClassVar[dict[str, int]] = {
+        "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8": 90,
+        "meta-llama/Llama-4-Scout-17B-16E-Instruct": 85,
+        "google/gemma-3-27b-it": 80,
+        "meta-llama/Meta-Llama-3.1-70B-Instruct": 84,
+        "meta-llama/Llama-3.2-3B-Instruct": 68,
+        "meta-llama/Llama-3.3-70B-Instruct-Turbo": 84,
+        "deepseek-ai/DeepSeek-R1-0528-Turbo": 90,
+    }
+
     def __init__(self, model: str, dual_mode: bool = False):
         api_base = "https://api.deepinfra.com/v1/openai"
         token = os.getenv("DEEPINFRA_API")
@@ -2877,6 +2904,11 @@ class DeepInfra(RemoteFullOpenLike):
     @property
     def supports_system(self):
         return True
+
+    def quality(self) -> int:
+        """Routing quality derived from the specific model (see
+        ``_MODEL_QUALITY``)."""
+        return self._MODEL_QUALITY.get(self.model, 82)
 
     @classmethod
     def models(cls) -> List[ModelDescription]:
@@ -2955,6 +2987,34 @@ class RateLimitedRemoteOpenLike(RemoteFullOpenLike):
 
     # Re-raise ClientResponseError from the parent _infer so we can detect 429.
     _propagate_http_errors: ClassVar[bool] = True
+
+    # Routing quality by provider tier, kept below the internal models' range
+    # (>=101) so internal backends stay preferred. Used to rank the "best"
+    # external models for fan-out (MLRouter.best_external_models). Subclasses
+    # expose each model's tier via get_tier().
+    _TIER_QUALITY: ClassVar[dict[str, int]] = {
+        "premium": 98,
+        "quality": 92,
+        "speed": 80,
+        "custom": 88,
+    }
+
+    def get_tier(self) -> str:
+        """Provider tier (speed/quality/premium/custom). Concrete subclasses
+        override with their own per-model mapping; this default keeps
+        ``quality()`` robust if a subclass omits it."""
+        return "unknown"
+
+    def quality(self) -> int:
+        """Routing quality derived from the model's tier (see ``_TIER_QUALITY``)."""
+        return self._TIER_QUALITY.get(self.get_tier(), 85)
+
+    def is_available(self) -> bool:
+        """Available when configured and not currently backing off. This mirrors
+        ``model_is_ok()`` for the paid providers, whose health signal is already
+        in-memory (API key/endpoint presence + rate-limit state) and never hits
+        the network, so it is safe to consult on the request path."""
+        return bool(self.model_is_ok())
 
     @classmethod
     def _ensure_rate_limiter(cls, model: str) -> None:

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -2897,6 +2897,10 @@ class DeepInfra(RemoteFullOpenLike):
     # models for fan-out (MLRouter.best_external_models). Unknown models fall
     # back to a mid value.
     _MODEL_QUALITY: ClassVar[dict[str, int]] = {
+        # Currently registered by models() (flagship Pro deepseek + gemma-4).
+        "deepseek-ai/DeepSeek-V4-Pro": 92,
+        "google/gemma-4-26B-A4B-it": 80,
+        # Retained for _old_models() should it be re-enabled.
         "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8": 90,
         "meta-llama/Llama-4-Scout-17B-16E-Instruct": 85,
         "google/gemma-3-27b-it": 80,

--- a/fighthealthinsurance/ml/ml_router.py
+++ b/fighthealthinsurance/ml/ml_router.py
@@ -309,7 +309,14 @@ class MLRouter(object):
             models += self.best_external_models()
         # Only fall back to all_models if use_external is True
         if not models and use_external:
-            models = self.all_models_by_cost[:6] if self.all_models_by_cost else []
+            # Keep the availability gate authoritative: don't re-introduce
+            # externals that best_external_models() just filtered out. Internal
+            # backends are always eligible; externals must pass the same gate.
+            models = [
+                m
+                for m in self.all_models_by_cost
+                if not m.external or self._external_selectable(m)
+            ][:6]
         return models
 
     def generate_text_backend_names(self, use_external: bool = False) -> list[str]:

--- a/fighthealthinsurance/ml/ml_router.py
+++ b/fighthealthinsurance/ml/ml_router.py
@@ -171,21 +171,47 @@ class MLRouter(object):
 
         "Best" means highest ``quality()`` (descending); because
         ``external_models_by_cost`` is cost-ordered and the sort is stable,
-        cheaper models win ties. Availability uses each model's cheap,
-        non-blocking ``is_available()`` signal, so paid providers that are
-        unconfigured or rate-limited (backing off) are skipped, while backends
-        without a cheap health signal fail open and rely on per-inference
-        fallback. At most one Groq backend is kept (matching the rest of the
-        router) to avoid double fan-out.
+        cheaper models win ties. Availability is judged from cheap, non-blocking
+        signals only — never a live network probe on the request path (see
+        :meth:`_external_selectable`): the model's in-memory ``is_available()``
+        plus, for backends without a live signal, the last cached
+        ``health_status`` sweep. At most one Groq backend is kept (matching the
+        rest of the router) to avoid double fan-out.
 
         Replaces the previous "cheapest N external" slices so that, instead of
         fanning out across every external backend, we route to the strongest
         few that are up.
         """
-        available = [m for m in self.external_models_by_cost if m.is_available()]
+        available = [
+            m for m in self.external_models_by_cost if self._external_selectable(m)
+        ]
         available = self._keep_single_groq(available)
         best = sorted(available, key=lambda m: -m.quality())
         return best[:limit]
+
+    def _external_selectable(self, model: RemoteModelLike) -> bool:
+        """Whether an external model should be offered for fan-out, using only
+        cheap, non-blocking signals — no live network calls in the router.
+
+        * ``is_available()`` — the model's own in-memory signal (paid providers
+          report config + rate-limit back-off; others fail open).
+        * the last cached ``health_status`` sweep — consulted only for models
+          that lack a live signal (``health_checked_live`` is False, e.g.
+          DeepInfra, which the sweep probes over the network). Models the last
+          sweep marked unhealthy are skipped; ones it hasn't checked yet fail
+          open, so we assume a backend is available until a real check says
+          otherwise.
+        """
+        if not model.is_available():
+            return False
+        if not model.health_checked_live:
+            # Imported lazily to avoid a circular import (health_status imports
+            # the router). model_ok() is a lock-free cache read.
+            from fighthealthinsurance.ml.health_status import health_status
+
+            if health_status.model_ok(model) is False:
+                return False
+        return True
 
     def _get_forced_models(
         self, task_description: str = "", *, use_external: bool = True

--- a/fighthealthinsurance/ml/ml_router.py
+++ b/fighthealthinsurance/ml/ml_router.py
@@ -165,6 +165,28 @@ class MLRouter(object):
             filtered.append(m)
         return filtered
 
+    def best_external_models(self, limit: int = 3) -> list[RemoteModelLike]:
+        """Return up to ``limit`` external models, best-quality first, limited to
+        those currently available.
+
+        "Best" means highest ``quality()`` (descending); because
+        ``external_models_by_cost`` is cost-ordered and the sort is stable,
+        cheaper models win ties. Availability uses each model's cheap,
+        non-blocking ``is_available()`` signal, so paid providers that are
+        unconfigured or rate-limited (backing off) are skipped, while backends
+        without a cheap health signal fail open and rely on per-inference
+        fallback. At most one Groq backend is kept (matching the rest of the
+        router) to avoid double fan-out.
+
+        Replaces the previous "cheapest N external" slices so that, instead of
+        fanning out across every external backend, we route to the strongest
+        few that are up.
+        """
+        available = [m for m in self.external_models_by_cost if m.is_available()]
+        available = self._keep_single_groq(available)
+        best = sorted(available, key=lambda m: -m.quality())
+        return best[:limit]
+
     def _get_forced_models(
         self, task_description: str = "", *, use_external: bool = True
     ) -> Optional[list[RemoteModelLike]]:
@@ -257,8 +279,8 @@ class MLRouter(object):
         models: list[RemoteModelLike] = []
         if self.internal_models_by_cost:
             models += self.internal_models_by_cost[:6]
-        if use_external and self.external_models_by_cost:
-            models += self.external_models_by_cost[:4]
+        if use_external:
+            models += self.best_external_models()
         # Only fall back to all_models if use_external is True
         if not models and use_external:
             models = self.all_models_by_cost[:6] if self.all_models_by_cost else []
@@ -349,10 +371,11 @@ class MLRouter(object):
             return False
 
         if use_external:
-            # Internal + external: take internal first, then external
+            # Internal + external: take internal first, then the best
+            # available external models.
             for model in self.internal_models_by_cost[:6]:
                 add_model_name(model)
-            for model in self.external_models_by_cost[:4]:
+            for model in self.best_external_models():
                 add_model_name(model)
         else:
             # Internal only
@@ -474,8 +497,7 @@ class MLRouter(object):
         if fhi_models:
             models += self.models_by_name[fhi_models[0]] * 2
         if use_external:
-            external_to_add = self._keep_single_groq(self.external_models_by_cost[:2])
-            models += external_to_add
+            models += self.best_external_models()
         internal_to_add = self.internal_models_by_cost[:6]
         models += internal_to_add
         logger.debug(
@@ -508,12 +530,8 @@ class MLRouter(object):
 
         fallback_models: list[RemoteModelLike] = []
         if use_external:
-            # Get external models sorted by quality for fallback
-            external_models = self._keep_single_groq(
-                [m for m in self.all_models_by_cost if m.external]
-            )
-            # Prefer higher quality models for chat fallback
-            fallback_models = sorted(external_models, key=lambda m: -m.quality())[:4]
+            # Prefer the best available external models for chat fallback.
+            fallback_models = self.best_external_models()
 
         return primary_models, fallback_models
 

--- a/tests/async-unit/test_anthropic_models.py
+++ b/tests/async-unit/test_anthropic_models.py
@@ -157,7 +157,13 @@ class TestRemoteAnthropicTiers(unittest.TestCase):
 
         self.assertGreater(opus.quality(), sonnet.quality())
         self.assertGreater(sonnet.quality(), haiku.quality())
-        # External models stay below the internal models' range (>=101).
+
+    @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"})
+    def test_quality_stays_below_internal_threshold(self):
+        """External Claude quality stays below the internal models' range (>=101)
+        so internal backends stay preferred in mixed scoring."""
+        opus = RemoteAnthropic(model="claude-opus-4-8")
+
         self.assertLess(opus.quality(), 101)
 
 

--- a/tests/async-unit/test_anthropic_models.py
+++ b/tests/async-unit/test_anthropic_models.py
@@ -147,6 +147,19 @@ class TestRemoteAnthropicTiers(unittest.TestCase):
 
         self.assertEqual(model.get_tier(), "premium")
 
+    @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"})
+    def test_quality_orders_opus_above_sonnet_above_haiku(self):
+        """Premium (Opus) outranks quality (Sonnet) outranks speed (Haiku) so the
+        router's best_external_models picks the strongest Claude first."""
+        opus = RemoteAnthropic(model="claude-opus-4-8")
+        sonnet = RemoteAnthropic(model="claude-sonnet-4-6")
+        haiku = RemoteAnthropic(model="claude-haiku-4-5-20251001")
+
+        self.assertGreater(opus.quality(), sonnet.quality())
+        self.assertGreater(sonnet.quality(), haiku.quality())
+        # External models stay below the internal models' range (>=101).
+        self.assertLess(opus.quality(), 101)
+
 
 class TestRemoteAnthropicInfer(unittest.TestCase):
     """Tests for RemoteAnthropic._infer method."""

--- a/tests/async-unit/test_anthropic_models.py
+++ b/tests/async-unit/test_anthropic_models.py
@@ -148,14 +148,19 @@ class TestRemoteAnthropicTiers(unittest.TestCase):
         self.assertEqual(model.get_tier(), "premium")
 
     @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"})
-    def test_quality_orders_opus_above_sonnet_above_haiku(self):
-        """Premium (Opus) outranks quality (Sonnet) outranks speed (Haiku) so the
-        router's best_external_models picks the strongest Claude first."""
+    def test_quality_opus_above_sonnet(self):
+        """Premium tier (Opus) outranks quality tier (Sonnet)."""
         opus = RemoteAnthropic(model="claude-opus-4-8")
+        sonnet = RemoteAnthropic(model="claude-sonnet-4-6")
+
+        self.assertGreater(opus.quality(), sonnet.quality())
+
+    @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"})
+    def test_quality_sonnet_above_haiku(self):
+        """Quality tier (Sonnet) outranks speed tier (Haiku)."""
         sonnet = RemoteAnthropic(model="claude-sonnet-4-6")
         haiku = RemoteAnthropic(model="claude-haiku-4-5-20251001")
 
-        self.assertGreater(opus.quality(), sonnet.quality())
         self.assertGreater(sonnet.quality(), haiku.quality())
 
     @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"})

--- a/tests/async-unit/test_groq_models.py
+++ b/tests/async-unit/test_groq_models.py
@@ -150,7 +150,13 @@ class TestRemoteGroqTiers(unittest.TestCase):
         instant = RemoteGroq(model="llama-3.1-8b-instant")
 
         self.assertGreater(versatile.quality(), instant.quality())
-        # External models stay below the internal models' range (>=101).
+
+    @patch.dict(os.environ, {"GROQ_API_KEY": "test-key"})
+    def test_quality_below_internal_threshold(self):
+        """External Groq quality stays below the internal models' range (>=101)
+        so internal backends stay preferred in mixed scoring."""
+        versatile = RemoteGroq(model="llama-3.3-70b-versatile")
+
         self.assertLess(versatile.quality(), 101)
 
     @patch.dict(os.environ, {"GROQ_API_KEY": "test-key"})

--- a/tests/async-unit/test_groq_models.py
+++ b/tests/async-unit/test_groq_models.py
@@ -143,6 +143,17 @@ class TestRemoteGroqTiers(unittest.TestCase):
             )
 
     @patch.dict(os.environ, {"GROQ_API_KEY": "test-key"})
+    def test_quality_versatile_above_instant(self):
+        """Quality tier (versatile) outranks speed tier (instant) so the router's
+        best_external_models prefers the stronger Groq model."""
+        versatile = RemoteGroq(model="llama-3.3-70b-versatile")
+        instant = RemoteGroq(model="llama-3.1-8b-instant")
+
+        self.assertGreater(versatile.quality(), instant.quality())
+        # External models stay below the internal models' range (>=101).
+        self.assertLess(versatile.quality(), 101)
+
+    @patch.dict(os.environ, {"GROQ_API_KEY": "test-key"})
     def test_speed_tier_model(self):
         """Test speed tier model is correctly identified."""
         model = RemoteGroq(model="llama-3.1-8b-instant")

--- a/tests/async-unit/test_ml_router.py
+++ b/tests/async-unit/test_ml_router.py
@@ -14,16 +14,21 @@ from fighthealthinsurance.ml.ml_models import (
 )
 
 
-def make_external_mock(quality: int = 100, available: bool = True) -> MagicMock:
+def make_external_mock(
+    quality: int = 100, available: bool = True, health_checked_live: bool = True
+) -> MagicMock:
     """Build a mock external ``RemoteModelLike`` for router-selection tests.
 
-    Centralizes the ``external`` / ``quality`` / ``is_available`` triple that
-    ``MLRouter.best_external_models`` reads, so tests don't hand-roll it.
+    Centralizes the attributes ``MLRouter.best_external_models`` reads, so tests
+    don't hand-roll them. Defaults to ``health_checked_live=True`` so selection
+    relies on ``is_available`` and does not consult the health sweep unless a
+    test opts in (by passing ``health_checked_live=False``).
     """
     model = MagicMock(spec=RemoteModelLike)
     model.external = True
     model.quality.return_value = quality
     model.is_available.return_value = available
+    model.health_checked_live = health_checked_live
     return model
 
 
@@ -277,6 +282,47 @@ class TestMLRouterBestExternalModels(unittest.TestCase):
         groqs = [m for m in result if isinstance(m, RemoteGroq)]
         self.assertEqual(len(groqs), 1)
         self.assertIs(groqs[0], versatile)
+
+    def test_skips_sweep_for_live_checked_models(self):
+        """Live-checked models (paid providers) are gated by is_available only;
+        the stale sweep result is not consulted for them."""
+        from fighthealthinsurance.ml.health_status import health_status
+
+        model = make_external_mock(quality=80, health_checked_live=True)
+        self.router.external_models_by_cost = [model]
+        with patch.object(health_status, "model_ok", return_value=False) as model_ok:
+            result = self.router.best_external_models(limit=3)
+
+        self.assertEqual(result, [model])
+        model_ok.assert_not_called()
+
+    def test_excludes_models_failing_cached_health_check(self):
+        """A sweep-checked model (e.g. DeepInfra) that the last health check
+        marked down is skipped, using the cached result (no live probe)."""
+        from fighthealthinsurance.ml.health_status import health_status
+
+        healthy = make_external_mock(quality=80, health_checked_live=False)
+        down = make_external_mock(quality=99, health_checked_live=False)
+        self.router.external_models_by_cost = [down, healthy]
+        with patch.object(
+            health_status, "model_ok", side_effect=lambda m: m is not down
+        ):
+            result = self.router.best_external_models(limit=3)
+
+        self.assertIn(healthy, result)
+        self.assertNotIn(down, result)
+
+    def test_unknown_cached_health_fails_open(self):
+        """A sweep-checked model the last sweep hasn't probed yet (model_ok is
+        None) is still offered — assume available until a real check says no."""
+        from fighthealthinsurance.ml.health_status import health_status
+
+        model = make_external_mock(quality=80, health_checked_live=False)
+        self.router.external_models_by_cost = [model]
+        with patch.object(health_status, "model_ok", return_value=None):
+            result = self.router.best_external_models(limit=3)
+
+        self.assertEqual(result, [model])
 
     def test_empty_when_no_external_models(self):
         """No external models registered yields an empty list."""

--- a/tests/async-unit/test_ml_router.py
+++ b/tests/async-unit/test_ml_router.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 from unittest.mock import MagicMock, AsyncMock, patch
 import asyncio
@@ -6,10 +7,24 @@ from typing import Optional
 from fighthealthinsurance.ml.ml_router import MLRouter
 from fighthealthinsurance.ml.ml_models import (
     ModelDescription,
+    RemoteGroq,
     RemoteHealthInsurance,
     RemoteModelLike,
     RemotePerplexity,
 )
+
+
+def make_external_mock(quality: int = 100, available: bool = True) -> MagicMock:
+    """Build a mock external ``RemoteModelLike`` for router-selection tests.
+
+    Centralizes the ``external`` / ``quality`` / ``is_available`` triple that
+    ``MLRouter.best_external_models`` reads, so tests don't hand-roll it.
+    """
+    model = MagicMock(spec=RemoteModelLike)
+    model.external = True
+    model.quality.return_value = quality
+    model.is_available.return_value = available
+    return model
 
 
 class TestMLRouterGenerateTextBackendNames(unittest.TestCase):
@@ -107,28 +122,11 @@ class TestMLRouterChatBackends(unittest.TestCase):
 
     def test_get_chat_backends_with_fallback_with_external(self):
         """Test get_chat_backends_with_fallback with use_external=True."""
-        # Create mock external models with different quality levels
-        mock_ext_model1 = MagicMock(spec=RemoteModelLike)
-        mock_ext_model1.external = True
-        mock_ext_model1.quality.return_value = 80
-        mock_ext_model1.is_available.return_value = True
-
-        mock_ext_model2 = MagicMock(spec=RemoteModelLike)
-        mock_ext_model2.external = True
-        mock_ext_model2.quality.return_value = 90
-        mock_ext_model2.is_available.return_value = True
-
-        mock_ext_model3 = MagicMock(spec=RemoteModelLike)
-        mock_ext_model3.external = True
-        mock_ext_model3.quality.return_value = 70
-        mock_ext_model3.is_available.return_value = True
-
-        # Set up router with external models (best_external_models reads
-        # external_models_by_cost).
+        # best_external_models reads external_models_by_cost.
         self.router.external_models_by_cost = [
-            mock_ext_model1,
-            mock_ext_model2,
-            mock_ext_model3,
+            make_external_mock(quality=80),
+            make_external_mock(quality=90),
+            make_external_mock(quality=70),
         ]
 
         primary_models, fallback_models = self.router.get_chat_backends_with_fallback(
@@ -145,27 +143,11 @@ class TestMLRouterChatBackends(unittest.TestCase):
 
     def test_get_chat_backends_with_fallback_sorts_by_quality(self):
         """Test that fallback models are sorted by quality (highest first)."""
-        # Create mock external models with different quality levels
-        mock_ext_model1 = MagicMock(spec=RemoteModelLike)
-        mock_ext_model1.external = True
-        mock_ext_model1.quality.return_value = 60
-        mock_ext_model1.is_available.return_value = True
-
-        mock_ext_model2 = MagicMock(spec=RemoteModelLike)
-        mock_ext_model2.external = True
-        mock_ext_model2.quality.return_value = 95
-        mock_ext_model2.is_available.return_value = True
-
-        mock_ext_model3 = MagicMock(spec=RemoteModelLike)
-        mock_ext_model3.external = True
-        mock_ext_model3.quality.return_value = 75
-        mock_ext_model3.is_available.return_value = True
-
-        # Set up router with external models
+        # Set up router with external models of differing quality.
         self.router.external_models_by_cost = [
-            mock_ext_model1,
-            mock_ext_model2,
-            mock_ext_model3,
+            make_external_mock(quality=60),
+            make_external_mock(quality=95),
+            make_external_mock(quality=75),
         ]
 
         _, fallback_models = self.router.get_chat_backends_with_fallback(
@@ -179,16 +161,9 @@ class TestMLRouterChatBackends(unittest.TestCase):
 
     def test_get_chat_backends_with_fallback_limits_to_three(self):
         """Test that fallback models are limited to the best ~3 models."""
-        # Create many mock external models
-        mock_models = []
-        for i in range(10):
-            mock_model = MagicMock(spec=RemoteModelLike)
-            mock_model.external = True
-            mock_model.quality.return_value = 50 + i
-            mock_model.is_available.return_value = True
-            mock_models.append(mock_model)
-
-        self.router.external_models_by_cost = mock_models
+        self.router.external_models_by_cost = [
+            make_external_mock(quality=50 + i) for i in range(10)
+        ]
 
         _, fallback_models = self.router.get_chat_backends_with_fallback(
             use_external=True
@@ -238,22 +213,15 @@ class TestMLRouterBestExternalModels(unittest.TestCase):
     def setUp(self):
         self.router = MLRouter()
 
-    def _ext(self, quality, available=True):
-        m = MagicMock(spec=RemoteModelLike)
-        m.external = True
-        m.quality.return_value = quality
-        m.is_available.return_value = available
-        return m
-
     def test_orders_by_quality_and_limits(self):
         """Returns the highest-quality models, capped at the limit."""
         # external_models_by_cost is cost-ordered; selection re-sorts by quality.
         self.router.external_models_by_cost = [
-            self._ext(70),
-            self._ext(95),
-            self._ext(60),
-            self._ext(88),
-            self._ext(99),
+            make_external_mock(quality=70),
+            make_external_mock(quality=95),
+            make_external_mock(quality=60),
+            make_external_mock(quality=88),
+            make_external_mock(quality=99),
         ]
 
         result = self.router.best_external_models(limit=3)
@@ -262,7 +230,9 @@ class TestMLRouterBestExternalModels(unittest.TestCase):
 
     def test_defaults_to_three(self):
         """The default limit is ~3 external models."""
-        self.router.external_models_by_cost = [self._ext(50 + i) for i in range(8)]
+        self.router.external_models_by_cost = [
+            make_external_mock(quality=50 + i) for i in range(8)
+        ]
 
         result = self.router.best_external_models()
 
@@ -270,14 +240,43 @@ class TestMLRouterBestExternalModels(unittest.TestCase):
 
     def test_excludes_unavailable_models(self):
         """Models failing the availability check are skipped."""
-        up = self._ext(80, available=True)
-        down = self._ext(99, available=False)
+        up = make_external_mock(quality=80, available=True)
+        down = make_external_mock(quality=99, available=False)
         self.router.external_models_by_cost = [down, up]
 
         result = self.router.best_external_models(limit=3)
 
         self.assertIn(up, result)
         self.assertNotIn(down, result)
+
+    def test_quality_ties_break_by_cost_order(self):
+        """Equal quality preserves cost order (stable sort over the
+        cost-ordered input), so the cheaper model is tried first."""
+        cheaper = make_external_mock(quality=90)
+        pricier = make_external_mock(quality=90)
+        # external_models_by_cost is cost-ordered: cheaper first.
+        self.router.external_models_by_cost = [cheaper, pricier]
+
+        result = self.router.best_external_models(limit=2)
+
+        self.assertEqual(result, [cheaper, pricier])
+
+    @patch.dict(os.environ, {"GROQ_API_KEY": "test-key"})
+    def test_keeps_single_groq(self):
+        """At most one Groq backend survives, and it is the cheaper
+        (quality-tier) one since selection runs on the cost-ordered list."""
+        RemoteGroq._rate_limiters.clear()
+        versatile = RemoteGroq(model="llama-3.3-70b-versatile")  # cost 4
+        instant = RemoteGroq(model="llama-3.1-8b-instant")  # cost 6
+        other = make_external_mock(quality=99)
+        # Cost-ordered: cheaper Groq first, then the pricier Groq.
+        self.router.external_models_by_cost = [versatile, instant, other]
+
+        result = self.router.best_external_models(limit=3)
+
+        groqs = [m for m in result if isinstance(m, RemoteGroq)]
+        self.assertEqual(len(groqs), 1)
+        self.assertIs(groqs[0], versatile)
 
     def test_empty_when_no_external_models(self):
         """No external models registered yields an empty list."""

--- a/tests/async-unit/test_ml_router.py
+++ b/tests/async-unit/test_ml_router.py
@@ -111,21 +111,21 @@ class TestMLRouterChatBackends(unittest.TestCase):
         mock_ext_model1 = MagicMock(spec=RemoteModelLike)
         mock_ext_model1.external = True
         mock_ext_model1.quality.return_value = 80
+        mock_ext_model1.is_available.return_value = True
 
         mock_ext_model2 = MagicMock(spec=RemoteModelLike)
         mock_ext_model2.external = True
         mock_ext_model2.quality.return_value = 90
+        mock_ext_model2.is_available.return_value = True
 
         mock_ext_model3 = MagicMock(spec=RemoteModelLike)
         mock_ext_model3.external = True
         mock_ext_model3.quality.return_value = 70
+        mock_ext_model3.is_available.return_value = True
 
-        mock_int_model = MagicMock(spec=RemoteModelLike)
-        mock_int_model.external = False
-
-        # Set up router with mixed models
-        self.router.all_models_by_cost = [
-            mock_int_model,
+        # Set up router with external models (best_external_models reads
+        # external_models_by_cost).
+        self.router.external_models_by_cost = [
             mock_ext_model1,
             mock_ext_model2,
             mock_ext_model3,
@@ -149,17 +149,20 @@ class TestMLRouterChatBackends(unittest.TestCase):
         mock_ext_model1 = MagicMock(spec=RemoteModelLike)
         mock_ext_model1.external = True
         mock_ext_model1.quality.return_value = 60
+        mock_ext_model1.is_available.return_value = True
 
         mock_ext_model2 = MagicMock(spec=RemoteModelLike)
         mock_ext_model2.external = True
         mock_ext_model2.quality.return_value = 95
+        mock_ext_model2.is_available.return_value = True
 
         mock_ext_model3 = MagicMock(spec=RemoteModelLike)
         mock_ext_model3.external = True
         mock_ext_model3.quality.return_value = 75
+        mock_ext_model3.is_available.return_value = True
 
         # Set up router with external models
-        self.router.all_models_by_cost = [
+        self.router.external_models_by_cost = [
             mock_ext_model1,
             mock_ext_model2,
             mock_ext_model3,
@@ -174,24 +177,25 @@ class TestMLRouterChatBackends(unittest.TestCase):
             qualities = [m.quality() for m in fallback_models]
             self.assertEqual(qualities, sorted(qualities, reverse=True))
 
-    def test_get_chat_backends_with_fallback_limits_to_four(self):
-        """Test that fallback models are limited to 4 models."""
+    def test_get_chat_backends_with_fallback_limits_to_three(self):
+        """Test that fallback models are limited to the best ~3 models."""
         # Create many mock external models
         mock_models = []
         for i in range(10):
             mock_model = MagicMock(spec=RemoteModelLike)
             mock_model.external = True
             mock_model.quality.return_value = 50 + i
+            mock_model.is_available.return_value = True
             mock_models.append(mock_model)
 
-        self.router.all_models_by_cost = mock_models
+        self.router.external_models_by_cost = mock_models
 
         _, fallback_models = self.router.get_chat_backends_with_fallback(
             use_external=True
         )
 
-        # Should limit to 4 models
-        self.assertLessEqual(len(fallback_models), 4)
+        # Should limit to the best 3 models
+        self.assertEqual(len(fallback_models), 3)
 
     def test_get_chat_backends_with_fallback_no_external_available(self):
         """Test behavior when no external models are available."""
@@ -203,6 +207,7 @@ class TestMLRouterChatBackends(unittest.TestCase):
         mock_int_model2.external = False
 
         self.router.all_models_by_cost = [mock_int_model1, mock_int_model2]
+        self.router.external_models_by_cost = []
 
         primary_models, fallback_models = self.router.get_chat_backends_with_fallback(
             use_external=True
@@ -225,6 +230,60 @@ class TestMLRouterChatBackends(unittest.TestCase):
             # Verify get_chat_backends was called with use_external=False
             mock_get_chat.assert_called_once_with(use_external=False)
             self.assertEqual(primary_models, ["mock_model"])
+
+
+class TestMLRouterBestExternalModels(unittest.TestCase):
+    """Tests for MLRouter.best_external_models (quality + health selection)."""
+
+    def setUp(self):
+        self.router = MLRouter()
+
+    def _ext(self, quality, available=True):
+        m = MagicMock(spec=RemoteModelLike)
+        m.external = True
+        m.quality.return_value = quality
+        m.is_available.return_value = available
+        return m
+
+    def test_orders_by_quality_and_limits(self):
+        """Returns the highest-quality models, capped at the limit."""
+        # external_models_by_cost is cost-ordered; selection re-sorts by quality.
+        self.router.external_models_by_cost = [
+            self._ext(70),
+            self._ext(95),
+            self._ext(60),
+            self._ext(88),
+            self._ext(99),
+        ]
+
+        result = self.router.best_external_models(limit=3)
+
+        self.assertEqual([m.quality() for m in result], [99, 95, 88])
+
+    def test_defaults_to_three(self):
+        """The default limit is ~3 external models."""
+        self.router.external_models_by_cost = [self._ext(50 + i) for i in range(8)]
+
+        result = self.router.best_external_models()
+
+        self.assertEqual(len(result), 3)
+
+    def test_excludes_unavailable_models(self):
+        """Models failing the availability check are skipped."""
+        up = self._ext(80, available=True)
+        down = self._ext(99, available=False)
+        self.router.external_models_by_cost = [down, up]
+
+        result = self.router.best_external_models(limit=3)
+
+        self.assertIn(up, result)
+        self.assertNotIn(down, result)
+
+    def test_empty_when_no_external_models(self):
+        """No external models registered yields an empty list."""
+        self.router.external_models_by_cost = []
+
+        self.assertEqual(self.router.best_external_models(), [])
 
 
 class TestContextOnlyModelFlag(unittest.TestCase):

--- a/tests/async-unit/test_ml_router.py
+++ b/tests/async-unit/test_ml_router.py
@@ -330,6 +330,19 @@ class TestMLRouterBestExternalModels(unittest.TestCase):
 
         self.assertEqual(self.router.best_external_models(), [])
 
+    def test_generate_text_backends_fallback_honors_availability_gate(self):
+        """With no internal models and every external unavailable, the
+        all-models fallback must not re-offer the filtered-out externals."""
+        down = make_external_mock(quality=90, available=False)
+        self.router.models_by_name = {}
+        self.router.internal_models_by_cost = []
+        self.router.external_models_by_cost = [down]
+        self.router.all_models_by_cost = [down]
+
+        result = self.router.generate_text_backends(use_external=True)
+
+        self.assertEqual(result, [])
+
 
 class TestContextOnlyModelFlag(unittest.TestCase):
     """Tests for the context_only flag and how the router handles it."""

--- a/tests/async/test_health_status.py
+++ b/tests/async/test_health_status.py
@@ -130,6 +130,21 @@ class TestHealthStatus(TestCase):
         assert snap["alive_models"] == 1
 
     @mock.patch("fighthealthinsurance.ml.ml_router.ml_router")
+    def test_model_ok_reflects_last_sweep(self, fake_router):
+        """model_ok() returns each backend's result from the last sweep, and
+        None for a backend that was never swept (so the router fails open)."""
+        fake_router.all_models_by_cost = [_ExternalGood(), _ExternalBad()]
+        from fighthealthinsurance.ml.health_status import _HealthStatus
+
+        _HealthStatus._refresh(health_status)
+
+        # Patch ensure_started so reading the cache doesn't spawn a real sweep.
+        with mock.patch.object(health_status, "ensure_started"):
+            assert health_status.model_ok(_ExternalGood()) is True
+            assert health_status.model_ok(_ExternalBad()) is False
+            assert health_status.model_ok(_InternalGood()) is None
+
+    @mock.patch("fighthealthinsurance.ml.ml_router.ml_router")
     def test_all_internal_dead_sends_alert(self, fake_router):
         """All internal backends failing triggers email + error log."""
         fake_router.all_models_by_cost = [_InternalBad(), _ExternalGood()]

--- a/tests/async/test_health_status.py
+++ b/tests/async/test_health_status.py
@@ -130,18 +130,40 @@ class TestHealthStatus(TestCase):
         assert snap["alive_models"] == 1
 
     @mock.patch("fighthealthinsurance.ml.ml_router.ml_router")
-    def test_model_ok_reflects_last_sweep(self, fake_router):
-        """model_ok() returns each backend's result from the last sweep, and
-        None for a backend that was never swept (so the router fails open)."""
-        fake_router.all_models_by_cost = [_ExternalGood(), _ExternalBad()]
+    def test_model_ok_true_for_healthy_backend(self, fake_router):
+        """model_ok() returns True for a backend the last sweep found healthy."""
+        good = _ExternalGood()
+        fake_router.all_models_by_cost = [good, _ExternalBad()]
         from fighthealthinsurance.ml.health_status import _HealthStatus
 
         _HealthStatus._refresh(health_status)
 
         # Patch ensure_started so reading the cache doesn't spawn a real sweep.
         with mock.patch.object(health_status, "ensure_started"):
-            assert health_status.model_ok(_ExternalGood()) is True
-            assert health_status.model_ok(_ExternalBad()) is False
+            assert health_status.model_ok(good) is True
+
+    @mock.patch("fighthealthinsurance.ml.ml_router.ml_router")
+    def test_model_ok_false_for_unhealthy_backend(self, fake_router):
+        """model_ok() returns False for a backend the last sweep found down."""
+        bad = _ExternalBad()
+        fake_router.all_models_by_cost = [_ExternalGood(), bad]
+        from fighthealthinsurance.ml.health_status import _HealthStatus
+
+        _HealthStatus._refresh(health_status)
+
+        with mock.patch.object(health_status, "ensure_started"):
+            assert health_status.model_ok(bad) is False
+
+    @mock.patch("fighthealthinsurance.ml.ml_router.ml_router")
+    def test_model_ok_none_for_unswept_backend(self, fake_router):
+        """model_ok() returns None for a backend the sweep never saw, so the
+        router fails open rather than excluding an unknown backend."""
+        fake_router.all_models_by_cost = [_ExternalGood(), _ExternalBad()]
+        from fighthealthinsurance.ml.health_status import _HealthStatus
+
+        _HealthStatus._refresh(health_status)
+
+        with mock.patch.object(health_status, "ensure_started"):
             assert health_status.model_ok(_InternalGood()) is None
 
     @mock.patch("fighthealthinsurance.ml.ml_router.ml_router")


### PR DESCRIPTION
## Summary

Refactor the ML router to select external models based on quality and availability rather than cost. This improves appeal generation by preferring stronger models that are currently healthy, while maintaining a single Groq backend and respecting rate-limit state.

## Key Changes

- **New `best_external_models()` method** in `MLRouter`: Returns up to 3 external models sorted by quality (highest first), filtered to only those currently available. Replaces previous "cheapest N external" slicing.

- **New `_external_selectable()` helper**: Determines if an external model should be offered using only cheap, non-blocking signals:
  - Model's own `is_available()` (in-memory signal for paid providers)
  - Cached `health_status` sweep result for backends without live signals (e.g., DeepInfra)
  - Fails open for models not yet checked by the sweep

- **New `is_available()` and `health_checked_live` interface** in `RemoteModelLike`:
  - `is_available()`: Non-blocking availability check (defaults to `True`, fail-open)
  - `health_checked_live` property: Whether `is_available()` is a complete, current signal the router can trust directly (defaults to `False`)

- **Quality scoring for external models**:
  - `RateLimitedRemoteOpenLike` (Anthropic, Groq, Perplexity): Quality by tier (premium=98, quality=92, speed=80, custom=88)
  - `DeepInfra`: Quality by specific model (range 68–90)
  - External models stay below 101 so internal backends remain preferred

- **Health status improvements**:
  - New `model_ok()` method: Lock-free, non-blocking cache read of the last sweep result per model
  - New `ensure_started()` method: Starts the periodic sweep in the background without blocking callers
  - New `_model_key()` helper: Stable identifier for backends (prefers friendly `name`, then `model`, then class name)
  - Per-model health map (`_health_map`) atomically rebound on each refresh

- **Router integration**:
  - `generate_text_backends()` and `get_chat_backends_with_fallback()` now call `best_external_models()` instead of slicing `external_models_by_cost`
  - `get_chat_backends()` uses `best_external_models()` for external selection
  - Maintains single-Groq filtering via `_keep_single_groq()`

- **Test coverage**:
  - New `make_external_mock()` helper centralizes mock setup for router tests
  - New `TestMLRouterBestExternalModels` test class with 10 tests covering quality ordering, availability filtering, health checks, Groq deduplication, and edge cases
  - Updated existing tests to use `external_models_by_cost` and the new mock helper
  - Changed fallback limit from 4 to 3 models
  - Added quality tests for Anthropic and Groq tier ordering

## Implementation Details

- The router never performs live network I/O on the request path; it consults only in-memory signals (`is_available()`) and the cached sweep result (`health_status.model_ok()`).
- Paid providers (Anthropic, Groq, Perplexity) override `is_available()` and `health_checked_live=True` so the router trusts their in-memory rate-limit state and skips the stale hourly sweep.
- Free/self-hosted backends (DeepInfra) rely on the periodic sweep; the router consults the cached result and fails open for models not yet checked.
- Quality ties are broken by cost order (stable sort), so cheaper models are tried first.
- At most one Groq backend survives selection to avoid double fan-out.

https://claude.ai/code/session_01Xib4dDucbKRaCLihCNpTG2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved external model selection to prefer models that are available and higher quality, using health-aware filtering and quality-based ranking.
* **Refactor**
  * Enhanced backend health caching for faster routing decisions.
  * Added live availability signaling for remote models, including tier-specific quality scoring for paid backends.
* **Tests**
  * Added/updated unit tests covering tier quality order, external-vs-internal quality thresholds, best-external selection, and health-status cache behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->