### PR TITLE
Redirect invalid appeal-flow form submissions instead of erroring

### DIFF
--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -1331,11 +1331,20 @@ class GenerateAppeal(View):
         logger.debug("Finishing up prior to appeal gen.")
         denial_id = form.cleaned_data["denial_id"]
         email = form.cleaned_data["email"]
-        denial = models.Denial.objects.filter(
-            denial_id=denial_id,
-            hashed_email=models.Denial.get_hashed_email(email),
-            semi_sekret=form.cleaned_data["semi_sekret"],
-        ).get()
+        try:
+            denial = models.Denial.objects.get(
+                denial_id=denial_id,
+                hashed_email=models.Denial.get_hashed_email(email),
+                semi_sekret=form.cleaned_data["semi_sekret"],
+            )
+        except models.Denial.DoesNotExist:
+            # The form only validates the triple's shape, so a well-formed
+            # reference that matches no denial (unknown id or mismatched
+            # email/secret) would otherwise 500 here. Fall back to the start
+            # of the flow like the GET handler and the invalid-form path.
+            # Log no PHI / submitted values.
+            logger.warning("generate_appeal: no denial matches the submitted reference")
+            return redirect("scan")
 
         # We copy _most_ of the input over for the form context
         elems = dict(request.POST)

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -1180,8 +1180,24 @@ class ChooseAppeal(View):
         form = core_forms.ChooseAppealForm(request.POST)
 
         if not form.is_valid():
-            logger.debug(form)
-            return
+            # Log field names only; the values in this flow contain PHI.
+            logger.warning(
+                f"Invalid ChooseAppealForm submission; fields with errors: "
+                f"{sorted(form.errors.keys())}"
+            )
+            if any(f in form.errors for f in ("denial_id", "email", "semi_sekret")):
+                return redirect("scan")
+            # The denial ref triple validated (e.g. only appeal_text was
+            # missing), so send the user back to the appeals page; the
+            # generate_appeal GET handler re-validates the triple.
+            return redirect(
+                build_back_url(
+                    "generate_appeal",
+                    form.cleaned_data["denial_id"],
+                    form.cleaned_data["email"],
+                    form.cleaned_data["semi_sekret"],
+                )
+            )
 
         (
             appeal_fax_number,
@@ -1302,8 +1318,15 @@ class GenerateAppeal(View):
     def post(self, request):
         form = core_forms.DenialRefForm(request.POST)
         if not form.is_valid():
-            # TODO: Send user back to fix the form.
-            return
+            # The form is only the hidden denial ref triple; if it's broken
+            # there is no state to rebuild the questions page from, so fall
+            # back to the start of the flow like the GET handler does.
+            # Log field names only; the values in this flow contain PHI.
+            logger.warning(
+                f"Invalid DenialRefForm submission to generate_appeal; fields "
+                f"with errors: {sorted(form.errors.keys())}"
+            )
+            return redirect("scan")
 
         logger.debug("Finishing up prior to appeal gen.")
         denial_id = form.cleaned_data["denial_id"]

--- a/tests/sync/test_rest_api.py
+++ b/tests/sync/test_rest_api.py
@@ -1004,6 +1004,20 @@ class AppealFlowInvalidFormTest(APITestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response["Location"], reverse("scan"))
 
+    def test_generate_appeal_post_wellformed_but_unmatched_ref_redirects(self):
+        """A well-formed triple that matches no denial (real id + email, wrong
+        semi_sekret) must redirect, not 500 on the .get() lookup."""
+        response = self.client.post(
+            reverse("generate_appeal"),
+            {
+                "denial_id": str(self.denial.denial_id),
+                "email": self.email,
+                "semi_sekret": "wrong-secret",
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], reverse("scan"))
+
 
 class NotifyPatientTest(APITestCase):
     """Test the notify_patient API endpoint."""

--- a/tests/sync/test_rest_api.py
+++ b/tests/sync/test_rest_api.py
@@ -947,6 +947,64 @@ class GenerateAppealUseExternalContextTest(APITestCase):
         self.assertNotContains(response, "external-models-prompt")
 
 
+class AppealFlowInvalidFormTest(APITestCase):
+    """Invalid POSTs to the consumer appeal flow must never 500.
+
+    These handlers used to return None on an invalid form, which Django
+    turns into a raw 500 at the worst moment of the flow (the user has a
+    generated appeal on screen). They should redirect back into the flow
+    instead."""
+
+    def setUp(self):
+        self.email = "flow@example.com"
+        self.denial = Denial.objects.create(
+            denial_text="Test denial",
+            hashed_email=Denial.get_hashed_email(self.email),
+        )
+
+    def test_generate_appeal_post_empty_form_redirects_to_scan(self):
+        response = self.client.post(reverse("generate_appeal"), {})
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], reverse("scan"))
+
+    def test_generate_appeal_post_non_integer_denial_id_redirects_to_scan(self):
+        response = self.client.post(
+            reverse("generate_appeal"),
+            {
+                "denial_id": "not-a-number",
+                "email": self.email,
+                "semi_sekret": self.denial.semi_sekret,
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], reverse("scan"))
+
+    def test_choose_appeal_post_missing_appeal_text_returns_to_appeals(self):
+        """A valid ref triple with no appeal_text sends the user back to
+        the appeals page (which regenerates appeals) rather than 500ing."""
+        response = self.client.post(
+            reverse("choose_appeal"),
+            {
+                "denial_id": str(self.denial.denial_id),
+                "email": self.email,
+                "semi_sekret": self.denial.semi_sekret,
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(response["Location"].startswith(reverse("generate_appeal")))
+        followed = self.client.get(response["Location"])
+        self.assertEqual(followed.status_code, 200)
+        self.assertTemplateUsed(followed, "appeals.html")
+
+    def test_choose_appeal_post_broken_ref_redirects_to_scan(self):
+        response = self.client.post(
+            reverse("choose_appeal"),
+            {"appeal_text": "Dear insurance company..."},
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], reverse("scan"))
+
+
 class NotifyPatientTest(APITestCase):
     """Test the notify_patient API endpoint."""
 


### PR DESCRIPTION
## Redirect invalid appeal-flow form submissions instead of erroring

Robustness fix for the consumer appeal flow. `ChooseAppeal.post` and `GenerateAppeal.post` returned `None` when their form failed validation, which Django renders as a 500 — landing the user on a server-error page right at the point where they've just generated an appeal.

### Change
Both handlers now redirect back into the flow instead of erroring:
- **`GenerateAppeal`**: an invalid denial ref → back to the start of the flow (`scan`), matching the GET handler's behavior.
- **`ChooseAppeal`**: if the denial-ref triple is intact and only the appeal body was missing → back to the appeals page (which regenerates); if the ref itself is incomplete → back to `scan`.
- Logs only the **names** of the fields with errors — this flow carries PHI, so field values are never logged.

No behavior change on the valid-form path.

### Tests
`tests/sync/test_rest_api.py::AppealFlowInvalidFormTest` — 4 tests covering empty form, non-integer denial id, valid-ref-but-missing-appeal (follows the redirect and asserts the appeals page renders), and incomplete ref. Each asserts a 302, never a 5xx. Local run: 4 passed. Black-clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the appeal flow’s handling of invalid or incomplete form submissions, ensuring users are redirected to the correct next step instead of stalling or failing.
  * Enhanced warning logging to report only which fields are invalid, avoiding sensitive values in logs.
  * Added safer handling when a submitted denial reference can’t be found, redirecting users back to scan.

* **Tests**
  * Added automated coverage for multiple malformed and mismatch scenarios to verify consistent redirect behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->