### PR TITLE
Improve shell script robustness and readability

### DIFF
--- a/scripts/create-or-fix-pg9-migration-role.sh
+++ b/scripts/create-or-fix-pg9-migration-role.sh
@@ -109,6 +109,8 @@ esac
 #    permission error on the probe query is acceptable, an auth/pg_hba
 #    rejection is NOT.
 # ---------------------------------------------------------------------------
+# Invoked indirectly via the EXIT trap below, so shellcheck can't see the call.
+# shellcheck disable=SC2317
 cleanup() { kubectl -n "$NAMESPACE" delete pod "$TEST_POD" --ignore-not-found --wait=false >/dev/null 2>&1 || true; }
 trap cleanup EXIT
 

--- a/scripts/restore-pg9-from-dump.sh
+++ b/scripts/restore-pg9-from-dump.sh
@@ -59,10 +59,14 @@ kubectl -n "$NAMESPACE" get pod "$TGT_POD" >/dev/null 2>&1 \
   || die "target pod $TGT_POD not found in $NAMESPACE"
 
 # locate dump files (newest by name if not pinned; names sort by timestamp)
-[ -n "$APP_DUMP" ]   || APP_DUMP="$(ls -1 "$DUMP_DIR"/app-*.dump 2>/dev/null | sort | tail -1 || true)"
-[ -n "$GLOBALS_SQL" ] || GLOBALS_SQL="$(ls -1 "$DUMP_DIR"/globals-*.sql 2>/dev/null | sort | tail -1 || true)"
-[ -n "$APP_DUMP" ] && [ -f "$APP_DUMP" ]       || die "no app dump found (looked in $DUMP_DIR/app-*.dump). Set APP_DUMP."
-[ -n "$GLOBALS_SQL" ] && [ -f "$GLOBALS_SQL" ] || die "no globals dump found ($DUMP_DIR/globals-*.sql). Set GLOBALS_SQL."
+[ -n "$APP_DUMP" ]   || APP_DUMP="$(find "$DUMP_DIR" -maxdepth 1 -name 'app-*.dump' 2>/dev/null | sort | tail -1 || true)"
+[ -n "$GLOBALS_SQL" ] || GLOBALS_SQL="$(find "$DUMP_DIR" -maxdepth 1 -name 'globals-*.sql' 2>/dev/null | sort | tail -1 || true)"
+if [ -z "$APP_DUMP" ] || [ ! -f "$APP_DUMP" ]; then
+  die "no app dump found (looked in $DUMP_DIR/app-*.dump). Set APP_DUMP."
+fi
+if [ -z "$GLOBALS_SQL" ] || [ ! -f "$GLOBALS_SQL" ]; then
+  die "no globals dump found ($DUMP_DIR/globals-*.sql). Set GLOBALS_SQL."
+fi
 
 psql_t() { kubectl -n "$NAMESPACE" exec -i "$TGT_POD" -c "$PG_CONTAINER" -- psql -U postgres -Atc "$1"; }
 
@@ -134,9 +138,11 @@ fi
 OWNED="$(kubectl -n "$NAMESPACE" exec -i "$TGT_POD" -c "$PG_CONTAINER" -- \
   psql -U postgres -d "$APP_DB" -Atc \
   "SELECT count(*) FROM pg_tables WHERE tableowner='$APP_ROLE';" | tr -d '[:space:]')"
-[ "${OWNED:-0}" -gt 0 ] 2>/dev/null \
-  && pass "tables owned by $APP_ROLE: $OWNED" \
-  || warn "no tables owned by $APP_ROLE -- check ownership (app may fail on permissions)"
+if [ "${OWNED:-0}" -gt 0 ] 2>/dev/null; then
+  pass "tables owned by $APP_ROLE: $OWNED"
+else
+  warn "no tables owned by $APP_ROLE -- check ownership (app may fail on permissions)"
+fi
 
 echo
 pass "RESTORE INTO $TGT_CLUSTER COMPLETE."


### PR DESCRIPTION
## Summary
Refactored PostgreSQL restore and migration scripts to improve code clarity, robustness, and maintainability by replacing compact conditional chains with explicit if-statements and switching from `ls` to `find` for safer file discovery.

## Key Changes

- **Replace `ls` with `find`** in `restore-pg9-from-dump.sh`:
  - Changed from `ls -1 "$DUMP_DIR"/app-*.dump` to `find "$DUMP_DIR" -maxdepth 1 -name 'app-*.dump'`
  - Changed from `ls -1 "$DUMP_DIR"/globals-*.sql` to `find "$DUMP_DIR" -maxdepth 1 -name 'globals-*.sql'`
  - `find` is more robust for file discovery and handles edge cases better (e.g., special characters, empty directories)

- **Refactor validation logic** in `restore-pg9-from-dump.sh`:
  - Replaced compact `[ condition ] || die` chains with explicit `if-then-else` blocks
  - Improves readability and makes error conditions clearer
  - Separates file existence checks into dedicated if-statements for app dump and globals SQL

- **Refactor table ownership check** in `restore-pg9-from-dump.sh`:
  - Replaced `[ condition ] && pass || warn` chain with explicit if-else block
  - Makes the pass/warn logic more explicit and easier to follow

- **Add shellcheck directive** in `create-or-fix-pg9-migration-role.sh`:
  - Added `# shellcheck disable=SC2317` comment above `cleanup()` function
  - Explains that the function is invoked indirectly via EXIT trap, which shellcheck cannot detect statically

## Implementation Details

These changes follow shell scripting best practices:
- Explicit control flow is more maintainable than compact conditional chains
- `find` is the POSIX-recommended tool for file discovery (more portable than `ls`)
- Proper shellcheck directives document intentional patterns that static analysis might flag

https://claude.ai/code/session_018HkjyhfoWJsMiFZq28Rd6o