### PR TITLE
Add Media References page and link "Featured in" from home page

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+fighthealthinsurance/static/images/newsweeklogo.png filter=lfs diff=lfs merge=lfs -text
+fighthealthinsurance/static/images/quartzlogo.png filter=lfs diff=lfs merge=lfs -text
+fighthealthinsurance/static/images/slashdotlogo.png filter=lfs diff=lfs merge=lfs -text
+fighthealthinsurance/static/images/kjzzlogo.png filter=lfs diff=lfs merge=lfs -text
+fighthealthinsurance/static/images/bgrlogo.png filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - uses: actions/setup-python@v5
 
@@ -38,6 +40,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
       - name: Install shell check
         run: sudo apt-get install -y shellcheck
       - name: Run shellcheck
@@ -47,6 +51,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - uses: actions/setup-python@v5
 
@@ -71,6 +77,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          lfs: true
       - name: Setup node
         uses: actions/setup-node@v6
 
@@ -101,6 +109,8 @@ jobs:
           df -h
 
       - uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Setup node
         uses: actions/setup-node@v3
@@ -177,6 +187,8 @@ jobs:
           df -h
 
       - uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Setup node
         uses: actions/setup-node@v3
@@ -248,6 +260,8 @@ jobs:
           df -h
 
       - uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Setup node
         uses: actions/setup-node@v3
@@ -398,6 +412,8 @@ jobs:
           df -h
 
       - uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Setup node
         uses: actions/setup-node@v3
@@ -479,6 +495,8 @@ jobs:
           df -h
 
       - uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Setup node
         uses: actions/setup-node@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
+          persist-credentials: false
 
       - uses: actions/setup-python@v5
 
@@ -42,6 +43,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
+          persist-credentials: false
       - name: Install shell check
         run: sudo apt-get install -y shellcheck
       - name: Run shellcheck
@@ -53,6 +55,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
+          persist-credentials: false
 
       - uses: actions/setup-python@v5
 
@@ -79,6 +82,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           lfs: true
+          persist-credentials: false
       - name: Setup node
         uses: actions/setup-node@v6
 
@@ -111,6 +115,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
+          persist-credentials: false
 
       - name: Setup node
         uses: actions/setup-node@v3
@@ -189,6 +194,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
+          persist-credentials: false
 
       - name: Setup node
         uses: actions/setup-node@v3
@@ -262,6 +268,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
+          persist-credentials: false
 
       - name: Setup node
         uses: actions/setup-node@v3
@@ -414,6 +421,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
+          persist-credentials: false
 
       - name: Setup node
         uses: actions/setup-node@v3
@@ -497,6 +505,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
+          persist-credentials: false
 
       - name: Setup node
         uses: actions/setup-node@v3

--- a/.github/workflows/update-browserslist-db.yml
+++ b/.github/workflows/update-browserslist-db.yml
@@ -29,6 +29,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          # Fetch real bytes for LFS-tracked assets (see .gitattributes) so this
+          # job can never commit pointer stubs over them. The `add-paths` below
+          # already scopes the commit to package-lock.json, but this keeps the
+          # checkout honest if that scope is ever widened.
+          lfs: true
           # Don't leave the job's write token in the local git config: the
           # updater step below runs third-party npm code, and create-pull-request
           # authenticates its own push via its `token` input, so nothing here

--- a/fighthealthinsurance/media_references.py
+++ b/fighthealthinsurance/media_references.py
@@ -1,0 +1,142 @@
+"""Single source of truth for press / media coverage of Fight Health Insurance.
+
+The ``MEDIA_REFERENCES`` list powers the public "Media References" page
+(``MediaReferencesView``). Keeping the coverage here as data (rather than
+hard-coded markup) lets the page, its tests, and any future consumers share one
+list instead of duplicating the same outlets and URLs across templates.
+
+Each entry is a plain dict so it can be rendered directly in a Django template:
+
+    outlet:            Human-readable name of the outlet (e.g. "Forbes").
+    kind:              Short category label ("Article", "Podcast", "TV").
+    cta:               Verb-first call to action for the link ("Read the article").
+    title:             Headline / episode / segment title.
+    url:               External URL to the coverage.
+    date:              Human-readable date string (kept as a string because some
+                       sources only give us a month or year).
+    description:       One- or two-sentence summary of the coverage.
+    logo:              Optional static path to the outlet's logo image.
+    internal_url_name: Optional Django URL name for an on-site page we maintain
+                       about this coverage (e.g. the PBS NewsHour page).
+
+Entries are ordered newest-first so the page reads as a reverse-chronological
+timeline of coverage.
+"""
+
+from typing import Optional, TypedDict
+
+
+class MediaReference(TypedDict, total=False):
+    outlet: str
+    kind: str
+    cta: str
+    title: str
+    url: str
+    date: str
+    description: str
+    logo: Optional[str]
+    internal_url_name: Optional[str]
+
+
+MEDIA_REFERENCES: list[MediaReference] = [
+    {
+        "outlet": "PBS NewsHour",
+        "kind": "TV",
+        "cta": "Watch the segment",
+        "title": "How patients are using AI to fight back against denied insurance claims",
+        "url": "https://www.pbs.org/newshour/show/how-patients-are-using-ai-to-fight-back-against-denied-insurance-claims",
+        "date": "2025",
+        "description": "PBS NewsHour looks at how patients are turning to AI tools like Fight Health Insurance to appeal denied claims and level the playing field with insurers.",
+        "internal_url_name": "pbs-newshour",
+    },
+    {
+        "outlet": "STAT News",
+        "kind": "Article",
+        "cta": "Read the article",
+        "title": "How artificial intelligence can help patients appeal health insurance denials",
+        "url": "https://www.statnews.com/2024/12/12/artificial-intelligence-appealing-health-insurance-denials",
+        "date": "December 12, 2024",
+        "description": "STAT News examines how AI is being used to help patients push back on health insurance denials.",
+        "logo": "images/statlogo.png",
+    },
+    {
+        "outlet": "Forbes",
+        "kind": "Article",
+        "cta": "Read the article",
+        "title": "These Entrepreneurs Are Using AI To Fight Health Insurance Claims Denials",
+        "url": "https://www.forbes.com/sites/amyfeldman/2024/12/11/these-entrepreneurs-are-using-ai-to-fight-health-insurance-claims-denials",
+        "date": "December 11, 2024",
+        "description": "Forbes profiles the founders using artificial intelligence to help patients appeal denied health insurance claims.",
+        "logo": "images/forbeslogo.png",
+    },
+    {
+        "outlet": "Business Insider",
+        "kind": "Article",
+        "cta": "Read the article",
+        "title": "This free project uses AI to help you appeal a health insurance claim denial",
+        "url": "https://www.businessinsider.com/free-health-insurance-claim-denial-appeal-project-startup-2024-12",
+        "date": "December 2024",
+        "description": "Business Insider covers the free project helping patients generate appeals for denied health insurance claims.",
+        "logo": "images/businessinsiderlogo.png",
+    },
+    {
+        "outlet": "CBS News",
+        "kind": "Article",
+        "cta": "Read the article",
+        "title": "Health insurance denials draw new scrutiny",
+        "url": "https://www.cbsnews.com/news/health-insurance-costs-inflation-denials-luigi-mangione-united-healthcare",
+        "date": "December 2024",
+        "description": "CBS News reports on rising frustration over health insurance denials and the tools patients are using to respond.",
+        "logo": "images/cbslogo.png",
+    },
+    {
+        "outlet": "WBUR — Here & Now",
+        "kind": "Radio",
+        "cta": "Listen to the segment",
+        "title": "Using AI to appeal health insurance denials",
+        "url": "https://www.wbur.org/hereandnow/2024/11/11/ai-insurance-appeals",
+        "date": "November 11, 2024",
+        "description": "WBUR's Here & Now discusses how AI can help patients write appeals when their health insurance claims are denied.",
+        "logo": "images/wbrlogo.png",
+    },
+    {
+        "outlet": "Fast Company",
+        "kind": "Article",
+        "cta": "Read the article",
+        "title": "If your health insurance denies a claim, this tool uses AI to help you fight back",
+        "url": "https://www.fastcompany.com/91209422/if-your-health-insurance-denies-a-claim-this-tool-uses-ai-to-help-you-fight-back",
+        "date": "2024",
+        "description": "Fast Company highlights how Fight Health Insurance uses AI to help patients contest denied claims.",
+        "logo": "images/fastcompanylogo.png",
+    },
+    {
+        "outlet": "NewsNation",
+        "kind": "TV",
+        "cta": "Watch the segment",
+        "title": "Fighting health insurance companies with AI (NewsNation Prime)",
+        "url": "https://www.newsnationnow.com/video/fighting-health-insurance-companies-with-ai-newsnation-prime/10025608",
+        "date": "2024",
+        "description": "NewsNation Prime features how patients can use AI to fight back against health insurance companies.",
+        "logo": "images/newsnationlogo.png",
+    },
+    {
+        "outlet": "An Arm and a Leg",
+        "kind": "Podcast",
+        "cta": "Listen to the episode",
+        "title": "Fight Health Insurance — with AI",
+        "url": "https://armandalegshow.com/episode/fight-health-insurance-with-ai",
+        "date": "2024",
+        "description": "The An Arm and a Leg podcast talks with the team behind Fight Health Insurance about using AI to appeal denials.",
+        "logo": "images/armleglogo.png",
+    },
+    {
+        "outlet": "The San Francisco Standard",
+        "kind": "Article",
+        "cta": "Read the article",
+        "title": "Holden Karau built a free tool to fight health insurance claim denials",
+        "url": "https://sfstandard.com/2024/08/23/holden-karau-fight-health-insurance-appeal-claims-denials",
+        "date": "August 23, 2024",
+        "description": "The San Francisco Standard profiles founder Holden Karau and the free tool she built to help people appeal insurance denials.",
+        "logo": "images/sflogo.png",
+    },
+]

--- a/fighthealthinsurance/media_references.py
+++ b/fighthealthinsurance/media_references.py
@@ -1,14 +1,15 @@
 """Single source of truth for press / media coverage of Fight Health Insurance.
 
-The ``MEDIA_REFERENCES`` list powers the public "Media References" page
-(``MediaReferencesView``). Keeping the coverage here as data (rather than
-hard-coded markup) lets the page, its tests, and any future consumers share one
-list instead of duplicating the same outlets and URLs across templates.
+``MEDIA_REFERENCES`` powers the public "Media References" page
+(``MediaReferencesView``) and ``SOCIAL_MEDIA_REFERENCES`` powers its social
+section. Keeping the coverage here as data (rather than hard-coded markup) lets
+the page, its tests, and any future consumers share one list instead of
+duplicating the same outlets and URLs across templates.
 
-Each entry is a plain dict so it can be rendered directly in a Django template:
+Every entry is a plain dict so it can be rendered directly in a Django template:
 
-    outlet:            Human-readable name of the outlet (e.g. "Forbes").
-    kind:              Short category label ("Article", "Podcast", "TV").
+    outlet:            Human-readable name of the outlet / creator (e.g. "Forbes").
+    kind:              Short category label ("Article", "Podcast", "TV", "TikTok").
     cta:               Verb-first call to action for the link ("Read the article").
     title:             Headline / episode / segment title.
     url:               External URL to the coverage.
@@ -19,8 +20,10 @@ Each entry is a plain dict so it can be rendered directly in a Django template:
     internal_url_name: Optional Django URL name for an on-site page we maintain
                        about this coverage (e.g. the PBS NewsHour page).
 
-Entries are ordered newest-first so the page reads as a reverse-chronological
-timeline of coverage.
+Only coverage that specifically references Fight Health Insurance / Fight
+Paperwork / Holden Karau's tool belongs here (not general "AI vs. insurance"
+stories). Entries are ordered newest-first so the page reads as a
+reverse-chronological timeline of coverage.
 """
 
 from typing import Optional, TypedDict
@@ -40,6 +43,15 @@ class MediaReference(TypedDict, total=False):
 
 MEDIA_REFERENCES: list[MediaReference] = [
     {
+        "outlet": "GOTO — The Brightest Minds in Tech",
+        "kind": "Podcast",
+        "cta": "Listen to the episode",
+        "title": "This AI Fights Health Insurance Denials — Holden Karau & Julian Wood",
+        "url": "https://open.spotify.com/episode/0KwGwhijL6IfxxgncORqg8",
+        "date": "January 2026",
+        "description": "Holden Karau joins GOTO's tech podcast to talk about how Fight Health Insurance uses AI to take on insurance denials.",
+    },
+    {
         "outlet": "PBS NewsHour",
         "kind": "TV",
         "cta": "Watch the segment",
@@ -48,6 +60,34 @@ MEDIA_REFERENCES: list[MediaReference] = [
         "date": "2025",
         "description": "PBS NewsHour looks at how patients are turning to AI tools like Fight Health Insurance to appeal denied claims and level the playing field with insurers.",
         "internal_url_name": "pbs-newshour",
+    },
+    {
+        "outlet": "The San Francisco Standard",
+        "kind": "Article",
+        "cta": "Read the article",
+        "title": "Health insurance is hellish. Doctors are fighting back with AI",
+        "url": "https://sfstandard.com/2025/06/30/fight-paperwork-health-insurance-ai-tool/",
+        "date": "June 30, 2025",
+        "description": "The San Francisco Standard reports on doctors using Fight Paperwork — the professional version of Fight Health Insurance — to appeal denials more efficiently.",
+        "logo": "images/sflogo.png",
+    },
+    {
+        "outlet": "Newsweek",
+        "kind": "Article",
+        "cta": "Read the article",
+        "title": "New Website Helps Americans 'Fight Health Insurance' Over Claims",
+        "url": "https://www.newsweek.com/health-insurance-claims-ai-website-2012389",
+        "date": "January 9, 2025",
+        "description": "Newsweek covers how Fight Health Insurance lets people upload a denial and generate a customized appeal draft.",
+    },
+    {
+        "outlet": "The Joe Reis Show",
+        "kind": "Podcast",
+        "cta": "Listen to the episode",
+        "title": "Holden Karau — Fight Health Insurance",
+        "url": "https://open.spotify.com/episode/6BUN3ACn8fL4rj8fkXV42o",
+        "date": "December 16, 2024",
+        "description": "Holden Karau talks with Joe Reis about building Fight Health Insurance and using AI to appeal claim denials.",
     },
     {
         "outlet": "STAT News",
@@ -100,24 +140,41 @@ MEDIA_REFERENCES: list[MediaReference] = [
         "logo": "images/wbrlogo.png",
     },
     {
-        "outlet": "Fast Company",
-        "kind": "Article",
-        "cta": "Read the article",
-        "title": "If your health insurance denies a claim, this tool uses AI to help you fight back",
-        "url": "https://www.fastcompany.com/91209422/if-your-health-insurance-denies-a-claim-this-tool-uses-ai-to-help-you-fight-back",
-        "date": "2024",
-        "description": "Fast Company highlights how Fight Health Insurance uses AI to help patients contest denied claims.",
-        "logo": "images/fastcompanylogo.png",
+        "outlet": "KJZZ — The Show",
+        "kind": "Radio",
+        "cta": "Listen to the interview",
+        "title": "How one software developer is using AI to help people fight health insurance denials",
+        "url": "https://www.kjzz.org/the-show/2024-10-03/how-one-software-developer-is-using-ai-to-help-people-fight-health-insurance-denials",
+        "date": "October 3, 2024",
+        "description": "Phoenix public radio station KJZZ interviews Holden Karau about building FightHealthInsurance.com to help people write appeals.",
     },
     {
-        "outlet": "NewsNation",
-        "kind": "TV",
-        "cta": "Watch the segment",
-        "title": "Fighting health insurance companies with AI (NewsNation Prime)",
-        "url": "https://www.newsnationnow.com/video/fighting-health-insurance-companies-with-ai-newsnation-prime/10025608",
-        "date": "2024",
-        "description": "NewsNation Prime features how patients can use AI to fight back against health insurance companies.",
-        "logo": "images/newsnationlogo.png",
+        "outlet": "Slashdot",
+        "kind": "Article",
+        "cta": "Read the story",
+        "title": "Tech Worker Builds Free AI-Powered Tool For Fighting US Health Insurance Denials",
+        "url": "https://science.slashdot.org/story/24/08/31/2131240/tech-worker-builds-free-ai-powered-tool-for-fighting-us-health-insurance-denials",
+        "date": "August 31, 2024",
+        "description": "Slashdot highlights the free, open-source tool Holden Karau built so patients can scan denials and generate appeal letters.",
+    },
+    {
+        "outlet": "BGR",
+        "kind": "Article",
+        "cta": "Read the article",
+        "title": "This Free Site Uses AI To Help You Fight Health Insurance Claim Denials",
+        "url": "https://www.bgr.com/tech/this-free-site-uses-ai-to-help-you-fight-health-insurance-claim-denials/",
+        "date": "August 27, 2024",
+        "description": "BGR walks through how the free Fight Health Insurance site uses AI to help people appeal denied claims.",
+    },
+    {
+        "outlet": "The San Francisco Standard",
+        "kind": "Article",
+        "cta": "Read the article",
+        "title": "Holden Karau built a free tool to fight health insurance claim denials",
+        "url": "https://sfstandard.com/2024/08/23/holden-karau-fight-health-insurance-appeal-claims-denials",
+        "date": "August 23, 2024",
+        "description": "The San Francisco Standard profiles founder Holden Karau and the free tool she built to help people appeal insurance denials.",
+        "logo": "images/sflogo.png",
     },
     {
         "outlet": "An Arm and a Leg",
@@ -130,13 +187,54 @@ MEDIA_REFERENCES: list[MediaReference] = [
         "logo": "images/armleglogo.png",
     },
     {
-        "outlet": "The San Francisco Standard",
+        "outlet": "NewsNation",
+        "kind": "TV",
+        "cta": "Watch the segment",
+        "title": "Fighting health insurance companies with AI (NewsNation Prime)",
+        "url": "https://www.newsnationnow.com/video/fighting-health-insurance-companies-with-ai-newsnation-prime/10025608",
+        "date": "2024",
+        "description": "NewsNation Prime features how patients can use AI to fight back against health insurance companies.",
+        "logo": "images/newsnationlogo.png",
+    },
+    {
+        "outlet": "Fast Company",
         "kind": "Article",
         "cta": "Read the article",
-        "title": "Holden Karau built a free tool to fight health insurance claim denials",
-        "url": "https://sfstandard.com/2024/08/23/holden-karau-fight-health-insurance-appeal-claims-denials",
-        "date": "August 23, 2024",
-        "description": "The San Francisco Standard profiles founder Holden Karau and the free tool she built to help people appeal insurance denials.",
-        "logo": "images/sflogo.png",
+        "title": "If your health insurance denies a claim, this tool uses AI to help you fight back",
+        "url": "https://www.fastcompany.com/91209422/if-your-health-insurance-denies-a-claim-this-tool-uses-ai-to-help-you-fight-back",
+        "date": "2024",
+        "description": "Fast Company highlights how Fight Health Insurance uses AI to help patients contest denied claims.",
+        "logo": "images/fastcompanylogo.png",
+    },
+    {
+        "outlet": "Quartz",
+        "kind": "Article",
+        "cta": "Read the article",
+        "title": "This free tool uses AI to appeal insurance denials — which may have been denied by AI",
+        "url": "https://qz.com/fight-health-insurance-denials-appeals-ai-1851733712",
+        "date": "2024",
+        "description": "Quartz spotlights Fight Health Insurance as a free tool that uses AI to appeal denials — some of which were themselves issued by AI.",
+    },
+]
+
+
+SOCIAL_MEDIA_REFERENCES: list[MediaReference] = [
+    {
+        "outlet": "The San Francisco Standard",
+        "kind": "TikTok",
+        "cta": "Watch on TikTok",
+        "title": "Holden Karau is using AI to fight health insurance denials",
+        "url": "https://www.tiktok.com/@sfstandard/video/7411675257297177886",
+        "date": "August 2024",
+        "description": "The SF Standard's TikTok on how Holden Karau built Fight Health Insurance after facing roughly 40 denials herself.",
+    },
+    {
+        "outlet": "NewsNation Prime",
+        "kind": "YouTube",
+        "cta": "Watch on YouTube",
+        "title": "Fighting health insurance companies with AI",
+        "url": "https://www.youtube.com/watch?v=lI26LrDU2dg",
+        "date": "2024",
+        "description": "The NewsNation Prime segment on fighting health insurance companies with AI, available on YouTube.",
     },
 ]

--- a/fighthealthinsurance/media_references.py
+++ b/fighthealthinsurance/media_references.py
@@ -1,12 +1,14 @@
-"""Single source of truth for press / media coverage of Fight Health Insurance.
+"""Press / media coverage of Fight Health Insurance for the Media References page.
 
 ``MEDIA_REFERENCES`` powers the public "Media References" page
 (``MediaReferencesView``) and ``SOCIAL_MEDIA_REFERENCES`` powers its social
-section. Keeping the coverage here as data (rather than hard-coded markup) lets
-the page, its tests, and any future consumers share one list instead of
-duplicating the same outlets and URLs across templates.
+section. This module is the source of truth for that page. Keeping the coverage
+here as data (rather than hard-coded markup) lets the page, its tests, and any
+future consumers share one list. (The curated "As Featured In" strip on the home
+page, ``partials/featured_section.html``, is a deliberately separate, hand-laid
+teaser with its own two-row highlight layout; it is not generated from this list.)
 
-Every entry is a plain dict so it can be rendered directly in a Django template:
+Every entry is a dict so it can be rendered directly in a Django template:
 
     outlet:            Human-readable name of the outlet / creator (e.g. "Forbes").
     kind:              Short category label ("Article", "Podcast", "TV", "TikTok").
@@ -29,14 +31,21 @@ reverse-chronological timeline of coverage.
 from typing import Optional, TypedDict
 
 
-class MediaReference(TypedDict, total=False):
+class _MediaReferenceRequired(TypedDict):
+    """Fields every reference must provide (enforced by mypy)."""
+
     outlet: str
     kind: str
     cta: str
     title: str
     url: str
-    date: str
     description: str
+
+
+class MediaReference(_MediaReferenceRequired, total=False):
+    """A media reference, plus optional presentation fields."""
+
+    date: str
     logo: Optional[str]
     internal_url_name: Optional[str]
 
@@ -242,15 +251,5 @@ SOCIAL_MEDIA_REFERENCES: list[MediaReference] = [
         "date": "August 2024",
         "description": "The SF Standard's TikTok on how Holden Karau built Fight Health Insurance after facing roughly 40 denials herself.",
         "logo": "images/sflogo.png",
-    },
-    {
-        "outlet": "NewsNation Prime",
-        "kind": "YouTube",
-        "cta": "Watch on YouTube",
-        "title": "Fighting health insurance companies with AI",
-        "url": "https://www.youtube.com/watch?v=lI26LrDU2dg",
-        "date": "2024",
-        "description": "The NewsNation Prime segment on fighting health insurance companies with AI, available on YouTube.",
-        "logo": "images/newsnationlogo.png",
     },
 ]

--- a/fighthealthinsurance/media_references.py
+++ b/fighthealthinsurance/media_references.py
@@ -79,6 +79,7 @@ MEDIA_REFERENCES: list[MediaReference] = [
         "url": "https://www.newsweek.com/health-insurance-claims-ai-website-2012389",
         "date": "January 9, 2025",
         "description": "Newsweek covers how Fight Health Insurance lets people upload a denial and generate a customized appeal draft.",
+        "logo": "images/newsweeklogo.png",
     },
     {
         "outlet": "The Joe Reis Show",
@@ -147,6 +148,7 @@ MEDIA_REFERENCES: list[MediaReference] = [
         "url": "https://www.kjzz.org/the-show/2024-10-03/how-one-software-developer-is-using-ai-to-help-people-fight-health-insurance-denials",
         "date": "October 3, 2024",
         "description": "Phoenix public radio station KJZZ interviews Holden Karau about building FightHealthInsurance.com to help people write appeals.",
+        "logo": "images/kjzzlogo.png",
     },
     {
         "outlet": "Slashdot",
@@ -156,6 +158,7 @@ MEDIA_REFERENCES: list[MediaReference] = [
         "url": "https://science.slashdot.org/story/24/08/31/2131240/tech-worker-builds-free-ai-powered-tool-for-fighting-us-health-insurance-denials",
         "date": "August 31, 2024",
         "description": "Slashdot highlights the free, open-source tool Holden Karau built so patients can scan denials and generate appeal letters.",
+        "logo": "images/slashdotlogo.png",
     },
     {
         "outlet": "BGR",
@@ -165,6 +168,7 @@ MEDIA_REFERENCES: list[MediaReference] = [
         "url": "https://www.bgr.com/tech/this-free-site-uses-ai-to-help-you-fight-health-insurance-claim-denials/",
         "date": "August 27, 2024",
         "description": "BGR walks through how the free Fight Health Insurance site uses AI to help people appeal denied claims.",
+        "logo": "images/bgrlogo.png",
     },
     {
         "outlet": "The San Francisco Standard",
@@ -214,11 +218,21 @@ MEDIA_REFERENCES: list[MediaReference] = [
         "url": "https://qz.com/fight-health-insurance-denials-appeals-ai-1851733712",
         "date": "2024",
         "description": "Quartz spotlights Fight Health Insurance as a free tool that uses AI to appeal denials — some of which were themselves issued by AI.",
+        "logo": "images/quartzlogo.png",
     },
 ]
 
 
 SOCIAL_MEDIA_REFERENCES: list[MediaReference] = [
+    {
+        "outlet": "Your Rich BFF (Vivian Tu)",
+        "kind": "YouTube",
+        "cta": "Watch on YouTube",
+        "title": "Using AI to fight a health insurance denial",
+        "url": "https://www.youtube.com/watch?v=rEudKDcGZ2g",
+        "date": "2024",
+        "description": "Personal-finance creator Your Rich BFF (Vivian Tu) shows her audience how to use Fight Health Insurance to appeal a denied claim.",
+    },
     {
         "outlet": "The San Francisco Standard",
         "kind": "TikTok",
@@ -227,6 +241,7 @@ SOCIAL_MEDIA_REFERENCES: list[MediaReference] = [
         "url": "https://www.tiktok.com/@sfstandard/video/7411675257297177886",
         "date": "August 2024",
         "description": "The SF Standard's TikTok on how Holden Karau built Fight Health Insurance after facing roughly 40 denials herself.",
+        "logo": "images/sflogo.png",
     },
     {
         "outlet": "NewsNation Prime",
@@ -236,5 +251,6 @@ SOCIAL_MEDIA_REFERENCES: list[MediaReference] = [
         "url": "https://www.youtube.com/watch?v=lI26LrDU2dg",
         "date": "2024",
         "description": "The NewsNation Prime segment on fighting health insurance companies with AI, available on YouTube.",
+        "logo": "images/newsnationlogo.png",
     },
 ]

--- a/fighthealthinsurance/media_references.py
+++ b/fighthealthinsurance/media_references.py
@@ -67,7 +67,10 @@ MEDIA_REFERENCES: list[MediaReference] = [
         "title": "How patients are using AI to fight back against denied insurance claims",
         "url": "https://www.pbs.org/newshour/show/how-patients-are-using-ai-to-fight-back-against-denied-insurance-claims",
         "date": "2025",
-        "description": "PBS NewsHour looks at how patients are turning to AI tools like Fight Health Insurance to appeal denied claims and level the playing field with insurers.",
+        # Fight Health Insurance appears on air in this segment; the published
+        # transcript covers AI appeal tools generally without naming us, so keep
+        # the wording to what the broadcast actually shows.
+        "description": "Fight Health Insurance appears in PBS NewsHour's report on how patients are using AI to fight back against denied insurance claims.",
         "internal_url_name": "pbs-newshour",
     },
     {

--- a/fighthealthinsurance/sitemap.py
+++ b/fighthealthinsurance/sitemap.py
@@ -36,6 +36,7 @@ class StaticViewSitemap(Sitemap):
             "root",
             "about",
             "pbs-newshour",
+            "media-references",
             "preparing-2026",
             "turning-26",
             "other-resources",

--- a/fighthealthinsurance/static/css/custom.css
+++ b/fighthealthinsurance/static/css/custom.css
@@ -1883,6 +1883,10 @@ section:not(.slider) .share-subcopy {
     color: #333;
     margin: 3rem 0 1.75rem;
 }
+/* First subhead follows the header, which already has bottom margin. */
+.media-references-header + .media-references-subhead {
+    margin-top: 0;
+}
 .media-reference-card {
     display: flex;
     flex-direction: column;
@@ -1979,7 +1983,7 @@ section:not(.slider) .share-subcopy {
     text-decoration: none;
 }
 .media-reference-link-internal {
-    color: #888;
+    color: #6b6b6b;
     font-weight: 500;
 }
 .media-references-cta {

--- a/fighthealthinsurance/static/css/custom.css
+++ b/fighthealthinsurance/static/css/custom.css
@@ -1876,6 +1876,13 @@ section:not(.slider) .share-subcopy {
     grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
     gap: 1.75rem;
 }
+.media-references-subhead {
+    text-align: center;
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #333;
+    margin: 3rem 0 1.75rem;
+}
 .media-reference-card {
     display: flex;
     flex-direction: column;

--- a/fighthealthinsurance/static/css/custom.css
+++ b/fighthealthinsurance/static/css/custom.css
@@ -1805,3 +1805,200 @@ section:not(.slider) .share-subcopy {
         gap: 0;
     }
 }
+
+/* Make the "Featured in ..." trust chip a link without losing chip styling. */
+.trust-chip-link {
+    text-decoration: none;
+    cursor: pointer;
+    transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+.trust-chip-link:hover,
+.trust-chip-link:focus {
+    color: #fff;
+    text-decoration: none;
+    background: rgba(165, 196, 34, 0.35);
+    border-color: rgba(165, 196, 34, 0.7);
+    transform: translateY(-1px);
+}
+
+/* "As Featured In" heading + "See all" link on the home page featured section. */
+.featured-title-link {
+    color: inherit;
+    text-decoration: none;
+    transition: color 0.2s ease;
+}
+.featured-title-link:hover,
+.featured-title-link:focus {
+    color: #f02eaa;
+    text-decoration: none;
+}
+.featured-see-all {
+    text-align: center;
+    margin-top: 1.5rem;
+}
+.featured-see-all-link {
+    display: inline-block;
+    font-weight: 600;
+    color: #7b920a;
+    text-decoration: none;
+    transition: color 0.2s ease, transform 0.2s ease;
+}
+.featured-see-all-link:hover,
+.featured-see-all-link:focus {
+    color: #f02eaa;
+    text-decoration: none;
+    transform: translateX(2px);
+}
+
+/* ===== Media References / Press Page ===== */
+.media-references-section {
+    padding: 6rem 0 4rem;
+    background: linear-gradient(135deg, rgba(165, 196, 34, 0.05) 0%, rgba(123, 146, 10, 0.08) 100%);
+}
+.media-references-header {
+    text-align: center;
+    max-width: 760px;
+    margin: 0 auto 3rem;
+}
+.media-references-title {
+    font-size: 2.4rem;
+    font-weight: 700;
+    color: #333;
+    margin-bottom: 1rem;
+}
+.media-references-subtitle {
+    font-size: 1.1rem;
+    color: #555;
+    line-height: 1.6;
+}
+.media-references-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 1.75rem;
+}
+.media-reference-card {
+    display: flex;
+    flex-direction: column;
+    background: #fff;
+    border-radius: 12px;
+    padding: 1.5rem;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+    border-bottom: 4px solid #f02eaa;
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+.media-reference-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+}
+.media-reference-card-top {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    min-height: 48px;
+    margin-bottom: 1rem;
+}
+.media-reference-logo {
+    max-height: 42px;
+    max-width: 150px;
+    width: auto;
+    object-fit: contain;
+}
+.media-reference-outlet-text {
+    font-size: 1.15rem;
+    font-weight: 700;
+    color: #333;
+}
+.media-reference-kind {
+    flex-shrink: 0;
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: #7b920a;
+    background: rgba(165, 196, 34, 0.15);
+    border-radius: 999px;
+    padding: 0.2rem 0.6rem;
+}
+.media-reference-body {
+    flex: 1 1 auto;
+}
+.media-reference-outlet {
+    font-size: 0.85rem;
+    color: #888;
+    margin-bottom: 0.4rem;
+}
+.media-reference-date {
+    white-space: nowrap;
+}
+.media-reference-headline {
+    font-size: 1.15rem;
+    font-weight: 600;
+    line-height: 1.35;
+    margin-bottom: 0.6rem;
+}
+.media-reference-headline a {
+    color: #333;
+    text-decoration: none;
+    transition: color 0.2s ease;
+}
+.media-reference-headline a:hover,
+.media-reference-headline a:focus {
+    color: #f02eaa;
+    text-decoration: none;
+}
+.media-reference-desc {
+    font-size: 0.95rem;
+    color: #555;
+    line-height: 1.55;
+    margin-bottom: 1rem;
+}
+.media-reference-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    align-items: center;
+    margin-top: auto;
+}
+.media-reference-link {
+    font-weight: 600;
+    color: #7b920a;
+    text-decoration: none;
+    transition: color 0.2s ease;
+}
+.media-reference-link:hover,
+.media-reference-link:focus {
+    color: #f02eaa;
+    text-decoration: none;
+}
+.media-reference-link-internal {
+    color: #888;
+    font-weight: 500;
+}
+.media-references-cta {
+    text-align: center;
+    margin-top: 3.5rem;
+}
+.media-references-cta p {
+    font-size: 1.2rem;
+    font-weight: 600;
+    color: #333;
+    margin-bottom: 1.25rem;
+}
+.media-references-contact {
+    text-align: center;
+    color: #888;
+    font-size: 0.9rem;
+    margin-top: 2.5rem;
+}
+@media (max-width: 768px) {
+    .media-references-section {
+        padding: 4rem 0 3rem;
+    }
+    .media-references-title {
+        font-size: 1.9rem;
+    }
+    .media-references-grid {
+        grid-template-columns: 1fr;
+    }
+}

--- a/fighthealthinsurance/static/css/custom.css
+++ b/fighthealthinsurance/static/css/custom.css
@@ -1926,7 +1926,9 @@ section:not(.slider) .share-subcopy {
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.04em;
-    color: #7b920a;
+    /* Darker than the site's usual green: this is small (0.7rem) text on a pale
+       green chip, so it needs the 4.5:1 body-text ratio (this pair is ~5.4:1). */
+    color: #566b07;
     background: rgba(165, 196, 34, 0.15);
     border-radius: 999px;
     padding: 0.2rem 0.6rem;

--- a/fighthealthinsurance/static/images/bgrlogo.png
+++ b/fighthealthinsurance/static/images/bgrlogo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d809eff100be71c9aa832bfc61336231e04a4074ed53ea7165bcc3810c100e3
+size 6995

--- a/fighthealthinsurance/static/images/kjzzlogo.png
+++ b/fighthealthinsurance/static/images/kjzzlogo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d3d90010ca92b8feb903161eb32f04a9ecd61e7b01800e09a3945c910c2d4ab
+size 24985

--- a/fighthealthinsurance/static/images/newsweeklogo.png
+++ b/fighthealthinsurance/static/images/newsweeklogo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac2a1a6977196a1b90c0a7d2fbf8df74d1417b80a24840f1f946ca50163b6c21
+size 5125

--- a/fighthealthinsurance/static/images/quartzlogo.png
+++ b/fighthealthinsurance/static/images/quartzlogo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39d5a412500c724d3e024dce8bd3ef6ac9a0e99cd6873ef5626948d51b8009fa
+size 17478

--- a/fighthealthinsurance/static/images/slashdotlogo.png
+++ b/fighthealthinsurance/static/images/slashdotlogo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b3e86e8dec606cb6effd7938126cfcceff1dbcffe86a88c6a08d98de132181d
+size 17452

--- a/fighthealthinsurance/templates/landing_base.html
+++ b/fighthealthinsurance/templates/landing_base.html
@@ -25,7 +25,7 @@
 	      </div>
 	      <div class="trust-strip">
 	        <span class="trust-chip"><span class="trust-chip-icon" aria-hidden="true">&#10003;</span> Free for everyone</span>
-	        <span class="trust-chip"><span class="trust-chip-icon" aria-hidden="true">&#9733;</span> Featured in Forbes, CBS &amp; more</span>
+	        <a href="{% url 'media-references' %}" class="trust-chip trust-chip-link"><span class="trust-chip-icon" aria-hidden="true">&#9733;</span> Featured in Forbes, CBS &amp; more</a>
 	        <span class="trust-chip"><span class="trust-chip-icon" aria-hidden="true">&#127482;&#127480;</span> 50-state coverage</span>
 	        <span class="trust-chip"><span class="trust-chip-icon" aria-hidden="true">&#128200;</span> 10,000+ appeals generated</span>
 	      </div>

--- a/fighthealthinsurance/templates/media_references.html
+++ b/fighthealthinsurance/templates/media_references.html
@@ -15,6 +15,7 @@
             </p>
         </div>
 
+        <h2 class="media-references-subhead">Press Coverage</h2>
         <div class="media-references-grid">
             {% for ref in media_references %}
             {% include 'partials/media_reference_card.html' %}

--- a/fighthealthinsurance/templates/media_references.html
+++ b/fighthealthinsurance/templates/media_references.html
@@ -1,0 +1,57 @@
+{% extends 'base.html' %}
+{% load static %}
+{% block title %}Media References &amp; Press - Fight Health Insurance{% endblock title %}
+{% block metatitle %}Media References &amp; Press - Fight Health Insurance{% endblock metatitle %}
+{% block metadescription %}Press coverage and media references for Fight Health Insurance - featured on PBS NewsHour, Forbes, CBS News, STAT News, Business Insider, Fast Company, WBUR, NewsNation and more.{% endblock metadescription %}
+
+{% block content %}
+<section class="media-references-section">
+    <div class="container">
+        <div class="media-references-header">
+            <h1 class="media-references-title">Media References</h1>
+            <p class="media-references-subtitle">
+                Fight Health Insurance has been featured in national news, radio, and podcasts.
+                Here's a look at where our work to help patients appeal denied claims has been covered.
+            </p>
+        </div>
+
+        <div class="media-references-grid">
+            {% for ref in media_references %}
+            <article class="media-reference-card">
+                <div class="media-reference-card-top">
+                    {% if ref.logo %}
+                    <img src="{% static ref.logo %}" alt="{{ ref.outlet }} logo" class="media-reference-logo" loading="lazy">
+                    {% else %}
+                    <span class="media-reference-outlet-text">{{ ref.outlet }}</span>
+                    {% endif %}
+                    {% if ref.kind %}<span class="media-reference-kind">{{ ref.kind }}</span>{% endif %}
+                </div>
+                <div class="media-reference-body">
+                    <div class="media-reference-outlet">{{ ref.outlet }}{% if ref.date %} &middot; <span class="media-reference-date">{{ ref.date }}</span>{% endif %}</div>
+                    <h2 class="media-reference-headline">
+                        <a href="{{ ref.url }}" target="_blank" rel="noopener noreferrer">{{ ref.title }}</a>
+                    </h2>
+                    {% if ref.description %}<p class="media-reference-desc">{{ ref.description }}</p>{% endif %}
+                </div>
+                <div class="media-reference-links">
+                    <a href="{{ ref.url }}" class="media-reference-link" target="_blank" rel="noopener noreferrer">{{ ref.cta|default:"Read more" }} &rarr;</a>
+                    {% if ref.internal_url_name %}
+                    <a href="{% url ref.internal_url_name %}" class="media-reference-link media-reference-link-internal">See our page</a>
+                    {% endif %}
+                </div>
+            </article>
+            {% endfor %}
+        </div>
+
+        <div class="media-references-cta">
+            <p>Denied by your health insurance? You don't have to fight alone.</p>
+            <a href="{% url 'scan' %}" class="section-btn btn btn-default">Generate Your Appeal for Free</a>
+        </div>
+
+        <p class="media-references-contact">
+            Members of the press: reach us at
+            <a class="link" href="mailto:media@fighthealthinsurance.com">media@fighthealthinsurance.com</a>.
+        </p>
+    </div>
+</section>
+{% endblock content %}

--- a/fighthealthinsurance/templates/media_references.html
+++ b/fighthealthinsurance/templates/media_references.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% block title %}Media References &amp; Press - Fight Health Insurance{% endblock title %}
 {% block metatitle %}Media References &amp; Press - Fight Health Insurance{% endblock metatitle %}
-{% block metadescription %}Press coverage and media references for Fight Health Insurance - featured on PBS NewsHour, Forbes, CBS News, STAT News, Business Insider, Fast Company, WBUR, NewsNation and more.{% endblock metadescription %}
+{% block metadescription %}Press coverage and media references for Fight Health Insurance - featured on PBS NewsHour, Forbes, Newsweek, CBS News, STAT News, Business Insider, Quartz, Fast Company, WBUR, NewsNation and more.{% endblock metadescription %}
 
 {% block content %}
 <section class="media-references-section">
@@ -17,31 +17,18 @@
 
         <div class="media-references-grid">
             {% for ref in media_references %}
-            <article class="media-reference-card">
-                <div class="media-reference-card-top">
-                    {% if ref.logo %}
-                    <img src="{% static ref.logo %}" alt="{{ ref.outlet }} logo" class="media-reference-logo" loading="lazy">
-                    {% else %}
-                    <span class="media-reference-outlet-text">{{ ref.outlet }}</span>
-                    {% endif %}
-                    {% if ref.kind %}<span class="media-reference-kind">{{ ref.kind }}</span>{% endif %}
-                </div>
-                <div class="media-reference-body">
-                    <div class="media-reference-outlet">{{ ref.outlet }}{% if ref.date %} &middot; <span class="media-reference-date">{{ ref.date }}</span>{% endif %}</div>
-                    <h2 class="media-reference-headline">
-                        <a href="{{ ref.url }}" target="_blank" rel="noopener noreferrer">{{ ref.title }}</a>
-                    </h2>
-                    {% if ref.description %}<p class="media-reference-desc">{{ ref.description }}</p>{% endif %}
-                </div>
-                <div class="media-reference-links">
-                    <a href="{{ ref.url }}" class="media-reference-link" target="_blank" rel="noopener noreferrer">{{ ref.cta|default:"Read more" }} &rarr;</a>
-                    {% if ref.internal_url_name %}
-                    <a href="{% url ref.internal_url_name %}" class="media-reference-link media-reference-link-internal">See our page</a>
-                    {% endif %}
-                </div>
-            </article>
+            {% include 'partials/media_reference_card.html' %}
             {% endfor %}
         </div>
+
+        {% if social_references %}
+        <h2 class="media-references-subhead">On Social Media</h2>
+        <div class="media-references-grid">
+            {% for ref in social_references %}
+            {% include 'partials/media_reference_card.html' %}
+            {% endfor %}
+        </div>
+        {% endif %}
 
         <div class="media-references-cta">
             <p>Denied by your health insurance? You don't have to fight alone.</p>

--- a/fighthealthinsurance/templates/partials/featured_section.html
+++ b/fighthealthinsurance/templates/partials/featured_section.html
@@ -2,7 +2,7 @@
 <!-- AS FEATURED IN -->
 <section id="featured" class="featured-section">
     <div class="container">
-        <h5 class="featured-title">As Featured In</h5>
+        <h5 class="featured-title"><a href="{% url 'media-references' %}" class="featured-title-link">As Featured In</a></h5>
         <div class="row no-gutters">
             <div class="col-md-12">
                 <div class="row no-gutters featured-row">
@@ -59,6 +59,9 @@
                     </div>
                 </div>
             </div>
+        </div>
+        <div class="featured-see-all">
+            <a href="{% url 'media-references' %}" class="featured-see-all-link">See all media references &rarr;</a>
         </div>
     </div>
 </section>

--- a/fighthealthinsurance/templates/partials/media_reference_card.html
+++ b/fighthealthinsurance/templates/partials/media_reference_card.html
@@ -1,0 +1,25 @@
+{% load static %}
+{# Renders a single media/social reference card. Expects `ref` in context. #}
+<article class="media-reference-card">
+    <div class="media-reference-card-top">
+        {% if ref.logo %}
+        <img src="{% static ref.logo %}" alt="{{ ref.outlet }} logo" class="media-reference-logo" loading="lazy">
+        {% else %}
+        <span class="media-reference-outlet-text">{{ ref.outlet }}</span>
+        {% endif %}
+        {% if ref.kind %}<span class="media-reference-kind">{{ ref.kind }}</span>{% endif %}
+    </div>
+    <div class="media-reference-body">
+        <div class="media-reference-outlet">{{ ref.outlet }}{% if ref.date %} &middot; <span class="media-reference-date">{{ ref.date }}</span>{% endif %}</div>
+        <h3 class="media-reference-headline">
+            <a href="{{ ref.url }}" target="_blank" rel="noopener noreferrer">{{ ref.title }}</a>
+        </h3>
+        {% if ref.description %}<p class="media-reference-desc">{{ ref.description }}</p>{% endif %}
+    </div>
+    <div class="media-reference-links">
+        <a href="{{ ref.url }}" class="media-reference-link" target="_blank" rel="noopener noreferrer">{{ ref.cta|default:"Read more" }} &rarr;</a>
+        {% if ref.internal_url_name %}
+        <a href="{% url ref.internal_url_name %}" class="media-reference-link media-reference-link-internal">See our page</a>
+        {% endif %}
+    </div>
+</article>

--- a/fighthealthinsurance/urls.py
+++ b/fighthealthinsurance/urls.py
@@ -251,6 +251,11 @@ urlpatterns: List[Union[URLPattern, URLResolver]] = [
         name="pbs-newshour",
     ),
     path(
+        "media-references",
+        views.MediaReferencesView.as_view(),
+        name="media-references",
+    ),
+    path(
         "bingo",
         views.BingoView.as_view(),
         name="bingo",

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -45,7 +45,10 @@ from fighthealthinsurance.denial_context import merge_qa
 from fighthealthinsurance.followup_emails import ThankyouEmailSender
 from fighthealthinsurance.helpers.data_helpers import RemoveDataHelper
 from fighthealthinsurance.helpers.stripe_helpers import StripeWebhookHelper
-from fighthealthinsurance.media_references import MEDIA_REFERENCES
+from fighthealthinsurance.media_references import (
+    MEDIA_REFERENCES,
+    SOCIAL_MEDIA_REFERENCES,
+)
 from fighthealthinsurance.models import (
     DeleteToken,
     PolicyDocument,
@@ -461,6 +464,7 @@ class MediaReferencesView(StaticIshView):
         """Add the list of media references to the context."""
         context = super().get_context_data(**kwargs)
         context["media_references"] = MEDIA_REFERENCES
+        context["social_references"] = SOCIAL_MEDIA_REFERENCES
         return context
 
 

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -45,6 +45,7 @@ from fighthealthinsurance.denial_context import merge_qa
 from fighthealthinsurance.followup_emails import ThankyouEmailSender
 from fighthealthinsurance.helpers.data_helpers import RemoveDataHelper
 from fighthealthinsurance.helpers.stripe_helpers import StripeWebhookHelper
+from fighthealthinsurance.media_references import MEDIA_REFERENCES
 from fighthealthinsurance.models import (
     DeleteToken,
     PolicyDocument,
@@ -449,6 +450,18 @@ class PBSNewsHourView(StaticIshView):
     """Page about the PBS NewsHour feature."""
 
     template_name = "as_seen_on_pbs.html"
+
+
+class MediaReferencesView(StaticIshView):
+    """Media references / press page listing coverage of Fight Health Insurance."""
+
+    template_name = "media_references.html"
+
+    def get_context_data(self, **kwargs):
+        """Add the list of media references to the context."""
+        context = super().get_context_data(**kwargs)
+        context["media_references"] = MEDIA_REFERENCES
+        return context
 
 
 class BingoView(StaticIshView):

--- a/scripts/build_static.sh
+++ b/scripts/build_static.sh
@@ -24,6 +24,18 @@ if [ "$FAST" = "FAST" ]; then
   exit 0
 fi
 
+# Materialize Git LFS assets (a few outlet logos, see .gitattributes) before the
+# collectstatic below copies raw bytes -- otherwise unsmudged LFS pointer stubs
+# would be served as .png. Warn rather than fail here since this path is used for
+# local/dev builds.
+if [ -f .gitattributes ] && grep -q "filter=lfs" .gitattributes; then
+  if command -v git-lfs >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    git lfs pull || echo "WARNING: 'git lfs pull' failed; logo images may render broken."
+  else
+    echo "WARNING: repo uses Git LFS but git-lfs is unavailable; logo images may render broken."
+  fi
+fi
+
 if [ -d "${JS_PATH}" ]; then
   # Calculate checksum of JS/TS source files
   # Using -maxdepth 1 because source files are in the js directory, not subdirectories

--- a/scripts/build_static.sh
+++ b/scripts/build_static.sh
@@ -25,16 +25,10 @@ if [ "$FAST" = "FAST" ]; then
 fi
 
 # Materialize Git LFS assets (a few outlet logos, see .gitattributes) before the
-# collectstatic below copies raw bytes -- otherwise unsmudged LFS pointer stubs
-# would be served as .png. Warn rather than fail here since this path is used for
-# local/dev builds.
-if [ -f .gitattributes ] && grep -q "filter=lfs" .gitattributes; then
-  if command -v git-lfs >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-    git lfs pull || echo "WARNING: 'git lfs pull' failed; logo images may render broken."
-  else
-    echo "WARNING: repo uses Git LFS but git-lfs is unavailable; logo images may render broken."
-  fi
-fi
+# collectstatic below copies raw bytes -- otherwise unsmudged pointer stubs would
+# be served as .png. Warn rather than fail: this path is used for local/dev builds.
+# Runs before the static checksum below so a repair correctly invalidates the cache.
+"$(dirname "${BASH_SOURCE[0]}")/ensure_lfs_assets.sh" --warn-only
 
 if [ -d "${JS_PATH}" ]; then
   # Calculate checksum of JS/TS source files

--- a/scripts/ensure_lfs_assets.sh
+++ b/scripts/ensure_lfs_assets.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Ensure Git LFS-tracked assets hold real bytes before anything copies them.
+#
+# collectstatic (and the Docker ADD that ships its output) copies raw file bytes,
+# so an LFS-tracked asset left as a ~130-byte pointer stub would be published as a
+# broken image. This checks the postcondition -- "is any LFS-tracked file still a
+# pointer stub?" -- rather than inferring from the environment. That way a source
+# tarball with real bytes and no .git directory passes cleanly, a checkout that was
+# never smudged gets repaired, and a file that `git lfs pull` could not replace
+# (e.g. it is locally modified, which pull skips while still exiting 0) is still
+# caught instead of silently shipping.
+#
+# Usage: ensure_lfs_assets.sh [--warn-only]
+#   --warn-only  Warn and exit 0 instead of failing, for local/dev builds.
+
+set -u
+
+WARN_ONLY=false
+if [ "${1:-}" = "--warn-only" ]; then
+  WARN_ONLY=true
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+GITATTRIBUTES="${REPO_ROOT}/.gitattributes"
+LFS_MAGIC="version https://git-lfs.github.com/spec/v1"
+
+# Nothing is tracked by LFS -> nothing to do.
+if [ ! -f "${GITATTRIBUTES}" ] || ! grep -q "filter=lfs" "${GITATTRIBUTES}"; then
+  exit 0
+fi
+
+# Print every LFS-tracked path that is still an unmaterialized pointer stub.
+unmaterialized_lfs_files() {
+  local pattern path
+  while read -r pattern _; do
+    # Unquoted on purpose so the .gitattributes pattern globs. A pattern that
+    # matches nothing stays literal and is skipped by the -f test below.
+    # shellcheck disable=SC2086
+    for path in ${REPO_ROOT}/${pattern}; do
+      if [ -f "${path}" ] && head -c "${#LFS_MAGIC}" "${path}" | grep -qF "${LFS_MAGIC}"; then
+        echo "${path}"
+      fi
+    done
+  done < <(grep "filter=lfs" "${GITATTRIBUTES}")
+}
+
+PENDING="$(unmaterialized_lfs_files)"
+
+# Materialize them when this is a git checkout that has git-lfs available.
+if [ -n "${PENDING}" ] && command -v git-lfs >/dev/null 2>&1 &&
+  git -C "${REPO_ROOT}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  git -C "${REPO_ROOT}" lfs pull || true
+  PENDING="$(unmaterialized_lfs_files)"
+fi
+
+if [ -z "${PENDING}" ]; then
+  exit 0
+fi
+
+echo "Git LFS assets are still pointer stubs and would ship as broken files:" >&2
+while IFS= read -r stub; do
+  echo "       ${stub}" >&2
+done <<<"${PENDING}"
+if command -v git-lfs >/dev/null 2>&1; then
+  echo "       Try 'git lfs pull' in ${REPO_ROOT}, and check for local modifications." >&2
+else
+  echo "       git-lfs is not installed; install it and run 'git lfs pull'." >&2
+fi
+
+if [ "${WARN_ONLY}" = true ]; then
+  echo "WARNING: continuing anyway -- these images may render broken." >&2
+  exit 0
+fi
+exit 1

--- a/scripts/ensure_lfs_assets.sh
+++ b/scripts/ensure_lfs_assets.sh
@@ -20,7 +20,12 @@ if [ "${1:-}" = "--warn-only" ]; then
   WARN_ONLY=true
 fi
 
-REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+# Resolve the repo root from THIS script's location, not the caller's cwd: the
+# callers below invoke it from wherever the build happens to be, and in a tree
+# with no .git (a source tarball) a cwd-based fallback would look for
+# .gitattributes in the wrong place and silently skip validation.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel 2>/dev/null || dirname "${SCRIPT_DIR}")"
 GITATTRIBUTES="${REPO_ROOT}/.gitattributes"
 LFS_MAGIC="version https://git-lfs.github.com/spec/v1"
 

--- a/scripts/setup_templates.sh
+++ b/scripts/setup_templates.sh
@@ -10,6 +10,21 @@ elif [ -f ./.venv/bin/activate ]; then
   source ./.venv/bin/activate
 fi
 
+# Materialize Git LFS assets before collectstatic. A few outlet logos on the
+# media-references page are stored via Git LFS (see .gitattributes). collectstatic
+# copies raw bytes, so if these are still LFS pointer stubs (e.g. the checkout ran
+# without git-lfs) the build would ship ~130-byte text files as .png. Smudge them
+# to real files now, and fail loudly rather than silently shipping broken images.
+if [ -f .gitattributes ] && grep -q "filter=lfs" .gitattributes; then
+  if command -v git-lfs >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    git lfs pull
+  else
+    echo "ERROR: this checkout uses Git LFS (see .gitattributes) but git-lfs is unavailable;" >&2
+    echo "       logo images would ship as broken pointer files. Install git-lfs and re-run." >&2
+    exit 1
+  fi
+fi
+
 if command -v tox >/dev/null 2>&1; then
   # Check if fhi_users directory exists for mypy
   if [ -d "./fhi_users" ]; then

--- a/scripts/setup_templates.sh
+++ b/scripts/setup_templates.sh
@@ -11,19 +11,10 @@ elif [ -f ./.venv/bin/activate ]; then
 fi
 
 # Materialize Git LFS assets before collectstatic. A few outlet logos on the
-# media-references page are stored via Git LFS (see .gitattributes). collectstatic
-# copies raw bytes, so if these are still LFS pointer stubs (e.g. the checkout ran
-# without git-lfs) the build would ship ~130-byte text files as .png. Smudge them
-# to real files now, and fail loudly rather than silently shipping broken images.
-if [ -f .gitattributes ] && grep -q "filter=lfs" .gitattributes; then
-  if command -v git-lfs >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-    git lfs pull
-  else
-    echo "ERROR: this checkout uses Git LFS (see .gitattributes) but git-lfs is unavailable;" >&2
-    echo "       logo images would ship as broken pointer files. Install git-lfs and re-run." >&2
-    exit 1
-  fi
-fi
+# media-references page are stored via Git LFS (see .gitattributes), and
+# collectstatic copies raw bytes, so an unsmudged pointer stub would ship as a
+# broken .png. This is the deploy build, so fail rather than publish broken images.
+"$(dirname "${BASH_SOURCE[0]}")/ensure_lfs_assets.sh"
 
 if command -v tox >/dev/null 2>&1; then
   # Check if fhi_users directory exists for mypy

--- a/tests/sync/test_media_references.py
+++ b/tests/sync/test_media_references.py
@@ -1,0 +1,76 @@
+"""Tests for the Media References (press) page and its underlying data."""
+
+from django.test import Client, TestCase
+from django.urls import reverse
+from django.utils.html import escape
+
+from fighthealthinsurance.media_references import MEDIA_REFERENCES
+from fighthealthinsurance.views import STATIC_ISH_PAGE_CACHE_SECONDS
+
+
+class TestMediaReferencesPage(TestCase):
+    """The Media References page renders every reference and is cache-friendly."""
+
+    def setUp(self):
+        self.client = Client()
+
+    def test_media_references_page_loads(self):
+        response = self.client.get(reverse("media-references"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "media_references.html")
+        self.assertTemplateUsed(response, "base.html")
+
+    def test_media_references_page_is_cached_like_other_static_ish_pages(self):
+        response = self.client.get(reverse("media-references"))
+        cache_control = response["Cache-Control"]
+        self.assertIn("public", cache_control)
+        self.assertIn(f"max-age={STATIC_ISH_PAGE_CACHE_SECONDS}", cache_control)
+
+    def test_media_references_page_lists_every_reference(self):
+        response = self.client.get(reverse("media-references"))
+        content = response.content.decode("utf-8")
+        for ref in MEDIA_REFERENCES:
+            # The template auto-escapes, so compare against escaped values
+            # (e.g. "&" -> "&amp;").
+            self.assertIn(escape(ref["outlet"]), content)
+            self.assertIn(escape(ref["title"]), content)
+            self.assertIn(ref["url"], content)
+
+    def test_media_references_page_links_to_internal_pbs_page(self):
+        # PBS is the one reference with an on-site page; make sure the link renders.
+        response = self.client.get(reverse("media-references"))
+        self.assertContains(response, reverse("pbs-newshour"))
+
+
+class TestHomePageLinksToMediaReferences(TestCase):
+    """The home page "featured in ..." affordances point at the press page."""
+
+    def test_home_page_links_to_media_references(self):
+        response = self.client.get(reverse("root"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, reverse("media-references"))
+
+
+class TestMediaReferencesData(TestCase):
+    """Guard the shape of the MEDIA_REFERENCES data used to render the page."""
+
+    def test_each_reference_has_required_fields(self):
+        for ref in MEDIA_REFERENCES:
+            for key in ("outlet", "kind", "cta", "title", "url", "description"):
+                self.assertTrue(
+                    ref.get(key), f"Reference {ref.get('outlet')!r} missing {key!r}"
+                )
+
+    def test_reference_urls_are_https(self):
+        for ref in MEDIA_REFERENCES:
+            self.assertTrue(
+                ref["url"].startswith("https://"),
+                f"Reference {ref['outlet']!r} URL is not https: {ref['url']}",
+            )
+
+    def test_internal_url_names_resolve(self):
+        for ref in MEDIA_REFERENCES:
+            internal = ref.get("internal_url_name")
+            if internal:
+                # Raises NoReverseMatch if the name isn't a real route.
+                reverse(internal)

--- a/tests/sync/test_media_references.py
+++ b/tests/sync/test_media_references.py
@@ -4,8 +4,13 @@ from django.test import Client, TestCase
 from django.urls import reverse
 from django.utils.html import escape
 
-from fighthealthinsurance.media_references import MEDIA_REFERENCES
+from fighthealthinsurance.media_references import (
+    MEDIA_REFERENCES,
+    SOCIAL_MEDIA_REFERENCES,
+)
 from fighthealthinsurance.views import STATIC_ISH_PAGE_CACHE_SECONDS
+
+ALL_REFERENCES = MEDIA_REFERENCES + SOCIAL_MEDIA_REFERENCES
 
 
 class TestMediaReferencesPage(TestCase):
@@ -29,12 +34,17 @@ class TestMediaReferencesPage(TestCase):
     def test_media_references_page_lists_every_reference(self):
         response = self.client.get(reverse("media-references"))
         content = response.content.decode("utf-8")
-        for ref in MEDIA_REFERENCES:
+        # Both the press grid and the social grid should render every entry.
+        for ref in ALL_REFERENCES:
             # The template auto-escapes, so compare against escaped values
             # (e.g. "&" -> "&amp;").
             self.assertIn(escape(ref["outlet"]), content)
             self.assertIn(escape(ref["title"]), content)
             self.assertIn(ref["url"], content)
+
+    def test_media_references_page_renders_social_section(self):
+        response = self.client.get(reverse("media-references"))
+        self.assertContains(response, "On Social Media")
 
     def test_media_references_page_links_to_internal_pbs_page(self):
         # PBS is the one reference with an on-site page; make sure the link renders.
@@ -52,24 +62,24 @@ class TestHomePageLinksToMediaReferences(TestCase):
 
 
 class TestMediaReferencesData(TestCase):
-    """Guard the shape of the MEDIA_REFERENCES data used to render the page."""
+    """Guard the shape of the reference data used to render the page."""
 
     def test_each_reference_has_required_fields(self):
-        for ref in MEDIA_REFERENCES:
+        for ref in ALL_REFERENCES:
             for key in ("outlet", "kind", "cta", "title", "url", "description"):
                 self.assertTrue(
                     ref.get(key), f"Reference {ref.get('outlet')!r} missing {key!r}"
                 )
 
     def test_reference_urls_are_https(self):
-        for ref in MEDIA_REFERENCES:
+        for ref in ALL_REFERENCES:
             self.assertTrue(
                 ref["url"].startswith("https://"),
                 f"Reference {ref['outlet']!r} URL is not https: {ref['url']}",
             )
 
     def test_internal_url_names_resolve(self):
-        for ref in MEDIA_REFERENCES:
+        for ref in ALL_REFERENCES:
             internal = ref.get("internal_url_name")
             if internal:
                 # Raises NoReverseMatch if the name isn't a real route.

--- a/tests/sync/test_media_references.py
+++ b/tests/sync/test_media_references.py
@@ -34,13 +34,16 @@ class TestMediaReferencesPage(TestCase):
     def test_media_references_page_lists_every_reference(self):
         response = self.client.get(reverse("media-references"))
         content = response.content.decode("utf-8")
-        # Both the press grid and the social grid should render every entry.
+        # Both the press grid and the social grid should render every entry,
+        # including the card body fields (guards the card partial from
+        # silently dropping a field). The template auto-escapes, so compare
+        # against escaped values (e.g. "&" -> "&amp;").
         for ref in ALL_REFERENCES:
-            # The template auto-escapes, so compare against escaped values
-            # (e.g. "&" -> "&amp;").
             self.assertIn(escape(ref["outlet"]), content)
             self.assertIn(escape(ref["title"]), content)
-            self.assertIn(ref["url"], content)
+            self.assertIn(escape(ref["url"]), content)
+            self.assertIn(escape(ref["description"]), content)
+            self.assertIn(escape(ref["cta"]), content)
 
     def test_media_references_page_renders_social_section(self):
         response = self.client.get(reverse("media-references"))

--- a/tests/sync/test_media_references.py
+++ b/tests/sync/test_media_references.py
@@ -1,5 +1,7 @@
 """Tests for the Media References (press) page and its underlying data."""
 
+import re
+
 from django.test import Client, TestCase
 from django.urls import reverse
 from django.utils.html import escape
@@ -61,7 +63,20 @@ class TestHomePageLinksToMediaReferences(TestCase):
     def test_home_page_links_to_media_references(self):
         response = self.client.get(reverse("root"))
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, reverse("media-references"))
+        url = reverse("media-references")
+        content = response.content.decode("utf-8")
+        # Assert each affordance individually: checking only that *some* link
+        # targets the route would still pass if two of the three were dropped.
+        for css_class in (
+            "trust-chip-link",  # hero "Featured in Forbes, CBS & more" chip
+            "featured-title-link",  # the "As Featured In" section heading
+            "featured-see-all-link",  # "See all media references" under the logos
+        ):
+            self.assertRegex(
+                content,
+                rf'<a href="{re.escape(url)}"[^>]*class="[^"]*{css_class}\b',
+                msg=f"home page is missing the {css_class} link to {url}",
+            )
 
 
 class TestMediaReferencesData(TestCase):


### PR DESCRIPTION
Create a dedicated Media References (press) page listing all coverage of Fight Health Insurance (PBS NewsHour, Forbes, CBS News, STAT News, Business Insider, Fast Company, WBUR, NewsNation, An Arm and a Leg, SF Standard) and point the home page's "Featured in ..." affordances at it.

- media_references.py holds the coverage list as a single source of truth
- MediaReferencesView (StaticIshView) + /media-references route render the page
- The hero "Featured in Forbes, CBS & more" trust chip, the "As Featured In" section heading, and a new "See all media references" link now open the page
- Add the page to the sitemap and cover it with tests


Claude-Session: https://claude.ai/code/session_01DdfC8q9MoDjdZMHU1xRHee

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Media References page featuring press coverage and social media mentions.
  * Added media reference cards with logos, descriptions, dates, and links.
  * Added links from the homepage’s featured section to view all media references.
  * Added the page to the site sitemap.

* **Improvements**
  * Improved handling of Git LFS-managed image assets during builds and setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->