### PR TITLE
Stop logging PHI to the browser console (+ strip chatty console in prod)

### DIFF
--- a/fighthealthinsurance/static/js/appeal_fetcher.ts
+++ b/fighthealthinsurance/static/js/appeal_fetcher.ts
@@ -871,7 +871,8 @@ async function fetchFallback(url: string, data: object, csrfToken: string): Prom
 }
 
 function processResponseChunk(chunk: string): void {
-  console.log(`Processing chunk ${chunk}`);
+  // Chunks carry appeal text (PHI) -- log only the size.
+  console.debug("Processing chunk, length", chunk.length);
   respBuffer += chunk;
   if (respBuffer.includes("\n")) {
     const lastIndex = respBuffer.lastIndexOf("\n");
@@ -966,7 +967,8 @@ function processResponseChunk(chunk: string): void {
         // Handle regular appeal content
         const appealText = parsedLine.content;
         if (appealText === undefined || appealText === null) {
-          console.warn('Skipping non-appeal frame without content', parsedLine);
+          // Frames come from the appeal stream; log field names only, not values.
+          console.warn('Skipping non-appeal frame without content, keys:', Object.keys(parsedLine));
           return;
         }
 
@@ -1063,12 +1065,16 @@ function processResponseChunk(chunk: string): void {
           (clonedForm[0] as HTMLElement).scrollIntoView({ behavior: "smooth", block: "start" });
         }
       } catch (error) {
-        console.error("Error parsing line:", error);
+        // Log only the error name: JSON.parse errors embed a snippet of the
+        // (PHI-bearing) line in their message, and console.error survives
+        // the production build.
+        console.error("Error parsing line:", (error as Error)?.name);
       }
     });
   } else {
     console.log("Waiting for more data.");
-    console.log(`So far:${respBuffer}`);
+    // The buffer holds partial appeal text (PHI) -- log only the size.
+    console.debug("Buffered so far, length", respBuffer.length);
   }
 }
 

--- a/fighthealthinsurance/static/js/chat_interface.tsx
+++ b/fighthealthinsurance/static/js/chat_interface.tsx
@@ -525,7 +525,8 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
 
       ws.onmessage = (event) => {
         const data = JSON.parse(event.data);
-        console.log("Received message:", data);
+        // Frames carry chat message content (PHI) -- log only the field names.
+        console.debug("Received message frame, keys:", Object.keys(data ?? {}));
 
         // Get user info for restoring personal info
         const userInfo = getUserInfo();
@@ -1271,7 +1272,9 @@ document.addEventListener("DOMContentLoaded", () => {
     const initialMessage = chatRoot.dataset.initialMessage || undefined;
     const enableVoiceIntake = chatRoot.dataset.enableVoiceIntake === "true";
     const enableLocalSTT = chatRoot.dataset.enableLocalStt === "true";
-    console.log("Using microsite settings", chatRoot.dataset)  
+    // Don't dump chatRoot.dataset: it can include data-initial-message, which
+    // is built from the user's denial text. Non-PHI fields are logged below.
+    console.log("Using microsite settings");
     if (defaultProcedure) {
       console.log("Default procedure from microsite:", defaultProcedure);
     }
@@ -1285,7 +1288,8 @@ document.addEventListener("DOMContentLoaded", () => {
       console.log("Microsite slug from microsite:", micrositeSlug);
     }
     if (initialMessage) {
-      console.log("Initial message provided:", initialMessage.substring(0, 100) + "...");
+      // The initial message is built from the user's denial text (PHI).
+      console.log("Initial message provided, length:", initialMessage.length);
     }
 
     const root = createRoot(chatRoot);

--- a/fighthealthinsurance/static/js/entity_fetcher.ts
+++ b/fighthealthinsurance/static/js/entity_fetcher.ts
@@ -75,7 +75,8 @@ function updateStatusList(taskName: string): void {
 }
 
 function processResponseChunk(chunk: string): void {
-  console.log("Processing:", chunk);
+  // Chunks can carry extracted denial entities (PHI) -- log only the size.
+  console.debug("Processing chunk, length", chunk.length);
   // Try to parse as task name
   if (chunk && chunk.length > 0 && chunk.length < 50) {
     updateStatusList(chunk.trim());

--- a/fighthealthinsurance/static/js/explain_denial.ts
+++ b/fighthealthinsurance/static/js/explain_denial.ts
@@ -72,9 +72,8 @@ async function recognizeEvent(event: Event): Promise<void> {
   try {
     for (let i = 0; i < filesToProcess.length; i++) {
       const file = filesToProcess[i];
-      console.log(
-        `Processing file ${i + 1}/${filesToProcess.length}: ${file.name}`
-      );
+      // Don't log file.name: user filenames can embed patient names.
+      console.log(`Processing file ${i + 1}/${filesToProcess.length}`);
       await recognize(file, addText);
     }
   } catch (error) {

--- a/fighthealthinsurance/static/js/scrub.ts
+++ b/fighthealthinsurance/static/js/scrub.ts
@@ -79,11 +79,9 @@ function setupScrub(): void {
   });
 
   // Restore previous local values
-  var input = document.getElementsByTagName("input");
-  console.log(input);
+  // Don't log the nodes themselves: the inputs hold name/address/email values.
   var nodes: NodeListOf<HTMLInputElement> = document.querySelectorAll("input");
-  console.log("Nodes:");
-  console.log(nodes);
+  console.debug("scrub: input nodes found", nodes.length);
   function handleStorage(node: HTMLInputElement) {
     // All store_ fields which are local only and the e-mail field which is local and non-local.
     if (node.id.startsWith("store_") || node.id.startsWith("email")) {

--- a/fighthealthinsurance/static/js/scrub_scrub.ts
+++ b/fighthealthinsurance/static/js/scrub_scrub.ts
@@ -103,17 +103,21 @@ function scrubText(text: string): string {
       }
     }
   }
-  console.log("Preparing to scrub:");
-  console.log(text);
-  console.log("Scrubbing with:");
-  console.log(reservedTokens);
-  console.log(scrubRegex);
+  // Log only sizes: the raw text and the reserved-token regexes contain PII.
+  console.debug(
+    "scrub: text length",
+    text.length,
+    "reserved tokens",
+    reservedTokens.length,
+    "rules",
+    scrubRegex.length,
+  );
   for (let i = 0; i < scrubRegex.length; i++) {
     const match = scrubRegex[i][0].exec(text);
     if (match !== null) {
       // I want to use the groups syntax here but it is not working so just index in I guess.
-      console.log("Match " + match + " groups " + match[1]);
-      console.log("Storing " + match[1] + " for " + scrubRegex[i][1]);
+      // Don't log the match itself -- it is the patient name/ID being scrubbed.
+      console.debug("scrub: rule matched, storing under", scrubRegex[i][1]);
       window.localStorage.setItem(scrubRegex[i][1], match[1]);
     }
     text = text.replace(scrubRegex[i][0], scrubRegex[i][2]);

--- a/fighthealthinsurance/static/js/user_info_storage.ts
+++ b/fighthealthinsurance/static/js/user_info_storage.ts
@@ -41,7 +41,10 @@ export function getUserInfo(): UserInfo | null {
       return JSON.parse(stored) as UserInfo;
     }
   } catch (e) {
-    console.error("Error parsing stored user info:", e);
+    // Log only the error name: JSON.parse errors embed a snippet of the
+    // stored (PII) JSON in their message, and console.error survives the
+    // production build.
+    console.error("Error parsing stored user info:", (e as Error)?.name);
   }
   return null;
 }

--- a/fighthealthinsurance/static/js/webpack.config.js
+++ b/fighthealthinsurance/static/js/webpack.config.js
@@ -46,7 +46,12 @@ module.exports = async (env, argv) => {
       new TerserPlugin({
         terserOptions: {
           compress: {
-            drop_console: false,  // Keep console.log for debugging production issues
+            // Strip chatty console levels from production bundles as a
+            // defense-in-depth against logging user health data (PHI) to the
+            // browser console. console.warn/error are kept so production
+            // issues stay debuggable (no browser error reporter is
+            // initialized) -- never log PHI at those levels.
+            pure_funcs: ['console.log', 'console.info', 'console.debug'],
           },
           format: {
             comments: false,


### PR DESCRIPTION
## Stop logging PHI to the browser console (+ strip chatty console in prod)

Phase 0 privacy fix (3 of 6) from the 2026-07-06 review. Branch off `main`.

### Problem
The consumer flow logged protected health information to the browser console, and the production webpack build deliberately kept all console output (`drop_console: false`). Anyone screen-sharing, or pasting console output into a support email, leaked their medical details. Worst offenders:

- `scrub_scrub.ts` — the **full raw denial text** before scrubbing, plus the reserved-token regexes built from the user's real name/address/email/phone, plus each captured `match[1]` (the patient name / subscriber ID being scrubbed).
- `appeal_fetcher.ts` — every streamed appeal chunk and the buffered partial appeal (diagnosis/treatment); JSON parse errors that embed a snippet of the PHI line in the message.
- `chat_interface.tsx` — every WS frame (chat message content), and `chatRoot.dataset` / the initial message, both derived from denial text.
- `scrub.ts`, `entity_fetcher.ts`, `explain_denial.ts` (uploaded file name), `user_info_storage.ts` (PII JSON parse error).

### Change
- Redacted every PHI-bearing console statement to log **sizes / field-names / error-names** instead of content (behavior otherwise unchanged — e.g. the `localStorage.setItem` in `scrub_scrub.ts` is untouched, only the log of the matched value is removed).
- `webpack.config.js`: production terser now strips `console.log/info/debug` via `pure_funcs`, while **keeping `console.warn`/`console.error`** — the app has no initialized browser error reporter, so those levels are the only production visibility. The three warn/error sites that carried PHI were redacted at the source too (defense-in-depth, since they survive the build).

### Scope
Logging only. Out of scope (each its own follow-up): the `localStorage` TTL/opt-out bypass at `scrub_scrub.ts:117`, initializing Sentry browser, the jQuery upgrade. `appeal_fetcher.ts` also appears in the `report-client-error-ownership` PR in a different region — no merge overlap expected.

### Testing
`node --check webpack.config.js` passes. `node_modules` isn't installed here so no full TS compile was run; each edit was verified by hand (`.length`/`Object.keys`/`(e as Error)?.name` are valid under the repo's `strict` TS). Please let CI's type-check confirm.
