### PR TITLE
Require ownership triple before touching a denial in ReportClientError

### DIFF
--- a/fighthealthinsurance/rest_views.py
+++ b/fighthealthinsurance/rest_views.py
@@ -561,22 +561,26 @@ class ReportClientError(APIView):
         # context that feeds appeal generation. A client-reported "0 appeals"
         # is frequently a context-window overflow, and seeing the per-field
         # token breakdown server-side makes that diagnosable without a repro.
-        # Never let this diagnostic enrichment break the error-report endpoint.
-        context_tokens = "unavailable"
-        if denial_id_valid:
+        #
+        # This enrichment reads PHI-bearing denial fields, so it is gated on the
+        # same (denial_id, email, semi_sekret) ownership triple that guards the
+        # appeal stream -- otherwise any sequential denial_id would load an
+        # arbitrary patient's denial (unauthenticated IDOR). Auth failure still
+        # records the error report: this endpoint is a fire-and-forget
+        # diagnostic sink that must work even in degraded client states, so we
+        # log without the token breakdown rather than reject. Never let the
+        # enrichment break the report.
+        context_tokens = "unauthorized"
+        denial = common_view_logic.get_denial_for_action(
+            denial_id=request.data.get("denial_id"),
+            email=str(request.data.get("email") or ""),
+            semi_sekret=str(request.data.get("semi_sekret") or ""),
+        )
+        if denial is not None:
             try:
-                denial = (
-                    Denial.objects.filter(denial_id=int(denial_id))
-                    .only(*context_utils.DENIAL_CONTEXT_TOKEN_FIELDS)
-                    .first()
-                )
-                if denial is not None:
-                    context_tokens = context_utils.summarize_denial_context_tokens(
-                        denial
-                    )
-                else:
-                    context_tokens = "denial_not_found"
+                context_tokens = context_utils.summarize_denial_context_tokens(denial)
             except Exception as e:
+                context_tokens = "unavailable"
                 logger.opt(exception=True).debug(
                     f"Failed to compute context token sizes for denial "
                     f"{denial_id}: {e}"

--- a/fighthealthinsurance/static/js/appeal_fetcher.ts
+++ b/fighthealthinsurance/static/js/appeal_fetcher.ts
@@ -651,6 +651,11 @@ function reportClientError(error: string): void {
     headers,
     body: JSON.stringify({
       denial_id: denialId ?? 'invalid',
+      // Ownership triple: lets the server attach denial-context token sizes to
+      // this report. Same credentials the appeal stream already sends; without
+      // them the server logs the error but skips the PHI-bearing enrichment.
+      email: (my_data as any).email || '',
+      semi_sekret: (my_data as any).semi_sekret || '',
       error,
       browser_info: browserInfo,
       diagnostics,

--- a/tests/sync/test_report_client_error.py
+++ b/tests/sync/test_report_client_error.py
@@ -2,7 +2,10 @@
 
 The endpoint is a fire-and-forget client error sink: it must always return
 204 and must never let the (best-effort) token-size annotation break the
-request. These tests pin that invariant plus the happy-path logging.
+request. The denial-context token breakdown is PHI-derived, so it is only
+computed when the caller proves ownership with the (denial_id, email,
+semi_sekret) triple -- an unauthenticated caller can still file an error
+report but never causes an arbitrary denial to be loaded (IDOR).
 """
 
 from unittest.mock import patch
@@ -17,8 +20,29 @@ from fighthealthinsurance.models import Denial
 class ReportClientErrorTest(APITestCase):
     """The unauthenticated client-error report endpoint."""
 
+    EMAIL = "reporter@example.com"
+    SEKRET = "sekret"
+
     def _url(self):
         return reverse("report_client_error")
+
+    def _make_denial(self, **kwargs):
+        """A denial owned by the (EMAIL, SEKRET) triple."""
+        return Denial.objects.create(
+            semi_sekret=self.SEKRET,
+            hashed_email=Denial.get_hashed_email(self.EMAIL),
+            **kwargs,
+        )
+
+    def _owner_payload(self, denial, **extra):
+        payload = {
+            "denial_id": str(denial.denial_id),
+            "email": self.EMAIL,
+            "semi_sekret": self.SEKRET,
+            "error": "e",
+        }
+        payload.update(extra)
+        return payload
 
     def _logged_error(self, mock_logger):
         """Join the positional args of the single logger.error call."""
@@ -32,13 +56,11 @@ class ReportClientErrorTest(APITestCase):
         )
         self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
 
-    def test_logs_context_tokens_for_existing_denial(self):
-        denial = Denial.objects.create(denial_text="x" * 400, qa_context="y" * 80)
+    def test_logs_context_tokens_for_owned_denial(self):
+        denial = self._make_denial(denial_text="x" * 400, qa_context="y" * 80)
         with patch("fighthealthinsurance.rest_views.logger") as mock_logger:
             resp = self.client.post(
-                self._url(),
-                {"denial_id": str(denial.denial_id), "error": "e"},
-                format="json",
+                self._url(), self._owner_payload(denial), format="json"
             )
         self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
         logged = self._logged_error(mock_logger)
@@ -46,31 +68,25 @@ class ReportClientErrorTest(APITestCase):
         self.assertIn("est_total=", logged)
         self.assertIn("denial_text=", logged)
 
-    def test_existing_denial_with_no_context_reports_none_breakdown(self):
-        denial = Denial.objects.create(denial_text="")
+    def test_owned_denial_with_no_context_reports_none_breakdown(self):
+        denial = self._make_denial(denial_text="")
         with patch("fighthealthinsurance.rest_views.logger") as mock_logger:
-            self.client.post(
-                self._url(),
-                {"denial_id": str(denial.denial_id), "error": "e"},
-                format="json",
-            )
+            self.client.post(self._url(), self._owner_payload(denial), format="json")
         self.assertIn("est_total=0tok (none)", self._logged_error(mock_logger))
 
     def test_never_500_when_token_computation_raises(self):
-        denial = Denial.objects.create(denial_text="x")
+        denial = self._make_denial(denial_text="x")
         with patch(
             "fighthealthinsurance.rest_views.context_utils.summarize_denial_context_tokens",
             side_effect=RuntimeError("boom"),
         ):
             resp = self.client.post(
-                self._url(),
-                {"denial_id": str(denial.denial_id), "error": "e"},
-                format="json",
+                self._url(), self._owner_payload(denial), format="json"
             )
         # The diagnostic failure is swallowed; the endpoint still 204s.
         self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
 
-    def test_invalid_denial_id_reports_unavailable(self):
+    def test_invalid_denial_id_reports_unauthorized(self):
         with patch("fighthealthinsurance.rest_views.logger") as mock_logger:
             resp = self.client.post(
                 self._url(),
@@ -78,4 +94,44 @@ class ReportClientErrorTest(APITestCase):
                 format="json",
             )
         self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
-        self.assertIn("context_tokens: unavailable", self._logged_error(mock_logger))
+        self.assertIn("context_tokens: unauthorized", self._logged_error(mock_logger))
+
+    # --- IDOR regression tests ------------------------------------------------
+
+    def test_no_triple_does_not_load_denial(self):
+        # A caller who supplies only a (sequential) denial_id -- no email /
+        # semi_sekret -- must NOT cause the denial to be loaded or summarized.
+        denial = self._make_denial(denial_text="x" * 400)
+        with patch(
+            "fighthealthinsurance.rest_views.context_utils.summarize_denial_context_tokens"
+        ) as mock_summarize, patch(
+            "fighthealthinsurance.rest_views.logger"
+        ) as mock_logger:
+            resp = self.client.post(
+                self._url(),
+                {"denial_id": str(denial.denial_id), "error": "e"},
+                format="json",
+            )
+        self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
+        mock_summarize.assert_not_called()
+        self.assertIn(
+            "context_tokens: unauthorized", self._logged_error(mock_logger)
+        )
+
+    def test_wrong_semi_sekret_is_unauthorized(self):
+        denial = self._make_denial(denial_text="x" * 400)
+        with patch(
+            "fighthealthinsurance.rest_views.context_utils.summarize_denial_context_tokens"
+        ) as mock_summarize, patch(
+            "fighthealthinsurance.rest_views.logger"
+        ) as mock_logger:
+            resp = self.client.post(
+                self._url(),
+                self._owner_payload(denial, semi_sekret="wrong"),
+                format="json",
+            )
+        self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
+        mock_summarize.assert_not_called()
+        self.assertIn(
+            "context_tokens: unauthorized", self._logged_error(mock_logger)
+        )


### PR DESCRIPTION
## Require the ownership triple before touching a denial in ReportClientError

Phase 0 privacy fix (2 of 6) from the 2026-07-06 review. Branch off `main`.

### Problem
`ReportClientError` (`rest_views.py`, unauthenticated `AllowAny`) took a bare integer `denial_id` from the request, loaded that `Denial`, and computed a token-size breakdown over its PHI fields (`denial_text`, `qa_context`, `health_history`, …). Any caller could walk sequential `denial_id`s and cause an arbitrary patient's denial to be loaded and summarized — an unauthenticated IDOR on a PHI-bearing row. (The sizes were logged server-side, not returned, so there's no direct read primitive, but the load itself and the found/not-found timing are the exposure.)

Sibling endpoints (`EnableExternalModels`, the appeal stream) already gate on the `(denial_id, email, semi_sekret)` ownership triple; this one didn't.

### Change
- The token-size enrichment now runs **only** when `common_view_logic.get_denial_for_action(denial_id, email, semi_sekret)` returns a denial — the same canonical ownership check used across the appeal flow. On auth failure the enrichment is skipped and logged as `context_tokens: unauthorized`.
- The endpoint still **accepts and logs** the error report without a valid triple — it's a fire-and-forget diagnostic sink that must work in degraded client states. Only the PHI-derived enrichment is gated.
- Frontend (`appeal_fetcher.ts`): the client now includes `email` + `semi_sekret` in the report body (the same credentials it already sends to the appeal stream from `my_data`), so the context-overflow diagnostic keeps working for the real client.

### ⚠️ Review notes
- Uniform `unauthorized` (instead of the old `denial_not_found` vs found) is deliberate — it removes the existence oracle.
- `appeal_fetcher.ts` is also touched by the `strip-phi-console-logs` PR, in a different region (fetch body ~653 vs console logs ~874+). No overlap expected on merge.

### Testing
`tests/sync/test_report_client_error.py` — 7 passed, including two IDOR regressions asserting that a `denial_id`-only call and a wrong-`semi_sekret` call never invoke `summarize_denial_context_tokens` (sqlite, `DJANGO_CONFIGURATION=Dev`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Client error reports now include the needed account details to better attach relevant context when available.
  * Denial-related context is now only shown when the submitted details match the associated record, improving privacy and access control.
  * Invalid or unauthorized cases now log as unavailable/unauthorized while still allowing the report to be submitted successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->