### PR TITLE
Add physical intro letter support to Pro Connector

### DIFF
--- a/fighthealthinsurance/proconnector.py
+++ b/fighthealthinsurance/proconnector.py
@@ -129,6 +129,31 @@ Sincerely,
 Holden Karau, Melanie Warrick, and the Fight Health Insurance team"""
 
 
+# The print-only physical letter. Same warm framing and compensation disclosure
+# as the email, but written to be mailed: a printed letter can't CC Cofactor AI,
+# so instead of naming a CC it asks the recipient to email the professional
+# contact address for the introduction. ``{greeting_name}`` is the recipient's
+# name (or a neutral greeting) and ``{contact_email}`` is the professional
+# contact address they should reach out to.
+BASE_INTRO_LETTER = """Dear {greeting_name},
+
+Thank you so much for your interest in the professional version of Fight Health Insurance.
+
+We'd like to introduce you to Cofactor AI. After our initial work launching Fight Paperwork, we've refocused Fight Health Insurance on our consumer mission, and we now have a sourcing agreement with Cofactor AI to introduce interested professionals who may benefit from their AI-powered support for appeals, prior authorization, and related backend workflows.
+
+As part of this sourcing agreement, Fight Health Insurance may receive compensation if you choose to work with Cofactor AI; that support helps us continue our consumer-focused mission.
+
+We've spent a lot of time talking with the Cofactor AI team, and they've built some truly impressive AI agents for appeals and administrative tasks. We think they may be a strong fit for the kinds of professional workflows many of you reached out to us about.
+
+If you're interested in an introduction, please email us at {contact_email} and we'll connect you with the Cofactor AI team.
+
+Thank you again for your interest and for trusting us with this work.
+
+Sincerely,
+
+Holden Karau, Melanie Warrick, and the Fight Health Insurance team"""
+
+
 INTRO_SYSTEM_PROMPT = (
     "You are an assistant for Fight Health Insurance (FHI) drafting a warm, "
     "professional, concise introduction email to a healthcare professional who "
@@ -171,21 +196,59 @@ def build_base_intro_email(pro: InterestedProfessional) -> str:
     return BASE_INTRO_EMAIL.format(greeting_name=_greeting_name(pro))
 
 
-def build_search_links(pro: InterestedProfessional) -> dict[str, Optional[str]]:
-    """Google + LinkedIn search URLs for the person's name plus organization.
+def build_base_intro_letter(pro: InterestedProfessional) -> str:
+    """Render the print-only physical intro letter for ``pro``.
 
-    Organization (``business_name``) is included only when present. Returns
-    ``None`` for each link when there is nothing to search on.
+    Uses the same warm framing and compensation disclosure as the email, but the
+    print-specific wording: a mailed letter can't CC Cofactor AI, so it asks the
+    recipient to email the professional contact address for the introduction
+    instead of naming a CC.
+    """
+    return BASE_INTRO_LETTER.format(
+        greeting_name=_greeting_name(pro),
+        contact_email=get_professional_cc_email(),
+    )
+
+
+def build_search_links(pro: InterestedProfessional) -> dict[str, Optional[str]]:
+    """Research search URLs for a professional.
+
+    ``google``/``linkedin`` search the person's name plus organization (the
+    organization is included only when present) to help staff research them.
+    ``google_address`` searches for a mailing address to help staff address the
+    physical intro letter (see :func:`build_address_search_link`). Each value is
+    ``None`` when there is nothing to search on.
     """
     parts = [p.strip() for p in (pro.name, pro.business_name) if p and p.strip()]
     terms = " ".join(parts).strip()
+    address_link = build_address_search_link(pro)
     if not terms:
-        return {"google": None, "linkedin": None}
+        return {"google": None, "linkedin": None, "google_address": address_link}
     q = urllib.parse.quote(terms)
     return {
         "google": f"https://www.google.com/search?q={q}",
         "linkedin": f"https://www.linkedin.com/search/results/all/?keywords={q}",
+        "google_address": address_link,
     }
+
+
+def build_address_search_link(pro: InterestedProfessional) -> Optional[str]:
+    """Google search URL to find or verify the professional's mailing address.
+
+    When an address is already on file it is searched directly (to locate /
+    verify it, e.g. on maps); otherwise the name and organization are searched
+    together with the word "address" to help staff track one down for the
+    physical intro letter. Returns ``None`` when there is nothing to search on.
+    """
+    address = (pro.address or "").strip()
+    if address:
+        terms = address
+    else:
+        parts = [p.strip() for p in (pro.name, pro.business_name) if p and p.strip()]
+        if not parts:
+            return None
+        terms = " ".join(parts + ["address"])
+    return f"https://www.google.com/search?q={urllib.parse.quote(terms)}"
 
 
 def describe_known_info(pro: InterestedProfessional) -> str:

--- a/fighthealthinsurance/staff_views.py
+++ b/fighthealthinsurance/staff_views.py
@@ -42,6 +42,7 @@ from fighthealthinsurance.email_utils import is_sendable_email
 from fighthealthinsurance.business_hours import describe_send_window
 from fighthealthinsurance.proconnector import (
     PROCONNECTOR_INTRO_SUBJECT,
+    build_base_intro_letter,
     build_search_links,
     claim_email_for_send,
     generate_intro_email,
@@ -800,6 +801,7 @@ class ProConnectorProcessView(View):
             "cc_email": get_professional_cc_email(),
             "google_search_url": links["google"],
             "linkedin_search_url": links["linkedin"],
+            "google_address_search_url": links["google_address"],
             "skip_reason": skip_reason,
             "test_email": test_email,
             "error": error,
@@ -1030,6 +1032,37 @@ class ProConnectorProcessView(View):
                 "record -- the real intro has NOT been sent."
             ),
         )
+
+
+class ProConnectorLetterView(View):
+    """Print-friendly physical intro letter for an interested professional.
+
+    A companion to :class:`ProConnectorProcessView`: for professionals worth
+    reaching by mail in addition to email, this renders the Cofactor AI
+    introduction as a physical business letter that staff open, print, and mail.
+    The wording differs from the email -- a printed letter can't CC Cofactor AI,
+    so instead of naming a CC it asks the recipient to email the professional
+    contact address for the introduction. This view only renders the letter; it
+    never claims, sends, or records anything on the professional's record, so it
+    can be opened without affecting the processing queue.
+    """
+
+    template_name = "proconnector_letter.html"
+
+    def get(self, request, pro_id: int) -> HttpResponse:
+        pro = InterestedProfessional.objects.filter(pk=pro_id).first()
+        if pro is None:
+            # Bad / stale id (deleted record, hand-edited URL). Send staff back
+            # to the processing page rather than 404 on a transient link.
+            return redirect("proconnector_process")
+        context = {
+            "title": "Pro Connector Letter",
+            "pro": pro,
+            "letter_body": build_base_intro_letter(pro),
+            "contact_email": get_professional_cc_email(),
+            "today": timezone.now().date(),
+        }
+        return render(request, self.template_name, context)
 
 
 class _CSVEcho:

--- a/fighthealthinsurance/templates/proconnector.html
+++ b/fighthealthinsurance/templates/proconnector.html
@@ -49,6 +49,17 @@
       text-decoration: none;
     }
     .research a:hover { background-color: #dbe6ff; }
+    a.print-letter {
+      display: inline-block;
+      margin-top: 6px;
+      padding: 10px 18px;
+      background-color: #6f42c1;
+      color: white;
+      border-radius: 4px;
+      text-decoration: none;
+      font-size: 15px;
+    }
+    a.print-letter:hover { background-color: #59339d; }
     label { display: block; font-weight: bold; margin-top: 14px; color: #444; }
     input[type=text], textarea {
       width: 100%;
@@ -158,13 +169,27 @@
         <tr><th>Last modified</th><td>{{ pro.mod_date }}</td></tr>
       </table>
 
-      {% if google_search_url or linkedin_search_url %}
+      {% if google_search_url or linkedin_search_url or google_address_search_url %}
         <h3>Research</h3>
         <div class="research">
           {% if google_search_url %}<a href="{{ google_search_url }}" target="_blank" rel="noopener noreferrer">Google search &#8599;</a>{% endif %}
           {% if linkedin_search_url %}<a href="{{ linkedin_search_url }}" target="_blank" rel="noopener noreferrer">LinkedIn search &#8599;</a>{% endif %}
+          {% if google_address_search_url %}<a href="{{ google_address_search_url }}" target="_blank" rel="noopener noreferrer">Google address &#8599;</a>{% endif %}
         </div>
       {% endif %}
+    </div>
+
+    <div class="card">
+      <h2>Physical letter (optional)</h2>
+      <p>
+        For professionals worth reaching by mail as well as email, print a
+        physical introduction letter to send by post. The printed letter uses
+        different wording &mdash; it can't CC Cofactor AI, so it asks the
+        recipient to email <strong>{{ cc_email }}</strong> for the introduction.
+        Use the <em>Google address</em> link above to find or verify a mailing
+        address.
+      </p>
+      <a class="print-letter" href="{% url 'proconnector_letter' pro.id %}" target="_blank" rel="noopener noreferrer">🖨 Open printable letter &#8599;</a>
     </div>
 
     <div class="card">

--- a/fighthealthinsurance/templates/proconnector_letter.html
+++ b/fighthealthinsurance/templates/proconnector_letter.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>{{ title|default:"Pro Connector Letter" }}</title>
+  <style>
+    body {
+      font-family: "Times New Roman", Georgia, serif;
+      max-width: 720px;
+      margin: 0 auto;
+      padding: 40px 20px;
+      color: #111;
+      background-color: #f5f5f5;
+    }
+    .toolbar {
+      max-width: 720px;
+      margin: 0 auto 20px;
+      display: flex;
+      gap: 12px;
+      align-items: center;
+      font-family: Arial, sans-serif;
+    }
+    .toolbar button {
+      padding: 10px 18px;
+      border: none;
+      border-radius: 4px;
+      font-size: 15px;
+      cursor: pointer;
+      background-color: #6f42c1;
+      color: white;
+    }
+    .toolbar button:hover { background-color: #59339d; }
+    .toolbar a { color: #007bff; text-decoration: none; }
+    .letter {
+      background: white;
+      padding: 56px 64px;
+      border-radius: 4px;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+      line-height: 1.5;
+    }
+    .letterhead {
+      border-bottom: 2px solid #333;
+      padding-bottom: 10px;
+      margin-bottom: 28px;
+    }
+    .letterhead .org { font-size: 1.4em; font-weight: bold; }
+    .letterhead .contact { font-size: 0.9em; color: #444; margin-top: 4px; }
+    .date { margin-bottom: 24px; }
+    .recipient { margin-bottom: 28px; }
+    .recipient .line { display: block; }
+    .muted { color: #888; font-style: italic; }
+    .body { white-space: pre-wrap; }
+    @media print {
+      body { background: white; padding: 0; max-width: none; }
+      .toolbar { display: none; }
+      .letter { box-shadow: none; border-radius: 0; padding: 0; }
+    }
+  </style>
+</head>
+<body>
+  <div class="toolbar">
+    <button type="button" onclick="window.print()">🖨 Print letter</button>
+    <a href="{% url 'proconnector_process' %}">&larr; Back to Pro Connector</a>
+  </div>
+
+  <div class="letter">
+    <div class="letterhead">
+      <div class="org">Fight Health Insurance</div>
+      <div class="contact">
+        <a href="https://www.fighthealthinsurance.com">www.fighthealthinsurance.com</a>
+        &middot; {{ contact_email }}
+      </div>
+    </div>
+
+    <div class="date">{{ today|date:"F j, Y" }}</div>
+
+    <div class="recipient">
+      {% if pro.name %}<span class="line">{{ pro.name }}</span>{% endif %}
+      {% if pro.business_name %}<span class="line">{{ pro.business_name }}</span>{% endif %}
+      {% if pro.address %}<span class="line">{{ pro.address|linebreaksbr }}</span>{% else %}<span class="line muted">[mailing address &mdash; fill in before mailing]</span>{% endif %}
+    </div>
+
+    <div class="body">{{ letter_body }}</div>
+  </div>
+</body>
+</html>

--- a/fighthealthinsurance/urls.py
+++ b/fighthealthinsurance/urls.py
@@ -129,6 +129,11 @@ urlpatterns: List[Union[URLPattern, URLResolver]] = [
         name="proconnector_process",
     ),
     path(
+        "timbit/help/proconnector/<int:pro_id>/letter",
+        staff_member_required(staff_views.ProConnectorLetterView.as_view()),
+        name="proconnector_letter",
+    ),
+    path(
         "timbit/help/proconnector_extract.csv",
         staff_member_required(staff_views.ProConnectorExtractCSVView.as_view()),
         name="proconnector_extract_csv",

--- a/tests/sync/test_proconnector.py
+++ b/tests/sync/test_proconnector.py
@@ -18,9 +18,12 @@ from fighthealthinsurance import proconnector
 from fighthealthinsurance.models import InterestedProfessional, ScheduledEmail
 from fighthealthinsurance.proconnector import (
     BASE_INTRO_EMAIL,
+    BASE_INTRO_LETTER,
     _claims_cofactor_relationship,
     _is_safe_intro_draft,
+    build_address_search_link,
     build_base_intro_email,
+    build_base_intro_letter,
     build_search_links,
     describe_known_info,
     generate_intro_email,
@@ -1210,6 +1213,35 @@ class DashboardLinkTest(TestCase):
         self.assertIsNotNone(links["google"])
         self.assertIn("Jane", links["google"])
 
+    def test_search_links_include_address_lookup(self):
+        # build_search_links exposes a Google address lookup for the physical
+        # letter, distinct from the name/org research search.
+        pro = _make_pro(name="Jane Smith", business_name="Acme Health")
+        links = build_search_links(pro)
+        self.assertIn("google_address", links)
+        self.assertIsNotNone(links["google_address"])
+
+    def test_address_search_uses_address_on_file_when_present(self):
+        # An address on file is searched directly (to locate / verify it).
+        pro = _make_pro(name="Jane Smith", address="123 Main St, Springfield IL")
+        link = build_address_search_link(pro)
+        self.assertIsNotNone(link)
+        self.assertIn("google.com/search", link)
+        self.assertIn("Main", link)
+
+    def test_address_search_falls_back_to_name_org_plus_address_word(self):
+        # With no address on file, search the name/org plus the word "address"
+        # so staff can track a mailing address down.
+        pro = _make_pro(name="Jane Smith", business_name="Acme Health", address="")
+        link = build_address_search_link(pro)
+        self.assertIsNotNone(link)
+        self.assertIn("Jane", link)
+        self.assertIn("address", link.lower())
+
+    def test_address_search_none_when_nothing_to_search(self):
+        pro = _make_pro(name="", business_name="", address="", email="x@xclinic.com")
+        self.assertIsNone(build_address_search_link(pro))
+
     def test_describe_known_info_handles_all_missing(self):
         pro = _make_pro(
             name="",
@@ -1258,6 +1290,104 @@ class BaseEmailWordingTest(TestCase):
         # Uses the agreed framing and includes the compensation disclosure.
         self.assertIn("sourcing agreement", BASE_INTRO_EMAIL)
         self.assertIn("compensation", BASE_INTRO_EMAIL)
+
+
+# ---------------------------------------------------------------------------
+# Physical intro letter (print-only wording + view)
+# ---------------------------------------------------------------------------
+class IntroLetterWordingTest(TestCase):
+    def test_letter_wording_constraints(self):
+        # Same hard rules as the email: no "partner" framing, keeps the sourcing
+        # agreement framing and the compensation disclosure.
+        self.assertNotIn("partner", BASE_INTRO_LETTER.lower())
+        self.assertIn("sourcing agreement", BASE_INTRO_LETTER)
+        self.assertIn("compensation", BASE_INTRO_LETTER)
+
+    def test_letter_does_not_mention_cc(self):
+        # A physical letter can't CC anyone; the print wording must not claim it.
+        self.assertNotIn("cc", BASE_INTRO_LETTER.lower())
+
+    def test_letter_directs_recipient_to_professional_email(self):
+        pro = _make_pro(name="Dr. Jane")
+        letter = build_base_intro_letter(pro)
+        self.assertIn("Dear Dr. Jane,", letter)
+        # Points them at the professional contact address for the introduction.
+        self.assertIn("professional@fighthealthinsurance.com", letter)
+
+    def test_letter_uses_neutral_greeting_when_no_name(self):
+        pro = _make_pro(name="", email="x@xclinic.com")
+        self.assertIn("Dear there,", build_base_intro_letter(pro))
+
+    def test_letter_passes_email_wording_rules(self):
+        # The letter keeps the compensation disclosure and avoids partner
+        # framing, so it also satisfies the shared wording guard.
+        pro = _make_pro(name="Dr. Jane")
+        self.assertIsNone(
+            proconnector.intro_wording_problem(build_base_intro_letter(pro))
+        )
+
+
+class LetterViewTest(TestCase):
+    def setUp(self):
+        self.pro = _make_pro(
+            name="Dr. Jane Smith",
+            business_name="Acme Health Clinic",
+            address="123 Main St, Springfield IL",
+            email="jane@janeclinic.com",
+        )
+        self.url = reverse("proconnector_letter", args=[self.pro.id])
+
+    def test_requires_staff(self):
+        response = self.client.get(self.url)
+        self.assertRedirects(
+            response,
+            f"{reverse('admin:login')}?next={self.url}",
+            fetch_redirect_response=False,
+        )
+
+    def test_staff_sees_printable_letter(self):
+        _login(self.client, is_staff=True)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "proconnector_letter.html")
+        # Recipient address block + print-specific wording.
+        self.assertContains(response, "Dr. Jane Smith")
+        self.assertContains(response, "Acme Health Clinic")
+        self.assertContains(response, "123 Main St")
+        self.assertContains(response, "professional@fighthealthinsurance.com")
+        # An easy print button and a print stylesheet.
+        self.assertContains(response, "window.print()")
+
+    def test_missing_record_redirects_to_process(self):
+        _login(self.client, is_staff=True)
+        response = self.client.get(reverse("proconnector_letter", args=[999999]))
+        self.assertRedirects(
+            response, reverse("proconnector_process"), fetch_redirect_response=False
+        )
+
+    def test_letter_view_does_not_record_anything(self):
+        # Rendering the letter must not claim / send / mark the record.
+        _login(self.client, is_staff=True)
+        self.client.get(self.url)
+        self.pro.refresh_from_db()
+        self.assertFalse(self.pro.proconnector_attempted)
+        self.assertFalse(self.pro.proconnector_skipped)
+        self.assertIsNone(self.pro.proconnector_sent_at)
+
+    @patch(
+        "fighthealthinsurance.staff_views.generate_intro_email",
+        return_value="A draft body with compensation disclosure.",
+    )
+    def test_process_page_links_to_printable_letter(self, _mock_gen):
+        _login(self.client, is_staff=True)
+        response = self.client.get(reverse("proconnector_process"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response, reverse("proconnector_letter", args=[self.pro.id])
+        )
+        self.assertContains(response, "printable letter")
+        # The Google address lookup link is offered for finding a mailing address.
+        self.assertContains(response, "Google address")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Adds support for printing and mailing physical introduction letters to interested professionals in the Pro Connector workflow. This complements the existing email-based introductions with a print-friendly alternative that uses different wording appropriate for postal mail.

## Key Changes

- **New `build_base_intro_letter()` function** - Renders the print-only physical letter with wording tailored for mailed correspondence. Uses the same warm framing and compensation disclosure as the email, but asks recipients to email the professional contact address instead of naming a CC (since a printed letter cannot CC anyone).

- **New `build_address_search_link()` function** - Generates a Google search URL to help staff find or verify mailing addresses. When an address is on file, it searches the address directly; otherwise it searches the professional's name/organization plus the word "address" to help staff track one down.

- **Updated `build_search_links()` function** - Now includes a `google_address` key that provides the address search link alongside the existing name/organization research links.

- **New `ProConnectorLetterView`** - Staff-only view that renders a printable letter template. The view is read-only and never claims, sends, or records anything on the professional's record, allowing staff to open it without affecting the processing queue.

- **New `proconnector_letter.html` template** - Print-friendly HTML template with professional letterhead, recipient address block, and print stylesheet. Includes a toolbar with print button and back link.

- **Updated Pro Connector process page** - Added a "Physical letter (optional)" card that links to the printable letter view and explains the different wording. The Google address search link is now exposed in the research section.

- **Comprehensive test coverage** - Added tests for letter wording constraints, address search logic, letter view access control, and process page integration.

## Implementation Details

- The physical letter uses `BASE_INTRO_LETTER` constant with the same compensation disclosure and sourcing agreement framing as the email, ensuring compliance with wording requirements.
- Address search intelligently falls back from on-file address to name/org + "address" keyword when no address is available.
- The letter view requires staff authentication but does not record any action, making it safe to preview without affecting the processing workflow.
- Template uses print-friendly styling with serif fonts and a print stylesheet that hides the toolbar.

https://claude.ai/code/session_0129bop8djcdVCaBy1CqYB4d