### PR TITLE
Require document-encryption secrets to be set in production

### DIFF
--- a/fighthealthinsurance/settings.py
+++ b/fighthealthinsurance/settings.py
@@ -23,6 +23,7 @@ from django.core.files.storage import Storage
 
 import minio as m
 from configurations import Configuration
+from django.core.exceptions import ImproperlyConfigured
 from corsheaders.defaults import default_methods
 from dj_easy_log import load_loguru
 from minio_storage.storage import MinioStorage
@@ -56,6 +57,22 @@ def _ucr_int(name: str, default: int, minimum: int) -> int:
     except ValueError:
         value = default
     return max(value, minimum)
+
+
+def _require_prod_secret(env_name: str) -> str:
+    """Return a required production secret from the environment.
+
+    Raises ImproperlyConfigured rather than returning a built-in default, so a
+    misconfigured production deploy fails fast at startup instead of silently
+    using a non-secret placeholder (e.g. for document-encryption keys).
+    """
+    value = os.getenv(env_name)
+    if not value:
+        raise ImproperlyConfigured(
+            f"{env_name} must be set in the production environment; refusing to "
+            "fall back to a built-in default."
+        )
+    return value
 
 
 class Base(Configuration):
@@ -792,6 +809,16 @@ class Prod(Base):
     FIGHT_HEALTH_INSURANCE_DOMAIN = "www.fighthealthinsurance.com"
 
     STRIPE_LIVE_MODE = True
+
+    # Fail closed on the document-encryption secrets: unlike Base/Dev/Test,
+    # production must never inherit the built-in default values for these.
+    @property
+    def DEFF_SALT(self):  # type: ignore
+        return _require_prod_secret("DEFF_SALT")
+
+    @property
+    def DEFF_PASSWORD(self):  # type: ignore
+        return _require_prod_secret("DEFF_PASSWORD")
 
     @property
     def SECRET_KEY(self):  # type: ignore

--- a/tests/sync/test_prod_secret_config.py
+++ b/tests/sync/test_prod_secret_config.py
@@ -1,0 +1,68 @@
+"""Production must not fall back to built-in defaults for encryption secrets.
+
+`DEFF_SALT` / `DEFF_PASSWORD` key the encrypted document storage. Base/Dev/Test
+carry placeholder defaults so local dev and CI work, but the `Prod`
+configuration should require them to be set in the environment and fail fast
+otherwise, rather than silently keying encryption with a non-secret default.
+"""
+
+import os
+from unittest.mock import patch
+
+from django.core.exceptions import ImproperlyConfigured
+from django.test import SimpleTestCase
+
+from fighthealthinsurance.settings import Base, Dev, Prod, _require_prod_secret
+
+
+class RequireProdSecretTest(SimpleTestCase):
+    def test_raises_when_env_missing(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("SOME_SECRET", None)
+            with self.assertRaises(ImproperlyConfigured):
+                _require_prod_secret("SOME_SECRET")
+
+    def test_raises_when_env_empty(self):
+        with patch.dict(os.environ, {"SOME_SECRET": ""}):
+            with self.assertRaises(ImproperlyConfigured):
+                _require_prod_secret("SOME_SECRET")
+
+    def test_returns_value_when_set(self):
+        with patch.dict(os.environ, {"SOME_SECRET": "real-value"}):
+            self.assertEqual(_require_prod_secret("SOME_SECRET"), "real-value")
+
+
+class ProdEncryptionSecretsTest(SimpleTestCase):
+    def _prod_getter(self, name):
+        # Grab the property descriptor without going through
+        # django-configurations, and return its getter (which ignores self).
+        prop = Prod.__dict__[name]
+        assert isinstance(prop, property)
+        return prop.fget
+
+    def test_prod_raises_when_deff_secrets_missing(self):
+        salt = self._prod_getter("DEFF_SALT")
+        password = self._prod_getter("DEFF_PASSWORD")
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("DEFF_SALT", None)
+            os.environ.pop("DEFF_PASSWORD", None)
+            with self.assertRaises(ImproperlyConfigured):
+                salt(None)
+            with self.assertRaises(ImproperlyConfigured):
+                password(None)
+
+    def test_prod_uses_env_values_when_set(self):
+        salt = self._prod_getter("DEFF_SALT")
+        password = self._prod_getter("DEFF_PASSWORD")
+        with patch.dict(
+            os.environ, {"DEFF_SALT": "real-salt", "DEFF_PASSWORD": "real-pw"}
+        ):
+            self.assertEqual(salt(None), "real-salt")
+            self.assertEqual(password(None), "real-pw")
+
+    def test_only_prod_requires_env(self):
+        # Non-prod configs keep a plain-string fallback so dev/CI never raise.
+        self.assertIsInstance(Prod.__dict__["DEFF_SALT"], property)
+        self.assertIsInstance(Prod.__dict__["DEFF_PASSWORD"], property)
+        self.assertNotIsInstance(Base.__dict__["DEFF_SALT"], property)
+        self.assertNotIsInstance(Dev.__dict__["DEFF_SALT"], property)


### PR DESCRIPTION
## Require DEFF_SALT / DEFF_PASSWORD in production

`DEFF_SALT` and `DEFF_PASSWORD` key the encrypted document storage (`django-encrypted-filefield`). `Base` defines them with a built-in default via `os.getenv("DEFF_SALT", "...")`, and `Prod(Base)` did not override them — so if those env vars aren't present in the production environment, production silently uses the non-secret default instead of failing.

### Change
- `Prod` now exposes `DEFF_SALT` / `DEFF_PASSWORD` as `@property` overrides that raise `ImproperlyConfigured` when the env var is unset or empty (via a small `_require_prod_secret` helper). Production fails fast at startup rather than keying encryption with a placeholder.
- `Base` / `Dev` / `Test` keep their string defaults, so local dev and CI are unaffected (verified: Dev/Test still import; CI never runs the `Prod` config).

### ⚠️ Deploy ordering — please read before merge
- Make sure `DEFF_SALT` and `DEFF_PASSWORD` are present in the **production secret store before this deploys** — no committed manifest sets them today, so please confirm where they come from.
- Set them to the values **already in effect**, so existing encrypted documents stay readable. If production has been relying on the inherited default, set the env vars to that same current value first; then this change is a no-op for existing files.
- Rotating to *new* values is a separate step that requires re-encrypting existing documents — don't change the effective key as part of this PR.

### Tests
`tests/sync/test_prod_secret_config.py` — 6 tests: helper raises on missing/empty and returns when set; Prod's DEFF properties raise when unset and return env values when set; Base/Dev keep plain-string fallbacks. Local run: 6 passed. Black-clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Production now refuses to start when required document-encryption secrets are missing or empty.
  * Production encryption settings now use the configured environment values when available.

* **Tests**
  * Added coverage confirming required production secrets fail safely and development configurations retain their existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->