### PR TITLE
Fix model usage dashboard win_rate calculation and normalize model names

### DIFF
--- a/fighthealthinsurance/chooser_tasks.py
+++ b/fighthealthinsurance/chooser_tasks.py
@@ -338,14 +338,13 @@ async def _generate_appeal_candidates(task: ChooserTask):
                 prompt=prompt,
             )
             if response and len(response.strip()) > 100:
-                model_name = canonical_model_name(model)
                 await sync_to_async(ChooserCandidate.objects.create)(
                     task=task,
                     candidate_index=candidate_index,
                     kind="appeal_letter",
-                    model_name=model_name,
+                    model_name=canonical_model_name(model),
                     content=response.strip(),
-                    metadata={"source": "synthetic", "model_name": model_name},
+                    metadata={"source": "synthetic"},
                 )
                 candidate_index += 1
                 task.num_candidates_generated = candidate_index
@@ -370,18 +369,13 @@ async def _generate_appeal_candidates(task: ChooserTask):
                     prompt=prompt,
                 )
                 if response and len(response.strip()) > 100:
-                    model_name = canonical_model_name(model)
                     await sync_to_async(ChooserCandidate.objects.create)(
                         task=task,
                         candidate_index=candidate_index,
                         kind="appeal_letter",
-                        model_name=model_name,
+                        model_name=canonical_model_name(model),
                         content=response.strip(),
-                        metadata={
-                            "source": "synthetic",
-                            "model_name": model_name,
-                            "retry": True,
-                        },
+                        metadata={"source": "synthetic", "retry": True},
                     )
                     candidate_index += 1
                     task.num_candidates_generated = candidate_index
@@ -567,16 +561,14 @@ async def _generate_chat_candidates(task: ChooserTask):
                 is_logged_in=True,
             )
             if response and len(response.strip()) > 50:
-                model_name = canonical_model_name(model)
                 await sync_to_async(ChooserCandidate.objects.create)(
                     task=task,
                     candidate_index=candidate_index,
                     kind="chat_response",
-                    model_name=model_name,
+                    model_name=canonical_model_name(model),
                     content=response.strip(),
                     metadata={
                         "source": "synthetic",
-                        "model_name": model_name,
                         "has_history": len(chat_history) > 0,
                     },
                 )
@@ -602,16 +594,14 @@ async def _generate_chat_candidates(task: ChooserTask):
                     is_logged_in=True,
                 )
                 if response and len(response.strip()) > 50:
-                    model_name = canonical_model_name(model)
                     await sync_to_async(ChooserCandidate.objects.create)(
                         task=task,
                         candidate_index=candidate_index,
                         kind="chat_response",
-                        model_name=model_name,
+                        model_name=canonical_model_name(model),
                         content=response.strip(),
                         metadata={
                             "source": "synthetic",
-                            "model_name": model_name,
                             "has_history": len(chat_history) > 0,
                             "retry": True,
                         },

--- a/fighthealthinsurance/chooser_tasks.py
+++ b/fighthealthinsurance/chooser_tasks.py
@@ -23,6 +23,10 @@ from django.conf import settings
 from loguru import logger
 
 from fighthealthinsurance.ml.ml_router import ml_router
+from fighthealthinsurance.ml.model_identity import (
+    SYNTHESIZED_MODEL_NAME,
+    canonical_model_name,
+)
 from fighthealthinsurance.models import ChooserCandidate, ChooserTask
 from fighthealthinsurance.utils import fire_and_forget_in_new_threadpool
 
@@ -334,13 +338,14 @@ async def _generate_appeal_candidates(task: ChooserTask):
                 prompt=prompt,
             )
             if response and len(response.strip()) > 100:
+                model_name = canonical_model_name(model)
                 await sync_to_async(ChooserCandidate.objects.create)(
                     task=task,
                     candidate_index=candidate_index,
                     kind="appeal_letter",
-                    model_name=_model_display_name(model),
+                    model_name=model_name,
                     content=response.strip(),
-                    metadata={"source": "synthetic"},
+                    metadata={"source": "synthetic", "model_name": model_name},
                 )
                 candidate_index += 1
                 task.num_candidates_generated = candidate_index
@@ -365,13 +370,18 @@ async def _generate_appeal_candidates(task: ChooserTask):
                     prompt=prompt,
                 )
                 if response and len(response.strip()) > 100:
+                    model_name = canonical_model_name(model)
                     await sync_to_async(ChooserCandidate.objects.create)(
                         task=task,
                         candidate_index=candidate_index,
                         kind="appeal_letter",
-                        model_name=_model_display_name(model),
+                        model_name=model_name,
                         content=response.strip(),
-                        metadata={"source": "synthetic", "retry": True},
+                        metadata={
+                            "source": "synthetic",
+                            "model_name": model_name,
+                            "retry": True,
+                        },
                     )
                     candidate_index += 1
                     task.num_candidates_generated = candidate_index
@@ -557,14 +567,16 @@ async def _generate_chat_candidates(task: ChooserTask):
                 is_logged_in=True,
             )
             if response and len(response.strip()) > 50:
+                model_name = canonical_model_name(model)
                 await sync_to_async(ChooserCandidate.objects.create)(
                     task=task,
                     candidate_index=candidate_index,
                     kind="chat_response",
-                    model_name=_model_display_name(model),
+                    model_name=model_name,
                     content=response.strip(),
                     metadata={
                         "source": "synthetic",
+                        "model_name": model_name,
                         "has_history": len(chat_history) > 0,
                     },
                 )
@@ -590,14 +602,16 @@ async def _generate_chat_candidates(task: ChooserTask):
                     is_logged_in=True,
                 )
                 if response and len(response.strip()) > 50:
+                    model_name = canonical_model_name(model)
                     await sync_to_async(ChooserCandidate.objects.create)(
                         task=task,
                         candidate_index=candidate_index,
                         kind="chat_response",
-                        model_name=_model_display_name(model),
+                        model_name=model_name,
                         content=response.strip(),
                         metadata={
                             "source": "synthetic",
+                            "model_name": model_name,
                             "has_history": len(chat_history) > 0,
                             "retry": True,
                         },
@@ -706,7 +720,7 @@ async def _maybe_add_synthesized_candidate(task: ChooserTask, kind: str) -> None
             task=task,
             candidate_index=next_index,
             kind=kind,
-            model_name="synthesized",
+            model_name=SYNTHESIZED_MODEL_NAME,
             synthesized=True,
             content=normalized,
             metadata={"source": "synthetic", "synthesized": True},

--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -526,8 +526,13 @@ def mark_proposal_chosen(
       2. exact appeal_text match against a chosen=False row for the same
          denial. Useful as a fallback when the frontend did not echo the id
          (older clients, share-appeal flow).
-      3. model_name=None - the user edited the draft heavily, or the
-         proposal predates the model_name field.
+      3. sole-draft inference - when every draft generated for the denial
+         came from one model, the pick necessarily did too (even after
+         edits or sub_in_appeals rewrites). Skipped for editted=True calls:
+         the share-appeal flow submits arbitrary text that may never have
+         been a draft.
+      4. model_name=None - the user edited the draft heavily and multiple
+         models were in play, or the proposal predates the model_name field.
     """
     original: Optional[ProposedAppeal] = None
     if proposed_appeal_id is not None:
@@ -542,8 +547,15 @@ def mark_proposal_chosen(
             .order_by("-id")
             .first()
         )
-    model_name = original.model_name if original is not None else None
-    synthesized = original.synthesized if original is not None else False
+    model_name: Optional[str] = None
+    synthesized = False
+    if original is not None:
+        model_name = original.model_name
+        synthesized = original.synthesized
+    elif not editted:
+        inferred = ProposedAppeal.sole_draft_attribution(denial.denial_id)
+        if inferred is not None:
+            model_name, synthesized = inferred
     pa = ProposedAppeal(
         appeal_text=appeal_text,
         for_denial=denial,

--- a/fighthealthinsurance/management/commands/backfill_model_usage_attribution.py
+++ b/fighthealthinsurance/management/commands/backfill_model_usage_attribution.py
@@ -123,8 +123,11 @@ class Command(BaseCommand):
         self.stdout.write("\n-- ProposedAppeal (chosen rows) --")
         total_chosen = ProposedAppeal.objects.filter(chosen=True).count()
         # Rows needing attention: never attributed, previously stamped as
-        # legacy (re-checked in case drafts have since appeared), or somehow
-        # carrying an object repr.
+        # legacy (re-checked in case drafts have since appeared), or possibly
+        # carrying an object repr. The ``startswith("<")`` clause is a cheap
+        # SQL prefilter for object reprs (is_object_repr is a regex that can't
+        # run in the DB); the loop below refines it, so a non-repr value that
+        # merely starts with "<" is fetched but left untouched.
         targets = ProposedAppeal.objects.filter(chosen=True).filter(
             Q(model_name__isnull=True)
             | Q(model_name=LEGACY_UNATTRIBUTED_LABEL)
@@ -143,18 +146,25 @@ class Command(BaseCommand):
             elif raw is not None and is_object_repr(raw):
                 new_name = normalize_model_label(raw)
                 counts["normalized_repr"] += 1
+            elif raw is not None:
+                # A non-null label that is neither an object repr nor
+                # recoverable: the legacy-unattributed marker itself, or a
+                # malformed/hand-entered value that merely starts with "<".
+                # Leave it exactly as-is — never relabel a value we don't
+                # understand.
+                counts["left_unchanged"] += 1
+                continue
             elif pa.created_at is None:
-                # Pre-tracking pick (model_name column didn't exist yet): its
-                # drafts can't be joined back, so it is genuinely
-                # unrecoverable. Label it rather than guess. Already-labeled
-                # rows re-derive the same label and fall through as no-ops.
+                # NULL model_name on a pre-tracking pick (the column didn't
+                # exist yet): its drafts can't be joined back, so it is
+                # genuinely unrecoverable. Label it rather than guess.
                 new_name = LEGACY_UNATTRIBUTED_LABEL
                 counts["labeled_legacy_unattributed"] += 1
             else:
-                # Post-tracking pick with no recoverable model (e.g. several
-                # models in play and the draft was edited away). Leave it NULL
-                # so it reports as "(unattributed)" and stays recoverable if
-                # matching drafts appear later.
+                # NULL model_name on a post-tracking pick (e.g. several models
+                # in play and the draft was edited away). Leave it NULL so it
+                # reports as "(unattributed)" and stays recoverable if matching
+                # drafts appear later.
                 counts["left_unattributed"] += 1
                 continue
             if new_name == raw and (
@@ -189,6 +199,9 @@ class Command(BaseCommand):
         )
         self.stdout.write(
             f"left NULL -> (unattributed):          {counts['left_unattributed']}"
+        )
+        self.stdout.write(
+            f"left unchanged (already labeled/other): {counts['left_unchanged']}"
         )
         verb = "changed" if apply_changes else "would change"
         self.stdout.write(f"rows {verb}: {counts['rows_changed']}")

--- a/fighthealthinsurance/management/commands/backfill_model_usage_attribution.py
+++ b/fighthealthinsurance/management/commands/backfill_model_usage_attribution.py
@@ -15,20 +15,20 @@ Repairs the two data problems behind the ML model usage dashboard's bad rows:
 
 * ``ChooserCandidate`` rows whose ``model_name`` is a default Python object
   repr (``<...DeepInfra object at 0x7f81...>``), written before model
-  instances had stable names. The configured model is unrecoverable (the
-  candidate metadata recorded no model identifier historically), so these
+  instances had stable names. The configured model is unrecoverable (no
+  related record captured a model identifier historically), so these
   normalize to ``legacy-unresolved (ClassName)`` — the class is the only
   stable information in the repr; the memory address is dropped so instances
-  aggregate. Newer rows that recorded ``metadata["model_name"]`` recover the
-  real name from there instead.
+  aggregate.
 
 Safety properties:
   * Dry run by default; ``--apply`` is required to write.
   * Idempotent: repaired rows no longer match any repair condition, and
     ``legacy-unattributed`` rows are only re-touched if recovery newly
     succeeds (it never overwrites a valid canonical name).
-  * Rows created after the command started are left for the live write
-    paths, which are fixed separately.
+  * Only pre-tracking chosen rows (``created_at`` NULL) are labeled; a chosen
+    row's ``model_name`` is already final when it appears, so there is no
+    live-write race to guard against.
 
 ``--audit`` prints a read-only data audit (totals, attribution gaps,
 distinct labels, per-window counts, chosen>presented anomalies) without
@@ -78,8 +78,7 @@ class Command(BaseCommand):
         apply_changes: bool = options["apply"]
         mode = "APPLY" if apply_changes else "DRY RUN (pass --apply to write)"
         self.stdout.write(f"== Model usage attribution backfill: {mode} ==")
-        started_at = timezone.now()
-        self._backfill_proposed_appeals(apply_changes, started_at)
+        self._backfill_proposed_appeals(apply_changes)
         self._backfill_chooser_candidates(apply_changes)
         if not apply_changes:
             self.stdout.write("Dry run complete; no rows were modified.")
@@ -113,19 +112,17 @@ class Command(BaseCommand):
                 return (inferred[0], inferred[1], "sole_draft")
         return None
 
-    def _backfill_proposed_appeals(
-        self, apply_changes: bool, started_at: datetime.datetime
-    ) -> None:
+    def _backfill_proposed_appeals(self, apply_changes: bool) -> None:
         self.stdout.write("\n-- ProposedAppeal (chosen rows) --")
         total_chosen = ProposedAppeal.objects.filter(chosen=True).count()
         # Rows needing attention: never attributed, previously stamped as
-        # legacy (retry recovery only), or somehow carrying an object repr.
+        # legacy (re-checked in case drafts have since appeared), or somehow
+        # carrying an object repr.
         targets = ProposedAppeal.objects.filter(chosen=True).filter(
             Q(model_name__isnull=True)
             | Q(model_name=LEGACY_UNATTRIBUTED_LABEL)
             | Q(model_name__startswith="<")
         )
-        # Snapshot before repairs: rows valid prior to this run.
         target_total = targets.count()
         counts: Counter = Counter()
         for pa in targets.iterator():
@@ -139,20 +136,19 @@ class Command(BaseCommand):
             elif raw is not None and is_object_repr(raw):
                 new_name = normalize_model_label(raw)
                 counts["normalized_repr"] += 1
-            elif raw == LEGACY_UNATTRIBUTED_LABEL:
-                # Still unrecoverable; keep the explicit label untouched.
-                counts["already_labeled_unrecoverable"] += 1
-                continue
-            elif pa.created_at is None or pa.created_at < started_at:
-                # No evidence in the database ties this pick to a model —
-                # its drafts predate model_name tracking (or were never
-                # saved). Label explicitly instead of guessing.
+            elif pa.created_at is None:
+                # Pre-tracking pick (model_name column didn't exist yet): its
+                # drafts can't be joined back, so it is genuinely
+                # unrecoverable. Label it rather than guess. Already-labeled
+                # rows re-derive the same label and fall through as no-ops.
                 new_name = LEGACY_UNATTRIBUTED_LABEL
                 counts["labeled_legacy_unattributed"] += 1
             else:
-                # Created while the command was running; the fixed live
-                # write path owns it.
-                counts["skipped_concurrent"] += 1
+                # Post-tracking pick with no recoverable model (e.g. several
+                # models in play and the draft was edited away). Leave it NULL
+                # so it reports as "(unattributed)" and stays recoverable if
+                # matching drafts appear later.
+                counts["left_unattributed"] += 1
                 continue
             if new_name == raw and (
                 new_synthesized is None or new_synthesized == pa.synthesized
@@ -185,13 +181,8 @@ class Command(BaseCommand):
             f"{counts['labeled_legacy_unattributed']}"
         )
         self.stdout.write(
-            f"previously labeled, still unrecoverable: "
-            f"{counts['already_labeled_unrecoverable']}"
+            f"left NULL -> (unattributed):          {counts['left_unattributed']}"
         )
-        if counts["skipped_concurrent"]:
-            self.stdout.write(
-                f"skipped (created mid-run):            {counts['skipped_concurrent']}"
-            )
         verb = "changed" if apply_changes else "would change"
         self.stdout.write(f"rows {verb}: {counts['rows_changed']}")
 
@@ -213,22 +204,11 @@ class Command(BaseCommand):
                 # than mangling a name we don't understand.
                 counts["skipped_unrecognized"] += 1
                 continue
+            # No related data records which configured model produced a
+            # repr-era candidate, so the class name inside the repr is the
+            # only stable evidence. Normalize to it; never guess a model.
             distinct_before.add(raw)
-            metadata = cand.metadata or {}
-            meta_name = metadata.get("model_name")
-            if (
-                isinstance(meta_name, str)
-                and meta_name.strip()
-                and not is_object_repr(meta_name)
-            ):
-                new_name = normalize_model_label(meta_name)
-                counts["recovered_from_metadata"] += 1
-            else:
-                # No related data records which configured model produced
-                # this candidate; the class name inside the repr is the only
-                # stable evidence. Do not guess a specific model.
-                new_name = normalize_model_label(raw)
-                counts["normalized_repr_class_only"] += 1
+            new_name = normalize_model_label(raw)
             distinct_after.add(new_name)
             counts["rows_changed"] += 1
             if apply_changes and new_name:
@@ -239,12 +219,7 @@ class Command(BaseCommand):
         self.stdout.write(
             f"already valid:                   {total - counts['rows_changed'] - counts['skipped_unrecognized']}"
         )
-        self.stdout.write(
-            f"recovered from stored metadata:  {counts['recovered_from_metadata']}"
-        )
-        self.stdout.write(
-            f"normalized to legacy-unresolved: {counts['normalized_repr_class_only']}"
-        )
+        self.stdout.write(f"normalized to legacy-unresolved: {counts['rows_changed']}")
         if counts["skipped_unrecognized"]:
             self.stdout.write(
                 f"skipped (unrecognized '<' name): {counts['skipped_unrecognized']}"

--- a/fighthealthinsurance/management/commands/backfill_model_usage_attribution.py
+++ b/fighthealthinsurance/management/commands/backfill_model_usage_attribution.py
@@ -1,0 +1,363 @@
+"""Backfill and normalize historical model attribution for usage reporting.
+
+Repairs the two data problems behind the ML model usage dashboard's bad rows:
+
+* Chosen ``ProposedAppeal`` rows with ``model_name`` NULL (picks recorded
+  before model tracking existed, or while the frontend id-echo was missing).
+  Recovery, strictly evidence-based and in order:
+    1. exact appeal_text match against a generated draft for the same denial;
+    2. sole-draft inference (every draft for the denial came from one model,
+       and the pick was not an arbitrary-text ``editted`` submission).
+  Rows with no recoverable evidence are stamped ``legacy-unattributed`` —
+  never guessed onto a current model. (Their generating model is simply not
+  in the database: the drafts they were picked from predate the
+  ``model_name`` column, so there is nothing to join back to.)
+
+* ``ChooserCandidate`` rows whose ``model_name`` is a default Python object
+  repr (``<...DeepInfra object at 0x7f81...>``), written before model
+  instances had stable names. The configured model is unrecoverable (the
+  candidate metadata recorded no model identifier historically), so these
+  normalize to ``legacy-unresolved (ClassName)`` — the class is the only
+  stable information in the repr; the memory address is dropped so instances
+  aggregate. Newer rows that recorded ``metadata["model_name"]`` recover the
+  real name from there instead.
+
+Safety properties:
+  * Dry run by default; ``--apply`` is required to write.
+  * Idempotent: repaired rows no longer match any repair condition, and
+    ``legacy-unattributed`` rows are only re-touched if recovery newly
+    succeeds (it never overwrites a valid canonical name).
+  * Rows created after the command started are left for the live write
+    paths, which are fixed separately.
+
+``--audit`` prints a read-only data audit (totals, attribution gaps,
+distinct labels, per-window counts, chosen>presented anomalies) without
+changing anything.
+"""
+
+import datetime
+from collections import Counter
+from typing import Optional, Tuple
+
+from django.core.management.base import BaseCommand
+from django.db.models import Q
+from django.utils import timezone
+
+from fighthealthinsurance.ml.model_identity import (
+    LEGACY_UNATTRIBUTED_LABEL,
+    is_object_repr,
+    normalize_model_label,
+)
+from fighthealthinsurance.models import ChooserCandidate, ChooserVote, ProposedAppeal
+
+
+class Command(BaseCommand):
+    help = (
+        "Backfill/normalize historical ML model attribution used by the "
+        "model-usage dashboard (dry run by default; --apply to write; "
+        "--audit for a read-only data audit)."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--apply",
+            action="store_true",
+            help="Write the changes. Without this flag the command only "
+            "reports what it would do.",
+        )
+        parser.add_argument(
+            "--audit",
+            action="store_true",
+            help="Print a read-only audit of model attribution data and exit.",
+        )
+
+    def handle(self, *args, **options):
+        if options["audit"]:
+            self._audit()
+            return
+        apply_changes: bool = options["apply"]
+        mode = "APPLY" if apply_changes else "DRY RUN (pass --apply to write)"
+        self.stdout.write(f"== Model usage attribution backfill: {mode} ==")
+        started_at = timezone.now()
+        self._backfill_proposed_appeals(apply_changes, started_at)
+        self._backfill_chooser_candidates(apply_changes)
+        if not apply_changes:
+            self.stdout.write("Dry run complete; no rows were modified.")
+
+    # ---------------------------------------------------------------- #
+    # ProposedAppeal (denial flow picks)
+    # ---------------------------------------------------------------- #
+
+    def _recover_proposed(self, pa: ProposedAppeal) -> Optional[Tuple[str, bool, str]]:
+        """Return (model_name, synthesized, method) recovered from related
+        records, or None when the database lacks sufficient evidence."""
+        if pa.for_denial_id is None:
+            return None
+        original = (
+            ProposedAppeal.objects.filter(
+                for_denial_id=pa.for_denial_id,
+                chosen=False,
+                appeal_text=pa.appeal_text,
+                model_name__isnull=False,
+            )
+            .order_by("-id")
+            .first()
+        )
+        if original is not None:
+            original_name = original.model_name
+            if original_name is not None and not is_object_repr(original_name):
+                return (original_name, original.synthesized, "text_match")
+        if not pa.editted:
+            inferred = ProposedAppeal.sole_draft_attribution(pa.for_denial_id)
+            if inferred is not None and not is_object_repr(inferred[0]):
+                return (inferred[0], inferred[1], "sole_draft")
+        return None
+
+    def _backfill_proposed_appeals(
+        self, apply_changes: bool, started_at: datetime.datetime
+    ) -> None:
+        self.stdout.write("\n-- ProposedAppeal (chosen rows) --")
+        total_chosen = ProposedAppeal.objects.filter(chosen=True).count()
+        # Rows needing attention: never attributed, previously stamped as
+        # legacy (retry recovery only), or somehow carrying an object repr.
+        targets = ProposedAppeal.objects.filter(chosen=True).filter(
+            Q(model_name__isnull=True)
+            | Q(model_name=LEGACY_UNATTRIBUTED_LABEL)
+            | Q(model_name__startswith="<")
+        )
+        # Snapshot before repairs: rows valid prior to this run.
+        target_total = targets.count()
+        counts: Counter = Counter()
+        for pa in targets.iterator():
+            raw = pa.model_name
+            recovered = self._recover_proposed(pa)
+            new_name: Optional[str] = None
+            new_synthesized: Optional[bool] = None
+            if recovered is not None:
+                new_name, new_synthesized, method = recovered
+                counts[f"recovered_{method}"] += 1
+            elif raw is not None and is_object_repr(raw):
+                new_name = normalize_model_label(raw)
+                counts["normalized_repr"] += 1
+            elif raw == LEGACY_UNATTRIBUTED_LABEL:
+                # Still unrecoverable; keep the explicit label untouched.
+                counts["already_labeled_unrecoverable"] += 1
+                continue
+            elif pa.created_at is None or pa.created_at < started_at:
+                # No evidence in the database ties this pick to a model —
+                # its drafts predate model_name tracking (or were never
+                # saved). Label explicitly instead of guessing.
+                new_name = LEGACY_UNATTRIBUTED_LABEL
+                counts["labeled_legacy_unattributed"] += 1
+            else:
+                # Created while the command was running; the fixed live
+                # write path owns it.
+                counts["skipped_concurrent"] += 1
+                continue
+            if new_name == raw and (
+                new_synthesized is None or new_synthesized == pa.synthesized
+            ):
+                counts["already_consistent"] += 1
+                continue
+            counts["rows_changed"] += 1
+            if apply_changes:
+                pa.model_name = new_name
+                update_fields = ["model_name"]
+                if new_synthesized is not None and new_synthesized != pa.synthesized:
+                    pa.synthesized = new_synthesized
+                    update_fields.append("synthesized")
+                pa.save(update_fields=update_fields)
+
+        already_valid = total_chosen - target_total
+        self.stdout.write(f"chosen rows total:                    {total_chosen}")
+        self.stdout.write(f"already valid:                        {already_valid}")
+        self.stdout.write(
+            f"recovered via exact draft text match: {counts['recovered_text_match']}"
+        )
+        self.stdout.write(
+            f"recovered via sole-draft inference:   {counts['recovered_sole_draft']}"
+        )
+        self.stdout.write(
+            f"normalized from object reprs:         {counts['normalized_repr']}"
+        )
+        self.stdout.write(
+            f"unrecoverable -> {LEGACY_UNATTRIBUTED_LABEL}:    "
+            f"{counts['labeled_legacy_unattributed']}"
+        )
+        self.stdout.write(
+            f"previously labeled, still unrecoverable: "
+            f"{counts['already_labeled_unrecoverable']}"
+        )
+        if counts["skipped_concurrent"]:
+            self.stdout.write(
+                f"skipped (created mid-run):            {counts['skipped_concurrent']}"
+            )
+        verb = "changed" if apply_changes else "would change"
+        self.stdout.write(f"rows {verb}: {counts['rows_changed']}")
+
+    # ---------------------------------------------------------------- #
+    # ChooserCandidate (appeal_letter + chat_response)
+    # ---------------------------------------------------------------- #
+
+    def _backfill_chooser_candidates(self, apply_changes: bool) -> None:
+        self.stdout.write("\n-- ChooserCandidate --")
+        total = ChooserCandidate.objects.count()
+        targets = ChooserCandidate.objects.filter(model_name__startswith="<")
+        counts: Counter = Counter()
+        distinct_before = set()
+        distinct_after = set()
+        for cand in targets.iterator():
+            raw = cand.model_name
+            if not is_object_repr(raw):
+                # "<" prefix but not a default repr; leave it alone rather
+                # than mangling a name we don't understand.
+                counts["skipped_unrecognized"] += 1
+                continue
+            distinct_before.add(raw)
+            metadata = cand.metadata or {}
+            meta_name = metadata.get("model_name")
+            if (
+                isinstance(meta_name, str)
+                and meta_name.strip()
+                and not is_object_repr(meta_name)
+            ):
+                new_name = normalize_model_label(meta_name)
+                counts["recovered_from_metadata"] += 1
+            else:
+                # No related data records which configured model produced
+                # this candidate; the class name inside the repr is the only
+                # stable evidence. Do not guess a specific model.
+                new_name = normalize_model_label(raw)
+                counts["normalized_repr_class_only"] += 1
+            distinct_after.add(new_name)
+            counts["rows_changed"] += 1
+            if apply_changes and new_name:
+                cand.model_name = new_name
+                cand.save(update_fields=["model_name"])
+
+        self.stdout.write(f"candidates total:                {total}")
+        self.stdout.write(
+            f"already valid:                   {total - counts['rows_changed'] - counts['skipped_unrecognized']}"
+        )
+        self.stdout.write(
+            f"recovered from stored metadata:  {counts['recovered_from_metadata']}"
+        )
+        self.stdout.write(
+            f"normalized to legacy-unresolved: {counts['normalized_repr_class_only']}"
+        )
+        if counts["skipped_unrecognized"]:
+            self.stdout.write(
+                f"skipped (unrecognized '<' name): {counts['skipped_unrecognized']}"
+            )
+        verb = "changed" if apply_changes else "would change"
+        self.stdout.write(f"rows {verb}: {counts['rows_changed']}")
+        if distinct_before:
+            self.stdout.write(
+                f"distinct object-repr values collapsed: {len(distinct_before)} "
+                f"-> {len(distinct_after)} labels: {sorted(x for x in distinct_after if x)}"
+            )
+
+    # ---------------------------------------------------------------- #
+    # Read-only audit
+    # ---------------------------------------------------------------- #
+
+    def _audit(self) -> None:
+        # Imported here: staff_views pulls in ray and the wider view stack,
+        # which the backfill paths above don't need.
+        from fighthealthinsurance.staff_views import ModelUsageDashboardView
+
+        now = timezone.now()
+        windows = [
+            ("All Time", None),
+            ("Last 1 Day", now - datetime.timedelta(days=1)),
+            ("Last 7 Days", now - datetime.timedelta(days=7)),
+            ("Last 30 Days", now - datetime.timedelta(days=30)),
+        ]
+        self.stdout.write("== Model usage attribution audit ==")
+
+        self.stdout.write("\n-- ProposedAppeal --")
+        qs = ProposedAppeal.objects
+        total = qs.count()
+        chosen_total = qs.filter(chosen=True).count()
+        drafts_named = qs.filter(chosen=False, model_name__isnull=False).count()
+        drafts_unnamed = qs.filter(chosen=False, model_name__isnull=True).count()
+        chosen_null = qs.filter(chosen=True, model_name__isnull=True)
+        chosen_null_legacy = chosen_null.filter(created_at__isnull=True).count()
+        chosen_null_recent = chosen_null.filter(created_at__isnull=False).count()
+        chosen_labeled_legacy = qs.filter(
+            chosen=True, model_name=LEGACY_UNATTRIBUTED_LABEL
+        ).count()
+        created_null = qs.filter(created_at__isnull=True).count()
+        self.stdout.write(f"rows total: {total} (chosen {chosen_total})")
+        self.stdout.write(
+            f"drafts (chosen=False): {drafts_named} with model_name, "
+            f"{drafts_unnamed} without (pre-tracking; excluded from presented "
+            f"so no denominator is fabricated)"
+        )
+        self.stdout.write(
+            f"chosen rows missing attribution: {chosen_null.count()} "
+            f"({chosen_null_legacy} pre-tracking/created_at NULL, "
+            f"{chosen_null_recent} post-tracking) + "
+            f"{chosen_labeled_legacy} already labeled {LEGACY_UNATTRIBUTED_LABEL}"
+        )
+        self.stdout.write(
+            f"rows with created_at NULL (only visible in All Time): {created_null}"
+        )
+        recoverable = 0
+        for pa in chosen_null.iterator():
+            if self._recover_proposed(pa) is not None:
+                recoverable += 1
+        self.stdout.write(
+            f"of the unattributed chosen rows, recoverable from related "
+            f"records: {recoverable}; unrecoverable (drafts predate "
+            f"model_name tracking or were never saved): "
+            f"{chosen_null.count() - recoverable}"
+        )
+
+        for kind in ("appeal_letter", "chat_response"):
+            self.stdout.write(f"\n-- ChooserCandidate/ChooserVote ({kind}) --")
+            cands = ChooserCandidate.objects.filter(kind=kind)
+            votes = ChooserVote.objects.filter(chosen_candidate__kind=kind)
+            # order_by() clears ChooserCandidate's default ordering, which
+            # would otherwise leak into the DISTINCT and make it per-row.
+            distinct = list(
+                cands.order_by().values_list("model_name", flat=True).distinct()
+            )
+            repr_cands = [v for v in distinct if is_object_repr(v)]
+            self.stdout.write(
+                f"candidates: {cands.count()}, votes: {votes.count()}, "
+                f"distinct model_name values: {len(distinct)} "
+                f"({len(repr_cands)} are object reprs)"
+            )
+            normalized = sorted({str(normalize_model_label(v)) for v in distinct if v})
+            self.stdout.write(f"distinct labels after normalization: {normalized}")
+
+        self.stdout.write("\n-- Dashboard aggregates by window --")
+        for label, since in windows:
+            proposed = ModelUsageDashboardView._proposed_appeal_stats(since)
+            appeal = ModelUsageDashboardView._chooser_stats("appeal_letter", since)
+            chat = ModelUsageDashboardView._chooser_stats("chat_response", since)
+            self.stdout.write(f"[{label}]")
+            for source_name, rows in (
+                ("ProposedAppeal", proposed),
+                ("Chooser-Appeal", appeal),
+                ("Chooser-Chat", chat),
+            ):
+                total_chosen = sum(r["chosen"] for r in rows)
+                total_presented = sum(r["presented"] for r in rows)
+                self.stdout.write(
+                    f"  {source_name}: models={len(rows)} "
+                    f"chosen={total_chosen} presented={total_presented}"
+                )
+                for r in rows:
+                    if "object at 0x" in r["model_name"]:
+                        self.stdout.write(
+                            self.style.ERROR(f"    REPR LEAK: {r['model_name']!r}")
+                        )
+                    if r["presented"] and r["chosen"] > r["presented"]:
+                        self.stdout.write(
+                            f"    chosen>presented for {r['model_name']}: "
+                            f"{r['chosen']}>{r['presented']} (multiple picks "
+                            f"recorded per denial, e.g. re-submits)"
+                        )
+        self.stdout.write("\nAudit complete (read-only; no rows modified).")

--- a/fighthealthinsurance/management/commands/backfill_model_usage_attribution.py
+++ b/fighthealthinsurance/management/commands/backfill_model_usage_attribution.py
@@ -40,7 +40,8 @@ from collections import Counter
 from typing import Optional, Tuple
 
 from django.core.management.base import BaseCommand
-from django.db.models import Q
+from django.db.models import Q, Value
+from django.db.models.functions import Coalesce, Trim
 from django.utils import timezone
 
 from fighthealthinsurance.ml.model_identity import (
@@ -122,32 +123,40 @@ class Command(BaseCommand):
     def _backfill_proposed_appeals(self, apply_changes: bool) -> None:
         self.stdout.write("\n-- ProposedAppeal (chosen rows) --")
         total_chosen = ProposedAppeal.objects.filter(chosen=True).count()
-        # Rows needing attention: never attributed, previously stamped as
-        # legacy (re-checked in case drafts have since appeared), or possibly
-        # carrying an object repr. The ``startswith("<")`` clause is a cheap
-        # SQL prefilter for object reprs (is_object_repr is a regex that can't
-        # run in the DB); the loop below refines it, so a non-repr value that
-        # merely starts with "<" is fetched but left untouched.
-        targets = ProposedAppeal.objects.filter(chosen=True).filter(
-            Q(model_name__isnull=True)
-            | Q(model_name=LEGACY_UNATTRIBUTED_LABEL)
-            | Q(model_name__startswith="<")
+        # Rows needing attention: missing attribution (NULL, empty, or
+        # whitespace-only model_name), previously stamped as legacy (re-checked
+        # in case drafts have since appeared), or possibly carrying an object
+        # repr. Blank labels are matched with a trimmed annotation so that ""
+        # and "  " are treated exactly like NULL (both mean "missing" once
+        # normalize_model_label strips them). The ``startswith("<")`` clause is
+        # a cheap SQL prefilter for object reprs (is_object_repr is a regex
+        # that can't run in the DB); the loop below refines it, so a non-repr
+        # value that merely starts with "<" is fetched but left untouched.
+        targets = (
+            ProposedAppeal.objects.filter(chosen=True)
+            .annotate(_trimmed_model=Trim(Coalesce("model_name", Value(""))))
+            .filter(
+                Q(_trimmed_model="")  # NULL, empty, or whitespace-only
+                | Q(model_name=LEGACY_UNATTRIBUTED_LABEL)
+                | Q(model_name__startswith="<")
+            )
         )
         target_total = targets.count()
         counts: Counter = Counter()
         for pa in targets.iterator():
             raw = pa.model_name
+            raw_blank = raw is None or not raw.strip()
             recovered = self._recover_proposed(pa)
             new_name: Optional[str] = None
             new_synthesized: Optional[bool] = None
             if recovered is not None:
                 new_name, new_synthesized, method = recovered
                 counts[f"recovered_{method}"] += 1
-            elif raw is not None and is_object_repr(raw):
+            elif not raw_blank and is_object_repr(raw):
                 new_name = normalize_model_label(raw)
                 counts["normalized_repr"] += 1
-            elif raw is not None:
-                # A non-null label that is neither an object repr nor
+            elif not raw_blank:
+                # A non-blank label that is neither an object repr nor
                 # recoverable: the legacy-unattributed marker itself, or a
                 # malformed/hand-entered value that merely starts with "<".
                 # Leave it exactly as-is — never relabel a value we don't
@@ -155,18 +164,25 @@ class Command(BaseCommand):
                 counts["left_unchanged"] += 1
                 continue
             elif pa.created_at is None:
-                # NULL model_name on a pre-tracking pick (the column didn't
-                # exist yet): its drafts can't be joined back, so it is
-                # genuinely unrecoverable. Label it rather than guess.
+                # Missing model_name (NULL/empty/whitespace) on a pre-tracking
+                # pick (the column didn't exist yet): its drafts can't be
+                # joined back, so it is genuinely unrecoverable. Label it
+                # rather than guess.
                 new_name = LEGACY_UNATTRIBUTED_LABEL
                 counts["labeled_legacy_unattributed"] += 1
-            else:
-                # NULL model_name on a post-tracking pick (e.g. several models
-                # in play and the draft was edited away). Leave it NULL so it
-                # reports as "(unattributed)" and stays recoverable if matching
-                # drafts appear later.
+            elif raw is None:
+                # Already-NULL post-tracking pick (e.g. several models in play
+                # and the draft was edited away). Leave it NULL so it reports
+                # as "(unattributed)" and stays recoverable if matching drafts
+                # appear later.
                 counts["left_unattributed"] += 1
                 continue
+            else:
+                # Blank (empty/whitespace) post-tracking pick: collapse the
+                # blank to NULL, the canonical "missing" value, so it reports
+                # as "(unattributed)" consistently with NULL rows.
+                new_name = None
+                counts["normalized_blank_to_null"] += 1
             if new_name == raw and (
                 new_synthesized is None or new_synthesized == pa.synthesized
             ):
@@ -199,6 +215,9 @@ class Command(BaseCommand):
         )
         self.stdout.write(
             f"left NULL -> (unattributed):          {counts['left_unattributed']}"
+        )
+        self.stdout.write(
+            f"blank -> NULL (unattributed):         {counts['normalized_blank_to_null']}"
         )
         self.stdout.write(
             f"left unchanged (already labeled/other): {counts['left_unchanged']}"

--- a/fighthealthinsurance/management/commands/backfill_model_usage_attribution.py
+++ b/fighthealthinsurance/management/commands/backfill_model_usage_attribution.py
@@ -92,6 +92,8 @@ class Command(BaseCommand):
         records, or None when the database lacks sufficient evidence."""
         if pa.for_denial_id is None:
             return None
+        # model_name is blank=True, so exclude empty strings too — a blank
+        # label is not usable evidence and must not be copied onto the pick.
         original = (
             ProposedAppeal.objects.filter(
                 for_denial_id=pa.for_denial_id,
@@ -99,12 +101,17 @@ class Command(BaseCommand):
                 appeal_text=pa.appeal_text,
                 model_name__isnull=False,
             )
+            .exclude(model_name="")
             .order_by("-id")
             .first()
         )
         if original is not None:
             original_name = original.model_name
-            if original_name is not None and not is_object_repr(original_name):
+            if (
+                original_name
+                and original_name.strip()
+                and not is_object_repr(original_name)
+            ):
                 return (original_name, original.synthesized, "text_match")
         if not pa.editted:
             inferred = ProposedAppeal.sole_draft_attribution(pa.for_denial_id)
@@ -304,7 +311,15 @@ class Command(BaseCommand):
                 f"distinct model_name values: {len(distinct)} "
                 f"({len(repr_cands)} are object reprs)"
             )
-            normalized = sorted({str(normalize_model_label(v)) for v in distinct if v})
+            # Drop labels that normalize to None (blank/whitespace) rather
+            # than stringifying them into a misleading literal "None".
+            normalized = sorted(
+                {
+                    label
+                    for v in distinct
+                    if (label := normalize_model_label(v)) is not None
+                }
+            )
             self.stdout.write(f"distinct labels after normalization: {normalized}")
 
         self.stdout.write("\n-- Dashboard aggregates by window --")

--- a/fighthealthinsurance/ml/model_identity.py
+++ b/fighthealthinsurance/ml/model_identity.py
@@ -1,0 +1,113 @@
+"""Canonical reporting identity for ML models.
+
+Everything that *persists* or *aggregates* a model name (ProposedAppeal rows,
+ChooserCandidate rows, the model-usage staff dashboard, backfills) must derive
+it through this module rather than ``str(model)`` / ``repr(model)`` so the
+stored identity is:
+
+* stable across processes and restarts (never a ``<... object at 0x...>``
+  repr, which embeds a per-process memory address),
+* stable across different Python instances of the same configured model,
+* human readable, and
+* specific enough to keep genuinely different configured models apart
+  (two ``DeepInfra`` instances serving different underlying models must not
+  collapse just because they share a class).
+
+Identity preference order (see ``canonical_model_name``):
+
+1. The router-stamped friendly name (``ModelDescription.name`` — the
+   ``MLRouter.models_by_name`` registry key). This is also exactly what the
+   appeal-generation pipeline records on ``ProposedAppeal.model_name``, so
+   using it first keeps every reporting source keyed the same way. Multiple
+   backend instances registered under one name intentionally aggregate.
+2. The explicit configured provider model identifier (``model.model``, e.g.
+   ``"google/gemma-4-26B-A4B-it"``) for instances the router has not stamped.
+3. The class name, as a documented last resort. It cannot distinguish two
+   differently-configured instances of the same class, but it is stable and
+   address-free; it should only ever be hit for hand-constructed instances
+   outside the router registry.
+
+The special ``synthesized`` bucket (drafts combined from multiple model
+outputs) is a reserved pseudo-model name and passes through normalization
+unchanged.
+"""
+
+import re
+from typing import Any, Optional
+
+# Reserved pseudo-model name for outputs synthesized from multiple drafts.
+SYNTHESIZED_MODEL_NAME = "synthesized"
+
+# Reporting label stamped by the backfill onto historical *chosen*
+# ProposedAppeal rows whose generating model cannot be recovered from any
+# related record (they predate model tracking, or no draft matches). Kept
+# distinct from live "(unattributed)" picks so legacy gaps stay visible
+# instead of being blamed on a guessed model.
+LEGACY_UNATTRIBUTED_LABEL = "legacy-unattributed"
+
+_LEGACY_UNRESOLVED_PREFIX = "legacy-unresolved"
+
+# Default CPython object repr, e.g.
+# "<fighthealthinsurance.ml.ml_models.DeepInfra object at 0x7f81456da840>".
+# Historical ChooserCandidate.model_name values were written through
+# str(model) before RemoteModelLike defined __str__, so this exact shape
+# reached the database.
+OBJECT_REPR_RE = re.compile(
+    r"^<(?P<path>[A-Za-z_][A-Za-z0-9_\.]*) object at 0x[0-9a-fA-F]+>$"
+)
+
+# Persisted model-name columns are CharField(max_length=200).
+MODEL_NAME_MAX_LENGTH = 200
+
+
+def is_object_repr(value: Optional[str]) -> bool:
+    """Return True when ``value`` is a default Python object repr."""
+    if not value:
+        return False
+    return OBJECT_REPR_RE.match(value.strip()) is not None
+
+
+def legacy_unresolved_label(class_name: str) -> str:
+    """Reporting label for a legacy row where only the implementation class
+    survived (via a stored object repr) and no related data can recover the
+    configured model. Aggregates at class granularity, without the address."""
+    return f"{_LEGACY_UNRESOLVED_PREFIX} ({class_name})"
+
+
+def canonical_model_name(model: Any) -> Optional[str]:
+    """Derive the stable reporting identity for an ML model instance.
+
+    Never returns a default object repr; returns None only for ``model is
+    None`` so NOT NULL columns are always safe to fill from a real instance.
+    """
+    if model is None:
+        return None
+    name = getattr(model, "name", None)
+    if isinstance(name, str) and name.strip() and not is_object_repr(name):
+        return name.strip()[:MODEL_NAME_MAX_LENGTH]
+    configured = getattr(model, "model", None)
+    if isinstance(configured, str) and configured.strip():
+        return configured.strip()[:MODEL_NAME_MAX_LENGTH]
+    return type(model).__name__[:MODEL_NAME_MAX_LENGTH]
+
+
+def normalize_model_label(raw: Optional[str]) -> Optional[str]:
+    """Normalize a *stored* model-name string for reporting.
+
+    * ``None`` / empty / whitespace → ``None`` (caller decides the bucket).
+    * Default object reprs → ``legacy-unresolved (ClassName)``: the class is
+      the only stable information in the repr; the memory address is dropped
+      so equivalent instances aggregate into one row.
+    * Anything else (including ``synthesized`` and the legacy labels) passes
+      through stripped and unchanged.
+    """
+    if raw is None:
+        return None
+    text = str(raw).strip()
+    if not text:
+        return None
+    match = OBJECT_REPR_RE.match(text)
+    if match:
+        class_name = match.group("path").rsplit(".", 1)[-1]
+        return legacy_unresolved_label(class_name)
+    return text[:MODEL_NAME_MAX_LENGTH]

--- a/fighthealthinsurance/models.py
+++ b/fighthealthinsurance/models.py
@@ -2566,8 +2566,10 @@ class ProposedAppeal(ExportModelOperationsMixin("ProposedAppeal"), models.Model)
         denial's presented drafts, so a pick can safely inherit the drafts'
         model when they all share one. Any draft with a NULL model_name makes
         the inference ambiguous (the pick could have come from it), so no
-        attribution is returned in that case. Used by mark_proposal_chosen as
-        a fallback and by the attribution backfill; must never guess.
+        attribution is returned in that case. A blank/whitespace model_name
+        (the field is ``blank=True``) is treated as missing for the same
+        reason. Used by mark_proposal_chosen as a fallback and by the
+        attribution backfill; must never guess.
         """
         pairs = list(
             ProposedAppeal.objects.filter(for_denial_id=denial_id, chosen=False)
@@ -2576,7 +2578,7 @@ class ProposedAppeal(ExportModelOperationsMixin("ProposedAppeal"), models.Model)
         )
         if len(pairs) == 1:
             model_name, synthesized = pairs[0]
-            if model_name is not None:
+            if model_name is not None and model_name.strip():
                 return (model_name, synthesized)
         return None
 

--- a/fighthealthinsurance/models.py
+++ b/fighthealthinsurance/models.py
@@ -2557,6 +2557,29 @@ class ProposedAppeal(ExportModelOperationsMixin("ProposedAppeal"), models.Model)
         else:
             return f"{self.appeal_text}"
 
+    @staticmethod
+    def sole_draft_attribution(denial_id) -> typing.Optional[typing.Tuple[str, bool]]:
+        """Return ``(model_name, synthesized)`` when every generated draft for
+        the denial is attributed to exactly one model, else ``None``.
+
+        The choose flow always picks (possibly after editing) one of the
+        denial's presented drafts, so a pick can safely inherit the drafts'
+        model when they all share one. Any draft with a NULL model_name makes
+        the inference ambiguous (the pick could have come from it), so no
+        attribution is returned in that case. Used by mark_proposal_chosen as
+        a fallback and by the attribution backfill; must never guess.
+        """
+        pairs = list(
+            ProposedAppeal.objects.filter(for_denial_id=denial_id, chosen=False)
+            .values_list("model_name", "synthesized")
+            .distinct()[:2]
+        )
+        if len(pairs) == 1:
+            model_name, synthesized = pairs[0]
+            if model_name is not None:
+                return (model_name, synthesized)
+        return None
+
 
 class RegulatorEscalation(ExportModelOperationsMixin("RegulatorEscalation"), models.Model):  # type: ignore
     """

--- a/fighthealthinsurance/rest_views.py
+++ b/fighthealthinsurance/rest_views.py
@@ -2484,7 +2484,11 @@ class ChooserViewSet(viewsets.ViewSet):
         session_key = self._get_session_key(request)
         task_id = serializer.validated_data["task_id"]
         chosen_candidate_id = serializer.validated_data["chosen_candidate_id"]
-        presented_candidate_ids = serializer.validated_data["presented_candidate_ids"]
+        # Deduplicate (order-preserving): a candidate was shown once per vote
+        # event, and repeated ids would inflate presented counts downstream.
+        presented_candidate_ids = list(
+            dict.fromkeys(serializer.validated_data["presented_candidate_ids"])
+        )
 
         # Validate task exists and is in valid state
         try:

--- a/fighthealthinsurance/staff_views.py
+++ b/fighthealthinsurance/staff_views.py
@@ -607,38 +607,31 @@ class ModelUsageDashboardView(generic.TemplateView):
     def _proposed_appeal_stats(
         since: Optional[datetime.datetime],
     ) -> List[Dict[str, Any]]:
-        # Keep chosen rows with model_name=NULL in the chosen aggregation —
-        # mark_proposal_chosen intentionally falls back to None when the
-        # picked text can't be matched to a generated draft, and those are
-        # still real user picks worth surfacing. NULL rows that predate model
-        # tracking entirely (created_at NULL, pre-migration-0182) are
-        # bucketed as LEGACY_UNATTRIBUTED_LABEL — matching what the backfill
-        # stamps — while post-tracking rows fall under UNKNOWN_MODEL_LABEL,
-        # so legacy gaps stay distinguishable from current attribution
-        # misses.
+        # Keep chosen rows with model_name=NULL: mark_proposal_chosen falls
+        # back to None when a pick can't be matched to a draft, and those are
+        # still real picks. NULL rows predating model tracking (created_at
+        # NULL, pre-migration-0182) bucket as LEGACY_UNATTRIBUTED_LABEL —
+        # matching what the backfill stamps — while later rows fall under
+        # UNKNOWN_MODEL_LABEL, so legacy gaps stay distinct from current
+        # attribution misses.
         chosen_qs = ProposedAppeal.objects.filter(chosen=True)
         if since is not None:
             chosen_qs = chosen_qs.filter(created_at__gte=since)
 
-        # Tie the presented universe to denials that were picked within
-        # the window. We intentionally do NOT filter presented_qs by
-        # created_at: a user can generate appeals on day 0 and pick one on
-        # day 1, and a 1-day window anchored on the pick should still count
-        # the drafts that were actually presented. Pass the subquery
-        # straight into __in to avoid materializing a potentially huge id
-        # list (Django keeps it as a SQL subquery). Drafts without a
-        # model_name (pre-tracking) stay excluded: attributing them to any
-        # bucket would fabricate a win-rate denominator we cannot back up,
-        # so legacy/unattributed chosen rows deliberately report presented=0
-        # and an em-dash win rate. Excluding LEGACY_UNATTRIBUTED_LABEL is
-        # defensive — the backfill only stamps chosen rows, so no draft
-        # should ever carry it.
+        # Tie the presented universe to denials picked within the window,
+        # NOT to draft created_at: a draft generated on day 0 and picked on
+        # day 1 should still count as presented in a 1-day window anchored on
+        # the pick. Pass the subquery straight into __in so Django emits SQL
+        # rather than materializing a large id list. Drafts without a
+        # model_name (pre-tracking) are excluded — attributing them to any
+        # bucket would fabricate a win-rate denominator — so legacy chosen
+        # rows report presented=0 and an em-dash win rate.
         chosen_denial_ids = chosen_qs.values_list("for_denial_id", flat=True).distinct()
         presented_qs = ProposedAppeal.objects.filter(
             chosen=False,
             model_name__isnull=False,
             for_denial_id__in=chosen_denial_ids,
-        ).exclude(model_name=LEGACY_UNATTRIBUTED_LABEL)
+        )
 
         chosen: Counter = Counter()
         for name, count in (
@@ -659,9 +652,9 @@ class ModelUsageDashboardView(generic.TemplateView):
         for name, count in presented_qs.values_list("model_name").annotate(
             c=Count("id")
         ):
-            label = normalize_model_label(name)
-            if label is not None:
-                presented[label] += count
+            presented_label = normalize_model_label(name)
+            if presented_label is not None:
+                presented[presented_label] += count
         return _merge_stats(dict(chosen), dict(presented))
 
     @staticmethod

--- a/fighthealthinsurance/staff_views.py
+++ b/fighthealthinsurance/staff_views.py
@@ -1,7 +1,7 @@
 import csv
 import datetime
 import json
-from collections import Counter, defaultdict
+from collections import Counter
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from django.db import transaction
@@ -40,6 +40,10 @@ from fighthealthinsurance.models import (
 )
 from fighthealthinsurance.email_utils import is_sendable_email
 from fighthealthinsurance.business_hours import describe_send_window
+from fighthealthinsurance.ml.model_identity import (
+    LEGACY_UNATTRIBUTED_LABEL,
+    normalize_model_label,
+)
 from fighthealthinsurance.proconnector import (
     PROCONNECTOR_INTRO_SUBJECT,
     build_search_links,
@@ -457,22 +461,31 @@ class SendMailingListMailView(generic.FormView):
             )
 
 
-# Bucket label for chosen ProposedAppeal rows whose model_name is NULL —
-# i.e. the user picked something we couldn't attribute back to a generated
-# draft (heavy edit, share-appeal flow, or a row predating the model_name
-# field). Surfacing them keeps the dashboard's total-picks number honest.
-UNKNOWN_MODEL_LABEL = "(unknown)"
+# Bucket label for chosen ProposedAppeal rows whose model_name is NULL and
+# whose created_at is set — i.e. a pick recorded after model tracking began
+# that still couldn't be attributed back to a generated draft (heavy edit
+# with multiple models in play, or the share-appeal flow). Surfacing them
+# keeps the dashboard's total-picks number honest. Rows predating tracking
+# (created_at NULL) or explicitly stamped by the backfill are reported under
+# LEGACY_UNATTRIBUTED_LABEL instead so legacy gaps stay distinguishable.
+UNKNOWN_MODEL_LABEL = "(unattributed)"
 
 
 def _merge_stats(
     chosen: Dict[str, int], presented: Dict[str, int]
 ) -> List[Dict[str, Any]]:
-    """Combine per-model chosen + presented counts into a sorted list of dicts."""
+    """Combine per-model chosen + presented counts into a sorted list of dicts.
+
+    ``win_rate`` is chosen/presented as a percentage, or ``None`` when the
+    model has no presented count (no denominator — e.g. legacy chosen rows
+    without presentation records). Templates render ``None`` as an em dash;
+    it must never be displayed as 0.0%.
+    """
     rows: List[Dict[str, Any]] = []
     for model_name in set(chosen) | set(presented):
         c = chosen.get(model_name, 0)
         p = presented.get(model_name, 0)
-        win_rate = (c / p * 100.0) if p > 0 else 0.0
+        win_rate = (c / p * 100.0) if p > 0 else None
         rows.append(
             {
                 "model_name": model_name,
@@ -481,17 +494,41 @@ def _merge_stats(
                 "win_rate": win_rate,
             }
         )
-    rows.sort(key=lambda r: (-r["chosen"], -r["win_rate"], r["model_name"]))
+    rows.sort(
+        key=lambda r: (
+            -r["chosen"],
+            -(r["win_rate"] if r["win_rate"] is not None else -1.0),
+            r["model_name"],
+        )
+    )
     return rows
 
 
 class ModelUsageDashboardView(generic.TemplateView):
     """Staff dashboard showing which ML models users pick most often.
 
-    Aggregates three signal sources across three time windows:
+    Aggregates three signal sources across four time windows:
       * ProposedAppeal.chosen=True  - implicit pick from real denial flow
       * ChooserVote (kind=appeal_letter) - synthetic chooser appeal vote
       * ChooserVote (kind=chat_response) - synthetic chooser chat vote
+
+    Time-window semantics (all timezone-aware, anchored on timezone.now()):
+      * Windows are rolling: "Last 1 Day" = the preceding 24 hours, "Last 7
+        Days" / "Last 30 Days" = the preceding 7/30 days. "All Time" has no
+        lower bound and additionally includes rows that predate timestamp
+        tracking (ProposedAppeal.created_at NULL, pre-migration-0182), which
+        no bounded window can include.
+      * The event timestamp is the *selection* event: the chosen
+        ProposedAppeal row's created_at (the pick), or ChooserVote.created_at
+        (the vote). Presented counts use the same event set: for votes, the
+        candidates listed on the in-window votes; for ProposedAppeal, the
+        drafts generated for denials picked in the window (a draft generated
+        on day 0 and picked on day 1 still counts as presented in a 1-day
+        window anchored on the pick).
+
+    All stored model names pass through normalize_model_label so historical
+    object-repr values aggregate per class (without memory addresses) even
+    before the backfill_model_usage_attribution command has run.
     """
 
     template_name = "model_usage_dashboard.html"
@@ -502,6 +539,7 @@ class ModelUsageDashboardView(generic.TemplateView):
         windows = [
             ("global", "All Time", None),
             ("1d", "Last 1 Day", now - datetime.timedelta(days=1)),
+            ("7d", "Last 7 Days", now - datetime.timedelta(days=7)),
             ("30d", "Last 30 Days", now - datetime.timedelta(days=30)),
         ]
         windows_ctx = []
@@ -572,8 +610,12 @@ class ModelUsageDashboardView(generic.TemplateView):
         # Keep chosen rows with model_name=NULL in the chosen aggregation —
         # mark_proposal_chosen intentionally falls back to None when the
         # picked text can't be matched to a generated draft, and those are
-        # still real user picks worth surfacing. They are bucketed under
-        # "(unknown)" below so they don't get silently dropped.
+        # still real user picks worth surfacing. NULL rows that predate model
+        # tracking entirely (created_at NULL, pre-migration-0182) are
+        # bucketed as LEGACY_UNATTRIBUTED_LABEL — matching what the backfill
+        # stamps — while post-tracking rows fall under UNKNOWN_MODEL_LABEL,
+        # so legacy gaps stay distinguishable from current attribution
+        # misses.
         chosen_qs = ProposedAppeal.objects.filter(chosen=True)
         if since is not None:
             chosen_qs = chosen_qs.filter(created_at__gte=since)
@@ -584,60 +626,86 @@ class ModelUsageDashboardView(generic.TemplateView):
         # day 1, and a 1-day window anchored on the pick should still count
         # the drafts that were actually presented. Pass the subquery
         # straight into __in to avoid materializing a potentially huge id
-        # list (Django keeps it as a SQL subquery).
+        # list (Django keeps it as a SQL subquery). Drafts without a
+        # model_name (pre-tracking) stay excluded: attributing them to any
+        # bucket would fabricate a win-rate denominator we cannot back up,
+        # so legacy/unattributed chosen rows deliberately report presented=0
+        # and an em-dash win rate. Excluding LEGACY_UNATTRIBUTED_LABEL is
+        # defensive — the backfill only stamps chosen rows, so no draft
+        # should ever carry it.
         chosen_denial_ids = chosen_qs.values_list("for_denial_id", flat=True).distinct()
         presented_qs = ProposedAppeal.objects.filter(
             chosen=False,
             model_name__isnull=False,
             for_denial_id__in=chosen_denial_ids,
-        )
+        ).exclude(model_name=LEGACY_UNATTRIBUTED_LABEL)
 
-        chosen: Dict[str, int] = {}
-        for name, count in chosen_qs.values_list("model_name").annotate(c=Count("id")):
-            label = name if name is not None else UNKNOWN_MODEL_LABEL
-            chosen[label] = chosen.get(label, 0) + count
-        presented = {
-            name: count
-            for name, count in presented_qs.values_list("model_name").annotate(
-                c=Count("id")
-            )
-        }
-        return _merge_stats(chosen, presented)
+        chosen: Counter = Counter()
+        for name, count in (
+            chosen_qs.filter(model_name__isnull=False)
+            .values_list("model_name")
+            .annotate(c=Count("id"))
+        ):
+            label = normalize_model_label(name) or UNKNOWN_MODEL_LABEL
+            chosen[label] += count
+        null_named = chosen_qs.filter(model_name__isnull=True)
+        legacy_count = null_named.filter(created_at__isnull=True).count()
+        unattributed_count = null_named.filter(created_at__isnull=False).count()
+        if legacy_count:
+            chosen[LEGACY_UNATTRIBUTED_LABEL] += legacy_count
+        if unattributed_count:
+            chosen[UNKNOWN_MODEL_LABEL] += unattributed_count
+        presented: Counter = Counter()
+        for name, count in presented_qs.values_list("model_name").annotate(
+            c=Count("id")
+        ):
+            label = normalize_model_label(name)
+            if label is not None:
+                presented[label] += count
+        return _merge_stats(dict(chosen), dict(presented))
 
     @staticmethod
     def _chooser_stats(
         kind: str, since: Optional[datetime.datetime]
     ) -> List[Dict[str, Any]]:
+        # Both chosen and presented derive from the same vote set (filtered
+        # by ChooserVote.created_at), so a window's win rates compare like
+        # with like: every vote event contributes its chosen candidate once
+        # and each distinct presented candidate once. Candidate creation
+        # time is irrelevant — candidates are generated ahead of votes.
         chosen_qs = ChooserVote.objects.filter(chosen_candidate__kind=kind)
         if since is not None:
             chosen_qs = chosen_qs.filter(created_at__gte=since)
-        chosen = {
-            name: count
-            for name, count in chosen_qs.values_list(
-                "chosen_candidate__model_name"
-            ).annotate(c=Count("id"))
-        }
+        chosen: Counter = Counter()
+        for name, count in chosen_qs.values_list(
+            "chosen_candidate__model_name"
+        ).annotate(c=Count("id")):
+            label = normalize_model_label(name) or UNKNOWN_MODEL_LABEL
+            chosen[label] += count
 
         # Presented: walk votes' presented_candidate_ids JSON lists into a
         # counter. We reuse chosen_qs (same filter) and call .iterator() so
         # the All Time window doesn't load every vote into a result cache.
+        # Dedupe ids within a vote: a candidate was shown once per vote
+        # event, and a duplicated id (buggy/hostile client, pre-dedupe
+        # historical rows) must not inflate the denominator.
         counter: Counter = Counter()
         for ids in chosen_qs.values_list(
             "presented_candidate_ids", flat=True
         ).iterator():
             if ids:
-                counter.update(ids)
+                counter.update(set(ids))
         cand_to_model = dict(
             ChooserCandidate.objects.filter(
                 id__in=list(counter.keys()), kind=kind
             ).values_list("id", "model_name")
         )
-        presented: Dict[str, int] = defaultdict(int)
+        presented: Counter = Counter()
         for cid, n in counter.items():
-            mn = cand_to_model.get(cid)
-            if mn:
-                presented[mn] += n
-        return _merge_stats(chosen, dict(presented))
+            presented_label = normalize_model_label(cand_to_model.get(cid))
+            if presented_label is not None:
+                presented[presented_label] += n
+        return _merge_stats(dict(chosen), dict(presented))
 
 
 class ModelBackendStatusView(generic.TemplateView):

--- a/fighthealthinsurance/templates/model_usage_dashboard.html
+++ b/fighthealthinsurance/templates/model_usage_dashboard.html
@@ -30,7 +30,17 @@
     <span class="legend-key" style="background:#1f77b4;"></span>ProposedAppeal (denial flow),
     <span class="legend-key" style="background:#ff7f0e;"></span>Chooser&mdash;Appeal,
     <span class="legend-key" style="background:#2ca02c;"></span>Chooser&mdash;Chat.
-    Win rate = chosen / presented. Synthesized appeals are bucketed as model_name &ldquo;synthesized&rdquo;.
+    Win rate = chosen / presented, shown as &ldquo;&mdash;&rdquo; when nothing was
+    presented (no denominator). Windows are rolling (last 24 hours / 7 days /
+    30 days, anchored on the pick or vote time); All Time additionally includes
+    rows predating timestamp tracking. Synthesized appeals are bucketed as
+    model_name &ldquo;synthesized&rdquo;. Special buckets:
+    &ldquo;legacy-unattributed&rdquo; = historical picks recorded before model
+    tracking whose generating model cannot be recovered;
+    &ldquo;legacy-unresolved (Class)&rdquo; = legacy chooser rows that stored a
+    Python object repr, aggregated by model class;
+    &ldquo;(unattributed)&rdquo; = post-tracking picks that could not be matched
+    to a generated draft. Legacy buckets have no presented counts by design.
   </p>
 
   {% for w in windows %}

--- a/fighthealthinsurance/templates/model_usage_table_partial.html
+++ b/fighthealthinsurance/templates/model_usage_table_partial.html
@@ -14,7 +14,12 @@
       <td>{{ r.model_name }}</td>
       <td class="num">{{ r.chosen }}</td>
       <td class="num">{{ r.presented }}</td>
+      {% if r.win_rate is None %}
+      {# No presented count => no denominator; never show this as 0.0%. #}
+      <td class="num">&mdash;</td>
+      {% else %}
       <td class="num">{{ r.win_rate|floatformat:1 }}%</td>
+      {% endif %}
     </tr>
     {% endfor %}
   </tbody>

--- a/tests/sync/test_backfill_model_usage_attribution.py
+++ b/tests/sync/test_backfill_model_usage_attribution.py
@@ -214,6 +214,23 @@ class BackfillProposedAppealTest(TestCase):
         pick.refresh_from_db()
         self.assertEqual(pick.model_name, "model-x")
 
+    def test_malformed_angle_bracket_name_not_relabeled(self):
+        # The target queryset prefilters on startswith("<") to catch object
+        # reprs cheaply, but a non-repr value that merely starts with "<" is
+        # not an object repr and must be left exactly as-is - even on a
+        # pre-tracking row, it must not be swept into legacy-unattributed.
+        pick = ProposedAppeal.objects.create(
+            for_denial=self.denial,
+            appeal_text="text",
+            chosen=True,
+            model_name="<not-a-repr>",
+        )
+        ProposedAppeal.objects.filter(pk=pick.pk).update(created_at=None)
+        out = run_command("--apply")
+        pick.refresh_from_db()
+        self.assertEqual(pick.model_name, "<not-a-repr>")
+        self.assertIn("rows changed: 0", out)
+
     def test_dry_run_by_default(self):
         pick = ProposedAppeal.objects.create(
             for_denial=self.denial,

--- a/tests/sync/test_backfill_model_usage_attribution.py
+++ b/tests/sync/test_backfill_model_usage_attribution.py
@@ -182,6 +182,27 @@ class BackfillProposedAppealTest(TestCase):
         draft.refresh_from_db()
         self.assertIsNone(draft.model_name)
 
+    def test_blank_draft_model_name_not_copied(self):
+        # model_name is blank=True. A matching draft whose model_name is an
+        # empty/whitespace string is not usable evidence: the pick must not
+        # inherit it (pre-tracking pick => labeled legacy instead).
+        ProposedAppeal.objects.create(
+            for_denial=self.denial,
+            appeal_text="draft text",
+            chosen=False,
+            model_name="  ",
+        )
+        pick = ProposedAppeal.objects.create(
+            for_denial=self.denial,
+            appeal_text="draft text",
+            chosen=True,
+            model_name=None,
+        )
+        ProposedAppeal.objects.filter(pk=pick.pk).update(created_at=None)
+        run_command("--apply")
+        pick.refresh_from_db()
+        self.assertEqual(pick.model_name, LEGACY_UNATTRIBUTED_LABEL)
+
     def test_valid_names_never_overwritten(self):
         pick = ProposedAppeal.objects.create(
             for_denial=self.denial,

--- a/tests/sync/test_backfill_model_usage_attribution.py
+++ b/tests/sync/test_backfill_model_usage_attribution.py
@@ -1,0 +1,334 @@
+"""Tests for the backfill_model_usage_attribution management command."""
+
+from io import StringIO
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from fighthealthinsurance.ml.model_identity import (
+    LEGACY_UNATTRIBUTED_LABEL,
+    legacy_unresolved_label,
+)
+from fighthealthinsurance.models import (
+    ChooserCandidate,
+    ChooserTask,
+    Denial,
+    ProposedAppeal,
+)
+
+REPR_DEEPINFRA = (
+    "<fighthealthinsurance.ml.ml_models.DeepInfra object at 0x7f81456da840>"
+)
+REPR_INTERNAL = (
+    "<fighthealthinsurance.ml.ml_models.NewRemoteInternal object at 0x7d65196f8bc0>"
+)
+
+
+def run_command(*args):
+    out = StringIO()
+    call_command("backfill_model_usage_attribution", *args, stdout=out)
+    return out.getvalue()
+
+
+class BackfillProposedAppealTest(TestCase):
+    def setUp(self):
+        self.denial = Denial.objects.create(
+            hashed_email="hash",
+            denial_text="denied",
+            procedure="MRI",
+            diagnosis="back pain",
+            insurance_company="TestIns",
+        )
+
+    def _denial(self, suffix):
+        return Denial.objects.create(
+            hashed_email=f"hash-{suffix}",
+            denial_text="denied",
+            procedure="MRI",
+            diagnosis="back pain",
+            insurance_company="TestIns",
+        )
+
+    def test_recovers_via_exact_text_match(self):
+        ProposedAppeal.objects.create(
+            for_denial=self.denial,
+            appeal_text="draft text",
+            chosen=False,
+            model_name="model-x",
+        )
+        pick = ProposedAppeal.objects.create(
+            for_denial=self.denial,
+            appeal_text="draft text",
+            chosen=True,
+            model_name=None,
+        )
+        run_command("--apply")
+        pick.refresh_from_db()
+        self.assertEqual(pick.model_name, "model-x")
+
+    def test_recovers_synthesized_flag_with_text_match(self):
+        ProposedAppeal.objects.create(
+            for_denial=self.denial,
+            appeal_text="synth text",
+            chosen=False,
+            model_name="synthesized",
+            synthesized=True,
+        )
+        pick = ProposedAppeal.objects.create(
+            for_denial=self.denial,
+            appeal_text="synth text",
+            chosen=True,
+            model_name=None,
+        )
+        run_command("--apply")
+        pick.refresh_from_db()
+        self.assertEqual(pick.model_name, "synthesized")
+        self.assertTrue(pick.synthesized)
+
+    def test_recovers_via_sole_draft_inference(self):
+        # Text was rewritten by sub_in_appeals, but every draft for the
+        # denial came from one model, so the pick is attributable.
+        ProposedAppeal.objects.create(
+            for_denial=self.denial,
+            appeal_text="raw draft {claim_id}",
+            chosen=False,
+            model_name="only-model",
+        )
+        ProposedAppeal.objects.create(
+            for_denial=self.denial,
+            appeal_text="another raw draft {claim_id}",
+            chosen=False,
+            model_name="only-model",
+        )
+        pick = ProposedAppeal.objects.create(
+            for_denial=self.denial,
+            appeal_text="raw draft ABC123",
+            chosen=True,
+            model_name=None,
+        )
+        run_command("--apply")
+        pick.refresh_from_db()
+        self.assertEqual(pick.model_name, "only-model")
+
+    def test_does_not_guess_across_multiple_models(self):
+        ProposedAppeal.objects.create(
+            for_denial=self.denial,
+            appeal_text="draft a",
+            chosen=False,
+            model_name="model-a",
+        )
+        ProposedAppeal.objects.create(
+            for_denial=self.denial,
+            appeal_text="draft b",
+            chosen=False,
+            model_name="model-b",
+        )
+        pick = ProposedAppeal.objects.create(
+            for_denial=self.denial,
+            appeal_text="edited beyond recognition",
+            chosen=True,
+            model_name=None,
+        )
+        run_command("--apply")
+        pick.refresh_from_db()
+        # Ambiguous: must be labeled, never guessed onto model-a or model-b.
+        self.assertEqual(pick.model_name, LEGACY_UNATTRIBUTED_LABEL)
+
+    def test_does_not_sole_draft_infer_for_editted_rows(self):
+        # editted=True rows come from the share-appeal flow and may contain
+        # text that never was a draft; sole-draft inference must not fire.
+        ProposedAppeal.objects.create(
+            for_denial=self.denial,
+            appeal_text="draft text",
+            chosen=False,
+            model_name="only-model",
+        )
+        pick = ProposedAppeal.objects.create(
+            for_denial=self.denial,
+            appeal_text="user-authored text",
+            chosen=True,
+            editted=True,
+            model_name=None,
+        )
+        run_command("--apply")
+        pick.refresh_from_db()
+        self.assertEqual(pick.model_name, LEGACY_UNATTRIBUTED_LABEL)
+
+    def test_legacy_row_without_drafts_labeled_unattributed(self):
+        pick = ProposedAppeal.objects.create(
+            for_denial=self.denial,
+            appeal_text="ancient pick",
+            chosen=True,
+            model_name=None,
+        )
+        ProposedAppeal.objects.filter(pk=pick.pk).update(created_at=None)
+        run_command("--apply")
+        pick.refresh_from_db()
+        self.assertEqual(pick.model_name, LEGACY_UNATTRIBUTED_LABEL)
+
+    def test_drafts_are_never_labeled(self):
+        # Labeling chosen=False rows would fabricate a presented denominator
+        # for the legacy bucket.
+        draft = ProposedAppeal.objects.create(
+            for_denial=self.denial,
+            appeal_text="legacy draft",
+            chosen=False,
+            model_name=None,
+        )
+        run_command("--apply")
+        draft.refresh_from_db()
+        self.assertIsNone(draft.model_name)
+
+    def test_valid_names_never_overwritten(self):
+        pick = ProposedAppeal.objects.create(
+            for_denial=self.denial,
+            appeal_text="text",
+            chosen=True,
+            model_name="model-x",
+        )
+        run_command("--apply")
+        pick.refresh_from_db()
+        self.assertEqual(pick.model_name, "model-x")
+
+    def test_dry_run_by_default(self):
+        pick = ProposedAppeal.objects.create(
+            for_denial=self.denial,
+            appeal_text="pick",
+            chosen=True,
+            model_name=None,
+        )
+        out = run_command()
+        pick.refresh_from_db()
+        self.assertIsNone(pick.model_name)
+        self.assertIn("DRY RUN", out)
+        self.assertIn("rows would change: 1", out)
+
+    def test_idempotent_second_run_changes_nothing(self):
+        ProposedAppeal.objects.create(
+            for_denial=self.denial,
+            appeal_text="draft text",
+            chosen=False,
+            model_name="model-x",
+        )
+        ProposedAppeal.objects.create(
+            for_denial=self.denial,
+            appeal_text="draft text",
+            chosen=True,
+            model_name=None,
+        )
+        unrecoverable_denial = self._denial("legacy")
+        ProposedAppeal.objects.create(
+            for_denial=unrecoverable_denial,
+            appeal_text="ancient",
+            chosen=True,
+            model_name=None,
+        )
+        first = run_command("--apply")
+        self.assertIn("rows changed: 2", first)
+        second = run_command("--apply")
+        # Both sections (ProposedAppeal + ChooserCandidate) report zero.
+        self.assertEqual(second.count("rows changed: 0"), 2, second)
+        # The label survives re-runs untouched.
+        self.assertEqual(
+            ProposedAppeal.objects.filter(model_name=LEGACY_UNATTRIBUTED_LABEL).count(),
+            1,
+        )
+
+    def test_relabeled_row_recovers_when_evidence_appears(self):
+        # legacy-unattributed rows are re-checked for recovery, so a rerun
+        # can only improve attribution (it never un-labels to NULL).
+        pick = ProposedAppeal.objects.create(
+            for_denial=self.denial,
+            appeal_text="draft text",
+            chosen=True,
+            model_name=LEGACY_UNATTRIBUTED_LABEL,
+        )
+        ProposedAppeal.objects.create(
+            for_denial=self.denial,
+            appeal_text="draft text",
+            chosen=False,
+            model_name="model-x",
+        )
+        run_command("--apply")
+        pick.refresh_from_db()
+        self.assertEqual(pick.model_name, "model-x")
+
+
+class BackfillChooserCandidateTest(TestCase):
+    def setUp(self):
+        self.task = ChooserTask.objects.create(
+            task_type="appeal", status="EXHAUSTED", source="synthetic"
+        )
+
+    def _candidate(self, index, model_name, metadata=None, kind="appeal_letter"):
+        return ChooserCandidate.objects.create(
+            task=self.task,
+            candidate_index=index,
+            kind=kind,
+            model_name=model_name,
+            content="x",
+            metadata=metadata,
+        )
+
+    def test_object_reprs_normalized_to_class_label(self):
+        c1 = self._candidate(0, REPR_DEEPINFRA)
+        c2 = self._candidate(1, REPR_INTERNAL)
+        run_command("--apply")
+        c1.refresh_from_db()
+        c2.refresh_from_db()
+        self.assertEqual(c1.model_name, legacy_unresolved_label("DeepInfra"))
+        self.assertEqual(c2.model_name, legacy_unresolved_label("NewRemoteInternal"))
+
+    def test_metadata_model_name_preferred_over_class_label(self):
+        cand = self._candidate(
+            0, REPR_DEEPINFRA, metadata={"model_name": "google/gemma-4-26B-A4B-it"}
+        )
+        run_command("--apply")
+        cand.refresh_from_db()
+        self.assertEqual(cand.model_name, "google/gemma-4-26B-A4B-it")
+
+    def test_clean_names_and_synthesized_untouched(self):
+        clean = self._candidate(0, "fhi-legacy")
+        synth = self._candidate(1, "synthesized")
+        run_command("--apply")
+        clean.refresh_from_db()
+        synth.refresh_from_db()
+        self.assertEqual(clean.model_name, "fhi-legacy")
+        self.assertEqual(synth.model_name, "synthesized")
+
+    def test_idempotent(self):
+        self._candidate(0, REPR_DEEPINFRA)
+        first = run_command("--apply")
+        self.assertIn("rows changed: 1", first)
+        second = run_command("--apply")
+        # Both sections (ProposedAppeal + ChooserCandidate) report zero.
+        self.assertEqual(second.count("rows changed: 0"), 2, second)
+
+    def test_no_address_survives_backfill(self):
+        self._candidate(0, REPR_DEEPINFRA)
+        self._candidate(1, REPR_INTERNAL)
+        run_command("--apply")
+        for value in ChooserCandidate.objects.values_list("model_name", flat=True):
+            self.assertNotIn("object at 0x", value)
+
+
+class BackfillAuditTest(TestCase):
+    def test_audit_is_read_only_and_reports_gaps(self):
+        denial = Denial.objects.create(
+            hashed_email="hash",
+            denial_text="denied",
+            procedure="MRI",
+            diagnosis="back pain",
+            insurance_company="TestIns",
+        )
+        pick = ProposedAppeal.objects.create(
+            for_denial=denial,
+            appeal_text="pick",
+            chosen=True,
+            model_name=None,
+        )
+        out = run_command("--audit")
+        pick.refresh_from_db()
+        self.assertIsNone(pick.model_name)
+        self.assertIn("chosen rows missing attribution: 1", out)
+        self.assertIn("read-only", out)

--- a/tests/sync/test_backfill_model_usage_attribution.py
+++ b/tests/sync/test_backfill_model_usage_attribution.py
@@ -231,6 +231,67 @@ class BackfillProposedAppealTest(TestCase):
         self.assertEqual(pick.model_name, "<not-a-repr>")
         self.assertIn("rows changed: 0", out)
 
+    def test_blank_pre_tracking_row_labeled_legacy(self):
+        # model_name is blank=True, so an empty-string chosen pick is "missing"
+        # just like NULL. A pre-tracking blank must be labeled legacy, not left
+        # to report as a current unattributed row.
+        pick = ProposedAppeal.objects.create(
+            for_denial=self.denial,
+            appeal_text="blank pick",
+            chosen=True,
+            model_name="",
+        )
+        ProposedAppeal.objects.filter(pk=pick.pk).update(created_at=None)
+        run_command("--apply")
+        pick.refresh_from_db()
+        self.assertEqual(pick.model_name, LEGACY_UNATTRIBUTED_LABEL)
+
+    def test_whitespace_pre_tracking_row_labeled_legacy(self):
+        pick = ProposedAppeal.objects.create(
+            for_denial=self.denial,
+            appeal_text="whitespace pick",
+            chosen=True,
+            model_name="   ",
+        )
+        ProposedAppeal.objects.filter(pk=pick.pk).update(created_at=None)
+        run_command("--apply")
+        pick.refresh_from_db()
+        self.assertEqual(pick.model_name, LEGACY_UNATTRIBUTED_LABEL)
+
+    def test_blank_post_tracking_row_normalized_to_null(self):
+        # A post-tracking blank pick is unrecoverable but shouldn't stay blank:
+        # collapse it to NULL, the canonical "missing" value, so it aggregates
+        # with other unattributed rows rather than forming its own bucket.
+        pick = ProposedAppeal.objects.create(
+            for_denial=self.denial,
+            appeal_text="post blank",
+            chosen=True,
+            model_name="",
+        )
+        run_command("--apply")
+        pick.refresh_from_db()
+        self.assertIsNone(pick.model_name)
+
+    def test_blank_row_recovered_when_sole_draft_exists(self):
+        # A blank chosen pick with a single-model draft set is recoverable and
+        # must be attributed to that model, not labeled legacy.
+        ProposedAppeal.objects.create(
+            for_denial=self.denial,
+            appeal_text="draft a",
+            chosen=False,
+            model_name="model-x",
+        )
+        pick = ProposedAppeal.objects.create(
+            for_denial=self.denial,
+            appeal_text="chosen text",
+            chosen=True,
+            model_name="",
+        )
+        ProposedAppeal.objects.filter(pk=pick.pk).update(created_at=None)
+        run_command("--apply")
+        pick.refresh_from_db()
+        self.assertEqual(pick.model_name, "model-x")
+
     def test_dry_run_by_default(self):
         pick = ProposedAppeal.objects.create(
             for_denial=self.denial,

--- a/tests/sync/test_backfill_model_usage_attribution.py
+++ b/tests/sync/test_backfill_model_usage_attribution.py
@@ -131,8 +131,10 @@ class BackfillProposedAppealTest(TestCase):
         )
         run_command("--apply")
         pick.refresh_from_db()
-        # Ambiguous: must be labeled, never guessed onto model-a or model-b.
-        self.assertEqual(pick.model_name, LEGACY_UNATTRIBUTED_LABEL)
+        # Ambiguous AND post-tracking (created_at set): never guessed onto
+        # model-a/model-b, and left NULL so it reports as "(unattributed)"
+        # rather than being mislabeled legacy.
+        self.assertIsNone(pick.model_name)
 
     def test_does_not_sole_draft_infer_for_editted_rows(self):
         # editted=True rows come from the share-appeal flow and may contain
@@ -152,7 +154,8 @@ class BackfillProposedAppealTest(TestCase):
         )
         run_command("--apply")
         pick.refresh_from_db()
-        self.assertEqual(pick.model_name, LEGACY_UNATTRIBUTED_LABEL)
+        # Post-tracking + unrecoverable => left NULL, not force-labeled.
+        self.assertIsNone(pick.model_name)
 
     def test_legacy_row_without_drafts_labeled_unattributed(self):
         pick = ProposedAppeal.objects.create(
@@ -197,6 +200,8 @@ class BackfillProposedAppealTest(TestCase):
             chosen=True,
             model_name=None,
         )
+        # Pre-tracking so it is a labelable legacy row (would change).
+        ProposedAppeal.objects.filter(pk=pick.pk).update(created_at=None)
         out = run_command()
         pick.refresh_from_db()
         self.assertIsNone(pick.model_name)
@@ -217,12 +222,14 @@ class BackfillProposedAppealTest(TestCase):
             model_name=None,
         )
         unrecoverable_denial = self._denial("legacy")
-        ProposedAppeal.objects.create(
+        ancient = ProposedAppeal.objects.create(
             for_denial=unrecoverable_denial,
             appeal_text="ancient",
             chosen=True,
             model_name=None,
         )
+        # Pre-tracking: labeled legacy (post-tracking NULL picks stay NULL).
+        ProposedAppeal.objects.filter(pk=ancient.pk).update(created_at=None)
         first = run_command("--apply")
         self.assertIn("rows changed: 2", first)
         second = run_command("--apply")
@@ -260,14 +267,13 @@ class BackfillChooserCandidateTest(TestCase):
             task_type="appeal", status="EXHAUSTED", source="synthetic"
         )
 
-    def _candidate(self, index, model_name, metadata=None, kind="appeal_letter"):
+    def _candidate(self, index, model_name, kind="appeal_letter"):
         return ChooserCandidate.objects.create(
             task=self.task,
             candidate_index=index,
             kind=kind,
             model_name=model_name,
             content="x",
-            metadata=metadata,
         )
 
     def test_object_reprs_normalized_to_class_label(self):
@@ -278,14 +284,6 @@ class BackfillChooserCandidateTest(TestCase):
         c2.refresh_from_db()
         self.assertEqual(c1.model_name, legacy_unresolved_label("DeepInfra"))
         self.assertEqual(c2.model_name, legacy_unresolved_label("NewRemoteInternal"))
-
-    def test_metadata_model_name_preferred_over_class_label(self):
-        cand = self._candidate(
-            0, REPR_DEEPINFRA, metadata={"model_name": "google/gemma-4-26B-A4B-it"}
-        )
-        run_command("--apply")
-        cand.refresh_from_db()
-        self.assertEqual(cand.model_name, "google/gemma-4-26B-A4B-it")
 
     def test_clean_names_and_synthesized_untouched(self):
         clean = self._candidate(0, "fhi-legacy")

--- a/tests/sync/test_mark_proposal_chosen.py
+++ b/tests/sync/test_mark_proposal_chosen.py
@@ -130,6 +130,18 @@ class MarkProposalChosenTest(TestCase):
         pa = mark_proposal_chosen(self.denial, "user authored text", editted=True)
         self.assertIsNone(pa.model_name)
 
+    def test_blank_sole_draft_model_name_not_inferred(self):
+        # model_name is blank=True; a blank/whitespace sole-draft label is
+        # not usable evidence and must not be stamped onto the pick.
+        ProposedAppeal.objects.create(
+            for_denial=self.denial,
+            appeal_text="blank-named draft",
+            chosen=False,
+            model_name="   ",
+        )
+        pa = mark_proposal_chosen(self.denial, "edited-text")
+        self.assertIsNone(pa.model_name)
+
     def test_sole_draft_inference_carries_synthesized_flag(self):
         ProposedAppeal.objects.create(
             for_denial=self.denial,

--- a/tests/sync/test_mark_proposal_chosen.py
+++ b/tests/sync/test_mark_proposal_chosen.py
@@ -68,7 +68,10 @@ class MarkProposalChosenTest(TestCase):
         self.assertTrue(pa.synthesized)
         self.assertEqual(pa.model_name, "synthesized")
 
-    def test_no_match_falls_back_to_none(self):
+    def test_no_match_single_model_denial_infers_that_model(self):
+        # sub_in_appeals rewrote the displayed text so no exact match exists,
+        # but every draft for this denial came from one model - the pick is
+        # attributable to it.
         ProposedAppeal.objects.create(
             for_denial=self.denial,
             appeal_text="original-text",
@@ -77,7 +80,67 @@ class MarkProposalChosenTest(TestCase):
         )
         pa = mark_proposal_chosen(self.denial, "edited-text")
         self.assertTrue(pa.chosen)
+        self.assertEqual(pa.model_name, "model-x")
+
+    def test_no_match_multiple_models_falls_back_to_none(self):
+        ProposedAppeal.objects.create(
+            for_denial=self.denial,
+            appeal_text="text-a",
+            chosen=False,
+            model_name="model-a",
+        )
+        ProposedAppeal.objects.create(
+            for_denial=self.denial,
+            appeal_text="text-b",
+            chosen=False,
+            model_name="model-b",
+        )
+        pa = mark_proposal_chosen(self.denial, "edited-text")
+        self.assertTrue(pa.chosen)
+        # Ambiguous - never guess between the candidate models.
         self.assertIsNone(pa.model_name)
+
+    def test_no_match_unnamed_draft_blocks_inference(self):
+        # A NULL-model draft could equally have been the pick's source, so
+        # the sole-draft inference must not fire.
+        ProposedAppeal.objects.create(
+            for_denial=self.denial,
+            appeal_text="named draft",
+            chosen=False,
+            model_name="model-x",
+        )
+        ProposedAppeal.objects.create(
+            for_denial=self.denial,
+            appeal_text="legacy draft",
+            chosen=False,
+            model_name=None,
+        )
+        pa = mark_proposal_chosen(self.denial, "edited-text")
+        self.assertIsNone(pa.model_name)
+
+    def test_editted_share_flow_never_infers(self):
+        # The share-appeal flow submits arbitrary user text (editted=True);
+        # even a single-model denial must not claim it.
+        ProposedAppeal.objects.create(
+            for_denial=self.denial,
+            appeal_text="only draft",
+            chosen=False,
+            model_name="model-x",
+        )
+        pa = mark_proposal_chosen(self.denial, "user authored text", editted=True)
+        self.assertIsNone(pa.model_name)
+
+    def test_sole_draft_inference_carries_synthesized_flag(self):
+        ProposedAppeal.objects.create(
+            for_denial=self.denial,
+            appeal_text="synth draft",
+            chosen=False,
+            model_name="synthesized",
+            synthesized=True,
+        )
+        pa = mark_proposal_chosen(self.denial, "rewritten synth pick")
+        self.assertEqual(pa.model_name, "synthesized")
+        self.assertTrue(pa.synthesized)
 
     def test_editted_flag_propagated(self):
         pa = mark_proposal_chosen(self.denial, "any-text", editted=True)

--- a/tests/sync/test_model_identity.py
+++ b/tests/sync/test_model_identity.py
@@ -1,0 +1,114 @@
+"""Tests for the canonical ML model reporting identity helpers."""
+
+from django.test import SimpleTestCase
+
+from fighthealthinsurance.ml.model_identity import (
+    LEGACY_UNATTRIBUTED_LABEL,
+    SYNTHESIZED_MODEL_NAME,
+    canonical_model_name,
+    is_object_repr,
+    legacy_unresolved_label,
+    normalize_model_label,
+)
+
+
+class FakeBackend:
+    """Duck-typed stand-in for RemoteModelLike: optional router-stamped
+    ``name`` plus the configured provider ``model`` string."""
+
+    name = None
+
+    def __init__(self, model=None, name=None):
+        if model is not None:
+            self.model = model
+        if name is not None:
+            self.name = name
+
+
+class BareBackend:
+    """No identity attributes at all - exercises the class-name fallback."""
+
+
+class CanonicalModelNameTest(SimpleTestCase):
+    def test_two_instances_of_same_configured_model_share_identity(self):
+        # Regression: previously str(model) produced per-instance
+        # "<... object at 0x...>" strings, splitting one configured model
+        # into many reporting rows.
+        a = FakeBackend(model="google/gemma-4-26B-A4B-it")
+        b = FakeBackend(model="google/gemma-4-26B-A4B-it")
+        self.assertEqual(canonical_model_name(a), canonical_model_name(b))
+        self.assertEqual(canonical_model_name(a), "google/gemma-4-26B-A4B-it")
+
+    def test_same_class_different_configured_models_stay_separate(self):
+        a = FakeBackend(model="deepseek-ai/DeepSeek-V4-Pro")
+        b = FakeBackend(model="google/gemma-4-26B-A4B-it")
+        self.assertNotEqual(canonical_model_name(a), canonical_model_name(b))
+
+    def test_router_stamped_name_preferred_over_provider_model(self):
+        # The registry key is what the appeal pipeline records on
+        # ProposedAppeal rows, so it wins for cross-source consistency.
+        m = FakeBackend(model="/models/fhi-2025-may", name="fhi-2025-may")
+        self.assertEqual(canonical_model_name(m), "fhi-2025-may")
+
+    def test_unstamped_none_name_falls_through_to_model(self):
+        # RemoteModelLike declares ``name = None`` at class level; an
+        # unstamped instance must not surface None (the old
+        # getattr(model, "name", str(model)) bug) nor a repr.
+        m = FakeBackend(model="sonar")
+        self.assertIsNone(m.name)
+        self.assertEqual(canonical_model_name(m), "sonar")
+
+    def test_class_name_fallback_is_stable_and_addressless(self):
+        a, b = BareBackend(), BareBackend()
+        self.assertEqual(canonical_model_name(a), "BareBackend")
+        self.assertEqual(canonical_model_name(a), canonical_model_name(b))
+
+    def test_never_contains_memory_address(self):
+        for candidate in (FakeBackend(model="x"), BareBackend(), FakeBackend()):
+            name = canonical_model_name(candidate)
+            self.assertIsNotNone(name)
+            self.assertNotIn("object at 0x", name)
+
+    def test_none_model_returns_none(self):
+        self.assertIsNone(canonical_model_name(None))
+
+
+class NormalizeModelLabelTest(SimpleTestCase):
+    REPR = "<fighthealthinsurance.ml.ml_models.DeepInfra object at 0x7f81456da840>"
+
+    def test_object_repr_normalizes_to_class_level_legacy_label(self):
+        self.assertEqual(
+            normalize_model_label(self.REPR), legacy_unresolved_label("DeepInfra")
+        )
+
+    def test_two_addresses_of_same_class_collapse(self):
+        other = "<fighthealthinsurance.ml.ml_models.DeepInfra object at 0x7deadbeef>"
+        self.assertEqual(normalize_model_label(self.REPR), normalize_model_label(other))
+
+    def test_normalized_label_never_keeps_address(self):
+        self.assertNotIn("0x", str(normalize_model_label(self.REPR)))
+        self.assertNotIn("object at", str(normalize_model_label(self.REPR)))
+
+    def test_regular_names_pass_through(self):
+        self.assertEqual(normalize_model_label("fhi-legacy"), "fhi-legacy")
+        self.assertEqual(normalize_model_label("  padded  "), "padded")
+
+    def test_synthesized_and_legacy_labels_pass_through(self):
+        self.assertEqual(
+            normalize_model_label(SYNTHESIZED_MODEL_NAME), SYNTHESIZED_MODEL_NAME
+        )
+        self.assertEqual(
+            normalize_model_label(LEGACY_UNATTRIBUTED_LABEL),
+            LEGACY_UNATTRIBUTED_LABEL,
+        )
+
+    def test_none_and_empty_normalize_to_none(self):
+        self.assertIsNone(normalize_model_label(None))
+        self.assertIsNone(normalize_model_label(""))
+        self.assertIsNone(normalize_model_label("   "))
+
+    def test_is_object_repr(self):
+        self.assertTrue(is_object_repr(self.REPR))
+        self.assertFalse(is_object_repr("fhi-legacy"))
+        self.assertFalse(is_object_repr(None))
+        self.assertFalse(is_object_repr("<html>"))

--- a/tests/sync/test_model_usage_dashboard.py
+++ b/tests/sync/test_model_usage_dashboard.py
@@ -1,12 +1,18 @@
 """Tests for the ML Model Usage staff dashboard."""
 
 import datetime
+import json
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
 
+from fighthealthinsurance.ml.model_identity import (
+    LEGACY_UNATTRIBUTED_LABEL,
+    SYNTHESIZED_MODEL_NAME,
+    legacy_unresolved_label,
+)
 from fighthealthinsurance.models import (
     ChooserCandidate,
     ChooserTask,
@@ -31,10 +37,19 @@ class MergeStatsTest(TestCase):
         self.assertAlmostEqual(rows[1]["win_rate"], 80.0)
 
     def test_merge_handles_zero_presented(self):
+        # No denominator: win_rate must be None (rendered as an em dash),
+        # never a misleading 0.0%.
         rows = _merge_stats({"a": 5}, {})
         self.assertEqual(rows[0]["chosen"], 5)
         self.assertEqual(rows[0]["presented"], 0)
-        self.assertEqual(rows[0]["win_rate"], 0.0)
+        self.assertIsNone(rows[0]["win_rate"])
+
+    def test_merge_zero_chosen_with_presented_is_zero_percent(self):
+        # A real denominator with zero wins IS a genuine 0.0%.
+        rows = _merge_stats({}, {"a": 4})
+        self.assertEqual(rows[0]["chosen"], 0)
+        self.assertEqual(rows[0]["presented"], 4)
+        self.assertAlmostEqual(rows[0]["win_rate"], 0.0)
 
     def test_merge_includes_presented_only_models(self):
         rows = _merge_stats({"a": 5}, {"a": 10, "b": 2})
@@ -257,12 +272,351 @@ class ModelUsageDashboardContentTest(TestCase):
         response = self.client.get(reverse("model_usage_dashboard"))
         rows = response.context["windows"][0]["proposed_appeal"]
         by_name = {r["model_name"]: r for r in rows}
-        # Both the attributed pick and the unknown pick show up.
+        # Both the attributed pick and the unattributed pick show up.
         self.assertIn("m1", by_name)
         self.assertIn(UNKNOWN_MODEL_LABEL, by_name)
         self.assertEqual(by_name["m1"]["chosen"], 1)
         self.assertEqual(by_name[UNKNOWN_MODEL_LABEL]["chosen"], 1)
-        # Unknown has no presented count (we don't know which model
-        # generated the draft), so win_rate is 0.
+        # Unattributed has no presented count (we don't know which model
+        # generated the draft), so win_rate is undefined - None, not 0%.
         self.assertEqual(by_name[UNKNOWN_MODEL_LABEL]["presented"], 0)
-        self.assertEqual(by_name[UNKNOWN_MODEL_LABEL]["win_rate"], 0.0)
+        self.assertIsNone(by_name[UNKNOWN_MODEL_LABEL]["win_rate"])
+
+
+class ChooserStatsHelperMixin:
+    """Shared builders for chooser tasks/candidates/votes in dashboard tests."""
+
+    def _make_task(self, task_type="appeal"):
+        return ChooserTask.objects.create(
+            task_type=task_type, status="EXHAUSTED", source="synthetic"
+        )
+
+    def _make_candidate(self, task, index, model_name, kind="appeal_letter", **kwargs):
+        return ChooserCandidate.objects.create(
+            task=task,
+            candidate_index=index,
+            kind=kind,
+            model_name=model_name,
+            content=f"content-{index}",
+            **kwargs,
+        )
+
+    def _vote(self, task, chosen, presented, session="sess1"):
+        return ChooserVote.objects.create(
+            task=task,
+            chosen_candidate=chosen,
+            presented_candidate_ids=[c.id for c in presented],
+            session_key=session,
+        )
+
+
+class ModelUsageDashboardNormalizationTest(ChooserStatsHelperMixin, TestCase):
+    """Object-repr model names must never leak into dashboard keys."""
+
+    REPR_A1 = "<fighthealthinsurance.ml.ml_models.DeepInfra object at 0x7f81456da840>"
+    REPR_A2 = "<fighthealthinsurance.ml.ml_models.DeepInfra object at 0x7deadbeef000>"
+    REPR_B = (
+        "<fighthealthinsurance.ml.ml_models.NewRemoteInternal object at 0x7d65196f8bc0>"
+    )
+
+    def setUp(self):
+        self.staff = User.objects.create_user(
+            username="staff", password="pw123", is_staff=True
+        )
+        self.client.login(username="staff", password="pw123")
+
+    def _get_windows(self):
+        response = self.client.get(reverse("model_usage_dashboard"))
+        return response, response.context["windows"]
+
+    def test_no_dashboard_key_contains_object_repr(self):
+        task = self._make_task()
+        c1 = self._make_candidate(task, 0, self.REPR_A1)
+        c2 = self._make_candidate(task, 1, self.REPR_B)
+        self._vote(task, c1, [c1, c2])
+        # A chat vote with a repr-named candidate too.
+        chat_task = self._make_task("chat")
+        c3 = self._make_candidate(chat_task, 0, self.REPR_A2, kind="chat_response")
+        self._vote(chat_task, c3, [c3])
+
+        response, windows = self._get_windows()
+        for w in windows:
+            for source in ("proposed_appeal", "chooser_appeal", "chooser_chat"):
+                for row in w[source]:
+                    self.assertNotIn("object at 0x", row["model_name"])
+            self.assertNotIn("object at 0x", w["chart_data_json"])
+        self.assertNotContains(response, "object at 0x")
+
+    def test_same_class_repr_instances_aggregate_into_one_row(self):
+        # Two different memory addresses of the same class - historically two
+        # separate dashboard rows - must aggregate under one class-level
+        # legacy label.
+        task1 = self._make_task()
+        c1 = self._make_candidate(task1, 0, self.REPR_A1)
+        c2 = self._make_candidate(task1, 1, "clean-model")
+        self._vote(task1, c1, [c1, c2])
+        task2 = self._make_task()
+        c3 = self._make_candidate(task2, 0, self.REPR_A2)
+        c4 = self._make_candidate(task2, 1, "clean-model")
+        self._vote(task2, c3, [c3, c4], session="sess2")
+
+        _, windows = self._get_windows()
+        rows = windows[0]["chooser_appeal"]
+        by_name = {r["model_name"]: r for r in rows}
+        label = legacy_unresolved_label("DeepInfra")
+        self.assertIn(label, by_name)
+        self.assertEqual(by_name[label]["chosen"], 2)
+        self.assertEqual(by_name[label]["presented"], 2)
+        # And the two addresses did not create separate rows.
+        self.assertEqual(
+            len([n for n in by_name if "DeepInfra" in n]), 1, by_name.keys()
+        )
+
+
+class ModelUsageDashboardSemanticsTest(ChooserStatsHelperMixin, TestCase):
+    def setUp(self):
+        self.staff = User.objects.create_user(
+            username="staff", password="pw123", is_staff=True
+        )
+        self.client.login(username="staff", password="pw123")
+
+    def _rows(self, source="chooser_appeal", window=0):
+        response = self.client.get(reverse("model_usage_dashboard"))
+        return response.context["windows"][window][source]
+
+    def test_presented_and_chosen_candidate_counts_once_each(self):
+        # One vote across three candidates: every candidate presented once,
+        # only the selected one chosen; selected contributes to both.
+        task = self._make_task()
+        a = self._make_candidate(task, 0, "model-a")
+        b = self._make_candidate(task, 1, "model-b")
+        c = self._make_candidate(task, 2, "model-c")
+        self._vote(task, a, [a, b, c])
+
+        by_name = {r["model_name"]: r for r in self._rows()}
+        self.assertEqual(by_name["model-a"]["presented"], 1)
+        self.assertEqual(by_name["model-a"]["chosen"], 1)
+        self.assertAlmostEqual(by_name["model-a"]["win_rate"], 100.0)
+        for loser in ("model-b", "model-c"):
+            self.assertEqual(by_name[loser]["presented"], 1)
+            self.assertEqual(by_name[loser]["chosen"], 0)
+            self.assertAlmostEqual(by_name[loser]["win_rate"], 0.0)
+
+    def test_duplicate_presented_ids_counted_once(self):
+        # A historical/hostile vote row with duplicated presented ids must
+        # not inflate the denominator.
+        task = self._make_task()
+        a = self._make_candidate(task, 0, "model-a")
+        b = self._make_candidate(task, 1, "model-b")
+        ChooserVote.objects.create(
+            task=task,
+            chosen_candidate=a,
+            presented_candidate_ids=[a.id, a.id, b.id, b.id, b.id],
+            session_key="sess1",
+        )
+        by_name = {r["model_name"]: r for r in self._rows()}
+        self.assertEqual(by_name["model-a"]["presented"], 1)
+        self.assertEqual(by_name["model-b"]["presented"], 1)
+
+    def test_multiple_chosen_rows_do_not_duplicate_presented(self):
+        # Two picks on the same denial (re-submit): drafts still count once.
+        denial = Denial.objects.create(
+            hashed_email="hash",
+            denial_text="denied",
+            procedure="MRI",
+            diagnosis="back pain",
+            insurance_company="TestIns",
+        )
+        ProposedAppeal.objects.create(
+            for_denial=denial, appeal_text="draft", chosen=False, model_name="m1"
+        )
+        for _ in range(2):
+            ProposedAppeal.objects.create(
+                for_denial=denial, appeal_text="draft", chosen=True, model_name="m1"
+            )
+        rows = self._rows(source="proposed_appeal")
+        m1 = next(r for r in rows if r["model_name"] == "m1")
+        self.assertEqual(m1["presented"], 1)
+        self.assertEqual(m1["chosen"], 2)
+
+    def test_zero_denominator_renders_em_dash(self):
+        denial = Denial.objects.create(
+            hashed_email="hash",
+            denial_text="denied",
+            procedure="MRI",
+            diagnosis="back pain",
+            insurance_company="TestIns",
+        )
+        # Legacy pick: no model, no created_at, no drafts.
+        pa = ProposedAppeal.objects.create(
+            for_denial=denial, appeal_text="legacy pick", chosen=True, model_name=None
+        )
+        ProposedAppeal.objects.filter(pk=pa.pk).update(created_at=None)
+
+        response = self.client.get(reverse("model_usage_dashboard"))
+        rows = response.context["windows"][0]["proposed_appeal"]
+        legacy = next(r for r in rows if r["model_name"] == LEGACY_UNATTRIBUTED_LABEL)
+        self.assertEqual(legacy["presented"], 0)
+        self.assertIsNone(legacy["win_rate"])
+        self.assertContains(response, '<td class="num">&mdash;</td>')
+
+    def test_legacy_null_created_at_only_in_all_time(self):
+        denial = Denial.objects.create(
+            hashed_email="hash",
+            denial_text="denied",
+            procedure="MRI",
+            diagnosis="back pain",
+            insurance_company="TestIns",
+        )
+        pa = ProposedAppeal.objects.create(
+            for_denial=denial, appeal_text="legacy pick", chosen=True, model_name=None
+        )
+        ProposedAppeal.objects.filter(pk=pa.pk).update(created_at=None)
+
+        response = self.client.get(reverse("model_usage_dashboard"))
+        by_slug = {w["slug"]: w for w in response.context["windows"]}
+        global_names = {r["model_name"] for r in by_slug["global"]["proposed_appeal"]}
+        self.assertIn(LEGACY_UNATTRIBUTED_LABEL, global_names)
+        for slug in ("1d", "7d", "30d"):
+            names = {r["model_name"] for r in by_slug[slug]["proposed_appeal"]}
+            self.assertNotIn(LEGACY_UNATTRIBUTED_LABEL, names, slug)
+
+    def test_synthesized_bucket_preserved(self):
+        denial = Denial.objects.create(
+            hashed_email="hash",
+            denial_text="denied",
+            procedure="MRI",
+            diagnosis="back pain",
+            insurance_company="TestIns",
+        )
+        ProposedAppeal.objects.create(
+            for_denial=denial,
+            appeal_text="synth draft",
+            chosen=False,
+            model_name=SYNTHESIZED_MODEL_NAME,
+            synthesized=True,
+        )
+        ProposedAppeal.objects.create(
+            for_denial=denial,
+            appeal_text="synth draft",
+            chosen=True,
+            model_name=SYNTHESIZED_MODEL_NAME,
+            synthesized=True,
+        )
+        task = self._make_task()
+        base = self._make_candidate(task, 0, "model-a")
+        synth = self._make_candidate(task, 1, SYNTHESIZED_MODEL_NAME, synthesized=True)
+        self._vote(task, synth, [base, synth])
+
+        response = self.client.get(reverse("model_usage_dashboard"))
+        proposed = response.context["windows"][0]["proposed_appeal"]
+        chooser = response.context["windows"][0]["chooser_appeal"]
+        prow = next(r for r in proposed if r["model_name"] == SYNTHESIZED_MODEL_NAME)
+        crow = next(r for r in chooser if r["model_name"] == SYNTHESIZED_MODEL_NAME)
+        self.assertEqual(prow["chosen"], 1)
+        self.assertEqual(prow["presented"], 1)
+        self.assertEqual(crow["chosen"], 1)
+        self.assertEqual(crow["presented"], 1)
+
+
+class ModelUsageDashboardWindowTest(ChooserStatsHelperMixin, TestCase):
+    """Rolling-window boundary behavior for 1d / 7d / 30d / All Time."""
+
+    def setUp(self):
+        self.staff = User.objects.create_user(
+            username="staff", password="pw123", is_staff=True
+        )
+        self.client.login(username="staff", password="pw123")
+
+    def _make_vote_hours_ago(self, model_name, hours, session):
+        task = self._make_task()
+        cand = self._make_candidate(task, 0, model_name)
+        vote = self._vote(task, cand, [cand], session=session)
+        ChooserVote.objects.filter(pk=vote.pk).update(
+            created_at=timezone.now() - datetime.timedelta(hours=hours)
+        )
+        return vote
+
+    def test_window_slugs_and_order(self):
+        response = self.client.get(reverse("model_usage_dashboard"))
+        slugs = [w["slug"] for w in response.context["windows"]]
+        self.assertEqual(slugs, ["global", "1d", "7d", "30d"])
+        labels = [w["label"] for w in response.context["windows"]]
+        self.assertEqual(
+            labels, ["All Time", "Last 1 Day", "Last 7 Days", "Last 30 Days"]
+        )
+
+    def test_rolling_window_boundaries(self):
+        # 23h old: in every window. 25h: out of 1d, in 7d/30d.
+        # 6d23h: in 7d. 7d1h: out of 7d, in 30d. 45d: All Time only.
+        self._make_vote_hours_ago("m-23h", 23, "s1")
+        self._make_vote_hours_ago("m-25h", 25, "s2")
+        self._make_vote_hours_ago("m-6d23h", 7 * 24 - 1, "s3")
+        self._make_vote_hours_ago("m-7d1h", 7 * 24 + 1, "s4")
+        self._make_vote_hours_ago("m-45d", 45 * 24, "s5")
+
+        response = self.client.get(reverse("model_usage_dashboard"))
+        by_slug = {w["slug"]: w for w in response.context["windows"]}
+
+        def names(slug):
+            return {r["model_name"] for r in by_slug[slug]["chooser_appeal"]}
+
+        self.assertEqual(
+            names("global"), {"m-23h", "m-25h", "m-6d23h", "m-7d1h", "m-45d"}
+        )
+        self.assertEqual(names("1d"), {"m-23h"})
+        self.assertEqual(names("7d"), {"m-23h", "m-25h", "m-6d23h"})
+        self.assertEqual(names("30d"), {"m-23h", "m-25h", "m-6d23h", "m-7d1h"})
+
+
+class ModelUsageDashboardChartTableAgreementTest(ChooserStatsHelperMixin, TestCase):
+    def setUp(self):
+        self.staff = User.objects.create_user(
+            username="staff", password="pw123", is_staff=True
+        )
+        self.client.login(username="staff", password="pw123")
+
+    def test_chart_series_match_table_rows(self):
+        denial = Denial.objects.create(
+            hashed_email="hash",
+            denial_text="denied",
+            procedure="MRI",
+            diagnosis="back pain",
+            insurance_company="TestIns",
+        )
+        ProposedAppeal.objects.create(
+            for_denial=denial, appeal_text="a", chosen=False, model_name="m1"
+        )
+        ProposedAppeal.objects.create(
+            for_denial=denial, appeal_text="a", chosen=True, model_name="m1"
+        )
+        task = self._make_task()
+        a = self._make_candidate(task, 0, "model-a")
+        b = self._make_candidate(task, 1, "model-b")
+        self._vote(task, a, [a, b])
+        chat_task = self._make_task("chat")
+        c = self._make_candidate(chat_task, 0, "chat-model", kind="chat_response")
+        self._vote(chat_task, c, [c])
+
+        response = self.client.get(reverse("model_usage_dashboard"))
+        for w in response.context["windows"]:
+            chart = json.loads(w["chart_data_json"])
+            series_by_name = {s["name"]: s for s in chart["series"]}
+            for source_key, series_name in (
+                ("proposed_appeal", "ProposedAppeal (denial flow)"),
+                ("chooser_appeal", "Chooser - Appeal"),
+                ("chooser_chat", "Chooser - Chat"),
+            ):
+                table = {r["model_name"]: r["chosen"] for r in w[source_key]}
+                points = {
+                    p["label"]: p["y"]
+                    for p in series_by_name[series_name]["dataPoints"]
+                }
+                # Every table row appears in the chart with the same count.
+                for name, chosen in table.items():
+                    self.assertEqual(points.get(name, 0), chosen, (w["slug"], name))
+                # And the chart never invents non-zero counts absent from
+                # the table.
+                for name, y in points.items():
+                    if y:
+                        self.assertEqual(table.get(name, 0), y, (w["slug"], name))


### PR DESCRIPTION
## Summary

This PR fixes critical bugs in the ML model usage dashboard's win-rate calculation and model name normalization, ensuring accurate attribution and preventing misleading statistics.

## Key Changes

### Win-Rate Calculation Fix
- **Changed win_rate semantics**: When a model has no presented count (zero denominator), `win_rate` is now `None` instead of `0.0%`. This prevents displaying misleading "0% win rate" for models with only chosen counts and no presentation records (e.g., legacy picks without draft attribution).
- **Template rendering**: Updated `model_usage_table_partial.html` to render `None` as an em dash (`&mdash;`) rather than a percentage, making the distinction between "0% (genuine zero wins)" and "undefined (no denominator)" visually clear.
- **Sorting fix**: Updated sort key to handle `None` win_rate values correctly, placing undefined rates after valid percentages.

### Model Name Normalization
- **New module `fighthealthinsurance/ml/model_identity.py`**: Provides canonical reporting identity for ML models with three-tier preference:
  1. Router-stamped friendly name (registry key)
  2. Configured provider model identifier
  3. Class name as stable fallback
  - Prevents memory addresses from leaking into dashboard keys
  - Ensures same configured model instances aggregate under one identity
  - Handles special `synthesized` pseudo-model name

- **Backfill command `backfill_model_usage_attribution.py`**: Repairs historical data problems:
  - Recovers `NULL` model_name on chosen `ProposedAppeal` rows via exact text match or sole-draft inference
  - Normalizes object repr values (`<...DeepInfra object at 0x...>`) to class-level legacy labels
  - Stamps unrecoverable pre-tracking rows with `legacy-unattributed` label
  - Dry-run by default; idempotent and safe

### Dashboard Improvements
- **Terminology update**: Changed "unknown" to "(unattributed)" for post-tracking picks with no model attribution
- **New label `LEGACY_UNATTRIBUTED_LABEL`**: Distinguishes pre-tracking picks (no recovery possible) from live unattributed picks (still recoverable)
- **Time-window semantics**: Documented that "All Time" window includes pre-tracking rows (created_at NULL), while bounded windows exclude them
- **Model name normalization in dashboard**: All stored model names pass through `normalize_model_label()` so historical object-repr values aggregate per class even before backfill runs

### Supporting Changes
- **`ProposedAppeal.sole_draft_attribution()`**: New static method for inferring model attribution when every draft for a denial came from one model
- **`mark_proposal_chosen()` enhancement**: Now uses sole-draft inference as fallback when exact text match fails (but skips inference for editted=True rows)
- **`ChooserStatsHelperMixin`**: Shared test builder for chooser tasks/candidates/votes
- **Comprehensive test coverage**: New test classes for normalization, semantics, and backfill command with edge cases (duplicate presented IDs, multiple chosen rows, legacy NULL created_at)

## Notable Implementation Details

- **Safety properties**: Backfill is idempotent (repaired rows no longer match repair conditions), only touches pre-tracking rows (created_at NULL), and never overwrites valid canonical names
- **Sorting stability**: Win-rate sort now treats `None` as -1.0 internally to place undefined rates after valid percentages
- **Dashboard aggregation**: Two different memory addresses of the same class (e.g., `DeepInfra` instances) now aggregate under one `legacy-unresolved (DeepInfra)` label
- **Presentation counting**: Duplicate presented IDs in votes are deduplicated; multiple chosen rows on same denial count presented once

https://claude.ai/code/session_013YhHN5S7XmKA245uxvib7y

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent model attribution across appeals, chat candidates, and synthesized results.
  * Added tools to audit and backfill historical model-usage attribution safely.
  * Improved recovery of model attribution when a single draft source is unambiguous.

* **Bug Fixes**
  * Removed duplicate presented candidates from voting and dashboard counts.
  * Prevented object-memory-address labels from appearing in model-usage reports.
  * Win rates without presented results now display an em dash instead of 0%.

* **Documentation**
  * Expanded dashboard explanations for time windows, legacy attribution, synthesized results, and win-rate calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->