### PR TITLE
Release idle DB connections held by long-lived Ray actors

### DIFF
--- a/fighthealthinsurance/base_refresh_actor.py
+++ b/fighthealthinsurance/base_refresh_actor.py
@@ -25,7 +25,7 @@ import os
 import time
 from typing import Optional
 
-from fighthealthinsurance.utils import get_env_variable
+from fighthealthinsurance.utils import aclose_old_connections, get_env_variable
 
 # How long to sleep after an unhandled exception in the run loop. Matches
 # the value used in every existing refresh actor so retry pressure on
@@ -95,6 +95,8 @@ class BaseRefreshActor:
             try:
                 interval_hours = self._interval_hours()
                 await self._maybe_refresh(interval_hours)
+                # Don't hold a Postgres slot while idling between checks.
+                await aclose_old_connections()
                 # Re-check hourly so configuration changes get picked up
                 # without restarting the actor.
                 await asyncio.sleep(3600)
@@ -102,6 +104,7 @@ class BaseRefreshActor:
                 self._logger.opt(exception=True).error(
                     f"Error in {self.actor_log_name} refresh cycle"
                 )
+                await aclose_old_connections()
                 await asyncio.sleep(self.error_backoff_seconds)
 
         self._logger.warning(f"{self.actor_log_name} stopped running")

--- a/fighthealthinsurance/chooser_refill_actor.py
+++ b/fighthealthinsurance/chooser_refill_actor.py
@@ -5,7 +5,7 @@ import time
 import ray
 from asgiref.sync import sync_to_async
 
-from fighthealthinsurance.utils import get_env_variable
+from fighthealthinsurance.utils import aclose_old_connections, get_env_variable
 
 name = "ChooserRefillActor"
 
@@ -43,12 +43,15 @@ class ChooserRefillActor:
                 # Check and refill the task pool
                 await check_and_refill_task_pool()
 
+                # Don't hold a Postgres slot while idling between checks.
+                await aclose_old_connections()
                 # Sleep for 5 minutes between checks
                 await asyncio.sleep(300)
             except Exception:
                 self._logger.opt(exception=True).error(
                     "Error while checking/refilling chooser task pool"
                 )
+                await aclose_old_connections()
                 # On error, wait a bit longer before retrying
                 await asyncio.sleep(60)
 

--- a/fighthealthinsurance/email_polling_actor.py
+++ b/fighthealthinsurance/email_polling_actor.py
@@ -10,7 +10,7 @@ from django.utils import timezone
 import ray
 from asgiref.sync import sync_to_async
 
-from fighthealthinsurance.utils import get_env_variable
+from fighthealthinsurance.utils import aclose_old_connections, get_env_variable
 
 name = "EmailPollingActor"
 
@@ -134,6 +134,8 @@ class EmailPollingActor:
                     await self._clear_expired_emails()
                     self.last_email_clear_check = now
 
+                # Don't hold a Postgres slot while idling between polls.
+                await aclose_old_connections()
                 # Jittered poll interval
                 await asyncio.sleep(random.uniform(8, 15))
                 error_count = 0
@@ -148,6 +150,7 @@ class EmailPollingActor:
                     f"Error #{error_count} while checking messages, "
                     f"backing off {total_wait:.0f}s"
                 )
+                await aclose_old_connections()
                 await asyncio.sleep(total_wait)
 
         self._logger.warning("EmailPollingActor stopped running")
@@ -155,6 +158,8 @@ class EmailPollingActor:
 
     async def _jittered_send_delay(self, sent_count: int) -> None:
         """Apply jittered delay proportional to emails sent."""
+        # This delay can run for hours; release the DB connection first.
+        await aclose_old_connections()
         base_delay = 600 * sent_count + 42
         jitter = random.uniform(-60, 60)
         await asyncio.sleep(max(10, base_delay + jitter))

--- a/fighthealthinsurance/fax_actor.py
+++ b/fighthealthinsurance/fax_actor.py
@@ -77,9 +77,9 @@ class FaxActor:
 
     def send_delayed_faxes(self) -> Tuple[int, int]:
         from django.conf import settings
-        from django.db import close_old_connections
 
         from fighthealthinsurance.models import FaxesToSend
+        from fighthealthinsurance.utils import close_old_connections_quietly
 
         if getattr(settings, "TEMPORAL_ENABLED", False):
             # Temporal's SendFaxWorkflow (delay_send timer) owns delayed sending;
@@ -122,7 +122,7 @@ class FaxActor:
             # Polled every ~60s from FaxPollingActor with no request
             # lifecycle; drop the connection so this thread doesn't pin a
             # Postgres slot while idle between polls.
-            close_old_connections()
+            close_old_connections_quietly()
 
     def do_send_fax(self, hashed_email: str, uuid_val: Union[str, uuid.UUID]) -> bool:
         # Now that we have an app instance we can import faxes to send

--- a/fighthealthinsurance/fax_actor.py
+++ b/fighthealthinsurance/fax_actor.py
@@ -77,6 +77,7 @@ class FaxActor:
 
     def send_delayed_faxes(self) -> Tuple[int, int]:
         from django.conf import settings
+        from django.db import close_old_connections
 
         from fighthealthinsurance.models import FaxesToSend
 
@@ -88,34 +89,40 @@ class FaxActor:
             )
             return (0, 0)
 
-        target_time = timezone.now() - timedelta(hours=1)
-        self._logger.info(f"Sending faxes older than target: {target_time}")
+        try:
+            target_time = timezone.now() - timedelta(hours=1)
+            self._logger.info(f"Sending faxes older than target: {target_time}")
 
-        delayed_faxes = FaxesToSend.objects.filter(
-            should_send=True,
-            sent=False,
-            date__lt=target_time,
-        )
-        t = 0
-        f = 0
-        for fax in delayed_faxes:
-            try:
-                self._logger.debug(f"Attempting to send fax {fax}")
-                t = t + 1
-                response = self.do_send_fax_object(fax)
-                if response:
-                    self._logger.info(f"Sent fax {fax} successfully")
-                else:
-                    self._logger.warning(f"Failed to send fax {fax}")
+            delayed_faxes = FaxesToSend.objects.filter(
+                should_send=True,
+                sent=False,
+                date__lt=target_time,
+            )
+            t = 0
+            f = 0
+            for fax in delayed_faxes:
+                try:
+                    self._logger.debug(f"Attempting to send fax {fax}")
+                    t = t + 1
+                    response = self.do_send_fax_object(fax)
+                    if response:
+                        self._logger.info(f"Sent fax {fax} successfully")
+                    else:
+                        self._logger.warning(f"Failed to send fax {fax}")
+                        f = f + 1
+                except Exception:
+                    self._logger.opt(exception=True).error(f"Error sending fax {fax}")
                     f = f + 1
-            except Exception:
-                self._logger.opt(exception=True).error(f"Error sending fax {fax}")
-                f = f + 1
-        if t > 0:
-            self._logger.info(f"Tried sending {t} faxes with {f} failures")
-        else:
-            self._logger.debug("No old faxes found to send")
-        return (t, f)
+            if t > 0:
+                self._logger.info(f"Tried sending {t} faxes with {f} failures")
+            else:
+                self._logger.debug("No old faxes found to send")
+            return (t, f)
+        finally:
+            # Polled every ~60s from FaxPollingActor with no request
+            # lifecycle; drop the connection so this thread doesn't pin a
+            # Postgres slot while idle between polls.
+            close_old_connections()
 
     def do_send_fax(self, hashed_email: str, uuid_val: Union[str, uuid.UUID]) -> bool:
         # Now that we have an app instance we can import faxes to send

--- a/fighthealthinsurance/imr_refresh_actor.py
+++ b/fighthealthinsurance/imr_refresh_actor.py
@@ -38,9 +38,8 @@ class IMRRefreshActor(BaseRefreshActor):
 
     @staticmethod
     def _refresh_source(source: str, url: str) -> Tuple[int, int, int, int]:
-        from django.db import close_old_connections
-
         from fighthealthinsurance.imr_ingest import fetch_csv, load_csv_text
+        from fighthealthinsurance.utils import close_old_connections_quietly
 
         try:
             csv_text = fetch_csv(url)
@@ -50,7 +49,7 @@ class IMRRefreshActor(BaseRefreshActor):
             # reused executor thread that BaseRefreshActor's thread-sensitive
             # cleanup can't reach — release this thread's own connection so
             # it doesn't pin a Postgres slot across the hourly sleep.
-            close_old_connections()
+            close_old_connections_quietly()
 
     async def _refresh_due(self, interval_hours: int) -> bool:
         sources = self._configured_sources()

--- a/fighthealthinsurance/imr_refresh_actor.py
+++ b/fighthealthinsurance/imr_refresh_actor.py
@@ -38,10 +38,19 @@ class IMRRefreshActor(BaseRefreshActor):
 
     @staticmethod
     def _refresh_source(source: str, url: str) -> Tuple[int, int, int, int]:
+        from django.db import close_old_connections
+
         from fighthealthinsurance.imr_ingest import fetch_csv, load_csv_text
 
-        csv_text = fetch_csv(url)
-        return load_csv_text(csv_text, source=source, source_url=url)
+        try:
+            csv_text = fetch_csv(url)
+            return load_csv_text(csv_text, source=source, source_url=url)
+        finally:
+            # This runs via sync_to_async(thread_sensitive=False), i.e. on a
+            # reused executor thread that BaseRefreshActor's thread-sensitive
+            # cleanup can't reach — release this thread's own connection so
+            # it doesn't pin a Postgres slot across the hourly sleep.
+            close_old_connections()
 
     async def _refresh_due(self, interval_hours: int) -> bool:
         sources = self._configured_sources()

--- a/fighthealthinsurance/ucr_refresh_actor.py
+++ b/fighthealthinsurance/ucr_refresh_actor.py
@@ -18,7 +18,7 @@ import time
 import ray
 from asgiref.sync import sync_to_async
 
-from fighthealthinsurance.utils import get_env_variable
+from fighthealthinsurance.utils import aclose_old_connections, get_env_variable
 
 name = "UCRRefreshActor"
 
@@ -69,6 +69,8 @@ class UCRRefreshController:
                 self._logger.opt(exception=True).error(
                     "UCR source refresh failed (#{})", self._actor_error_count
                 )
+            # Don't hold a Postgres slot across the hours-long sleep below.
+            await aclose_old_connections()
             base = settings.UCR_SOURCE_REFRESH_INTERVAL_HOURS * 3600
             await asyncio.sleep(random.uniform(base * 0.85, base * 1.15))
 
@@ -93,6 +95,8 @@ class UCRRefreshController:
                     "UCR denial refresh loop crashed (#{})",
                     self._actor_error_count,
                 )
+            # Don't hold a Postgres slot while idling between polls.
+            await aclose_old_connections()
             base = settings.UCR_DENIAL_REFRESH_INTERVAL_MINUTES * 60
             await asyncio.sleep(random.uniform(base * 0.75, base * 1.25))
 

--- a/fighthealthinsurance/utils.py
+++ b/fighthealthinsurance/utils.py
@@ -101,25 +101,36 @@ pubmed_fetcher = (
 )
 
 
-async def aclose_old_connections() -> None:
-    """Release this process's stale/idle Django DB connections.
+def close_old_connections_quietly() -> None:
+    """Release this thread's stale/idle Django DB connections; never raise.
 
     Long-lived Ray actors and background loops never get Django's
     per-request connection cleanup, so with CONN_MAX_AGE=0 an idle
     connection would otherwise hold a Postgres slot until the process
-    dies. Runs through the default thread-sensitive executor — the same
-    thread the async ORM uses — so it closes the connection that thread
-    actually owns. Never raises: connection cleanup must not take down a
-    poll loop that may already be handling an error.
+    dies. Runs in ``finally`` blocks of poll loops and worker threads,
+    where raising would mask the real work's outcome — and under
+    pytest-django's no-DB guard, even touching connection state raises in
+    tests that never used the database.
+    """
+    try:
+        from django.db import close_old_connections
+
+        close_old_connections()
+    except Exception:
+        logger.opt(exception=True).warning("Failed to close old DB connections")
+
+
+async def aclose_old_connections() -> None:
+    """Async flavor of ``close_old_connections_quietly``; never raises.
+
+    Runs through the thread-sensitive executor (asgiref's default, stated
+    explicitly) — the same thread the async ORM uses — so it closes the
+    connection that thread actually owns.
     """
     try:
         from asgiref.sync import sync_to_async
-        from django.db import close_old_connections
 
-        # thread_sensitive=True (stated explicitly, though it is asgiref's
-        # default) so this runs on the same executor thread as the async ORM
-        # and closes the connection that thread actually owns.
-        await sync_to_async(close_old_connections, thread_sensitive=True)()
+        await sync_to_async(close_old_connections_quietly, thread_sensitive=True)()
     except Exception:
         logger.opt(exception=True).warning("Failed to close old DB connections")
 

--- a/fighthealthinsurance/utils.py
+++ b/fighthealthinsurance/utils.py
@@ -101,6 +101,29 @@ pubmed_fetcher = (
 )
 
 
+async def aclose_old_connections() -> None:
+    """Release this process's stale/idle Django DB connections.
+
+    Long-lived Ray actors and background loops never get Django's
+    per-request connection cleanup, so with CONN_MAX_AGE=0 an idle
+    connection would otherwise hold a Postgres slot until the process
+    dies. Runs through the default thread-sensitive executor — the same
+    thread the async ORM uses — so it closes the connection that thread
+    actually owns. Never raises: connection cleanup must not take down a
+    poll loop that may already be handling an error.
+    """
+    try:
+        from asgiref.sync import sync_to_async
+        from django.db import close_old_connections
+
+        # thread_sensitive=True (stated explicitly, though it is asgiref's
+        # default) so this runs on the same executor thread as the async ORM
+        # and closes the connection that thread actually owns.
+        await sync_to_async(close_old_connections, thread_sensitive=True)()
+    except Exception:
+        logger.opt(exception=True).warning("Failed to close old DB connections")
+
+
 def warn_too_short_appeal(text: Optional[str], context: str) -> None:
     """Log a warning that a too-short appeal is being filtered out.
 


### PR DESCRIPTION
## Summary
Complements #878 (real psycopg3 pooling, `max_connections` 100→300, idle timeouts): long-lived Ray actors and background polling loops never trigger Django's per-request connection cleanup, so each actor pinned a Postgres backend indefinitely between polls — including across multi-hour jittered sleeps — contributing to the connection-slot exhaustion that locked `streaming_replica` out of the primary (SQLSTATE 53300) and crash-looped the replicas.

> Originally this PR also carried the psycopg3/pool settings, `max_connections` raise, and idle timeouts; those landed on main first via #878, and this branch was rebased to keep only the actor-side cleanup (adopting #878's pool config, which is a superset of what was here).

## Key Changes

### Connection cleanup in actors
- **New `utils.aclose_old_connections()`**: runs `close_old_connections()` on the same thread-sensitive executor thread the async ORM uses (`thread_sensitive=True` stated explicitly), and never raises — cleanup must not take down a poll loop that is already handling an error.
- Called before every idle sleep in:
  - `email_polling_actor.py` — normal polls, error backoffs, and the multi-hour `_jittered_send_delay`
  - `chooser_refill_actor.py` — between task-pool checks and after errors
  - `ucr_refresh_actor.py` — both the source and denial refresh loops
  - `base_refresh_actor.py` — after refresh checks and error handling (covers PA)
- **`imr_refresh_actor.py`**: `_refresh_source` runs via `sync_to_async(thread_sensitive=False)`, i.e. on a reused executor thread the base actor's thread-sensitive cleanup can't reach — it now releases its own thread's connection in a `finally`.
- **`fax_actor.py`**: `send_delayed_faxes()` wrapped in try/finally so the ~60s poll from `FaxPollingActor` doesn't hold a slot while idle (preserves the `TEMPORAL_ENABLED` early-return from #854; the `(t, f)` counting semantics are unchanged).

## Interaction with #878's pool
With the per-process pool deployed, these calls return connections to the bounded pool promptly (and `max_idle` then shrinks it toward `min_size`); without the pool they hard-close the connection, which is equally safe — the next ORM call reconnects.

## Testing
- `tox -e py313-black`, `tox -e py313-mypy` (clean)
- `tox -e py313-django52-sync-actor` (12 passed, on the rebased tree)
- Pool `OPTIONS` shape from #878 validated against real `psycopg_pool` + `django-prometheus` engine (constructs cleanly, checkout health checks wired, instrumented cursor_factory preserved)

https://claude.ai/code/session_019PmhMns2gunpb6H2XRXBRr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database connection cleanup during background refresh, polling, fax, email, and refill operations.
  * Prevented stale connections from remaining open during extended wait and retry periods.
  * Ensured connections are released even when synchronization or processing encounters errors.
  * Added safeguards so connection cleanup failures are logged without interrupting ongoing tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->