### PR TITLE
Use native async ORM for model relation access instead of lambda bridges

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,8 +89,10 @@ python manage.py loaddata initial followup plan_source insurance_companies pa_re
   needlessly churn DB connections there. `async_to_sync` stays asgiref.
   **Exception — tests only:** in `tests/`, wrap DB-touching callables with
   plain asgiref `sync_to_async` instead — `database_sync_to_async`'s
-  per-call connection cleanup causes lock-contention storms against the
-  sqlite test database. App code is never exempt. And in tests as
+  per-call connection cleanup buys nothing against the in-memory sqlite
+  test database (closing an in-memory sqlite connection is a no-op) and
+  has been implicated in sqlite lock-contention storms. App code is never
+  exempt. And in tests as
   everywhere, prefer the native async ORM / `aget_related` over any wrapper
   when it can do the job.
   Don't flip existing functions between sync and async (or rewrite working

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,11 @@ python manage.py loaddata initial followup plan_source insurance_companies pa_re
   Django's native async ORM first** — `aget`/`acreate`/`asave`/`adelete`/
   `acount`/`aexists`/`aget_or_create` and `async for` over querysets — which
   needs no bridge at all; async-first is the preferred shape for new code.
+  Forward FK/OneToOne access has no native async accessor: use
+  `select_related` when you control the queryset, or
+  `fighthealthinsurance.utils.aget_related(instance, "field_name")` when
+  handed a bare instance — don't bridge a lambda through
+  `database_sync_to_async` just to read a relation.
   When wrapping existing sync code instead, **bridge choice matters:**
   use channels' `database_sync_to_async` for any wrapped callable that touches
   the Django ORM — it closes the thread's DB connections around each call,
@@ -82,6 +87,12 @@ python manage.py loaddata initial followup plan_source insurance_companies pa_re
   `sync_to_async` ONLY for callables that touch no ORM (subprocess, network,
   file work) and leave a comment saying so, since the database variant would
   needlessly churn DB connections there. `async_to_sync` stays asgiref.
+  **Exception — tests only:** in `tests/`, wrap DB-touching callables with
+  plain asgiref `sync_to_async` instead — `database_sync_to_async`'s
+  per-call connection cleanup causes lock-contention storms against the
+  sqlite test database. App code is never exempt. And in tests as
+  everywhere, prefer the native async ORM / `aget_related` over any wrapper
+  when it can do the job.
   Don't flip existing functions between sync and async (or rewrite working
   bridges into native-async) just to satisfy this preference — apply it to
   new code and to call sites you're already changing.

--- a/fighthealthinsurance/chat/tools/appeal_tool.py
+++ b/fighthealthinsurance/chat/tools/appeal_tool.py
@@ -9,8 +9,9 @@ import json
 import re
 from typing import Any, Awaitable, Callable, Optional, Tuple
 
-from channels.db import database_sync_to_async
 from loguru import logger
+
+from fighthealthinsurance.utils import aget_related
 
 from .base_tool import BaseTool
 from .patterns import CREATE_OR_UPDATE_APPEAL_REGEX
@@ -137,12 +138,14 @@ class AppealTool(BaseTool):
         denial = None
 
         if await chat.appeals.aexists():
-            appeal = await chat.appeals.afirst()
+            # select_related caches for_denial so the attribute access below
+            # stays async-safe without a bridge.
+            appeal = await chat.appeals.select_related("for_denial").afirst()
             if appeal:
                 await self.send_status_message(f"Updating existing Appeal #{appeal.id}")
-                denial = await database_sync_to_async(lambda x: x.for_denial)(appeal)
+                denial = appeal.for_denial
         else:
-            pro_user = await database_sync_to_async(lambda: chat.professional_user)()
+            pro_user = await aget_related(chat, "professional_user")
             denial = await Denial.objects.acreate(creating_professional=pro_user)
             appeal = await Appeal.objects.acreate(
                 chat=chat, creating_professional=pro_user, for_denial=denial
@@ -153,10 +156,10 @@ class AppealTool(BaseTool):
                 if chat.hashed_email:
                     appeal_data["hashed_email"] = chat.hashed_email
                 elif chat.user_id is not None:
-                    user_email = await database_sync_to_async(lambda: chat.user.email)()
-                    if user_email:
+                    user = await aget_related(chat, "user")
+                    if user and user.email:
                         appeal_data["hashed_email"] = Denial.get_hashed_email(
-                            user_email
+                            user.email
                         )
                 elif appeal_data.get("email"):
                     appeal_data["hashed_email"] = Denial.get_hashed_email(

--- a/fighthealthinsurance/chat/tools/prior_auth_tool.py
+++ b/fighthealthinsurance/chat/tools/prior_auth_tool.py
@@ -11,6 +11,8 @@ from typing import Any, Awaitable, Callable, Optional, Tuple
 
 from loguru import logger
 
+from fighthealthinsurance.utils import aget_related
+
 from .base_tool import BaseTool
 from .patterns import CREATE_OR_UPDATE_PRIOR_AUTH_REGEX
 
@@ -152,7 +154,7 @@ class PriorAuthTool(BaseTool):
         else:
             prior_auth = await PriorAuthRequest.objects.acreate(
                 chat=chat,
-                creator_professional_user=chat.professional_user,
+                creator_professional_user=await aget_related(chat, "professional_user"),
             )
 
         return prior_auth

--- a/fighthealthinsurance/chat_interface.py
+++ b/fighthealthinsurance/chat_interface.py
@@ -785,7 +785,9 @@ class ChatInterface:
                     "Prior Auth Request not found or you do not have permission to access it."
                 )
                 return
-            prior_auth_details = await database_sync_to_async(prior_auth.details)()
+            # PriorAuthRequest.details() only reads local columns (unlike
+            # Appeal.details(), which walks relations) — no bridge needed.
+            prior_auth_details = prior_auth.details()
             if prior_auth.chat_id != chat.id:
                 prior_auth.chat = chat
                 await prior_auth.asave()

--- a/fighthealthinsurance/chat_interface.py
+++ b/fighthealthinsurance/chat_interface.py
@@ -648,13 +648,14 @@ class ChatInterface:
                             # Try to get state from a linked denial if available
                             rag_state = None
                             if await chat.appeals.aexists():
-                                appeal = await chat.appeals.afirst()
-                                if appeal:
-                                    linked_denial = await database_sync_to_async(
-                                        lambda x: x.for_denial
-                                    )(appeal)
-                                    if linked_denial:
-                                        rag_state = linked_denial.state
+                                # select_related caches for_denial so the
+                                # attribute access below stays async-safe
+                                # without a bridge.
+                                appeal = await chat.appeals.select_related(
+                                    "for_denial"
+                                ).afirst()
+                                if appeal and appeal.for_denial:
+                                    rag_state = appeal.for_denial.state
 
                             rag_awaitable = get_rag_context_for_denial(
                                 denial_text=rag_query,

--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -2044,7 +2044,12 @@ class DenialCreatorHelper:
         """
         from fighthealthinsurance.models import InsurancePlan
 
-        denial = await Denial.objects.filter(denial_id=denial_id).aget()
+        # select_related caches both FKs so the insurance_*_obj reads below
+        # stay async-safe (a lazy read would raise SynchronousOnlyOperation,
+        # silently eaten by the except blocks).
+        denial = await Denial.objects.select_related(
+            "insurance_plan_obj", "insurance_company_obj"
+        ).aget(denial_id=denial_id)
 
         try:
             # Only proceed if we don't already have a plan matched

--- a/fighthealthinsurance/extralink_prefetch_actor.py
+++ b/fighthealthinsurance/extralink_prefetch_actor.py
@@ -145,13 +145,15 @@ class ExtraLinkPrefetchActor:
         logger.info("Starting PubMed pre-fetch")
 
         try:
-            from channels.db import database_sync_to_async
+            # Plain asgiref sync_to_async ON PURPOSE: the microsites
+            # static-json load touches no ORM (same rule as extralink_fetcher).
+            from asgiref.sync import sync_to_async
 
             from fighthealthinsurance.microsites import get_all_microsites
             from fighthealthinsurance.pubmed_tools import PubMedTools
 
             pubmed_tools = PubMedTools()
-            microsites = await database_sync_to_async(get_all_microsites)()
+            microsites = await sync_to_async(get_all_microsites)()
 
             stats = {"fetched": 0, "failed": 0, "total": 0}
 

--- a/fighthealthinsurance/generate_prior_auth.py
+++ b/fighthealthinsurance/generate_prior_auth.py
@@ -15,7 +15,7 @@ from fighthealthinsurance.ml.ml_router import ml_router
 from fighthealthinsurance.models import PriorAuthRequest, ProposedPriorAuth
 from fighthealthinsurance.prior_auth_utils import PriorAuthTextSubstituter
 from fighthealthinsurance.rxnorm_tools import RxNormTools
-from fighthealthinsurance.utils import as_available
+from fighthealthinsurance.utils import aget_related, as_available
 
 
 def _build_rxnorm_context(treatment: str, normalized: Any) -> str:
@@ -94,13 +94,12 @@ class PriorAuthGenerator:
         diagnosis = prior_auth.diagnosis
         treatment = prior_auth.treatment
         insurance_company = prior_auth.insurance_company
-        # Convert the provider info, can result in a query through domain.
-        provider_info = await database_sync_to_async(str)(
-            (
-                prior_auth.created_for_professional_user
-                or prior_auth.creator_professional_user
-            )
-        )
+        provider = await aget_related(
+            prior_auth, "created_for_professional_user"
+        ) or await aget_related(prior_auth, "creator_professional_user")
+        # Converting the provider to a string can query through domain, so
+        # str() itself still needs the bridge.
+        provider_info = await database_sync_to_async(str)(provider)
         patient_health_history = prior_auth.patient_health_history
         answers = prior_auth.answers
         patient_info = {}

--- a/fighthealthinsurance/models.py
+++ b/fighthealthinsurance/models.py
@@ -3214,7 +3214,9 @@ class OngoingChat(models.Model):
         return self.chat_type in (ChatType.PROFESSIONAL, ChatType.TRIAL_PROFESSIONAL)
 
     def is_logged_in_user(self):
-        return self.user is not None
+        # user_id rather than user: never triggers a query, so this stays
+        # safe to call directly from async code.
+        return self.user_id is not None
 
 
 class ChatDocument(models.Model):

--- a/fighthealthinsurance/pa_requirements_fetcher.py
+++ b/fighthealthinsurance/pa_requirements_fetcher.py
@@ -27,6 +27,7 @@ from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urlparse
 
 import aiohttp
+from asgiref.sync import sync_to_async
 from channels.db import database_sync_to_async
 from django.db import transaction
 from loguru import logger
@@ -192,7 +193,9 @@ class PaRequirementsFetcher:
             apply_enrichment(reqs, enrichment_for_host(urlparse(url).hostname or ""))
             return reqs
 
-        result: List[ParsedPARequirement] = await database_sync_to_async(
+        # Plain asgiref sync_to_async ON PURPOSE: parsing + enrichment are
+        # pure HTML/PDF work with no ORM access.
+        result: List[ParsedPARequirement] = await sync_to_async(
             _parse_and_enrich, thread_sensitive=False
         )()
         return result

--- a/fighthealthinsurance/utils.py
+++ b/fighthealthinsurance/utils.py
@@ -36,6 +36,7 @@ from uuid import UUID
 
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives, send_mail
+from django.db.models import ForeignKey, Model
 from django.template.loader import render_to_string
 from django.urls import reverse
 
@@ -538,6 +539,43 @@ def get_unsubscribe_url(email: str) -> Optional[str]:
         return subscriber.get_unsubscribe_url()
     except MailingListSubscriber.DoesNotExist:
         return None
+
+
+async def aget_related(instance: Model, field_name: str) -> Optional[Any]:
+    """Fetch a forward FK/OneToOne related object without leaving async code.
+
+    Django (as of 5.2) has no native async accessor for forward relations:
+    ``instance.some_fk`` raises ``SynchronousOnlyOperation`` from async code
+    on a cache miss, which is why call sites used to bridge a lambda through
+    ``database_sync_to_async``. Prefer ``select_related`` when you control
+    the queryset; reach for this when you're handed a bare instance.
+
+    Serves from the relation cache when warm (e.g. after ``select_related``),
+    otherwise runs a native ``aget`` — no thread bridge — and warms the cache
+    so later synchronous attribute access is safe. Returns ``None`` for null
+    FKs.
+    """
+    field = instance._meta.get_field(field_name)
+    if not isinstance(field, ForeignKey):
+        # (OneToOneField subclasses ForeignKey.) Reverse and many-to-many
+        # relations already have native async methods on their managers.
+        raise TypeError(
+            f"{field_name!r} on {type(instance).__name__} is not a forward "
+            "relation (ForeignKey/OneToOneField)"
+        )
+    if field.is_cached(instance):
+        return getattr(instance, field_name)
+    target_value = getattr(instance, field.attname)
+    if target_value is None:
+        return None
+    related_model = cast("type[Model]", field.related_model)
+    # _base_manager (not objects) mirrors how Django's own lazy relation
+    # loading resolves the object.
+    rel_obj = await related_model._base_manager.aget(
+        **{field.target_field.attname: target_value}
+    )
+    field.set_cached_value(instance, rel_obj)
+    return rel_obj
 
 
 async def cancel_tasks(tasks: List[asyncio.Task]) -> None:

--- a/fighthealthinsurance/utils.py
+++ b/fighthealthinsurance/utils.py
@@ -557,24 +557,39 @@ async def aget_related(instance: Model, field_name: str) -> Optional[Any]:
     """
     field = instance._meta.get_field(field_name)
     if not isinstance(field, ForeignKey):
-        # (OneToOneField subclasses ForeignKey.) Reverse and many-to-many
-        # relations already have native async methods on their managers.
+        # (OneToOneField subclasses ForeignKey.) Reverse FK and many-to-many
+        # relations have native async methods on their managers instead;
+        # reverse OneToOne has neither and isn't supported here.
         raise TypeError(
             f"{field_name!r} on {type(instance).__name__} is not a forward "
             "relation (ForeignKey/OneToOneField)"
         )
     if field.is_cached(instance):
         return getattr(instance, field_name)
+    if field.attname in instance.get_deferred_fields():
+        # A deferred FK column would lazy-load synchronously on attribute
+        # access (raising SynchronousOnlyOperation here); refresh natively.
+        await instance.arefresh_from_db(fields=[field.name])
     target_value = getattr(instance, field.attname)
     if target_value is None:
-        return None
+        if field.null:
+            return None
+        # Match the descriptor's behavior for non-null FKs on unsaved
+        # instances instead of silently returning None.
+        raise getattr(type(instance), field_name).RelatedObjectDoesNotExist(
+            f"{type(instance).__name__} has no {field.name}."
+        )
     related_model = cast("type[Model]", field.related_model)
-    # _base_manager (not objects) mirrors how Django's own lazy relation
-    # loading resolves the object.
-    rel_obj = await related_model._base_manager.aget(
-        **{field.target_field.attname: target_value}
-    )
+    # Mirror Django's descriptor: _base_manager (not objects) is how lazy
+    # relation loading resolves objects, and db_manager(hints=...) lets DB
+    # routers (and the instance's own alias) pick the right database.
+    rel_obj = await related_model._base_manager.db_manager(
+        hints={"instance": instance}
+    ).aget(**{field.target_field.attname: target_value})
     field.set_cached_value(instance, rel_obj)
+    if not field.remote_field.multiple:
+        # OneToOne: warm the reverse cache too, like the descriptor does.
+        field.remote_field.set_cached_value(rel_obj, instance)
     return rel_obj
 
 

--- a/fighthealthinsurance/websockets.py
+++ b/fighthealthinsurance/websockets.py
@@ -703,10 +703,10 @@ class OngoingChatConsumer(AsyncWebsocketConsumer):
                 # Get the analysis from the model
                 response_text, _ = await model.generate_chat_response(
                     full_prompt,
-                    is_professional=await database_sync_to_async(
-                        chat.is_professional_user
-                    )(),
-                    is_logged_in=await database_sync_to_async(chat.is_logged_in_user)(),
+                    # Both helpers only read local columns (chat_type /
+                    # user_id) — no queries, so no bridge needed.
+                    is_professional=chat.is_professional_user(),
+                    is_logged_in=chat.is_logged_in_user(),
                 )
 
                 if response_text:

--- a/tests/async-unit/test_denial_types.py
+++ b/tests/async-unit/test_denial_types.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import pytest
 
 # Test the denial_base including the regexes from the initial fixtures.
-from channels.db import database_sync_to_async
+from asgiref.sync import sync_to_async
 from django.test import TestCase
 
 from fighthealthinsurance.forms.questions import EmergencyServicesQuestions
@@ -148,10 +148,10 @@ class TestDenialTypes(TestCase):
         # Fixture PlanType rows have blank regexes (non-selective); create
         # two rows with explicit regexes so we can verify the positive match
         # and the negative_regex exclusion branch in isolation.
-        await database_sync_to_async(PlanType.objects.create)(
+        await sync_to_async(PlanType.objects.create)(
             name="TestHMO", alt_name="Test HMO plan", regex="HMO-only-text"
         )
-        await database_sync_to_async(PlanType.objects.create)(
+        await sync_to_async(PlanType.objects.create)(
             name="TestPPO",
             alt_name="Test PPO plan",
             regex="PPO-only-text",
@@ -176,7 +176,7 @@ class TestDenialTypes(TestCase):
     async def test_get_regulator_matches_erisa_and_respects_negative(self):
         # Create a regulator with a non-empty negative_regex so we can verify
         # the exclusion branch without perturbing the fixture rows.
-        await database_sync_to_async(Regulator.objects.create)(
+        await sync_to_async(Regulator.objects.create)(
             name="TestRegulator",
             website="https://example.test/",
             alt_name="TR",
@@ -229,7 +229,7 @@ class TestDenialTypes(TestCase):
 
     @pytest.mark.asyncio
     async def test_process_denial_codes_icd_block_description_preventive(self):
-        processor = await database_sync_to_async(ProcessDenialCodes)()
+        processor = await sync_to_async(ProcessDenialCodes)()
         fake_tag = SimpleNamespace(
             block_description="Encounter for preventive screening"
         )
@@ -250,7 +250,7 @@ class TestDenialTypes(TestCase):
         """Returns the preventive denial when the ICD code is in the
         preventive_diagnosis CSV override (even if block description does not
         contain 'preventive')."""
-        processor = await database_sync_to_async(ProcessDenialCodes)()
+        processor = await sync_to_async(ProcessDenialCodes)()
         # Inject a known code into the CSV override; keeps the test hermetic
         # regardless of whether ./data/preventive_diagnosis.csv is present.
         processor.preventive_diagnosis = {"Z00.00": "general exam"}
@@ -269,7 +269,7 @@ class TestDenialTypes(TestCase):
 
     @pytest.mark.asyncio
     async def test_process_denial_codes_preventive_cpt_override(self):
-        processor = await database_sync_to_async(ProcessDenialCodes)()
+        processor = await sync_to_async(ProcessDenialCodes)()
         # Inject a known CPT code into the CSV override. 99391 is a real
         # preventive medicine E/M code and matches the cpt_code_re
         # (\d{4}[A-Z0-9]) regex.
@@ -286,7 +286,7 @@ class TestDenialTypes(TestCase):
 
     @pytest.mark.asyncio
     async def test_process_denial_codes_unrelated_text_returns_empty(self):
-        processor = await database_sync_to_async(ProcessDenialCodes)()
+        processor = await sync_to_async(ProcessDenialCodes)()
         processor.preventive_diagnosis = {}
         processor.preventive_codes = {}
 
@@ -300,7 +300,7 @@ class TestDenialTypes(TestCase):
     async def test_process_denial_codes_icd_match_but_not_preventive(self):
         """Returns [] when an ICD-10 code matches but is neither a preventive
         block description nor in the preventive_diagnosis override."""
-        processor = await database_sync_to_async(ProcessDenialCodes)()
+        processor = await sync_to_async(ProcessDenialCodes)()
         processor.preventive_diagnosis = {}
         processor.preventive_codes = {}
         # Block description deliberately omits the substring "preventive" so
@@ -322,7 +322,7 @@ class TestDenialTypes(TestCase):
     @pytest.mark.asyncio
     async def test_process_denial_codes_uspstf_fallback_flags_preventive(self):
         """When CSV lookups miss but USPSTF matches the code, classify as preventive."""
-        processor = await database_sync_to_async(ProcessDenialCodes)()
+        processor = await sync_to_async(ProcessDenialCodes)()
         processor.preventive_diagnosis = {}
         processor.preventive_codes = {}
         fake_tag = SimpleNamespace(block_description="Some unrelated description")
@@ -346,7 +346,7 @@ class TestDenialTypes(TestCase):
     async def test_find_uspstf_evidence_extracts_cpt_and_hcpcs_codes(self):
         """find_uspstf_evidence should pass non-ICD procedure codes through
         to USPSTF lookup so CPT/HCPCS-only denials still surface guidance."""
-        processor = await database_sync_to_async(ProcessDenialCodes)()
+        processor = await sync_to_async(ProcessDenialCodes)()
         fake_recs = [{"id": "rec-1", "grade": "B"}]
 
         with patch(
@@ -364,7 +364,7 @@ class TestDenialTypes(TestCase):
     @pytest.mark.asyncio
     async def test_find_uspstf_evidence_returns_empty_on_error(self):
         """find_uspstf_evidence swallows exceptions so classification never breaks."""
-        processor = await database_sync_to_async(ProcessDenialCodes)()
+        processor = await sync_to_async(ProcessDenialCodes)()
         with patch(
             "fighthealthinsurance.uspstf_api.find_recommendations_for_codes",
             side_effect=RuntimeError("boom"),
@@ -378,7 +378,7 @@ class TestDenialTypes(TestCase):
         preventive_codes CSV override - the previous CPT-only branch
         silently dropped HCPCS-coded preventive items (e.g. supply
         codes for screening test strips)."""
-        processor = await database_sync_to_async(ProcessDenialCodes)()
+        processor = await sync_to_async(ProcessDenialCodes)()
         # Inject a known HCPCS code into the CSV override.
         processor.preventive_codes = {"A4253": "blood glucose test strips"}
         processor.preventive_diagnosis = {}
@@ -396,7 +396,7 @@ class TestDenialTypes(TestCase):
         identifies durable medical equipment (E/K) or orthotic /
         prosthetic items (L). Drug (J) and supply (A) codes are
         excluded."""
-        processor = await database_sync_to_async(ProcessDenialCodes)()
+        processor = await sync_to_async(ProcessDenialCodes)()
         result = await processor.get_dme_codes(
             "Patient prescribed E0260 hospital bed, K0001 wheelchair, "
             "L0631 brace, J3490 drug, A4253 strips."
@@ -405,7 +405,7 @@ class TestDenialTypes(TestCase):
 
     @pytest.mark.asyncio
     async def test_process_denial_codes_get_dme_codes_empty(self):
-        processor = await database_sync_to_async(ProcessDenialCodes)()
+        processor = await sync_to_async(ProcessDenialCodes)()
         result = await processor.get_dme_codes(
             "Generic denial with CPT 99213 only - no HCPCS items."
         )

--- a/tests/async-unit/test_followup_emails.py
+++ b/tests/async-unit/test_followup_emails.py
@@ -2,7 +2,7 @@
 
 import datetime
 import pytest
-from channels.db import database_sync_to_async
+from asgiref.sync import sync_to_async
 from unittest.mock import patch, MagicMock
 from django.core import mail
 from django.template.loader import render_to_string
@@ -1187,13 +1187,13 @@ class TestFollowUpEmailGroupingAsync:
         """Async: two denials for the same email → only 1 email sent."""
         email = "patient@gmail.com"
         hashed = Denial.get_hashed_email(email)
-        denial1 = await database_sync_to_async(Denial.objects.create)(
+        denial1 = await sync_to_async(Denial.objects.create)(
             denial_text="Denial 1",
             hashed_email=hashed,
             raw_email=email,
             health_history="",
         )
-        denial2 = await database_sync_to_async(Denial.objects.create)(
+        denial2 = await sync_to_async(Denial.objects.create)(
             denial_text="Denial 2",
             hashed_email=hashed,
             raw_email=email,
@@ -1201,14 +1201,14 @@ class TestFollowUpEmailGroupingAsync:
         )
         fut_7 = followup_types[0]
 
-        sched1 = await database_sync_to_async(FollowUpSched.objects.create)(
+        sched1 = await sync_to_async(FollowUpSched.objects.create)(
             email=email,
             denial_id=denial1,
             follow_up_type=fut_7,
             follow_up_date=datetime.date.today() - datetime.timedelta(days=1),
             follow_up_sent=False,
         )
-        sched2 = await database_sync_to_async(FollowUpSched.objects.create)(
+        sched2 = await sync_to_async(FollowUpSched.objects.create)(
             email=email,
             denial_id=denial2,
             follow_up_type=fut_7,
@@ -1222,8 +1222,8 @@ class TestFollowUpEmailGroupingAsync:
         assert count == 1
         assert mock_send_email.call_count == 1
 
-        await database_sync_to_async(sched1.refresh_from_db)()
-        await database_sync_to_async(sched2.refresh_from_db)()
+        await sync_to_async(sched1.refresh_from_db)()
+        await sync_to_async(sched2.refresh_from_db)()
         assert sched1.follow_up_sent is True
         assert sched2.follow_up_sent is True
 
@@ -1235,13 +1235,13 @@ class TestFollowUpEmailGroupingAsync:
         """Async: stale best candidate is skipped, next valid one is sent."""
         email = "patient@gmail.com"
         hashed = Denial.get_hashed_email(email)
-        denial1 = await database_sync_to_async(Denial.objects.create)(
+        denial1 = await sync_to_async(Denial.objects.create)(
             denial_text="Denial 1",
             hashed_email=hashed,
             raw_email=email,
             health_history="",
         )
-        denial2 = await database_sync_to_async(Denial.objects.create)(
+        denial2 = await sync_to_async(Denial.objects.create)(
             denial_text="Denial 2",
             hashed_email=hashed,
             raw_email=email,
@@ -1250,7 +1250,7 @@ class TestFollowUpEmailGroupingAsync:
         fut_7, fut_30, _ = followup_types
 
         # Denial 1: 30-day already sent → its 7-day is stale
-        await database_sync_to_async(FollowUpSched.objects.create)(
+        await sync_to_async(FollowUpSched.objects.create)(
             email=email,
             denial_id=denial1,
             follow_up_type=fut_30,
@@ -1258,7 +1258,7 @@ class TestFollowUpEmailGroupingAsync:
             follow_up_sent=True,
             follow_up_sent_date=timezone.now() - datetime.timedelta(days=10),
         )
-        sched1_7 = await database_sync_to_async(FollowUpSched.objects.create)(
+        sched1_7 = await sync_to_async(FollowUpSched.objects.create)(
             email=email,
             denial_id=denial1,
             follow_up_type=fut_7,
@@ -1267,7 +1267,7 @@ class TestFollowUpEmailGroupingAsync:
         )
 
         # Denial 2: valid 7-day
-        sched2_7 = await database_sync_to_async(FollowUpSched.objects.create)(
+        sched2_7 = await sync_to_async(FollowUpSched.objects.create)(
             email=email,
             denial_id=denial2,
             follow_up_type=fut_7,
@@ -1281,8 +1281,8 @@ class TestFollowUpEmailGroupingAsync:
         assert count == 1
         assert mock_send_email.call_count == 1
 
-        await database_sync_to_async(sched1_7.refresh_from_db)()
-        await database_sync_to_async(sched2_7.refresh_from_db)()
+        await sync_to_async(sched1_7.refresh_from_db)()
+        await sync_to_async(sched2_7.refresh_from_db)()
         assert sched1_7.follow_up_sent is True
         assert sched2_7.follow_up_sent is True
 
@@ -1334,7 +1334,7 @@ class TestFollowUpEmailSenderAsync:
         result = await sender.adosend(follow_up_sched=valid_email_followup_sched)
         assert result is True
         mock_send_email.assert_called_once()
-        await database_sync_to_async(valid_email_followup_sched.refresh_from_db)()
+        await sync_to_async(valid_email_followup_sched.refresh_from_db)()
         assert valid_email_followup_sched.follow_up_sent is True
 
     @patch("fighthealthinsurance.followup_emails.send_fallback_email")
@@ -1345,7 +1345,7 @@ class TestFollowUpEmailSenderAsync:
         # Create multiple follow-ups with valid emails
         for i in range(3):
             email = f"patient{i}@gmail.com"
-            await database_sync_to_async(FollowUpSched.objects.create)(
+            await sync_to_async(FollowUpSched.objects.create)(
                 email=email,
                 denial_id=valid_email_denial,
                 follow_up_date=datetime.date.today() - datetime.timedelta(days=1),
@@ -1364,7 +1364,7 @@ class TestFollowUpEmailSenderAsync:
     ):
         for i in range(5):
             email = f"patient{i}@gmail.com"
-            await database_sync_to_async(FollowUpSched.objects.create)(
+            await sync_to_async(FollowUpSched.objects.create)(
                 email=email,
                 denial_id=valid_email_denial,
                 follow_up_date=datetime.date.today() - datetime.timedelta(days=1),
@@ -1397,7 +1397,7 @@ class TestThankyouEmailSenderAsync:
     async def test_asend_all_sends_thankyou_emails(self, mock_sleep, mock_send_email):
         from fighthealthinsurance.models import InterestedProfessional
 
-        await database_sync_to_async(InterestedProfessional.objects.create)(
+        await sync_to_async(InterestedProfessional.objects.create)(
             name="Dr. Test",
             email="doctor@hospital.org",
             thankyou_email_sent=False,

--- a/tests/async/test_aget_related.py
+++ b/tests/async/test_aget_related.py
@@ -1,0 +1,66 @@
+"""
+Tests for fighthealthinsurance.utils.aget_related — async-safe forward
+FK/OneToOne access without a sync-to-async bridge.
+"""
+
+import typing
+
+from django.contrib.auth import get_user_model
+from rest_framework.test import APITestCase
+
+from fighthealthinsurance.models import OngoingChat
+from fighthealthinsurance.utils import aget_related
+
+if typing.TYPE_CHECKING:
+    from django.contrib.auth.models import User
+else:
+    User = get_user_model()
+
+
+class AgetRelatedTest(APITestCase):
+    """Exercise aget_related against OngoingChat's nullable FKs."""
+
+    async def _make_user_and_chat(self) -> typing.Tuple["User", OngoingChat]:
+        user = await User.objects.acreate(
+            username="aget_related_user", email="aget_related@example.com"
+        )
+        chat = await OngoingChat.objects.acreate(user=user, chat_history=[])
+        # Re-fetch without select_related so the relation cache starts cold.
+        chat = await OngoingChat.objects.aget(id=chat.id)
+        return user, chat
+
+    async def test_uncached_foreign_key_fetched_without_bridge(self):
+        user, chat = await self._make_user_and_chat()
+        fetched = await aget_related(chat, "user")
+        self.assertEqual(fetched.pk, user.pk)
+
+    async def test_fetch_warms_cache_so_sync_attribute_access_is_safe(self):
+        user, chat = await self._make_user_and_chat()
+        fetched = await aget_related(chat, "user")
+        # Direct attribute access would raise SynchronousOnlyOperation in
+        # async code on a cold cache; passing proves the cache was warmed.
+        self.assertIs(chat.user, fetched)
+
+    async def test_null_foreign_key_returns_none(self):
+        _, chat = await self._make_user_and_chat()
+        self.assertIsNone(await aget_related(chat, "professional_user"))
+
+    async def test_select_related_instance_served_from_cache(self):
+        user, chat = await self._make_user_and_chat()
+        chat = await OngoingChat.objects.select_related("user").aget(id=chat.id)
+        cached = chat.user
+        # A fresh DB fetch would return a different object; identity proves
+        # the select_related cache was reused.
+        self.assertIs(await aget_related(chat, "user"), cached)
+
+    async def test_non_relation_field_raises_type_error(self):
+        _, chat = await self._make_user_and_chat()
+        with self.assertRaises(TypeError):
+            await aget_related(chat, "chat_type")
+
+    async def test_reverse_relation_raises_type_error(self):
+        # Reverse relations have native async on their managers already
+        # (e.g. chat.appeals.afirst()); aget_related should refuse them.
+        _, chat = await self._make_user_and_chat()
+        with self.assertRaises(TypeError):
+            await aget_related(chat, "appeals")

--- a/tests/async/test_aget_related.py
+++ b/tests/async/test_aget_related.py
@@ -6,9 +6,10 @@ FK/OneToOne access without a sync-to-async bridge.
 import typing
 
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ObjectDoesNotExist
 from rest_framework.test import APITestCase
 
-from fighthealthinsurance.models import OngoingChat
+from fighthealthinsurance.models import ChatDocument, OngoingChat
 from fighthealthinsurance.utils import aget_related
 
 if typing.TYPE_CHECKING:
@@ -64,3 +65,19 @@ class AgetRelatedTest(APITestCase):
         _, chat = await self._make_user_and_chat()
         with self.assertRaises(TypeError):
             await aget_related(chat, "appeals")
+
+    async def test_deferred_fk_column_is_refreshed_natively(self):
+        # only("id") defers user_id; a direct attribute read would lazy-load
+        # synchronously, but the helper refreshes the column natively first.
+        user, chat = await self._make_user_and_chat()
+        chat = await OngoingChat.objects.only("id").aget(id=chat.id)
+        fetched = await aget_related(chat, "user")
+        self.assertEqual(fetched.pk, user.pk)
+
+    async def test_non_null_fk_on_unsaved_instance_raises_like_descriptor(self):
+        # ChatDocument.chat is null=False: descriptor access on an unsaved
+        # instance raises RelatedObjectDoesNotExist, and so does the helper
+        # (instead of silently returning None).
+        doc = ChatDocument(document_name="doc", full_text="text")
+        with self.assertRaises(ObjectDoesNotExist):
+            await aget_related(doc, "chat")

--- a/tests/async/test_background_summary.py
+++ b/tests/async/test_background_summary.py
@@ -15,7 +15,7 @@ from channels.testing import WebsocketCommunicator
 from django.contrib.auth import get_user_model
 from rest_framework.test import APITestCase
 
-from channels.db import database_sync_to_async
+from asgiref.sync import sync_to_async
 
 from fighthealthinsurance.chat.context_manager import MISSING_CONTEXT_PREFIX
 from fighthealthinsurance.models import OngoingChat, ProfessionalUser
@@ -72,16 +72,16 @@ class BackgroundSummaryIntegrationTest(APITestCase):
                 )
             )
 
-            user = await database_sync_to_async(User.objects.create_user)(
+            user = await sync_to_async(User.objects.create_user)(
                 username="bg_summary_user",
                 password="testpass",
                 email="bgsummary@example.com",
             )
-            professional = await database_sync_to_async(
-                ProfessionalUser.objects.create
-            )(user=user, active=True, npi_number="5555555555")
+            professional = await sync_to_async(ProfessionalUser.objects.create)(
+                user=user, active=True, npi_number="5555555555"
+            )
 
-            chat = await database_sync_to_async(OngoingChat.objects.create)(
+            chat = await sync_to_async(OngoingChat.objects.create)(
                 professional_user=professional,
                 chat_history=[],
                 summary_for_next_call=[],
@@ -169,16 +169,16 @@ class BackgroundSummaryIntegrationTest(APITestCase):
                 "Patient denied GLP-1 coverage, asking for help"
             )
 
-            user = await database_sync_to_async(User.objects.create_user)(
+            user = await sync_to_async(User.objects.create_user)(
                 username="bg_replace_user",
                 password="testpass",
                 email="bgreplace@example.com",
             )
-            professional = await database_sync_to_async(
-                ProfessionalUser.objects.create
-            )(user=user, active=True, npi_number="6666666666")
+            professional = await sync_to_async(ProfessionalUser.objects.create)(
+                user=user, active=True, npi_number="6666666666"
+            )
 
-            chat = await database_sync_to_async(OngoingChat.objects.create)(
+            chat = await sync_to_async(OngoingChat.objects.create)(
                 professional_user=professional,
                 chat_history=[],
                 summary_for_next_call=[],
@@ -250,16 +250,16 @@ class BackgroundSummaryIntegrationTest(APITestCase):
                 )
             )
 
-            user = await database_sync_to_async(User.objects.create_user)(
+            user = await sync_to_async(User.objects.create_user)(
                 username="normal_ctx_user",
                 password="testpass",
                 email="normalctx@example.com",
             )
-            professional = await database_sync_to_async(
-                ProfessionalUser.objects.create
-            )(user=user, active=True, npi_number="7777777777")
+            professional = await sync_to_async(ProfessionalUser.objects.create)(
+                user=user, active=True, npi_number="7777777777"
+            )
 
-            chat = await database_sync_to_async(OngoingChat.objects.create)(
+            chat = await sync_to_async(OngoingChat.objects.create)(
                 professional_user=professional,
                 chat_history=[],
                 summary_for_next_call=[],

--- a/tests/async/test_chat_history_and_microsite_context.py
+++ b/tests/async/test_chat_history_and_microsite_context.py
@@ -21,7 +21,7 @@ from fighthealthinsurance.models import OngoingChat, ProfessionalUser, Appeal, D
 from fighthealthinsurance.websockets import OngoingChatConsumer
 from tests.sync.mock_chat_model import MockChatModel
 
-from channels.db import database_sync_to_async
+from asgiref.sync import sync_to_async
 
 if typing.TYPE_CHECKING:
     from django.contrib.auth.models import User
@@ -39,15 +39,15 @@ class CrisisResponseHistoryTest(APITestCase):
         When a user sends a crisis-related message and chat_history is empty,
         both the user message and crisis response should be saved.
         """
-        user = await database_sync_to_async(User.objects.create_user)(
+        user = await sync_to_async(User.objects.create_user)(
             username="crisisuser1", password="testpass", email="crisis1@example.com"
         )
-        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
+        professional = await sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="1111111112"
         )
 
         # Create a chat with empty history
-        chat = await database_sync_to_async(OngoingChat.objects.create)(
+        chat = await sync_to_async(OngoingChat.objects.create)(
             professional_user=professional,
             chat_history=[],
             summary_for_next_call=[],
@@ -77,9 +77,7 @@ class CrisisResponseHistoryTest(APITestCase):
             self.assertIn("988", response["content"])  # Crisis hotline number
 
             # Verify chat history was saved
-            chat_refreshed = await database_sync_to_async(OngoingChat.objects.get)(
-                id=chat.id
-            )
+            chat_refreshed = await sync_to_async(OngoingChat.objects.get)(id=chat.id)
             self.assertEqual(
                 len(chat_refreshed.chat_history),
                 2,
@@ -106,15 +104,15 @@ class CrisisResponseHistoryTest(APITestCase):
         This is a regression test to ensure that when chat_history is NOT empty,
         new messages are still appended and saved.
         """
-        user = await database_sync_to_async(User.objects.create_user)(
+        user = await sync_to_async(User.objects.create_user)(
             username="crisisuser2", password="testpass", email="crisis2@example.com"
         )
-        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
+        professional = await sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="2222222223"
         )
 
         # Create a chat with EXISTING history
-        chat = await database_sync_to_async(OngoingChat.objects.create)(
+        chat = await sync_to_async(OngoingChat.objects.create)(
             professional_user=professional,
             chat_history=[
                 {
@@ -154,9 +152,7 @@ class CrisisResponseHistoryTest(APITestCase):
             self.assertIn("content", response)
 
             # Verify chat history was appended (should now have 4 messages)
-            chat_refreshed = await database_sync_to_async(OngoingChat.objects.get)(
-                id=chat.id
-            )
+            chat_refreshed = await sync_to_async(OngoingChat.objects.get)(id=chat.id)
             self.assertEqual(
                 len(chat_refreshed.chat_history),
                 4,
@@ -191,20 +187,20 @@ class LinkMessageHistoryTest(APITestCase):
         """
         Test that link message is saved when linking an appeal to a chat with empty history.
         """
-        user = await database_sync_to_async(User.objects.create_user)(
+        user = await sync_to_async(User.objects.create_user)(
             username="linkuser1", password="testpass", email="link1@example.com"
         )
-        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
+        professional = await sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="3333333334"
         )
 
         # Create a denial first (required for appeal)
-        denial = await database_sync_to_async(Denial.objects.create)(
+        denial = await sync_to_async(Denial.objects.create)(
             creating_professional=professional,
         )
 
         # Create an appeal for linking
-        appeal = await database_sync_to_async(Appeal.objects.create)(
+        appeal = await sync_to_async(Appeal.objects.create)(
             creating_professional=professional,
             primary_professional=professional,
             hashed_email="linkhash1@example.com",
@@ -212,7 +208,7 @@ class LinkMessageHistoryTest(APITestCase):
         )
 
         # Create a chat with empty history
-        chat = await database_sync_to_async(OngoingChat.objects.create)(
+        chat = await sync_to_async(OngoingChat.objects.create)(
             professional_user=professional,
             chat_history=[],
             summary_for_next_call=[],
@@ -246,9 +242,7 @@ class LinkMessageHistoryTest(APITestCase):
             self.assertIn("linked", response["content"].lower())
 
             # Verify chat history was saved
-            chat_refreshed = await database_sync_to_async(OngoingChat.objects.get)(
-                id=chat.id
-            )
+            chat_refreshed = await sync_to_async(OngoingChat.objects.get)(id=chat.id)
             self.assertEqual(
                 len(chat_refreshed.chat_history),
                 2,
@@ -265,20 +259,20 @@ class LinkMessageHistoryTest(APITestCase):
         This is a regression test to ensure that when chat_history is NOT empty,
         new link messages are still appended and saved.
         """
-        user = await database_sync_to_async(User.objects.create_user)(
+        user = await sync_to_async(User.objects.create_user)(
             username="linkuser2", password="testpass", email="link2@example.com"
         )
-        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
+        professional = await sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="4444444445"
         )
 
         # Create a denial first (required for appeal)
-        denial = await database_sync_to_async(Denial.objects.create)(
+        denial = await sync_to_async(Denial.objects.create)(
             creating_professional=professional,
         )
 
         # Create an appeal for linking
-        appeal = await database_sync_to_async(Appeal.objects.create)(
+        appeal = await sync_to_async(Appeal.objects.create)(
             creating_professional=professional,
             primary_professional=professional,
             hashed_email="linkhash2@example.com",
@@ -286,7 +280,7 @@ class LinkMessageHistoryTest(APITestCase):
         )
 
         # Create a chat with EXISTING history
-        chat = await database_sync_to_async(OngoingChat.objects.create)(
+        chat = await sync_to_async(OngoingChat.objects.create)(
             professional_user=professional,
             chat_history=[
                 {
@@ -330,9 +324,7 @@ class LinkMessageHistoryTest(APITestCase):
             self.assertIn("content", response)
 
             # Verify chat history was appended (should now have 4 messages)
-            chat_refreshed = await database_sync_to_async(OngoingChat.objects.get)(
-                id=chat.id
-            )
+            chat_refreshed = await sync_to_async(OngoingChat.objects.get)(id=chat.id)
             self.assertEqual(
                 len(chat_refreshed.chat_history),
                 4,

--- a/tests/async/test_chat_long_message.py
+++ b/tests/async/test_chat_long_message.py
@@ -17,7 +17,7 @@ from channels.testing import WebsocketCommunicator
 from django.contrib.auth import get_user_model
 from rest_framework.test import APITestCase
 
-from channels.db import database_sync_to_async
+from asgiref.sync import sync_to_async
 
 from fighthealthinsurance.chat.message_preprocessor import (
     DIRECT_CHAT_HARD_LIMIT_CHARS,
@@ -49,13 +49,13 @@ class RecordingMockModel(MockChatModel):
 
 
 async def _make_professional_chat(username, npi):
-    user = await database_sync_to_async(User.objects.create_user)(
+    user = await sync_to_async(User.objects.create_user)(
         username=username, password="testpass", email=f"{username}@example.com"
     )
-    professional = await database_sync_to_async(ProfessionalUser.objects.create)(
+    professional = await sync_to_async(ProfessionalUser.objects.create)(
         user=user, active=True, npi_number=npi
     )
-    chat = await database_sync_to_async(OngoingChat.objects.create)(
+    chat = await sync_to_async(OngoingChat.objects.create)(
         professional_user=professional,
         chat_history=[],
         summary_for_next_call=[],

--- a/tests/async/test_microsite_chat_integration.py
+++ b/tests/async/test_microsite_chat_integration.py
@@ -17,7 +17,7 @@ from fighthealthinsurance.models import OngoingChat, ProfessionalUser, Appeal
 from fighthealthinsurance.websockets import OngoingChatConsumer
 from tests.sync.mock_chat_model import MockChatModel
 
-from channels.db import database_sync_to_async
+from asgiref.sync import sync_to_async
 
 if typing.TYPE_CHECKING:
     from django.contrib.auth.models import User
@@ -54,14 +54,14 @@ class MicrositeChatIntegrationTest(APITestCase):
         mock_get_microsite.return_value = mock_microsite
 
         try:
-            user = await database_sync_to_async(User.objects.create_user)(
+            user = await sync_to_async(User.objects.create_user)(
                 username="testuser", password="testpass", email="test@example.com"
             )
-            professional = await database_sync_to_async(
-                ProfessionalUser.objects.create
-            )(user=user, active=True, npi_number="1111111111")
+            professional = await sync_to_async(ProfessionalUser.objects.create)(
+                user=user, active=True, npi_number="1111111111"
+            )
 
-            chat = await database_sync_to_async(OngoingChat.objects.create)(
+            chat = await sync_to_async(OngoingChat.objects.create)(
                 professional_user=professional,
                 microsite_slug="test-microsite",
                 chat_history=[],
@@ -115,22 +115,22 @@ class ChatHistoryAppendingTest(APITestCase):
         mock_get_chat_backends.return_value = [mock_model]
 
         try:
-            user = await database_sync_to_async(User.objects.create_user)(
+            user = await sync_to_async(User.objects.create_user)(
                 username="historyuser", password="testpass", email="history@example.com"
             )
-            professional = await database_sync_to_async(
-                ProfessionalUser.objects.create
-            )(user=user, active=True, npi_number="1234567890")
+            professional = await sync_to_async(ProfessionalUser.objects.create)(
+                user=user, active=True, npi_number="1234567890"
+            )
 
             # Create an appeal for linking
-            appeal = await database_sync_to_async(Appeal.objects.create)(
+            appeal = await sync_to_async(Appeal.objects.create)(
                 creating_professional=professional,
                 primary_professional=professional,
                 hashed_email="hashtest@example.com",
             )
 
             # Create a chat with EXISTING history
-            chat = await database_sync_to_async(OngoingChat.objects.create)(
+            chat = await sync_to_async(OngoingChat.objects.create)(
                 professional_user=professional,
                 chat_history=[
                     {
@@ -171,9 +171,7 @@ class ChatHistoryAppendingTest(APITestCase):
             self.assertIn("content", response)
 
             # Verify that chat history was appended (should now have 4 messages)
-            chat_refreshed = await database_sync_to_async(OngoingChat.objects.get)(
-                id=chat.id
-            )
+            chat_refreshed = await sync_to_async(OngoingChat.objects.get)(id=chat.id)
             self.assertEqual(
                 len(chat_refreshed.chat_history),
                 4,

--- a/tests/async/test_microsite_context_fetching.py
+++ b/tests/async/test_microsite_context_fetching.py
@@ -19,7 +19,7 @@ from fighthealthinsurance.models import OngoingChat, ProfessionalUser
 from fighthealthinsurance.websockets import OngoingChatConsumer
 from tests.sync.mock_chat_model import MockChatModel
 
-from channels.db import database_sync_to_async
+from asgiref.sync import sync_to_async
 
 if typing.TYPE_CHECKING:
     from django.contrib.auth.models import User
@@ -75,16 +75,16 @@ class MicrositeContextFetchingTest(APITestCase):
         mock_get_microsite.return_value = mock_microsite
 
         try:
-            user = await database_sync_to_async(User.objects.create_user)(
+            user = await sync_to_async(User.objects.create_user)(
                 username="extralinkuser",
                 password="testpass",
                 email="extralink@example.com",
             )
-            professional = await database_sync_to_async(
-                ProfessionalUser.objects.create
-            )(user=user, active=True, npi_number="1111111111")
+            professional = await sync_to_async(ProfessionalUser.objects.create)(
+                user=user, active=True, npi_number="1111111111"
+            )
 
-            chat = await database_sync_to_async(OngoingChat.objects.create)(
+            chat = await sync_to_async(OngoingChat.objects.create)(
                 professional_user=professional,
                 microsite_slug="test-microsite",
                 chat_history=[],
@@ -173,14 +173,14 @@ class MicrositeContextFetchingTest(APITestCase):
         mock_get_microsite.return_value = mock_microsite
 
         try:
-            user = await database_sync_to_async(User.objects.create_user)(
+            user = await sync_to_async(User.objects.create_user)(
                 username="pubmeduser", password="testpass", email="pubmed@example.com"
             )
-            professional = await database_sync_to_async(
-                ProfessionalUser.objects.create
-            )(user=user, active=True, npi_number="2222222222")
+            professional = await sync_to_async(ProfessionalUser.objects.create)(
+                user=user, active=True, npi_number="2222222222"
+            )
 
-            chat = await database_sync_to_async(OngoingChat.objects.create)(
+            chat = await sync_to_async(OngoingChat.objects.create)(
                 professional_user=professional,
                 microsite_slug="test-pubmed-microsite",
                 chat_history=[],
@@ -268,14 +268,14 @@ class MicrositeContextFetchingTest(APITestCase):
         mock_get_microsite.return_value = mock_microsite
 
         try:
-            user = await database_sync_to_async(User.objects.create_user)(
+            user = await sync_to_async(User.objects.create_user)(
                 username="bothuser", password="testpass", email="both@example.com"
             )
-            professional = await database_sync_to_async(
-                ProfessionalUser.objects.create
-            )(user=user, active=True, npi_number="3333333333")
+            professional = await sync_to_async(ProfessionalUser.objects.create)(
+                user=user, active=True, npi_number="3333333333"
+            )
 
-            chat = await database_sync_to_async(OngoingChat.objects.create)(
+            chat = await sync_to_async(OngoingChat.objects.create)(
                 professional_user=professional,
                 microsite_slug="test-both-microsite",
                 chat_history=[],
@@ -344,16 +344,16 @@ class MicrositeContextFetchingTest(APITestCase):
         mock_fire_and_forget = fire_and_forget_patcher.start()
 
         try:
-            user = await database_sync_to_async(User.objects.create_user)(
+            user = await sync_to_async(User.objects.create_user)(
                 username="nomicrositeuser",
                 password="testpass",
                 email="nomicrosite@example.com",
             )
-            professional = await database_sync_to_async(
-                ProfessionalUser.objects.create
-            )(user=user, active=True, npi_number="4444444444")
+            professional = await sync_to_async(ProfessionalUser.objects.create)(
+                user=user, active=True, npi_number="4444444444"
+            )
 
-            chat = await database_sync_to_async(OngoingChat.objects.create)(
+            chat = await sync_to_async(OngoingChat.objects.create)(
                 professional_user=professional,
                 microsite_slug=None,  # No microsite
                 chat_history=[],

--- a/tests/sync/test_chat_delete_data_integration.py
+++ b/tests/sync/test_chat_delete_data_integration.py
@@ -12,7 +12,7 @@ Two end-to-end paths through `ChatInterface.handle_chat_message`:
 import typing
 from unittest.mock import AsyncMock, patch
 
-from channels.db import database_sync_to_async
+from asgiref.sync import sync_to_async
 from django.contrib.auth import get_user_model
 from rest_framework.test import APITestCase
 
@@ -71,15 +71,15 @@ class DeleteDataHandoffIntegrationTest(APITestCase):
         chat_history=None,
     ):
         """Create a professional user, chat, and ChatInterface wired to `captured`."""
-        user = await database_sync_to_async(User.objects.create_user)(
+        user = await sync_to_async(User.objects.create_user)(
             username=username,
             password="testpass",
             email=f"{username}@example.com",
         )
-        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
+        professional = await sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number=npi_number
         )
-        chat = await database_sync_to_async(OngoingChat.objects.create)(
+        chat = await sync_to_async(OngoingChat.objects.create)(
             professional_user=professional,
             chat_type=ChatType.PROFESSIONAL,
             chat_history=chat_history if chat_history is not None else [],
@@ -118,7 +118,7 @@ class DeleteDataHandoffIntegrationTest(APITestCase):
             self.assertEqual(len(assistant_payloads), 1)
             self.assertEqual(assistant_payloads[0]["content"], DELETE_DATA_RESPONSE)
 
-            await database_sync_to_async(chat.refresh_from_db)()
+            await sync_to_async(chat.refresh_from_db)()
             self.assertEqual(len(chat.chat_history), 2)
             self.assertEqual(chat.chat_history[0]["role"], "user")
             self.assertEqual(

--- a/tests/sync/test_chat_fallback.py
+++ b/tests/sync/test_chat_fallback.py
@@ -12,7 +12,7 @@ from fighthealthinsurance.models import OngoingChat, ProfessionalUser
 from fighthealthinsurance.websockets import OngoingChatConsumer
 from .mock_chat_model import MockChatModel
 
-from channels.db import database_sync_to_async
+from asgiref.sync import sync_to_async
 
 if typing.TYPE_CHECKING:
     from django.contrib.auth.models import User
@@ -60,13 +60,13 @@ class ChatFallbackTest(APITestCase):
             "Response from primary model", "Primary context"
         )
 
-        user = await database_sync_to_async(User.objects.create_user)(
+        user = await sync_to_async(User.objects.create_user)(
             username="testuser", password="testpass", email="test@example.com"
         )
-        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
+        professional = await sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="1234567890"
         )
-        chat = await database_sync_to_async(OngoingChat.objects.create)(
+        chat = await sync_to_async(OngoingChat.objects.create)(
             professional_user=professional,
             chat_history=[],
             summary_for_next_call=[],
@@ -114,13 +114,13 @@ class ChatFallbackTest(APITestCase):
             "Response from fallback model", "Fallback context"
         )
 
-        user = await database_sync_to_async(User.objects.create_user)(
+        user = await sync_to_async(User.objects.create_user)(
             username="testuser2", password="testpass", email="test2@example.com"
         )
-        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
+        professional = await sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="2345678901"
         )
-        chat = await database_sync_to_async(OngoingChat.objects.create)(
+        chat = await sync_to_async(OngoingChat.objects.create)(
             professional_user=professional,
             chat_history=[],
             summary_for_next_call=[],
@@ -161,13 +161,13 @@ class ChatFallbackTest(APITestCase):
         # Set up to return empty fallback when external is disabled
         self.mock_get_backends.return_value = ([self.mock_primary_model], [])
 
-        user = await database_sync_to_async(User.objects.create_user)(
+        user = await sync_to_async(User.objects.create_user)(
             username="testuser3", password="testpass", email="test3@example.com"
         )
-        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
+        professional = await sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="3456789012"
         )
-        chat = await database_sync_to_async(OngoingChat.objects.create)(
+        chat = await sync_to_async(OngoingChat.objects.create)(
             professional_user=professional,
             chat_history=[],
             summary_for_next_call=[],
@@ -201,13 +201,13 @@ class ChatFallbackTest(APITestCase):
         """Test that use_external_models can be toggled during a chat session."""
         await self.asyncSetUp()
 
-        user = await database_sync_to_async(User.objects.create_user)(
+        user = await sync_to_async(User.objects.create_user)(
             username="testuser4", password="testpass", email="test4@example.com"
         )
-        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
+        professional = await sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="4567890123"
         )
-        chat = await database_sync_to_async(OngoingChat.objects.create)(
+        chat = await sync_to_async(OngoingChat.objects.create)(
             professional_user=professional,
             chat_history=[],
             summary_for_next_call=[],

--- a/tests/sync/test_chat_status_messages.py
+++ b/tests/sync/test_chat_status_messages.py
@@ -18,7 +18,7 @@ from fighthealthinsurance.websockets import OngoingChatConsumer
 from fighthealthinsurance.chat_interface import ChatInterface
 from .mock_chat_model import MockChatModel
 
-from channels.db import database_sync_to_async
+from asgiref.sync import sync_to_async
 
 if typing.TYPE_CHECKING:
     from django.contrib.auth.models import User
@@ -66,13 +66,13 @@ class ChatStatusMessageTest(APITestCase):
         await self.asyncSetUp()
 
         # Create a user and chat
-        user = await database_sync_to_async(User.objects.create_user)(
+        user = await sync_to_async(User.objects.create_user)(
             username="statususer", password="testpass", email="status@example.com"
         )
-        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
+        professional = await sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="1234567890"
         )
-        chat = await database_sync_to_async(OngoingChat.objects.create)(
+        chat = await sync_to_async(OngoingChat.objects.create)(
             professional_user=professional,
             chat_type=ChatType.PROFESSIONAL,
             chat_history=[],
@@ -112,13 +112,13 @@ class ChatStatusMessageTest(APITestCase):
         """Test that status messages are sent during PubMed searches."""
         await self.asyncSetUp()
 
-        user = await database_sync_to_async(User.objects.create_user)(
+        user = await sync_to_async(User.objects.create_user)(
             username="pubmeduser", password="testpass", email="pubmed@example.com"
         )
-        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
+        professional = await sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="9876543210"
         )
-        chat = await database_sync_to_async(OngoingChat.objects.create)(
+        chat = await sync_to_async(OngoingChat.objects.create)(
             professional_user=professional,
             chat_type=ChatType.PROFESSIONAL,
             chat_history=[],
@@ -174,13 +174,13 @@ class ChatStatusMessageTest(APITestCase):
         """Test that status messages are sent during Medicaid lookups."""
         await self.asyncSetUp()
 
-        user = await database_sync_to_async(User.objects.create_user)(
+        user = await sync_to_async(User.objects.create_user)(
             username="medicaiduser", password="testpass", email="medicaid@example.com"
         )
-        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
+        professional = await sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="5555555555"
         )
-        chat = await database_sync_to_async(OngoingChat.objects.create)(
+        chat = await sync_to_async(OngoingChat.objects.create)(
             professional_user=professional,
             chat_type=ChatType.PROFESSIONAL,
             chat_history=[],
@@ -240,7 +240,7 @@ class ChatStatusMessageTest(APITestCase):
         session_key = "test_session_key_123"
 
         # Create a ChatLeads entry for trial professional
-        await database_sync_to_async(ChatLeads.objects.create)(
+        await sync_to_async(ChatLeads.objects.create)(
             session_id=session_key,
             email="trial@example.com",
             name="Trial User",
@@ -317,15 +317,15 @@ class ChatStatusMessageTest(APITestCase):
         """Test that multiple status updates are properly sent and tracked."""
         await self.asyncSetUp()
 
-        user = await database_sync_to_async(User.objects.create_user)(
+        user = await sync_to_async(User.objects.create_user)(
             username="multistatususer",
             password="testpass",
             email="multistatus@example.com",
         )
-        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
+        professional = await sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="3333333333"
         )
-        chat = await database_sync_to_async(OngoingChat.objects.create)(
+        chat = await sync_to_async(OngoingChat.objects.create)(
             professional_user=professional,
             chat_type=ChatType.PROFESSIONAL,
             chat_history=[],
@@ -367,15 +367,15 @@ class ChatStatusMessageTest(APITestCase):
         """Test that status messages are sent during appeal creation."""
         await self.asyncSetUp()
 
-        user = await database_sync_to_async(User.objects.create_user)(
+        user = await sync_to_async(User.objects.create_user)(
             username="appealstatususer",
             password="testpass",
             email="appealstatus@example.com",
         )
-        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
+        professional = await sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="4444444444"
         )
-        chat = await database_sync_to_async(OngoingChat.objects.create)(
+        chat = await sync_to_async(OngoingChat.objects.create)(
             professional_user=professional,
             chat_type=ChatType.PROFESSIONAL,
             chat_history=[],
@@ -425,13 +425,13 @@ class ChatStatusMessageTest(APITestCase):
         """Test that error messages are properly sent via status."""
         await self.asyncSetUp()
 
-        user = await database_sync_to_async(User.objects.create_user)(
+        user = await sync_to_async(User.objects.create_user)(
             username="erroruser", password="testpass", email="error@example.com"
         )
-        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
+        professional = await sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="6666666666"
         )
-        chat = await database_sync_to_async(OngoingChat.objects.create)(
+        chat = await sync_to_async(OngoingChat.objects.create)(
             professional_user=professional,
             chat_type=ChatType.PROFESSIONAL,
             chat_history=[],
@@ -473,7 +473,7 @@ class ChatStatusMessageTest(APITestCase):
         session_key = "test_session_key_456"
 
         # Create a ChatLeads entry
-        await database_sync_to_async(ChatLeads.objects.create)(
+        await sync_to_async(ChatLeads.objects.create)(
             session_id=session_key,
             email="clear@example.com",
             name="Clear User",
@@ -535,13 +535,13 @@ class ChatStatusMessageTest(APITestCase):
         """Test that retry functionality can be triggered when needed."""
         await self.asyncSetUp()
 
-        user = await database_sync_to_async(User.objects.create_user)(
+        user = await sync_to_async(User.objects.create_user)(
             username="retryuser", password="testpass", email="retry@example.com"
         )
-        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
+        professional = await sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="7777777777"
         )
-        chat = await database_sync_to_async(OngoingChat.objects.create)(
+        chat = await sync_to_async(OngoingChat.objects.create)(
             professional_user=professional,
             chat_type=ChatType.PROFESSIONAL,
             chat_history=[

--- a/tests/sync/test_ongoing_chat.py
+++ b/tests/sync/test_ongoing_chat.py
@@ -16,7 +16,7 @@ from fighthealthinsurance.websockets import OngoingChatConsumer
 from fhi_users.models import ProfessionalDomainRelation
 from .mock_chat_model import MockChatModel
 
-from channels.db import database_sync_to_async
+from asgiref.sync import sync_to_async
 
 if typing.TYPE_CHECKING:
     from django.contrib.auth.models import User
@@ -30,12 +30,12 @@ class OngoingChatWebSocketTest(APITestCase):
         """Test _analyze_denied_items stores denied_item and denied_reason independently and applies guardrails."""
         await self.asyncSetUp()
         consumer = OngoingChatConsumer()
-        user = await database_sync_to_async(User.objects.create_user)(
+        user = await sync_to_async(User.objects.create_user)(
             username="denieduser", password="testpass", email="denied@example.com"
         )
 
         # Case 1: Both denied_item and denied_reason are empty/unclear (patient)
-        chat1 = await database_sync_to_async(OngoingChat.objects.create)(
+        chat1 = await sync_to_async(OngoingChat.objects.create)(
             is_patient=True,
             user=user,
             chat_history=[
@@ -50,14 +50,12 @@ class OngoingChatWebSocketTest(APITestCase):
             '{"denied_item": null, "denied_reason": null}', ""
         )
         await consumer._analyze_denied_items(str(chat1.id))
-        refreshed1 = await database_sync_to_async(OngoingChat.objects.get)(
-            id=str(chat1.id)
-        )
+        refreshed1 = await sync_to_async(OngoingChat.objects.get)(id=str(chat1.id))
         self.assertIsNone(refreshed1.denied_item)
         self.assertIsNone(refreshed1.denied_reason)
 
         # Case 2: Only denied_item is clear (patient)
-        chat2 = await database_sync_to_async(OngoingChat.objects.create)(
+        chat2 = await sync_to_async(OngoingChat.objects.create)(
             is_patient=True,
             user=user,
             chat_history=[
@@ -72,14 +70,12 @@ class OngoingChatWebSocketTest(APITestCase):
             '{"denied_item": "MRI scan", "denied_reason": null}', ""
         )
         await consumer._analyze_denied_items(str(chat2.id))
-        refreshed2 = await database_sync_to_async(OngoingChat.objects.get)(
-            id=str(chat2.id)
-        )
+        refreshed2 = await sync_to_async(OngoingChat.objects.get)(id=str(chat2.id))
         self.assertEqual(refreshed2.denied_item, "MRI scan")
         self.assertIsNone(refreshed2.denied_reason)
 
         # Case 3: Only denied_reason is clear (patient)
-        chat3 = await database_sync_to_async(OngoingChat.objects.create)(
+        chat3 = await sync_to_async(OngoingChat.objects.create)(
             is_patient=True,
             user=user,
             chat_history=[
@@ -94,14 +90,12 @@ class OngoingChatWebSocketTest(APITestCase):
             '{"denied_item": null, "denied_reason": "Lack of medical necessity"}', ""
         )
         await consumer._analyze_denied_items(str(chat3.id))
-        refreshed3 = await database_sync_to_async(OngoingChat.objects.get)(
-            id=str(chat3.id)
-        )
+        refreshed3 = await sync_to_async(OngoingChat.objects.get)(id=str(chat3.id))
         self.assertIsNone(refreshed3.denied_item)
         self.assertEqual(refreshed3.denied_reason, "Lack of medical necessity")
 
         # Case 4: Both are clear (patient)
-        chat4 = await database_sync_to_async(OngoingChat.objects.create)(
+        chat4 = await sync_to_async(OngoingChat.objects.create)(
             is_patient=True,
             user=user,
             chat_history=[
@@ -117,14 +111,12 @@ class OngoingChatWebSocketTest(APITestCase):
             "",
         )
         await consumer._analyze_denied_items(str(chat4.id))
-        refreshed4 = await database_sync_to_async(OngoingChat.objects.get)(
-            id=str(chat4.id)
-        )
+        refreshed4 = await sync_to_async(OngoingChat.objects.get)(id=str(chat4.id))
         self.assertEqual(refreshed4.denied_item, "MRI scan")
         self.assertEqual(refreshed4.denied_reason, "Lack of medical necessity")
 
         # Case 5: Unclear/generic values (should not store) (patient)
-        chat5 = await database_sync_to_async(OngoingChat.objects.create)(
+        chat5 = await sync_to_async(OngoingChat.objects.create)(
             is_patient=True,
             user=user,
             chat_history=[
@@ -136,9 +128,7 @@ class OngoingChatWebSocketTest(APITestCase):
             '{"denied_item": "unknown", "denied_reason": "unclear"}', ""
         )
         await consumer._analyze_denied_items(str(chat5.id))
-        refreshed5 = await database_sync_to_async(OngoingChat.objects.get)(
-            id=str(chat5.id)
-        )
+        refreshed5 = await sync_to_async(OngoingChat.objects.get)(id=str(chat5.id))
         self.assertIsNone(refreshed5.denied_item)
         self.assertIsNone(refreshed5.denied_reason)
 
@@ -165,20 +155,20 @@ class OngoingChatWebSocketTest(APITestCase):
     async def test_link_chat_to_appeal_success(self):
         """Test linking a chat to an appeal with permission."""
         await self.asyncSetUp()
-        user = await database_sync_to_async(User.objects.create_user)(
+        user = await sync_to_async(User.objects.create_user)(
             username="appealuser", password="testpass", email="appeal@example.com"
         )
-        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
+        professional = await sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="1111111111"
         )
-        chat = await database_sync_to_async(OngoingChat.objects.create)(
+        chat = await sync_to_async(OngoingChat.objects.create)(
             professional_user=professional,
             chat_history=[],
             summary_for_next_call=[],
         )
         from fighthealthinsurance.models import Appeal
 
-        appeal = await database_sync_to_async(Appeal.objects.create)(
+        appeal = await sync_to_async(Appeal.objects.create)(
             creating_professional=professional,
             primary_professional=professional,
             hashed_email="hashappeal@example.com",
@@ -202,7 +192,7 @@ class OngoingChatWebSocketTest(APITestCase):
         self.assertIn("content", response)
         self.assertIn("linked", response["content"])
         # Appeal is linked
-        appeal_refresh = await database_sync_to_async(Appeal.objects.get)(id=appeal.id)
+        appeal_refresh = await sync_to_async(Appeal.objects.get)(id=appeal.id)
         self.assertEqual(appeal_refresh.chat_id, chat.id)
         await communicator.disconnect()
         await self.asyncTearDown()
@@ -210,20 +200,20 @@ class OngoingChatWebSocketTest(APITestCase):
     async def test_link_chat_to_prior_auth_success(self):
         """Test linking a chat to a prior auth with permission."""
         await self.asyncSetUp()
-        user = await database_sync_to_async(User.objects.create_user)(
+        user = await sync_to_async(User.objects.create_user)(
             username="priorauthuser", password="testpass", email="priorauth@example.com"
         )
-        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
+        professional = await sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="2222222222"
         )
-        chat = await database_sync_to_async(OngoingChat.objects.create)(
+        chat = await sync_to_async(OngoingChat.objects.create)(
             professional_user=professional,
             chat_history=[],
             summary_for_next_call=[],
         )
         from fighthealthinsurance.models import PriorAuthRequest
 
-        prior_auth = await database_sync_to_async(PriorAuthRequest.objects.create)(
+        prior_auth = await sync_to_async(PriorAuthRequest.objects.create)(
             creator_professional_user=professional,
             created_for_professional_user=professional,
             diagnosis="Test diagnosis",
@@ -249,7 +239,7 @@ class OngoingChatWebSocketTest(APITestCase):
         self.assertIn("content", response)
         self.assertIn("linked", response["content"])
         # PriorAuthRequest is linked
-        prior_auth_refresh = await database_sync_to_async(PriorAuthRequest.objects.get)(
+        prior_auth_refresh = await sync_to_async(PriorAuthRequest.objects.get)(
             id=prior_auth.id
         )
         self.assertEqual(prior_auth_refresh.chat_id, chat.id)
@@ -260,9 +250,9 @@ class OngoingChatWebSocketTest(APITestCase):
         await self.asyncSetUp()
         consumer = OngoingChatConsumer()
         consumer.chat_interface = object()
-        chat = await database_sync_to_async(OngoingChat.objects.create)(
+        chat = await sync_to_async(OngoingChat.objects.create)(
             is_patient=True,
-            user=await database_sync_to_async(User.objects.create_user)(
+            user=await sync_to_async(User.objects.create_user)(
                 username="enqueueuser", password="testpass", email="enqueue@example.com"
             ),
             chat_history=[],
@@ -285,9 +275,9 @@ class OngoingChatWebSocketTest(APITestCase):
         await self.asyncSetUp()
         consumer = OngoingChatConsumer()
         consumer.chat_interface = object()
-        chat = await database_sync_to_async(OngoingChat.objects.create)(
+        chat = await sync_to_async(OngoingChat.objects.create)(
             is_patient=True,
-            user=await database_sync_to_async(User.objects.create_user)(
+            user=await sync_to_async(User.objects.create_user)(
                 username="failuser", password="testpass", email="fail@example.com"
             ),
             chat_history=[],
@@ -319,26 +309,26 @@ class OngoingChatWebSocketTest(APITestCase):
     async def test_link_chat_to_appeal_permission_denied(self):
         """Test linking a chat to an appeal without permission is denied."""
         await self.asyncSetUp()
-        user1 = await database_sync_to_async(User.objects.create_user)(
+        user1 = await sync_to_async(User.objects.create_user)(
             username="user1", password="testpass", email="user1@example.com"
         )
-        user2 = await database_sync_to_async(User.objects.create_user)(
+        user2 = await sync_to_async(User.objects.create_user)(
             username="user2", password="testpass", email="user2@example.com"
         )
-        professional1 = await database_sync_to_async(ProfessionalUser.objects.create)(
+        professional1 = await sync_to_async(ProfessionalUser.objects.create)(
             user=user1, active=True, npi_number="3333333333"
         )
-        professional2 = await database_sync_to_async(ProfessionalUser.objects.create)(
+        professional2 = await sync_to_async(ProfessionalUser.objects.create)(
             user=user2, active=True, npi_number="4444444444"
         )
-        chat = await database_sync_to_async(OngoingChat.objects.create)(
+        chat = await sync_to_async(OngoingChat.objects.create)(
             professional_user=professional2,
             chat_history=[],
             summary_for_next_call=[],
         )
         from fighthealthinsurance.models import Appeal
 
-        appeal = await database_sync_to_async(Appeal.objects.create)(
+        appeal = await sync_to_async(Appeal.objects.create)(
             creating_professional=professional1,
             primary_professional=professional1,
             hashed_email="hashappeal2@example.com",
@@ -362,7 +352,7 @@ class OngoingChatWebSocketTest(APITestCase):
         self.assertIn("error", response)
         self.assertIn("permission", response["error"])
         # Appeal is not linked
-        appeal_refresh = await database_sync_to_async(Appeal.objects.get)(id=appeal.id)
+        appeal_refresh = await sync_to_async(Appeal.objects.get)(id=appeal.id)
         self.assertIsNone(appeal_refresh.chat_id)
         await communicator.disconnect()
         await self.asyncTearDown()
@@ -370,26 +360,26 @@ class OngoingChatWebSocketTest(APITestCase):
     async def test_link_chat_to_prior_auth_permission_denied(self):
         """Test linking a chat to a prior auth without permission is denied."""
         await self.asyncSetUp()
-        user1 = await database_sync_to_async(User.objects.create_user)(
+        user1 = await sync_to_async(User.objects.create_user)(
             username="user3", password="testpass", email="user3@example.com"
         )
-        user2 = await database_sync_to_async(User.objects.create_user)(
+        user2 = await sync_to_async(User.objects.create_user)(
             username="user4", password="testpass", email="user4@example.com"
         )
-        professional1 = await database_sync_to_async(ProfessionalUser.objects.create)(
+        professional1 = await sync_to_async(ProfessionalUser.objects.create)(
             user=user1, active=True, npi_number="5555555555"
         )
-        professional2 = await database_sync_to_async(ProfessionalUser.objects.create)(
+        professional2 = await sync_to_async(ProfessionalUser.objects.create)(
             user=user2, active=True, npi_number="6666666666"
         )
-        chat = await database_sync_to_async(OngoingChat.objects.create)(
+        chat = await sync_to_async(OngoingChat.objects.create)(
             professional_user=professional2,
             chat_history=[],
             summary_for_next_call=[],
         )
         from fighthealthinsurance.models import PriorAuthRequest
 
-        prior_auth = await database_sync_to_async(PriorAuthRequest.objects.create)(
+        prior_auth = await sync_to_async(PriorAuthRequest.objects.create)(
             creator_professional_user=professional1,
             created_for_professional_user=professional1,
             diagnosis="Test diagnosis",
@@ -415,7 +405,7 @@ class OngoingChatWebSocketTest(APITestCase):
         self.assertIn("error", response)
         self.assertIn("permission", response["error"])
         # PriorAuthRequest is not linked
-        prior_auth_refresh = await database_sync_to_async(PriorAuthRequest.objects.get)(
+        prior_auth_refresh = await sync_to_async(PriorAuthRequest.objects.get)(
             id=prior_auth.id
         )
         self.assertIsNone(prior_auth_refresh.chat_id)
@@ -428,15 +418,15 @@ class OngoingChatWebSocketTest(APITestCase):
         await self.asyncSetUp()
 
         # Create a user
-        user = await database_sync_to_async(User.objects.create_user)(
+        user = await sync_to_async(User.objects.create_user)(
             username="testuser", password="testpass", email="test@example.com"
         )
-        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
+        professional = await sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="1234567890"
         )
 
         # Create a chat
-        chat = await database_sync_to_async(OngoingChat.objects.create)(
+        chat = await sync_to_async(OngoingChat.objects.create)(
             professional_user=professional,
             chat_history=[
                 {
@@ -487,7 +477,7 @@ class OngoingChatWebSocketTest(APITestCase):
         await communicator.disconnect()
 
         # Verify message was added to chat history
-        chat = await database_sync_to_async(OngoingChat.objects.get)(id=chat.id)
+        chat = await sync_to_async(OngoingChat.objects.get)(id=chat.id)
         self.assertEqual(
             len(chat.chat_history), 4
         )  # Original 2 messages + new user message + assistant response
@@ -514,10 +504,10 @@ class OngoingChatWebSocketTest(APITestCase):
         await self.asyncSetUp()
 
         # Create a user
-        user = await database_sync_to_async(User.objects.create_user)(
+        user = await sync_to_async(User.objects.create_user)(
             username="testuser", password="testpass", email="test@example.com"
         )
-        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
+        professional = await sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="1234567890"
         )
 
@@ -555,7 +545,7 @@ class OngoingChatWebSocketTest(APITestCase):
         self.assertTrue(chat_exists)
 
         # Verify message was added to chat history
-        chat = await database_sync_to_async(OngoingChat.objects.get)(id=chat_id)
+        chat = await sync_to_async(OngoingChat.objects.get)(id=chat_id)
         self.assertEqual(len(chat.chat_history), 2)  # User message + assistant response
         self.assertEqual(chat.chat_history[0]["role"], "user")
         self.assertEqual(
@@ -625,15 +615,15 @@ class OngoingChatWebSocketTest(APITestCase):
         with patch(
             "django.conf.settings.FIGHT_PAPERWORK_DOMAIN", "test-domain.example.com"
         ):
-            user = await database_sync_to_async(User.objects.create_user)(
+            user = await sync_to_async(User.objects.create_user)(
                 username="appealurluser",
                 password="testpass",
                 email="appealurl@example.com",
             )
-            professional = await database_sync_to_async(
-                ProfessionalUser.objects.create
-            )(user=user, active=True, npi_number="5555555555")
-            chat = await database_sync_to_async(OngoingChat.objects.create)(
+            professional = await sync_to_async(ProfessionalUser.objects.create)(
+                user=user, active=True, npi_number="5555555555"
+            )
+            chat = await sync_to_async(OngoingChat.objects.create)(
                 professional_user=professional,
                 chat_history=[],
                 summary_for_next_call=[],
@@ -669,9 +659,7 @@ class OngoingChatWebSocketTest(APITestCase):
             # Check that the response contains a properly formatted URL with the domain
             from fighthealthinsurance.models import Appeal
 
-            appeals = await database_sync_to_async(list)(
-                Appeal.objects.filter(chat=chat)
-            )
+            appeals = await sync_to_async(list)(Appeal.objects.filter(chat=chat))
             self.assertTrue(len(appeals) > 0)
             appeal_id = appeals[0].id
             expected_url_part = f"/appeals/{appeal_id}"
@@ -687,15 +675,15 @@ class OngoingChatWebSocketTest(APITestCase):
         with patch(
             "django.conf.settings.FIGHT_PAPERWORK_DOMAIN", "test-domain.example.com"
         ):
-            user = await database_sync_to_async(User.objects.create_user)(
+            user = await sync_to_async(User.objects.create_user)(
                 username="priorauthurl",
                 password="testpass",
                 email="priorauthurl@example.com",
             )
-            professional = await database_sync_to_async(
-                ProfessionalUser.objects.create
-            )(user=user, active=True, npi_number="6666666666")
-            chat = await database_sync_to_async(OngoingChat.objects.create)(
+            professional = await sync_to_async(ProfessionalUser.objects.create)(
+                user=user, active=True, npi_number="6666666666"
+            )
+            chat = await sync_to_async(OngoingChat.objects.create)(
                 professional_user=professional,
                 chat_history=[],
                 summary_for_next_call=[],
@@ -731,7 +719,7 @@ class OngoingChatWebSocketTest(APITestCase):
             # Check that the response contains a properly formatted URL with the domain
             from fighthealthinsurance.models import PriorAuthRequest
 
-            prior_auths = await database_sync_to_async(list)(
+            prior_auths = await sync_to_async(list)(
                 PriorAuthRequest.objects.filter(chat=chat)
             )
             self.assertTrue(len(prior_auths) > 0)

--- a/tests/sync/test_prior_auth_api.py
+++ b/tests/sync/test_prior_auth_api.py
@@ -26,7 +26,7 @@ from fighthealthinsurance.websockets import PriorAuthConsumer
 from fhi_users.models import ProfessionalDomainRelation
 from .mock_prior_auth_model import MockPriorAuthModel
 
-from channels.db import database_sync_to_async
+from asgiref.sync import sync_to_async
 
 if typing.TYPE_CHECKING:
     from django.contrib.auth.models import User
@@ -341,14 +341,14 @@ class PriorAuthWebSocketTest(APITestCase):
         await self.asyncSetUp()
 
         # Create a user and a prior auth request with answers
-        user = await database_sync_to_async(User.objects.create_user)(
+        user = await sync_to_async(User.objects.create_user)(
             username="testuser", password="testpass", email="test@example.com"
         )
-        professional = await database_sync_to_async(ProfessionalUser.objects.create)(
+        professional = await sync_to_async(ProfessionalUser.objects.create)(
             user=user, active=True, npi_number="1234567890"
         )
 
-        prior_auth = await database_sync_to_async(PriorAuthRequest.objects.create)(
+        prior_auth = await sync_to_async(PriorAuthRequest.objects.create)(
             creator_professional_user=professional,
             diagnosis="Rheumatoid Arthritis",
             treatment="Biologic Therapy",
@@ -398,9 +398,7 @@ class PriorAuthWebSocketTest(APITestCase):
         await communicator.disconnect()
 
         # Verify prior auth status was updated
-        prior_auth = await database_sync_to_async(PriorAuthRequest.objects.get)(
-            id=prior_auth.id
-        )
+        prior_auth = await sync_to_async(PriorAuthRequest.objects.get)(id=prior_auth.id)
         self.assertEqual(prior_auth.status, "prior_auth_requested")
 
         # Clean up

--- a/tests/sync/test_pubmed_api.py
+++ b/tests/sync/test_pubmed_api.py
@@ -10,8 +10,7 @@ from django.urls import reverse
 from django.contrib.auth import get_user_model
 from django.utils import timezone
 from django.test import TestCase, TransactionTestCase
-from asgiref.sync import async_to_sync
-from channels.db import database_sync_to_async
+from asgiref.sync import async_to_sync, sync_to_async
 
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -604,7 +603,7 @@ class PubMedE2EAppealFlowTest(TransactionTestCase):
             self.assertLessEqual(len(articles), PER_QUERY * 2)
 
             # Verify per-query cache rows were created (denial_id=NULL)
-            cache_rows = await database_sync_to_async(
+            cache_rows = await sync_to_async(
                 lambda: list(PubMedQueryData.objects.filter(denial_id__isnull=True))
             )()
             self.assertGreater(len(cache_rows), 0, "Per-query cache rows should exist")
@@ -615,7 +614,7 @@ class PubMedE2EAppealFlowTest(TransactionTestCase):
                 self.assertGreater(len(parsed), 0, "Cache rows should not be empty")
 
             # Verify denial summary row was created (denial_id=self.denial)
-            summary_rows = await database_sync_to_async(
+            summary_rows = await sync_to_async(
                 lambda: list(PubMedQueryData.objects.filter(denial_id=self.denial))
             )()
             self.assertEqual(len(summary_rows), 1, "Exactly one denial summary row")
@@ -644,7 +643,7 @@ class PubMedE2EAppealFlowTest(TransactionTestCase):
             await Denial.objects.filter(denial_id=self.denial.denial_id).aupdate(
                 pubmed_ids_json=article_pmids
             )
-            await database_sync_to_async(self.denial.refresh_from_db)()
+            await sync_to_async(self.denial.refresh_from_db)()
 
             context = await tools.find_context_for_denial(self.denial)
 
@@ -660,7 +659,7 @@ class PubMedE2EAppealFlowTest(TransactionTestCase):
             self.assertGreater(len(articles2), 0)
 
             # Verify no duplicate denial summary rows were created
-            summary_rows_after = await database_sync_to_async(
+            summary_rows_after = await sync_to_async(
                 lambda: list(PubMedQueryData.objects.filter(denial_id=self.denial))
             )()
             self.assertEqual(
@@ -670,7 +669,7 @@ class PubMedE2EAppealFlowTest(TransactionTestCase):
             )
 
             # Verify denial's base fields are unchanged
-            await database_sync_to_async(self.denial.refresh_from_db)()
+            await sync_to_async(self.denial.refresh_from_db)()
             self.assertEqual(self.denial.procedure, "physical therapy")
             self.assertEqual(self.denial.diagnosis, "rheumatoid arthritis")
 
@@ -761,7 +760,7 @@ class PubMedE2EAppealFlowTest(TransactionTestCase):
             )
 
             # Verify denial summary row has composite query string
-            summary_rows = await database_sync_to_async(
+            summary_rows = await sync_to_async(
                 lambda: list(PubMedQueryData.objects.filter(denial_id=self.denial))
             )()
             self.assertEqual(len(summary_rows), 1)
@@ -777,7 +776,7 @@ class PubMedE2EAppealFlowTest(TransactionTestCase):
                 self.assertIn(term, summary_query)
 
             # Verify per-query cache rows don't have denial_id
-            cache_rows = await database_sync_to_async(
+            cache_rows = await sync_to_async(
                 lambda: list(PubMedQueryData.objects.filter(denial_id__isnull=True))
             )()
             self.assertGreater(len(cache_rows), 0)
@@ -794,7 +793,7 @@ class PubMedE2EAppealFlowTest(TransactionTestCase):
             await Denial.objects.filter(denial_id=self.denial.denial_id).aupdate(
                 pubmed_ids_json=article_pmids
             )
-            await database_sync_to_async(self.denial.refresh_from_db)()
+            await sync_to_async(self.denial.refresh_from_db)()
 
             context = await tools.find_context_for_denial(self.denial)
             self.assertEqual(context, "Summarized context with microsite articles")
@@ -813,7 +812,7 @@ class PubMedE2EAppealFlowTest(TransactionTestCase):
             self.assertEqual(len(articles), 0)
 
             # No denial summary row should be created
-            summary_count = await database_sync_to_async(
+            summary_count = await sync_to_async(
                 PubMedQueryData.objects.filter(denial_id=self.denial).count
             )()
             self.assertEqual(
@@ -823,7 +822,7 @@ class PubMedE2EAppealFlowTest(TransactionTestCase):
             # Empty results from a successful NCBI call ARE negative-cached
             # so repeated empty-query lookups don't hammer NCBI. (Errors and
             # timeouts still aren't persisted; see negative-cache tests.)
-            cache_rows = await database_sync_to_async(
+            cache_rows = await sync_to_async(
                 lambda: list(PubMedQueryData.objects.filter(denial_id__isnull=True))
             )()
             self.assertGreater(
@@ -889,7 +888,7 @@ class PubMedE2EAppealFlowTest(TransactionTestCase):
             self.assertGreater(len(articles), 0)
 
             # Denial summary row should exist even though base query was empty
-            summary_rows = await database_sync_to_async(
+            summary_rows = await sync_to_async(
                 lambda: list(PubMedQueryData.objects.filter(denial_id=denial))
             )()
             self.assertEqual(
@@ -903,7 +902,7 @@ class PubMedE2EAppealFlowTest(TransactionTestCase):
             self.assertGreater(len(summary_pmids), 0)
 
             # Verify denial still has empty base fields
-            await database_sync_to_async(denial.refresh_from_db)()
+            await sync_to_async(denial.refresh_from_db)()
             self.assertEqual(denial.procedure, "")
             self.assertEqual(denial.diagnosis, "")
 
@@ -928,7 +927,7 @@ class PubMedNegativeCachingTest(TransactionTestCase):
             result = await tools.find_pubmed_article_ids_for_query("no hits query")
             self.assertEqual(result, [])
 
-            rows = await database_sync_to_async(
+            rows = await sync_to_async(
                 lambda: list(
                     PubMedQueryData.objects.filter(
                         query="no hits query", denial_id__isnull=True
@@ -995,7 +994,7 @@ class PubMedNegativeCachingTest(TransactionTestCase):
             with self.assertRaises(RuntimeError):
                 await tools.find_pubmed_article_ids_for_query("failing query")
 
-            rows = await database_sync_to_async(
+            rows = await sync_to_async(
                 lambda: list(PubMedQueryData.objects.filter(query="failing query"))
             )()
             self.assertEqual(rows, [], "Errors must not produce negative-cache rows")

--- a/tests/sync/test_rest_api.py
+++ b/tests/sync/test_rest_api.py
@@ -1,7 +1,6 @@
 """Test the rest API functionality"""
 
-from asgiref.sync import async_to_sync
-from channels.db import database_sync_to_async
+from asgiref.sync import async_to_sync, sync_to_async
 from unittest.mock import patch
 
 import asyncio
@@ -158,7 +157,7 @@ class DenialEndToEnd(APITestCase):
     @pytest.mark.asyncio
     # Testing end to end for professional user
     async def test_denial_end_to_end(self):
-        login_result = await database_sync_to_async(self.client.login)(
+        login_result = await sync_to_async(self.client.login)(
             username=self.username, password=self.password
         )
         self.assertTrue(login_result)
@@ -170,7 +169,7 @@ class DenialEndToEnd(APITestCase):
         ).acount()
         assert denials_for_user_count == 0
         # Create a denial
-        response = await database_sync_to_async(self.client.post)(
+        response = await sync_to_async(self.client.post)(
             url,
             json.dumps(
                 {
@@ -234,7 +233,7 @@ class DenialEndToEnd(APITestCase):
                 pass
         # Set health history before next steps
         health_history_url = reverse("healthhistory-list")
-        health_history_response = await database_sync_to_async(self.client.post)(
+        health_history_response = await sync_to_async(self.client.post)(
             health_history_url,
             json.dumps(
                 {
@@ -249,9 +248,7 @@ class DenialEndToEnd(APITestCase):
         self.assertTrue(status.is_success(health_history_response.status_code))
         # Ok now lets get the additional info
         find_next_steps_url = reverse("nextsteps-list")
-        find_next_steps_response: JsonResponse = await database_sync_to_async(
-            self.client.post
-        )(
+        find_next_steps_response: JsonResponse = await sync_to_async(self.client.post)(
             find_next_steps_url,
             json.dumps(
                 {
@@ -323,7 +320,7 @@ class DenialEndToEnd(APITestCase):
         # Now lets go ahead and provide follow up
         denial = await Denial.objects.aget(denial_id=denial_id)
         followup_url = reverse("followups-list")
-        followup_response = await database_sync_to_async(self.client.post)(
+        followup_response = await sync_to_async(self.client.post)(
             followup_url,
             json.dumps(
                 {
@@ -345,13 +342,13 @@ class DenialEndToEnd(APITestCase):
     async def test_appeal_generation_status_messages(self):
         """Test that appeal generation WebSocket sends status messages."""
         # Setup: Create a denial through the API
-        login_result = await database_sync_to_async(self.client.login)(
+        login_result = await sync_to_async(self.client.login)(
             username=self.username, password=self.password
         )
         self.assertTrue(login_result)
         url = reverse("denials-list")
         email = "test@example.com"
-        response = await database_sync_to_async(self.client.post)(
+        response = await sync_to_async(self.client.post)(
             url,
             json.dumps(
                 {
@@ -698,7 +695,7 @@ class StreamingAppealsRestFallbackTest(APITestCase):
         path in tests without real WS failure injection."""
         from fighthealthinsurance import websockets
 
-        denial = await database_sync_to_async(self._make_real_denial)()
+        denial = await sync_to_async(self._make_real_denial)()
 
         original = websockets.SUPPRESS_APPEAL_WS_DELIVERY
         websockets.SUPPRESS_APPEAL_WS_DELIVERY = True


### PR DESCRIPTION
- Add utils.aget_related(): async-safe forward FK/OneToOne access that serves from the relation cache when warm, otherwise runs a native aget (no thread bridge) and warms the cache for later sync access.
- Use select_related() where we control the fetch (appeal_tool, chat_interface) so for_denial access needs no bridge or extra query.
- Call OngoingChat.is_professional_user()/is_logged_in_user() directly in websockets: both only read local columns now (is_logged_in_user checks user_id so it never queries).
- generate_prior_auth: fetch the provider via aget_related so the FK access no longer happens outside the str() bridge.
- Tests only: switch database_sync_to_async wrappers to plain asgiref sync_to_async — per-call connection cleanup caused sqlite lock contention storms. App code keeps the database-aware bridge.
- Document both rules in CLAUDE.md; add tests for aget_related.


Claude-Session: https://claude.ai/code/session_01EZ9rdzyugcyyTcM4UbekGR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of asynchronous chat, appeal, prior-authorization, and insurance-plan workflows.
  * Prevented failures when accessing linked records during async processing.
  * Improved login-state detection for ongoing chats.

* **Tests**
  * Added coverage for safe asynchronous relationship loading.
  * Updated async integration tests to improve database operation reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->