### PR TITLE
Harden ReportClientError: cover the ownership lookup with the 204 fallback

### DIFF
--- a/fighthealthinsurance/rest_views.py
+++ b/fighthealthinsurance/rest_views.py
@@ -587,8 +587,7 @@ class ReportClientError(APIView):
         except Exception as e:
             context_tokens = "unavailable"
             logger.opt(exception=True).debug(
-                f"Failed to compute context token sizes for denial "
-                f"{denial_id}: {e}"
+                f"Failed to compute context token sizes for denial " f"{denial_id}: {e}"
             )
         logger.error(
             f"Client-reported appeal error for denial {denial_id}: "

--- a/fighthealthinsurance/rest_views.py
+++ b/fighthealthinsurance/rest_views.py
@@ -571,20 +571,25 @@ class ReportClientError(APIView):
         # log without the token breakdown rather than reject. Never let the
         # enrichment break the report.
         context_tokens = "unauthorized"
-        denial = common_view_logic.get_denial_for_action(
-            denial_id=request.data.get("denial_id"),
-            email=str(request.data.get("email") or ""),
-            semi_sekret=str(request.data.get("semi_sekret") or ""),
-        )
-        if denial is not None:
-            try:
+        # Wrap BOTH the ownership lookup and the summarize call: this endpoint's
+        # whole contract is "always 204, never let the diagnostic enrichment
+        # break the report", and get_denial_for_action does a DB query that can
+        # raise. Keeping it outside the try would let a DB/runtime error there
+        # escape and 500 the error reporter.
+        try:
+            denial = common_view_logic.get_denial_for_action(
+                denial_id=request.data.get("denial_id"),
+                email=str(request.data.get("email") or ""),
+                semi_sekret=str(request.data.get("semi_sekret") or ""),
+            )
+            if denial is not None:
                 context_tokens = context_utils.summarize_denial_context_tokens(denial)
-            except Exception as e:
-                context_tokens = "unavailable"
-                logger.opt(exception=True).debug(
-                    f"Failed to compute context token sizes for denial "
-                    f"{denial_id}: {e}"
-                )
+        except Exception as e:
+            context_tokens = "unavailable"
+            logger.opt(exception=True).debug(
+                f"Failed to compute context token sizes for denial "
+                f"{denial_id}: {e}"
+            )
         logger.error(
             f"Client-reported appeal error for denial {denial_id}: "
             f"{error_message} | browser: {browser_info} | "

--- a/tests/sync/test_report_client_error.py
+++ b/tests/sync/test_report_client_error.py
@@ -86,6 +86,20 @@ class ReportClientErrorTest(APITestCase):
         # The diagnostic failure is swallowed; the endpoint still 204s.
         self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
 
+    def test_never_500_when_ownership_lookup_raises(self):
+        # The ownership lookup does a DB query; if it raises, the endpoint must
+        # still honor its always-204 contract (regression for the lookup being
+        # outside the try/except).
+        denial = self._make_denial(denial_text="x")
+        with patch(
+            "fighthealthinsurance.rest_views.common_view_logic.get_denial_for_action",
+            side_effect=RuntimeError("db exploded"),
+        ):
+            resp = self.client.post(
+                self._url(), self._owner_payload(denial), format="json"
+            )
+        self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
+
     def test_invalid_denial_id_reports_unauthorized(self):
         with patch("fighthealthinsurance.rest_views.logger") as mock_logger:
             resp = self.client.post(


### PR DESCRIPTION
## Harden ReportClientError: cover the ownership lookup with the 204 fallback

Small follow-up to #869 (already merged), addressing a CodeRabbit review point on that PR.

### Problem
`ReportClientError`'s contract is "always return 204, never let the diagnostic token-size enrichment break the report." After #869, the `summarize_denial_context_tokens` call was wrapped in `try/except`, but `common_view_logic.get_denial_for_action(...)` — which does a DB query — was left **outside** the `try`. A DB/runtime error in the ownership lookup would escape and 500 the error reporter.

### Change
- Wrap both the ownership lookup and the summarize call in one `try/except`, falling back to `context_tokens = "unavailable"`. No behavior change on the happy path or the auth-fail path (`"unauthorized"` is still set before the lookup).
- Added `test_never_500_when_ownership_lookup_raises`: patches `get_denial_for_action` to raise and asserts the endpoint still returns 204.

### Testing
`tests/sync/test_report_client_error.py` — 8 passed (sqlite, `DJANGO_CONFIGURATION=Dev`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented client error reporting from failing with a server error when related ownership lookup or context summarization encounters an exception.
  * The endpoint now consistently returns a no-content response and falls back to unavailable context details when diagnostics can’t be generated.
* **Tests**
  * Added a regression test to verify the client error endpoint does not return a server error if ownership lookup fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->