### PR TITLE
ci: add automated Browserslist DB update workflow

### DIFF
--- a/.github/workflows/update-browserslist-db.yml
+++ b/.github/workflows/update-browserslist-db.yml
@@ -1,0 +1,64 @@
+name: Update Browserslist DB
+
+# Keeps the frontend browser support baseline current by refreshing the
+# Browserslist database (the `caniuse-lite` + `baseline-browser-mapping`
+# packages) that webpack/babel consult when compiling the React/TS bundle.
+# Stale data produces "Browserslist: caniuse-lite is outdated" build warnings
+# and can miss newer browsers, so we refresh it on a schedule and open a PR
+# with the change for review.
+
+on:
+  schedule:
+    # 06:00 UTC on the 1st day of every 3rd month (Jan, Apr, Jul, Oct),
+    # i.e. roughly once a quarter / every few months.
+    - cron: "0 6 1 */3 *"
+  # Allow maintainers to trigger the refresh on demand from the Actions tab.
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: update-browserslist-db
+  cancel-in-progress: false
+
+jobs:
+  update-browserslist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Update Browserslist database
+        working-directory: fighthealthinsurance/static/js
+        run: npx --yes update-browserslist-db@latest
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          # Prefer a PAT (secret BROWSERSLIST_UPDATE_TOKEN) so the resulting PR
+          # triggers the CI workflows; fall back to the default GITHUB_TOKEN,
+          # which opens the PR but (by design) will not kick off other workflows.
+          token: ${{ secrets.BROWSERSLIST_UPDATE_TOKEN || github.token }}
+          add-paths: fighthealthinsurance/static/js/package-lock.json
+          branch: chore/update-browserslist-db
+          delete-branch: true
+          commit-message: "chore(deps): update Browserslist DB (caniuse-lite)"
+          title: "chore(deps): update Browserslist DB"
+          body: |
+            Automated refresh of the Browserslist database via
+            `npx update-browserslist-db@latest`, run from
+            `fighthealthinsurance/static/js`.
+
+            This bumps the `caniuse-lite` and `baseline-browser-mapping` entries
+            in `package-lock.json` so the browser support baseline used by
+            webpack/babel stays current and the "caniuse-lite is outdated" build
+            warning stays quiet.
+
+            Opened automatically by the `Update Browserslist DB` workflow. If no
+            update was available this PR will not be created.

--- a/.github/workflows/update-browserslist-db.yml
+++ b/.github/workflows/update-browserslist-db.yml
@@ -28,15 +28,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Don't leave the job's write token in the local git config: the
+          # updater step below runs third-party npm code, and create-pull-request
+          # authenticates its own push via its `token` input, so nothing here
+          # needs persisted checkout credentials.
+          persist-credentials: false
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
 
       - name: Update Browserslist database
         working-directory: fighthealthinsurance/static/js
-        run: npx --yes update-browserslist-db@latest
+        # Pin the updater tool to a known-good version (bump intentionally)
+        # rather than @latest, so a scheduled run can't pull and execute an
+        # unvetted release. The tool still fetches the newest browser DATA
+        # (caniuse-lite / baseline-browser-mapping), which is the point.
+        run: npx --yes update-browserslist-db@1.1.3
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
@@ -52,7 +62,7 @@ jobs:
           title: "chore(deps): update Browserslist DB"
           body: |
             Automated refresh of the Browserslist database via
-            `npx update-browserslist-db@latest`, run from
+            `npx update-browserslist-db`, run from
             `fighthealthinsurance/static/js`.
 
             This bumps the `caniuse-lite` and `baseline-browser-mapping` entries


### PR DESCRIPTION
## Summary
Adds a new GitHub Actions workflow that automatically updates the Browserslist database (caniuse-lite and baseline-browser-mapping packages) on a quarterly schedule. This keeps the frontend browser support baseline current and prevents stale data warnings during webpack/babel compilation.

## Key Changes
- **New workflow file**: `.github/workflows/update-browserslist-db.yml`
  - Scheduled to run quarterly (1st day of Jan, Apr, Jul, Oct at 06:00 UTC)
  - Can be manually triggered via the Actions tab
  - Runs `npx update-browserslist-db@latest` in the `fighthealthinsurance/static/js` directory
  - Automatically opens a pull request with the updated `package-lock.json`

## Implementation Details
- Uses `peter-evans/create-pull-request@v7` to create PRs with proper branch management
- Prefers a custom PAT token (`BROWSERSLIST_UPDATE_TOKEN`) to trigger CI workflows on the resulting PR; falls back to `GITHUB_TOKEN` if unavailable
- Includes clear commit message and PR body explaining the purpose of the update
- Sets `cancel-in-progress: false` to ensure updates complete even if triggered multiple times
- Only commits changes to `package-lock.json` (the actual dependency updates)

This automation ensures the "caniuse-lite is outdated" build warning stays quiet and the browser support data used by webpack/babel remains current without manual intervention.

https://claude.ai/code/session_019uvyrA6M9uX5rhd98BjD8J

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated quarterly updates for browser compatibility data.
  * Updates can also be triggered manually.
  * Automated updates create a pull request for review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->