### PR TITLE
Denial-context token diagnostics + proactive context-shed dual-call for appeal generation

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -58,6 +58,7 @@ fi
 if [ -n "${CLAUDE_ENV_FILE:-}" ] && ! grep -qs 'fhi-session-start-path' "$CLAUDE_ENV_FILE"; then
   {
     echo '# fhi-session-start-path'
+    # shellcheck disable=SC2016  # literal on purpose: expands when the env file is sourced
     echo 'export PATH="$HOME/.local/bin:$PATH"'
   } >> "$CLAUDE_ENV_FILE"
 fi

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# SessionStart hook for Claude Code on the web.
+#
+# Installs the Python test/lint toolchain (tox) and pre-builds the tox
+# environments used by this repo's tests and linters, plus the JS deps, so
+# `tox -e ...`, black, and mypy work without a per-session cold install.
+# Runs synchronously so the session only starts once deps are ready.
+#
+# Local (non-web) development is unchanged: it uses the conda/venv setup in
+# CLAUDE.md, so this hook no-ops outside the remote container.
+set -euo pipefail
+
+# Only run inside Claude Code on the web (remote) containers.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+# Trust the agent proxy CA for pip/git when it is present (no-op elsewhere).
+if [ -f /root/.ccr/ca-bundle.crt ]; then
+  export PIP_CERT="/root/.ccr/ca-bundle.crt"
+  export GIT_SSL_CAINFO="/root/.ccr/ca-bundle.crt"
+fi
+
+PYTHON="$(command -v python3.13 || command -v python3)"
+
+# 1. Install tox into the user site (idempotent; reuses cached wheels).
+"$PYTHON" -m pip install --user --upgrade pip
+"$PYTHON" -m pip install --user tox
+export PATH="$HOME/.local/bin:$PATH"
+
+# 2. Pre-build the tox environments the tests/linters use. `--notest` installs
+#    every dependency into .tox/<env> (cached with the container image) but
+#    skips running the suites, so the session's `tox -e ...` reuses the env
+#    and starts fast. Note: the type-check env is `mypy` (the `py313-mypy`
+#    env resolves to an empty command list in tox 4, so it runs nothing).
+#    Add -e py313-django52-async / -selenium here if you want those cached too.
+if ! tox --notest \
+  -e py313-django52-sync,py313-django52-async-unit,py313-black,mypy; then
+  echo "ERROR: tox environment build failed." >&2
+  echo "If the failure above is a 'git clone ... 403' for one of the" >&2
+  echo "git+https dependencies in requirements.txt (static-thumbnails," >&2
+  echo "django-cookie-consent, django-encrypted-model-fields, llm-result-utils)," >&2
+  echo "this environment's network policy is blocking GitHub egress for those" >&2
+  echo "repos. Grant the web environment access to them (or vendor them)." >&2
+  exit 1
+fi
+
+# 3. Install JS deps so the webpack build (scripts/test_setup.sh, run by the
+#    async/selenium/actor test envs and for manual verification) works.
+if command -v npm >/dev/null 2>&1; then
+  (cd fighthealthinsurance/static/js && npm install --no-audit --no-fund)
+fi
+
+# 4. Persist tox on PATH for the session (guard against duplicate appends on
+#    resume/clear/compact re-runs of the hook).
+if [ -n "${CLAUDE_ENV_FILE:-}" ] && ! grep -qs 'fhi-session-start-path' "$CLAUDE_ENV_FILE"; then
+  {
+    echo '# fhi-session-start-path'
+    echo 'export PATH="$HOME/.local/bin:$PATH"'
+  } >> "$CLAUDE_ENV_FILE"
+fi
+
+echo "Fight Health Insurance session-start hook complete."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/fighthealthinsurance/context_utils.py
+++ b/fighthealthinsurance/context_utils.py
@@ -21,7 +21,7 @@ Centralizes patterns that were previously scattered across the codebase:
 from __future__ import annotations
 
 import re
-from typing import Any, Iterable, List, Optional, Tuple, Union
+from typing import Any, Iterable, List, Optional, Sequence, Tuple, Union
 
 # Sentence-ending punctuation followed by whitespace or end-of-string.
 _SENTENCE_END_RE = re.compile(r"[.!?](?=\s|$)")
@@ -29,6 +29,75 @@ _SENTENCE_END_RE = re.compile(r"[.!?](?=\s|$)")
 DEFAULT_ELLIPSIS = "..."
 
 CitationContext = Optional[Union[str, List[Any]]]
+
+# Rough average characters-per-token for English prose. The real tokenizer
+# is model-specific, but ~4 chars/token is the standard back-of-envelope
+# estimate (matches ``chat.llm_client.estimate_history_tokens``) and is good
+# enough for "is this context overflowing the window?" triage.
+CHARS_PER_TOKEN = 4
+
+
+def estimate_tokens(value: Any) -> int:
+    """Roughly estimate the token count of a text value.
+
+    Non-string values (e.g. ``JSONField`` lists/dicts holding citation or
+    UCR context) are stringified first so they still get counted. Empty,
+    ``None``, and falsy values estimate to ``0``.
+    """
+    if not value:
+        return 0
+    if not isinstance(value, str):
+        value = str(value)
+    return len(value) // CHARS_PER_TOKEN
+
+
+# Denial fields that feed appeal-generation context, in the rough order they
+# contribute to the prompt / ``context_extra`` injection. Mirrors the
+# assembly in ``generate_appeal.make_appeals`` and
+# ``common_view_logic.AppealsBackendHelper.generate_appeals``: ``denial_text``
+# anchors the prompt; ``qa_context`` + ``health_history`` become the
+# patient/medical context; ``plan_context`` + ``plan_documents_summary`` the
+# plan context; the rest are enrichment contexts that the tier-shed retry
+# drops first when output is empty (see ``generate_appeal._shed_context``).
+DENIAL_CONTEXT_TOKEN_FIELDS: Tuple[str, ...] = (
+    "denial_text",
+    "qa_context",
+    "health_history",
+    "plan_context",
+    "plan_documents_summary",
+    "pubmed_context",
+    "ml_citation_context",
+    "rag_context",
+    "nice_context",
+    "imr_context",
+    "ucr_context",
+)
+
+
+def summarize_denial_context_tokens(
+    denial: Any,
+    *,
+    fields: Sequence[str] = DENIAL_CONTEXT_TOKEN_FIELDS,
+) -> str:
+    """Return a compact ``est_total=Ntok (field=Ntok ...)`` breakdown of a
+    denial's appeal-generation context size.
+
+    Estimates are rough (``estimate_tokens``); the intent is operational
+    triage — spotting when the denial text plus enrichment context is large
+    enough to risk context-window overflow during appeal generation. Only
+    non-zero fields are listed (to keep the line compact), but the total
+    always reflects every field. ``getattr`` is used so the helper stays
+    Django-free and tolerates partially-populated/stale denial instances.
+    """
+    parts: List[str] = []
+    total = 0
+    for field in fields:
+        tok = estimate_tokens(getattr(denial, field, None))
+        if tok:
+            parts.append(f"{field}={tok}")
+        total += tok
+    breakdown = " ".join(parts) if parts else "none"
+    return f"est_total={total}tok ({breakdown})"
 
 
 def truncate_at_boundary(

--- a/fighthealthinsurance/generate_appeal.py
+++ b/fighthealthinsurance/generate_appeal.py
@@ -24,7 +24,7 @@ class GeneratedAppeal:
     model_name: Optional[str]
 
 
-from fighthealthinsurance.context_utils import truncate_at_boundary
+from fighthealthinsurance.context_utils import estimate_tokens, truncate_at_boundary
 from fighthealthinsurance.denial_base import DenialBase
 
 from .exec import executor
@@ -923,6 +923,72 @@ def _shed_context(
             _apply_tier2_truncations(new, _TIER2_TRUNCATIONS, changed, label="")
         new_calls.append(new)
     return new_calls, sorted(changed)
+
+
+# Proactive dual-call threshold. When a call's estimated token footprint
+# exceeds this fraction of a model's advertised context window, we fan out a
+# context-shed variant alongside the full call on the FIRST iteration. The
+# ratio is < 1.0 because (a) the window must also hold the generated appeal
+# and (b) both the char-based token estimate and the advertised max_len are
+# approximate — better to shed a little early than to overflow and waste a
+# full primary+backup cycle discovering it.
+_DUAL_CALL_CONTEXT_RATIO = 0.8
+
+
+def _estimate_call_token_footprint(call: dict) -> int:
+    """Rough token estimate of what a model call actually sends.
+
+    Sums the prompt with the patient/plan/pubmed/citation context that the
+    model re-injects via ``context_extra`` (see
+    ``ml_models.RemoteOpenLike._build_context_extra``). Enrichment baked
+    into the prompt string is already counted via ``prompt``; the call-dict
+    contexts are added on top because that mirrors what is sent on the wire.
+    """
+    return (
+        estimate_tokens(call.get("prompt"))
+        + estimate_tokens(call.get("patient_context"))
+        + estimate_tokens(call.get("plan_context"))
+        + estimate_tokens(call.get("pubmed_context"))
+        + estimate_tokens(call.get("ml_citations_context"))
+    )
+
+
+def _model_context_limit(model_name: Optional[str]) -> Optional[int]:
+    """Smallest advertised context window (tokens) across the backends that
+    serve ``model_name``, or ``None`` when unknown.
+
+    ``min`` because ``get_model_result`` may route the call to any backend
+    for the name, so we size against the tightest window to decide whether
+    overflow is a risk. Never raises — an unexpected backend degrades to
+    "unknown" (no proactive shed) rather than aborting generation.
+    """
+    if not model_name:
+        return None
+    backends = ml_router.models_by_name.get(model_name)
+    if not backends:
+        return None
+    limits: List[int] = []
+    for backend in backends:
+        try:
+            limits.append(int(backend.get_max_context()))
+        except Exception:
+            continue
+    return min(limits) if limits else None
+
+
+def _calls_over_context_budget(calls: List[dict]) -> List[dict]:
+    """Return the subset of ``calls`` whose estimated footprint exceeds the
+    fuzzy context window (``_DUAL_CALL_CONTEXT_RATIO`` * limit) of their
+    model. Calls whose model window is unknown are left out (no proactive
+    shed)."""
+    over: List[dict] = []
+    for call in calls:
+        limit = _model_context_limit(call.get("model_name"))
+        if limit is None:
+            continue
+        if _estimate_call_token_footprint(call) > limit * _DUAL_CALL_CONTEXT_RATIO:
+            over.append(call)
+    return over
 
 
 _T_peek = TypeVar("_T_peek")
@@ -2303,8 +2369,43 @@ class AppealGenerator(object):
             ]
             return generated_text_futures
 
+        # Proactive dual-call: when a call is estimated to exceed its model's
+        # (fuzzy) context window, fan out a tier-1 context-shed variant
+        # alongside the full call on the FIRST iteration instead of waiting
+        # for the primary+backup cycle to fail before shedding. max_len is
+        # approximate, so we keep BOTH: the full call may still fit (and tends
+        # to be higher quality), while the shed call is insurance against an
+        # overflow. Whichever returns a real appeal first wins via
+        # as_available_nested. ``calls`` is left untouched so the reactive
+        # ladder below still escalates to tier 2 if every call comes back empty.
+        first_iteration_calls = calls
+        over_budget_calls = _calls_over_context_budget(calls)
+        if over_budget_calls:
+            variants, changed = _shed_context(
+                over_budget_calls,
+                tier=1,
+                open_prompt_kwargs=open_prompt_kwargs,
+                rebuild_prompt=self.make_open_prompt,
+                original_open_prompt=open_prompt,
+            )
+            # Drop no-op variants: a call over budget purely from
+            # patient_context isn't reduced at tier 1, so its variant would
+            # just duplicate the full call (tier-2 patient/plan truncation
+            # for that case is left to the reactive fallback).
+            shed_variants = [
+                v for v, src in zip(variants, over_budget_calls) if v != src
+            ]
+            if shed_variants:
+                logger.info(
+                    f"make_appeals: {len(shed_variants)} of "
+                    f"{len(over_budget_calls)} over-budget call(s) for denial "
+                    f"{denial.denial_id} get a first-iteration tier-1 shed "
+                    f"variant alongside the full call (changed={changed})"
+                )
+                first_iteration_calls = calls + shed_variants
+
         generated_text_futures: List[Future[Iterator[GeneratedAppeal]]] = (
-            make_async_model_calls(calls)
+            make_async_model_calls(first_iteration_calls)
         )
 
         # Tiered fallback: primary -> backup -> retry primary with shed

--- a/fighthealthinsurance/generate_appeal.py
+++ b/fighthealthinsurance/generate_appeal.py
@@ -935,7 +935,9 @@ def _shed_context(
 _DUAL_CALL_CONTEXT_RATIO = 0.8
 
 
-def _estimate_call_token_footprint(call: dict) -> int:
+def _estimate_call_token_footprint(
+    call: dict, *, patient_context_char_cap: Optional[int] = None
+) -> int:
     """Rough token estimate of what a model call actually sends.
 
     Sums the prompt with the patient/plan/pubmed/citation context that the
@@ -943,10 +945,24 @@ def _estimate_call_token_footprint(call: dict) -> int:
     ``ml_models.RemoteOpenLike._build_context_extra``). Enrichment baked
     into the prompt string is already counted via ``prompt``; the call-dict
     contexts are added on top because that mirrors what is sent on the wire.
+
+    ``patient_context_char_cap`` mirrors the on-the-wire truncation that
+    ``_build_context_extra`` applies (``patient_context[0:max_len/2]``): the
+    caller passes the model's cap so a huge ``patient_context`` is counted at
+    the size actually sent, not at its full size. Without this the estimate
+    over-counts patient context and false-positives the over-budget check on
+    a field that tier-1 shedding cannot reduce anyway.
     """
+    patient_context = call.get("patient_context")
+    if (
+        patient_context_char_cap is not None
+        and isinstance(patient_context, str)
+        and len(patient_context) > patient_context_char_cap
+    ):
+        patient_context = patient_context[:patient_context_char_cap]
     return (
         estimate_tokens(call.get("prompt"))
-        + estimate_tokens(call.get("patient_context"))
+        + estimate_tokens(patient_context)
         + estimate_tokens(call.get("plan_context"))
         + estimate_tokens(call.get("pubmed_context"))
         + estimate_tokens(call.get("ml_citations_context"))
@@ -986,9 +1002,58 @@ def _calls_over_context_budget(calls: List[dict]) -> List[dict]:
         limit = _model_context_limit(call.get("model_name"))
         if limit is None:
             continue
-        if _estimate_call_token_footprint(call) > limit * _DUAL_CALL_CONTEXT_RATIO:
+        # ``_build_context_extra`` only sends ``patient_context[0:max_len/2]``
+        # chars on the wire, so size patient context against that same cap;
+        # otherwise an oversized patient_context (which tier-1 cannot shed)
+        # yields a false-positive flag and a useless no-op sibling.
+        footprint = _estimate_call_token_footprint(
+            call, patient_context_char_cap=limit // 2
+        )
+        if footprint > limit * _DUAL_CALL_CONTEXT_RATIO:
             over.append(call)
     return over
+
+
+def _add_proactive_shed_variants(
+    calls: List[dict],
+    *,
+    open_prompt_kwargs: dict,
+    rebuild_prompt: Callable[..., Optional[str]],
+    original_open_prompt: Optional[str],
+    denial_id: Any = None,
+) -> List[dict]:
+    """Return ``calls`` plus a tier-1 context-shed sibling for each call whose
+    estimated footprint exceeds its model's fuzzy context window.
+
+    This is the proactive half of the dual-call: rather than waiting for the
+    primary+backup cycle to fail before shedding, fan out a shed variant
+    alongside the full call on the first iteration. ``calls`` is never
+    mutated (a new list is returned) so the reactive tier-shed ladder still
+    sees the original full calls. No-op variants — a call not actually
+    reduced by tier-1 shedding (e.g. over budget purely from ``plan_context``,
+    which only truncates at tier 2) — are dropped so we don't merely
+    duplicate the full call. Returns ``calls`` unchanged when nothing is over
+    budget or every variant was a no-op.
+    """
+    over_budget_calls = _calls_over_context_budget(calls)
+    if not over_budget_calls:
+        return calls
+    variants, changed = _shed_context(
+        over_budget_calls,
+        tier=1,
+        open_prompt_kwargs=open_prompt_kwargs,
+        rebuild_prompt=rebuild_prompt,
+        original_open_prompt=original_open_prompt,
+    )
+    shed_variants = [v for v, src in zip(variants, over_budget_calls) if v != src]
+    if not shed_variants:
+        return calls
+    logger.info(
+        f"make_appeals: {len(shed_variants)} of {len(over_budget_calls)} "
+        f"over-budget call(s) for denial {denial_id} get a first-iteration "
+        f"tier-1 shed variant alongside the full call (changed={changed})"
+    )
+    return calls + shed_variants
 
 
 _T_peek = TypeVar("_T_peek")
@@ -2378,31 +2443,13 @@ class AppealGenerator(object):
         # overflow. Whichever returns a real appeal first wins via
         # as_available_nested. ``calls`` is left untouched so the reactive
         # ladder below still escalates to tier 2 if every call comes back empty.
-        first_iteration_calls = calls
-        over_budget_calls = _calls_over_context_budget(calls)
-        if over_budget_calls:
-            variants, changed = _shed_context(
-                over_budget_calls,
-                tier=1,
-                open_prompt_kwargs=open_prompt_kwargs,
-                rebuild_prompt=self.make_open_prompt,
-                original_open_prompt=open_prompt,
-            )
-            # Drop no-op variants: a call over budget purely from
-            # patient_context isn't reduced at tier 1, so its variant would
-            # just duplicate the full call (tier-2 patient/plan truncation
-            # for that case is left to the reactive fallback).
-            shed_variants = [
-                v for v, src in zip(variants, over_budget_calls) if v != src
-            ]
-            if shed_variants:
-                logger.info(
-                    f"make_appeals: {len(shed_variants)} of "
-                    f"{len(over_budget_calls)} over-budget call(s) for denial "
-                    f"{denial.denial_id} get a first-iteration tier-1 shed "
-                    f"variant alongside the full call (changed={changed})"
-                )
-                first_iteration_calls = calls + shed_variants
+        first_iteration_calls = _add_proactive_shed_variants(
+            calls,
+            open_prompt_kwargs=open_prompt_kwargs,
+            rebuild_prompt=self.make_open_prompt,
+            original_open_prompt=open_prompt,
+            denial_id=denial.denial_id,
+        )
 
         generated_text_futures: List[Future[Iterator[GeneratedAppeal]]] = (
             make_async_model_calls(first_iteration_calls)

--- a/fighthealthinsurance/generate_appeal.py
+++ b/fighthealthinsurance/generate_appeal.py
@@ -970,26 +970,31 @@ def _estimate_call_token_footprint(
 
 
 def _model_context_limit(model_name: Optional[str]) -> Optional[int]:
-    """Smallest advertised context window (tokens) across the backends that
-    serve ``model_name``, or ``None`` when unknown.
+    """Advertised context window (tokens) of the first backend serving
+    ``model_name``, or ``None`` when unknown.
 
-    ``min`` because ``get_model_result`` may route the call to any backend
-    for the name, so we size against the tightest window to decide whether
-    overflow is a risk. Never raises — an unexpected backend degrades to
-    "unknown" (no proactive shed) rather than aborting generation.
+    First-in-routing-order rather than ``min()`` across the pool because
+    ``get_model_result`` submits to backends in order and returns the first
+    successful submission — so the first backend is the one that actually
+    receives the call, and sizing against a smaller later backend would
+    over-trigger shed siblings. Never raises — an unexpected backend
+    degrades to "unknown" (no proactive shed) rather than aborting
+    generation.
     """
     if not model_name:
         return None
     backends = ml_router.models_by_name.get(model_name)
     if not backends:
         return None
-    limits: List[int] = []
     for backend in backends:
         try:
-            limits.append(int(backend.get_max_context()))
-        except Exception:
-            continue
-    return min(limits) if limits else None
+            return int(backend.get_max_context())
+        except Exception as e:
+            logger.debug(
+                f"_model_context_limit: backend {backend} for "
+                f"{model_name} has no usable max context: {e}"
+            )
+    return None
 
 
 def _calls_over_context_budget(calls: List[dict]) -> List[dict]:

--- a/fighthealthinsurance/rest_views.py
+++ b/fighthealthinsurance/rest_views.py
@@ -36,7 +36,11 @@ from stopit import ThreadingTimeout as Timeout
 
 from fhi_users.auth import auth_utils
 from fhi_users.models import PatientUser, ProfessionalUser, UserDomain
-from fighthealthinsurance import common_view_logic, rest_serializers as serializers
+from fighthealthinsurance import (
+    common_view_logic,
+    context_utils,
+    rest_serializers as serializers,
+)
 from fighthealthinsurance.denial_context import merge_qa
 from fighthealthinsurance.external_review import (
     generate_external_review_packet,
@@ -552,10 +556,35 @@ class ReportClientError(APIView):
         diagnostics = _sanitize(str(request.data.get("diagnostics", "")), 1000)
         session_key = request.session.session_key or "no_session_key"
         denial_id_valid = is_valid_denial_id(denial_id)
+        # Annotate with the (estimated) token sizes of the denial text and the
+        # context that feeds appeal generation. A client-reported "0 appeals"
+        # is frequently a context-window overflow, and seeing the per-field
+        # token breakdown server-side makes that diagnosable without a repro.
+        # Never let this diagnostic enrichment break the error-report endpoint.
+        context_tokens = "unavailable"
+        if denial_id_valid:
+            try:
+                denial = (
+                    Denial.objects.filter(denial_id=int(denial_id))
+                    .only(*context_utils.DENIAL_CONTEXT_TOKEN_FIELDS)
+                    .first()
+                )
+                if denial is not None:
+                    context_tokens = context_utils.summarize_denial_context_tokens(
+                        denial
+                    )
+                else:
+                    context_tokens = "denial_not_found"
+            except Exception as e:
+                logger.opt(exception=True).debug(
+                    f"Failed to compute context token sizes for denial "
+                    f"{denial_id}: {e}"
+                )
         logger.error(
             f"Client-reported appeal error for denial {denial_id}: "
             f"{error_message} | browser: {browser_info} | "
             f"diagnostics: {diagnostics} | "
+            f"context_tokens: {context_tokens} | "
             f"session_key={session_key} | remote_ip={request.META.get('REMOTE_ADDR', 'unknown')} | "
             f"denial_id_valid={denial_id_valid} | denial_id_raw={denial_id_raw}"
         )

--- a/tests/async-unit/test_generate_appeal.py
+++ b/tests/async-unit/test_generate_appeal.py
@@ -757,12 +757,18 @@ class TestDualCallContextBudget:
         ):
             assert _model_context_limit("fhi-internal") == 8000
 
-    def test_model_context_limit_unknown_model_is_none(self):
+    def test_model_context_limit_missing_model_key_is_none(self):
         with patch(
             "fighthealthinsurance.generate_appeal.ml_router.models_by_name",
             new={},
         ):
             assert _model_context_limit("missing") is None
+
+    def test_model_context_limit_none_model_name_is_none(self):
+        with patch(
+            "fighthealthinsurance.generate_appeal.ml_router.models_by_name",
+            new={},
+        ):
             assert _model_context_limit(None) is None
 
     def test_model_context_limit_survives_backend_error(self):

--- a/tests/async-unit/test_generate_appeal.py
+++ b/tests/async-unit/test_generate_appeal.py
@@ -8,6 +8,7 @@ from fighthealthinsurance.generate_appeal import (
     AppealGenerator,
     AppealTemplateGenerator,
     GeneratedAppeal,
+    _add_proactive_shed_variants,
     _calls_over_context_budget,
     _DUAL_CALL_CONTEXT_RATIO,
     _estimate_call_token_footprint,
@@ -700,15 +701,35 @@ class TestDualCallContextBudget:
         assert _estimate_call_token_footprint(call) == 50
 
     def test_estimate_handles_none_and_list_contexts(self):
+        citations = ["x" * 20, "y" * 20]
         call = _make_call(
             prompt=None,
             patient_context=None,
             plan_context=None,
             pubmed_context=None,
-            ml_citations_context=["x" * 20, "y" * 20],
+            ml_citations_context=citations,
         )
         # Only the list contributes; it is stringified before counting.
-        assert _estimate_call_token_footprint(call) > 0
+        from fighthealthinsurance.context_utils import estimate_tokens
+
+        assert _estimate_call_token_footprint(call) == estimate_tokens(citations)
+
+    def test_estimate_caps_patient_context_to_wire_size(self):
+        # _build_context_extra only sends patient_context[0:max_len/2] chars,
+        # so the estimate must count the capped size, not the full string.
+        big_patient = "a" * 40000  # 10000 tokens uncapped
+        call = _make_call(
+            prompt=None,
+            patient_context=big_patient,
+            plan_context=None,
+            pubmed_context=None,
+            ml_citations_context=None,
+        )
+        # cap of 4000 chars -> 1000 tokens, far below the uncapped 10000.
+        assert (
+            _estimate_call_token_footprint(call, patient_context_char_cap=4000) == 1000
+        )
+        assert _estimate_call_token_footprint(call) == 10000
 
     def test_model_context_limit_uses_smallest_backend(self):
         models_by_name = {
@@ -742,16 +763,30 @@ class TestDualCallContextBudget:
             assert _model_context_limit("fhi-internal") is None
 
     def test_over_budget_detects_calls_above_ratio(self):
-        # ~8000 tokens of context vs an 8000-token window comfortably clears
-        # the 0.8*8000=6400 threshold.
+        # ~8000 tokens of (sheddable) enrichment vs an 8000-token window
+        # comfortably clears the 0.8*8000=6400 threshold.
         big = "x" * (8000 * 4)  # ~8000 tokens in one field
-        call = _make_call(patient_context=big)
+        call = _make_call(pubmed_context=big)
         with patch(
             "fighthealthinsurance.generate_appeal.ml_router.models_by_name",
             new={"fhi-internal": [_backend_with_context(8000)]},
         ):
             over = _calls_over_context_budget([call])
         assert over == [call]
+
+    def test_patient_context_alone_not_flagged_due_to_wire_cap(self):
+        # A huge patient_context is capped to max_len/2 chars on the wire, so
+        # it must NOT trip the over-budget check (tier-1 can't shed it anyway).
+        big_patient = "x" * (8000 * 4)  # 8000 tokens uncapped
+        call = _make_call(
+            patient_context=big_patient, pubmed_context=None, ml_citations_context=None
+        )
+        with patch(
+            "fighthealthinsurance.generate_appeal.ml_router.models_by_name",
+            new={"fhi-internal": [_backend_with_context(8000)]},
+        ):
+            # Capped to 4000 chars -> 1000 tokens, well under 6400.
+            assert _calls_over_context_budget([call]) == []
 
     def test_under_budget_returns_empty(self):
         call = _make_call(prompt="short", patient_context="short", plan_context="short")
@@ -762,9 +797,10 @@ class TestDualCallContextBudget:
             assert _calls_over_context_budget([call]) == []
 
     def test_unknown_model_window_is_not_flagged(self):
-        # No proactive shed when we can't size the window.
+        # No proactive shed when we can't size the window, even when the call
+        # would otherwise be over budget.
         big = "x" * (8000 * 4)
-        call = _make_call(patient_context=big)
+        call = _make_call(pubmed_context=big)
         with patch(
             "fighthealthinsurance.generate_appeal.ml_router.models_by_name",
             new={},
@@ -773,6 +809,79 @@ class TestDualCallContextBudget:
 
     def test_ratio_is_a_sane_fraction(self):
         assert 0.0 < _DUAL_CALL_CONTEXT_RATIO < 1.0
+
+    # --- _add_proactive_shed_variants integration (the make_appeals wiring) --
+
+    @staticmethod
+    def _noop_rebuild(**kwargs):
+        # make_appeals passes self.make_open_prompt; tests inject this so the
+        # prompt-rebuild path is exercised without a real prompt builder.
+        return "REBUILT_PROMPT"
+
+    def test_adds_shed_sibling_for_over_budget_call(self):
+        big = "x" * (8000 * 4)
+        call = _make_call(prompt="ORIGINAL", pubmed_context=big)
+        original_snapshot = dict(call)
+        with patch(
+            "fighthealthinsurance.generate_appeal.ml_router.models_by_name",
+            new={"fhi-internal": [_backend_with_context(8000)]},
+        ):
+            result = _add_proactive_shed_variants(
+                [call],
+                open_prompt_kwargs={"pubmed_context": "enrichment"},
+                rebuild_prompt=self._noop_rebuild,
+                original_open_prompt="ORIGINAL",
+                denial_id=1,
+            )
+        # Full call kept first and left untouched...
+        assert result[0] is call
+        assert call == original_snapshot
+        # ...with a shed sibling appended that nulls the call-dict enrichment
+        # and swaps in the rebuilt prompt.
+        assert len(result) == 2
+        sibling = result[1]
+        assert sibling["pubmed_context"] is None
+        assert sibling["ml_citations_context"] is None
+        assert sibling["prompt"] == "REBUILT_PROMPT"
+
+    def test_no_sibling_when_under_budget(self):
+        call = _make_call(prompt="ORIGINAL")
+        with patch(
+            "fighthealthinsurance.generate_appeal.ml_router.models_by_name",
+            new={"fhi-internal": [_backend_with_context(200000)]},
+        ):
+            result = _add_proactive_shed_variants(
+                [call],
+                open_prompt_kwargs={},
+                rebuild_prompt=self._noop_rebuild,
+                original_open_prompt="ORIGINAL",
+                denial_id=1,
+            )
+        assert result == [call]
+
+    def test_no_sibling_when_tier1_shed_is_noop(self):
+        # Over budget purely from plan_context (tier-1 doesn't touch it) with
+        # no sheddable enrichment and an unrelated prompt -> the variant equals
+        # the source and is dropped rather than duplicating the full call.
+        big_plan = "x" * (8000 * 4)
+        call = _make_call(
+            prompt="UNRELATED",
+            plan_context=big_plan,
+            pubmed_context=None,
+            ml_citations_context=None,
+        )
+        with patch(
+            "fighthealthinsurance.generate_appeal.ml_router.models_by_name",
+            new={"fhi-internal": [_backend_with_context(8000)]},
+        ):
+            result = _add_proactive_shed_variants(
+                [call],
+                open_prompt_kwargs={},
+                rebuild_prompt=self._noop_rebuild,
+                original_open_prompt="DIFFERENT",
+                denial_id=1,
+            )
+        assert result == [call]
 
 
 # --- make_appeals router-call-pattern tests --------------------------------

--- a/tests/async-unit/test_generate_appeal.py
+++ b/tests/async-unit/test_generate_appeal.py
@@ -731,13 +731,26 @@ class TestDualCallContextBudget:
         )
         assert _estimate_call_token_footprint(call) == 10000
 
-    def test_model_context_limit_uses_smallest_backend(self):
+    def test_model_context_limit_uses_first_backend_in_routing_order(self):
+        # get_model_result submits to backends in order and the first
+        # successful submission serves the call, so the first backend's
+        # window is the one that matters — not the smallest in the pool.
         models_by_name = {
             "fhi-internal": [
                 _backend_with_context(100000),
                 _backend_with_context(8000),
             ]
         }
+        with patch(
+            "fighthealthinsurance.generate_appeal.ml_router.models_by_name",
+            new=models_by_name,
+        ):
+            assert _model_context_limit("fhi-internal") == 100000
+
+    def test_model_context_limit_falls_back_past_erroring_backend(self):
+        bad = MagicMock()
+        bad.get_max_context.side_effect = RuntimeError("boom")
+        models_by_name = {"fhi-internal": [bad, _backend_with_context(8000)]}
         with patch(
             "fighthealthinsurance.generate_appeal.ml_router.models_by_name",
             new=models_by_name,

--- a/tests/async-unit/test_generate_appeal.py
+++ b/tests/async-unit/test_generate_appeal.py
@@ -8,6 +8,10 @@ from fighthealthinsurance.generate_appeal import (
     AppealGenerator,
     AppealTemplateGenerator,
     GeneratedAppeal,
+    _calls_over_context_budget,
+    _DUAL_CALL_CONTEXT_RATIO,
+    _estimate_call_token_footprint,
+    _model_context_limit,
     _peek_real_or_none,
     _shed_context,
     _PROMPT_TIER1_NULLS,
@@ -668,6 +672,107 @@ class TestShedContextPromptRebuild:
         )
         assert calls_count[0] == 0, "rebuild fired on truly-empty enrichment"
         assert not any(c.startswith("prompt.") for c in changed)
+
+
+# --- proactive dual-call (over-context-budget) tests ------------------------
+
+
+def _backend_with_context(max_context):
+    """A minimal model backend stub exposing get_max_context()."""
+    backend = MagicMock()
+    backend.get_max_context.return_value = max_context
+    return backend
+
+
+class TestDualCallContextBudget:
+    """Proactive dual-call: over-budget calls get a tier-1 shed sibling on
+    the first iteration (see make_appeals)."""
+
+    def test_estimate_sums_prompt_and_context_surfaces(self):
+        call = _make_call(
+            prompt="p" * 40,
+            patient_context="a" * 40,
+            plan_context="b" * 40,
+            pubmed_context="c" * 40,
+            ml_citations_context="d" * 40,
+        )
+        # 5 fields x (40 // 4 chars-per-token) = 5 x 10 = 50.
+        assert _estimate_call_token_footprint(call) == 50
+
+    def test_estimate_handles_none_and_list_contexts(self):
+        call = _make_call(
+            prompt=None,
+            patient_context=None,
+            plan_context=None,
+            pubmed_context=None,
+            ml_citations_context=["x" * 20, "y" * 20],
+        )
+        # Only the list contributes; it is stringified before counting.
+        assert _estimate_call_token_footprint(call) > 0
+
+    def test_model_context_limit_uses_smallest_backend(self):
+        models_by_name = {
+            "fhi-internal": [
+                _backend_with_context(100000),
+                _backend_with_context(8000),
+            ]
+        }
+        with patch(
+            "fighthealthinsurance.generate_appeal.ml_router.models_by_name",
+            new=models_by_name,
+        ):
+            assert _model_context_limit("fhi-internal") == 8000
+
+    def test_model_context_limit_unknown_model_is_none(self):
+        with patch(
+            "fighthealthinsurance.generate_appeal.ml_router.models_by_name",
+            new={},
+        ):
+            assert _model_context_limit("missing") is None
+            assert _model_context_limit(None) is None
+
+    def test_model_context_limit_survives_backend_error(self):
+        bad = MagicMock()
+        bad.get_max_context.side_effect = RuntimeError("boom")
+        with patch(
+            "fighthealthinsurance.generate_appeal.ml_router.models_by_name",
+            new={"fhi-internal": [bad]},
+        ):
+            # All backends erroring -> unknown, not a raised exception.
+            assert _model_context_limit("fhi-internal") is None
+
+    def test_over_budget_detects_calls_above_ratio(self):
+        # ~8000 tokens of context vs an 8000-token window comfortably clears
+        # the 0.8*8000=6400 threshold.
+        big = "x" * (8000 * 4)  # ~8000 tokens in one field
+        call = _make_call(patient_context=big)
+        with patch(
+            "fighthealthinsurance.generate_appeal.ml_router.models_by_name",
+            new={"fhi-internal": [_backend_with_context(8000)]},
+        ):
+            over = _calls_over_context_budget([call])
+        assert over == [call]
+
+    def test_under_budget_returns_empty(self):
+        call = _make_call(prompt="short", patient_context="short", plan_context="short")
+        with patch(
+            "fighthealthinsurance.generate_appeal.ml_router.models_by_name",
+            new={"fhi-internal": [_backend_with_context(8000)]},
+        ):
+            assert _calls_over_context_budget([call]) == []
+
+    def test_unknown_model_window_is_not_flagged(self):
+        # No proactive shed when we can't size the window.
+        big = "x" * (8000 * 4)
+        call = _make_call(patient_context=big)
+        with patch(
+            "fighthealthinsurance.generate_appeal.ml_router.models_by_name",
+            new={},
+        ):
+            assert _calls_over_context_budget([call]) == []
+
+    def test_ratio_is_a_sane_fraction(self):
+        assert 0.0 < _DUAL_CALL_CONTEXT_RATIO < 1.0
 
 
 # --- make_appeals router-call-pattern tests --------------------------------

--- a/tests/sync/test_context_utils.py
+++ b/tests/sync/test_context_utils.py
@@ -7,12 +7,29 @@ supplemental-citation attach pattern used in the appeal/denial flow.
 import unittest
 
 from fighthealthinsurance.context_utils import (
+    CHARS_PER_TOKEN,
+    DENIAL_CONTEXT_TOKEN_FIELDS,
     attach_supplemental_to_citations,
     dedupe_blocks,
+    estimate_tokens,
     flatten_citation_context,
     merge_context_blocks,
+    summarize_denial_context_tokens,
     truncate_at_boundary,
 )
+
+
+class _FakeDenial:
+    """Minimal stand-in for a Denial row.
+
+    ``summarize_denial_context_tokens`` reads context fields via getattr,
+    so a plain attribute bag is sufficient and keeps the test Django-free.
+    Any field not set defaults to None (handled by getattr's default).
+    """
+
+    def __init__(self, **fields):
+        for key, value in fields.items():
+            setattr(self, key, value)
 
 
 class TestTruncateAtBoundary(unittest.TestCase):
@@ -227,8 +244,7 @@ class TestAttachSupplementalToCitations(unittest.TestCase):
         # Realistic shape: existing already has the supplemental block
         # appended via \n\n from a prior call.
         microsite_block = (
-            "## Additional Medical Evidence\n\n"
-            "Microsite link: https://example.com/x"
+            "## Additional Medical Evidence\n\n" "Microsite link: https://example.com/x"
         )
         existing = f"original ml citations\n\n{microsite_block}"
         ml, pm = attach_supplemental_to_citations(existing, None, microsite_block)
@@ -278,6 +294,62 @@ class TestAttachSupplementalToCitations(unittest.TestCase):
         ml, pm = attach_supplemental_to_citations(existing_list, None, supp)
         self.assertIs(ml, existing_list)
         self.assertIsNone(pm)
+
+
+class TestEstimateTokens(unittest.TestCase):
+    def test_empty_and_none_estimate_to_zero(self):
+        self.assertEqual(estimate_tokens(None), 0)
+        self.assertEqual(estimate_tokens(""), 0)
+        self.assertEqual(estimate_tokens([]), 0)
+        self.assertEqual(estimate_tokens({}), 0)
+        self.assertEqual(estimate_tokens(0), 0)
+
+    def test_string_uses_chars_per_token(self):
+        text = "x" * 400
+        self.assertEqual(estimate_tokens(text), 400 // CHARS_PER_TOKEN)
+
+    def test_non_string_is_stringified_then_counted(self):
+        # JSONField context (lists/dicts) must still contribute to the
+        # estimate rather than being silently dropped.
+        value = ["citation one", "citation two"]
+        self.assertEqual(estimate_tokens(value), len(str(value)) // CHARS_PER_TOKEN)
+
+
+class TestSummarizeDenialContextTokens(unittest.TestCase):
+    def test_reports_total_and_only_nonzero_fields(self):
+        denial = _FakeDenial(
+            denial_text="d" * 40,
+            qa_context="q" * 80,
+            # health_history left unset (None) -> omitted from breakdown
+            pubmed_context="",  # empty -> omitted
+        )
+        summary = summarize_denial_context_tokens(denial)
+        expected_total = (40 // CHARS_PER_TOKEN) + (80 // CHARS_PER_TOKEN)
+        self.assertIn(f"est_total={expected_total}tok", summary)
+        self.assertIn(f"denial_text={40 // CHARS_PER_TOKEN}", summary)
+        self.assertIn(f"qa_context={80 // CHARS_PER_TOKEN}", summary)
+        self.assertNotIn("health_history=", summary)
+        self.assertNotIn("pubmed_context=", summary)
+
+    def test_no_context_reports_zero_total_and_none(self):
+        summary = summarize_denial_context_tokens(_FakeDenial())
+        self.assertEqual(summary, "est_total=0tok (none)")
+
+    def test_counts_json_context_fields(self):
+        # ml_citation_context / ucr_context are JSONFields; their non-string
+        # values must be included in the total.
+        citations = ["a" * 100, "b" * 100]
+        denial = _FakeDenial(ml_citation_context=citations)
+        summary = summarize_denial_context_tokens(denial)
+        expected = len(str(citations)) // CHARS_PER_TOKEN
+        self.assertIn(f"ml_citation_context={expected}", summary)
+        self.assertIn(f"est_total={expected}tok", summary)
+
+    def test_field_list_covers_appeal_generation_context(self):
+        # Guards against the breakdown silently drifting from the fields
+        # that actually feed appeal generation.
+        for field in ("denial_text", "qa_context", "health_history"):
+            self.assertIn(field, DENIAL_CONTEXT_TOKEN_FIELDS)
 
 
 if __name__ == "__main__":

--- a/tests/sync/test_report_client_error.py
+++ b/tests/sync/test_report_client_error.py
@@ -1,0 +1,81 @@
+"""Tests for the ReportClientError diagnostic endpoint (rest_views).
+
+The endpoint is a fire-and-forget client error sink: it must always return
+204 and must never let the (best-effort) token-size annotation break the
+request. These tests pin that invariant plus the happy-path logging.
+"""
+
+from unittest.mock import patch
+
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from fighthealthinsurance.models import Denial
+
+
+class ReportClientErrorTest(APITestCase):
+    """The unauthenticated client-error report endpoint."""
+
+    def _url(self):
+        return reverse("report_client_error")
+
+    def _logged_error(self, mock_logger):
+        """Join the positional args of the single logger.error call."""
+        return " ".join(str(a) for a in mock_logger.error.call_args[0])
+
+    def test_returns_204_for_unknown_denial(self):
+        resp = self.client.post(
+            self._url(),
+            {"denial_id": "999999", "error": "boom"},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_logs_context_tokens_for_existing_denial(self):
+        denial = Denial.objects.create(denial_text="x" * 400, qa_context="y" * 80)
+        with patch("fighthealthinsurance.rest_views.logger") as mock_logger:
+            resp = self.client.post(
+                self._url(),
+                {"denial_id": str(denial.denial_id), "error": "e"},
+                format="json",
+            )
+        self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
+        logged = self._logged_error(mock_logger)
+        self.assertIn("context_tokens:", logged)
+        self.assertIn("est_total=", logged)
+        self.assertIn("denial_text=", logged)
+
+    def test_existing_denial_with_no_context_reports_none_breakdown(self):
+        denial = Denial.objects.create(denial_text="")
+        with patch("fighthealthinsurance.rest_views.logger") as mock_logger:
+            self.client.post(
+                self._url(),
+                {"denial_id": str(denial.denial_id), "error": "e"},
+                format="json",
+            )
+        self.assertIn("est_total=0tok (none)", self._logged_error(mock_logger))
+
+    def test_never_500_when_token_computation_raises(self):
+        denial = Denial.objects.create(denial_text="x")
+        with patch(
+            "fighthealthinsurance.rest_views.context_utils.summarize_denial_context_tokens",
+            side_effect=RuntimeError("boom"),
+        ):
+            resp = self.client.post(
+                self._url(),
+                {"denial_id": str(denial.denial_id), "error": "e"},
+                format="json",
+            )
+        # The diagnostic failure is swallowed; the endpoint still 204s.
+        self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_invalid_denial_id_reports_unavailable(self):
+        with patch("fighthealthinsurance.rest_views.logger") as mock_logger:
+            resp = self.client.post(
+                self._url(),
+                {"denial_id": "not-an-int", "error": "e"},
+                format="json",
+            )
+        self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertIn("context_tokens: unavailable", self._logged_error(mock_logger))


### PR DESCRIPTION
This PR does two related things — observability for context-window overflows, and a behavior change to appeal generation that acts on the same signal — plus review-driven fixes and a dev-environment hook.

## 1. Token-size diagnostics on client-reported appeal errors
When a client reports an appeal error (e.g. "0 appeals received"), the root cause is frequently a context-window overflow during appeal generation, but the error log had no visibility into how large the denial text and its associated context were.

- Add `estimate_tokens` / `summarize_denial_context_tokens` to `context_utils` (rough ~4 chars/token, matching `chat.llm_client.estimate_history_tokens`).
- `ReportClientError` now logs a per-field `context_tokens` breakdown (denial_text, qa/health/plan context, pubmed/ml-citation/rag/nice/imr/ucr enrichment). The lookup is wrapped so the diagnostic can never break the endpoint (pinned by new tests).

## 2. Behavior change: proactive dual-call in `make_appeals`
Previously, context shedding was purely reactive: it fired only after primary **and** backup model calls both returned zero appeals, costing users a full multi-minute failure cycle on oversized denials.

Now, when a call's estimated token footprint exceeds ~80% of its model's advertised context window (`_DUAL_CALL_CONTEXT_RATIO`), `make_appeals` fans out a **tier-1 context-shed sibling alongside the full call on the first iteration**. Both run; whichever yields a real appeal first wins.

Cost/latency implications:
- Extra model calls happen **only** for calls estimated over the threshold — typical denials against 32k–200k windows never trigger it.
- The full call is kept because advertised `max_len` values are fuzzy: it may still fit and tends to be higher quality; the shed sibling is insurance against overflow.
- The reactive primary → backup → tier-1/tier-2 ladder is unchanged and still runs if everything comes back empty.
- Privacy invariant unchanged: shed siblings derive from the internal-only primary call list.

Calibration details (from review): `patient_context` is counted at its on-the-wire size (`_build_context_extra` sends only `patient_context[:max_len/2]`), and the window is sized against the **first backend in routing order** (matching `get_model_result`'s actual selection), so the over-budget signal matches what is really sent.

## 3. Review-driven fixes
- Extracted `_add_proactive_shed_variants` for testability; integration tests cover sibling creation, no-op-variant dropping, and that the original call list is untouched.
- New `tests/sync/test_report_client_error.py` pins the endpoint's never-500 invariant.

## 4. Dev environment
- SessionStart hook (`.claude/hooks/session-start.sh`) pre-builds the tox envs and installs JS deps for Claude Code on the web sessions. Note: it requires the environment's network policy to allow cloning the four `git+https` deps in requirements.txt.

Claude-Session: https://claude.ai/code/session_01FVjb8fBrUokqjTheHyy7DL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by CodeRabbit

* **New Features**
  * Enhanced appeal generation with proactive, smaller-context fallback when approaching model context limits.
  * Added token-breakdown diagnostics for denial-related context to improve observability.
* **Bug Fixes**
  * Improved resilience of client-error reporting so token/context diagnostics never block normal responses.
* **Chores**
  * Updated remote development session setup to pre-build environments and install frontend dependencies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved appeal generation with proactive, smaller-context fallback when requests near model context limits.
  * Added token-size breakdown diagnostics for denial-related context to enhance visibility.
* **Bug Fixes**
  * Strengthened client-error reporting so diagnostic token/context computation never blocks normal responses.
* **Tests**
  * Expanded coverage for context token estimation, denial token breakdowns, and the proactive dual-call budgeting behavior.
* **Chores**
  * Updated remote development session setup to pre-build environments and install frontend dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->