### PR TITLE
Fix duplicate collectstatic warnings and add build.sh --no-build mode

### DIFF
--- a/fighthealthinsurance/microsites.py
+++ b/fighthealthinsurance/microsites.py
@@ -350,12 +350,16 @@ def _find_microsites_json() -> Optional[str]:
     except Exception as e:
         logger.debug(f"Could not open microsites.json via staticfiles_storage: {e}")
 
-    # Fallback: search STATICFILES_DIRS directly (for test environments)
-    staticfiles_dirs = getattr(settings, "STATICFILES_DIRS", [])
-    for static_dir in staticfiles_dirs:
+    # Fallback: search the app static dir / STATICFILES_DIRS directly (for test
+    # environments where collectstatic has not run).
+    search_dirs = list(getattr(settings, "STATICFILES_DIRS", []))
+    app_static_dir = getattr(settings, "APP_STATIC_DIR", None)
+    if app_static_dir:
+        search_dirs.append(app_static_dir)
+    for static_dir in search_dirs:
         json_path = Path(static_dir) / "microsites.json"
         if json_path.exists():
-            logger.debug(f"Found microsites.json in STATICFILES_DIRS: {json_path}")
+            logger.debug(f"Found microsites.json in static source dir: {json_path}")
             with open(json_path, "r") as f:
                 return f.read()
 

--- a/fighthealthinsurance/settings.py
+++ b/fighthealthinsurance/settings.py
@@ -219,10 +219,18 @@ class Base(Configuration):
     SENTRY_ENDPOINT = os.getenv("SENTRY_ENDPOINT")
     # Application definition
 
-    # Ensure Django finds static/blog/ for .mdx blog posts
-    STATICFILES_DIRS = [
-        os.path.join(BASE_DIR, "fighthealthinsurance/static"),
-    ]
+    # The fighthealthinsurance app's own static directory (holds js/dist bundles,
+    # blog/*.md posts, microsites.json, etc.). Because "fighthealthinsurance" is
+    # an installed app, AppDirectoriesFinder already discovers this directory, so
+    # it must NOT also be listed in STATICFILES_DIRS -- otherwise every file is
+    # found twice and collectstatic logs a "Found another file with the
+    # destination path ..." warning for each one.
+    APP_STATIC_DIR = os.path.join(BASE_DIR, "fighthealthinsurance/static")
+
+    # Project-level static source dirs that live outside any installed app. The
+    # fighthealthinsurance app static dir is intentionally excluded here (see
+    # APP_STATIC_DIR above) to avoid duplicate collectstatic warnings.
+    STATICFILES_DIRS: list[str] = []
 
     SITE_ID = 1
 

--- a/fighthealthinsurance/urls.py
+++ b/fighthealthinsurance/urls.py
@@ -487,10 +487,10 @@ urlpatterns += staticfiles_urlpatterns()
 
 # Serve static files in development
 if settings.DEBUG:
-    # Serve files from STATICFILES_DIRS in development
+    # Serve files from the app static dir in development
     if settings.STATIC_URL:
         urlpatterns += static(
-            settings.STATIC_URL, document_root=settings.STATICFILES_DIRS[0]
+            settings.STATIC_URL, document_root=settings.APP_STATIC_DIR
         )
     if settings.MEDIA_URL:
         urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,8 +5,11 @@ SCRIPT_DIR="$(dirname "$0")"
 
 BUILDX_CMD=${BUILDX_CMD:-push}
 
-# --no-build: skip building the container images and assume they already exist
-# in the registry, only running the kubectl deploy steps.
+# --no-build: assume the container images are already built and pushed, and only
+# run the kubectl deploy steps. This skips every build step -- template/static
+# setup (mypy, migrations, collectstatic, npm build) and the image builds -- so
+# the script can run on a deploy-only host or CI job that has just kubectl and
+# envsubst (no Python/Node build toolchain).
 NO_BUILD=false
 for arg in "$@"; do
     case "$arg" in
@@ -15,7 +18,8 @@ for arg in "$@"; do
             ;;
         -h|--help)
             echo "Usage: $0 [--no-build]"
-            echo "  --no-build  Skip building images; assume they are already built and just deploy."
+            echo "  --no-build  Skip all build steps (template/static setup and image builds);"
+            echo "              assume images are already built and pushed, and only deploy."
             exit 0
             ;;
         *)
@@ -26,7 +30,14 @@ for arg in "$@"; do
     esac
 done
 
-source "${SCRIPT_DIR}/setup_templates.sh"
+# Prepare build artifacts (mypy, migrations check, collectstatic, npm build).
+# These are only needed to build the images, so skip them with --no-build; a
+# deploy-only host may not have the Python/Node build toolchain installed.
+if [ "$NO_BUILD" = true ]; then
+    echo "--no-build: skipping template/static setup (setup_templates.sh)"
+else
+    source "${SCRIPT_DIR}/setup_templates.sh"
+fi
 
 # BUILDKIT_NO_CLIENT_TOKEN=true
 FHI_VERSION=v0.18.2a

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,6 +5,27 @@ SCRIPT_DIR="$(dirname "$0")"
 
 BUILDX_CMD=${BUILDX_CMD:-push}
 
+# --no-build: skip building the container images and assume they already exist
+# in the registry, only running the kubectl deploy steps.
+NO_BUILD=false
+for arg in "$@"; do
+    case "$arg" in
+        --no-build)
+            NO_BUILD=true
+            ;;
+        -h|--help)
+            echo "Usage: $0 [--no-build]"
+            echo "  --no-build  Skip building images; assume they are already built and just deploy."
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $arg" >&2
+            echo "Usage: $0 [--no-build]" >&2
+            exit 1
+            ;;
+    esac
+done
+
 source "${SCRIPT_DIR}/setup_templates.sh"
 
 # BUILDKIT_NO_CLIENT_TOKEN=true
@@ -28,8 +49,12 @@ FHI_VERSION_OG=${FHI_VERSION}
 FHI_VERSION=${FHI_VERSION}-dev
 export FHI_VERSION
 
-# Build the dev containers
-source "${SCRIPT_DIR}/build_django.sh"
+# Build the dev containers (skipped with --no-build; assumes image already exists)
+if [ "$NO_BUILD" = true ]; then
+    echo "--no-build: skipping django image build (${FHI_BASE}:${FHI_VERSION})"
+else
+    source "${SCRIPT_DIR}/build_django.sh"
+fi
 
 # Deploy dev
 envsubst < k8s/deploy_dev.yaml | kubectl delete -f - || echo "No existing dev deployment present"
@@ -49,7 +74,12 @@ export FHI_VERSION
 # Build the ray container -- we don't use it in staging *BUT*
 # better to have built than be stuck with a half deployed system if
 # dockerhub is having a day.
-source "${SCRIPT_DIR}/build_ray.sh"
+# (skipped with --no-build; assumes image already exists)
+if [ "$NO_BUILD" = true ]; then
+    echo "--no-build: skipping ray image build (${RAY_BASE}:${FHI_VERSION})"
+else
+    source "${SCRIPT_DIR}/build_ray.sh"
+fi
 
 # Deploy a staging env
 envsubst < k8s/deploy_staging.yaml | kubectl apply -f -


### PR DESCRIPTION
The fighthealthinsurance app's static dir was listed in STATICFILES_DIRS
*and* auto-discovered by AppDirectoriesFinder (since fighthealthinsurance
is an installed app), so collectstatic found every file twice and logged a
"Found another file with the destination path ..." warning for each one.

Drop the app static dir from STATICFILES_DIRS and expose it as a dedicated
APP_STATIC_DIR setting instead. The two former consumers of
STATICFILES_DIRS[0] (dev static serving in urls.py and the microsites.json
test-env fallback) now use APP_STATIC_DIR, so behavior is unchanged while
each file is collected exactly once.

Also add a --no-build flag to scripts/build.sh that skips the django/ray
image builds and just runs the kubectl deploy steps, assuming the images
are already built. All deploy manifests only reference env vars set
directly in build.sh, so skipping the build sub-scripts is safe.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014BwfyDsuWy7c4RSCbW3phy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--no-build` option to the build script to skip template/static setup and image builds when not required.
* **Bug Fixes**
  * Improved microsite configuration discovery so `microsites.json` is reliably found using the correct static directories.
  * Updated static file configuration to avoid duplicate handling of the app’s own static assets.
  * Adjusted local development static serving to use the correct app static directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->