### PR TITLE
Increase WebSocket idle timeout to 10 minutes

### DIFF
--- a/conf/nginx.default
+++ b/conf/nginx.default
@@ -21,6 +21,12 @@ server {
 	proxy_http_version 1.1;
 	proxy_set_header Upgrade $http_upgrade;
 	proxy_set_header Connection "upgrade";
+	# Idle websocket timeout: without these nginx falls back to its 60s
+	# default and drops sockets that go quiet mid-conversation. Allow 10
+	# minutes of silence in either direction (the ingress already permits
+	# an hour, so this in-pod proxy was the real bottleneck).
+	proxy_read_timeout 600s;
+	proxy_send_timeout 600s;
     }
 
     location / {

--- a/conf/nginx.default
+++ b/conf/nginx.default
@@ -21,10 +21,16 @@ server {
 	proxy_http_version 1.1;
 	proxy_set_header Upgrade $http_upgrade;
 	proxy_set_header Connection "upgrade";
-	# Idle websocket timeout: without these nginx falls back to its 60s
-	# default and drops sockets that go quiet mid-conversation. Allow 10
-	# minutes of silence in either direction (the ingress already permits
-	# an hour, so this in-pod proxy was the real bottleneck).
+	# Idle websocket timeout. Without these nginx falls back to its 60s
+	# default and drops sockets that go quiet mid-conversation -- a chat
+	# socket while the user reads/types, or a gap between the server's
+	# ~20-45s keep-alive frames. The application governs its own limits:
+	# the appeal client escalates to REST after 90s of frame silence and
+	# hard-caps the socket at 7min (WS_HARD_TIMEOUT_MS in appeal_fetcher.ts).
+	# Give nginx 10min of idle headroom -- above that 7min app cap -- so this
+	# in-pod proxy is never the layer that severs a still-live connection.
+	# The ingress already allows an hour; this proxy in front of uvicorn was
+	# the real 60s bottleneck.
 	proxy_read_timeout 600s;
 	proxy_send_timeout 600s;
     }


### PR DESCRIPTION
## Summary
Increases the nginx proxy timeout for WebSocket connections from the default 60 seconds to 10 minutes (600 seconds) to prevent premature socket disconnection during long periods of inactivity.

## Changes
- Added `proxy_read_timeout 600s` and `proxy_send_timeout 600s` directives to the WebSocket location block in nginx configuration
- These timeouts allow WebSocket connections to remain idle for up to 10 minutes without being dropped by the in-pod nginx proxy
- The upstream ingress already permits an hour of idle time, so the nginx proxy was the actual bottleneck causing mid-conversation disconnections

## Details
Without these timeout settings, nginx falls back to its 60-second default and closes WebSocket connections that go quiet, interrupting real-time appeal generation streams. This change ensures the in-pod proxy doesn't prematurely terminate connections that are legitimately idle but still active in the application layer.

https://claude.ai/code/session_01TVa41JnWx86UFEuD5kDdvx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket connection stability by extending Nginx idle timeouts.
  * Prevents quiet WebSocket conversations from being disconnected after approximately one minute.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->