### PR TITLE
Add cross-origin pro signup endpoint for fightpaperwork.com

### DIFF
--- a/fighthealthinsurance/forms/__init__.py
+++ b/fighthealthinsurance/forms/__init__.py
@@ -84,8 +84,16 @@ class ReCaptchaOptionalMixin(_ReCaptchaMixinBase):
 
 
 # Actual forms
-class InterestedProfessionalForm(ReCaptchaOptionalMixin, forms.ModelForm):
-    captcha = forms.CharField(required=False, widget=forms.HiddenInput())
+class _InterestedProfessionalFieldsForm(forms.ModelForm):
+    """Shared field declarations for the interested-professional intake forms.
+
+    Not used directly. Concrete subclasses layer on their own spam protection:
+    :class:`InterestedProfessionalForm` (the on-site /pro_version form) adds
+    reCAPTCHA via ``ReCaptchaOptionalMixin``, while
+    :class:`ExternalInterestedProfessionalForm` (the off-site fightpaperwork.com
+    classic form) uses a honeypot because its host page runs no JavaScript.
+    """
+
     business_name = forms.CharField(required=False)
     address = forms.CharField(
         required=False,
@@ -121,6 +129,25 @@ class InterestedProfessionalForm(ReCaptchaOptionalMixin, forms.ModelForm):
             "mod_date",
             "thankyou_email_sent",
         ]
+
+
+class InterestedProfessionalForm(
+    ReCaptchaOptionalMixin, _InterestedProfessionalFieldsForm
+):
+    captcha = forms.CharField(required=False, widget=forms.HiddenInput())
+
+
+class ExternalInterestedProfessionalForm(_InterestedProfessionalFieldsForm):
+    """Off-site (fightpaperwork.com) classic-HTML variant of the interest form.
+
+    Captures the same fields as :class:`InterestedProfessionalForm` but drops
+    reCAPTCHA: the static Fight Paperwork page runs no JavaScript, so the form
+    is submitted as a classic top-level POST and bot protection is a hidden
+    honeypot instead. ``website`` is invisible to humans; any non-empty value
+    marks the submission as a bot, which the view drops silently.
+    """
+
+    website = forms.CharField(required=False, widget=forms.HiddenInput())
 
 
 class DeleteDataForm(forms.Form):

--- a/fighthealthinsurance/forms/__init__.py
+++ b/fighthealthinsurance/forms/__init__.py
@@ -121,13 +121,22 @@ class _InterestedProfessionalFieldsForm(forms.ModelForm):
 
     class Meta:
         model = InterestedProfessional
-        # Block mass-assignment of internal/state-tracking fields via a public POST.
-        exclude = [
-            "paid",
-            "clicked_for_paid",
-            "signup_date",
-            "mod_date",
-            "thankyou_email_sent",
+        # Positive allow-list of the public intake fields. A `fields` list
+        # (rather than `exclude`) means any model field NOT named here — the
+        # payment/state flags and, crucially, the internal proconnector_*
+        # workflow fields (proconnector_attempted, proconnector_skipped, ...) —
+        # can never be mass-assigned from a public POST. That matters because a
+        # crafted submission setting proconnector_attempted/skipped=True would
+        # otherwise drop the lead out of proconnector.processable_queryset().
+        fields = [
+            "name",
+            "email",
+            "business_name",
+            "address",
+            "comments",
+            "phone_number",
+            "job_title_or_provider_type",
+            "most_common_denial",
         ]
 
 

--- a/fighthealthinsurance/urls.py
+++ b/fighthealthinsurance/urls.py
@@ -313,6 +313,14 @@ urlpatterns: List[Union[URLPattern, URLResolver]] = [
         name="state_help",
     ),
     path("pro_version", views.ProVersionView.as_view(), name="pro_version"),
+    # Cross-origin classic-form intake for the interested-professional lead form
+    # hosted on the static site (fightpaperwork.com). csrf_exempt because that
+    # page can't obtain a CSRF token; a hidden honeypot field guards it instead.
+    path(
+        "pro_version_signup",
+        csrf_exempt(views.ExternalProSignupView.as_view()),
+        name="pro_version_external_signup",
+    ),
     path(
         "professionals/patient-access",
         cache_control(public=True)(

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -350,13 +350,16 @@ class ExternalProSignupView(View):
         return HttpResponseRedirect(reverse("pro_version"))
 
     def post(self, request, *args, **kwargs):
+        # Honeypot first, read straight from the raw POST: a filled "website"
+        # field means a bot, so drop the submission silently and land it on the
+        # thank-you page like any other. Checking before form validation means
+        # a bot can't dodge the honeypot by also omitting a required field
+        # (which would otherwise bounce it to /pro_version and reveal the trap).
+        if request.POST.get("website", "").strip():
+            return HttpResponseRedirect(reverse("pro_version_thankyou"))
         form = core_forms.ExternalInterestedProfessionalForm(request.POST)
         if not form.is_valid():
             return HttpResponseRedirect(reverse("pro_version"))
-        # Honeypot: a filled "website" field means a bot. Land it on the
-        # thank-you page like any other submission, but drop it silently.
-        if form.cleaned_data.get("website"):
-            return HttpResponseRedirect(reverse("pro_version_thankyou"))
         interested_pro = form.save(commit=False)
         _persist_interested_professional_lead(
             interested_pro,

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -184,6 +184,51 @@ class FollowUpView(generic.FormView):
         return render(self.request, "followup_thankyou.html")
 
 
+def _persist_interested_professional_lead(
+    interested_pro: "models.InterestedProfessional",
+    *,
+    source: str,
+    subject_prefix: str,
+) -> None:
+    """Persist a new interested-professional lead and fan out notifications.
+
+    Shared by the on-site /pro_version form (:class:`ProVersionView`) and the
+    off-site fightpaperwork.com classic-form endpoint
+    (:class:`ExternalProSignupView`) so both dedup, notify, and thank
+    identically.
+
+    Dedup by email (case-insensitive, matching the REST endpoint and the
+    pro-connector queue): if a lead with this address already exists, do
+    nothing — no duplicate row, no re-notification, no second thank-you. The
+    caller still sends the submitter to the thank-you page. Otherwise record
+    the lead as not-clicked-for-paid (the pay-to-express-interest choice is no
+    longer collected), notify the professional-signup inbox, and send the
+    thank-you email immediately. Mail failures are logged, never raised, so
+    they can't fail an already-persisted lead.
+    """
+    if models.InterestedProfessional.objects.filter(
+        email__iexact=interested_pro.email
+    ).exists():
+        return
+    interested_pro.clicked_for_paid = False
+    interested_pro.save()
+    notify_interested_professional(
+        interested_pro,
+        source=source,
+        subject=f"{subject_prefix} #{interested_pro.id}",
+    )
+    # Send the thank-you email synchronously so the signer gets it right away.
+    # The batched ThankyouEmailSender will skip records where
+    # thankyou_email_sent=True, which dosend() sets on success.
+    try:
+        ThankyouEmailSender().dosend(interested_pro=interested_pro)
+    except Exception:
+        logger.opt(exception=True).warning(
+            f"Error sending immediate pro signup thank-you "
+            f"(interested_professional_id={interested_pro.id})"
+        )
+
+
 class ProVersionThankYouView(TemplateView):
     """Thank you page displayed after professional version signup."""
 
@@ -274,42 +319,51 @@ class ProVersionView(generic.FormView):
         return reverse("pro_version_thankyou")
 
     def form_valid(self, form):
-        # The pay-to-express-interest checkbox is no longer collected; explicitly
-        # mark new records as not clicked so the (legacy default=True) model
-        # field reflects reality.
         interested_pro = form.save(commit=False)
-        interested_pro.clicked_for_paid = False
-        # Dedup by email: if this professional already expressed interest, reuse
-        # the existing lead — don't create a duplicate row, re-notify the
-        # professional inbox, or re-send the thank-you. They still land on the
-        # thank-you page.
-        if models.InterestedProfessional.objects.filter(
-            email=interested_pro.email
-        ).exists():
-            return super().form_valid(form)
-        interested_pro.save()
-        self._notify_professional_signup(interested_pro)
-        # Send the thank-you email synchronously so the signer gets it right
-        # away. The batched ThankyouEmailSender will skip records where
-        # thankyou_email_sent=True, which dosend() sets on success.
-        try:
-            ThankyouEmailSender().dosend(interested_pro=interested_pro)
-        except Exception:
-            logger.opt(exception=True).warning(
-                f"Error sending immediate pro signup thank-you "
-                f"(interested_professional_id={interested_pro.id})"
-            )
-        return super().form_valid(form)
-
-    @staticmethod
-    def _notify_professional_signup(
-        interested_pro: "models.InterestedProfessional",
-    ) -> None:
-        notify_interested_professional(
+        _persist_interested_professional_lead(
             interested_pro,
             source="/pro_version",
-            subject=f"New pro version signup #{interested_pro.id}",
+            subject_prefix="New pro version signup",
         )
+        return super().form_valid(form)
+
+
+class ExternalProSignupView(View):
+    """Cross-origin classic-form endpoint for the interested-professional lead
+    form hosted on the static Fight Paperwork site (fightpaperwork.com).
+
+    That site is a plain-HTML shell: it can't obtain a Django CSRF token and
+    runs none of our JavaScript, so a fetch()-based POST would fail silently.
+    This endpoint accepts a classic top-level form POST instead — it is
+    csrf_exempt (applied at the URLconf, matching ProVersionThankYouView) and,
+    on success, 302-redirects the browser to the shared thank-you page. Bot
+    protection is a hidden honeypot field on the form (see
+    ExternalInterestedProfessionalForm), so no JavaScript or reCAPTCHA is
+    needed.
+
+    A GET, or a submission that fails validation, sends the visitor to the
+    on-site /pro_version form, which re-validates with full server-side error
+    display (there is no cross-origin page here to re-render errors into).
+    """
+
+    def get(self, request, *args, **kwargs):
+        return HttpResponseRedirect(reverse("pro_version"))
+
+    def post(self, request, *args, **kwargs):
+        form = core_forms.ExternalInterestedProfessionalForm(request.POST)
+        if not form.is_valid():
+            return HttpResponseRedirect(reverse("pro_version"))
+        # Honeypot: a filled "website" field means a bot. Land it on the
+        # thank-you page like any other submission, but drop it silently.
+        if form.cleaned_data.get("website"):
+            return HttpResponseRedirect(reverse("pro_version_thankyou"))
+        interested_pro = form.save(commit=False)
+        _persist_interested_professional_lead(
+            interested_pro,
+            source="fightpaperwork.com",
+            subject_prefix="New Fight Paperwork pro signup",
+        )
+        return HttpResponseRedirect(reverse("pro_version_thankyou"))
 
 
 class PatientAccessView(generic.TemplateView):

--- a/tests/sync/test_pro_version_signup.py
+++ b/tests/sync/test_pro_version_signup.py
@@ -192,6 +192,130 @@ class ProVersionSignupEdgeCaseTest(TestCase):
         )
 
 
+class ExternalProSignupTest(TestCase):
+    """The cross-origin classic-form intake used by the static Fight Paperwork
+    site (fightpaperwork.com) POSTing to /pro_version_signup.
+
+    Unlike /pro_version this endpoint is csrf_exempt (the static page can't get
+    a token) and always 302-redirects rather than re-rendering, so behavior is
+    asserted via the redirect target, the DB, and the outbox.
+    """
+
+    URL_NAME = "pro_version_external_signup"
+
+    PAYLOAD = {
+        "name": "Ext Pro",
+        "email": "ext@clinic.example",
+        "job_title_or_provider_type": "Biller",
+        "business_name": "Static Clinic",
+        "phone_number": "555-0199",
+        "most_common_denial": "Prior auth",
+        "comments": "Sent from fightpaperwork.com",
+    }
+
+    def test_valid_submission_redirects_to_thankyou(self):
+        response = self.client.post(reverse(self.URL_NAME), self.PAYLOAD)
+        self.assertRedirects(
+            response,
+            reverse("pro_version_thankyou"),
+            fetch_redirect_response=False,
+        )
+
+    def test_valid_submission_creates_lead_and_notifies(self):
+        self.client.post(reverse(self.URL_NAME), self.PAYLOAD)
+        pro = InterestedProfessional.objects.get(email="ext@clinic.example")
+        self.assertEqual(pro.business_name, "Static Clinic")
+        self.assertFalse(pro.clicked_for_paid)
+        # Team notification names the off-site source in its subject.
+        self.assertTrue(
+            any(
+                m.subject == f"New Fight Paperwork pro signup #{pro.id}"
+                and m.to == ["professional@fighthealthinsurance.com"]
+                for m in mail.outbox
+            )
+        )
+
+    def test_valid_submission_sends_thankyou_to_signer(self):
+        self.client.post(reverse(self.URL_NAME), self.PAYLOAD)
+        self.assertTrue(
+            any(
+                "Thanks for your interest" in m.subject and "ext@clinic.example" in m.to
+                for m in mail.outbox
+            )
+        )
+
+    def test_accepts_post_without_csrf_token(self):
+        """The static site can't obtain a CSRF token, so the endpoint must not
+        enforce one (contrast with /pro_version which does)."""
+        csrf_client = Client(enforce_csrf_checks=True)
+        response = csrf_client.post(reverse(self.URL_NAME), self.PAYLOAD)
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(
+            InterestedProfessional.objects.filter(email="ext@clinic.example").exists()
+        )
+
+    def test_honeypot_submission_is_dropped_but_looks_successful(self):
+        """A filled honeypot marks a bot: land on thankyou, save nothing, mail
+        nothing."""
+        payload = {**self.PAYLOAD, "website": "http://spam.example"}
+        response = self.client.post(reverse(self.URL_NAME), payload)
+        self.assertRedirects(
+            response,
+            reverse("pro_version_thankyou"),
+            fetch_redirect_response=False,
+        )
+        self.assertFalse(InterestedProfessional.objects.exists())
+        self.assertEqual(mail.outbox, [])
+
+    def test_invalid_submission_redirects_to_onsite_form(self):
+        """Missing the required email can't be re-rendered across origins, so
+        the visitor is bounced to the on-site /pro_version form; nothing saved."""
+        response = self.client.post(
+            reverse(self.URL_NAME), {"name": "No Email", "email": ""}
+        )
+        self.assertRedirects(
+            response, reverse("pro_version"), fetch_redirect_response=False
+        )
+        self.assertFalse(InterestedProfessional.objects.exists())
+        self.assertEqual(mail.outbox, [])
+
+    def test_get_redirects_to_onsite_form(self):
+        response = self.client.get(reverse(self.URL_NAME))
+        self.assertRedirects(
+            response, reverse("pro_version"), fetch_redirect_response=False
+        )
+
+    def test_repeat_submission_dedups_by_email_case_insensitively(self):
+        self.client.post(reverse(self.URL_NAME), self.PAYLOAD)
+        self.client.post(
+            reverse(self.URL_NAME),
+            {**self.PAYLOAD, "email": "EXT@clinic.example"},
+        )
+        self.assertEqual(
+            InterestedProfessional.objects.filter(
+                email__iexact="ext@clinic.example"
+            ).count(),
+            1,
+        )
+        thankyous = [
+            m
+            for m in mail.outbox
+            if "Thanks for your interest" in m.subject
+            and any("ext@clinic.example" in t.lower() for t in m.to)
+        ]
+        self.assertEqual(len(thankyous), 1)
+
+    def test_rejects_mass_assignment_of_internal_fields(self):
+        with patch("fighthealthinsurance.views.ThankyouEmailSender.dosend"):
+            self.client.post(
+                reverse(self.URL_NAME),
+                {**self.PAYLOAD, "paid": "true", "thankyou_email_sent": "true"},
+            )
+        pro = InterestedProfessional.objects.get(email="ext@clinic.example")
+        self.assertFalse(pro.paid)
+        self.assertFalse(pro.thankyou_email_sent)
+
+
 @override_settings(PRO_VERSION_AVAILABLE=True)
 class ProVersionAvailableModeTest(TestCase):
     """When the flag is on, /pro_version shows the available-now page (no form)."""

--- a/tests/sync/test_pro_version_signup.py
+++ b/tests/sync/test_pro_version_signup.py
@@ -267,6 +267,22 @@ class ExternalProSignupTest(TestCase):
         self.assertFalse(InterestedProfessional.objects.exists())
         self.assertEqual(mail.outbox, [])
 
+    def test_honeypot_wins_even_when_required_fields_missing(self):
+        """The honeypot is checked before validation, so a bot can't dodge the
+        trap by also omitting the required email: it still lands on thankyou
+        (not the on-site form) and nothing is saved."""
+        response = self.client.post(
+            reverse(self.URL_NAME),
+            {"name": "Bot", "email": "", "website": "http://spam.example"},
+        )
+        self.assertRedirects(
+            response,
+            reverse("pro_version_thankyou"),
+            fetch_redirect_response=False,
+        )
+        self.assertFalse(InterestedProfessional.objects.exists())
+        self.assertEqual(mail.outbox, [])
+
     def test_invalid_submission_redirects_to_onsite_form(self):
         """Missing the required email can't be re-rendered across origins, so
         the visitor is bounced to the on-site /pro_version form; nothing saved."""
@@ -314,6 +330,25 @@ class ExternalProSignupTest(TestCase):
         pro = InterestedProfessional.objects.get(email="ext@clinic.example")
         self.assertFalse(pro.paid)
         self.assertFalse(pro.thankyou_email_sent)
+
+    def test_rejects_mass_assignment_of_proconnector_state(self):
+        """A crafted POST must not preset pro-connector workflow state. If it
+        could set proconnector_attempted/skipped=True, the lead would be born
+        already-handled and proconnector.processable_queryset() would skip it,
+        silently dropping a real lead from the outreach queue."""
+        self.client.post(
+            reverse(self.URL_NAME),
+            {
+                **self.PAYLOAD,
+                "proconnector_attempted": "true",
+                "proconnector_skipped": "true",
+                "proconnector_skip_reason": "injected",
+            },
+        )
+        pro = InterestedProfessional.objects.get(email="ext@clinic.example")
+        self.assertFalse(pro.proconnector_attempted)
+        self.assertFalse(pro.proconnector_skipped)
+        self.assertIsNone(pro.proconnector_skip_reason)
 
 
 @override_settings(PRO_VERSION_AVAILABLE=True)


### PR DESCRIPTION
## Summary
Adds a new CSRF-exempt endpoint (`/pro_version_signup`) to accept interested-professional lead submissions from the static Fight Paperwork site (fightpaperwork.com). This enables cross-origin form submissions without requiring CSRF tokens or JavaScript, using a honeypot field for bot protection instead.

## Key Changes

- **New `ExternalProSignupView`**: A simple view that accepts POST requests from the external Fight Paperwork site, validates submissions, and redirects to the thank-you page. GET requests and invalid submissions redirect to the on-site `/pro_version` form.

- **Extracted shared lead persistence logic**: Created `_persist_interested_professional_lead()` helper function to deduplicate code between the on-site form (`ProVersionView`) and the new external endpoint. Both now:
  - Dedup by email (case-insensitive)
  - Notify the professional-signup inbox with source-specific subject lines
  - Send thank-you emails immediately
  - Handle mail failures gracefully without raising exceptions

- **New `ExternalInterestedProfessionalForm`**: A variant of `InterestedProfessionalForm` that:
  - Drops reCAPTCHA (the static page runs no JavaScript)
  - Adds a hidden honeypot `website` field for bot detection
  - Captures the same fields as the on-site form

- **Updated `ProVersionView.form_valid()`**: Refactored to use the new shared `_persist_interested_professional_lead()` helper, removing duplicated notification and thank-you email logic.

- **URL routing**: Added `/pro_version_signup` path with `csrf_exempt` decorator to allow cross-origin classic-form POSTs.

## Implementation Details

- The honeypot approach is transparent to legitimate users (the field is hidden) but catches bots that fill all fields. Honeypot submissions land on the thank-you page but save nothing and send no emails.
- Invalid submissions (e.g., missing email) redirect to `/pro_version` rather than re-rendering errors, since there's no cross-origin page to display them.
- Deduplication is case-insensitive (matching the REST endpoint and pro-connector queue behavior).
- The `source` parameter in `_persist_interested_professional_lead()` allows different subject lines for team notifications: "New pro version signup" for on-site, "New Fight Paperwork pro signup" for external.
- Comprehensive test coverage in `ExternalProSignupTest` validates redirects, lead creation, deduplication, honeypot behavior, and mass-assignment protection.

https://claude.ai/code/session_01TupuuNwaR96aDGiZd9S95q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new external signup flow for professionals, with a simpler form that works without JavaScript and supports cross-site submissions.
  * Submissions now redirect to a thank-you page after sending the signup request.

* **Bug Fixes**
  * Duplicate signups are now prevented using the submitter’s email address.
  * Bot-like submissions are filtered out, and invalid submissions return users to the main signup form without creating records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->