### PR TITLE
Cancel the losing task in _infer dual mode instead of awaiting it

### DIFF
--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -2000,27 +2000,45 @@ class RemoteOpenLike(RemoteModel):
 
                     # Wait for the first task to complete
                     done, pending = await asyncio.wait(
-                        [primary_task, backup_task], return_when=asyncio.FIRST_COMPLETED
+                        [primary_task, backup_task],
+                        return_when=asyncio.FIRST_COMPLETED,
                     )
 
-                    # Get the result from the completed task
+                    # Take the first valid result from whichever finished first.
                     for task in done:
                         try:
                             result = await task
                             if result and result[0]:
                                 raw_response = result
                                 break
-                        except Exception:
-                            pass
-                    # If the first result was not valid grab the pending task.
-                    for task in pending:
-                        try:
-                            result = await task
-                            if result and result[0]:
-                                raw_response = result
-                                break
-                        except Exception:
-                            pass
+                        except Exception as e:
+                            # Log the type only: exception text can embed the
+                            # prompt / patient context.
+                            logger.debug(f"dual-mode task failed: {type(e).__name__}")
+
+                    # Only wait on a still-pending task if the first result was
+                    # unusable; otherwise the loser is pure added latency, so we
+                    # cancel it below rather than await its full backup timeout.
+                    if not (raw_response and raw_response[0]):
+                        for task in pending:
+                            try:
+                                result = await task
+                                if result and result[0]:
+                                    raw_response = result
+                                    break
+                            except Exception as e:
+                                logger.debug(
+                                    f"dual-mode fallback task failed: {type(e).__name__}"
+                                )
+
+                    # Cancel and drain anything still running so a losing task
+                    # can't leak or emit "Task was destroyed but it is pending!".
+                    for task in (primary_task, backup_task):
+                        if not task.done():
+                            task.cancel()
+                    await asyncio.gather(
+                        primary_task, backup_task, return_exceptions=True
+                    )
                 else:
                     raw_response = await self.__timeout_infer(
                         system_prompt=system_prompt,

--- a/tests/async/test_ml_models.py
+++ b/tests/async/test_ml_models.py
@@ -486,3 +486,67 @@ class TestRemoteFullOpenLike(TestCase):
             len(generic_prompts) > 0,
             "Should return default prompts when specific ones don't exist",
         )
+
+
+class TestDualModeInfer(TestCase):
+    """_infer's dual-mode path must not await the losing task (which added the
+    full backup timeout as latency on every call) and must fall back to the
+    still-pending task only when the first result is unusable.
+    """
+
+    def _make_dual_model(self):
+        return RemoteOpenLike(
+            api_base="http://primary",
+            token="test_token",
+            model="primary_model",
+            system_prompts_map={"test": ["p"]},
+            dual_mode=True,
+            backup_api_base="http://backup",
+            backup_model="backup_model",
+        )
+
+    async def async_test_valid_winner_cancels_loser(self):
+        backup_cancelled = asyncio.Event()
+
+        async def fake_infer(*args, **kwargs):
+            if kwargs.get("model") == "primary_model":
+                return ("primary result", ["c1"])
+            # The losing backup would block for 30s if it were awaited.
+            try:
+                await asyncio.sleep(30)
+                return ("backup result", ["c2"])
+            except asyncio.CancelledError:
+                backup_cancelled.set()
+                raise
+
+        model = self._make_dual_model()
+        with patch.object(model, "_RemoteOpenLike__timeout_infer", new=fake_infer):
+            # Old behaviour awaited the loser (~30s) and would time out here;
+            # the fix cancels it, so this returns promptly.
+            result = await asyncio.wait_for(
+                model._infer(system_prompts=["p"], prompt="q"), timeout=5
+            )
+
+        self.assertEqual(result, ("primary result", ["c1"]))
+        self.assertTrue(backup_cancelled.is_set())
+
+    def test_valid_winner_cancels_loser(self):
+        asyncio.run(self.async_test_valid_winner_cancels_loser())
+
+    async def async_test_falls_back_when_first_result_invalid(self):
+        async def fake_infer(*args, **kwargs):
+            if kwargs.get("model") == "primary_model":
+                return (None, None)  # completes first, but unusable
+            await asyncio.sleep(0.05)
+            return ("backup result", ["c2"])
+
+        model = self._make_dual_model()
+        with patch.object(model, "_RemoteOpenLike__timeout_infer", new=fake_infer):
+            result = await asyncio.wait_for(
+                model._infer(system_prompts=["p"], prompt="q"), timeout=5
+            )
+
+        self.assertEqual(result, ("backup result", ["c2"]))
+
+    def test_falls_back_when_first_result_invalid(self):
+        asyncio.run(self.async_test_falls_back_when_first_result_invalid())


### PR DESCRIPTION
## Don't await the losing task in `_infer` dual mode

When `RemoteOpenLike._infer` runs in dual mode it launches the primary and backup model calls concurrently and takes the first to finish (`asyncio.wait(FIRST_COMPLETED)`). But after the first task completed, it **unconditionally awaited the still-pending task** — so every dual-mode call paid the full backup timeout as latency even when the winner had already returned a valid result, and the loser could overwrite the winner's result. Errors from either task were swallowed with a bare `except: pass`.

### Change
- Take the first valid result from whichever task finished first.
- Fall back to the still-pending task **only if** the first result was unusable; otherwise cancel it rather than awaiting its full timeout.
- Cancel and drain any still-running task (`gather(..., return_exceptions=True)`) so a loser can't leak or emit `Task was destroyed but it is pending!`.
- Replace the bare `except: pass` with a debug log of the exception **type** only — exception text can embed the prompt / patient context.

### Tests
`tests/async/test_ml_models.py::TestDualModeInfer` — 2 tests: a valid winner cancels the loser (the backup sleeps 30s; the test asserts `_infer` returns promptly and the backup received `CancelledError`), and an unusable first result falls back to the pending task. Full `test_ml_models.py`: 13 passed.

Note: this is the dual-call-cancellation half of the "bound the generation ladder" item; bounding the *overall* ladder wall-clock (serial retries + sleeps in `generate_appeal.py`) is a larger, separate change and not included here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when using primary and backup inference concurrently.
  * Automatically falls back to a usable backup result when the first result is unavailable.
  * Prevented lingering background operations after a result is selected, reducing related warnings and resource issues.

* **Tests**
  * Added coverage for backup fallback behavior and cancellation of losing inference operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->