### PR TITLE
Max Conn issue cleanup: pg limits, reaper + alerts, idle-gated ws sweeps, test/docs alignment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,21 @@ python manage.py loaddata initial followup plan_source insurance_companies pa_re
 ### Async Processing
 - Ray actors (`*_actor.py`) for distributed background tasks
 - WebSocket streaming for long-running ML operations
-- async/await patterns with sync-to-async bridges via asgiref
+- async/await patterns with sync-to-async bridges. **In async code, reach for
+  Django's native async ORM first** — `aget`/`acreate`/`asave`/`adelete`/
+  `acount`/`aexists`/`aget_or_create` and `async for` over querysets — which
+  needs no bridge at all; async-first is the preferred shape for new code.
+  When wrapping existing sync code instead, **bridge choice matters:**
+  use channels' `database_sync_to_async` for any wrapped callable that touches
+  the Django ORM — it closes the thread's DB connections around each call,
+  even when the awaiting task is cancelled, where plain asgiref leaks them
+  (the July 2026 connection-starvation incident). Use plain asgiref
+  `sync_to_async` ONLY for callables that touch no ORM (subprocess, network,
+  file work) and leave a comment saying so, since the database variant would
+  needlessly churn DB connections there. `async_to_sync` stays asgiref.
+  Don't flip existing functions between sync and async (or rewrite working
+  bridges into native-async) just to satisfy this preference — apply it to
+  new code and to call sites you're already changing.
 
 ### Frontend
 - React 19 + TypeScript components in `fighthealthinsurance/static/js/`

--- a/fighthealthinsurance/websockets.py
+++ b/fighthealthinsurance/websockets.py
@@ -11,8 +11,13 @@ from django.db import transaction
 
 # channels' database_sync_to_async (NOT asgiref's sync_to_async): consumers run
 # outside the HTTP request cycle, so only its close_old_connections wrapping
-# ever closes the DB connections these calls open.
-from channels.db import database_sync_to_async
+# ever closes the DB connections these calls open. aclose_old_connections is
+# called at receive() entry via _aclose_if_socket_was_idle: native async ORM
+# (aget/afirst/...) binds connections to this consumer's long-lived thread, and
+# the server's idle_session_timeout kills them while a socket sits idle --
+# closing first makes the next ORM call reconnect instead of raising
+# OperationalError.
+from channels.db import aclose_old_connections, database_sync_to_async
 from channels.generic.websocket import AsyncWebsocketConsumer
 from loguru import logger
 
@@ -33,6 +38,31 @@ from fighthealthinsurance.models import (
 )
 
 from .chat_interface import ChatInterface
+
+# Only sweep connections after a real idle gap. idle_session_timeout is 30min,
+# so anything over a minute of socket silence earns a sweep; on an active
+# socket the sweep is pure churn -- close_if_unusable_or_obsolete reconnects
+# initialized-but-closed wrappers just to read autocommit, so a per-message
+# sweep opens and closes a connection per frame, which hammers the shared
+# in-memory test database (lock-contention flakes) for zero benefit.
+_IDLE_SWEEP_THRESHOLD_SECONDS = 60.0
+
+
+async def _aclose_if_socket_was_idle(consumer: AsyncWebsocketConsumer) -> None:
+    """Drop idle-killed DB connections, but only after a real idle gap.
+
+    The first message after connect skips the sweep: the consumer's thread is
+    fresh then, and the incident this guards against (Sentry: "terminating
+    connection due to idle-session timeout") comes from sockets going quiet
+    MID-conversation. From the second message on, any gap over the threshold
+    sweeps before touching the ORM.
+    """
+    loop = asyncio.get_running_loop()
+    now = loop.time()
+    last = getattr(consumer, "_last_receive_monotonic", None)
+    consumer._last_receive_monotonic = now  # type: ignore[attr-defined]
+    if last is not None and (now - last) >= _IDLE_SWEEP_THRESHOLD_SECONDS:
+        await aclose_old_connections()
 
 
 async def enqueue_denied_items_analysis(*, chat_id: str) -> None:
@@ -233,6 +263,9 @@ class StreamingAppealsBackend(AsyncWebsocketConsumer):
         logger.debug(f"appeals ws: disconnect code={close_code}")
 
     async def receive(self, text_data):
+        # Drop connections the server's idle-session timeout may have
+        # killed while this socket sat idle (see channels.db import note).
+        await _aclose_if_socket_was_idle(self)
         # streaming_protocol=True so the client's type==='error' branch
         # in processResponseChunk fires instead of treating this as an
         # unrecognized frame. The helper also rejects non-object JSON
@@ -347,6 +380,9 @@ class StreamingEscalationBackend(AsyncWebsocketConsumer):
         logger.debug(f"escalation ws: disconnect code={close_code}")
 
     async def receive(self, text_data):
+        # Drop connections the server's idle-session timeout may have
+        # killed while this socket sat idle (see channels.db import note).
+        await _aclose_if_socket_was_idle(self)
         data = await _parse_json_or_close(
             self,
             text_data,
@@ -401,6 +437,9 @@ class StreamingEntityBackend(AsyncWebsocketConsumer):
         logger.debug(f"entity ws: disconnect code={close_code}")
 
     async def receive(self, text_data):
+        # Drop connections the server's idle-session timeout may have
+        # killed while this socket sat idle (see channels.db import note).
+        await _aclose_if_socket_was_idle(self)
         data = await _parse_json_or_close(
             self,
             text_data,
@@ -448,6 +487,9 @@ class PriorAuthConsumer(AsyncWebsocketConsumer):
         logger.debug(f"prior-auth ws: disconnect code={close_code}")
 
     async def receive(self, text_data):
+        # Drop connections the server's idle-session timeout may have
+        # killed while this socket sat idle (see channels.db import note).
+        await _aclose_if_socket_was_idle(self)
         data = await _parse_json_or_close(
             self,
             text_data,
@@ -770,6 +812,9 @@ class OngoingChatConsumer(AsyncWebsocketConsumer):
             chat.save(update_fields=["denied_item", "denied_reason"])
 
     async def receive(self, text_data):
+        # Drop connections the server's idle-session timeout may have
+        # killed while this socket sat idle (see channels.db import note).
+        await _aclose_if_socket_was_idle(self)
         data = await _parse_json_or_close(
             self,
             text_data,

--- a/k8s/fhi-pg-main-9-alerts.yaml
+++ b/k8s/fhi-pg-main-9-alerts.yaml
@@ -119,3 +119,58 @@ spec:
               Ready replica count dropped. If this coincides with a plugin
               upgrade, check that the barman-cloud Service EndpointSlice is
               non-empty (the v0.9->v0.13 selector break that took -8 down).
+
+        # ---- CONNECTION SATURATION (the 'too many clients' failure mode) ----
+        # With max_connections=6000 the pressure reaper (50% threshold) is the
+        # load-bearing control; these fire if usage climbs anyway.
+        # VERIFY-LIVE: confirm the exact backends metric name your CNPG build
+        # exports (cnpg_backends_total is the historical default set).
+        # Per-pod (sum by): max_connections is a PER-INSTANCE limit, and only
+        # the primary holds app connections -- a cluster-wide sum would both
+        # false-positive on replica noise and hide which instance is full.
+        - alert: FhiPg9ConnectionsHighWarning
+          expr: sum by (pod) (cnpg_backends_total{namespace="totallylegitco", pod=~"fhi-pg-main-9-.*"}) > 2400
+          for: 10m
+          labels:
+            severity: warning
+            cluster: fhi-pg-main-9
+          annotations:
+            summary: "{{ $labels.pod }} backends above 40% of max_connections ({{ $value }})"
+            description: >-
+              Connection usage exceeds 2400 of 6000 for 10m. The pressure
+              reaper should be evicting idle connections above 3000 -- check
+              the pg-conn-pressure-reaper CronJob and run
+              scripts/pg-conn-census.sh to fingerprint the holders.
+
+        - alert: FhiPg9ConnectionsHighCritical
+          expr: sum by (pod) (cnpg_backends_total{namespace="totallylegitco", pod=~"fhi-pg-main-9-.*"}) > 4200
+          for: 5m
+          labels:
+            severity: critical
+            cluster: fhi-pg-main-9
+          annotations:
+            summary: "{{ $labels.pod }} backends above 70% of max_connections ({{ $value }})"
+            description: >-
+              Approaching the hard cap; new app connections will start failing
+              with 'too many clients'. The reaper is not keeping up or cannot
+              connect -- intervene now.
+
+        # ---- PRESSURE REAPER HEALTH (do not let the safety net fail silently)
+        # VERIFY-LIVE: requires kube-state-metrics job metrics; adjust the
+        # job_name pattern if the scrape labels differ.
+        # sum() is load-bearing: every CronJob run is a UNIQUE job_name series
+        # that (backoffLimit: 0) never exceeds 1, so a per-series increase()
+        # could never cross 2 and the alert would never fire.
+        - alert: FhiPg9PressureReaperFailing
+          expr: sum(increase(kube_job_status_failed{namespace="totallylegitco", job_name=~"pg-conn-pressure-reaper-.*"}[30m])) > 2
+          for: 5m
+          labels:
+            severity: warning
+            cluster: fhi-pg-main-9
+          annotations:
+            summary: "pg-conn-pressure-reaper jobs are failing"
+            description: >-
+              The connection pressure reaper has failed repeatedly in the last
+              30m (auth, DB unreachable, or SQL error -- pipefail makes psql
+              failures fail the Job). Connection pressure is unmanaged while
+              this persists.

--- a/k8s/fhi-pg-main-9-cluster.yaml
+++ b/k8s/fhi-pg-main-9-cluster.yaml
@@ -141,15 +141,28 @@ spec:
       max_worker_processes: "32"
       max_parallel_workers: "32"
 
-      # Connection capacity + leak reapers. These lived on -8 (see the pg
-      # pooling/connection PR) but were lost in the -9 rewrite, leaving -9 at
-      # the default max_connections=100 while the app fleet holds ~50+ and
-      # client threads that leak connections push it higher. The idle reapers
-      # make leaked (client-side unpooled) connections self-heal server-side.
+      # Connection capacity + leak reapers. Unpooled clients (PG_USE_POOL off)
+      # mean per-request connections, and aborted ASGI requests can strand
+      # connections until the idle reaper collects them -- bursts blew through
+      # 200 (Sentry: too many clients). 6000 is a deliberate never-again
+      # ceiling, far beyond direct-connection norms: mostly-idle backends cost
+      # a few MB each, so even half-full is ~10-20GB -- fits these nodes, but
+      # do not expect healthy operation anywhere near the cap. Actual usage is
+      # bounded by the idle reapers below plus the pressure reaper CronJob
+      # (k8s/pg-conn-pressure-reaper.yaml), which evicts the OLDEST idle app
+      # connections when usage crosses 50% of this cap.
       # NOTE: max_connections requires a Postgres restart; with
       # primaryUpdateStrategy: supervised that restart waits for a human
-      # (kubectl cnpg restart fhi-pg-main-9).
-      max_connections: "200"
+      # (kubectl cnpg restart fhi-pg-main-9). It is also a one-way ratchet in
+      # practice: standbys require max_connections >= the primary's, so any
+      # future DECREASE must restart the primary first (or lockstep) or the
+      # replicas refuse to start.
+      max_connections: "6000"
+      # Default is 3: at a 6000 cap a full-cap event would leave the CNPG
+      # operator, the isolationCheck liveness probe, and the pressure-reaper
+      # CronJob fighting over 3 slots -- the reaper must be able to connect
+      # exactly then.
+      superuser_reserved_connections: "10"
       idle_session_timeout: "30min"
       idle_in_transaction_session_timeout: "10min"
 

--- a/k8s/pg-conn-pressure-reaper.yaml
+++ b/k8s/pg-conn-pressure-reaper.yaml
@@ -1,0 +1,95 @@
+# Pressure-based connection reaper for fhi-pg-main-9.
+#
+# Postgres has no built-in "close the oldest connection when near
+# max_connections" -- its only levers are age-based (idle_session_timeout,
+# already set on the cluster). This CronJob adds the pressure-based half:
+# once a minute, if total backends exceed REAP_THRESHOLD_PCT of
+# max_connections, it pg_terminate_backend()s the LONGEST-IDLE app
+# connections (never active queries, never replication/superuser sessions)
+# until usage is back under the threshold, up to REAP_MAX_PER_RUN per run.
+#
+# Victims must have been idle at least 5 minutes: a connection that is
+# merely between two queries of a live request/task is never touched, so
+# for unpooled clients a reap is behaviorally identical to the server's
+# idle_session_timeout firing early -- the client opens a fresh connection
+# on its next query. "idle in transaction" (the aborted-request stranding
+# state) is included; the 10min idle_in_transaction_session_timeout would
+# kill those anyway.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: pg-conn-pressure-reaper
+  namespace: totallylegitco
+spec:
+  schedule: "* * * * *"
+  # Bound missed-start counting: without this, >100 missed schedules
+  # (controller outage) permanently wedges the CronJob.
+  startingDeadlineSeconds: 30
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      activeDeadlineSeconds: 55
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: reaper
+              # Same image as the cluster: guarantees a matching psql.
+              image: ghcr.io/cloudnative-pg/postgresql:18.1-system-trixie
+              env:
+                - name: PGHOST
+                  value: fhi-pg-main-9-rw.totallylegitco.svc
+                - name: PGDATABASE
+                  value: app
+                - name: PGUSER
+                  valueFrom:
+                    secretKeyRef:
+                      name: fhi-superuser-pg-secret
+                      key: username
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: fhi-superuser-pg-secret
+                      key: password
+                - name: REAP_THRESHOLD_PCT
+                  value: "50"
+                - name: REAP_MAX_PER_RUN
+                  value: "500"
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+              command:
+                - /bin/bash
+                - -ec
+                - |
+                  set -o pipefail
+                  psql -v ON_ERROR_STOP=1 -Atc "
+                    WITH cap AS (
+                      SELECT current_setting('max_connections')::int AS max_conn
+                    ), usage AS (
+                      SELECT count(*) AS used FROM pg_stat_activity
+                    ), victims AS (
+                      SELECT pid, client_addr, now() - state_change AS idle_for
+                      FROM pg_stat_activity, cap, usage
+                      WHERE usage.used > cap.max_conn * ${REAP_THRESHOLD_PCT} / 100
+                        AND usename = 'ziggystardust'
+                        AND state LIKE 'idle%'
+                        AND now() - state_change > interval '5 min'
+                      ORDER BY state_change ASC
+                      LIMIT LEAST(
+                        ${REAP_MAX_PER_RUN},
+                        GREATEST(0, (SELECT used FROM usage)
+                                    - (SELECT max_conn * ${REAP_THRESHOLD_PCT} / 100
+                                       FROM cap))
+                      )
+                    )
+                    SELECT pg_terminate_backend(pid), pid, client_addr, idle_for
+                    FROM victims;
+                  " | while IFS='|' read -r ok pid addr idle; do
+                    echo "reaped pid=${pid} client=${addr} idle=${idle} ok=${ok}"
+                  done
+                  echo "pressure check done"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,8 @@
-seleniumbase>=4.32
+# Exact pin: seleniumbase exact-pins beautifulsoup4 per release, and 4.35.0+
+# wants bs4==4.13.3 while requirements.txt pins bs4==4.12.3, so with only a
+# floor here pip probes ~130 releases (4.51 -> 4.34) on every tox env install
+# before landing on 4.34.6. To upgrade: bump beautifulsoup4 first, then this.
+seleniumbase==4.34.6
 urllib3>=2.0
 pytest
 pytest-django

--- a/scripts/pg-conn-census.sh
+++ b/scripts/pg-conn-census.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# pg-conn-census.sh -- who is holding Postgres connections on fhi-pg-main-9?
+#
+# Prints, from the current primary: connection counts per client/state, the
+# last query of long-idle (likely stranded) connections, and the total vs
+# max_connections. The long-idle "last query" fingerprints which code path a
+# leaked connection came from -- this is how the chooser/banner leaks were
+# attributed during the July 2026 connection-starvation incident.
+#
+# Usage: ./scripts/pg-conn-census.sh [minutes-idle-threshold]   (default 30)
+set -euo pipefail
+
+NS=totallylegitco
+THRESHOLD="${1:-30}"
+case "$THRESHOLD" in
+  '' | *[!0-9]*)
+    echo "usage: $0 [minutes-idle-threshold]  (integer minutes)" >&2
+    exit 1
+    ;;
+esac
+PRIMARY="$(kubectl -n "$NS" get cluster fhi-pg-main-9 -o jsonpath='{.status.currentPrimary}')"
+
+run_sql() {
+  kubectl -n "$NS" exec "$PRIMARY" -c postgres -- psql -U postgres -d app -Atc "$1"
+}
+
+echo "== connections by client/state (primary: $PRIMARY) =="
+run_sql "SELECT coalesce(client_addr::text,'local'), state, count(*),
+                date_trunc('second', max(now()-state_change))::text AS oldest
+         FROM pg_stat_activity WHERE usename='ziggystardust'
+         GROUP BY 1,2 ORDER BY 1,2;"
+echo
+echo "== last query of connections idle > ${THRESHOLD} min (leak fingerprints) =="
+run_sql "SELECT coalesce(client_addr::text,'local'),
+                date_trunc('second', now()-state_change)::text AS idle_for, left(query,90)
+         FROM pg_stat_activity
+         WHERE usename='ziggystardust' AND state='idle'
+           AND now()-state_change > interval '${THRESHOLD} minutes'
+         ORDER BY 1, now()-state_change DESC;"
+echo
+echo "== total backends vs max_connections =="
+run_sql "SELECT count(*) || ' / ' || current_setting('max_connections') FROM pg_stat_activity;"

--- a/tests/async-unit/test_denial_types.py
+++ b/tests/async-unit/test_denial_types.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import pytest
 
 # Test the denial_base including the regexes from the initial fixtures.
-from asgiref.sync import sync_to_async
+from channels.db import database_sync_to_async
 from django.test import TestCase
 
 from fighthealthinsurance.forms.questions import EmergencyServicesQuestions
@@ -148,10 +148,10 @@ class TestDenialTypes(TestCase):
         # Fixture PlanType rows have blank regexes (non-selective); create
         # two rows with explicit regexes so we can verify the positive match
         # and the negative_regex exclusion branch in isolation.
-        await sync_to_async(PlanType.objects.create)(
+        await database_sync_to_async(PlanType.objects.create)(
             name="TestHMO", alt_name="Test HMO plan", regex="HMO-only-text"
         )
-        await sync_to_async(PlanType.objects.create)(
+        await database_sync_to_async(PlanType.objects.create)(
             name="TestPPO",
             alt_name="Test PPO plan",
             regex="PPO-only-text",
@@ -176,7 +176,7 @@ class TestDenialTypes(TestCase):
     async def test_get_regulator_matches_erisa_and_respects_negative(self):
         # Create a regulator with a non-empty negative_regex so we can verify
         # the exclusion branch without perturbing the fixture rows.
-        await sync_to_async(Regulator.objects.create)(
+        await database_sync_to_async(Regulator.objects.create)(
             name="TestRegulator",
             website="https://example.test/",
             alt_name="TR",
@@ -229,7 +229,7 @@ class TestDenialTypes(TestCase):
 
     @pytest.mark.asyncio
     async def test_process_denial_codes_icd_block_description_preventive(self):
-        processor = await sync_to_async(ProcessDenialCodes)()
+        processor = await database_sync_to_async(ProcessDenialCodes)()
         fake_tag = SimpleNamespace(
             block_description="Encounter for preventive screening"
         )
@@ -250,7 +250,7 @@ class TestDenialTypes(TestCase):
         """Returns the preventive denial when the ICD code is in the
         preventive_diagnosis CSV override (even if block description does not
         contain 'preventive')."""
-        processor = await sync_to_async(ProcessDenialCodes)()
+        processor = await database_sync_to_async(ProcessDenialCodes)()
         # Inject a known code into the CSV override; keeps the test hermetic
         # regardless of whether ./data/preventive_diagnosis.csv is present.
         processor.preventive_diagnosis = {"Z00.00": "general exam"}
@@ -269,7 +269,7 @@ class TestDenialTypes(TestCase):
 
     @pytest.mark.asyncio
     async def test_process_denial_codes_preventive_cpt_override(self):
-        processor = await sync_to_async(ProcessDenialCodes)()
+        processor = await database_sync_to_async(ProcessDenialCodes)()
         # Inject a known CPT code into the CSV override. 99391 is a real
         # preventive medicine E/M code and matches the cpt_code_re
         # (\d{4}[A-Z0-9]) regex.
@@ -286,7 +286,7 @@ class TestDenialTypes(TestCase):
 
     @pytest.mark.asyncio
     async def test_process_denial_codes_unrelated_text_returns_empty(self):
-        processor = await sync_to_async(ProcessDenialCodes)()
+        processor = await database_sync_to_async(ProcessDenialCodes)()
         processor.preventive_diagnosis = {}
         processor.preventive_codes = {}
 
@@ -300,7 +300,7 @@ class TestDenialTypes(TestCase):
     async def test_process_denial_codes_icd_match_but_not_preventive(self):
         """Returns [] when an ICD-10 code matches but is neither a preventive
         block description nor in the preventive_diagnosis override."""
-        processor = await sync_to_async(ProcessDenialCodes)()
+        processor = await database_sync_to_async(ProcessDenialCodes)()
         processor.preventive_diagnosis = {}
         processor.preventive_codes = {}
         # Block description deliberately omits the substring "preventive" so
@@ -322,7 +322,7 @@ class TestDenialTypes(TestCase):
     @pytest.mark.asyncio
     async def test_process_denial_codes_uspstf_fallback_flags_preventive(self):
         """When CSV lookups miss but USPSTF matches the code, classify as preventive."""
-        processor = await sync_to_async(ProcessDenialCodes)()
+        processor = await database_sync_to_async(ProcessDenialCodes)()
         processor.preventive_diagnosis = {}
         processor.preventive_codes = {}
         fake_tag = SimpleNamespace(block_description="Some unrelated description")
@@ -346,7 +346,7 @@ class TestDenialTypes(TestCase):
     async def test_find_uspstf_evidence_extracts_cpt_and_hcpcs_codes(self):
         """find_uspstf_evidence should pass non-ICD procedure codes through
         to USPSTF lookup so CPT/HCPCS-only denials still surface guidance."""
-        processor = await sync_to_async(ProcessDenialCodes)()
+        processor = await database_sync_to_async(ProcessDenialCodes)()
         fake_recs = [{"id": "rec-1", "grade": "B"}]
 
         with patch(
@@ -364,7 +364,7 @@ class TestDenialTypes(TestCase):
     @pytest.mark.asyncio
     async def test_find_uspstf_evidence_returns_empty_on_error(self):
         """find_uspstf_evidence swallows exceptions so classification never breaks."""
-        processor = await sync_to_async(ProcessDenialCodes)()
+        processor = await database_sync_to_async(ProcessDenialCodes)()
         with patch(
             "fighthealthinsurance.uspstf_api.find_recommendations_for_codes",
             side_effect=RuntimeError("boom"),
@@ -378,7 +378,7 @@ class TestDenialTypes(TestCase):
         preventive_codes CSV override - the previous CPT-only branch
         silently dropped HCPCS-coded preventive items (e.g. supply
         codes for screening test strips)."""
-        processor = await sync_to_async(ProcessDenialCodes)()
+        processor = await database_sync_to_async(ProcessDenialCodes)()
         # Inject a known HCPCS code into the CSV override.
         processor.preventive_codes = {"A4253": "blood glucose test strips"}
         processor.preventive_diagnosis = {}
@@ -396,7 +396,7 @@ class TestDenialTypes(TestCase):
         identifies durable medical equipment (E/K) or orthotic /
         prosthetic items (L). Drug (J) and supply (A) codes are
         excluded."""
-        processor = await sync_to_async(ProcessDenialCodes)()
+        processor = await database_sync_to_async(ProcessDenialCodes)()
         result = await processor.get_dme_codes(
             "Patient prescribed E0260 hospital bed, K0001 wheelchair, "
             "L0631 brace, J3490 drug, A4253 strips."
@@ -405,7 +405,7 @@ class TestDenialTypes(TestCase):
 
     @pytest.mark.asyncio
     async def test_process_denial_codes_get_dme_codes_empty(self):
-        processor = await sync_to_async(ProcessDenialCodes)()
+        processor = await database_sync_to_async(ProcessDenialCodes)()
         result = await processor.get_dme_codes(
             "Generic denial with CPT 99213 only - no HCPCS items."
         )

--- a/tests/async-unit/test_followup_emails.py
+++ b/tests/async-unit/test_followup_emails.py
@@ -2,7 +2,7 @@
 
 import datetime
 import pytest
-from asgiref.sync import sync_to_async
+from channels.db import database_sync_to_async
 from unittest.mock import patch, MagicMock
 from django.core import mail
 from django.template.loader import render_to_string
@@ -73,8 +73,6 @@ def followup_types(db):
         },
     )
     return fut_7, fut_30, fut_90
-
-
 
 
 @pytest.mark.django_db
@@ -367,7 +365,12 @@ class TestScheduleFollowUps:
         assert scheds.count() == 4
 
         type_names = set(s.follow_up_type.name for s in scheds)
-        assert type_names == {"followup_1day", "followup_7day", "followup_30day", "followup_90day"}
+        assert type_names == {
+            "followup_1day",
+            "followup_7day",
+            "followup_30day",
+            "followup_90day",
+        }
 
     def test_correct_follow_up_dates(self, test_denial, followup_types):
         """Test that follow-up dates are correctly calculated."""
@@ -456,7 +459,12 @@ class TestScheduleFollowUps:
         """Test that nothing is created when the expected FollowUpType records don't exist."""
         # Remove any matching types (may exist from data migration)
         FollowUpType.objects.filter(
-            name__in=["followup_1day", "followup_7day", "followup_30day", "followup_90day"]
+            name__in=[
+                "followup_1day",
+                "followup_7day",
+                "followup_30day",
+                "followup_90day",
+            ]
         ).delete()
 
         schedule_follow_ups(test_denial.raw_email, test_denial)
@@ -1179,13 +1187,13 @@ class TestFollowUpEmailGroupingAsync:
         """Async: two denials for the same email → only 1 email sent."""
         email = "patient@gmail.com"
         hashed = Denial.get_hashed_email(email)
-        denial1 = await sync_to_async(Denial.objects.create)(
+        denial1 = await database_sync_to_async(Denial.objects.create)(
             denial_text="Denial 1",
             hashed_email=hashed,
             raw_email=email,
             health_history="",
         )
-        denial2 = await sync_to_async(Denial.objects.create)(
+        denial2 = await database_sync_to_async(Denial.objects.create)(
             denial_text="Denial 2",
             hashed_email=hashed,
             raw_email=email,
@@ -1193,14 +1201,14 @@ class TestFollowUpEmailGroupingAsync:
         )
         fut_7 = followup_types[0]
 
-        sched1 = await sync_to_async(FollowUpSched.objects.create)(
+        sched1 = await database_sync_to_async(FollowUpSched.objects.create)(
             email=email,
             denial_id=denial1,
             follow_up_type=fut_7,
             follow_up_date=datetime.date.today() - datetime.timedelta(days=1),
             follow_up_sent=False,
         )
-        sched2 = await sync_to_async(FollowUpSched.objects.create)(
+        sched2 = await database_sync_to_async(FollowUpSched.objects.create)(
             email=email,
             denial_id=denial2,
             follow_up_type=fut_7,
@@ -1214,8 +1222,8 @@ class TestFollowUpEmailGroupingAsync:
         assert count == 1
         assert mock_send_email.call_count == 1
 
-        await sync_to_async(sched1.refresh_from_db)()
-        await sync_to_async(sched2.refresh_from_db)()
+        await database_sync_to_async(sched1.refresh_from_db)()
+        await database_sync_to_async(sched2.refresh_from_db)()
         assert sched1.follow_up_sent is True
         assert sched2.follow_up_sent is True
 
@@ -1227,13 +1235,13 @@ class TestFollowUpEmailGroupingAsync:
         """Async: stale best candidate is skipped, next valid one is sent."""
         email = "patient@gmail.com"
         hashed = Denial.get_hashed_email(email)
-        denial1 = await sync_to_async(Denial.objects.create)(
+        denial1 = await database_sync_to_async(Denial.objects.create)(
             denial_text="Denial 1",
             hashed_email=hashed,
             raw_email=email,
             health_history="",
         )
-        denial2 = await sync_to_async(Denial.objects.create)(
+        denial2 = await database_sync_to_async(Denial.objects.create)(
             denial_text="Denial 2",
             hashed_email=hashed,
             raw_email=email,
@@ -1242,7 +1250,7 @@ class TestFollowUpEmailGroupingAsync:
         fut_7, fut_30, _ = followup_types
 
         # Denial 1: 30-day already sent → its 7-day is stale
-        await sync_to_async(FollowUpSched.objects.create)(
+        await database_sync_to_async(FollowUpSched.objects.create)(
             email=email,
             denial_id=denial1,
             follow_up_type=fut_30,
@@ -1250,7 +1258,7 @@ class TestFollowUpEmailGroupingAsync:
             follow_up_sent=True,
             follow_up_sent_date=timezone.now() - datetime.timedelta(days=10),
         )
-        sched1_7 = await sync_to_async(FollowUpSched.objects.create)(
+        sched1_7 = await database_sync_to_async(FollowUpSched.objects.create)(
             email=email,
             denial_id=denial1,
             follow_up_type=fut_7,
@@ -1259,7 +1267,7 @@ class TestFollowUpEmailGroupingAsync:
         )
 
         # Denial 2: valid 7-day
-        sched2_7 = await sync_to_async(FollowUpSched.objects.create)(
+        sched2_7 = await database_sync_to_async(FollowUpSched.objects.create)(
             email=email,
             denial_id=denial2,
             follow_up_type=fut_7,
@@ -1273,8 +1281,8 @@ class TestFollowUpEmailGroupingAsync:
         assert count == 1
         assert mock_send_email.call_count == 1
 
-        await sync_to_async(sched1_7.refresh_from_db)()
-        await sync_to_async(sched2_7.refresh_from_db)()
+        await database_sync_to_async(sched1_7.refresh_from_db)()
+        await database_sync_to_async(sched2_7.refresh_from_db)()
         assert sched1_7.follow_up_sent is True
         assert sched2_7.follow_up_sent is True
 
@@ -1326,7 +1334,7 @@ class TestFollowUpEmailSenderAsync:
         result = await sender.adosend(follow_up_sched=valid_email_followup_sched)
         assert result is True
         mock_send_email.assert_called_once()
-        await sync_to_async(valid_email_followup_sched.refresh_from_db)()
+        await database_sync_to_async(valid_email_followup_sched.refresh_from_db)()
         assert valid_email_followup_sched.follow_up_sent is True
 
     @patch("fighthealthinsurance.followup_emails.send_fallback_email")
@@ -1337,7 +1345,7 @@ class TestFollowUpEmailSenderAsync:
         # Create multiple follow-ups with valid emails
         for i in range(3):
             email = f"patient{i}@gmail.com"
-            await sync_to_async(FollowUpSched.objects.create)(
+            await database_sync_to_async(FollowUpSched.objects.create)(
                 email=email,
                 denial_id=valid_email_denial,
                 follow_up_date=datetime.date.today() - datetime.timedelta(days=1),
@@ -1356,7 +1364,7 @@ class TestFollowUpEmailSenderAsync:
     ):
         for i in range(5):
             email = f"patient{i}@gmail.com"
-            await sync_to_async(FollowUpSched.objects.create)(
+            await database_sync_to_async(FollowUpSched.objects.create)(
                 email=email,
                 denial_id=valid_email_denial,
                 follow_up_date=datetime.date.today() - datetime.timedelta(days=1),
@@ -1389,7 +1397,7 @@ class TestThankyouEmailSenderAsync:
     async def test_asend_all_sends_thankyou_emails(self, mock_sleep, mock_send_email):
         from fighthealthinsurance.models import InterestedProfessional
 
-        await sync_to_async(InterestedProfessional.objects.create)(
+        await database_sync_to_async(InterestedProfessional.objects.create)(
             name="Dr. Test",
             email="doctor@hospital.org",
             thankyou_email_sent=False,

--- a/tests/async/test_background_summary.py
+++ b/tests/async/test_background_summary.py
@@ -15,7 +15,7 @@ from channels.testing import WebsocketCommunicator
 from django.contrib.auth import get_user_model
 from rest_framework.test import APITestCase
 
-from asgiref.sync import sync_to_async
+from channels.db import database_sync_to_async
 
 from fighthealthinsurance.chat.context_manager import MISSING_CONTEXT_PREFIX
 from fighthealthinsurance.models import OngoingChat, ProfessionalUser
@@ -54,9 +54,7 @@ class BackgroundSummaryIntegrationTest(APITestCase):
 
         with contextlib.ExitStack() as stack:
             mock_get_chat_backends = stack.enter_context(
-                patch(
-                    "fighthealthinsurance.ml.ml_router.MLRouter.get_chat_backends"
-                )
+                patch("fighthealthinsurance.ml.ml_router.MLRouter.get_chat_backends")
             )
             mock_get_chat_backends.return_value = [mock_model]
 
@@ -74,16 +72,16 @@ class BackgroundSummaryIntegrationTest(APITestCase):
                 )
             )
 
-            user = await sync_to_async(User.objects.create_user)(
+            user = await database_sync_to_async(User.objects.create_user)(
                 username="bg_summary_user",
                 password="testpass",
                 email="bgsummary@example.com",
             )
-            professional = await sync_to_async(ProfessionalUser.objects.create)(
-                user=user, active=True, npi_number="5555555555"
-            )
+            professional = await database_sync_to_async(
+                ProfessionalUser.objects.create
+            )(user=user, active=True, npi_number="5555555555")
 
-            chat = await sync_to_async(OngoingChat.objects.create)(
+            chat = await database_sync_to_async(OngoingChat.objects.create)(
                 professional_user=professional,
                 chat_history=[],
                 summary_for_next_call=[],
@@ -139,9 +137,7 @@ class BackgroundSummaryIntegrationTest(APITestCase):
 
         with contextlib.ExitStack() as stack:
             mock_get_chat_backends = stack.enter_context(
-                patch(
-                    "fighthealthinsurance.ml.ml_router.MLRouter.get_chat_backends"
-                )
+                patch("fighthealthinsurance.ml.ml_router.MLRouter.get_chat_backends")
             )
             mock_get_chat_backends.return_value = [mock_model]
 
@@ -173,16 +169,16 @@ class BackgroundSummaryIntegrationTest(APITestCase):
                 "Patient denied GLP-1 coverage, asking for help"
             )
 
-            user = await sync_to_async(User.objects.create_user)(
+            user = await database_sync_to_async(User.objects.create_user)(
                 username="bg_replace_user",
                 password="testpass",
                 email="bgreplace@example.com",
             )
-            professional = await sync_to_async(ProfessionalUser.objects.create)(
-                user=user, active=True, npi_number="6666666666"
-            )
+            professional = await database_sync_to_async(
+                ProfessionalUser.objects.create
+            )(user=user, active=True, npi_number="6666666666")
 
-            chat = await sync_to_async(OngoingChat.objects.create)(
+            chat = await database_sync_to_async(OngoingChat.objects.create)(
                 professional_user=professional,
                 chat_history=[],
                 summary_for_next_call=[],
@@ -236,9 +232,7 @@ class BackgroundSummaryIntegrationTest(APITestCase):
 
         with contextlib.ExitStack() as stack:
             mock_get_chat_backends = stack.enter_context(
-                patch(
-                    "fighthealthinsurance.ml.ml_router.MLRouter.get_chat_backends"
-                )
+                patch("fighthealthinsurance.ml.ml_router.MLRouter.get_chat_backends")
             )
             mock_get_chat_backends.return_value = [mock_model]
 
@@ -256,16 +250,16 @@ class BackgroundSummaryIntegrationTest(APITestCase):
                 )
             )
 
-            user = await sync_to_async(User.objects.create_user)(
+            user = await database_sync_to_async(User.objects.create_user)(
                 username="normal_ctx_user",
                 password="testpass",
                 email="normalctx@example.com",
             )
-            professional = await sync_to_async(ProfessionalUser.objects.create)(
-                user=user, active=True, npi_number="7777777777"
-            )
+            professional = await database_sync_to_async(
+                ProfessionalUser.objects.create
+            )(user=user, active=True, npi_number="7777777777")
 
-            chat = await sync_to_async(OngoingChat.objects.create)(
+            chat = await database_sync_to_async(OngoingChat.objects.create)(
                 professional_user=professional,
                 chat_history=[],
                 summary_for_next_call=[],

--- a/tests/async/test_chat_history_and_microsite_context.py
+++ b/tests/async/test_chat_history_and_microsite_context.py
@@ -21,7 +21,7 @@ from fighthealthinsurance.models import OngoingChat, ProfessionalUser, Appeal, D
 from fighthealthinsurance.websockets import OngoingChatConsumer
 from tests.sync.mock_chat_model import MockChatModel
 
-from asgiref.sync import sync_to_async
+from channels.db import database_sync_to_async
 
 if typing.TYPE_CHECKING:
     from django.contrib.auth.models import User
@@ -39,15 +39,15 @@ class CrisisResponseHistoryTest(APITestCase):
         When a user sends a crisis-related message and chat_history is empty,
         both the user message and crisis response should be saved.
         """
-        user = await sync_to_async(User.objects.create_user)(
+        user = await database_sync_to_async(User.objects.create_user)(
             username="crisisuser1", password="testpass", email="crisis1@example.com"
         )
-        professional = await sync_to_async(ProfessionalUser.objects.create)(
+        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="1111111112"
         )
 
         # Create a chat with empty history
-        chat = await sync_to_async(OngoingChat.objects.create)(
+        chat = await database_sync_to_async(OngoingChat.objects.create)(
             professional_user=professional,
             chat_history=[],
             summary_for_next_call=[],
@@ -77,7 +77,9 @@ class CrisisResponseHistoryTest(APITestCase):
             self.assertIn("988", response["content"])  # Crisis hotline number
 
             # Verify chat history was saved
-            chat_refreshed = await sync_to_async(OngoingChat.objects.get)(id=chat.id)
+            chat_refreshed = await database_sync_to_async(OngoingChat.objects.get)(
+                id=chat.id
+            )
             self.assertEqual(
                 len(chat_refreshed.chat_history),
                 2,
@@ -104,15 +106,15 @@ class CrisisResponseHistoryTest(APITestCase):
         This is a regression test to ensure that when chat_history is NOT empty,
         new messages are still appended and saved.
         """
-        user = await sync_to_async(User.objects.create_user)(
+        user = await database_sync_to_async(User.objects.create_user)(
             username="crisisuser2", password="testpass", email="crisis2@example.com"
         )
-        professional = await sync_to_async(ProfessionalUser.objects.create)(
+        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="2222222223"
         )
 
         # Create a chat with EXISTING history
-        chat = await sync_to_async(OngoingChat.objects.create)(
+        chat = await database_sync_to_async(OngoingChat.objects.create)(
             professional_user=professional,
             chat_history=[
                 {
@@ -152,7 +154,9 @@ class CrisisResponseHistoryTest(APITestCase):
             self.assertIn("content", response)
 
             # Verify chat history was appended (should now have 4 messages)
-            chat_refreshed = await sync_to_async(OngoingChat.objects.get)(id=chat.id)
+            chat_refreshed = await database_sync_to_async(OngoingChat.objects.get)(
+                id=chat.id
+            )
             self.assertEqual(
                 len(chat_refreshed.chat_history),
                 4,
@@ -187,20 +191,20 @@ class LinkMessageHistoryTest(APITestCase):
         """
         Test that link message is saved when linking an appeal to a chat with empty history.
         """
-        user = await sync_to_async(User.objects.create_user)(
+        user = await database_sync_to_async(User.objects.create_user)(
             username="linkuser1", password="testpass", email="link1@example.com"
         )
-        professional = await sync_to_async(ProfessionalUser.objects.create)(
+        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="3333333334"
         )
 
         # Create a denial first (required for appeal)
-        denial = await sync_to_async(Denial.objects.create)(
+        denial = await database_sync_to_async(Denial.objects.create)(
             creating_professional=professional,
         )
 
         # Create an appeal for linking
-        appeal = await sync_to_async(Appeal.objects.create)(
+        appeal = await database_sync_to_async(Appeal.objects.create)(
             creating_professional=professional,
             primary_professional=professional,
             hashed_email="linkhash1@example.com",
@@ -208,7 +212,7 @@ class LinkMessageHistoryTest(APITestCase):
         )
 
         # Create a chat with empty history
-        chat = await sync_to_async(OngoingChat.objects.create)(
+        chat = await database_sync_to_async(OngoingChat.objects.create)(
             professional_user=professional,
             chat_history=[],
             summary_for_next_call=[],
@@ -242,7 +246,9 @@ class LinkMessageHistoryTest(APITestCase):
             self.assertIn("linked", response["content"].lower())
 
             # Verify chat history was saved
-            chat_refreshed = await sync_to_async(OngoingChat.objects.get)(id=chat.id)
+            chat_refreshed = await database_sync_to_async(OngoingChat.objects.get)(
+                id=chat.id
+            )
             self.assertEqual(
                 len(chat_refreshed.chat_history),
                 2,
@@ -259,20 +265,20 @@ class LinkMessageHistoryTest(APITestCase):
         This is a regression test to ensure that when chat_history is NOT empty,
         new link messages are still appended and saved.
         """
-        user = await sync_to_async(User.objects.create_user)(
+        user = await database_sync_to_async(User.objects.create_user)(
             username="linkuser2", password="testpass", email="link2@example.com"
         )
-        professional = await sync_to_async(ProfessionalUser.objects.create)(
+        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="4444444445"
         )
 
         # Create a denial first (required for appeal)
-        denial = await sync_to_async(Denial.objects.create)(
+        denial = await database_sync_to_async(Denial.objects.create)(
             creating_professional=professional,
         )
 
         # Create an appeal for linking
-        appeal = await sync_to_async(Appeal.objects.create)(
+        appeal = await database_sync_to_async(Appeal.objects.create)(
             creating_professional=professional,
             primary_professional=professional,
             hashed_email="linkhash2@example.com",
@@ -280,7 +286,7 @@ class LinkMessageHistoryTest(APITestCase):
         )
 
         # Create a chat with EXISTING history
-        chat = await sync_to_async(OngoingChat.objects.create)(
+        chat = await database_sync_to_async(OngoingChat.objects.create)(
             professional_user=professional,
             chat_history=[
                 {
@@ -324,7 +330,9 @@ class LinkMessageHistoryTest(APITestCase):
             self.assertIn("content", response)
 
             # Verify chat history was appended (should now have 4 messages)
-            chat_refreshed = await sync_to_async(OngoingChat.objects.get)(id=chat.id)
+            chat_refreshed = await database_sync_to_async(OngoingChat.objects.get)(
+                id=chat.id
+            )
             self.assertEqual(
                 len(chat_refreshed.chat_history),
                 4,

--- a/tests/async/test_chat_long_message.py
+++ b/tests/async/test_chat_long_message.py
@@ -17,7 +17,7 @@ from channels.testing import WebsocketCommunicator
 from django.contrib.auth import get_user_model
 from rest_framework.test import APITestCase
 
-from asgiref.sync import sync_to_async
+from channels.db import database_sync_to_async
 
 from fighthealthinsurance.chat.message_preprocessor import (
     DIRECT_CHAT_HARD_LIMIT_CHARS,
@@ -49,13 +49,13 @@ class RecordingMockModel(MockChatModel):
 
 
 async def _make_professional_chat(username, npi):
-    user = await sync_to_async(User.objects.create_user)(
+    user = await database_sync_to_async(User.objects.create_user)(
         username=username, password="testpass", email=f"{username}@example.com"
     )
-    professional = await sync_to_async(ProfessionalUser.objects.create)(
+    professional = await database_sync_to_async(ProfessionalUser.objects.create)(
         user=user, active=True, npi_number=npi
     )
-    chat = await sync_to_async(OngoingChat.objects.create)(
+    chat = await database_sync_to_async(OngoingChat.objects.create)(
         professional_user=professional,
         chat_history=[],
         summary_for_next_call=[],

--- a/tests/async/test_microsite_chat_integration.py
+++ b/tests/async/test_microsite_chat_integration.py
@@ -17,7 +17,7 @@ from fighthealthinsurance.models import OngoingChat, ProfessionalUser, Appeal
 from fighthealthinsurance.websockets import OngoingChatConsumer
 from tests.sync.mock_chat_model import MockChatModel
 
-from asgiref.sync import sync_to_async
+from channels.db import database_sync_to_async
 
 if typing.TYPE_CHECKING:
     from django.contrib.auth.models import User
@@ -54,14 +54,14 @@ class MicrositeChatIntegrationTest(APITestCase):
         mock_get_microsite.return_value = mock_microsite
 
         try:
-            user = await sync_to_async(User.objects.create_user)(
+            user = await database_sync_to_async(User.objects.create_user)(
                 username="testuser", password="testpass", email="test@example.com"
             )
-            professional = await sync_to_async(ProfessionalUser.objects.create)(
-                user=user, active=True, npi_number="1111111111"
-            )
+            professional = await database_sync_to_async(
+                ProfessionalUser.objects.create
+            )(user=user, active=True, npi_number="1111111111")
 
-            chat = await sync_to_async(OngoingChat.objects.create)(
+            chat = await database_sync_to_async(OngoingChat.objects.create)(
                 professional_user=professional,
                 microsite_slug="test-microsite",
                 chat_history=[],
@@ -115,22 +115,22 @@ class ChatHistoryAppendingTest(APITestCase):
         mock_get_chat_backends.return_value = [mock_model]
 
         try:
-            user = await sync_to_async(User.objects.create_user)(
+            user = await database_sync_to_async(User.objects.create_user)(
                 username="historyuser", password="testpass", email="history@example.com"
             )
-            professional = await sync_to_async(ProfessionalUser.objects.create)(
-                user=user, active=True, npi_number="1234567890"
-            )
+            professional = await database_sync_to_async(
+                ProfessionalUser.objects.create
+            )(user=user, active=True, npi_number="1234567890")
 
             # Create an appeal for linking
-            appeal = await sync_to_async(Appeal.objects.create)(
+            appeal = await database_sync_to_async(Appeal.objects.create)(
                 creating_professional=professional,
                 primary_professional=professional,
                 hashed_email="hashtest@example.com",
             )
 
             # Create a chat with EXISTING history
-            chat = await sync_to_async(OngoingChat.objects.create)(
+            chat = await database_sync_to_async(OngoingChat.objects.create)(
                 professional_user=professional,
                 chat_history=[
                     {
@@ -171,7 +171,9 @@ class ChatHistoryAppendingTest(APITestCase):
             self.assertIn("content", response)
 
             # Verify that chat history was appended (should now have 4 messages)
-            chat_refreshed = await sync_to_async(OngoingChat.objects.get)(id=chat.id)
+            chat_refreshed = await database_sync_to_async(OngoingChat.objects.get)(
+                id=chat.id
+            )
             self.assertEqual(
                 len(chat_refreshed.chat_history),
                 4,

--- a/tests/async/test_microsite_context_fetching.py
+++ b/tests/async/test_microsite_context_fetching.py
@@ -19,7 +19,7 @@ from fighthealthinsurance.models import OngoingChat, ProfessionalUser
 from fighthealthinsurance.websockets import OngoingChatConsumer
 from tests.sync.mock_chat_model import MockChatModel
 
-from asgiref.sync import sync_to_async
+from channels.db import database_sync_to_async
 
 if typing.TYPE_CHECKING:
     from django.contrib.auth.models import User
@@ -75,16 +75,16 @@ class MicrositeContextFetchingTest(APITestCase):
         mock_get_microsite.return_value = mock_microsite
 
         try:
-            user = await sync_to_async(User.objects.create_user)(
+            user = await database_sync_to_async(User.objects.create_user)(
                 username="extralinkuser",
                 password="testpass",
                 email="extralink@example.com",
             )
-            professional = await sync_to_async(ProfessionalUser.objects.create)(
-                user=user, active=True, npi_number="1111111111"
-            )
+            professional = await database_sync_to_async(
+                ProfessionalUser.objects.create
+            )(user=user, active=True, npi_number="1111111111")
 
-            chat = await sync_to_async(OngoingChat.objects.create)(
+            chat = await database_sync_to_async(OngoingChat.objects.create)(
                 professional_user=professional,
                 microsite_slug="test-microsite",
                 chat_history=[],
@@ -173,14 +173,14 @@ class MicrositeContextFetchingTest(APITestCase):
         mock_get_microsite.return_value = mock_microsite
 
         try:
-            user = await sync_to_async(User.objects.create_user)(
+            user = await database_sync_to_async(User.objects.create_user)(
                 username="pubmeduser", password="testpass", email="pubmed@example.com"
             )
-            professional = await sync_to_async(ProfessionalUser.objects.create)(
-                user=user, active=True, npi_number="2222222222"
-            )
+            professional = await database_sync_to_async(
+                ProfessionalUser.objects.create
+            )(user=user, active=True, npi_number="2222222222")
 
-            chat = await sync_to_async(OngoingChat.objects.create)(
+            chat = await database_sync_to_async(OngoingChat.objects.create)(
                 professional_user=professional,
                 microsite_slug="test-pubmed-microsite",
                 chat_history=[],
@@ -268,14 +268,14 @@ class MicrositeContextFetchingTest(APITestCase):
         mock_get_microsite.return_value = mock_microsite
 
         try:
-            user = await sync_to_async(User.objects.create_user)(
+            user = await database_sync_to_async(User.objects.create_user)(
                 username="bothuser", password="testpass", email="both@example.com"
             )
-            professional = await sync_to_async(ProfessionalUser.objects.create)(
-                user=user, active=True, npi_number="3333333333"
-            )
+            professional = await database_sync_to_async(
+                ProfessionalUser.objects.create
+            )(user=user, active=True, npi_number="3333333333")
 
-            chat = await sync_to_async(OngoingChat.objects.create)(
+            chat = await database_sync_to_async(OngoingChat.objects.create)(
                 professional_user=professional,
                 microsite_slug="test-both-microsite",
                 chat_history=[],
@@ -344,16 +344,16 @@ class MicrositeContextFetchingTest(APITestCase):
         mock_fire_and_forget = fire_and_forget_patcher.start()
 
         try:
-            user = await sync_to_async(User.objects.create_user)(
+            user = await database_sync_to_async(User.objects.create_user)(
                 username="nomicrositeuser",
                 password="testpass",
                 email="nomicrosite@example.com",
             )
-            professional = await sync_to_async(ProfessionalUser.objects.create)(
-                user=user, active=True, npi_number="4444444444"
-            )
+            professional = await database_sync_to_async(
+                ProfessionalUser.objects.create
+            )(user=user, active=True, npi_number="4444444444")
 
-            chat = await sync_to_async(OngoingChat.objects.create)(
+            chat = await database_sync_to_async(OngoingChat.objects.create)(
                 professional_user=professional,
                 microsite_slug=None,  # No microsite
                 chat_history=[],

--- a/tests/sync/test_chat_delete_data_integration.py
+++ b/tests/sync/test_chat_delete_data_integration.py
@@ -12,7 +12,7 @@ Two end-to-end paths through `ChatInterface.handle_chat_message`:
 import typing
 from unittest.mock import AsyncMock, patch
 
-from asgiref.sync import sync_to_async
+from channels.db import database_sync_to_async
 from django.contrib.auth import get_user_model
 from rest_framework.test import APITestCase
 
@@ -71,15 +71,15 @@ class DeleteDataHandoffIntegrationTest(APITestCase):
         chat_history=None,
     ):
         """Create a professional user, chat, and ChatInterface wired to `captured`."""
-        user = await sync_to_async(User.objects.create_user)(
+        user = await database_sync_to_async(User.objects.create_user)(
             username=username,
             password="testpass",
             email=f"{username}@example.com",
         )
-        professional = await sync_to_async(ProfessionalUser.objects.create)(
+        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number=npi_number
         )
-        chat = await sync_to_async(OngoingChat.objects.create)(
+        chat = await database_sync_to_async(OngoingChat.objects.create)(
             professional_user=professional,
             chat_type=ChatType.PROFESSIONAL,
             chat_history=chat_history if chat_history is not None else [],
@@ -118,7 +118,7 @@ class DeleteDataHandoffIntegrationTest(APITestCase):
             self.assertEqual(len(assistant_payloads), 1)
             self.assertEqual(assistant_payloads[0]["content"], DELETE_DATA_RESPONSE)
 
-            await sync_to_async(chat.refresh_from_db)()
+            await database_sync_to_async(chat.refresh_from_db)()
             self.assertEqual(len(chat.chat_history), 2)
             self.assertEqual(chat.chat_history[0]["role"], "user")
             self.assertEqual(

--- a/tests/sync/test_chat_fallback.py
+++ b/tests/sync/test_chat_fallback.py
@@ -12,7 +12,7 @@ from fighthealthinsurance.models import OngoingChat, ProfessionalUser
 from fighthealthinsurance.websockets import OngoingChatConsumer
 from .mock_chat_model import MockChatModel
 
-from asgiref.sync import sync_to_async
+from channels.db import database_sync_to_async
 
 if typing.TYPE_CHECKING:
     from django.contrib.auth.models import User
@@ -60,13 +60,13 @@ class ChatFallbackTest(APITestCase):
             "Response from primary model", "Primary context"
         )
 
-        user = await sync_to_async(User.objects.create_user)(
+        user = await database_sync_to_async(User.objects.create_user)(
             username="testuser", password="testpass", email="test@example.com"
         )
-        professional = await sync_to_async(ProfessionalUser.objects.create)(
+        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="1234567890"
         )
-        chat = await sync_to_async(OngoingChat.objects.create)(
+        chat = await database_sync_to_async(OngoingChat.objects.create)(
             professional_user=professional,
             chat_history=[],
             summary_for_next_call=[],
@@ -114,13 +114,13 @@ class ChatFallbackTest(APITestCase):
             "Response from fallback model", "Fallback context"
         )
 
-        user = await sync_to_async(User.objects.create_user)(
+        user = await database_sync_to_async(User.objects.create_user)(
             username="testuser2", password="testpass", email="test2@example.com"
         )
-        professional = await sync_to_async(ProfessionalUser.objects.create)(
+        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="2345678901"
         )
-        chat = await sync_to_async(OngoingChat.objects.create)(
+        chat = await database_sync_to_async(OngoingChat.objects.create)(
             professional_user=professional,
             chat_history=[],
             summary_for_next_call=[],
@@ -161,13 +161,13 @@ class ChatFallbackTest(APITestCase):
         # Set up to return empty fallback when external is disabled
         self.mock_get_backends.return_value = ([self.mock_primary_model], [])
 
-        user = await sync_to_async(User.objects.create_user)(
+        user = await database_sync_to_async(User.objects.create_user)(
             username="testuser3", password="testpass", email="test3@example.com"
         )
-        professional = await sync_to_async(ProfessionalUser.objects.create)(
+        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="3456789012"
         )
-        chat = await sync_to_async(OngoingChat.objects.create)(
+        chat = await database_sync_to_async(OngoingChat.objects.create)(
             professional_user=professional,
             chat_history=[],
             summary_for_next_call=[],
@@ -201,13 +201,13 @@ class ChatFallbackTest(APITestCase):
         """Test that use_external_models can be toggled during a chat session."""
         await self.asyncSetUp()
 
-        user = await sync_to_async(User.objects.create_user)(
+        user = await database_sync_to_async(User.objects.create_user)(
             username="testuser4", password="testpass", email="test4@example.com"
         )
-        professional = await sync_to_async(ProfessionalUser.objects.create)(
+        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="4567890123"
         )
-        chat = await sync_to_async(OngoingChat.objects.create)(
+        chat = await database_sync_to_async(OngoingChat.objects.create)(
             professional_user=professional,
             chat_history=[],
             summary_for_next_call=[],

--- a/tests/sync/test_chat_status_messages.py
+++ b/tests/sync/test_chat_status_messages.py
@@ -18,7 +18,7 @@ from fighthealthinsurance.websockets import OngoingChatConsumer
 from fighthealthinsurance.chat_interface import ChatInterface
 from .mock_chat_model import MockChatModel
 
-from asgiref.sync import sync_to_async
+from channels.db import database_sync_to_async
 
 if typing.TYPE_CHECKING:
     from django.contrib.auth.models import User
@@ -66,13 +66,13 @@ class ChatStatusMessageTest(APITestCase):
         await self.asyncSetUp()
 
         # Create a user and chat
-        user = await sync_to_async(User.objects.create_user)(
+        user = await database_sync_to_async(User.objects.create_user)(
             username="statususer", password="testpass", email="status@example.com"
         )
-        professional = await sync_to_async(ProfessionalUser.objects.create)(
+        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="1234567890"
         )
-        chat = await sync_to_async(OngoingChat.objects.create)(
+        chat = await database_sync_to_async(OngoingChat.objects.create)(
             professional_user=professional,
             chat_type=ChatType.PROFESSIONAL,
             chat_history=[],
@@ -112,13 +112,13 @@ class ChatStatusMessageTest(APITestCase):
         """Test that status messages are sent during PubMed searches."""
         await self.asyncSetUp()
 
-        user = await sync_to_async(User.objects.create_user)(
+        user = await database_sync_to_async(User.objects.create_user)(
             username="pubmeduser", password="testpass", email="pubmed@example.com"
         )
-        professional = await sync_to_async(ProfessionalUser.objects.create)(
+        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="9876543210"
         )
-        chat = await sync_to_async(OngoingChat.objects.create)(
+        chat = await database_sync_to_async(OngoingChat.objects.create)(
             professional_user=professional,
             chat_type=ChatType.PROFESSIONAL,
             chat_history=[],
@@ -174,13 +174,13 @@ class ChatStatusMessageTest(APITestCase):
         """Test that status messages are sent during Medicaid lookups."""
         await self.asyncSetUp()
 
-        user = await sync_to_async(User.objects.create_user)(
+        user = await database_sync_to_async(User.objects.create_user)(
             username="medicaiduser", password="testpass", email="medicaid@example.com"
         )
-        professional = await sync_to_async(ProfessionalUser.objects.create)(
+        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="5555555555"
         )
-        chat = await sync_to_async(OngoingChat.objects.create)(
+        chat = await database_sync_to_async(OngoingChat.objects.create)(
             professional_user=professional,
             chat_type=ChatType.PROFESSIONAL,
             chat_history=[],
@@ -240,7 +240,7 @@ class ChatStatusMessageTest(APITestCase):
         session_key = "test_session_key_123"
 
         # Create a ChatLeads entry for trial professional
-        await sync_to_async(ChatLeads.objects.create)(
+        await database_sync_to_async(ChatLeads.objects.create)(
             session_id=session_key,
             email="trial@example.com",
             name="Trial User",
@@ -317,15 +317,15 @@ class ChatStatusMessageTest(APITestCase):
         """Test that multiple status updates are properly sent and tracked."""
         await self.asyncSetUp()
 
-        user = await sync_to_async(User.objects.create_user)(
+        user = await database_sync_to_async(User.objects.create_user)(
             username="multistatususer",
             password="testpass",
             email="multistatus@example.com",
         )
-        professional = await sync_to_async(ProfessionalUser.objects.create)(
+        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="3333333333"
         )
-        chat = await sync_to_async(OngoingChat.objects.create)(
+        chat = await database_sync_to_async(OngoingChat.objects.create)(
             professional_user=professional,
             chat_type=ChatType.PROFESSIONAL,
             chat_history=[],
@@ -367,15 +367,15 @@ class ChatStatusMessageTest(APITestCase):
         """Test that status messages are sent during appeal creation."""
         await self.asyncSetUp()
 
-        user = await sync_to_async(User.objects.create_user)(
+        user = await database_sync_to_async(User.objects.create_user)(
             username="appealstatususer",
             password="testpass",
             email="appealstatus@example.com",
         )
-        professional = await sync_to_async(ProfessionalUser.objects.create)(
+        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="4444444444"
         )
-        chat = await sync_to_async(OngoingChat.objects.create)(
+        chat = await database_sync_to_async(OngoingChat.objects.create)(
             professional_user=professional,
             chat_type=ChatType.PROFESSIONAL,
             chat_history=[],
@@ -425,13 +425,13 @@ class ChatStatusMessageTest(APITestCase):
         """Test that error messages are properly sent via status."""
         await self.asyncSetUp()
 
-        user = await sync_to_async(User.objects.create_user)(
+        user = await database_sync_to_async(User.objects.create_user)(
             username="erroruser", password="testpass", email="error@example.com"
         )
-        professional = await sync_to_async(ProfessionalUser.objects.create)(
+        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="6666666666"
         )
-        chat = await sync_to_async(OngoingChat.objects.create)(
+        chat = await database_sync_to_async(OngoingChat.objects.create)(
             professional_user=professional,
             chat_type=ChatType.PROFESSIONAL,
             chat_history=[],
@@ -473,7 +473,7 @@ class ChatStatusMessageTest(APITestCase):
         session_key = "test_session_key_456"
 
         # Create a ChatLeads entry
-        await sync_to_async(ChatLeads.objects.create)(
+        await database_sync_to_async(ChatLeads.objects.create)(
             session_id=session_key,
             email="clear@example.com",
             name="Clear User",
@@ -535,13 +535,13 @@ class ChatStatusMessageTest(APITestCase):
         """Test that retry functionality can be triggered when needed."""
         await self.asyncSetUp()
 
-        user = await sync_to_async(User.objects.create_user)(
+        user = await database_sync_to_async(User.objects.create_user)(
             username="retryuser", password="testpass", email="retry@example.com"
         )
-        professional = await sync_to_async(ProfessionalUser.objects.create)(
+        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="7777777777"
         )
-        chat = await sync_to_async(OngoingChat.objects.create)(
+        chat = await database_sync_to_async(OngoingChat.objects.create)(
             professional_user=professional,
             chat_type=ChatType.PROFESSIONAL,
             chat_history=[

--- a/tests/sync/test_ongoing_chat.py
+++ b/tests/sync/test_ongoing_chat.py
@@ -16,7 +16,7 @@ from fighthealthinsurance.websockets import OngoingChatConsumer
 from fhi_users.models import ProfessionalDomainRelation
 from .mock_chat_model import MockChatModel
 
-from asgiref.sync import sync_to_async, async_to_sync
+from channels.db import database_sync_to_async
 
 if typing.TYPE_CHECKING:
     from django.contrib.auth.models import User
@@ -30,12 +30,12 @@ class OngoingChatWebSocketTest(APITestCase):
         """Test _analyze_denied_items stores denied_item and denied_reason independently and applies guardrails."""
         await self.asyncSetUp()
         consumer = OngoingChatConsumer()
-        user = await sync_to_async(User.objects.create_user)(
+        user = await database_sync_to_async(User.objects.create_user)(
             username="denieduser", password="testpass", email="denied@example.com"
         )
 
         # Case 1: Both denied_item and denied_reason are empty/unclear (patient)
-        chat1 = await sync_to_async(OngoingChat.objects.create)(
+        chat1 = await database_sync_to_async(OngoingChat.objects.create)(
             is_patient=True,
             user=user,
             chat_history=[
@@ -50,12 +50,14 @@ class OngoingChatWebSocketTest(APITestCase):
             '{"denied_item": null, "denied_reason": null}', ""
         )
         await consumer._analyze_denied_items(str(chat1.id))
-        refreshed1 = await sync_to_async(OngoingChat.objects.get)(id=str(chat1.id))
+        refreshed1 = await database_sync_to_async(OngoingChat.objects.get)(
+            id=str(chat1.id)
+        )
         self.assertIsNone(refreshed1.denied_item)
         self.assertIsNone(refreshed1.denied_reason)
 
         # Case 2: Only denied_item is clear (patient)
-        chat2 = await sync_to_async(OngoingChat.objects.create)(
+        chat2 = await database_sync_to_async(OngoingChat.objects.create)(
             is_patient=True,
             user=user,
             chat_history=[
@@ -70,12 +72,14 @@ class OngoingChatWebSocketTest(APITestCase):
             '{"denied_item": "MRI scan", "denied_reason": null}', ""
         )
         await consumer._analyze_denied_items(str(chat2.id))
-        refreshed2 = await sync_to_async(OngoingChat.objects.get)(id=str(chat2.id))
+        refreshed2 = await database_sync_to_async(OngoingChat.objects.get)(
+            id=str(chat2.id)
+        )
         self.assertEqual(refreshed2.denied_item, "MRI scan")
         self.assertIsNone(refreshed2.denied_reason)
 
         # Case 3: Only denied_reason is clear (patient)
-        chat3 = await sync_to_async(OngoingChat.objects.create)(
+        chat3 = await database_sync_to_async(OngoingChat.objects.create)(
             is_patient=True,
             user=user,
             chat_history=[
@@ -90,12 +94,14 @@ class OngoingChatWebSocketTest(APITestCase):
             '{"denied_item": null, "denied_reason": "Lack of medical necessity"}', ""
         )
         await consumer._analyze_denied_items(str(chat3.id))
-        refreshed3 = await sync_to_async(OngoingChat.objects.get)(id=str(chat3.id))
+        refreshed3 = await database_sync_to_async(OngoingChat.objects.get)(
+            id=str(chat3.id)
+        )
         self.assertIsNone(refreshed3.denied_item)
         self.assertEqual(refreshed3.denied_reason, "Lack of medical necessity")
 
         # Case 4: Both are clear (patient)
-        chat4 = await sync_to_async(OngoingChat.objects.create)(
+        chat4 = await database_sync_to_async(OngoingChat.objects.create)(
             is_patient=True,
             user=user,
             chat_history=[
@@ -111,12 +117,14 @@ class OngoingChatWebSocketTest(APITestCase):
             "",
         )
         await consumer._analyze_denied_items(str(chat4.id))
-        refreshed4 = await sync_to_async(OngoingChat.objects.get)(id=str(chat4.id))
+        refreshed4 = await database_sync_to_async(OngoingChat.objects.get)(
+            id=str(chat4.id)
+        )
         self.assertEqual(refreshed4.denied_item, "MRI scan")
         self.assertEqual(refreshed4.denied_reason, "Lack of medical necessity")
 
         # Case 5: Unclear/generic values (should not store) (patient)
-        chat5 = await sync_to_async(OngoingChat.objects.create)(
+        chat5 = await database_sync_to_async(OngoingChat.objects.create)(
             is_patient=True,
             user=user,
             chat_history=[
@@ -128,7 +136,9 @@ class OngoingChatWebSocketTest(APITestCase):
             '{"denied_item": "unknown", "denied_reason": "unclear"}', ""
         )
         await consumer._analyze_denied_items(str(chat5.id))
-        refreshed5 = await sync_to_async(OngoingChat.objects.get)(id=str(chat5.id))
+        refreshed5 = await database_sync_to_async(OngoingChat.objects.get)(
+            id=str(chat5.id)
+        )
         self.assertIsNone(refreshed5.denied_item)
         self.assertIsNone(refreshed5.denied_reason)
 
@@ -155,20 +165,20 @@ class OngoingChatWebSocketTest(APITestCase):
     async def test_link_chat_to_appeal_success(self):
         """Test linking a chat to an appeal with permission."""
         await self.asyncSetUp()
-        user = await sync_to_async(User.objects.create_user)(
+        user = await database_sync_to_async(User.objects.create_user)(
             username="appealuser", password="testpass", email="appeal@example.com"
         )
-        professional = await sync_to_async(ProfessionalUser.objects.create)(
+        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="1111111111"
         )
-        chat = await sync_to_async(OngoingChat.objects.create)(
+        chat = await database_sync_to_async(OngoingChat.objects.create)(
             professional_user=professional,
             chat_history=[],
             summary_for_next_call=[],
         )
         from fighthealthinsurance.models import Appeal
 
-        appeal = await sync_to_async(Appeal.objects.create)(
+        appeal = await database_sync_to_async(Appeal.objects.create)(
             creating_professional=professional,
             primary_professional=professional,
             hashed_email="hashappeal@example.com",
@@ -192,7 +202,7 @@ class OngoingChatWebSocketTest(APITestCase):
         self.assertIn("content", response)
         self.assertIn("linked", response["content"])
         # Appeal is linked
-        appeal_refresh = await sync_to_async(Appeal.objects.get)(id=appeal.id)
+        appeal_refresh = await database_sync_to_async(Appeal.objects.get)(id=appeal.id)
         self.assertEqual(appeal_refresh.chat_id, chat.id)
         await communicator.disconnect()
         await self.asyncTearDown()
@@ -200,20 +210,20 @@ class OngoingChatWebSocketTest(APITestCase):
     async def test_link_chat_to_prior_auth_success(self):
         """Test linking a chat to a prior auth with permission."""
         await self.asyncSetUp()
-        user = await sync_to_async(User.objects.create_user)(
+        user = await database_sync_to_async(User.objects.create_user)(
             username="priorauthuser", password="testpass", email="priorauth@example.com"
         )
-        professional = await sync_to_async(ProfessionalUser.objects.create)(
+        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="2222222222"
         )
-        chat = await sync_to_async(OngoingChat.objects.create)(
+        chat = await database_sync_to_async(OngoingChat.objects.create)(
             professional_user=professional,
             chat_history=[],
             summary_for_next_call=[],
         )
         from fighthealthinsurance.models import PriorAuthRequest
 
-        prior_auth = await sync_to_async(PriorAuthRequest.objects.create)(
+        prior_auth = await database_sync_to_async(PriorAuthRequest.objects.create)(
             creator_professional_user=professional,
             created_for_professional_user=professional,
             diagnosis="Test diagnosis",
@@ -239,7 +249,7 @@ class OngoingChatWebSocketTest(APITestCase):
         self.assertIn("content", response)
         self.assertIn("linked", response["content"])
         # PriorAuthRequest is linked
-        prior_auth_refresh = await sync_to_async(PriorAuthRequest.objects.get)(
+        prior_auth_refresh = await database_sync_to_async(PriorAuthRequest.objects.get)(
             id=prior_auth.id
         )
         self.assertEqual(prior_auth_refresh.chat_id, chat.id)
@@ -250,9 +260,9 @@ class OngoingChatWebSocketTest(APITestCase):
         await self.asyncSetUp()
         consumer = OngoingChatConsumer()
         consumer.chat_interface = object()
-        chat = await sync_to_async(OngoingChat.objects.create)(
+        chat = await database_sync_to_async(OngoingChat.objects.create)(
             is_patient=True,
-            user=await sync_to_async(User.objects.create_user)(
+            user=await database_sync_to_async(User.objects.create_user)(
                 username="enqueueuser", password="testpass", email="enqueue@example.com"
             ),
             chat_history=[],
@@ -275,9 +285,9 @@ class OngoingChatWebSocketTest(APITestCase):
         await self.asyncSetUp()
         consumer = OngoingChatConsumer()
         consumer.chat_interface = object()
-        chat = await sync_to_async(OngoingChat.objects.create)(
+        chat = await database_sync_to_async(OngoingChat.objects.create)(
             is_patient=True,
-            user=await sync_to_async(User.objects.create_user)(
+            user=await database_sync_to_async(User.objects.create_user)(
                 username="failuser", password="testpass", email="fail@example.com"
             ),
             chat_history=[],
@@ -309,26 +319,26 @@ class OngoingChatWebSocketTest(APITestCase):
     async def test_link_chat_to_appeal_permission_denied(self):
         """Test linking a chat to an appeal without permission is denied."""
         await self.asyncSetUp()
-        user1 = await sync_to_async(User.objects.create_user)(
+        user1 = await database_sync_to_async(User.objects.create_user)(
             username="user1", password="testpass", email="user1@example.com"
         )
-        user2 = await sync_to_async(User.objects.create_user)(
+        user2 = await database_sync_to_async(User.objects.create_user)(
             username="user2", password="testpass", email="user2@example.com"
         )
-        professional1 = await sync_to_async(ProfessionalUser.objects.create)(
+        professional1 = await database_sync_to_async(ProfessionalUser.objects.create)(
             user=user1, active=True, npi_number="3333333333"
         )
-        professional2 = await sync_to_async(ProfessionalUser.objects.create)(
+        professional2 = await database_sync_to_async(ProfessionalUser.objects.create)(
             user=user2, active=True, npi_number="4444444444"
         )
-        chat = await sync_to_async(OngoingChat.objects.create)(
+        chat = await database_sync_to_async(OngoingChat.objects.create)(
             professional_user=professional2,
             chat_history=[],
             summary_for_next_call=[],
         )
         from fighthealthinsurance.models import Appeal
 
-        appeal = await sync_to_async(Appeal.objects.create)(
+        appeal = await database_sync_to_async(Appeal.objects.create)(
             creating_professional=professional1,
             primary_professional=professional1,
             hashed_email="hashappeal2@example.com",
@@ -352,7 +362,7 @@ class OngoingChatWebSocketTest(APITestCase):
         self.assertIn("error", response)
         self.assertIn("permission", response["error"])
         # Appeal is not linked
-        appeal_refresh = await sync_to_async(Appeal.objects.get)(id=appeal.id)
+        appeal_refresh = await database_sync_to_async(Appeal.objects.get)(id=appeal.id)
         self.assertIsNone(appeal_refresh.chat_id)
         await communicator.disconnect()
         await self.asyncTearDown()
@@ -360,26 +370,26 @@ class OngoingChatWebSocketTest(APITestCase):
     async def test_link_chat_to_prior_auth_permission_denied(self):
         """Test linking a chat to a prior auth without permission is denied."""
         await self.asyncSetUp()
-        user1 = await sync_to_async(User.objects.create_user)(
+        user1 = await database_sync_to_async(User.objects.create_user)(
             username="user3", password="testpass", email="user3@example.com"
         )
-        user2 = await sync_to_async(User.objects.create_user)(
+        user2 = await database_sync_to_async(User.objects.create_user)(
             username="user4", password="testpass", email="user4@example.com"
         )
-        professional1 = await sync_to_async(ProfessionalUser.objects.create)(
+        professional1 = await database_sync_to_async(ProfessionalUser.objects.create)(
             user=user1, active=True, npi_number="5555555555"
         )
-        professional2 = await sync_to_async(ProfessionalUser.objects.create)(
+        professional2 = await database_sync_to_async(ProfessionalUser.objects.create)(
             user=user2, active=True, npi_number="6666666666"
         )
-        chat = await sync_to_async(OngoingChat.objects.create)(
+        chat = await database_sync_to_async(OngoingChat.objects.create)(
             professional_user=professional2,
             chat_history=[],
             summary_for_next_call=[],
         )
         from fighthealthinsurance.models import PriorAuthRequest
 
-        prior_auth = await sync_to_async(PriorAuthRequest.objects.create)(
+        prior_auth = await database_sync_to_async(PriorAuthRequest.objects.create)(
             creator_professional_user=professional1,
             created_for_professional_user=professional1,
             diagnosis="Test diagnosis",
@@ -405,7 +415,7 @@ class OngoingChatWebSocketTest(APITestCase):
         self.assertIn("error", response)
         self.assertIn("permission", response["error"])
         # PriorAuthRequest is not linked
-        prior_auth_refresh = await sync_to_async(PriorAuthRequest.objects.get)(
+        prior_auth_refresh = await database_sync_to_async(PriorAuthRequest.objects.get)(
             id=prior_auth.id
         )
         self.assertIsNone(prior_auth_refresh.chat_id)
@@ -418,15 +428,15 @@ class OngoingChatWebSocketTest(APITestCase):
         await self.asyncSetUp()
 
         # Create a user
-        user = await sync_to_async(User.objects.create_user)(
+        user = await database_sync_to_async(User.objects.create_user)(
             username="testuser", password="testpass", email="test@example.com"
         )
-        professional = await sync_to_async(ProfessionalUser.objects.create)(
+        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="1234567890"
         )
 
         # Create a chat
-        chat = await sync_to_async(OngoingChat.objects.create)(
+        chat = await database_sync_to_async(OngoingChat.objects.create)(
             professional_user=professional,
             chat_history=[
                 {
@@ -477,7 +487,7 @@ class OngoingChatWebSocketTest(APITestCase):
         await communicator.disconnect()
 
         # Verify message was added to chat history
-        chat = await sync_to_async(OngoingChat.objects.get)(id=chat.id)
+        chat = await database_sync_to_async(OngoingChat.objects.get)(id=chat.id)
         self.assertEqual(
             len(chat.chat_history), 4
         )  # Original 2 messages + new user message + assistant response
@@ -504,10 +514,10 @@ class OngoingChatWebSocketTest(APITestCase):
         await self.asyncSetUp()
 
         # Create a user
-        user = await sync_to_async(User.objects.create_user)(
+        user = await database_sync_to_async(User.objects.create_user)(
             username="testuser", password="testpass", email="test@example.com"
         )
-        professional = await sync_to_async(ProfessionalUser.objects.create)(
+        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="1234567890"
         )
 
@@ -545,7 +555,7 @@ class OngoingChatWebSocketTest(APITestCase):
         self.assertTrue(chat_exists)
 
         # Verify message was added to chat history
-        chat = await sync_to_async(OngoingChat.objects.get)(id=chat_id)
+        chat = await database_sync_to_async(OngoingChat.objects.get)(id=chat_id)
         self.assertEqual(len(chat.chat_history), 2)  # User message + assistant response
         self.assertEqual(chat.chat_history[0]["role"], "user")
         self.assertEqual(
@@ -615,15 +625,15 @@ class OngoingChatWebSocketTest(APITestCase):
         with patch(
             "django.conf.settings.FIGHT_PAPERWORK_DOMAIN", "test-domain.example.com"
         ):
-            user = await sync_to_async(User.objects.create_user)(
+            user = await database_sync_to_async(User.objects.create_user)(
                 username="appealurluser",
                 password="testpass",
                 email="appealurl@example.com",
             )
-            professional = await sync_to_async(ProfessionalUser.objects.create)(
-                user=user, active=True, npi_number="5555555555"
-            )
-            chat = await sync_to_async(OngoingChat.objects.create)(
+            professional = await database_sync_to_async(
+                ProfessionalUser.objects.create
+            )(user=user, active=True, npi_number="5555555555")
+            chat = await database_sync_to_async(OngoingChat.objects.create)(
                 professional_user=professional,
                 chat_history=[],
                 summary_for_next_call=[],
@@ -659,7 +669,9 @@ class OngoingChatWebSocketTest(APITestCase):
             # Check that the response contains a properly formatted URL with the domain
             from fighthealthinsurance.models import Appeal
 
-            appeals = await sync_to_async(list)(Appeal.objects.filter(chat=chat))
+            appeals = await database_sync_to_async(list)(
+                Appeal.objects.filter(chat=chat)
+            )
             self.assertTrue(len(appeals) > 0)
             appeal_id = appeals[0].id
             expected_url_part = f"/appeals/{appeal_id}"
@@ -675,15 +687,15 @@ class OngoingChatWebSocketTest(APITestCase):
         with patch(
             "django.conf.settings.FIGHT_PAPERWORK_DOMAIN", "test-domain.example.com"
         ):
-            user = await sync_to_async(User.objects.create_user)(
+            user = await database_sync_to_async(User.objects.create_user)(
                 username="priorauthurl",
                 password="testpass",
                 email="priorauthurl@example.com",
             )
-            professional = await sync_to_async(ProfessionalUser.objects.create)(
-                user=user, active=True, npi_number="6666666666"
-            )
-            chat = await sync_to_async(OngoingChat.objects.create)(
+            professional = await database_sync_to_async(
+                ProfessionalUser.objects.create
+            )(user=user, active=True, npi_number="6666666666")
+            chat = await database_sync_to_async(OngoingChat.objects.create)(
                 professional_user=professional,
                 chat_history=[],
                 summary_for_next_call=[],
@@ -719,7 +731,7 @@ class OngoingChatWebSocketTest(APITestCase):
             # Check that the response contains a properly formatted URL with the domain
             from fighthealthinsurance.models import PriorAuthRequest
 
-            prior_auths = await sync_to_async(list)(
+            prior_auths = await database_sync_to_async(list)(
                 PriorAuthRequest.objects.filter(chat=chat)
             )
             self.assertTrue(len(prior_auths) > 0)

--- a/tests/sync/test_prior_auth_api.py
+++ b/tests/sync/test_prior_auth_api.py
@@ -26,7 +26,7 @@ from fighthealthinsurance.websockets import PriorAuthConsumer
 from fhi_users.models import ProfessionalDomainRelation
 from .mock_prior_auth_model import MockPriorAuthModel
 
-from asgiref.sync import sync_to_async, async_to_sync
+from channels.db import database_sync_to_async
 
 if typing.TYPE_CHECKING:
     from django.contrib.auth.models import User
@@ -341,14 +341,14 @@ class PriorAuthWebSocketTest(APITestCase):
         await self.asyncSetUp()
 
         # Create a user and a prior auth request with answers
-        user = await sync_to_async(User.objects.create_user)(
+        user = await database_sync_to_async(User.objects.create_user)(
             username="testuser", password="testpass", email="test@example.com"
         )
-        professional = await sync_to_async(ProfessionalUser.objects.create)(
+        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="1234567890"
         )
 
-        prior_auth = await sync_to_async(PriorAuthRequest.objects.create)(
+        prior_auth = await database_sync_to_async(PriorAuthRequest.objects.create)(
             creator_professional_user=professional,
             diagnosis="Rheumatoid Arthritis",
             treatment="Biologic Therapy",
@@ -398,7 +398,9 @@ class PriorAuthWebSocketTest(APITestCase):
         await communicator.disconnect()
 
         # Verify prior auth status was updated
-        prior_auth = await sync_to_async(PriorAuthRequest.objects.get)(id=prior_auth.id)
+        prior_auth = await database_sync_to_async(PriorAuthRequest.objects.get)(
+            id=prior_auth.id
+        )
         self.assertEqual(prior_auth.status, "prior_auth_requested")
 
         # Clean up

--- a/tests/sync/test_pubmed_api.py
+++ b/tests/sync/test_pubmed_api.py
@@ -10,7 +10,8 @@ from django.urls import reverse
 from django.contrib.auth import get_user_model
 from django.utils import timezone
 from django.test import TestCase, TransactionTestCase
-from asgiref.sync import async_to_sync, sync_to_async
+from asgiref.sync import async_to_sync
+from channels.db import database_sync_to_async
 
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -603,7 +604,7 @@ class PubMedE2EAppealFlowTest(TransactionTestCase):
             self.assertLessEqual(len(articles), PER_QUERY * 2)
 
             # Verify per-query cache rows were created (denial_id=NULL)
-            cache_rows = await sync_to_async(
+            cache_rows = await database_sync_to_async(
                 lambda: list(PubMedQueryData.objects.filter(denial_id__isnull=True))
             )()
             self.assertGreater(len(cache_rows), 0, "Per-query cache rows should exist")
@@ -614,7 +615,7 @@ class PubMedE2EAppealFlowTest(TransactionTestCase):
                 self.assertGreater(len(parsed), 0, "Cache rows should not be empty")
 
             # Verify denial summary row was created (denial_id=self.denial)
-            summary_rows = await sync_to_async(
+            summary_rows = await database_sync_to_async(
                 lambda: list(PubMedQueryData.objects.filter(denial_id=self.denial))
             )()
             self.assertEqual(len(summary_rows), 1, "Exactly one denial summary row")
@@ -643,7 +644,7 @@ class PubMedE2EAppealFlowTest(TransactionTestCase):
             await Denial.objects.filter(denial_id=self.denial.denial_id).aupdate(
                 pubmed_ids_json=article_pmids
             )
-            await sync_to_async(self.denial.refresh_from_db)()
+            await database_sync_to_async(self.denial.refresh_from_db)()
 
             context = await tools.find_context_for_denial(self.denial)
 
@@ -659,7 +660,7 @@ class PubMedE2EAppealFlowTest(TransactionTestCase):
             self.assertGreater(len(articles2), 0)
 
             # Verify no duplicate denial summary rows were created
-            summary_rows_after = await sync_to_async(
+            summary_rows_after = await database_sync_to_async(
                 lambda: list(PubMedQueryData.objects.filter(denial_id=self.denial))
             )()
             self.assertEqual(
@@ -669,7 +670,7 @@ class PubMedE2EAppealFlowTest(TransactionTestCase):
             )
 
             # Verify denial's base fields are unchanged
-            await sync_to_async(self.denial.refresh_from_db)()
+            await database_sync_to_async(self.denial.refresh_from_db)()
             self.assertEqual(self.denial.procedure, "physical therapy")
             self.assertEqual(self.denial.diagnosis, "rheumatoid arthritis")
 
@@ -760,7 +761,7 @@ class PubMedE2EAppealFlowTest(TransactionTestCase):
             )
 
             # Verify denial summary row has composite query string
-            summary_rows = await sync_to_async(
+            summary_rows = await database_sync_to_async(
                 lambda: list(PubMedQueryData.objects.filter(denial_id=self.denial))
             )()
             self.assertEqual(len(summary_rows), 1)
@@ -776,7 +777,7 @@ class PubMedE2EAppealFlowTest(TransactionTestCase):
                 self.assertIn(term, summary_query)
 
             # Verify per-query cache rows don't have denial_id
-            cache_rows = await sync_to_async(
+            cache_rows = await database_sync_to_async(
                 lambda: list(PubMedQueryData.objects.filter(denial_id__isnull=True))
             )()
             self.assertGreater(len(cache_rows), 0)
@@ -793,7 +794,7 @@ class PubMedE2EAppealFlowTest(TransactionTestCase):
             await Denial.objects.filter(denial_id=self.denial.denial_id).aupdate(
                 pubmed_ids_json=article_pmids
             )
-            await sync_to_async(self.denial.refresh_from_db)()
+            await database_sync_to_async(self.denial.refresh_from_db)()
 
             context = await tools.find_context_for_denial(self.denial)
             self.assertEqual(context, "Summarized context with microsite articles")
@@ -812,7 +813,7 @@ class PubMedE2EAppealFlowTest(TransactionTestCase):
             self.assertEqual(len(articles), 0)
 
             # No denial summary row should be created
-            summary_count = await sync_to_async(
+            summary_count = await database_sync_to_async(
                 PubMedQueryData.objects.filter(denial_id=self.denial).count
             )()
             self.assertEqual(
@@ -822,7 +823,7 @@ class PubMedE2EAppealFlowTest(TransactionTestCase):
             # Empty results from a successful NCBI call ARE negative-cached
             # so repeated empty-query lookups don't hammer NCBI. (Errors and
             # timeouts still aren't persisted; see negative-cache tests.)
-            cache_rows = await sync_to_async(
+            cache_rows = await database_sync_to_async(
                 lambda: list(PubMedQueryData.objects.filter(denial_id__isnull=True))
             )()
             self.assertGreater(
@@ -888,7 +889,7 @@ class PubMedE2EAppealFlowTest(TransactionTestCase):
             self.assertGreater(len(articles), 0)
 
             # Denial summary row should exist even though base query was empty
-            summary_rows = await sync_to_async(
+            summary_rows = await database_sync_to_async(
                 lambda: list(PubMedQueryData.objects.filter(denial_id=denial))
             )()
             self.assertEqual(
@@ -902,7 +903,7 @@ class PubMedE2EAppealFlowTest(TransactionTestCase):
             self.assertGreater(len(summary_pmids), 0)
 
             # Verify denial still has empty base fields
-            await sync_to_async(denial.refresh_from_db)()
+            await database_sync_to_async(denial.refresh_from_db)()
             self.assertEqual(denial.procedure, "")
             self.assertEqual(denial.diagnosis, "")
 
@@ -927,7 +928,7 @@ class PubMedNegativeCachingTest(TransactionTestCase):
             result = await tools.find_pubmed_article_ids_for_query("no hits query")
             self.assertEqual(result, [])
 
-            rows = await sync_to_async(
+            rows = await database_sync_to_async(
                 lambda: list(
                     PubMedQueryData.objects.filter(
                         query="no hits query", denial_id__isnull=True
@@ -994,7 +995,7 @@ class PubMedNegativeCachingTest(TransactionTestCase):
             with self.assertRaises(RuntimeError):
                 await tools.find_pubmed_article_ids_for_query("failing query")
 
-            rows = await sync_to_async(
+            rows = await database_sync_to_async(
                 lambda: list(PubMedQueryData.objects.filter(query="failing query"))
             )()
             self.assertEqual(rows, [], "Errors must not produce negative-cache rows")

--- a/tests/sync/test_rest_api.py
+++ b/tests/sync/test_rest_api.py
@@ -1,6 +1,7 @@
 """Test the rest API functionality"""
 
-from asgiref.sync import async_to_sync, sync_to_async
+from asgiref.sync import async_to_sync
+from channels.db import database_sync_to_async
 from unittest.mock import patch
 
 import asyncio
@@ -157,7 +158,7 @@ class DenialEndToEnd(APITestCase):
     @pytest.mark.asyncio
     # Testing end to end for professional user
     async def test_denial_end_to_end(self):
-        login_result = await sync_to_async(self.client.login)(
+        login_result = await database_sync_to_async(self.client.login)(
             username=self.username, password=self.password
         )
         self.assertTrue(login_result)
@@ -169,7 +170,7 @@ class DenialEndToEnd(APITestCase):
         ).acount()
         assert denials_for_user_count == 0
         # Create a denial
-        response = await sync_to_async(self.client.post)(
+        response = await database_sync_to_async(self.client.post)(
             url,
             json.dumps(
                 {
@@ -233,7 +234,7 @@ class DenialEndToEnd(APITestCase):
                 pass
         # Set health history before next steps
         health_history_url = reverse("healthhistory-list")
-        health_history_response = await sync_to_async(self.client.post)(
+        health_history_response = await database_sync_to_async(self.client.post)(
             health_history_url,
             json.dumps(
                 {
@@ -248,7 +249,9 @@ class DenialEndToEnd(APITestCase):
         self.assertTrue(status.is_success(health_history_response.status_code))
         # Ok now lets get the additional info
         find_next_steps_url = reverse("nextsteps-list")
-        find_next_steps_response: JsonResponse = await sync_to_async(self.client.post)(
+        find_next_steps_response: JsonResponse = await database_sync_to_async(
+            self.client.post
+        )(
             find_next_steps_url,
             json.dumps(
                 {
@@ -320,7 +323,7 @@ class DenialEndToEnd(APITestCase):
         # Now lets go ahead and provide follow up
         denial = await Denial.objects.aget(denial_id=denial_id)
         followup_url = reverse("followups-list")
-        followup_response = await sync_to_async(self.client.post)(
+        followup_response = await database_sync_to_async(self.client.post)(
             followup_url,
             json.dumps(
                 {
@@ -342,13 +345,13 @@ class DenialEndToEnd(APITestCase):
     async def test_appeal_generation_status_messages(self):
         """Test that appeal generation WebSocket sends status messages."""
         # Setup: Create a denial through the API
-        login_result = await sync_to_async(self.client.login)(
+        login_result = await database_sync_to_async(self.client.login)(
             username=self.username, password=self.password
         )
         self.assertTrue(login_result)
         url = reverse("denials-list")
         email = "test@example.com"
-        response = await sync_to_async(self.client.post)(
+        response = await database_sync_to_async(self.client.post)(
             url,
             json.dumps(
                 {
@@ -695,7 +698,7 @@ class StreamingAppealsRestFallbackTest(APITestCase):
         path in tests without real WS failure injection."""
         from fighthealthinsurance import websockets
 
-        denial = await sync_to_async(self._make_real_denial)()
+        denial = await database_sync_to_async(self._make_real_denial)()
 
         original = websockets.SUPPRESS_APPEAL_WS_DELIVERY
         websockets.SUPPRESS_APPEAL_WS_DELIVERY = True


### PR DESCRIPTION
Now the infra/tests/docs half of the original branch — the app-code `database_sync_to_async` conversions moved to #900 so CI can isolate which half trips the async suite.

## What stays here

- **k8s**: `fhi-pg-main-9` `max_connections` → 6000 (takes effect only after `kubectl cnpg restart fhi-pg-main-9`), a connection-pressure reaper CronJob that evicts the oldest idle connections under saturation, and Prometheus alerts for connection saturation and reaper failures.
- **`scripts/pg-conn-census.sh`**: snapshot who holds pg connections during an incident.
- **websockets**: sweep idle-killed DB connections at consumer `receive()` entry via `aclose_old_connections`, gated on a real idle gap (>=60s since the previous frame, never on the first frame after connect). Fixes the Sentry "terminating connection due to idle-session timeout" OperationalErrors without per-frame connect/close churn — Django 5.2's `close_if_unusable_or_obsolete` reconnects an initialized-but-closed wrapper just to read autocommit, so an ungated sweep would open+close a connection per message.
- **CLAUDE.md**: the async DB ladder — native async ORM (`aget`/`acreate`/...) first for new code; channels' `database_sync_to_async` for ORM-touching wraps; plain asgiref only for non-ORM callables with a comment; don't flip existing working code between shapes.
- **tests**: ~200+ ORM-touching `sync_to_async` call sites across 14 test files → `database_sync_to_async` (includes the reviewer-flagged `test_followup_emails` wrap of `Denial.objects.create`). Mechanical name-swap + import updates.
- **requirements-dev**: pin `seleniumbase==4.34.6` — stops pip probing ~130 releases (bs4 4.12.3 vs seleniumbase 4.35.0+'s bs4==4.13.3 exact pin), which is where CI's IncompleteRead flakes landed. Duplicated identically on #900.

## Verification (local, this branch alone on top of main)

- `tox -e py313-black` / `tox -e py313-mypy`: clean
- `tox -e py313-django52-async-unit`: 1208 passed, 2 skipped
- `tox -e py313-django52-async`: 463 passed, 19 skipped, 0 failures/errors
- `tox -e py313-django52-sync`: 1641 passed

## Deploy notes

Apply cluster yaml, then `kubectl cnpg restart fhi-pg-main-9` (max_connections needs it), then reaper + alerts manifests, then the app roll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0131sie14pm2wJe5G2cY4r87