### PR TITLE
entity_extract: deliver form_context via json_script (+ protocol-aware WebSocket URL)

### DIFF
--- a/fighthealthinsurance/templates/entity_extract.html
+++ b/fighthealthinsurance/templates/entity_extract.html
@@ -37,17 +37,25 @@ Analyzing Your Denial
     to { transform: rotate(360deg); }
 }
 </style>
+{{ form_context|json_script:"entity-form-context" }}
 <script>
   // Call the typescript on load
   document.addEventListener('DOMContentLoaded', () => {
-      const backendUrl = `wss://${window.location.host}/ws/streaming-entity-backend/`;
+      // wss:// over HTTPS, ws:// over plain HTTP (local dev) instead of a
+      // hardcoded wss:// that breaks on http://localhost.
+      const wsProto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+      const backendUrl = `${wsProto}//${window.location.host}/ws/streaming-entity-backend/`;
+      // form_context is emitted as JSON via json_script above, so values like
+      // an apostrophe in an email or a literal </script> in a field can't
+      // break out of the script and stall extraction.
+      const formContext = JSON.parse(
+          document.getElementById('entity-form-context').textContent
+      );
       const data = {
-	  {% autoescape off %}
-          ...{{form_context}},
-          {% endautoescape %}
-          ...{
-              'csrfmiddlewaretoken': '{{ csrf_token }}',
-              'timbit': 'is most awesomex2'}}
+          ...formContext,
+          csrfmiddlewaretoken: '{{ csrf_token }}',
+          timbit: 'is most awesomex2',
+      };
       const retries = 0;
 
       // Call the doQuery function

--- a/tests/sync/test_entity_extract_render.py
+++ b/tests/sync/test_entity_extract_render.py
@@ -1,0 +1,43 @@
+"""entity_extract.html delivers form_context via Django's json_script filter.
+
+Previously the denial-ref dict was spread into an inline <script> under
+{% autoescape off %}, so a field value containing an apostrophe or a literal
+</script> (e.g. in the email) could break out of the script and stall the
+extraction step. These tests pin the safe delivery.
+"""
+
+from django.test import TestCase
+from django.urls import reverse
+
+from fighthealthinsurance.models import Denial
+
+
+class EntityExtractFormContextTest(TestCase):
+    def setUp(self):
+        self.denial = Denial.objects.create(denial_text="Test denial")
+
+    def _get(self, email):
+        return self.client.get(
+            reverse("eev"),
+            {
+                "denial_id": str(self.denial.denial_id),
+                "email": email,
+                "semi_sekret": self.denial.semi_sekret,
+            },
+        )
+
+    def test_form_context_delivered_via_json_script(self):
+        response = self._get("plain@example.com")
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'id="entity-form-context"')
+
+    def test_hostile_email_is_escaped_not_injected(self):
+        # An apostrophe used to break the JS string; a </script> used to break
+        # the whole script element. Both must be neutralised by json_script.
+        hostile = "o'brien</script><script>alert(1)</script>@x.com"
+        response = self._get(hostile)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'id="entity-form-context"')
+        # The raw break-out sequences must not appear verbatim in the page.
+        self.assertNotContains(response, "o'brien</script>")
+        self.assertNotContains(response, "<script>alert(1)</script>@x.com")


### PR DESCRIPTION
## Deliver `form_context` via `json_script` on the entity-extraction step

`entity_extract.html` spread the denial-ref `form_context` dict into an inline `<script>` under `{% autoescape off %}`. A field value containing an apostrophe or a literal `</script>` (an email is the realistic case) could break the inline script and stall the extraction step, leaving the user on a page that never advances.

### Change
- Emit `form_context` through Django's `json_script` filter (the pattern already used in `escalation_packet.html`) and `JSON.parse` it on the client. Values are HTML-escaped, so a field value can't break out of the script.
- Select `wss://` vs `ws://` from `window.location.protocol` instead of hardcoding `wss://`, which never connected over `http://localhost`.
- No change to the data sent or to extraction behavior; `retries` stays `0`.

### Tests
`tests/sync/test_entity_extract_render.py` — 2 tests: `form_context` is delivered via the `json_script` element, and a hostile email (apostrophe + `</script><script>`) is escaped rather than emitted raw. Local run: 2 passed.

Note: `appeals.html` inlines a `json.dumps` **string** in a similar spot — a separate case (string vs dict), left for a follow-up.
