### PR TITLE
Add support42@ to professional signup notifications

### DIFF
--- a/fighthealthinsurance/models.py
+++ b/fighthealthinsurance/models.py
@@ -3666,6 +3666,10 @@ class ModelHealthAlertState(models.Model):
     dead. This single-row-per-key table records when the last alert email was
     sent so that, across all pods sharing the database, at most one email goes
     out per throttle window.
+
+    Also reused as a general cross-pod one-per-window email throttle under
+    other key prefixes (e.g. returning-lead signup notifications via
+    utils.should_notify_returning_lead).
     """
 
     key = models.CharField(max_length=64, unique=True)

--- a/fighthealthinsurance/rest_views.py
+++ b/fighthealthinsurance/rest_views.py
@@ -1698,10 +1698,14 @@ class InterestedProfessionalViewSet(viewsets.ViewSet, CreateMixin):
             # comment is the interesting part), borrowing the stored row's pk
             # only so the admin deep-link resolves. The transient instance is
             # never saved — matching the web-form returning path — so the
-            # stored lead is not overwritten.
-            fresh = InterestedProfessional(**serializer.validated_data)
-            fresh.id = existing.id
-            self._notify_interested_professional(fresh, returning=True)
+            # stored lead is not overwritten. The shared cooldown gate bounds
+            # inbox amplification across every intake path.
+            from fighthealthinsurance.utils import should_notify_returning_lead
+
+            if should_notify_returning_lead(existing.email):
+                fresh = InterestedProfessional(**serializer.validated_data)
+                fresh.id = existing.id
+                self._notify_interested_professional(fresh, returning=True)
             return Response(
                 serializers.StatusResponseSerializer({"status": "subscribed"}).data,
                 status=status.HTTP_201_CREATED,

--- a/fighthealthinsurance/rest_views.py
+++ b/fighthealthinsurance/rest_views.py
@@ -1682,15 +1682,19 @@ class InterestedProfessionalViewSet(viewsets.ViewSet, CreateMixin):
     def perform_create(self, request: Request, serializer) -> Response:
         """Save the lead, then notify the professional-signup inbox."""
         # Dedup by email: a returning lead reuses the existing record rather
-        # than accumulating duplicate rows or re-notifying the professional
-        # inbox. Repeat submissions still get the standard success response.
-        # Case-insensitive to match how the pro-connector queue collapses
-        # duplicates (email__iexact).
+        # than accumulating duplicate rows (case-insensitive to match how the
+        # pro-connector queue collapses duplicates, email__iexact). The team
+        # notification still fires — flagged "(returning)" — so repeat
+        # interest is never silently swallowed. Repeat submissions get the
+        # standard success response either way.
         email = serializer.validated_data.get("email")
-        if (
-            email
-            and InterestedProfessional.objects.filter(email__iexact=email).exists()
-        ):
+        existing = (
+            InterestedProfessional.objects.filter(email__iexact=email).first()
+            if email
+            else None
+        )
+        if existing is not None:
+            self._notify_interested_professional(existing, returning=True)
             return Response(
                 serializers.StatusResponseSerializer({"status": "subscribed"}).data,
                 status=status.HTTP_201_CREATED,
@@ -1707,20 +1711,25 @@ class InterestedProfessionalViewSet(viewsets.ViewSet, CreateMixin):
 
     @staticmethod
     def _notify_interested_professional(
-        interested_pro: InterestedProfessional,
+        interested_pro: InterestedProfessional, *, returning: bool = False
     ) -> None:
-        """Notify the professional-signup inbox about a new REST interest lead.
+        """Notify the professional-signup inbox about a REST interest lead.
 
         Delegates to the shared notify_interested_professional helper so the web
         /pro_version form and this endpoint send an identical inbox format.
+        `returning=True` marks a repeat submission from an email that already
+        has a lead (the notification then describes the stored record).
         Best-effort: mail failures are logged, not raised, so they never fail
         the already-persisted lead."""
         from fighthealthinsurance.utils import notify_interested_professional
 
+        subject = f"New pro REST signup #{interested_pro.id}"
+        if returning:
+            subject += " (returning)"
         notify_interested_professional(
             interested_pro,
             source="the Fight Paperwork REST API",
-            subject=f"New pro REST signup #{interested_pro.id}",
+            subject=subject,
         )
 
 

--- a/fighthealthinsurance/rest_views.py
+++ b/fighthealthinsurance/rest_views.py
@@ -1694,7 +1694,14 @@ class InterestedProfessionalViewSet(viewsets.ViewSet, CreateMixin):
             else None
         )
         if existing is not None:
-            self._notify_interested_professional(existing, returning=True)
+            # Notify with the freshly submitted values (a new phone number or
+            # comment is the interesting part), borrowing the stored row's pk
+            # only so the admin deep-link resolves. The transient instance is
+            # never saved — matching the web-form returning path — so the
+            # stored lead is not overwritten.
+            fresh = InterestedProfessional(**serializer.validated_data)
+            fresh.id = existing.id
+            self._notify_interested_professional(fresh, returning=True)
             return Response(
                 serializers.StatusResponseSerializer({"status": "subscribed"}).data,
                 status=status.HTTP_201_CREATED,
@@ -1718,7 +1725,8 @@ class InterestedProfessionalViewSet(viewsets.ViewSet, CreateMixin):
         Delegates to the shared notify_interested_professional helper so the web
         /pro_version form and this endpoint send an identical inbox format.
         `returning=True` marks a repeat submission from an email that already
-        has a lead (the notification then describes the stored record).
+        has a lead (the caller passes a transient instance carrying the fresh
+        submission with the stored row's pk for the admin link).
         Best-effort: mail failures are logged, not raised, so they never fail
         the already-persisted lead."""
         from fighthealthinsurance.utils import notify_interested_professional

--- a/fighthealthinsurance/rest_views.py
+++ b/fighthealthinsurance/rest_views.py
@@ -1663,8 +1663,9 @@ class InterestedProfessionalViewSet(viewsets.ViewSet, CreateMixin):
     REST API.
 
     Public counterpart to the web /pro_version interest form: it records an
-    InterestedProfessional lead and notifies the professional-signup inbox
-    (defaults to professional@fighthealthinsurance.com, extendable via
+    InterestedProfessional lead and notifies the professional-signup inboxes
+    (default to support42@fighthealthinsurance.com and
+    professional@fighthealthinsurance.com, extendable via
     settings.PROFESSIONAL_SIGNUP_NOTIFICATION_EMAILS). Create-only: this is a
     public, unauthenticated endpoint, so lead removal is intentionally not
     exposed here (an email-only delete would let anyone erase a lead); data

--- a/fighthealthinsurance/settings.py
+++ b/fighthealthinsurance/settings.py
@@ -142,11 +142,12 @@ class Base(Configuration):
 
     # Professional-signup notifications — the web /pro_version interest form and
     # the Fight Paperwork (FPW) REST professional sign-up endpoint — default to
-    # professional@fighthealthinsurance.com; additional recipients can be
-    # configured via the PROFESSIONAL_SIGNUP_EXTRA_NOTIFICATION_EMAILS env var
-    # (comma-separated).
+    # support42@fighthealthinsurance.com and professional@fighthealthinsurance.com;
+    # additional recipients can be configured via the
+    # PROFESSIONAL_SIGNUP_EXTRA_NOTIFICATION_EMAILS env var (comma-separated).
     PROFESSIONAL_SIGNUP_NOTIFICATION_EMAILS = [
-        "professional@fighthealthinsurance.com"
+        "support42@fighthealthinsurance.com",
+        "professional@fighthealthinsurance.com",
     ] + [
         e.strip()
         for e in os.getenv("PROFESSIONAL_SIGNUP_EXTRA_NOTIFICATION_EMAILS", "").split(

--- a/fighthealthinsurance/utils.py
+++ b/fighthealthinsurance/utils.py
@@ -457,15 +457,19 @@ def notify_professional_signup(subject: str, body: str) -> None:
 
     Shared by the web /pro_version interest form and the Fight Paperwork REST
     professional sign-up endpoint. Recipients default to
-    professional@fighthealthinsurance.com and can be extended via
-    settings.PROFESSIONAL_SIGNUP_NOTIFICATION_EMAILS. A mail failure is logged
-    and swallowed so it never breaks the signup it is reporting on.
+    support42@fighthealthinsurance.com and professional@fighthealthinsurance.com
+    and can be extended via settings.PROFESSIONAL_SIGNUP_NOTIFICATION_EMAILS. A
+    mail failure is logged and swallowed so it never breaks the signup it is
+    reporting on.
     """
     recipients = list(
         getattr(
             settings,
             "PROFESSIONAL_SIGNUP_NOTIFICATION_EMAILS",
-            ["professional@fighthealthinsurance.com"],
+            [
+                "support42@fighthealthinsurance.com",
+                "professional@fighthealthinsurance.com",
+            ],
         )
     )
     if not recipients:

--- a/fighthealthinsurance/utils.py
+++ b/fighthealthinsurance/utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import concurrent
+import hashlib
 import os
 import random
 import re
@@ -484,6 +485,38 @@ def notify_professional_signup(subject: str, body: str) -> None:
         logger.opt(exception=True).error(
             f"Error sending professional signup notification email to {recipients}"
         )
+
+
+RETURNING_LEAD_NOTIFY_COOLDOWN_SECONDS = 15 * 60
+
+
+def should_notify_returning_lead(email: str) -> bool:
+    """Cross-pod cooldown gate for returning-lead team notifications.
+
+    A returning lead (an email that already has an InterestedProfessional row)
+    re-notifies the team on resubmission, which without a bound is an
+    inbox-amplification vector: anyone re-POSTing the same address would mail
+    the signup inboxes on every request. This grants at most one returning
+    notification per address per RETURNING_LEAD_NOTIFY_COOLDOWN_SECONDS across
+    all pods (via ModelHealthAlertState.try_claim). The key is a hash of the
+    lowercased address so it fits the 64-char key column and keeps the address
+    itself out of the throttle table. New-lead notifications never pass
+    through here — a brand-new email always notifies. Fails open: if the claim
+    check errors, the notification is sent, since a repeat notification beats
+    silently dropping real signal.
+    """
+    from fighthealthinsurance.models import ModelHealthAlertState
+
+    key = f"prl:{hashlib.sha256(email.strip().lower().encode()).hexdigest()[:48]}"
+    try:
+        return ModelHealthAlertState.try_claim(
+            key, RETURNING_LEAD_NOTIFY_COOLDOWN_SECONDS
+        )
+    except Exception:
+        logger.opt(exception=True).warning(
+            "Returning-lead notify cooldown check failed; sending anyway"
+        )
+        return True
 
 
 def notify_interested_professional(

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -229,10 +229,58 @@ def _persist_interested_professional_lead(
         )
 
 
+def _handle_classic_pro_lead_post(
+    request: HttpRequest, *, source: str, subject_prefix: str
+) -> HttpResponseRedirect:
+    """Process a classic (top-level, non-JS) interested-professional form POST.
+
+    Shared by the dedicated cross-origin intake endpoint
+    (:class:`ExternalProSignupView`) and the thank-you page
+    (:class:`ProVersionThankYouView`), which older embeds of the static
+    Fight Paperwork form still POST to directly.
+
+    Honeypot first, read straight from the raw POST: a filled "website" field
+    means a bot, so drop the submission silently and land it on the thank-you
+    page like any other. Checking before form validation means a bot can't
+    dodge the honeypot by also omitting a required field (which would
+    otherwise bounce it to /pro_version and reveal the trap). A submission
+    that fails validation is sent to the on-site /pro_version form, which
+    re-validates with full server-side error display (there is no
+    cross-origin page here to re-render errors into).
+    """
+    if request.POST.get("website", "").strip():
+        return HttpResponseRedirect(reverse("pro_version_thankyou"))
+    form = core_forms.ExternalInterestedProfessionalForm(request.POST)
+    if not form.is_valid():
+        return HttpResponseRedirect(reverse("pro_version"))
+    interested_pro = form.save(commit=False)
+    _persist_interested_professional_lead(
+        interested_pro,
+        source=source,
+        subject_prefix=subject_prefix,
+    )
+    return HttpResponseRedirect(reverse("pro_version_thankyou"))
+
+
 class ProVersionThankYouView(TemplateView):
-    """Thank you page displayed after professional version signup."""
+    """Thank you page displayed after professional version signup.
+
+    Also accepts direct classic-form POSTs (the URLconf marks it csrf_exempt
+    for exactly this reason): older deployed/cached copies of the static
+    Fight Paperwork interest form submit straight to this URL, so a POST here
+    must persist the lead and fan out the signup notification emails rather
+    than returning 405 and silently dropping the signup. POST-redirect-GET:
+    a successful submission 302s back to this page, which then renders.
+    """
 
     template_name = "professional_thankyou.html"
+
+    def post(self, request, *args, **kwargs):
+        return _handle_classic_pro_lead_post(
+            request,
+            source="/pro_version_thankyou",
+            subject_prefix="New pro version signup",
+        )
 
 
 class BRB(TemplateView):
@@ -350,23 +398,11 @@ class ExternalProSignupView(View):
         return HttpResponseRedirect(reverse("pro_version"))
 
     def post(self, request, *args, **kwargs):
-        # Honeypot first, read straight from the raw POST: a filled "website"
-        # field means a bot, so drop the submission silently and land it on the
-        # thank-you page like any other. Checking before form validation means
-        # a bot can't dodge the honeypot by also omitting a required field
-        # (which would otherwise bounce it to /pro_version and reveal the trap).
-        if request.POST.get("website", "").strip():
-            return HttpResponseRedirect(reverse("pro_version_thankyou"))
-        form = core_forms.ExternalInterestedProfessionalForm(request.POST)
-        if not form.is_valid():
-            return HttpResponseRedirect(reverse("pro_version"))
-        interested_pro = form.save(commit=False)
-        _persist_interested_professional_lead(
-            interested_pro,
+        return _handle_classic_pro_lead_post(
+            request,
             source="fightpaperwork.com",
             subject_prefix="New Fight Paperwork pro signup",
         )
-        return HttpResponseRedirect(reverse("pro_version_thankyou"))
 
 
 class PatientAccessView(generic.TemplateView):

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -55,6 +55,7 @@ from fighthealthinsurance.utils import (
     is_valid_denial_id,
     notify_interested_professional,
     send_fallback_email,
+    should_notify_returning_lead,
 )
 
 
@@ -201,13 +202,16 @@ def _persist_interested_professional_lead(
     Dedup by email (case-insensitive, matching the REST endpoint and the
     pro-connector queue) keeps one row per address: a returning lead never
     creates a duplicate InterestedProfessional and never overwrites the
-    stored one. The team notification is sent on every submission though —
-    repeat interest is real signal, and silently swallowing it makes
-    successful signups look broken — with a "(returning)" subject marker and
-    the freshly submitted field values in the body. The thank-you email goes
-    out immediately for new leads; for returning ones it is only retried when
-    no send has succeeded yet (thankyou_email_sent=False), so repeatedly
-    submitting someone else's address can't be used to spam them. New leads
+    stored one. The team is still notified on repeat submissions — repeat
+    interest is real signal, and silently swallowing it makes successful
+    signups look broken — with a "(returning)" subject marker and the freshly
+    submitted field values in the body, bounded to at most one returning
+    notification per address per cooldown window (see
+    should_notify_returning_lead) so re-POSTing an address can't flood the
+    inboxes. The thank-you email goes out immediately for new leads; for
+    returning ones it is only retried when no send has succeeded yet
+    (thankyou_email_sent=False), so repeatedly submitting someone else's
+    address can't be used to spam them. New leads
     are recorded as not-clicked-for-paid (the pay-to-express-interest choice
     is no longer collected). Mail failures are logged, never raised, so they
     can't fail an already-persisted lead.
@@ -221,12 +225,15 @@ def _persist_interested_professional_lead(
         # phone number or comment is the interesting part). The unsaved
         # instance is discarded afterwards — never save() it here, or an
         # unauthenticated resubmission would overwrite the stored lead.
+        # The cooldown gate bounds inbox amplification: at most one returning
+        # notification per address per window, no matter how fast repeats come.
         interested_pro.id = existing.id
-        notify_interested_professional(
-            interested_pro,
-            source=source,
-            subject=f"{subject_prefix} #{existing.id} (returning)",
-        )
+        if should_notify_returning_lead(existing.email):
+            notify_interested_professional(
+                interested_pro,
+                source=source,
+                subject=f"{subject_prefix} #{existing.id} (returning)",
+            )
         if not existing.thankyou_email_sent:
             try:
                 ThankyouEmailSender().dosend(interested_pro=existing)

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -192,23 +192,49 @@ def _persist_interested_professional_lead(
 ) -> None:
     """Persist a new interested-professional lead and fan out notifications.
 
-    Shared by the on-site /pro_version form (:class:`ProVersionView`) and the
+    Shared by the on-site /pro_version form (:class:`ProVersionView`), the
     off-site fightpaperwork.com classic-form endpoint
-    (:class:`ExternalProSignupView`) so both dedup, notify, and thank
+    (:class:`ExternalProSignupView`), and direct posts to the thank-you page
+    (:class:`ProVersionThankYouView`) so all intakes dedup, notify, and thank
     identically.
 
     Dedup by email (case-insensitive, matching the REST endpoint and the
-    pro-connector queue): if a lead with this address already exists, do
-    nothing — no duplicate row, no re-notification, no second thank-you. The
-    caller still sends the submitter to the thank-you page. Otherwise record
-    the lead as not-clicked-for-paid (the pay-to-express-interest choice is no
-    longer collected), notify the professional-signup inbox, and send the
-    thank-you email immediately. Mail failures are logged, never raised, so
-    they can't fail an already-persisted lead.
+    pro-connector queue) keeps one row per address: a returning lead never
+    creates a duplicate InterestedProfessional and never overwrites the
+    stored one. The team notification is sent on every submission though —
+    repeat interest is real signal, and silently swallowing it makes
+    successful signups look broken — with a "(returning)" subject marker and
+    the freshly submitted field values in the body. The thank-you email goes
+    out immediately for new leads; for returning ones it is only retried when
+    no send has succeeded yet (thankyou_email_sent=False), so repeatedly
+    submitting someone else's address can't be used to spam them. New leads
+    are recorded as not-clicked-for-paid (the pay-to-express-interest choice
+    is no longer collected). Mail failures are logged, never raised, so they
+    can't fail an already-persisted lead.
     """
-    if models.InterestedProfessional.objects.filter(
+    existing = models.InterestedProfessional.objects.filter(
         email__iexact=interested_pro.email
-    ).exists():
+    ).first()
+    if existing is not None:
+        # Borrow the existing row's pk so the notification's admin deep-link
+        # resolves, while the body carries what was just submitted (a fresh
+        # phone number or comment is the interesting part). The unsaved
+        # instance is discarded afterwards — never save() it here, or an
+        # unauthenticated resubmission would overwrite the stored lead.
+        interested_pro.id = existing.id
+        notify_interested_professional(
+            interested_pro,
+            source=source,
+            subject=f"{subject_prefix} #{existing.id} (returning)",
+        )
+        if not existing.thankyou_email_sent:
+            try:
+                ThankyouEmailSender().dosend(interested_pro=existing)
+            except Exception:
+                logger.opt(exception=True).warning(
+                    f"Error retrying pro signup thank-you "
+                    f"(interested_professional_id={existing.id})"
+                )
         return
     interested_pro.clicked_for_paid = False
     interested_pro.save()

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -270,9 +270,12 @@ def _handle_classic_pro_lead_post(
     page like any other. Checking before form validation means a bot can't
     dodge the honeypot by also omitting a required field (which would
     otherwise bounce it to /pro_version and reveal the trap). A submission
-    that fails validation is sent to the on-site /pro_version form, which
-    re-validates with full server-side error display (there is no
-    cross-origin page here to re-render errors into).
+    that fails validation is bounced to the on-site /pro_version form to try
+    again there: the redirect is a plain GET, so the failed input and errors
+    are not carried across (there is no cross-origin page to re-render errors
+    into), but the on-site form gives full error display on resubmission —
+    and since email is the only required field, marked required client-side
+    on the known senders, this path is rare.
     """
     if request.POST.get("website", "").strip():
         return HttpResponseRedirect(reverse("pro_version_thankyou"))
@@ -416,8 +419,8 @@ class ExternalProSignupView(View):
     needed.
 
     A GET, or a submission that fails validation, sends the visitor to the
-    on-site /pro_version form, which re-validates with full server-side error
-    display (there is no cross-origin page here to re-render errors into).
+    on-site /pro_version form to try again (as a plain GET redirect — see
+    _handle_classic_pro_lead_post for why errors can't be carried across).
     """
 
     def get(self, request, *args, **kwargs):

--- a/tests/async/test_rest_auth_views.py
+++ b/tests/async/test_rest_auth_views.py
@@ -363,7 +363,8 @@ class RestAuthViewsTests(TestCase):
 
     def test_professional_signup_notifies_professional_inbox(self) -> None:
         """A successful FPW REST professional signup emails the professional
-        notification inbox (defaults to professional@fighthealthinsurance.com).
+        notification inboxes (default to support42@fighthealthinsurance.com
+        and professional@fighthealthinsurance.com).
 
         Uses the join-existing-domain path so no Stripe call is involved, and
         captures on_commit callbacks since the notification is deferred until
@@ -391,7 +392,13 @@ class RestAuthViewsTests(TestCase):
             for m in mail.outbox
             if m.subject == "New professional signup: notifypro@test-fhi.com"
         )
-        self.assertEqual(notification.to, ["professional@fighthealthinsurance.com"])
+        self.assertEqual(
+            notification.to,
+            [
+                "support42@fighthealthinsurance.com",
+                "professional@fighthealthinsurance.com",
+            ],
+        )
         self.assertIn("notifypro@test-fhi.com", notification.body)
         self.assertIn("Notify Pro", notification.body)
 

--- a/tests/sync/test_pro_version_signup.py
+++ b/tests/sync/test_pro_version_signup.py
@@ -49,9 +49,13 @@ class ProVersionSignupSuccessTest(TestCase):
         # Pay-to-express-interest is no longer collected.
         self.assertFalse(self.pro.clicked_for_paid)
 
-    def test_sends_team_notification_to_professional_inbox(self):
+    def test_sends_team_notification_to_support_and_professional_inboxes(self):
         self.assertEqual(
-            self._team_email().to, ["professional@fighthealthinsurance.com"]
+            self._team_email().to,
+            [
+                "support42@fighthealthinsurance.com",
+                "professional@fighthealthinsurance.com",
+            ],
         )
 
     def test_team_notification_includes_captured_fields(self):
@@ -230,7 +234,11 @@ class ExternalProSignupTest(TestCase):
         self.assertTrue(
             any(
                 m.subject == f"New Fight Paperwork pro signup #{pro.id}"
-                and m.to == ["professional@fighthealthinsurance.com"]
+                and m.to
+                == [
+                    "support42@fighthealthinsurance.com",
+                    "professional@fighthealthinsurance.com",
+                ]
                 for m in mail.outbox
             )
         )
@@ -349,6 +357,112 @@ class ExternalProSignupTest(TestCase):
         self.assertFalse(pro.proconnector_attempted)
         self.assertFalse(pro.proconnector_skipped)
         self.assertIsNone(pro.proconnector_skip_reason)
+
+
+class ProVersionThankYouDirectPostTest(TestCase):
+    """Direct classic-form POSTs to /pro_version_thankyou.
+
+    Older deployed/cached copies of the static Fight Paperwork interest form
+    submit straight to the thank-you URL (which is csrf_exempt in the URLconf
+    for exactly this reason). These posts must persist the lead and fan out
+    the notification + thank-you emails instead of 405-ing and silently
+    dropping the signup — the regression this class guards against.
+    """
+
+    URL_NAME = "pro_version_thankyou"
+
+    PAYLOAD = {
+        "name": "Direct Poster",
+        "email": "direct@clinic.example",
+        "job_title_or_provider_type": "Office manager",
+        "business_name": "Legacy Clinic",
+        "phone_number": "555-0142",
+        "most_common_denial": "Out of network",
+        "comments": "Posted straight to the thank-you page",
+    }
+
+    def test_get_still_renders_thankyou_page(self):
+        response = self.client.get(reverse(self.URL_NAME))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Thank you for believing in us")
+
+    def test_post_redirects_to_thankyou_page(self):
+        # POST-redirect-GET back to the same page, matching the external
+        # endpoint's contract (and refreshing won't re-submit).
+        response = self.client.post(reverse(self.URL_NAME), self.PAYLOAD)
+        self.assertRedirects(response, reverse(self.URL_NAME))
+
+    def test_post_creates_lead(self):
+        self.client.post(reverse(self.URL_NAME), self.PAYLOAD)
+        pro = InterestedProfessional.objects.get(email="direct@clinic.example")
+        self.assertEqual(pro.business_name, "Legacy Clinic")
+        self.assertFalse(pro.clicked_for_paid)
+
+    def test_post_notifies_support_and_professional_inboxes(self):
+        self.client.post(reverse(self.URL_NAME), self.PAYLOAD)
+        pro = InterestedProfessional.objects.get(email="direct@clinic.example")
+        notification = next(
+            m for m in mail.outbox if m.subject == f"New pro version signup #{pro.id}"
+        )
+        self.assertEqual(
+            notification.to,
+            [
+                "support42@fighthealthinsurance.com",
+                "professional@fighthealthinsurance.com",
+            ],
+        )
+        # The body names the intake path so the team can tell a legacy
+        # direct post apart from the on-site form.
+        self.assertIn("/pro_version_thankyou", notification.body)
+
+    def test_post_sends_thankyou_email_to_signer(self):
+        self.client.post(reverse(self.URL_NAME), self.PAYLOAD)
+        self.assertTrue(
+            any(
+                "Thanks for your interest" in m.subject
+                and "direct@clinic.example" in m.to
+                for m in mail.outbox
+            )
+        )
+
+    def test_accepts_post_without_csrf_token(self):
+        """Cross-origin static pages can't obtain a CSRF token, so the
+        endpoint must not enforce one."""
+        csrf_client = Client(enforce_csrf_checks=True)
+        response = csrf_client.post(reverse(self.URL_NAME), self.PAYLOAD)
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(
+            InterestedProfessional.objects.filter(
+                email="direct@clinic.example"
+            ).exists()
+        )
+
+    def test_honeypot_submission_is_dropped_but_looks_successful(self):
+        payload = {**self.PAYLOAD, "website": "http://spam.example"}
+        response = self.client.post(reverse(self.URL_NAME), payload)
+        self.assertRedirects(response, reverse(self.URL_NAME))
+        self.assertFalse(InterestedProfessional.objects.exists())
+        self.assertEqual(mail.outbox, [])
+
+    def test_invalid_submission_redirects_to_onsite_form(self):
+        response = self.client.post(
+            reverse(self.URL_NAME), {"name": "No Email", "email": ""}
+        )
+        self.assertRedirects(
+            response, reverse("pro_version"), fetch_redirect_response=False
+        )
+        self.assertFalse(InterestedProfessional.objects.exists())
+        self.assertEqual(mail.outbox, [])
+
+    def test_repeat_submission_dedups_by_email(self):
+        self.client.post(reverse(self.URL_NAME), self.PAYLOAD)
+        self.client.post(reverse(self.URL_NAME), self.PAYLOAD)
+        self.assertEqual(
+            InterestedProfessional.objects.filter(
+                email__iexact="direct@clinic.example"
+            ).count(),
+            1,
+        )
 
 
 @override_settings(PRO_VERSION_AVAILABLE=True)

--- a/tests/sync/test_pro_version_signup.py
+++ b/tests/sync/test_pro_version_signup.py
@@ -363,10 +363,12 @@ class RepeatSignupNotificationTest(TestCase):
     """Repeat submissions from an email address that already has a lead.
 
     The row is still deduped (one lead per address, matching the pro-connector
-    queue), but the team notification fires on every submission — flagged
-    "(returning)" and carrying the freshly submitted field values — so repeat
-    interest is never silently swallowed. The thank-you email is only retried
-    when no send has succeeded yet.
+    queue), but the team notification still fires — flagged "(returning)" and
+    carrying the freshly submitted field values — so repeat interest is never
+    silently swallowed. It is bounded to one returning notification per
+    address per cooldown window, so re-POSTing an address can't flood the
+    inboxes. The thank-you email is only retried when no send has succeeded
+    yet.
     """
 
     PAYLOAD = {"name": "Returning", "email": "returning@clinic.example"}
@@ -426,6 +428,32 @@ class RepeatSignupNotificationTest(TestCase):
                 for m in mail.outbox
             )
         )
+
+    def test_second_repeat_within_cooldown_is_not_renotified(self):
+        """The first repeat claims the per-email notification slot; an
+        immediate second repeat stays silent, bounding inbox amplification."""
+        self.client.post(reverse("pro_version"), self.PAYLOAD)  # new lead
+        self.client.post(reverse("pro_version"), self.PAYLOAD)  # first repeat
+        mail.outbox.clear()
+        self.client.post(reverse("pro_version"), self.PAYLOAD)  # second repeat
+        self.assertFalse(any("(returning)" in m.subject for m in mail.outbox))
+
+    def test_repeat_notifies_again_after_cooldown_expires(self):
+        import datetime
+
+        from django.utils import timezone
+
+        from fighthealthinsurance.models import ModelHealthAlertState
+
+        self.client.post(reverse("pro_version"), self.PAYLOAD)  # new lead
+        self.client.post(reverse("pro_version"), self.PAYLOAD)  # claims the slot
+        # Backdate the throttle row so the cooldown window has elapsed.
+        ModelHealthAlertState.objects.update(
+            last_alert_sent=timezone.now() - datetime.timedelta(minutes=16)
+        )
+        mail.outbox.clear()
+        self.client.post(reverse("pro_version"), self.PAYLOAD)
+        self.assertTrue(any("(returning)" in m.subject for m in mail.outbox))
 
     def test_repeat_submission_works_from_thankyou_page_intake(self):
         """The relaxed dedup applies to the legacy direct-post path too — the

--- a/tests/sync/test_pro_version_signup.py
+++ b/tests/sync/test_pro_version_signup.py
@@ -359,6 +359,90 @@ class ExternalProSignupTest(TestCase):
         self.assertIsNone(pro.proconnector_skip_reason)
 
 
+class RepeatSignupNotificationTest(TestCase):
+    """Repeat submissions from an email address that already has a lead.
+
+    The row is still deduped (one lead per address, matching the pro-connector
+    queue), but the team notification fires on every submission — flagged
+    "(returning)" and carrying the freshly submitted field values — so repeat
+    interest is never silently swallowed. The thank-you email is only retried
+    when no send has succeeded yet.
+    """
+
+    PAYLOAD = {"name": "Returning", "email": "returning@clinic.example"}
+
+    def test_repeat_submission_notifies_team_as_returning(self):
+        self.client.post(reverse("pro_version"), self.PAYLOAD)
+        mail.outbox.clear()
+        self.client.post(
+            reverse("pro_version"), {**self.PAYLOAD, "phone_number": "555-0777"}
+        )
+        pro = InterestedProfessional.objects.get(email="returning@clinic.example")
+        notification = next(
+            m
+            for m in mail.outbox
+            if m.subject == f"New pro version signup #{pro.id} (returning)"
+        )
+        self.assertEqual(
+            notification.to,
+            [
+                "support42@fighthealthinsurance.com",
+                "professional@fighthealthinsurance.com",
+            ],
+        )
+        # The body carries the freshly submitted values, not the stored row.
+        self.assertIn("555-0777", notification.body)
+
+    def test_repeat_submission_does_not_overwrite_stored_lead(self):
+        self.client.post(reverse("pro_version"), self.PAYLOAD)
+        self.client.post(
+            reverse("pro_version"), {**self.PAYLOAD, "phone_number": "555-0777"}
+        )
+        pro = InterestedProfessional.objects.get(email="returning@clinic.example")
+        self.assertEqual(pro.phone_number, "")
+
+    def test_repeat_submission_does_not_resend_sent_thankyou(self):
+        self.client.post(reverse("pro_version"), self.PAYLOAD)
+        mail.outbox.clear()
+        self.client.post(reverse("pro_version"), self.PAYLOAD)
+        self.assertFalse(
+            any("Thanks for your interest" in m.subject for m in mail.outbox)
+        )
+
+    def test_repeat_submission_retries_unsent_thankyou(self):
+        # A lead whose thank-you never went out (thankyou_email_sent=False)
+        # gets it on resubmission, instead of being stuck silent forever.
+        InterestedProfessional.objects.create(
+            email="unthanked@clinic.example", thankyou_email_sent=False
+        )
+        self.client.post(
+            reverse("pro_version"),
+            {"name": "Unthanked", "email": "unthanked@clinic.example"},
+        )
+        self.assertTrue(
+            any(
+                "Thanks for your interest" in m.subject
+                and "unthanked@clinic.example" in m.to
+                for m in mail.outbox
+            )
+        )
+
+    def test_repeat_submission_works_from_thankyou_page_intake(self):
+        """The relaxed dedup applies to the legacy direct-post path too — the
+        scenario where repeat testing previously looked like a dead endpoint."""
+        self.client.post(reverse("pro_version_thankyou"), self.PAYLOAD)
+        mail.outbox.clear()
+        response = self.client.post(reverse("pro_version_thankyou"), self.PAYLOAD)
+        self.assertRedirects(response, reverse("pro_version_thankyou"))
+        pro = InterestedProfessional.objects.get(email="returning@clinic.example")
+        self.assertTrue(
+            any(
+                m.subject == f"New pro version signup #{pro.id} (returning)"
+                for m in mail.outbox
+            )
+        )
+
+
 class ProVersionThankYouDirectPostTest(TestCase):
     """Direct classic-form POSTs to /pro_version_thankyou.
 

--- a/tests/sync/test_pro_version_signup.py
+++ b/tests/sync/test_pro_version_signup.py
@@ -455,6 +455,18 @@ class RepeatSignupNotificationTest(TestCase):
         self.client.post(reverse("pro_version"), self.PAYLOAD)
         self.assertTrue(any("(returning)" in m.subject for m in mail.outbox))
 
+    def test_cooldown_check_failure_fails_open(self):
+        """A broken throttle check must not silently drop the notification —
+        the gate fails open, so infrastructure trouble degrades to a possible
+        repeat email rather than lost signal."""
+        from fighthealthinsurance.utils import should_notify_returning_lead
+
+        with patch(
+            "fighthealthinsurance.models.ModelHealthAlertState.try_claim",
+            side_effect=RuntimeError("db down"),
+        ):
+            self.assertTrue(should_notify_returning_lead("someone@example.com"))
+
     def test_repeat_submission_works_from_thankyou_page_intake(self):
         """The relaxed dedup applies to the legacy direct-post path too — the
         scenario where repeat testing previously looked like a dead endpoint."""

--- a/tests/sync/test_rest_api.py
+++ b/tests/sync/test_rest_api.py
@@ -2173,7 +2173,8 @@ class DemoRequestEndpointTest(APITestCase):
 
     def test_demo_request_notifies_professional_inbox(self):
         # The lead notification goes through the shared
-        # notify_interested_professional helper, i.e. to the professional inbox.
+        # notify_interested_professional helper, i.e. to the professional-signup
+        # inboxes (support42@ + professional@).
         response = self.client.post(
             reverse("demorequest-list"),
             data=json.dumps({"email": "lead6@example.com"}),
@@ -2181,8 +2182,9 @@ class DemoRequestEndpointTest(APITestCase):
         )
         self.assertEqual(response.status_code, 201)
         notification = next(
-            m for m in mail.outbox if m.to == ["professional@fighthealthinsurance.com"]
+            m for m in mail.outbox if "professional@fighthealthinsurance.com" in m.to
         )
+        self.assertIn("support42@fighthealthinsurance.com", notification.to)
         self.assertIn("lead6@example.com", notification.body)
         self.assertIn("a Fight Paperwork demo request", notification.body)
 
@@ -2210,7 +2212,8 @@ class DemoRequestEndpointTest(APITestCase):
 class InterestedProfessionalEndpointTest(APITestCase):
     """The interested_professional REST endpoint records a professional-interest
     lead (the FPW counterpart to the web /pro_version form) and notifies the
-    professional-signup inbox (defaults to professional@fighthealthinsurance.com).
+    professional-signup inboxes (default to support42@fighthealthinsurance.com
+    and professional@fighthealthinsurance.com).
     The notification flows through fighthealthinsurance.utils.notify_professional_signup,
     so that is the send_mail patch target."""
 
@@ -2240,6 +2243,7 @@ class InterestedProfessionalEndpointTest(APITestCase):
         mock_send.assert_called_once()
         # send_mail(subject, body, from_email, recipients)
         subject, body, _from, recipients = mock_send.call_args.args
+        self.assertIn("support42@fighthealthinsurance.com", recipients)
         self.assertIn("professional@fighthealthinsurance.com", recipients)
         self.assertIn("pro@example.com", body)
         self.assertIn(str(pro.id), subject)

--- a/tests/sync/test_rest_api.py
+++ b/tests/sync/test_rest_api.py
@@ -2264,6 +2264,36 @@ class InterestedProfessionalEndpointTest(APITestCase):
         recipients = mock_send.call_args.args[3]
         self.assertIn("sales@example.com", recipients)
 
+    def test_repeat_submission_notifies_as_returning_without_duplicate_row(self):
+        # The row is deduped (case-insensitively), but the team is still
+        # notified — flagged "(returning)" — instead of the repeat being
+        # silently swallowed.
+        from fighthealthinsurance.models import InterestedProfessional
+
+        first = self.client.post(
+            reverse("interested-professional-list"),
+            data=json.dumps({"email": "again@example.com"}),
+            content_type="application/json",
+        )
+        with patch("fighthealthinsurance.utils.send_mail") as mock_send:
+            second = self.client.post(
+                reverse("interested-professional-list"),
+                data=json.dumps({"email": "Again@example.com"}),
+                content_type="application/json",
+            )
+        self.assertEqual(first.status_code, 201)
+        self.assertEqual(second.status_code, 201)
+        self.assertEqual(
+            InterestedProfessional.objects.filter(
+                email__iexact="again@example.com"
+            ).count(),
+            1,
+        )
+        pro = InterestedProfessional.objects.get(email__iexact="again@example.com")
+        mock_send.assert_called_once()
+        subject = mock_send.call_args.args[0]
+        self.assertEqual(subject, f"New pro REST signup #{pro.id} (returning)")
+
     def test_mail_failure_does_not_fail_request(self):
         # The lead is persisted before the notification is attempted, so a mail
         # backend error must not turn into a 500.

--- a/tests/sync/test_rest_api.py
+++ b/tests/sync/test_rest_api.py
@@ -2266,19 +2266,21 @@ class InterestedProfessionalEndpointTest(APITestCase):
 
     def test_repeat_submission_notifies_as_returning_without_duplicate_row(self):
         # The row is deduped (case-insensitively), but the team is still
-        # notified — flagged "(returning)" — instead of the repeat being
-        # silently swallowed.
+        # notified — flagged "(returning)" and carrying the freshly submitted
+        # values — instead of the repeat being silently swallowed.
         from fighthealthinsurance.models import InterestedProfessional
 
         first = self.client.post(
             reverse("interested-professional-list"),
-            data=json.dumps({"email": "again@example.com"}),
+            data=json.dumps({"email": "again@example.com", "name": "First Try"}),
             content_type="application/json",
         )
         with patch("fighthealthinsurance.utils.send_mail") as mock_send:
             second = self.client.post(
                 reverse("interested-professional-list"),
-                data=json.dumps({"email": "Again@example.com"}),
+                data=json.dumps(
+                    {"email": "Again@example.com", "phone_number": "555-0888"}
+                ),
                 content_type="application/json",
             )
         self.assertEqual(first.status_code, 201)
@@ -2291,8 +2293,13 @@ class InterestedProfessionalEndpointTest(APITestCase):
         )
         pro = InterestedProfessional.objects.get(email__iexact="again@example.com")
         mock_send.assert_called_once()
-        subject = mock_send.call_args.args[0]
+        subject, body = mock_send.call_args.args[0], mock_send.call_args.args[1]
         self.assertEqual(subject, f"New pro REST signup #{pro.id} (returning)")
+        # Body reflects the repeat submission, not the stored row (which keeps
+        # its original values).
+        self.assertIn("555-0888", body)
+        self.assertEqual(pro.name, "First Try")
+        self.assertEqual(pro.phone_number, "")
 
     def test_mail_failure_does_not_fail_request(self):
         # The lead is persisted before the notification is attempted, so a mail

--- a/tests/sync/test_rest_api.py
+++ b/tests/sync/test_rest_api.py
@@ -2301,6 +2301,26 @@ class InterestedProfessionalEndpointTest(APITestCase):
         self.assertEqual(pro.name, "First Try")
         self.assertEqual(pro.phone_number, "")
 
+    def test_second_repeat_within_cooldown_suppresses_notification(self):
+        # The first repeat claims the per-email notification slot; a second
+        # repeat inside the cooldown window must not email the team again
+        # (bounds inbox amplification), while still returning the standard
+        # success response.
+        for _ in range(2):  # new lead, then first repeat (claims the slot)
+            self.client.post(
+                reverse("interested-professional-list"),
+                data=json.dumps({"email": "again2@example.com"}),
+                content_type="application/json",
+            )
+        with patch("fighthealthinsurance.utils.send_mail") as mock_send:
+            response = self.client.post(
+                reverse("interested-professional-list"),
+                data=json.dumps({"email": "again2@example.com"}),
+                content_type="application/json",
+            )
+        self.assertEqual(response.status_code, 201)
+        mock_send.assert_not_called()
+
     def test_mail_failure_does_not_fail_request(self):
         # The lead is persisted before the notification is attempted, so a mail
         # backend error must not turn into a 500.


### PR DESCRIPTION
## Summary
Expands professional signup notification recipients to include both a support inbox and the existing professional inbox, ensuring signup notifications reach both teams.

## Key Changes
- **Default recipients**: Updated `PROFESSIONAL_SIGNUP_NOTIFICATION_EMAILS` in settings to include both `support42@fighthealthinsurance.com` and `professional@fighthealthinsurance.com` (previously only professional@)
- **Shared notification logic**: Modified `notify_professional_signup()` utility to use the expanded default recipient list
- **Classic form POST handling**: Extracted common form processing logic into `_handle_classic_pro_lead_post()` helper to support both:
  - External Fight Paperwork form submissions (fightpaperwork.com)
  - Direct POSTs to the thank-you page (legacy cached form embeds)
- **Thank-you page POST support**: Added POST handler to `ProVersionThankYouView` to accept and process direct form submissions from older deployed static forms, preventing silent data loss
- **Test coverage**: Added comprehensive `ProVersionThankYouDirectPostTest` class covering:
  - Lead creation from direct POSTs
  - Dual-inbox notification delivery
  - CSRF exemption for cross-origin forms
  - Honeypot spam filtering
  - Form validation and error handling
  - Deduplication by email
- **Updated test assertions**: Modified existing tests across sync/async test suites to verify both support42@ and professional@ recipients in notification emails

## Implementation Details
- The honeypot check (website field) happens before form validation to prevent bots from discovering the trap via validation errors
- Invalid submissions from the thank-you page redirect to `/pro_version` (the on-site form) for proper error display
- POST-redirect-GET pattern prevents form resubmission on page refresh
- Shared `_handle_classic_pro_lead_post()` function reduces duplication between external and thank-you endpoints while allowing different source/subject labels for audit trails

https://claude.ai/code/session_01MVZ3HY1fu9CMpk2dsWzsN1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Direct submissions to the pro signup thank-you page are now accepted and processed.

* **Bug Fixes**
  * Professional signup notifications now default to both the support and professional inboxes.
  * Repeat pro signups are deduplicated by email (case-insensitive), sending a single “returning” notification when allowed and throttled within a 15-minute cooldown.
  * Thank-you emails are retried if a prior send didn’t succeed.
  * Classic and cross-origin pro flows now share consistent redirect and email behavior.

* **Tests**
  * Added/expanded coverage for recipient fanout, returning notification content, cooldown throttling, and legacy direct-post handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->