### PR TITLE
Configure PostgreSQL connection pooling for ASGI deployment

### DIFF
--- a/deploy-requirements.txt
+++ b/deploy-requirements.txt
@@ -1,5 +1,6 @@
 py-spy
 gunicorn
 mysqlclient
-psycopg2
-psycopg-pool
+# psycopg 3 (with C speedups + pooling) -- Django's "pool" OPTION requires
+# psycopg >= 3 and psycopg-pool; it is ignored/rejected with psycopg2.
+psycopg[binary,pool]

--- a/fighthealthinsurance/settings.py
+++ b/fighthealthinsurance/settings.py
@@ -807,6 +807,11 @@ class Prod(Base):
 
     @property
     def DATABASES(self):  # type: ignore
+        # Postgres connection pooling (requires psycopg 3 + psycopg-pool,
+        # installed via deploy-requirements.txt). We serve with uvicorn/ASGI,
+        # where Django documents that persistent connections (CONN_MAX_AGE > 0)
+        # should stay disabled and a pool be used instead:
+        # https://docs.djangoproject.com/en/5.2/ref/databases/#connection-pool
         mysql_engine = "django_prometheus.db.backends.mysql"
         postgres_engine = "django_prometheus.db.backends.postgresql"
         return {
@@ -817,7 +822,30 @@ class Prod(Base):
                 "PASSWORD": os.getenv("PDBPASSWORD"),
                 "HOST": os.getenv("PDBHOST"),
                 "ATOMIC_REQUESTS": False,
-                "pool": True,
+                # Django refuses to pool with CONN_MAX_AGE != 0; connection
+                # reuse and max age are governed by the pool options below.
+                "CONN_MAX_AGE": 0,
+                # With a pool, this makes Django verify connections on
+                # checkout, transparently replacing ones severed by
+                # failovers or server-side timeouts.
+                "CONN_HEALTH_CHECKS": True,
+                "OPTIONS": {
+                    # Every uvicorn worker (and Ray actor process) keeps its
+                    # own pool: size the server's max_connections to fit
+                    # (processes * max_size) plus headroom.
+                    "pool": {
+                        "min_size": int(os.getenv("PG_POOL_MIN_SIZE", "2")),
+                        "max_size": int(os.getenv("PG_POOL_MAX_SIZE", "10")),
+                        # Fail after 10s waiting for a free connection instead
+                        # of stalling requests for the default 30s.
+                        "timeout": 10,
+                        # Recycle connections after 30 minutes (and drop idle
+                        # ones after 5) so pooled connections never trip the
+                        # server-side 120min idle_session_timeout.
+                        "max_lifetime": 1800,
+                        "max_idle": 300,
+                    },
+                },
             },
             "mysql": {
                 "ENGINE": mysql_engine,

--- a/pg-bootstrap-raw.yaml
+++ b/pg-bootstrap-raw.yaml
@@ -29,6 +29,24 @@ spec:
     topologyKey: kubernetes.io/hostname
 
   #############################################################
+  # PostgreSQL server configuration
+  #############################################################
+  postgresql:
+    parameters:
+      # Default is 100. Sized for the Django connection pools:
+      # (web + back + staging uvicorn workers + Ray actor processes)
+      # * pool max_size (10), plus replication/operator headroom.
+      # NOTE: changing max_connections triggers a rolling restart.
+      max_connections: "300"
+      # Server-side safety net: kill sessions idle for 2 hours so leaked
+      # client connections can't exhaust max_connections. Django's pool
+      # recycles connections long before this (max_lifetime 30min).
+      idle_session_timeout: "120min"
+      # Same guard for sessions idle inside an open transaction, which
+      # additionally hold locks and block vacuum.
+      idle_in_transaction_session_timeout: "120min"
+
+  #############################################################
   # Monitoring
   #############################################################
   monitoring:


### PR DESCRIPTION
## Summary
Configures Django to use psycopg 3's connection pooling for PostgreSQL in ASGI (uvicorn) deployments, replacing the previous psycopg2 setup. This ensures efficient connection management across multiple worker processes while maintaining safety through health checks and connection recycling.

## Key Changes

- **Django database configuration** (`settings.py`):
  - Replaced `"pool": True` with explicit `CONN_MAX_AGE: 0` (required for ASGI with pooling)
  - Enabled `CONN_HEALTH_CHECKS: True` to transparently replace severed connections
  - Added comprehensive pool configuration under `OPTIONS["pool"]`:
    - `min_size: 2`, `max_size: 10` (configurable via `PG_POOL_MIN_SIZE`/`PG_POOL_MAX_SIZE` env vars)
    - `timeout: 10s` to fail fast instead of stalling requests
    - `max_lifetime: 1800s` (30 min) and `max_idle: 300s` (5 min) to prevent hitting server-side idle timeouts
  - Added detailed comments explaining the pooling strategy and ASGI requirements

- **PostgreSQL server configuration** (`pg-bootstrap-raw.yaml`):
  - Set `max_connections: 300` sized for all uvicorn workers and Ray actor processes (accounting for pool max_size of 10)
  - Added `idle_session_timeout: 120min` as a server-side safety net to kill leaked connections
  - Added `idle_in_transaction_session_timeout: 120min` to prevent idle transactions from holding locks

- **Deployment dependencies** (`deploy-requirements.txt`):
  - Replaced `psycopg2` and separate `psycopg-pool` with `psycopg[binary,pool]` (psycopg 3 with C speedups and pooling support)
  - Added clarifying comment that Django's pool option requires psycopg >= 3

## Implementation Details

The pooling configuration is sized to support multiple deployment scenarios:
- Each uvicorn worker and Ray actor process maintains its own pool (min 2, max 10 connections)
- Server `max_connections` (300) accommodates all processes plus headroom
- Connection recycling (30 min lifetime, 5 min idle) ensures pooled connections never hit the 120-minute server-side idle timeout
- Health checks transparently handle failovers and server-side timeouts without stalling requests
- Fast timeout (10s) prevents request queuing when the pool is exhausted

https://claude.ai/code/session_01Ks6dexZKEhSnX7uQzcCyaE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved production database connection pooling for more reliable application performance.
  * Added connection health checks and configurable pool limits, timeouts, and lifetimes.
  * Added safeguards to automatically close idle database sessions and transactions.
  * Updated deployment configuration to use the supported PostgreSQL driver with pooling support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->