### PR TITLE
Fix six issues found reviewing the June feature window

### DIFF
--- a/fighthealthinsurance/fax_health_status.py
+++ b/fighthealthinsurance/fax_health_status.py
@@ -57,7 +57,9 @@ def _probe_backend(backend: Any, timeout: float) -> tuple[bool, Optional[str]]:
         ok = bool(future.result(timeout=outer_timeout))
         return (ok, None if ok else "health check returned False")
     except concurrent.futures.TimeoutError:
-        return (False, f"timeout>{outer_timeout}s")
+        # :g so a multiplied float budget renders as "6s"/"0.6s" rather than
+        # "0.6000000000000001s" on the dashboard.
+        return (False, f"timeout>{outer_timeout:g}s")
     except Exception as e:
         return (False, str(e))
     finally:

--- a/fighthealthinsurance/fax_health_status.py
+++ b/fighthealthinsurance/fax_health_status.py
@@ -27,23 +27,37 @@ class FaxBackendHealthDetail:
     error: Optional[str] = None
 
 
+# A ``check_health`` probe can make several sequential HTTP round-trips
+# (SonicFax: login GET + login POST + members-page GET), each budgeted
+# ``timeout`` individually. The outer deadline must cover their sum, or a
+# backend answering every request comfortably within its per-request budget
+# (i.e. working, just slow) would be reported as a false "timeout" failure.
+_MAX_SEQUENTIAL_PROBE_REQUESTS = 3
+
+
 def _probe_backend(backend: Any, timeout: float) -> tuple[bool, Optional[str]]:
     """Run ``backend.check_health()`` under a timeout.
+
+    ``timeout`` is the per-HTTP-request budget passed to the backend; the
+    probe as a whole is capped at ``timeout * _MAX_SEQUENTIAL_PROBE_REQUESTS``
+    so the sum of individually-within-budget requests can't trip the outer
+    deadline.
 
     Returns ``(ok, error)``. A timeout or any raised exception is reported as
     not-ok with a descriptive error rather than propagating, so one slow/broken
     backend never takes down the whole status page.
     """
     ex = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    outer_timeout = timeout * _MAX_SEQUENTIAL_PROBE_REQUESTS
     try:
         # Pass the probe budget through so a backend's own per-request default
         # (e.g. SonicFax's 3s) doesn't report it down under latency well within
         # `timeout`.
         future = ex.submit(backend.check_health, timeout=timeout)
-        ok = bool(future.result(timeout=timeout))
+        ok = bool(future.result(timeout=outer_timeout))
         return (ok, None if ok else "health check returned False")
     except concurrent.futures.TimeoutError:
-        return (False, f"timeout>{timeout}s")
+        return (False, f"timeout>{outer_timeout}s")
     except Exception as e:
         return (False, str(e))
     finally:

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -2223,17 +2223,24 @@ class RemoteOpenLike(RemoteModel):
                         headers={"Authorization": f"Bearer {self.token}"},
                         json=request_body,
                     ) as response:
+                        # Read the error body BEFORE raise_for_status():
+                        # depending on the aiohttp version, raising can
+                        # release the connection and make text() unreadable
+                        # afterwards, which would reduce every error body to
+                        # the fallback string — hiding the payload from the
+                        # logs and from the unsupported-temperature detection
+                        # the retry below depends on.
+                        response_body = ""
+                        if response.status >= 400:
+                            try:
+                                response_body = await response.text()
+                            except Exception:
+                                response_body = "<failed to read response body>"
                         # Raise ClientResponseError for HTTP error status codes (4xx, 5xx)
                         # This allows subclasses to catch and handle specific errors like 429
                         try:
                             response.raise_for_status()
                         except aiohttp.ClientResponseError as e:
-                            response_body = ""
-                            try:
-                                response_body = await response.text()
-                            except Exception:
-                                response_body = "<failed to read response body>"
-
                             if (
                                 sent_temperature
                                 and _http_error_indicates_unsupported_temperature(

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -9,7 +9,7 @@ import traceback
 from abc import abstractmethod
 from concurrent.futures import Future
 from dataclasses import dataclass
-from typing import Callable, ClassVar, Iterable, List, Optional, Tuple, Union
+from typing import Any, Callable, ClassVar, Iterable, List, Optional, Tuple, Union
 
 import aiohttp
 import requests
@@ -2047,6 +2047,24 @@ class RemoteOpenLike(RemoteModel):
 
         return None
 
+    def _supports_custom_temperature(self, model: str) -> bool:
+        """Whether ``model`` accepts a non-default ``temperature``.
+
+        OpenAI's reasoning models (the gpt-5 family and o-series) reject any
+        temperature other than the default with HTTP 400 ("Only the default
+        (1) value is supported"), on both openai.com and Azure OpenAI
+        deployments. For those models the request body must omit the field
+        entirely or every call fails. Matched on the bare deployment/model
+        name so provider-prefixed registrations (``azure-openai/gpt-5``) are
+        covered too.
+        """
+        name = model.split("/")[-1].lower()
+        if name == "gpt-5" or name.startswith("gpt-5-"):
+            return False
+        if re.match(r"^o[134](-|$)", name):
+            return False
+        return True
+
     async def __timeout_infer(
         self,
         *args,
@@ -2153,14 +2171,19 @@ class RemoteOpenLike(RemoteModel):
                     logger.debug(
                         f"Prepared {len(cleaned_messages)} messages for model {model}: {cleaned_messages}"
                     )
+                request_body: dict[str, Any] = {
+                    "model": model,
+                    "messages": cleaned_messages,
+                }
+                # Reasoning models (gpt-5 family, o-series) reject any
+                # non-default temperature with HTTP 400; omit the field for
+                # them so the request can succeed at all.
+                if self._supports_custom_temperature(model):
+                    request_body["temperature"] = temperature
                 async with s.post(
                     url,
                     headers={"Authorization": f"Bearer {self.token}"},
-                    json={
-                        "model": model,
-                        "messages": cleaned_messages,
-                        "temperature": temperature,
-                    },
+                    json=request_body,
                 ) as response:
                     # Raise ClientResponseError for HTTP error status codes (4xx, 5xx)
                     # This allows subclasses to catch and handle specific errors like 429

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -71,6 +71,29 @@ def _http_status_is_expected(status: Optional[int]) -> bool:
     return status in EXPECTED_HTTP_STATUS_CODES
 
 
+def _http_error_indicates_unsupported_temperature(status: int, body: str) -> bool:
+    """True when a 400 means the model rejected the ``temperature`` parameter
+    outright (OpenAI/Azure reasoning models accept only the default value).
+
+    Name-based detection in ``_supports_custom_temperature`` can't recognize a
+    reasoning model behind a custom deployment name (e.g. an Azure gpt-5
+    deployment called "appeals-prod"), so the transport uses this to fall back
+    at runtime: retry the request once without the field and remember the
+    deployment. Matched loosely on the error text, e.g. "Unsupported value:
+    'temperature' ... Only the default (1) value is supported."
+    """
+    if status != 400 or not body:
+        return False
+    lowered = body.lower()
+    if "temperature" not in lowered:
+        return False
+    return (
+        "unsupported" in lowered
+        or "only the default" in lowered
+        or "not supported" in lowered
+    )
+
+
 def _count_items(items: list[str]) -> dict[str, int]:
     """Count occurrences of each normalized (stripped+lowered) item."""
     counts: dict[str, int] = {}
@@ -1337,6 +1360,12 @@ class RemoteOpenLike(RemoteModel):
         self.backup_api_base = backup_api_base
         self._expensive = expensive
         self.dual_mode = dual_mode
+        # Deployments observed rejecting the ``temperature`` parameter at
+        # runtime (reasoning models behind custom deployment names that
+        # ``_supports_custom_temperature`` can't recognize). Router-registered
+        # instances are long-lived, so one rejection stops the field being
+        # sent on every later call.
+        self._temperature_unsupported_models: set[str] = set()
 
     def model_is_ok(self):
         """Check that the backend supports this model, returns true if found in list.
@@ -2056,8 +2085,12 @@ class RemoteOpenLike(RemoteModel):
         deployments. For those models the request body must omit the field
         entirely or every call fails. Matched on the bare deployment/model
         name so provider-prefixed registrations (``azure-openai/gpt-5``) are
-        covered too.
+        covered too. Deployments that can't be recognized by name are caught
+        at runtime instead: a temperature-rejection 400 lands them in
+        ``_temperature_unsupported_models`` (see ``__infer``).
         """
+        if model in self._temperature_unsupported_models:
+            return False
         name = model.split("/")[-1].lower()
         if name == "gpt-5" or name.startswith("gpt-5-"):
             return False
@@ -2177,46 +2210,79 @@ class RemoteOpenLike(RemoteModel):
                 }
                 # Reasoning models (gpt-5 family, o-series) reject any
                 # non-default temperature with HTTP 400; omit the field for
-                # them so the request can succeed at all.
-                if self._supports_custom_temperature(model):
+                # them so the request can succeed at all. Models we can't
+                # recognize by name (custom deployment names) are handled by
+                # the temperature-rejection retry below, so the loop runs at
+                # most twice.
+                sent_temperature = self._supports_custom_temperature(model)
+                if sent_temperature:
                     request_body["temperature"] = temperature
-                async with s.post(
-                    url,
-                    headers={"Authorization": f"Bearer {self.token}"},
-                    json=request_body,
-                ) as response:
-                    # Raise ClientResponseError for HTTP error status codes (4xx, 5xx)
-                    # This allows subclasses to catch and handle specific errors like 429
-                    try:
-                        response.raise_for_status()
-                    except aiohttp.ClientResponseError as e:
-                        response_body = ""
+                while True:
+                    async with s.post(
+                        url,
+                        headers={"Authorization": f"Bearer {self.token}"},
+                        json=request_body,
+                    ) as response:
+                        # Raise ClientResponseError for HTTP error status codes (4xx, 5xx)
+                        # This allows subclasses to catch and handle specific errors like 429
                         try:
-                            response_body = await response.text()
-                        except Exception:
-                            response_body = "<failed to read response body>"
+                            response.raise_for_status()
+                        except aiohttp.ClientResponseError as e:
+                            response_body = ""
+                            try:
+                                response_body = await response.text()
+                            except Exception:
+                                response_body = "<failed to read response body>"
 
-                        response_body_preview = response_body[:2000]
-                        # Expected operational errors (quota/auth/rate-limit)
-                        # are summarized concisely by _infer; keep their body
-                        # preview at debug so they don't double-warn. Real
-                        # failures stay at WARNING so the body aids debugging.
-                        if _http_status_is_expected(e.status):
-                            logger.debug(
-                                f"HTTP {e.status} (expected) from {api_base} for "
-                                f"model {model}. Body preview (truncated): "
-                                f"{response_body_preview}"
-                            )
-                        else:
-                            logger.warning(
-                                f"HTTP {e.status} error from {api_base} for model "
-                                f"{model}. Body preview (truncated): "
-                                f"{response_body_preview}"
-                            )
-                        raise
-                    json_result = await response.json()
-                    if json_result.get("object") == "error":
-                        logger.warning(f"Bad response from {self} with {model}")
+                            if (
+                                sent_temperature
+                                and _http_error_indicates_unsupported_temperature(
+                                    e.status, response_body
+                                )
+                            ):
+                                # A reasoning model behind a deployment name
+                                # we couldn't recognize. Remember it so later
+                                # calls skip the field, and retry once
+                                # without it.
+                                logger.warning(
+                                    f"Model {model} at {api_base} rejected "
+                                    f"'temperature'; retrying without it and "
+                                    f"omitting it for this deployment from now on."
+                                )
+                                self._temperature_unsupported_models.add(model)
+                                sent_temperature = False
+                                # Fresh dict rather than popping in place: the
+                                # sent body may still be referenced elsewhere
+                                # (e.g. captured by tests or tracing).
+                                request_body = {
+                                    k: v
+                                    for k, v in request_body.items()
+                                    if k != "temperature"
+                                }
+                                continue
+
+                            response_body_preview = response_body[:2000]
+                            # Expected operational errors (quota/auth/rate-limit)
+                            # are summarized concisely by _infer; keep their body
+                            # preview at debug so they don't double-warn. Real
+                            # failures stay at WARNING so the body aids debugging.
+                            if _http_status_is_expected(e.status):
+                                logger.debug(
+                                    f"HTTP {e.status} (expected) from {api_base} for "
+                                    f"model {model}. Body preview (truncated): "
+                                    f"{response_body_preview}"
+                                )
+                            else:
+                                logger.warning(
+                                    f"HTTP {e.status} error from {api_base} for model "
+                                    f"{model}. Body preview (truncated): "
+                                    f"{response_body_preview}"
+                                )
+                            raise
+                        json_result = await response.json()
+                        if json_result.get("object") == "error":
+                            logger.warning(f"Bad response from {self} with {model}")
+                    break
         except aiohttp.ClientResponseError as e:
             # Already logged with a body preview above; keep this at debug to
             # avoid double-logging. Re-raise so _infer (and opted-in subclasses

--- a/fighthealthinsurance/ml/ml_router.py
+++ b/fighthealthinsurance/ml/ml_router.py
@@ -297,11 +297,14 @@ class MLRouter(object):
         if forced_models:
             return forced_models
 
-        # First try to find specific text generation models
-        if "meta-llama/Llama-4-Scout-17B-16E-Instruct" in self.models_by_name:
-            return self.cheapest("meta-llama/Llama-4-Scout-17B-16E-Instruct")
+        # NOTE: there used to be an early return here preferring DeepInfra's
+        # Llama-4-Scout for all text generation. It went dead when the model
+        # was dropped from the DeepInfra catalog, and it is deliberately NOT
+        # re-pointed at a successor: the early return bypassed the
+        # ``use_external`` privacy gate below, routing internal-only requests
+        # to an external model whenever DeepInfra was configured.
 
-        # Fall back to internal models, optionally appending external if allowed
+        # Internal models first, optionally appending external if allowed
         models: list[RemoteModelLike] = []
         if self.internal_models_by_cost:
             models += self.internal_models_by_cost[:6]
@@ -438,9 +441,10 @@ class MLRouter(object):
         models += self.internal_models_by_cost[:3]
 
         if use_external:
-            # Add Llama Scout model if available
-            if "meta-llama/Llama-4-Scout-17B-16E-Instruct" in self.models_by_name:
-                models += self.cheapest("meta-llama/Llama-4-Scout-17B-16E-Instruct")
+            # Add a cheap external generalist if available (successor to the
+            # dropped Llama-4-Scout entry in the DeepInfra catalog)
+            if "google/gemma-4-26B-A4B-it" in self.models_by_name:
+                models += self.cheapest("google/gemma-4-26B-A4B-it")
             # Add Perplexity for web-informed questions
             if "sonar" in self.models_by_name:
                 models += self.cheapest("sonar")
@@ -450,7 +454,10 @@ class MLRouter(object):
     def partial_qa_backends(self) -> list[RemoteModelLike]:
         """
         Return models for handling partial question-answer pairs (when we have less context).
-        Includes internal FHI models and Llama Scout if available.
+        Internal FHI models only: this method has no ``use_external`` gate, so
+        it must never include external backends. (It used to append DeepInfra's
+        Llama-4-Scout unconditionally; that branch went dead when the model was
+        dropped from the catalog and is deliberately not re-pointed.)
 
         Returns:
             List of RemoteModelLike models suitable for partial QA tasks
@@ -458,9 +465,6 @@ class MLRouter(object):
         models: list[RemoteModelLike] = []
         # Always include internal FHI models
         models += self.internal_models_by_cost
-        # Add Llama Scout model if available
-        if "meta-llama/Llama-4-Scout-17B-16E-Instruct" in self.models_by_name:
-            models += self.cheapest("meta-llama/Llama-4-Scout-17B-16E-Instruct")
         return models
 
     def full_find_citation_backends(self, use_external=False) -> list[RemoteModelLike]:
@@ -664,9 +668,15 @@ class MLRouter(object):
         self, title: Optional[str], text: Optional[str], abstract: Optional[str] = None
     ) -> Optional[str]:
         models: list[RemoteModelLike] = []
-        if "google/gemma-3-27b-it" in self.models_by_name:
+        # Prefer the cheap DeepInfra generalist (successor to the dropped
+        # gemma-3-27b entry) for article summaries. The inputs are public
+        # article text (title/abstract/body), not patient data, so an
+        # external model is fine here — and without it a DeepInfra-only
+        # deployment has an empty internal pool and summarize() would
+        # silently return None.
+        if "google/gemma-4-26B-A4B-it" in self.models_by_name:
             models = (
-                self.models_by_name["google/gemma-3-27b-it"]
+                self.models_by_name["google/gemma-4-26B-A4B-it"]
                 + self.internal_models_by_cost
             )
         else:

--- a/fighthealthinsurance/ml/ml_router.py
+++ b/fighthealthinsurance/ml/ml_router.py
@@ -424,7 +424,8 @@ class MLRouter(object):
         """
         Return models for handling question-answer pairs for appeal generation.
         Always includes internal FHI models. When use_external is True, also
-        includes external models like Llama Scout and Perplexity.
+        includes a cheap external generalist (google/gemma-4-26B-A4B-it) and
+        Perplexity for web-informed questions.
 
         Args:
             use_external: Whether to use external models
@@ -442,9 +443,17 @@ class MLRouter(object):
 
         if use_external:
             # Add a cheap external generalist if available (successor to the
-            # dropped Llama-4-Scout entry in the DeepInfra catalog)
+            # dropped Llama-4-Scout entry in the DeepInfra catalog). Gate on
+            # availability like best_external_models() does: question
+            # generation waits on every fanned-out task, so appending a
+            # backend the health sweep already marked down would stall it
+            # for the full model timeout.
             if "google/gemma-4-26B-A4B-it" in self.models_by_name:
-                models += self.cheapest("google/gemma-4-26B-A4B-it")
+                models += [
+                    m
+                    for m in self.cheapest("google/gemma-4-26B-A4B-it")
+                    if self._external_selectable(m)
+                ]
             # Add Perplexity for web-informed questions
             if "sonar" in self.models_by_name:
                 models += self.cheapest("sonar")
@@ -673,12 +682,14 @@ class MLRouter(object):
         # article text (title/abstract/body), not patient data, so an
         # external model is fine here — and without it a DeepInfra-only
         # deployment has an empty internal pool and summarize() would
-        # silently return None.
+        # silently return None. Gated on availability so a sweep-marked-down
+        # DeepInfra doesn't add a doomed call before the internal fallbacks.
         if "google/gemma-4-26B-A4B-it" in self.models_by_name:
-            models = (
-                self.models_by_name["google/gemma-4-26B-A4B-it"]
-                + self.internal_models_by_cost
-            )
+            models = [
+                m
+                for m in self.models_by_name["google/gemma-4-26B-A4B-it"]
+                if self._external_selectable(m)
+            ] + self.internal_models_by_cost
         else:
             models = self.internal_models_by_cost
         abstract_optional = ""

--- a/fighthealthinsurance/static/js/appeal_fetcher.ts
+++ b/fighthealthinsurance/static/js/appeal_fetcher.ts
@@ -440,6 +440,13 @@ let usingRestFallback = false;
 // concurrent ws.onclose doesn't run done() in parallel and tear
 // down the UI while the REST stream is still in flight.
 let handingOffToRest = false;
+// Set when the hard timeout gives up with no REST fallback available.
+// The module-level hard-timeout handler can't set the per-attempt
+// retryScheduled closure flag, so without this latch the closed socket's
+// onclose would run its normal-completion path: paint the checklist green,
+// show "Your appeals are ready!" over the give-up error, and call done()
+// a second time.
+let wsGaveUp = false;
 let hasAutoScrolledToFirstAppeal = false;
 
 // Diagnostic counters used in the client error report so server logs
@@ -572,6 +579,11 @@ function armHardTimeout(): void {
     // letting slow WS attempts keep the user waiting indefinitely.
     if (!usingRestFallback && !handingOffToRest) {
       retries = maxRetries;
+      // Latch before closing: the socket's onclose/onerror fire async after
+      // done() below, and without this they'd run the normal-completion path
+      // (green checklist + "appeals are ready" over the give-up message) and
+      // call done() a second time.
+      wsGaveUp = true;
       closeActiveWebSocket();
       endCurrentAttempt();
       fadeStatusMessage(
@@ -770,6 +782,12 @@ async function requestExternalModels(
     retries = 0;
     respBuffer = "";
     hasAutoScrolledToFirstAppeal = false;
+    // The wait for the next appeal starts now, not when the last pre-rerun
+    // appeal arrived — otherwise the "Current appeal" clock would include
+    // however long the user spent reading drafts before opting in. The
+    // total/first-appeal clocks deliberately keep their original anchor
+    // (see the startTime comment in showLoading).
+    lastAppealArrivedAtMs = Date.now();
     doQuery(my_backend_url, my_data, my_rest_fallback_url);
   } catch (error) {
     console.error("Failed to enable external models:", error);
@@ -1066,7 +1084,9 @@ function connectWebSocket(
     // was queued (e.g. ws.onerror's 1s retry firing right as the hard cap
     // hits) and now. Don't open a parallel socket — REST owns the stream,
     // and starting an attempt here would also stomp the REST leg's timer.
-    if (handingOffToRest || usingRestFallback) {
+    // Same for a hard-timeout give-up: a queued reconnect firing after it
+    // would open a socket the user was just told to abandon.
+    if (handingOffToRest || usingRestFallback || wsGaveUp) {
       return;
     }
     // Start the per-attempt wait timer. connectWebSocket is called
@@ -1168,14 +1188,17 @@ function connectWebSocket(
       console.log("WebSocket connection closed:", event.code, event.reason);
       lastWsCloseCode = event.code;
       lastWsCloseReason = event.reason || '';
-      // Two reasons to short-circuit done():
+      // Three reasons to short-circuit done():
       //   1. handingOffToRest: REST fallback owns the final done() call
       //      and will record its own attempt duration.
       //   2. retryScheduled: ws.onerror or the inactivity-timeout path
       //      already queued a reconnect for this attempt and recorded
       //      its duration; calling done()/endCurrentAttempt() here
       //      would stomp on it.
-      if (handingOffToRest || retryScheduled) {
+      //   3. wsGaveUp: the hard timeout already gave up, showed the error
+      //      message, and called done(); running the normal-completion path
+      //      here would paint false success over it and double-fire done().
+      if (handingOffToRest || retryScheduled || wsGaveUp) {
         return;
       }
       // Normal close path: record the attempt duration before done().
@@ -1187,8 +1210,9 @@ function connectWebSocket(
     // Handle errors
     ws.onerror = (error) => {
       // A reconnect/fallback was already scheduled for this socket (e.g. by
-      // the inactivity timeout or hard cap closing it); don't double-handle.
-      if (retryScheduled || handingOffToRest) return;
+      // the inactivity timeout or hard cap closing it), or the hard timeout
+      // already gave up and reported; don't double-handle.
+      if (retryScheduled || handingOffToRest || wsGaveUp) return;
       console.error("WebSocket error:", error);
       lastWsErrorMessage = (error as any)?.message || (error as any)?.type || 'unknown';
       updateStatusIndicator('error', appealsSoFar.length);
@@ -1219,6 +1243,7 @@ export function doQuery(backend_url: string, data: Map<string, string>, rest_fal
   my_rest_fallback_url = rest_fallback_url || '';
   usingRestFallback = false;
   handingOffToRest = false;
+  wsGaveUp = false;
   // Start the aggregate wait clock only on the first call. doQuery
   // recurses on retry via done(), and we want the total to span the
   // entire user-visible wait, not just the latest retry.

--- a/fighthealthinsurance/templates/professional_thankyou.html
+++ b/fighthealthinsurance/templates/professional_thankyou.html
@@ -12,7 +12,7 @@ Fighthealthinsurance Professional Version -- Thank You!
 	<h2>Thank you!</h2>
       </div>
       <p>
-	Thank you for believing in us! We'll keep follow up shortly. If you have <b>any</b> questions, please reach out to <a href="mailto:support42@fighthealthinsurance.com">support42@fighthealthinsurance.com</a>!
+	Thank you for believing in us! We'll follow up shortly. If you have <b>any</b> questions, please reach out to <a href="mailto:support42@fighthealthinsurance.com">support42@fighthealthinsurance.com</a>!
       </p>
     </div>
 </section>

--- a/tests/async-unit/test_azure_models.py
+++ b/tests/async-unit/test_azure_models.py
@@ -300,6 +300,43 @@ class TestAzureInfer(unittest.TestCase):
 
         asyncio.run(run())
 
+    def _capture_chat_completions_body(self, model: str) -> dict:
+        """Drive the OpenAI-compatible transport end-to-end against a fake
+        session and return the captured request body."""
+        capture: dict = {}
+
+        async def run():
+            """Run _infer with a canned 200 chat-completions response."""
+            m = RemoteAzureOpenAI(model=model)
+            response = _FakeAiohttpResponse(
+                {"choices": [{"message": {"content": "Dear insurer, please."}}]}
+            )
+            session = _FakeAiohttpSession(response, capture)
+            with patch.object(aiohttp, "ClientSession", return_value=session):
+                await m._infer(system_prompts=["be helpful"], prompt="appeal this")
+
+        asyncio.run(run())
+        return capture["json"]
+
+    @patch.dict(os.environ, AZURE_OPENAI_ENV)
+    def test_gpt5_request_omits_temperature(self):
+        """gpt-5-family deployments reject any non-default temperature with
+        HTTP 400, so the request body must omit the field entirely."""
+        body = self._capture_chat_completions_body("gpt-5")
+        self.assertNotIn("temperature", body)
+
+    @patch.dict(os.environ, AZURE_OPENAI_ENV)
+    def test_gpt5_mini_request_omits_temperature(self):
+        """The gpt-5 prefix match covers the -mini variant too."""
+        body = self._capture_chat_completions_body("gpt-5-mini")
+        self.assertNotIn("temperature", body)
+
+    @patch.dict(os.environ, AZURE_OPENAI_ENV)
+    def test_non_reasoning_model_request_keeps_temperature(self):
+        """Non-reasoning deployments keep the router-supplied temperature."""
+        body = self._capture_chat_completions_body("gpt-4.1-mini")
+        self.assertIn("temperature", body)
+
 
 class TestAzureClaudeMessages(unittest.TestCase):
     """RemoteAzureClaude's Anthropic Messages API transport (Foundry)."""

--- a/tests/async-unit/test_azure_models.py
+++ b/tests/async-unit/test_azure_models.py
@@ -50,11 +50,12 @@ def _clear_azure_env():
 class _FakeAiohttpResponse:
     """Minimal async-context-manager stand-in for an aiohttp response."""
 
-    def __init__(self, json_data=None, status=200, headers=None):
-        """Capture the canned JSON body, HTTP status, and response headers."""
+    def __init__(self, json_data=None, status=200, headers=None, text=""):
+        """Capture the canned JSON body, HTTP status, headers, and body text."""
         self._json_data = json_data or {}
         self.status = status
         self._headers = headers or {}
+        self._text = text
 
     async def __aenter__(self):
         """Enter the ``async with`` response context."""
@@ -67,6 +68,10 @@ class _FakeAiohttpResponse:
     async def json(self):
         """Return the canned JSON body."""
         return self._json_data
+
+    async def text(self):
+        """Return the canned body text (read by error-handling paths)."""
+        return self._text
 
     def raise_for_status(self):
         """Raise ClientResponseError for >=400 statuses (like aiohttp)."""
@@ -102,6 +107,28 @@ class _FakeAiohttpSession:
         self._capture["headers"] = headers
         self._capture["json"] = json
         return self._response
+
+
+class _FakeSequencedSession:
+    """Session stand-in returning queued responses, recording every POST body."""
+
+    def __init__(self, responses, bodies):
+        """Take the response queue and the list to append request bodies to."""
+        self._responses = list(responses)
+        self._bodies = bodies
+
+    async def __aenter__(self):
+        """Enter the ``async with`` session context."""
+        return self
+
+    async def __aexit__(self, *exc):
+        """Exit the session context without suppressing exceptions."""
+        return False
+
+    def post(self, url, headers=None, json=None):
+        """Record the body and return the next queued response."""
+        self._bodies.append(json)
+        return self._responses.pop(0)
 
 
 class TestAzureBackends(unittest.TestCase):
@@ -336,6 +363,67 @@ class TestAzureInfer(unittest.TestCase):
         """Non-reasoning deployments keep the router-supplied temperature."""
         body = self._capture_chat_completions_body("gpt-4.1-mini")
         self.assertIn("temperature", body)
+
+    _TEMPERATURE_REJECTION_TEXT = (
+        "Unsupported value: 'temperature' does not support 0.7 with this "
+        "model. Only the default (1) value is supported."
+    )
+    _OK_COMPLETION = {"choices": [{"message": {"content": "Dear insurer, please."}}]}
+
+    @patch.dict(os.environ, AZURE_OPENAI_ENV)
+    def test_custom_deployment_temperature_rejection_retries_without(self):
+        """A reasoning model behind a custom deployment name (which the
+        name-based check can't recognize) must trigger a single retry with
+        temperature stripped instead of failing with the 400."""
+
+        async def run():
+            """Queue a temperature-rejection 400 then a 200 and inspect bodies."""
+            m = RemoteAzureOpenAI(model="appeals-prod")
+            bodies: list = []
+            session = _FakeSequencedSession(
+                [
+                    _FakeAiohttpResponse(
+                        status=400, text=self._TEMPERATURE_REJECTION_TEXT
+                    ),
+                    _FakeAiohttpResponse(self._OK_COMPLETION),
+                ],
+                bodies,
+            )
+            with patch.object(aiohttp, "ClientSession", return_value=session):
+                result = await m._infer(system_prompts=["x"], prompt="y")
+            self.assertIsNotNone(result)
+            self.assertEqual(len(bodies), 2)
+            self.assertIn("temperature", bodies[0])
+            self.assertNotIn("temperature", bodies[1])
+
+        asyncio.run(run())
+
+    @patch.dict(os.environ, AZURE_OPENAI_ENV)
+    def test_temperature_rejection_memoized_for_later_calls(self):
+        """After one rejection the deployment is remembered: the next call's
+        first attempt already omits temperature (no wasted 400 round-trip)."""
+
+        async def run():
+            """Run two calls through one queue and inspect the third body."""
+            m = RemoteAzureOpenAI(model="appeals-prod")
+            bodies: list = []
+            session = _FakeSequencedSession(
+                [
+                    _FakeAiohttpResponse(
+                        status=400, text=self._TEMPERATURE_REJECTION_TEXT
+                    ),
+                    _FakeAiohttpResponse(self._OK_COMPLETION),
+                    _FakeAiohttpResponse(self._OK_COMPLETION),
+                ],
+                bodies,
+            )
+            with patch.object(aiohttp, "ClientSession", return_value=session):
+                await m._infer(system_prompts=["x"], prompt="y")
+                await m._infer(system_prompts=["x"], prompt="y")
+            self.assertEqual(len(bodies), 3)
+            self.assertNotIn("temperature", bodies[2])
+
+        asyncio.run(run())
 
 
 class TestAzureClaudeMessages(unittest.TestCase):

--- a/tests/async-unit/test_ml_router.py
+++ b/tests/async-unit/test_ml_router.py
@@ -343,6 +343,28 @@ class TestMLRouterBestExternalModels(unittest.TestCase):
 
         self.assertEqual(result, [])
 
+    def test_full_qa_backends_includes_available_gemma(self):
+        """An available gemma-4 external is offered for QA with use_external."""
+        gemma = make_external_mock(quality=80)
+        self.router.models_by_name = {"google/gemma-4-26B-A4B-it": [gemma]}
+        self.router.internal_models_by_cost = []
+
+        result = self.router.full_qa_backends(use_external=True)
+
+        self.assertIn(gemma, result)
+
+    def test_full_qa_backends_skips_unavailable_gemma(self):
+        """The named gemma-4 QA append honors the availability gate: a
+        rate-limited/down backend must not be handed to question generation,
+        which waits on every fanned-out task until the timeout."""
+        down = make_external_mock(quality=80, available=False)
+        self.router.models_by_name = {"google/gemma-4-26B-A4B-it": [down]}
+        self.router.internal_models_by_cost = []
+
+        result = self.router.full_qa_backends(use_external=True)
+
+        self.assertNotIn(down, result)
+
 
 class TestContextOnlyModelFlag(unittest.TestCase):
     """Tests for the context_only flag and how the router handles it."""

--- a/tests/sync/test_admin_status.py
+++ b/tests/sync/test_admin_status.py
@@ -301,7 +301,7 @@ class FaxBackendsHealthTest(TestCase):
         budget but sum past it (e.g. Sonic's login GET + POST + members GET,
         each just under ``timeout``) is slow-but-working, not dead. The outer
         probe deadline covers the sum, so it must report healthy instead of a
-        false ``timeout>``."""
+        false ``timeout>Ns`` failure."""
         from fighthealthinsurance.fax_health_status import _probe_backend
 
         def slow_but_healthy(timeout):

--- a/tests/sync/test_admin_status.py
+++ b/tests/sync/test_admin_status.py
@@ -296,6 +296,25 @@ class FaxBackendsHealthTest(TestCase):
         self.assertIn("bad login", result["sonic"]["error"])
         self.assertFalse(result["backends"][0]["ok"])
 
+    def test_probe_outer_cap_covers_sequential_per_request_budgets(self):
+        """A backend whose sequential round-trips each fit the per-request
+        budget but sum past it (e.g. Sonic's login GET + POST + members GET,
+        each just under ``timeout``) is slow-but-working, not dead. The outer
+        probe deadline covers the sum, so it must report healthy instead of a
+        false ``timeout>``."""
+        from fighthealthinsurance.fax_health_status import _probe_backend
+
+        def slow_but_healthy(timeout):
+            # Longer than one per-request budget, well within the 3x cap.
+            time.sleep(timeout * 1.5)
+            return True
+
+        backend = mock.Mock()
+        backend.check_health = slow_but_healthy
+        ok, error = _probe_backend(backend, timeout=0.2)
+        self.assertTrue(ok)
+        self.assertIsNone(error)
+
     def test_sonic_not_configured_reports_reason(self):
         from fighthealthinsurance import fax_utils
         from fighthealthinsurance.fax_health_status import check_fax_backends_health

--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,11 @@ deps =
   -rrequirements.txt
   -rrequirements-dev.txt
 
-[testenv:mypy]
+# The pyXXX-mypy names must be listed in this header (like the black env
+# above): a separate `[testenv:py313-mypy]` section would NOT inherit this
+# section's commands, so `tox -e py313-mypy` would install the package, run
+# nothing, and report success. basepython is derived from the pyXXX factor.
+[testenv:py{311,312,313}-mypy,mypy]
 setenv =
     DJANGO_SETTINGS_MODULE=fighthealthinsurance.settings
     PYTHONPATH={toxinidir}
@@ -88,15 +92,6 @@ allowlist_externals = pytest, black, mypy
 commands =
     mypy: mypy --config-file mypy.ini -p fighthealthinsurance -p fhi_users
     pyright: pyright {posargs}
-
-[testenv:py311-mypy]
-basepython = python3.11
-
-[testenv:py312-mypy]
-basepython = python3.12
-
-[testenv:py313-mypy]
-basepython = python3.13
 
 # sync tests
 [testenv:{sync,py311-django52-sync,py312-django52-sync,py313-django52-sync,pyright,py312-pyright}]


### PR DESCRIPTION
Review of the June 6-21 commits surfaced six defects; this fixes all of
them:

- Azure OpenAI gpt-5/gpt-5-mini could never return a completion: the
  shared OpenAI-compatible transport always sent "temperature", which
  reasoning models (gpt-5 family, o-series) reject with HTTP 400. Add
  RemoteOpenLike._supports_custom_temperature and omit the field for
  those models. Regression tests pin the request body for gpt-5,
  gpt-5-mini, and gpt-4.1-mini.

- ml_router still special-cased the DeepInfra model names dropped in
  #856, leaving four permanently-false branches. summarize() and
  full_qa_backends now prefer the successor google/gemma-4-26B-A4B-it
  (restoring PubMed article summaries in DeepInfra-only deployments);
  the dead branches in generate_text_backends and partial_qa_backends
  are removed rather than re-pointed because both bypassed the
  use_external privacy gate.

- The staff-dashboard fax probe capped the whole Sonic check at the
  same value it passed as the per-request timeout, so three sequential
  round-trips each within budget reported a false "timeout" failure.
  The outer deadline is now timeout * 3 (login GET + POST + members
  GET), with a regression test.

- appeal_fetcher.ts: the hard-timeout give-up path (no REST fallback
  URL) closed the socket without any latch the onclose handler checks,
  so onclose painted the checklist green with "Your appeals are
  ready!" over the give-up error and double-fired done(). A new
  wsGaveUp latch short-circuits onclose/onerror and queued reconnects.

- appeal_fetcher.ts: the external-models rerun didn't reset the
  "Current appeal" wait clock, so it included however long the user
  spent reading drafts before opting in.

- professional_thankyou.html: fix garbled sentence "We'll keep follow
  up shortly."

Verified: full sync suite (1364 passed), full async-unit suite (1110
passed, 2 skipped), mypy clean, black clean, webpack bundle builds.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015jQ4g1SEqgNVDpwPi3mArT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved health-check handling for slower multi-step backend probes so they don’t fail prematurely.
  * Fixed WebSocket “give up” behavior to avoid duplicate completion/error handling and corrected the current-appeal timer on regeneration.
  * Updated AI request building to automatically omit unsupported temperature settings and retry when the provider rejects them.
  * Refreshed model routing for text generation, QA, and summarization to use more reliable default/generalist selections.
  * Updated the professional thank-you message text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->