### PR TITLE
Use database_sync_to_async for ORM-touching async bridges in app code

### DIFF
--- a/fighthealthinsurance/chat/tools/appeal_tool.py
+++ b/fighthealthinsurance/chat/tools/appeal_tool.py
@@ -9,7 +9,7 @@ import json
 import re
 from typing import Any, Awaitable, Callable, Optional, Tuple
 
-from asgiref.sync import sync_to_async
+from channels.db import database_sync_to_async
 from loguru import logger
 
 from .base_tool import BaseTool
@@ -140,9 +140,9 @@ class AppealTool(BaseTool):
             appeal = await chat.appeals.afirst()
             if appeal:
                 await self.send_status_message(f"Updating existing Appeal #{appeal.id}")
-                denial = await sync_to_async(lambda x: x.for_denial)(appeal)
+                denial = await database_sync_to_async(lambda x: x.for_denial)(appeal)
         else:
-            pro_user = await sync_to_async(lambda: chat.professional_user)()
+            pro_user = await database_sync_to_async(lambda: chat.professional_user)()
             denial = await Denial.objects.acreate(creating_professional=pro_user)
             appeal = await Appeal.objects.acreate(
                 chat=chat, creating_professional=pro_user, for_denial=denial
@@ -153,7 +153,7 @@ class AppealTool(BaseTool):
                 if chat.hashed_email:
                     appeal_data["hashed_email"] = chat.hashed_email
                 elif chat.user_id is not None:
-                    user_email = await sync_to_async(lambda: chat.user.email)()
+                    user_email = await database_sync_to_async(lambda: chat.user.email)()
                     if user_email:
                         appeal_data["hashed_email"] = Denial.get_hashed_email(
                             user_email

--- a/fighthealthinsurance/chat/tools/json_followup_tool.py
+++ b/fighthealthinsurance/chat/tools/json_followup_tool.py
@@ -3,7 +3,7 @@ Reusable base class for chat tools that follow this shape:
 
     1. Detect a ``**tool_name {JSON}**`` invocation in the LLM response.
     2. Parse the JSON payload.
-    3. Run a synchronous lookup via ``sync_to_async``.
+    3. Run a synchronous lookup via ``database_sync_to_async``.
     4. Re-invoke the LLM with the lookup result so the next reply can quote it.
     5. Merge the additional response and context back in.
 

--- a/fighthealthinsurance/chat/tools/pa_requirement_tool.py
+++ b/fighthealthinsurance/chat/tools/pa_requirement_tool.py
@@ -16,7 +16,7 @@ Example call shape the model is expected to emit::
 import re
 from typing import Optional, Tuple
 
-from asgiref.sync import sync_to_async
+from channels.db import database_sync_to_async
 
 from .json_followup_tool import JsonFollowupTool, extract_balanced_json
 from .patterns import LOOKUP_PA_REQUIREMENT_REGEX
@@ -46,7 +46,7 @@ class PaRequirementLookupTool(JsonFollowupTool):
     async def run(
         self, params: dict, *, current_message_for_llm: str = ""
     ) -> Tuple[str, str]:
-        pa_block, summary = await sync_to_async(_run_lookup)(params)
+        pa_block, summary = await database_sync_to_async(_run_lookup)(params)
         # Empty pa_block means the lookup found nothing usable; honor the
         # JsonFollowupTool short-circuit contract by returning an empty
         # note so the LLM follow-up pass is skipped.
@@ -66,7 +66,7 @@ def _resolve_insurance_company(payer: Optional[str]):
 
 def _run_lookup(params: dict) -> Tuple[str, str]:
     """
-    Synchronous core of the lookup, suitable for sync_to_async wrapping.
+    Synchronous core of the lookup, suitable for database_sync_to_async wrapping.
     Returns ``(formatted_context, status_summary)``.
 
     When a payer name is supplied but cannot be resolved we refuse the

--- a/fighthealthinsurance/chat/tools/uspstf_tool.py
+++ b/fighthealthinsurance/chat/tools/uspstf_tool.py
@@ -10,7 +10,7 @@ for preventive-care denial appeals.
 
 from typing import Tuple
 
-from asgiref.sync import sync_to_async
+from channels.db import database_sync_to_async
 
 from .json_followup_tool import JsonFollowupTool
 from .patterns import USPSTF_LOOKUP_REGEX
@@ -41,7 +41,7 @@ class USPSTFLookupTool(JsonFollowupTool):
     ) -> Tuple[str, str]:
         from fighthealthinsurance.uspstf_api import get_uspstf_info
 
-        info = await sync_to_async(get_uspstf_info)(params)
+        info = await database_sync_to_async(get_uspstf_info)(params)
         if not info:
             return "", ""
 

--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -44,7 +44,8 @@ from django.utils.html import escape as html_escape
 import asyncstdlib as a
 import ray
 import uszipcode
-from asgiref.sync import async_to_sync, sync_to_async
+from asgiref.sync import async_to_sync
+from channels.db import database_sync_to_async
 from loguru import logger
 from PyPDF2 import PdfMerger
 from stopit.utils import TimeoutException
@@ -1583,7 +1584,7 @@ class DenialCreatorHelper:
             denial = await Denial.objects.filter(denial_id=denial_id).aget()
             if not is_under_reimbursement_claim(denial.denial_text):
                 return
-            await sync_to_async(dispatch_ucr_refresh)(denial.pk)
+            await database_sync_to_async(dispatch_ucr_refresh)(denial.pk)
         except Exception:
             logger.opt(exception=True).warning(
                 "UCR fire-and-forget dispatch failed for denial {}", denial_id
@@ -2480,7 +2481,7 @@ async def _refresh_sync_denial_context(
     """
     try:
         getter = getter_factory()
-        return await sync_to_async(getter)(denial) or None
+        return await database_sync_to_async(getter)(denial) or None
     except Exception as e:
         logger.opt(exception=True).debug(f"{label} context refresh failed: {e}")
         return None
@@ -2840,7 +2841,7 @@ class AppealsBackendHelper:
         # Apply all of our 'expert system'
         # (aka six regexes in a trench coat hiding behind a database).
         async for dt in denial.denial_type.all():
-            form = await sync_to_async(dt.get_form)()
+            form = await database_sync_to_async(dt.get_form)()
             if form is not None:
                 parsed = form(parameters)
                 if parsed.is_valid():
@@ -3103,7 +3104,7 @@ class AppealsBackendHelper:
 
             pa_context_awaitable = tracked_awaitable(
                 asyncio.wait_for(
-                    sync_to_async(get_pa_context_for_denial)(denial),
+                    database_sync_to_async(get_pa_context_for_denial)(denial),
                     timeout=10,
                 ),
                 substep="pa_requirements",
@@ -3121,7 +3122,7 @@ class AppealsBackendHelper:
 
             uspstf_context_awaitable = tracked_awaitable(
                 asyncio.wait_for(
-                    sync_to_async(get_uspstf_context_for_denial)(denial),
+                    database_sync_to_async(get_uspstf_context_for_denial)(denial),
                     timeout=10,
                 ),
                 substep="uspstf",
@@ -3280,7 +3281,7 @@ class AppealsBackendHelper:
                 # lose trial evidence. The reader is already async (DB-only — no
                 # live registry call), so it can't go through
                 # _refresh_sync_denial_context (which wraps a sync getter in
-                # sync_to_async); use an inline guard with the same
+                # database_sync_to_async); use an inline guard with the same
                 # degrade-to-None behavior. wait_for bounds the DB read with
                 # the same 10s budget the gather path uses so a stalled query
                 # can't hang this resilience path (TimeoutError is an
@@ -3329,7 +3330,7 @@ class AppealsBackendHelper:
             # ClinicalTrials lookup is also DB-only against the prefetched
             # cache, so re-render it on retries. The reader is async, so it
             # uses an inline guard rather than _refresh_sync_denial_context
-            # (which wraps a sync getter in sync_to_async). wait_for bounds
+            # (which wraps a sync getter in database_sync_to_async). wait_for bounds
             # the DB read with the same 10s budget as the gather path.
             try:
                 clinical_trials_context = await asyncio.wait_for(
@@ -3425,7 +3426,7 @@ class AppealsBackendHelper:
             plan_parts.append(denial.plan_documents_summary)
         model_plan_context: Optional[str] = "\n\n".join(plan_parts) or None
 
-        appeals: Iterator[GeneratedAppeal] = await sync_to_async(
+        appeals: Iterator[GeneratedAppeal] = await database_sync_to_async(
             appealGenerator.make_appeals
         )(
             denial,
@@ -3708,7 +3709,7 @@ class EscalationPacketHelper:
             yield json.dumps({"type": "error", "message": "Denial not found"}) + "\n"
             return
 
-        recipients = await sync_to_async(get_recipients_for_denial)(denial)
+        recipients = await database_sync_to_async(get_recipients_for_denial)(denial)
         if not recipients:
             yield json.dumps(
                 {"type": "error", "message": "No regulator recipients available"}

--- a/fighthealthinsurance/extralink_fetcher.py
+++ b/fighthealthinsurance/extralink_fetcher.py
@@ -16,6 +16,10 @@ from django.db import models
 
 import aiohttp
 import PyPDF2
+
+# Plain asgiref sync_to_async ON PURPOSE: wrapped callables (microsites
+# static-json load, pandoc subprocess) touch no ORM; the channels database
+# variant would churn DB connections for nothing.
 from asgiref.sync import sync_to_async
 from bs4 import BeautifulSoup
 from loguru import logger

--- a/fighthealthinsurance/generate_appeal.py
+++ b/fighthealthinsurance/generate_appeal.py
@@ -1453,12 +1453,12 @@ class AppealGenerator(object):
         # Load known companies from database dynamically
         known_companies: list[str] = []
         try:
-            from asgiref.sync import sync_to_async
+            from channels.db import database_sync_to_async
 
             from fighthealthinsurance.models import InsuranceCompany
 
             # Get all insurance companies from database
-            companies = await sync_to_async(
+            companies = await database_sync_to_async(
                 lambda: list(InsuranceCompany.objects.values_list("name", "alt_names"))
             )()
             for name, alt_names in companies:

--- a/fighthealthinsurance/generate_prior_auth.py
+++ b/fighthealthinsurance/generate_prior_auth.py
@@ -5,7 +5,8 @@ import uuid
 from concurrent.futures import Future
 from typing import Any, AsyncIterator, Dict, List, Optional
 
-from asgiref.sync import async_to_sync, sync_to_async
+from asgiref.sync import async_to_sync
+from channels.db import database_sync_to_async
 from loguru import logger
 
 from fighthealthinsurance.exec import executor
@@ -94,7 +95,7 @@ class PriorAuthGenerator:
         treatment = prior_auth.treatment
         insurance_company = prior_auth.insurance_company
         # Convert the provider info, can result in a query through domain.
-        provider_info = await sync_to_async(str)(
+        provider_info = await database_sync_to_async(str)(
             (
                 prior_auth.created_for_professional_user
                 or prior_auth.creator_professional_user
@@ -225,7 +226,7 @@ class PriorAuthGenerator:
                 }
 
             # Substitute in patient and provider information
-            substituted_text = await sync_to_async(
+            substituted_text = await database_sync_to_async(
                 PriorAuthTextSubstituter.substitute_patient_and_provider_info
             )(prior_auth, proposal_text)
 

--- a/fighthealthinsurance/management/commands/ingest_pa_requirements.py
+++ b/fighthealthinsurance/management/commands/ingest_pa_requirements.py
@@ -18,9 +18,9 @@ Usage::
 from __future__ import annotations
 
 import asyncio
-from typing import Any, List, Optional
+from typing import Any, List, Optional, cast
 
-from asgiref.sync import sync_to_async
+from channels.db import database_sync_to_async
 from django.core.management.base import BaseCommand
 
 from fighthealthinsurance.models import InsuranceCompany
@@ -95,7 +95,7 @@ class Command(BaseCommand):
             if company is None:
                 stats["failed"] += 1
         else:
-            companies = await sync_to_async(
+            companies = await database_sync_to_async(
                 lambda: list(
                     InsuranceCompany.objects.filter(
                         pa_requirement_list_url_is_parseable=True,
@@ -123,6 +123,9 @@ class Command(BaseCommand):
 
     @staticmethod
     async def _resolve_company(name: str) -> Optional[InsuranceCompany]:
-        return await sync_to_async(
-            lambda: InsuranceCompany.objects.filter(name__iexact=name).first()
-        )()
+        return cast(
+            Optional[InsuranceCompany],
+            await database_sync_to_async(
+                lambda: InsuranceCompany.objects.filter(name__iexact=name).first()
+            )(),
+        )

--- a/fighthealthinsurance/management/commands/load_medicare_pfs.py
+++ b/fighthealthinsurance/management/commands/load_medicare_pfs.py
@@ -35,7 +35,7 @@ from pathlib import Path
 from typing import Any, Iterable, NamedTuple, Optional
 
 import aiohttp
-from asgiref.sync import sync_to_async
+from channels.db import database_sync_to_async
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
@@ -235,7 +235,7 @@ async def refresh_medicare_pfs(
                 multipliers=multipliers,
             )
 
-    written, skipped = await sync_to_async(_persist, thread_sensitive=True)()
+    written, skipped = await database_sync_to_async(_persist, thread_sensitive=True)()
     return RefreshResult(
         localities=len(localities),
         rates=len(rate_rows),

--- a/fighthealthinsurance/ml/ml_appeal_questions_helper.py
+++ b/fighthealthinsurance/ml/ml_appeal_questions_helper.py
@@ -3,7 +3,7 @@ import re
 import time
 from typing import Any, Callable, Coroutine, Dict, List, Optional, Tuple, cast
 
-from asgiref.sync import sync_to_async
+from channels.db import database_sync_to_async
 from loguru import logger
 
 from fighthealthinsurance.ml.ml_router import ml_router
@@ -291,7 +291,9 @@ class MLAppealQuestionsHelper:
                 get_pa_questions_for_denial,
             )
 
-            pa_questions = await sync_to_async(get_pa_questions_for_denial)(denial)
+            pa_questions = await database_sync_to_async(get_pa_questions_for_denial)(
+                denial
+            )
         except Exception as e:
             logger.opt(exception=True).debug(
                 f"PA-aware question lookup failed for denial {denial.denial_id}: {e}"

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -13,7 +13,7 @@ from typing import Any, Callable, ClassVar, Iterable, List, Optional, Tuple, Uni
 
 import aiohttp
 import requests
-from asgiref.sync import async_to_sync, sync_to_async
+from asgiref.sync import async_to_sync
 from loguru import logger
 
 

--- a/fighthealthinsurance/process_denial.py
+++ b/fighthealthinsurance/process_denial.py
@@ -2,7 +2,7 @@ import csv
 import re
 
 import icd10
-from asgiref.sync import sync_to_async
+from channels.db import database_sync_to_async
 from loguru import logger
 
 from fighthealthinsurance.denial_base import DenialBase
@@ -100,7 +100,7 @@ class ProcessDenialCodes(DenialBase):
         # carry the ACA cost-sharing mandate, so we only reclassify the denial
         # as preventive when at least one match is grade A or B. The lookup
         # touches Django's sync ORM, so it must run off the event loop.
-        evidence = await sync_to_async(self.find_uspstf_evidence)(denial_text)
+        evidence = await database_sync_to_async(self.find_uspstf_evidence)(denial_text)
         if any((rec.get("grade") or "").upper() in {"A", "B"} for rec in evidence):
             return [self.preventive_denial]
         return []

--- a/fighthealthinsurance/pubmed_tools.py
+++ b/fighthealthinsurance/pubmed_tools.py
@@ -25,6 +25,10 @@ from urllib.parse import quote, urlencode, urljoin
 
 import aiohttp
 import PyPDF2
+
+# Plain asgiref sync_to_async ON PURPOSE: every wrapped callable here is
+# metapub/network work with no ORM inside; the channels database variant
+# would close the connections this module's interleaved async ORM reuses.
 from asgiref.sync import async_to_sync, sync_to_async
 from django.core.cache import cache
 from django.utils import timezone

--- a/fighthealthinsurance/rest_views.py
+++ b/fighthealthinsurance/rest_views.py
@@ -14,7 +14,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 
-from asgiref.sync import async_to_sync, sync_to_async
+from asgiref.sync import async_to_sync
 from dateutil.relativedelta import relativedelta
 from django_encrypted_filefield.crypt import Cryptographer
 from drf_spectacular.types import OpenApiTypes

--- a/fighthealthinsurance/ucr_helper.py
+++ b/fighthealthinsurance/ucr_helper.py
@@ -6,7 +6,7 @@ gets written to `Denial.ucr_context` and surfaced in the appeal letter prompt
 via AppealGenerator.make_open_prompt's UCR PRICING block.
 
 The helper is sync-only on purpose; async callers (the refresh actor) wrap calls
-in `sync_to_async`. Keeps the helper simple and directly testable from sync
+in `database_sync_to_async`. Keeps the helper simple and directly testable from sync
 TestCase classes.
 """
 

--- a/fighthealthinsurance/uspstf_api.py
+++ b/fighthealthinsurance/uspstf_api.py
@@ -20,10 +20,10 @@ recommendations so appeal generation can still cite preventive guidance.
 
 import asyncio
 import re
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Tuple, cast
 
 import aiohttp
-from asgiref.sync import sync_to_async
+from channels.db import database_sync_to_async
 from django.db import transaction
 from django.utils import timezone
 from loguru import logger
@@ -439,10 +439,10 @@ class USPSTFClient:
         if not records:
             logger.info("Using bundled USPSTF fallback dataset (API empty/unreachable)")
             records = [_coerce_record(item) for item in FALLBACK_RECOMMENDATIONS]
-        return await _store_records(records)
+        return cast(int, await _store_records(records))
 
 
-@sync_to_async
+@database_sync_to_async
 def _store_records(records: Iterable[Dict[str, Any]]) -> int:
     """Persist normalized records into the USPSTFRecommendation table.
 
@@ -754,7 +754,7 @@ def get_uspstf_context_for_denial(denial: Any) -> str:
 
     This is the appeal-generation counterpart to :func:`get_uspstf_info`,
     which is wired into the chat surface. It runs as a cheap synchronous
-    ORM lookup wrapped via ``sync_to_async`` in the gather block.
+    ORM lookup wrapped via ``database_sync_to_async`` in the gather block.
     """
     from fighthealthinsurance.medical_code_extractor import (
         collect_denial_text,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,8 @@
-seleniumbase>=4.32
+# Exact pin: seleniumbase exact-pins beautifulsoup4 per release, and 4.35.0+
+# wants bs4==4.13.3 while requirements.txt pins bs4==4.12.3, so with only a
+# floor here pip probes ~130 releases (4.51 -> 4.34) on every tox env install
+# before landing on 4.34.6. To upgrade: bump beautifulsoup4 first, then this.
+seleniumbase==4.34.6
 urllib3>=2.0
 pytest
 pytest-django

--- a/tests/async-unit/test_appeals_backend_citations.py
+++ b/tests/async-unit/test_appeals_backend_citations.py
@@ -214,7 +214,7 @@ class TestAppealsBackendHelperWithCitations:
                 return_value="PubMed context data",
             ),
             patch(
-                "fighthealthinsurance.common_view_logic.sync_to_async",
+                "fighthealthinsurance.common_view_logic.database_sync_to_async",
             ) as mock_sync_to_async,
             patch(
                 "fighthealthinsurance.common_view_logic.interleave_iterator_for_keep_alive",
@@ -302,7 +302,7 @@ class TestAppealsBackendHelperWithCitations:
                 side_effect=asyncio.TimeoutError("PubMed timeout"),
             ),
             patch(
-                "fighthealthinsurance.common_view_logic.sync_to_async",
+                "fighthealthinsurance.common_view_logic.database_sync_to_async",
             ) as mock_sync_to_async,
             patch(
                 "fighthealthinsurance.common_view_logic.interleave_iterator_for_keep_alive",
@@ -388,7 +388,7 @@ class TestAppealsBackendHelperWithCitations:
                 return_value="PubMed context data",
             ) as mock_find_pubmed,
             patch(
-                "fighthealthinsurance.common_view_logic.sync_to_async",
+                "fighthealthinsurance.common_view_logic.database_sync_to_async",
             ) as mock_sync_to_async,
             patch(
                 "fighthealthinsurance.common_view_logic.interleave_iterator_for_keep_alive",
@@ -481,7 +481,7 @@ class TestAppealsBackendHelperWithCitations:
                 return_value="PubMed context data",
             ),
             patch(
-                "fighthealthinsurance.common_view_logic.sync_to_async",
+                "fighthealthinsurance.common_view_logic.database_sync_to_async",
             ) as mock_sync_to_async,
             patch(
                 "fighthealthinsurance.common_view_logic.interleave_iterator_for_keep_alive",
@@ -575,7 +575,7 @@ class TestAppealsBackendHelperWithCitations:
                 return_value=ct_payload,
             ) as mock_get_ct_context,
             patch(
-                "fighthealthinsurance.common_view_logic.sync_to_async",
+                "fighthealthinsurance.common_view_logic.database_sync_to_async",
             ) as mock_sync_to_async,
             patch(
                 "fighthealthinsurance.common_view_logic.interleave_iterator_for_keep_alive",
@@ -661,7 +661,7 @@ async def test_synthesis_threshold(saved_texts, synthesis_should_run):
             return_value="",
         ),
         patch(
-            "fighthealthinsurance.common_view_logic.sync_to_async",
+            "fighthealthinsurance.common_view_logic.database_sync_to_async",
         ) as mock_sync_to_async,
         patch(
             "fighthealthinsurance.common_view_logic.interleave_iterator_for_keep_alive",
@@ -744,7 +744,7 @@ async def test_synthesis_skips_verbatim_duplicate():
             return_value="",
         ),
         patch(
-            "fighthealthinsurance.common_view_logic.sync_to_async",
+            "fighthealthinsurance.common_view_logic.database_sync_to_async",
         ) as mock_sync_to_async,
         patch(
             "fighthealthinsurance.common_view_logic.interleave_iterator_for_keep_alive",
@@ -831,7 +831,7 @@ async def test_synthesis_too_short_output_is_filtered():
             return_value="",
         ),
         patch(
-            "fighthealthinsurance.common_view_logic.sync_to_async",
+            "fighthealthinsurance.common_view_logic.database_sync_to_async",
         ) as mock_sync_to_async,
         patch(
             "fighthealthinsurance.common_view_logic.interleave_iterator_for_keep_alive",
@@ -909,7 +909,7 @@ async def test_existing_too_short_appeal_is_skipped():
             return_value="",
         ),
         patch(
-            "fighthealthinsurance.common_view_logic.sync_to_async",
+            "fighthealthinsurance.common_view_logic.database_sync_to_async",
         ) as mock_sync_to_async,
         patch(
             "fighthealthinsurance.common_view_logic.interleave_iterator_for_keep_alive",

--- a/tests/sync/test_load_medicare_pfs.py
+++ b/tests/sync/test_load_medicare_pfs.py
@@ -21,8 +21,8 @@ _LOCALITY_HEADER = "locality,description\n"
 
 
 # TransactionTestCase (not TestCase): the loader bridges async->sync via
-# sync_to_async, which uses a thread that holds its own DB connection. The
-# resulting writes commit instead of nesting under TestCase's atomic wrapper,
+# database_sync_to_async, which uses a thread that holds its own DB connection.
+# The resulting writes commit instead of nesting under TestCase's atomic wrapper,
 # so we let TransactionTestCase truncate tables between cases.
 class LoadMedicarePFSTests(TransactionTestCase):
     def setUp(self):

--- a/tests/sync/test_payer_policy_helper.py
+++ b/tests/sync/test_payer_policy_helper.py
@@ -372,7 +372,7 @@ class FetcherIngestTests(TransactionTestCase):
     surfaces them via keyword match.
 
     Uses TransactionTestCase because the fetcher runs DB writes inside an
-    asyncio loop via sync_to_async; under SQLite, the regular TestCase's
+    asyncio loop via database_sync_to_async; under SQLite, the regular TestCase's
     outer transaction would lock the connection from the inner sync call.
     """
 

--- a/tests/sync/test_safety_appeal_scenarios.py
+++ b/tests/sync/test_safety_appeal_scenarios.py
@@ -264,8 +264,8 @@ class PriorAuthToolUseTests(TestCase):
 
     def test_tool_async_run_matches_sync_lookup(self):
         # The tool's production entry point is ``run`` (an async method that
-        # wraps ``_run_lookup`` via sync_to_async). Drive it the same way
-        # the chat consumer does and confirm the (block, summary) result is
+        # wraps ``_run_lookup`` via database_sync_to_async). Drive it the same
+        # way the chat consumer does and confirm the (block, summary) result is
         # the same as calling the sync core directly. We use async_to_sync
         # rather than asyncio.run so Django manages DB connections cleanly.
         tool = PaRequirementLookupTool(AsyncMock())


### PR DESCRIPTION
Second half of the #899 split: this PR carries exactly the app-code bridge conversions, while #899 keeps the k8s/tests/docs/websockets half — so an async-suite CI failure can be attributed to one change-set or the other.

## What

Swap plain asgiref `sync_to_async` for channels' `database_sync_to_async` wherever the wrapped callable touches the Django ORM. The channels variant runs `close_old_connections()` before each call and again in a `finally`, so thread-local DB connections are cleaned up even when the awaiting task is cancelled; plain asgiref leaks them (the July 2026 connection-starvation incident).

Converted modules: `common_view_logic`, `process_denial`, `generate_appeal`, `generate_prior_auth`, `rest_views`, `uspstf_api`, `ucr_helper`, `ml/ml_appeal_questions_helper`, `ml/ml_models`, the chat tools (`appeal_tool`, `json_followup_tool`, `pa_requirement_tool`, `uspstf_tool`), and the `ingest_pa_requirements` / `load_medicare_pfs` management commands.

Deliberately left on plain asgiref (now commented as such): `pubmed_tools` and `extralink_fetcher` — their wrapped callables do network/subprocess/static-file work with no ORM access, so the database variant would churn DB connections there for nothing.

Four test files ride along because they encode the conversion: `test_appeals_backend_citations` patches `common_view_logic.database_sync_to_async` (an attribute that only exists after this change), and three comment-only updates (`test_load_medicare_pfs`, `test_payer_policy_helper`, `test_safety_appeal_scenarios`) describe the converted internals.

`requirements-dev.txt` (the `seleniumbase==4.34.6` pin) is intentionally identical on both halves so each PR's CI installs deterministically; the duplicate line merges cleanly.

## Verification (local, this branch alone on top of main)

- `tox -e py313-black` / `tox -e py313-mypy`: clean (456 source files)
- `tox -e py313-django52-async-unit`: 1208 passed, 2 skipped
- `tox -e py313-django52-async`: 463 passed, 19 skipped, 0 failures/errors
- `tox -e py313-django52-sync`: 1641 passed

Housekeeping note: this reuses the old `claude/relaxed-hopper-4twm41` branch. Its July 19 commits were content-merged via #897 (from `claude/pool-leak-fixes`) or superseded by main's `monitor.fighthealthinsurance.com` (9fb01c6, vs. the branch's `uptimerobot.*` variant). Pre-split tip was 4d4a77a if anything ever needs recovering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0131sie14pm2wJe5G2cY4r87

---
_Generated by [Claude Code](https://claude.ai/code/session_0131sie14pm2wJe5G2cY4r87)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance & Reliability**
  * Improved handling of database-backed operations during asynchronous workflows.
  * Reduced the risk of database connection issues across appeal generation, prior authorization, policy, and evidence lookups.
  * Preserved existing appeal, research, and lookup behavior.

* **Maintenance**
  * Clarified documentation around asynchronous database access and non-database background work.
  * Pinned the development SeleniumBase version for more consistent testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->