### PR TITLE
Fail-close the denial/appeal and chat training exports

### DIFF
--- a/charts/views.py
+++ b/charts/views.py
@@ -604,26 +604,19 @@ def generate_denial_appeal_lines():
     )
 
     for denial in denials:
-        denial_text = denial.manual_deidentified_denial or denial.denial_text
+        # Fail closed: only export a (denial, appeal) pair once a human has
+        # de-identified BOTH halves. The prior `manual_deidentified_* or <raw>`
+        # fallback silently emitted raw denial text and raw proposed/finalized
+        # appeal text whenever the manual field was blank, baking patient PHI
+        # into the training corpus. Mirrors generate_de_identified_lines, which
+        # already excludes records lacking manual_deidentified_denial.
+        denial_text = denial.manual_deidentified_denial
+        appeal_text = denial.manual_deidentified_appeal
+        if not denial_text or not appeal_text:
+            continue
+
         procedure = _get_verified_or_raw(denial, "procedure")
         diagnosis = _get_verified_or_raw(denial, "diagnosis")
-
-        appeal_text = None
-        if denial.manual_deidentified_appeal:
-            appeal_text = denial.manual_deidentified_appeal
-        else:
-            chosen_proposed = next(
-                (p for p in denial.proposedappeal_set.all() if p.chosen), None
-            )
-            if chosen_proposed:
-                appeal_text = chosen_proposed.appeal_text
-            else:
-                appeals = list(denial.appeal_set.all())
-                if appeals:
-                    appeal_text = appeals[0].appeal_text
-
-        if not appeal_text:
-            continue
 
         # Build Q&A from prefetched DenialQA records
         qa_pairs = []
@@ -649,28 +642,24 @@ def generate_denial_appeal_lines():
 
 
 def generate_chat_lines():
-    """Yield JSONL lines of de-identified chat histories (non-pro only)."""
-    chats = (
-        OngoingChat.objects.filter(
-            professional_user__isnull=True,
-            domain__isnull=True,
-        )
-        .exclude(chat_history__isnull=True)
-        .exclude(chat_history=[])
-        .exclude(hashed_email__in=_get_excluded_hashed_emails())
-        .prefetch_related("appeals")
-    )
+    """Yield de-identified chat histories (non-pro only).
 
-    for chat in chats:
-        appeal_texts = [a.appeal_text for a in chat.appeals.all() if a.appeal_text]
-        record = {
-            "chat_id": str(chat.id),
-            "chat_history": chat.chat_history,
-            "denied_item": chat.denied_item,
-            "denied_reason": chat.denied_reason,
-            "appeal_texts": appeal_texts,
-        }
-        yield json.dumps(record, default=str) + "\n"
+    Fail closed: OngoingChat has no manually de-identified counterpart, so
+    every field this previously emitted -- chat_history (the raw patient
+    conversation), denied_item/denied_reason, and the linked appeal_text --
+    is unredacted PHI despite the "de-identified" docstring. Until a
+    de-identification pass exists for chats, emit nothing rather than write
+    raw PHI into a training export. Re-enable by sourcing from
+    manual_deidentified_* fields once they exist on OngoingChat.
+    """
+    logger.warning(
+        "chat export skipped: no de-identified source for OngoingChat; "
+        "emitting 0 records under fail-closed export policy"
+    )
+    return
+    # Unreachable: keeps this a generator so callers that iterate it
+    # (run_exports, the streaming view) work unchanged.
+    yield  # pragma: no cover
 
 
 @staff_member_required

--- a/charts/views.py
+++ b/charts/views.py
@@ -597,21 +597,30 @@ def generate_denial_appeal_lines():
         ProposedAppeal.objects.filter(for_denial=OuterRef("pk"), chosen=True)
     )
     has_appeal = Exists(Appeal.objects.filter(for_denial=OuterRef("pk")))
+    # Fail closed: only export a (denial, appeal) pair once a human has
+    # de-identified BOTH halves. The prior `manual_deidentified_* or <raw>`
+    # fallback silently emitted raw denial text and raw proposed/finalized
+    # appeal text whenever the manual field was blank, baking patient PHI into
+    # the training corpus. Exclude those rows at the DB layer (mirroring
+    # generate_de_identified_lines) so they are never fetched; the loop then
+    # only reads denialqa_set, so the proposedappeal/appeal prefetches are
+    # dropped.
     denials = (
         _non_pro_unflagged_denials()
         .filter(has_chosen_proposed | has_appeal)
-        .prefetch_related("proposedappeal_set", "appeal_set", "denialqa_set")
+        .exclude(
+            Q(manual_deidentified_denial="")
+            | Q(manual_deidentified_denial__isnull=True)
+            | Q(manual_deidentified_appeal="")
+            | Q(manual_deidentified_appeal__isnull=True)
+        )
+        .prefetch_related("denialqa_set")
     )
 
     for denial in denials:
-        # Fail closed: only export a (denial, appeal) pair once a human has
-        # de-identified BOTH halves. The prior `manual_deidentified_* or <raw>`
-        # fallback silently emitted raw denial text and raw proposed/finalized
-        # appeal text whenever the manual field was blank, baking patient PHI
-        # into the training corpus. Mirrors generate_de_identified_lines, which
-        # already excludes records lacking manual_deidentified_denial.
         denial_text = denial.manual_deidentified_denial
         appeal_text = denial.manual_deidentified_appeal
+        # Defensive guard: the DB-level exclude above already drops these.
         if not denial_text or not appeal_text:
             continue
 

--- a/tests/sync/test_export_views.py
+++ b/tests/sync/test_export_views.py
@@ -185,7 +185,10 @@ class ChooserRankedExportContentTest(StaffExportTestBase):
 class DenialAppealExportContentTest(StaffExportTestBase):
     """Test the content of the denial + appeal export."""
 
-    def test_denial_appeal_export_with_chosen_proposed(self):
+    def test_denial_appeal_export_skips_without_manual_deid(self):
+        # Fail closed: a denial with a chosen (raw) proposed appeal but no
+        # manual de-identification must NOT be exported -- previously its raw
+        # denial_text and appeal_text leaked into the training corpus.
         denial = self._create_denial()
         ProposedAppeal.objects.create(
             for_denial=denial,
@@ -193,13 +196,19 @@ class DenialAppealExportContentTest(StaffExportTestBase):
             chosen=True,
         )
 
-        lines = self.get_export_lines("denial_appeal_export")
-        self.assertEqual(len(lines), 1)
+        self.assert_export_empty("denial_appeal_export")
 
-        record = lines[0]
-        self.assertEqual(record["denial_text"], "Your claim was denied")
-        self.assertEqual(record["appeal_text"], "This is the chosen appeal text")
-        self.assertEqual(record["procedure"], "MRI")
+    def test_denial_appeal_export_skips_with_partial_manual_deid(self):
+        # Both halves must be de-identified: a manual denial with no manual
+        # appeal (the raw proposed text is not a substitute) is still skipped.
+        denial = self._create_denial(manual_deidentified_denial="De-id denial")
+        ProposedAppeal.objects.create(
+            for_denial=denial,
+            appeal_text="Raw appeal text",
+            chosen=True,
+        )
+
+        self.assert_export_empty("denial_appeal_export")
 
     def test_denial_appeal_export_prefers_manual_deid(self):
         denial = self._create_denial(
@@ -228,7 +237,12 @@ class DenialAppealExportContentTest(StaffExportTestBase):
             username="prouser", password="testpass123"
         )
         pro = ProfessionalUser.objects.create(user=pro_user_auth, active=True)
-        denial = self._create_denial(creating_professional=pro)
+        # Fully de-identified so the ONLY reason it is excluded is the pro owner.
+        denial = self._create_denial(
+            creating_professional=pro,
+            manual_deidentified_denial="De-id denial text",
+            manual_deidentified_appeal="De-id appeal text",
+        )
         ProposedAppeal.objects.create(
             for_denial=denial,
             appeal_text="Pro appeal text",
@@ -238,7 +252,12 @@ class DenialAppealExportContentTest(StaffExportTestBase):
         self.assert_export_empty("denial_appeal_export")
 
     def test_denial_appeal_export_excludes_flagged(self):
-        denial = self._create_denial(flag_for_exclude=True)
+        # Fully de-identified so the ONLY reason it is excluded is the flag.
+        denial = self._create_denial(
+            flag_for_exclude=True,
+            manual_deidentified_denial="De-id denial text",
+            manual_deidentified_appeal="De-id appeal text",
+        )
         ProposedAppeal.objects.create(
             for_denial=denial,
             appeal_text="Flagged appeal",
@@ -247,8 +266,13 @@ class DenialAppealExportContentTest(StaffExportTestBase):
 
         self.assert_export_empty("denial_appeal_export")
 
-    def test_denial_appeal_export_with_finalized_appeal(self):
-        denial = self._create_denial()
+    def test_denial_appeal_export_uses_manual_deid_over_finalized(self):
+        # A finalized Appeal exists with raw text, but the export must emit the
+        # manually de-identified appeal, never the raw finalized text.
+        denial = self._create_denial(
+            manual_deidentified_denial="De-id denial text",
+            manual_deidentified_appeal="De-id appeal text",
+        )
         Appeal.objects.create(
             for_denial=denial,
             appeal_text="Finalized appeal text",
@@ -257,11 +281,14 @@ class DenialAppealExportContentTest(StaffExportTestBase):
 
         lines = self.get_export_lines("denial_appeal_export")
         self.assertEqual(len(lines), 1)
-        self.assertEqual(lines[0]["appeal_text"], "Finalized appeal text")
+        self.assertEqual(lines[0]["denial_text"], "De-id denial text")
+        self.assertEqual(lines[0]["appeal_text"], "De-id appeal text")
 
     def test_denial_appeal_export_includes_qa_and_pubmed_context(self):
         denial = self._create_denial(
             pubmed_context="PubMed says treatment is effective per PMID 12345",
+            manual_deidentified_denial="De-id denial text",
+            manual_deidentified_appeal="De-id appeal text",
         )
         ProposedAppeal.objects.create(
             for_denial=denial,
@@ -310,7 +337,9 @@ class DenialAppealExportContentTest(StaffExportTestBase):
 class ChatExportContentTest(StaffExportTestBase):
     """Test the content of the chat export."""
 
-    def test_chat_export_content(self):
+    def test_chat_export_is_fail_closed(self):
+        # OngoingChat has no de-identified source, so the export must emit
+        # nothing rather than leak raw chat_history / appeal_text PHI.
         chat = OngoingChat.objects.create(
             chat_history=[
                 {"role": "user", "content": "My claim was denied"},
@@ -326,13 +355,7 @@ class ChatExportContentTest(StaffExportTestBase):
             hashed_email="chathash123",
         )
 
-        lines = self.get_export_lines("chat_export")
-        self.assertEqual(len(lines), 1)
-
-        record = lines[0]
-        self.assertEqual(record["denied_item"], "MRI scan")
-        self.assertEqual(len(record["chat_history"]), 2)
-        self.assertEqual(record["appeal_texts"], ["Chat-based appeal text"])
+        self.assert_export_empty("chat_export")
 
     def test_chat_export_excludes_pro_chats(self):
         from fhi_users.models import ProfessionalUser
@@ -349,8 +372,8 @@ class ChatExportContentTest(StaffExportTestBase):
 
         self.assert_export_empty("chat_export")
 
-    def test_chat_export_without_appeal(self):
-        """Chats without appeals should still be exported."""
+    def test_chat_export_without_appeal_is_fail_closed(self):
+        """Even a chat with no linked appeal is not exported (raw PHI)."""
         OngoingChat.objects.create(
             chat_history=[
                 {"role": "user", "content": "My claim was denied"},
@@ -359,9 +382,7 @@ class ChatExportContentTest(StaffExportTestBase):
             hashed_email="noappealhash",
         )
 
-        lines = self.get_export_lines("chat_export")
-        self.assertEqual(len(lines), 1)
-        self.assertEqual(lines[0]["appeal_texts"], [])
+        self.assert_export_empty("chat_export")
 
 
 class QuestionsByProcedureExportContentTest(StaffExportTestBase):


### PR DESCRIPTION
## Fail-close the denial/appeal and chat training exports

Phase 0 privacy fix (1 of 6) from the 2026-07-06 review. Read-only branch off `main`.

### Problem
The JSONL training exports fell **open** to raw PHI when a record wasn't hand-de-identified:

- `generate_denial_appeal_lines` used `manual_deidentified_denial or denial.denial_text` and fell back to raw `ProposedAppeal`/`Appeal` text when `manual_deidentified_appeal` was blank (`charts/views.py:607,619,623`). A record with no manual de-identification exported the patient's **raw** denial and appeal text.
- `generate_chat_lines` exported `chat_history`, `denied_item/reason`, and linked `appeal_text` with **no de-identification at all**, despite its "de-identified" docstring.

The June change gated these views (`@staff_member_required` + `EXPORT_ENABLED`), but a single staff export run with the env set still wrote raw PHI into `denial_appeal.jsonl` / `chat.jsonl`.

### Change
- `generate_denial_appeal_lines` now emits a record **only when both** `manual_deidentified_denial` and `manual_deidentified_appeal` are present, and uses those fields (no raw fallback). This mirrors the already-correct `generate_de_identified_lines`.
- `generate_chat_lines` **fails closed**: `OngoingChat` has no de-identified source, so it now emits nothing and logs a warning, rather than write raw conversation PHI. Re-enable by sourcing from `manual_deidentified_*` once those exist on `OngoingChat`.
- Tests updated to encode the fail-closed contract; the two exclusion tests that would otherwise pass vacuously now set manual-deid fields so they still prove the pro/flag exclusion specifically.

### ⚠️ Review notes
- **Behavior change:** the `chat` export now produces an **empty file** until a chat de-identification pipeline exists. Intentional — flagged for your call on whether an internal-only raw chat export should live behind a different, clearly-non-de-identified path.
- **Out of scope / your decision:** `generate_denial_appeal_lines` still emits `qa_pairs` (the `DenialQA.text_answer` free-text is patient-entered and not guaranteed de-identified) and `generated_questions` (LLM-generated, may embed names). `generate_de_identified_lines` already emits `generated_questions`, so I left both as-is rather than unilaterally change training-data shape — but the qa free-text is the next thing to decide on.

### Testing
`tests/sync/test_export_views.py` — 25 passed (sqlite, `DJANGO_CONFIGURATION=Dev`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Denial/appeal exports now “fail closed” and include a record only when both manually de-identified denial and appeal text are present, preventing incomplete or mixed-source exports.
  * Chat exports now emit no records when a manually de-identified chat source isn’t available.
  * When manual de-identified text is available, exports consistently use it instead of falling back to other text sources.
* **Tests**
  * Updated export tests to enforce the new fail-closed behavior and align expectations for manual de-identified fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->