### PR TITLE
Add test email preview feature to Pro Connector staff interface

### DIFF
--- a/fighthealthinsurance/proconnector.py
+++ b/fighthealthinsurance/proconnector.py
@@ -389,6 +389,37 @@ def send_proconnector_intro_email(
     )
 
 
+def send_proconnector_test_email(
+    pro: InterestedProfessional,
+    subject: str,
+    body: str,
+    test_email: str,
+) -> None:
+    """Send a *test* copy of the intro email to ``test_email`` now.
+
+    Lets staff preview exactly how the (edited) draft renders in a real inbox
+    before committing to the real send. Unlike the real send it goes only to
+    the test address (the professional is NOT emailed and the professional
+    contact address is NOT CC'd), the subject and body are clearly marked as a
+    test, and -- critically -- nothing is written to the record: the intro is
+    not marked attempted/sent, so it stays in the queue. Raises on a blocked
+    test address or send failure so the caller can surface the problem.
+    """
+    if is_blocked_email(test_email):
+        raise ValueError("Test email address is blocked or unsendable")
+    test_banner = (
+        f"[TEST] This is a test preview of the intro email for {pro.email} "
+        f"(InterestedProfessional #{pro.id}). The real intro has NOT been "
+        "sent and the record has NOT been marked as sent."
+    )
+    send_fallback_email(
+        subject=f"TEST: {subject}",
+        template_name="proconnector_intro",
+        context={"body": f"{test_banner}\n\n{body}", "name": pro.name},
+        to_email=test_email,
+    )
+
+
 def queue_proconnector_intro_email(
     pro: InterestedProfessional,
     subject: str,

--- a/fighthealthinsurance/rest_views.py
+++ b/fighthealthinsurance/rest_views.py
@@ -1581,8 +1581,10 @@ class DemoRequestsViewSet(viewsets.ViewSet, CreateMixin, DeleteMixin):
             # duplicate InterestedProfessional, re-notify the professional inbox,
             # or re-send the thank-you. The DemoRequests row + the support
             # notification (_notify_demo_request) already captured this repeat
-            # submission for the team.
-            if InterestedProfessional.objects.filter(email=demo.email).exists():
+            # submission for the team. Case-insensitive to match how the
+            # pro-connector queue collapses duplicates (email__iexact), so
+            # Jane@clinic.org resubmitting as jane@clinic.org isn't re-thanked.
+            if InterestedProfessional.objects.filter(email__iexact=demo.email).exists():
                 return
             interested_pro = InterestedProfessional.objects.create(
                 name=demo.name or "",
@@ -1677,8 +1679,13 @@ class InterestedProfessionalViewSet(viewsets.ViewSet, CreateMixin):
         # Dedup by email: a returning lead reuses the existing record rather
         # than accumulating duplicate rows or re-notifying the professional
         # inbox. Repeat submissions still get the standard success response.
+        # Case-insensitive to match how the pro-connector queue collapses
+        # duplicates (email__iexact).
         email = serializer.validated_data.get("email")
-        if email and InterestedProfessional.objects.filter(email=email).exists():
+        if (
+            email
+            and InterestedProfessional.objects.filter(email__iexact=email).exists()
+        ):
             return Response(
                 serializers.StatusResponseSerializer({"status": "subscribed"}).data,
                 status=status.HTTP_201_CREATED,

--- a/fighthealthinsurance/staff_views.py
+++ b/fighthealthinsurance/staff_views.py
@@ -56,6 +56,7 @@ from fighthealthinsurance.proconnector import (
     subject_wording_problem,
     remaining_interested_professionals_count,
     send_proconnector_intro_email,
+    send_proconnector_test_email,
 )
 from fighthealthinsurance.type_utils import User
 from fighthealthinsurance.utils import mask_email_for_logging
@@ -647,8 +648,10 @@ class ProConnectorProcessView(View):
     known details, research links, and an AI-drafted (editable) intro email.
     Staff either send the (edited) email -- which CCs the professional contact
     address and records the send -- queue it to go out during the recipient's
-    likely business hours, or skip the record. Any action advances to the next
-    unprocessed record. Nothing is sent automatically.
+    likely business hours, or skip the record. Any of those actions advances to
+    the next unprocessed record. Staff can also send a TEST-marked copy of the
+    draft to a test address first; that emails nobody else, records nothing on
+    the record, and stays on the same record. Nothing is sent automatically.
     """
 
     template_name = "proconnector.html"
@@ -661,16 +664,25 @@ class ProConnectorProcessView(View):
         draft: Optional[str] = None,
         subject: Optional[str] = None,
         skip_reason: str = "",
+        test_email: Optional[str] = None,
         error: Optional[str] = None,
+        notice: Optional[str] = None,
         status: int = 200,
     ) -> HttpResponse:
         """Render the processing page for a single record.
 
         ``draft`` is generated via AI only when not supplied so that re-renders
         after a validation/send error preserve the staff member's edits.
+        ``test_email`` similarly falls back to whatever was posted (preserving
+        the field across validation errors), then to the staff member's own
+        address so the "send test" button works without retyping it.
         """
         if draft is None:
             draft = generate_intro_email(pro)
+        if test_email is None:
+            test_email = (request.POST.get("test_email") or "").strip() or (
+                getattr(request.user, "email", "") or ""
+            )
         links = build_search_links(pro)
         context = {
             "title": "Pro Connector",
@@ -681,7 +693,9 @@ class ProConnectorProcessView(View):
             "google_search_url": links["google"],
             "linkedin_search_url": links["linkedin"],
             "skip_reason": skip_reason,
+            "test_email": test_email,
             "error": error,
+            "notice": notice,
             "remaining_count": remaining_interested_professionals_count(),
             "send_window_hint": describe_send_window(pro.phone_number),
         }
@@ -729,6 +743,12 @@ class ProConnectorProcessView(View):
                 f"InterestedProfessional {pro.id} ({mask_email_for_logging(pro.email)})"
             )
             return redirect("proconnector_process")
+
+        # "send_test" previews the draft in a real inbox: it emails only the
+        # staff-supplied test address with TEST markers and never touches the
+        # record, so the intro still shows as unsent and stays in the queue.
+        if action == "send_test":
+            return self._handle_send_test(request, pro)
 
         # "send" delivers now; "queue" defers to the recipient's likely business
         # hours. They share validation and edit-preserving error handling.
@@ -783,6 +803,25 @@ class ProConnectorProcessView(View):
         # Unknown / missing action -- re-render the current record.
         return self._render_record(request, pro, error="Unknown action.", status=400)
 
+    @staticmethod
+    def _intro_form_problem(body: str, subject: str) -> Optional[str]:
+        """First problem with the editable intro fields, or ``None``.
+
+        Shared by the real send/queue path and the test-send path so a draft
+        that previews cleanly is exactly one that can be sent: same empty-body
+        rule, same wording rules -- partner framing (body *or* subject) and the
+        required compensation disclosure -- run against the *final* (possibly
+        hand-edited) values, not just the AI draft, and the same length cap
+        matching the scheduled-email column so the immediate and queued paths
+        behave identically.
+        """
+        subject_max = ScheduledEmail._meta.get_field("subject").max_length
+        if not body:
+            return "Email body cannot be empty."
+        if subject_max is not None and len(subject) > subject_max:
+            return f"Subject is too long (max {subject_max} characters)."
+        return intro_wording_problem(body) or subject_wording_problem(subject)
+
     def _validated_intro(
         self, request, pro: InterestedProfessional
     ) -> Union[Tuple[str, str, str], HttpResponse]:
@@ -790,31 +829,17 @@ class ProConnectorProcessView(View):
 
         Returns ``(body, subject, skip_reason)`` when valid, or an error
         ``HttpResponse`` (re-rendering the record with the staff edits preserved)
-        when the body is empty, the recipient address is unsendable, the subject
-        is too long for the scheduled-email column, or the (possibly hand-edited)
-        wording breaks the intro rules -- partner framing (body *or* subject) or a
-        missing compensation disclosure -- which must hold for the final sent
-        text, not just the AI draft.
+        when the shared form checks fail (see :meth:`_intro_form_problem`) or
+        the recipient address is unsendable.
         """
         body = (request.POST.get("email_body") or "").strip()
         subject = (
             request.POST.get("subject") or ""
         ).strip() or PROCONNECTOR_INTRO_SUBJECT
         skip_reason = (request.POST.get("skip_reason") or "").strip()
-        # First failing check wins. The wording rules run against the *final*
-        # (possibly hand-edited) values, not just the AI draft, and cover the
-        # subject line too; the length cap matches the scheduled-email column so
-        # the immediate and queued paths behave identically.
-        subject_max = ScheduledEmail._meta.get_field("subject").max_length
-        error: Optional[str]
-        if not body:
-            error = "Email body cannot be empty."
-        elif not is_sendable_email(pro.email):
+        error = self._intro_form_problem(body, subject)
+        if error is None and not is_sendable_email(pro.email):
             error = f"{pro.email} is not a sendable address; cannot send."
-        elif subject_max is not None and len(subject) > subject_max:
-            error = f"Subject is too long (max {subject_max} characters)."
-        else:
-            error = intro_wording_problem(body) or subject_wording_problem(subject)
         if error:
             return self._render_record(
                 request,
@@ -826,6 +851,77 @@ class ProConnectorProcessView(View):
                 status=400,
             )
         return body, subject, skip_reason
+
+    def _handle_send_test(self, request, pro: InterestedProfessional) -> HttpResponse:
+        """Send a TEST-marked preview of the draft to the staff-supplied address.
+
+        Runs the same form validation as a real send (so a draft that previews
+        cleanly is exactly one that can be sent) but gates on the *test*
+        address being sendable -- the professional is not emailed -- and never
+        writes to the record: no claim, no attempted/sent/body updates, so the
+        intro stays unsent and remains in the queue. Success re-renders the
+        same record (edits preserved) rather than advancing.
+        """
+        body = (request.POST.get("email_body") or "").strip()
+        subject = (
+            request.POST.get("subject") or ""
+        ).strip() or PROCONNECTOR_INTRO_SUBJECT
+        skip_reason = (request.POST.get("skip_reason") or "").strip()
+        test_email = (request.POST.get("test_email") or "").strip()
+        error = self._intro_form_problem(body, subject)
+        if error is None:
+            if not test_email:
+                error = "Enter a test email address to send the test to."
+            elif not is_sendable_email(test_email):
+                error = f"{test_email} is not a sendable address; cannot send the test."
+        if error:
+            return self._render_record(
+                request,
+                pro,
+                draft=body or request.POST.get("email_body", ""),
+                subject=subject,
+                skip_reason=skip_reason,
+                error=error,
+                status=400,
+            )
+        try:
+            send_proconnector_test_email(
+                pro, subject=subject, body=body, test_email=test_email
+            )
+        except Exception as e:
+            logger.opt(exception=True).error(
+                f"Failed to send pro-connector TEST intro for "
+                f"InterestedProfessional {pro.id} to "
+                f"{mask_email_for_logging(test_email)}: {e}"
+            )
+            return self._render_record(
+                request,
+                pro,
+                draft=body,
+                subject=subject,
+                skip_reason=skip_reason,
+                error=(
+                    "Failed to send the test email. The error has been logged; "
+                    "please try again."
+                ),
+                status=500,
+            )
+        logger.info(
+            f"Staff user {request.user.username} sent pro-connector TEST intro for "
+            f"InterestedProfessional {pro.id} ({mask_email_for_logging(pro.email)}) "
+            f"to {mask_email_for_logging(test_email)}"
+        )
+        return self._render_record(
+            request,
+            pro,
+            draft=body,
+            subject=subject,
+            skip_reason=skip_reason,
+            notice=(
+                f"Test email sent to {test_email}. Nothing was recorded on this "
+                "record -- the real intro has NOT been sent."
+            ),
+        )
 
 
 class _CSVEcho:

--- a/fighthealthinsurance/templates/proconnector.html
+++ b/fighthealthinsurance/templates/proconnector.html
@@ -100,6 +100,29 @@
       border-radius: 4px;
       margin-bottom: 16px;
     }
+    .notice {
+      background: #d1e7dd;
+      border: 1px solid #a3cfbb;
+      color: #0a3622;
+      padding: 12px 16px;
+      border-radius: 4px;
+      margin-bottom: 16px;
+    }
+    .test-send {
+      margin-top: 18px;
+      padding: 12px 14px;
+      background: #f3eefe;
+      border: 1px solid #d9c9f7;
+      border-radius: 4px;
+    }
+    .test-send label { margin-top: 0; }
+    .test-send .hint {
+      font-size: 0.88em;
+      color: #4d3a73;
+      margin: 8px 0 0;
+    }
+    button.test { background-color: #6f42c1; color: white; margin-top: 10px; }
+    button.test:hover { background-color: #59339d; }
     .readonly { color: #333; }
     .back { display: inline-block; margin-top: 10px; color: #007bff; }
   </style>
@@ -109,6 +132,9 @@
 
   {% if error %}
     <div class="error">{{ error }}</div>
+  {% endif %}
+  {% if notice %}
+    <div class="notice">{{ notice }}</div>
   {% endif %}
 
   {% if pro %}
@@ -178,6 +204,18 @@
           <button type="submit" class="send" name="action" value="send">Send intro email now</button>
           <button type="submit" class="queue" name="action" value="queue">Send during business hours</button>
           <button type="submit" class="skip" name="action" value="skip" formnovalidate>Skip</button>
+        </div>
+
+        <div class="test-send">
+          <label for="test_email">Send a test copy to</label>
+          <input type="text" id="test_email" name="test_email" value="{{ test_email }}" placeholder="you@fighthealthinsurance.com">
+          <button type="submit" class="test" name="action" value="send_test">Send test e-mail</button>
+          <p class="hint">
+            Sends the draft above to the test address only, with a TEST marker
+            in the subject and body. {{ pro.email }} is not emailed, nothing is
+            CC'd, and the record is <strong>not</strong> marked as sent &mdash;
+            it stays in the queue.
+          </p>
         </div>
       </form>
     </div>

--- a/tests/sync/test_proconnector.py
+++ b/tests/sync/test_proconnector.py
@@ -28,6 +28,7 @@ from fighthealthinsurance.proconnector import (
     get_professional_cc_email,
     partner_framing_problem,
     queue_proconnector_intro_email,
+    send_proconnector_test_email,
 )
 
 User = get_user_model()
@@ -814,6 +815,141 @@ class SendFailureTest(_ProcessViewTestCase):
         self.assertFalse(pro.proconnector_attempted)
         self.assertIsNone(pro.proconnector_sent_at)
         self.assertIsNone(pro.proconnector_email_body)
+
+
+# ---------------------------------------------------------------------------
+# Test-email flow (preview send that must never mark the record)
+# ---------------------------------------------------------------------------
+class SendTestEmailFlowTest(_ProcessViewTestCase):
+    BODY = "Edited intro body with the compensation disclosure."
+
+    def _post_test(self, pro, **overrides):
+        fields = {
+            "interested_professional_id": pro.id,
+            "subject": "Intro to Cofactor AI",
+            "email_body": self.BODY,
+            "test_email": "staff-tester@fhi-staff.org",
+        }
+        fields.update(overrides)
+        return self._post("send_test", **fields)
+
+    def test_send_test_emails_target_and_does_not_mark_record(self):
+        pro = _make_pro(email="jane@janeclinic.com")
+        response = self._post_test(pro)
+        # Re-renders the same record (no redirect/advance) with a confirmation.
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Test email sent to staff-tester@fhi-staff.org")
+        self.assertContains(response, "NOT been sent")
+        # The staff edits are preserved on the re-render.
+        self.assertContains(response, self.BODY)
+
+        # The test email goes to the test address only, with no CC of
+        # professional@ (send_fallback_email also drops an internal BCC-copy
+        # message, so check recipients rather than outbox length).
+        self.assertGreaterEqual(len(mail.outbox), 1)
+        msg = mail.outbox[0]
+        self.assertEqual(msg.to, ["staff-tester@fhi-staff.org"])
+        self.assertEqual(msg.cc, [])
+        # TEST markers in subject and body, plus the real draft content.
+        self.assertEqual(msg.subject, "TEST: Intro to Cofactor AI")
+        self.assertIn("[TEST]", msg.body)
+        self.assertIn("jane@janeclinic.com", msg.body)
+        self.assertIn(self.BODY, msg.body)
+        # The interested professional is never a recipient of ANY message.
+        for m in mail.outbox:
+            self.assertNotIn("jane@janeclinic.com", m.to + m.cc + m.bcc)
+
+        # Nothing recorded: not attempted/sent/skipped, no body stored, and the
+        # record is still the next one in the queue.
+        pro.refresh_from_db()
+        self.assertFalse(pro.proconnector_attempted)
+        self.assertIsNone(pro.proconnector_sent_at)
+        self.assertIsNone(pro.proconnector_email_body)
+        self.assertFalse(pro.proconnector_skipped)
+        self.assertEqual(get_next_interested_professional().pk, pro.pk)
+
+    def test_send_test_requires_test_address(self):
+        pro = _make_pro(email="jane@janeclinic.com")
+        response = self._post_test(pro, test_email="   ")
+        self.assertEqual(response.status_code, 400)
+        self.assertContains(response, "Enter a test email address", status_code=400)
+        self.assertEqual(len(mail.outbox), 0)
+        pro.refresh_from_db()
+        self.assertFalse(pro.proconnector_attempted)
+
+    def test_send_test_rejects_blocked_test_address(self):
+        # example.com is a blocked domain -> not sendable, rejected up front.
+        pro = _make_pro(email="jane@janeclinic.com")
+        response = self._post_test(pro, test_email="tester@example.com")
+        self.assertEqual(response.status_code, 400)
+        self.assertContains(response, "not a sendable address", status_code=400)
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_send_test_allows_blocked_recipient_record(self):
+        # The real recipient's sendability must NOT gate a test: staff may want
+        # to preview the draft even though the record itself can't be sent to.
+        pro = _make_pro(email="blocked@example.com")
+        response = self._post_test(pro)
+        self.assertEqual(response.status_code, 200)
+        self.assertGreaterEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].to, ["staff-tester@fhi-staff.org"])
+
+    def test_send_test_enforces_wording_rules(self):
+        # Same validation as a real send, so a draft that previews cleanly is
+        # exactly one that can be sent.
+        pro = _make_pro(email="jane@janeclinic.com")
+        response = self._post_test(
+            pro, email_body="FHI has partnered with Cofactor AI. Compensated."
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_send_test_empty_body_rejected(self):
+        pro = _make_pro(email="jane@janeclinic.com")
+        response = self._post_test(pro, email_body="   ")
+        self.assertEqual(response.status_code, 400)
+        self.assertContains(response, "cannot be empty", status_code=400)
+        self.assertEqual(len(mail.outbox), 0)
+
+    @patch(
+        "fighthealthinsurance.staff_views.send_proconnector_test_email",
+        side_effect=Exception("smtp boom"),
+    )
+    def test_send_test_failure_shows_error_and_marks_nothing(self, _mock_send):
+        pro = _make_pro(email="jane@janeclinic.com")
+        response = self._post_test(pro)
+        self.assertEqual(response.status_code, 500)
+        self.assertContains(response, "Failed to send the test email", status_code=500)
+        # Edits preserved for retry; record untouched.
+        self.assertContains(response, self.BODY, status_code=500)
+        pro.refresh_from_db()
+        self.assertFalse(pro.proconnector_attempted)
+        self.assertIsNone(pro.proconnector_email_body)
+
+    @patch(
+        "fighthealthinsurance.staff_views.generate_intro_email",
+        return_value="A draft body with compensation disclosure.",
+    )
+    def test_test_email_field_prefilled_with_staff_address(self, _mock_gen):
+        # The logged-in staff user (created by _login) has no email, so set one.
+        User.objects.filter(username="u").update(email="staff@fhi-staff.org")
+        _make_pro(email="jane@janeclinic.com")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'value="send_test"')
+        self.assertContains(response, "Send test e-mail")
+        self.assertContains(response, 'value="staff@fhi-staff.org"')
+
+    def test_send_test_helper_blocked_address_raises(self):
+        pro = _make_pro(email="jane@janeclinic.com")
+        with self.assertRaises(ValueError):
+            send_proconnector_test_email(
+                pro,
+                subject="Intro",
+                body="Body with compensation disclosure.",
+                test_email="nope@example.com",
+            )
+        self.assertEqual(len(mail.outbox), 0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/sync/test_rest_api.py
+++ b/tests/sync/test_rest_api.py
@@ -2139,6 +2139,38 @@ class DemoRequestEndpointTest(APITestCase):
         ]
         self.assertEqual(len(thankyous), 1)
 
+    def test_demo_request_lead_dedup_is_case_insensitive(self):
+        # A resubmission that only differs in email case must reuse the existing
+        # lead (matching the pro-connector queue's email__iexact collapsing),
+        # not create a duplicate InterestedProfessional or re-send the thank-you.
+        from fighthealthinsurance.models import InterestedProfessional
+
+        first = self.client.post(
+            reverse("demorequest-list"),
+            data=json.dumps({"email": "casey@clinic.example", "name": "Casey"}),
+            content_type="application/json",
+        )
+        second = self.client.post(
+            reverse("demorequest-list"),
+            data=json.dumps({"email": "Casey@Clinic.example", "name": "Casey"}),
+            content_type="application/json",
+        )
+        self.assertEqual(first.status_code, 201)
+        self.assertEqual(second.status_code, 201)
+        self.assertEqual(
+            InterestedProfessional.objects.filter(
+                email__iexact="casey@clinic.example"
+            ).count(),
+            1,
+        )
+        thankyous = [
+            m
+            for m in mail.outbox
+            if [a.lower() for a in m.to] == ["casey@clinic.example"]
+            and "Thanks for your interest" in m.subject
+        ]
+        self.assertEqual(len(thankyous), 1)
+
     def test_demo_request_notifies_professional_inbox(self):
         # The lead notification goes through the shared
         # notify_interested_professional helper, i.e. to the professional inbox.


### PR DESCRIPTION
## Summary
Adds a "Send test e-mail" feature to the Pro Connector staff processing view, allowing staff to preview the draft introduction email in a real inbox before committing to the actual send. Test emails are sent only to a staff-supplied address with TEST markers and never modify the professional record, keeping it in the queue.

## Key Changes

- **New test email action** (`send_test`): Staff can now send a preview copy of the draft to any test address without marking the record as attempted/sent
  - Test emails include `[TEST]` markers in both subject and body
  - Only the test address receives the email (no CC of professional contact)
  - The professional record remains untouched and stays in the queue
  - Staff edits to the draft are preserved on re-render

- **Shared validation logic**: Extracted `_intro_form_problem()` static method to ensure test email drafts pass the same validation rules (empty body check, subject length, wording rules) as real sends
  - A draft that previews cleanly is guaranteed to be sendable

- **New helper function** `send_proconnector_test_email()` in `proconnector.py`:
  - Validates test address is sendable (raises on blocked domains)
  - Sends with TEST banner and professional email context
  - Never writes to the InterestedProfessional record

- **UI updates** (`proconnector.html`):
  - Added "Send a test copy to" input field with placeholder
  - New purple-themed test send section with explanatory hint
  - Test email field pre-fills with logged-in staff member's email address
  - Success/error messages preserved across re-renders

- **Case-insensitive email deduplication** in REST API (`rest_views.py`):
  - Fixed `_record_interested_professional()` and `perform_create()` to use `email__iexact` matching
  - Prevents duplicate InterestedProfessional records when leads resubmit with different email case (e.g., Jane@clinic.org vs jane@clinic.org)

## Testing
Comprehensive test coverage added in `test_proconnector.py`:
- Test email sends to target address only with TEST markers
- Record remains untouched (not marked attempted/sent/skipped)
- Validation enforces same rules as real sends
- Blocked test addresses are rejected
- Blocked recipient records can still be previewed
- Send failures show error without modifying record
- Test address field pre-fills with staff member's email
- Helper function raises on blocked addresses

Additional REST API test for case-insensitive email deduplication.

https://claude.ai/code/session_01XA2nzXCGM5vnv8nrnHyFUM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a staff preview option to send a test copy of the pro-connector email to a specified address, with clear test labeling and a visible confirmation message.
* **Bug Fixes**
  * Improved lead deduplication so email addresses are treated case-insensitively, helping prevent duplicate records and repeat notifications.
* **Tests**
  * Expanded coverage for the new test-send flow and case-insensitive email handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->