### PR TITLE
Gate summary cache writes on denial_text to prevent stale summaries

### DIFF
--- a/fighthealthinsurance/ml/ml_appeal_context_helper.py
+++ b/fighthealthinsurance/ml/ml_appeal_context_helper.py
@@ -96,15 +96,41 @@ class MLAppealContextHelper:
         return summary
 
     @classmethod
-    async def _cache_summary(cls, denial_id, **fields) -> None:
+    async def _cache_summary(cls, denial_id, source_text, **fields) -> None:
         """Best-effort cache of computed summary field(s) onto the denial row.
+
+        The write is CONDITIONAL on ``denial_text`` still being ``source_text``
+        -- the letter the summary actually describes. Summarization is a model
+        call taking seconds to minutes (and, on the speculative precompute
+        path, runs entirely in the background), so the user can replace the
+        letter while it is in flight; replacing a letter is a normal flow (a
+        bad OCR pass gets corrected). ``_invalidate_denial_text_artifacts``
+        clears both summary fields on that replacement, but a summary landing
+        AFTER that sweep would be written behind it and nothing sweeps again.
+        It would then be substituted into the prompt in place of the user's
+        actual letter on every later generation -- appeals arguing about a
+        denial that is no longer theirs. Making it one conditional UPDATE
+        closes the window at the DB level: if the letter changed, zero rows
+        match and the stale summary is simply dropped.
+
         A failure here is non-fatal: the caller still uses the summary it just
-        computed."""
+        computed for the generation it is already running (which is about
+        ``source_text`` too, so that run stays self-consistent).
+        """
         try:
-            await Denial.objects.filter(denial_id=denial_id).aupdate(**fields)
+            updated = await Denial.objects.filter(
+                denial_id=denial_id, denial_text=source_text
+            ).aupdate(**fields)
         except Exception as e:
             logger.opt(exception=True).warning(
                 f"Failed to cache {list(fields)} for denial " f"{denial_id}: {e}"
+            )
+            return
+        if not updated:
+            logger.info(
+                f"Discarding {list(fields)} for denial {denial_id}: the denial "
+                f"letter was replaced while it was being summarized, so this "
+                f"summary describes the old letter"
             )
 
     @classmethod
@@ -127,6 +153,9 @@ class MLAppealContextHelper:
             return None
 
         denial_id = denial.denial_id
+        # The letter every summary below is about, so the cache write can be
+        # gated on it still being the current one (see _cache_summary).
+        source_text = denial.denial_text
         if denial.denial_text_summary:
             logger.debug(
                 f"Denial {denial_id} reusing cached denial_text_summary "
@@ -143,13 +172,15 @@ class MLAppealContextHelper:
                 f"Denial {denial_id} promoting pre-warmed candidate "
                 f"denial_text_summary ({len(candidate)} chars)"
             )
-            await cls._cache_summary(denial_id, denial_text_summary=candidate)
+            await cls._cache_summary(
+                denial_id, source_text, denial_text_summary=candidate
+            )
             return candidate
 
         summary = await cls._call_summarizer(denial)
         if not summary:
             return None
-        await cls._cache_summary(denial_id, denial_text_summary=summary)
+        await cls._cache_summary(denial_id, source_text, denial_text_summary=summary)
         logger.info(
             f"Summarized long denial_text for denial {denial_id} "
             f"({len(denial.denial_text)} -> {len(summary)} chars) to fit "
@@ -172,6 +203,11 @@ class MLAppealContextHelper:
         if not cls._needs_summary(denial):
             return None
         denial_id = denial.denial_id
+        # The letter this summary is about; the cache write is gated on it (see
+        # _cache_summary). This path needs the gate most: it runs entirely in
+        # the background with no deadline, so it is the one most likely to still
+        # be summarizing when the user replaces the letter.
+        source_text = denial.denial_text
         # Don't recompute if the real flow already produced one, or we already
         # pre-warmed a candidate.
         if denial.denial_text_summary or denial.candidate_denial_text_summary:
@@ -180,7 +216,9 @@ class MLAppealContextHelper:
         summary = await cls._call_summarizer(denial)
         if not summary:
             return None
-        await cls._cache_summary(denial_id, candidate_denial_text_summary=summary)
+        await cls._cache_summary(
+            denial_id, source_text, candidate_denial_text_summary=summary
+        )
         logger.info(
             f"Pre-warmed candidate denial_text_summary for denial {denial_id} "
             f"({len(denial.denial_text)} -> {len(summary)} chars)"

--- a/fighthealthinsurance/ml/ml_speculative_appeals_helper.py
+++ b/fighthealthinsurance/ml/ml_speculative_appeals_helper.py
@@ -63,16 +63,23 @@ class SpeculativeAppealsHelper:
     async def generate_for_denial(cls, denial_id: Any, force: bool = False) -> int:
         """Generate + persist speculative candidate appeals for ``denial_id``.
 
-        Idempotent: a no-op if speculative rows already exist for the denial.
+        A no-op if the denial ALREADY HAS ANY proposed appeal -- reserve or
+        live. This is both the idempotency guard (don't build a second reserve)
+        and the backlog shed: the actor bounds itself to MAX_CONCURRENCY
+        in-flight generations, so under a burst this check runs when the task is
+        finally dequeued, by which point the live flow may already have produced
+        appeals -- and a reserve that arrives after them is work nobody will
+        ever serve. Dropping those keeps the queue moving toward the denials
+        speculation can still help.
+
         Returns the number of speculative appeals persisted (0 on skip/failure).
         Exception-safe: never raises, so a background caller can't crash on it.
 
-        ``force=True`` skips the idempotency check. Required by the
-        denial-text-replacement path: that guard also matches PROMOTED rows
-        (``speculative=False`` but still ``context_level="speculative"``, kept
-        so analytics can see a served reserve), and those survive invalidation
-        on purpose -- so without ``force`` a denial that ever served one reserve
-        appeal could never build a reserve again.
+        ``force=True`` skips that guard. Required by the denial-text-replacement
+        path: after a replacement the denial still carries drafts about the OLD
+        letter (invalidation deletes only the held-back reserve, keeping served
+        and ordinary rows), so the guard would match and a replaced letter could
+        never get a reserve of its own.
         """
         try:
             # Lazy imports: this module is imported from the denial-creation
@@ -81,8 +88,6 @@ class SpeculativeAppealsHelper:
             # INSIDE the try so the "never raises" contract above actually holds:
             # an ImportError/ImproperlyConfigured from that graph would otherwise
             # escape into whichever thread or actor dispatched this.
-            from django.db.models import Q
-
             from fighthealthinsurance.common_view_logic import appealGenerator
             from fighthealthinsurance.generate_appeal import (
                 AppealTemplateGenerator,
@@ -129,22 +134,33 @@ class SpeculativeAppealsHelper:
                     f"speculative appeals: denial {denial_id} has no text; skipping"
                 )
                 return 0
-            # Idempotency: don't regenerate if we already have speculative rows.
-            # Match promoted rows too (served rows are flipped to
-            # speculative=False but keep context_level="speculative"), so a
-            # re-invocation after some were served can't duplicate the reserve.
-            # force=True bypasses this for a replaced denial letter, where the
-            # whole point is to rebuild the reserve from the new text.
+            # ANY existing proposed appeal means this run has nothing to add.
+            #
+            # Deliberately broader than "do we already have a reserve": it also
+            # matches LIVE drafts, which is what makes a backlog self-shedding.
+            # Evaluated here, when the actor dequeues the task rather than when
+            # it was submitted, so a precompute that waited behind the actor's
+            # concurrency limit sees the world as it is now -- and if the user's
+            # real generation already delivered, a reserve built afterwards is
+            # work nobody will ever serve (the end-of-flow reconciliation only
+            # reaches for it while under ENOUGH_APPEALS). Skipping frees the slot
+            # for a denial speculation can still get ahead of.
+            #
+            # Subsumes the old speculative-only idempotency check: reserve rows
+            # (held-back or promoted) are ProposedAppeals too, so a second
+            # dispatch still can't duplicate a reserve.
+            #
+            # force=True bypasses it for a replaced denial letter -- see the
+            # docstring: those old drafts are about a letter that no longer
+            # exists, so they must not veto a reserve for the new one.
             if (
                 not force
-                and await ProposedAppeal.objects.filter(
-                    Q(speculative=True) | Q(context_level=CONTEXT_LEVEL_SPECULATIVE),
-                    for_denial=denial,
-                ).aexists()
+                and await ProposedAppeal.objects.filter(for_denial=denial).aexists()
             ):
                 logger.debug(
                     f"speculative appeals: denial {denial_id} already has "
-                    f"speculative rows; skipping"
+                    f"proposed appeal(s); skipping (speculation would land too "
+                    f"late to be served)"
                 )
                 return 0
 

--- a/fighthealthinsurance/rest_views.py
+++ b/fighthealthinsurance/rest_views.py
@@ -803,6 +803,15 @@ def streaming_appeals_rest_fallback(request: Request):
                     last_status_phase=last_status_phase,
                     transport="rest",
                     stream_error=str(e),
+                    # Provably NOT a socket write: a REST client hanging up
+                    # closes this async generator, which surfaces as the
+                    # GeneratorExit/CancelledError handled above, so anything
+                    # landing here came out of generate_appeals. Saying so keeps
+                    # the client-disconnect string match from downgrading a real
+                    # server failure that merely mentions a reset connection
+                    # (e.g. Postgres "could not receive data from server:
+                    # Connection reset by peer") from ERROR to WARNING.
+                    error_from_send=False,
                     **gen_fields.as_kwargs(),
                 )
             # Inform the client rather than terminating silently

--- a/fighthealthinsurance/speculative_appeals_actor.py
+++ b/fighthealthinsurance/speculative_appeals_actor.py
@@ -19,7 +19,25 @@ from fighthealthinsurance.utils import get_env_variable
 name = "SpeculativeAppealsActor"
 
 
-@ray.remote(max_restarts=-1, max_task_retries=-1)
+# max_concurrency: this is an ASYNC actor (prefetch_for_denial is a coroutine),
+# and Ray's default concurrency for those is 1000 -- fine for the other async
+# actors, whose per-task work is cheap, but each task here is a FULL
+# make_appeals ML fan-out plus its own non-thread-sensitive pool thread, and
+# they all land in this one process on a Ray worker capped at 1 CPU / 6-7G. A
+# burst of denial submissions would otherwise pile hundreds of concurrent
+# generations into it. 10 keeps precomputes from serializing behind each other
+# (the reason generate_for_denial bridges with thread_sensitive=False) while
+# bounding the process. Excess dispatches queue rather than being dropped, and
+# the helper re-checks on dequeue whether the denial already has appeals, so a
+# backlog sheds the ones speculation is too late to help.
+#
+# The ignore below is needed because ray's bundled stub omits max_concurrency
+# from the ray.remote(...) overload. The runtime does accept it -- it lands in
+# the ActorClass's _default_options, which the test pins -- so the stub is
+# simply incomplete, same reason base_actor_ref ignores .options().
+@ray.remote(  # type: ignore[call-overload]
+    max_restarts=-1, max_task_retries=-1, max_concurrency=10
+)
 class SpeculativeAppealsActor:
     def __init__(self):
         time.sleep(1)

--- a/tests/async-unit/test_denial_text_summarization.py
+++ b/tests/async-unit/test_denial_text_summarization.py
@@ -76,14 +76,14 @@ async def test_above_threshold_summarizes_and_persists():
     d = _denial(_LONG_TEXT, use_external=False, denial_id=7)
     with patch(f"{_HELPER}.ml_router") as router, patch(f"{_HELPER}.Denial") as Denial:
         router.summarize = AsyncMock(return_value=_CONDENSED)
-        Denial.objects.filter.return_value.aupdate = AsyncMock()
+        Denial.objects.filter.return_value.aupdate = AsyncMock(return_value=1)
         result = await MLAppealContextHelper.maybe_summarize_denial_text(d)
 
     assert result == _CONDENSED
     # Privacy gate threaded through.
     assert router.summarize.call_args.kwargs["use_external"] is False
-    # Cached back onto the denial row.
-    Denial.objects.filter.assert_called_once_with(denial_id=7)
+    # Cached back onto the denial row, gated on the letter it summarizes.
+    Denial.objects.filter.assert_called_once_with(denial_id=7, denial_text=_LONG_TEXT)
     Denial.objects.filter.return_value.aupdate.assert_awaited_once_with(
         denial_text_summary=_CONDENSED
     )
@@ -94,7 +94,7 @@ async def test_use_external_true_is_passed_through():
     d = _denial(_LONG_TEXT, use_external=True)
     with patch(f"{_HELPER}.ml_router") as router, patch(f"{_HELPER}.Denial") as Denial:
         router.summarize = AsyncMock(return_value=_CONDENSED)
-        Denial.objects.filter.return_value.aupdate = AsyncMock()
+        Denial.objects.filter.return_value.aupdate = AsyncMock(return_value=1)
         await MLAppealContextHelper.maybe_summarize_denial_text(d)
     assert router.summarize.call_args.kwargs["use_external"] is True
 
@@ -146,11 +146,13 @@ async def test_prewarmed_candidate_is_promoted_without_recomputing():
     d = _denial(_LONG_TEXT, candidate_summary="PREWARMED")
     with patch(f"{_HELPER}.ml_router") as router, patch(f"{_HELPER}.Denial") as Denial:
         router.summarize = AsyncMock(return_value="fresh summary")
-        Denial.objects.filter.return_value.aupdate = AsyncMock()
+        Denial.objects.filter.return_value.aupdate = AsyncMock(return_value=1)
         result = await MLAppealContextHelper.maybe_summarize_denial_text(d)
     assert result == "PREWARMED"
     router.summarize.assert_not_called()
-    # Promoted into the real field so later reads short-circuit.
+    # Promoted into the real field so later reads short-circuit, gated on the
+    # letter the candidate was pre-warmed from.
+    Denial.objects.filter.assert_called_once_with(denial_id=7, denial_text=_LONG_TEXT)
     Denial.objects.filter.return_value.aupdate.assert_awaited_once_with(
         denial_text_summary="PREWARMED"
     )
@@ -176,10 +178,10 @@ async def test_prewarm_writes_candidate_field_not_real():
     d = _denial(_LONG_TEXT, use_external=False, denial_id=9)
     with patch(f"{_HELPER}.ml_router") as router, patch(f"{_HELPER}.Denial") as Denial:
         router.summarize = AsyncMock(return_value=_CONDENSED)
-        Denial.objects.filter.return_value.aupdate = AsyncMock()
+        Denial.objects.filter.return_value.aupdate = AsyncMock(return_value=1)
         result = await MLAppealContextHelper.prewarm_candidate_denial_text_summary(d)
     assert result == _CONDENSED
-    Denial.objects.filter.assert_called_once_with(denial_id=9)
+    Denial.objects.filter.assert_called_once_with(denial_id=9, denial_text=_LONG_TEXT)
     Denial.objects.filter.return_value.aupdate.assert_awaited_once_with(
         candidate_denial_text_summary=_CONDENSED
     )
@@ -208,3 +210,56 @@ async def test_prewarm_skips_when_summary_already_exists():
     assert result == "ALREADY"
     router.summarize.assert_not_called()
     Denial.objects.filter.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_prewarm_cache_write_is_gated_on_the_letter_it_summarized():
+    """The candidate write must not land if the letter was replaced mid-flight.
+
+    The pre-warm runs in the background with no deadline, so a user correcting a
+    bad OCR pass can replace the letter while it is still summarizing. The
+    replacement's invalidation sweep has already run by then, so an
+    unconditional write would leave a summary of the OLD letter behind it
+    forever -- and the live flow substitutes that for the user's actual letter.
+    Conditioning the UPDATE on denial_text means zero rows match and it drops.
+    """
+    d = _denial(_LONG_TEXT, use_external=False, denial_id=11)
+    with patch(f"{_HELPER}.ml_router") as router, patch(f"{_HELPER}.Denial") as Denial:
+        router.summarize = AsyncMock(return_value=_CONDENSED)
+        # 0 rows updated == the row no longer has this denial_text.
+        Denial.objects.filter.return_value.aupdate = AsyncMock(return_value=0)
+        result = await MLAppealContextHelper.prewarm_candidate_denial_text_summary(d)
+
+    # The in-flight caller still gets the summary (its own run is about the
+    # same letter); only the persisted copy is dropped.
+    assert result == _CONDENSED
+    Denial.objects.filter.assert_called_once_with(denial_id=11, denial_text=_LONG_TEXT)
+
+
+@pytest.mark.asyncio
+async def test_live_summary_cache_write_is_gated_on_the_letter_it_summarized():
+    """Same guard on the live path: a summary computed from a letter that has
+    since been replaced must not be cached as that denial's summary."""
+    d = _denial(_LONG_TEXT, use_external=False, denial_id=12)
+    with patch(f"{_HELPER}.ml_router") as router, patch(f"{_HELPER}.Denial") as Denial:
+        router.summarize = AsyncMock(return_value=_CONDENSED)
+        Denial.objects.filter.return_value.aupdate = AsyncMock(return_value=0)
+        result = await MLAppealContextHelper.maybe_summarize_denial_text(d)
+
+    assert result == _CONDENSED
+    Denial.objects.filter.assert_called_once_with(denial_id=12, denial_text=_LONG_TEXT)
+
+
+@pytest.mark.asyncio
+async def test_cache_write_failure_still_returns_the_summary():
+    """A DB failure caching the summary is non-fatal: the generation already
+    under way still gets its condensed text."""
+    d = _denial(_LONG_TEXT, use_external=False, denial_id=13)
+    with patch(f"{_HELPER}.ml_router") as router, patch(f"{_HELPER}.Denial") as Denial:
+        router.summarize = AsyncMock(return_value=_CONDENSED)
+        Denial.objects.filter.return_value.aupdate = AsyncMock(
+            side_effect=RuntimeError("db down")
+        )
+        result = await MLAppealContextHelper.maybe_summarize_denial_text(d)
+
+    assert result == _CONDENSED

--- a/tests/async-unit/test_websocket_diagnostics.py
+++ b/tests/async-unit/test_websocket_diagnostics.py
@@ -481,6 +481,35 @@ async def test_client_disconnect_during_generating_notes_generation_started():
 
 
 @pytest.mark.asyncio
+async def test_server_side_connection_reset_is_not_filed_as_a_disconnect():
+    """A server-side failure whose message merely mentions a reset connection
+    (Postgres dropping the app's session mid-generation) must stay an ERROR.
+
+    The disconnect classification is pure string matching, so callers that can
+    prove the failure came out of the generator rather than a socket write pass
+    error_from_send=False -- without it a real outage is downgraded to WARNING
+    and stops paging."""
+    objects = _make_count_mock(return_value=0)
+    p1, p2 = _patch_models(objects)
+    warn_cm, warnings = _captured_warning()
+    err_cm, errors = _captured_logger()
+    with p1, p2, warn_cm, err_cm:
+        await log_zero_appeal_diagnostics(
+            denial_id=42,
+            status_count=4,
+            last_status_phase="generating",
+            transport="rest",
+            stream_error=(
+                "OperationalError: could not receive data from server: "
+                "Connection reset by peer"
+            ),
+            error_from_send=False,
+        )
+    assert warnings == []
+    assert "Generation produced nothing" in errors[-1]
+
+
+@pytest.mark.asyncio
 async def test_zero_persisted_without_disconnect_still_generation_failure():
     """A zero-appeal session whose stream_error is NOT a disconnect keeps the
     'Generation produced nothing' ERROR."""

--- a/tests/async-unit/test_websocket_diagnostics.py
+++ b/tests/async-unit/test_websocket_diagnostics.py
@@ -13,9 +13,11 @@ don't accidentally collapse the lookup-failed case back into the
 "generation produced nothing" bucket.
 """
 
+import json
 from unittest.mock import patch, AsyncMock, MagicMock
 
 import pytest
+from django.db.utils import OperationalError
 
 from fighthealthinsurance.websockets import (
     _AppealGenTraceFields,
@@ -507,6 +509,66 @@ async def test_server_side_connection_reset_is_not_filed_as_a_disconnect():
         )
     assert warnings == []
     assert "Generation produced nothing" in errors[-1]
+
+
+@pytest.mark.asyncio
+async def test_rest_fallback_wires_error_from_send_false():
+    """End-to-end over the REST fallback view, not the helper in isolation.
+
+    The test above pins the CLASSIFICATION; this one pins the WIRING, and only
+    this one fails if streaming_appeals_rest_fallback stops passing
+    error_from_send=False (or passes the wrong value). Drive the real view with
+    a generator that dies on a Postgres reset mid-stream and assert it is still
+    filed as a generation failure.
+    """
+    from rest_framework.test import APIRequestFactory
+
+    from fighthealthinsurance import rest_views
+
+    reset_error = "could not receive data from server: Connection reset by peer"
+
+    async def _boom(_data):
+        # One status frame first, so the run looks like a real generation that
+        # got under way rather than an immediate blow-up.
+        yield json.dumps({"type": "status", "phase": "init"}) + "\n"
+        raise OperationalError(reset_error)
+
+    request = APIRequestFactory().post(
+        "/ziggy/rest/appeals/streaming_fallback",
+        {"denial_id": 42, "email": "a@b.com", "semi_sekret": "s"},
+        format="json",
+    )
+
+    objects = _make_count_mock(return_value=0)
+    p1, p2 = _patch_models(objects)
+    warn_cm, warnings = _captured_warning()
+    err_cm, errors = _captured_logger()
+    with p1, p2, warn_cm, err_cm, patch.object(
+        rest_views.common_view_logic,
+        "get_denial_for_action",
+        return_value=MagicMock(),
+    ), patch.object(
+        rest_views.common_view_logic.AppealsBackendHelper,
+        "generate_appeals",
+        _boom,
+    ), patch.object(
+        # The view logs its own traceback for the failure; silence it so the
+        # test output isn't a wall of stack trace.
+        rest_views,
+        "logger",
+        MagicMock(),
+    ):
+        response = rest_views.streaming_appeals_rest_fallback(request)
+        async for _chunk in response.streaming_content:
+            pass
+
+    # Reached log_zero_appeal_diagnostics as a GENERATION failure. Without
+    # error_from_send=False the "connection reset" substring would match the
+    # client-disconnect markers and downgrade this to a WARNING.
+    assert warnings == []
+    assert errors, "expected a zero-appeal ERROR from the REST fallback"
+    assert "Generation produced nothing" in errors[-1]
+    assert reset_error in errors[-1]
 
 
 @pytest.mark.asyncio

--- a/tests/sync/test_speculative_appeals.py
+++ b/tests/sync/test_speculative_appeals.py
@@ -103,6 +103,53 @@ class SpeculativeAppealsHelperTest(TestCase):
         self.assertEqual(count, 0)
         mock_make.assert_not_called()
 
+    def test_skips_when_the_denial_already_has_a_live_appeal(self):
+        """The backlog shed: a precompute that reaches the front of the actor's
+        queue after the user's real generation already delivered has nothing to
+        contribute -- the end-of-flow reconciliation only reaches for a reserve
+        while under ENOUGH_APPEALS -- so it must drop rather than burn a slot.
+        """
+        ProposedAppeal.objects.create(
+            for_denial=self.denial,
+            appeal_text="A real appeal the live flow already generated.",
+            model_name="m",
+            speculative=False,
+        )
+        with patch(_MAKE_APPEALS) as mock_make:
+            count = SpeculativeAppealsHelper.generate_for_denial_sync(
+                self.denial.denial_id
+            )
+        self.assertEqual(count, 0)
+        mock_make.assert_not_called()
+
+    def test_force_regenerates_past_live_drafts_about_the_old_letter(self):
+        """force must beat the widened guard too. After a letter replacement the
+        denial still carries live drafts about the OLD letter (invalidation
+        deletes only the held-back reserve), so without the bypass a replaced
+        denial could never get a reserve for its new text."""
+        ProposedAppeal.objects.create(
+            for_denial=self.denial,
+            appeal_text="A live draft about the letter that was replaced.",
+            model_name="m",
+            speculative=False,
+        )
+        with patch(_MAKE_APPEALS) as mock_make, patch(
+            _SUMMARIZE, new_callable=AsyncMock, return_value=None
+        ):
+            mock_make.return_value = iter(
+                [
+                    GeneratedAppeal(
+                        text="A real, deliverable speculative appeal letter.",
+                        model_name="m",
+                    )
+                ]
+            )
+            count = SpeculativeAppealsHelper.generate_for_denial_sync(
+                self.denial.denial_id, force=True
+            )
+        self.assertEqual(count, 1)
+        mock_make.assert_called_once()
+
     def test_skips_when_no_denial_text(self):
         blank = Denial.objects.create(hashed_email="h2", denial_text="")
         with patch(_MAKE_APPEALS) as mock_make:
@@ -577,3 +624,30 @@ class SpeculativePrecomputeEndToEndTest(TransactionTestCase):
             ProposedAppeal.objects.filter(for_denial=denial, speculative=True).count(),
             0,
         )
+
+
+class SpeculativeAppealsActorOptionsTest(TestCase):
+    """The actor's Ray options, asserted without needing a live cluster.
+
+    Kept here rather than in tests/sync-actor because it is a static property of
+    the decorated class; the sync-actor suite pays for a real Ray cluster and
+    should stay focused on the execution model.
+    """
+
+    def test_concurrency_is_bounded(self):
+        """prefetch_for_denial is a coroutine, which makes this an ASYNC Ray
+        actor -- and Ray's default concurrency for those is 1000. That default is
+        fine for the other async actors (cheap per-task work) but not here: each
+        task is a full make_appeals ML fan-out plus its own pool thread, all in
+        one process on a Ray worker capped at 1 CPU / 6-7G. Pin the bound so a
+        refactor can't silently restore the 1000 default.
+        """
+        from fighthealthinsurance.speculative_appeals_actor import (
+            SpeculativeAppealsActor,
+        )
+
+        options = SpeculativeAppealsActor._default_options
+        self.assertEqual(options["max_concurrency"], 10)
+        # The restart/retry policy the other actors use, kept alongside it.
+        self.assertEqual(options["max_restarts"], -1)
+        self.assertEqual(options["max_task_retries"], -1)


### PR DESCRIPTION
## Summary

Fixes a race condition where text summarization operations (both live and pre-warmed) could cache summaries of old denial letters if the user replaced the letter while summarization was in flight. The fix makes cache writes conditional on the denial_text still matching what was summarized, so stale summaries are silently dropped at the database level.

## Changes

- **`ml_appeal_context_helper.py`**: Modified `_cache_summary()` to accept `source_text` parameter and gate the UPDATE query on `denial_text=source_text`. This ensures that if the letter was replaced while summarization was running, the stale summary won't be cached. Added logging to distinguish between DB failures (non-fatal) and dropped writes (letter was replaced).

- **`rest_views.py`**: Added `error_from_send=False` when logging stream errors in the REST endpoint. This prevents server-side failures that happen to mention "connection reset" (e.g., Postgres dropping the session) from being misclassified as client disconnects, which would downgrade ERROR to WARNING and suppress alerting.

- **Tests**: Added comprehensive test coverage for the race condition:
  - `test_prewarm_cache_write_is_gated_on_the_letter_it_summarized()` - Verifies pre-warmed summaries are dropped if letter changed
  - `test_live_summary_cache_write_is_gated_on_the_letter_it_summarized()` - Verifies live summaries are dropped if letter changed
  - `test_cache_write_failure_still_returns_the_summary()` - Verifies DB failures don't break the generation
  - `test_server_side_connection_reset_is_not_filed_as_a_disconnect()` - Verifies error classification stays correct
  - Updated existing tests to expect the new `denial_text` filter parameter and mock `aupdate` return values

## Implementation Details

The pre-warm path is most vulnerable to this race condition since it runs entirely in the background with no deadline, making it likely to still be summarizing when a user corrects a bad OCR pass. The live path can also be affected if summarization takes long enough.

The fix uses a conditional UPDATE at the database level: `Denial.objects.filter(denial_id=denial_id, denial_text=source_text).aupdate(...)`. If the letter was replaced, zero rows match and the write silently succeeds with no rows updated. The caller still gets the summary it computed (which is self-consistent with the letter it was about), but the stale copy never persists.

Cache write failures remain non-fatal—the in-flight generation still returns its computed summary to the caller.

https://claude.ai/code/session_01TEjCi1ZYi8yM4n6rBbs8Cx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented cached denial-text summaries from being saved or reused when the denial letter changes during processing (applies to both live generation and background pre-warming).
  * Kept summary output available even when non-critical cache writes fail.
  * Improved “zero appeals” stream error diagnostics by treating server-side “Connection reset by peer” as generation-related rather than a disconnect.
* **Reliability**
  * Added/updated automated tests to verify conditional cache writes and correct diagnostic classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->