### PR TITLE
Add REST fallback diagnostics for transport failures

### DIFF
--- a/fighthealthinsurance/rest_views.py
+++ b/fighthealthinsurance/rest_views.py
@@ -1,6 +1,7 @@
 import asyncio
 import datetime
 import json
+import time
 import typing
 from typing import Optional
 
@@ -551,13 +552,16 @@ class ReportClientError(APIView):
         # Sanitize inputs: truncate and strip CR/LF to prevent log injection
         denial_id = _sanitize(str(request.data.get("denial_id", "unknown")), 200)
         denial_id_raw = _sanitize(str(request.data.get("denial_id_raw", "")), 200)
-        error_message = _sanitize(str(request.data.get("error", "unknown error")), 500)
+        error_message = _sanitize(str(request.data.get("error", "unknown error")), 800)
         browser_info = _sanitize(str(request.data.get("browser_info", "")), 500)
         # Delivery diagnostics are client-collected counters (status frames,
         # ws close code/reason, server-reported totals, etc). They share the
         # same sanitization rules but get their own field so a long mobile
-        # user-agent string in browser_info doesn't crowd them out.
-        diagnostics = _sanitize(str(request.data.get("diagnostics", "")), 1000)
+        # user-agent string in browser_info doesn't crowd them out. The cap is
+        # well above the ~650 chars the client currently emits: truncation
+        # silently drops the trailing fields (wait times, gen_id), which are
+        # the ones triage joins on, so keep real headroom for new counters.
+        diagnostics = _sanitize(str(request.data.get("diagnostics", "")), 1600)
         session_key = request.session.session_key or "no_session_key"
         denial_id_valid = is_valid_denial_id(denial_id)
         # Annotate with the (estimated) token sizes of the denial text and the
@@ -738,6 +742,22 @@ def streaming_appeals_rest_fallback(request: Request):
         status_count = 0
         last_status_phase: Optional[str] = None
         gen_fields = _AppealGenTraceFields()
+        # Server-side mirror of the client's rest_idle_ms. When a REST
+        # fallback dies mid-stream the client can only report "the connection
+        # dropped"; pairing that with how long WE had gone without producing a
+        # frame is what distinguishes "an intermediary reaped an idle stream"
+        # (long, suspiciously round idle gap) from "the user's network went
+        # away" (we were still writing when it died).
+        stream_started_at = time.monotonic()
+        last_yield_at = stream_started_at
+
+        def _timing() -> str:
+            now = time.monotonic()
+            return (
+                f"elapsed={now - stream_started_at:.1f}s "
+                f"idle={now - last_yield_at:.1f}s"
+            )
+
         try:
             # Flush a leading newline before awaiting generate_appeals
             # so anti-buffering headers and intermediary heuristics
@@ -753,6 +773,7 @@ def streaming_appeals_rest_fallback(request: Request):
                 # still flush early, matching the WS keepalive cadence.
                 yield record
                 yield "\n"
+                last_yield_at = time.monotonic()
                 stripped = record.strip()
                 if stripped:
                     try:
@@ -786,7 +807,8 @@ def streaming_appeals_rest_fallback(request: Request):
                     f"APPEAL_GEN_DIAG [rest] client disconnected mid-stream for "
                     f"denial {denial_id}: generation "
                     f"{'not reached' if last_status_phase in (None, 'init', 'research') else 'in progress'} "
-                    f"(last_phase={last_status_phase}, status_frames={status_count})"
+                    f"(last_phase={last_status_phase}, status_frames={status_count}, "
+                    f"{_timing()})"
                 )
             raise
         except Exception as e:
@@ -794,7 +816,7 @@ def streaming_appeals_rest_fallback(request: Request):
                 f"Error streaming REST fallback appeals for denial "
                 f"{denial_id} after {appeal_count} appeals / "
                 f"{status_count} status frames (last phase="
-                f"{last_status_phase}): {e}"
+                f"{last_status_phase}, {_timing()}): {e}"
             )
             if appeal_count == 0:
                 await log_zero_appeal_diagnostics(

--- a/fighthealthinsurance/rest_views.py
+++ b/fighthealthinsurance/rest_views.py
@@ -763,17 +763,26 @@ def streaming_appeals_rest_fallback(request: Request):
             # so anti-buffering headers and intermediary heuristics
             # engage immediately. Otherwise a slow first ML call can
             # make the fallback look hung even when it's working.
+            last_yield_at = time.monotonic()
             yield "\n"
             async for record in common_view_logic.AppealsBackendHelper.generate_appeals(
                 data
             ):
+                # Stamp BEFORE each yield, never after. A client hangup injects
+                # GeneratorExit at whichever `yield` we're suspended on, so a
+                # trailing assignment never runs for the frame just sent -- and
+                # the disconnect warning would then report the whole preceding
+                # generation gap as idle time, right when we were actively
+                # writing. That's the exact confusion this metric exists to
+                # remove.
+                last_yield_at = time.monotonic()
                 # Mirror the WebSocket framing: each record is already
                 # newline-terminated JSON, but we add an extra "\n"
                 # framing newline so intermediaries that buffer per-line
                 # still flush early, matching the WS keepalive cadence.
                 yield record
-                yield "\n"
                 last_yield_at = time.monotonic()
+                yield "\n"
                 stripped = record.strip()
                 if stripped:
                     try:

--- a/fighthealthinsurance/static/js/appeal_fetcher.ts
+++ b/fighthealthinsurance/static/js/appeal_fetcher.ts
@@ -461,6 +461,37 @@ let lastWsCloseCode = -1;
 let lastWsCloseReason = '';
 let lastWsErrorMessage = '';
 let lastRestErrorMessage = '';
+// REST fallback leg diagnostics. The browser's message for a failed fetch is
+// uselessly vague on its own -- Chrome says "Failed to fetch" when the request
+// never got headers and "network error" when the *body stream* dies after a
+// successful response, Safari says "Load failed", Firefox "NetworkError when
+// attempting to fetch resource" -- and none of them say whether we ever
+// reached the server, whether any bytes arrived, or how long the connection
+// sat idle before dying. Those three facts are what separates "origin/proxy
+// killed an idle stream" from "user's network dropped" from "server 5xx'd
+// instantly", so track them explicitly.
+//
+// restStage is the furthest point the REST leg reached:
+//   'none'        -- REST fallback never ran
+//   'connecting'  -- fetch() issued, no response headers yet
+//   'headers'     -- headers arrived, body reader not started
+//   'streaming'   -- reading the body
+//   'complete'    -- body fully read
+let restStage = 'none';
+let restHttpStatus = -1;
+let restTimeToHeadersMs = -1;
+let restBytesReceived = 0;
+let restFramesReceived = 0;
+let restStartedAtMs = 0;
+// Timestamp of the most recent byte off the REST body, so a failure can
+// report how long the stream had been silent. A proxy/gateway idle timeout
+// shows up as "died after ~N seconds of silence"; a mid-flow reset (user
+// network dropped, server crashed while writing) shows a near-zero idle gap.
+let restLastByteAtMs = 0;
+// Set when our own inactivity watchdog aborts the REST fetch, so the
+// resulting AbortError is reported as a deliberate client-side give-up
+// rather than an unexplained "network error".
+let restAbortReason = '';
 // Why the WebSocket transport ended, for the error report. `retries` only
 // counts WS reconnects, so a timeout-driven escalation to REST reports
 // retries=0 — which reads as "gave up immediately" unless we also say the
@@ -509,6 +540,13 @@ const WS_INACTIVITY_TIMEOUT_MS = 90000;
 // isn't stuck. Kept generous because a healthy run can legitimately take
 // several minutes; the 90s inactivity timeout handles dead streams sooner.
 const WS_HARD_TIMEOUT_MS = 420000;
+// Inactivity watchdog for the REST fallback leg. Without it the REST leg has
+// no timeout at all: escalateToRest() clears both WS timers and nothing
+// re-arms them, so a fetch that connects and then hangs leaves the user on a
+// spinner indefinitely. Same 90s budget as the WS inactivity timeout -- the
+// REST fallback streams the *same* generator with the same keep-alive
+// cadence, so the same "longest legitimate quiet stretch" reasoning applies.
+const REST_INACTIVITY_TIMEOUT_MS = 90000;
 
 let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
 // Absolute-deadline timer for the WebSocket transport (see escalateToRest).
@@ -629,6 +667,10 @@ function reportClientError(error: string): void {
     ? Date.now() - doQueryStartedAtMs : -1;
   const inflightWaitMs = currentAttemptStartedAtMs > 0
     ? Date.now() - currentAttemptStartedAtMs : -1;
+  // How long the REST body had been silent when we gave up. -1 when the REST
+  // leg never ran; measured from the last byte (or from the request start, if
+  // nothing ever arrived).
+  const restIdleMs = restStartedAtMs > 0 ? Date.now() - restLastByteAtMs : -1;
   // Delivery diagnostics live in their own field so a long mobile
   // user-agent string in browser_info doesn't truncate them.
   const diagnostics = [
@@ -649,6 +691,25 @@ function reportClientError(error: string): void {
     `max_retries=${maxRetries}`,
     `rest_fallback=${usingRestFallback}`,
     `rest_err=${lastRestErrorMessage || 'none'}`,
+    // How far the REST leg got and what it saw. A bare "network error" is
+    // ambiguous without these: stage tells us whether the server ever
+    // answered, status/ttfb whether it answered healthily, and bytes/frames
+    // whether the stream was producing before it died.
+    `rest_stage=${restStage}`,
+    `rest_status=${restHttpStatus}`,
+    `rest_ttfb_ms=${restTimeToHeadersMs}`,
+    `rest_bytes=${restBytesReceived}`,
+    `rest_frames=${restFramesReceived}`,
+    // Silence before the failure. Close to a round number of seconds (60s,
+    // 100s) points at an intermediary's idle timeout rather than a flaky
+    // client network; near zero means the connection was cut mid-write.
+    `rest_idle_ms=${restIdleMs}`,
+    // Client-side environment at report time. `offline` explains an
+    // otherwise-inexplicable transport failure outright, and a hidden tab is
+    // the usual cause on mobile Safari, where backgrounding kills in-flight
+    // streams.
+    `net_online=${typeof navigator.onLine === 'boolean' ? navigator.onLine : 'unknown'}`,
+    `page_hidden=${document.visibilityState === 'hidden'}`,
     `wait_total_ms=${aggregateWaitMs}`,
     `wait_attempts_ms=${attemptDurationsMs.join(',') || 'none'}`,
     `wait_inflight_ms=${inflightWaitMs}`,
@@ -705,8 +766,14 @@ function done(): void {
       // "WS went silent mid-generation -> inactivity timeout -> REST fallback
       // also failed", which the old "exhausted N retries" wording hid because
       // a timeout escalation never increments `retries`.
+      // Name the REST leg's outcome in the headline, not just in the
+      // diagnostics blob: "REST fallback delivered 0 appeals" reads like the
+      // server returned nothing, when the common case is that the transport
+      // died before the server got to answer.
       const detail = usingRestFallback
-        ? `WS ended (${wsEndReason}) then REST fallback delivered 0 appeals`
+        ? `WS ended (${wsEndReason}) then REST fallback delivered 0 appeals ` +
+          `[stage=${restStage} frames=${restFramesReceived} bytes=${restBytesReceived} ` +
+          `err=${lastRestErrorMessage || 'none'}]`
         : `WS ended (${wsEndReason}) with 0 appeals and no REST fallback`;
       reportClientError(
         `Client received 0 appeals via ${transport}: ${detail} ` +
@@ -838,6 +905,46 @@ async function requestExternalModels(
   }
 }
 
+// Turn a thrown fetch failure into something a log reader can act on.
+// `error.message` alone is the ambiguous part ("network error", "Failed to
+// fetch", "Load failed"), so prefix the constructor name and append the stage
+// we died at plus a plain-English reading of the browser's wording. The result
+// lands in `rest_err=` in the client error report.
+function describeFetchError(error: unknown): string {
+  const name = (error as any)?.name || 'Error';
+  const message = (error as any)?.message || String(error);
+  const normalized = String(message).toLowerCase();
+  let interpretation = '';
+  if (name === 'AbortError') {
+    // Our own watchdog (restAbortReason) or a page teardown.
+    interpretation = restAbortReason
+      ? `client aborted: ${restAbortReason}`
+      : 'request aborted (page navigation/teardown?)';
+  } else if (
+    // Chrome uses the bare "network error" specifically for a body stream
+    // that dies AFTER response headers were accepted -- i.e. we did reach
+    // the server and it did answer; the connection was cut mid-response.
+    // Safari's equivalent is "the network connection was lost".
+    normalized === 'network error' ||
+    normalized.includes('connection was lost') ||
+    normalized.includes('connection closed')
+  ) {
+    interpretation = 'connection dropped mid-response (idle proxy timeout, origin restart, or transient network loss)';
+  } else if (
+    // Every browser's "the request never completed a round trip" wording.
+    normalized.includes('failed to fetch') ||
+    normalized.includes('load failed') ||
+    normalized.includes('networkerror when attempting')
+  ) {
+    interpretation = 'request never got a response (DNS/TLS/connect refused, offline, or blocked)';
+  }
+  const parts = [`${name}: ${message}`, `stage=${restStage}`];
+  if (interpretation) {
+    parts.push(interpretation);
+  }
+  return parts.join(' | ');
+}
+
 // REST fallback for when WebSockets are unavailable (e.g. iPhone Safari, corporate proxies)
 async function fetchFallback(url: string, data: object, csrfToken: string): Promise<void> {
   console.log("Using REST fallback for appeal generation");
@@ -845,12 +952,40 @@ async function fetchFallback(url: string, data: object, csrfToken: string): Prom
   // ws.onerror already called endCurrentAttempt() before handoff, so
   // start a fresh attempt timer for the REST leg.
   beginAttempt();
+  restStage = 'connecting';
+  restStartedAtMs = Date.now();
+  restLastByteAtMs = restStartedAtMs;
   const statusMessage = document.getElementById('status-message');
   if (statusMessage) {
     statusMessage.textContent = 'Using alternative connection method...';
   }
   updateStatusIndicator('connected', appealsSoFar.length);
 
+  // Watchdog: abort the fetch if the stream goes quiet. Re-armed on every
+  // chunk (and on headers), cleared in the finally below.
+  const controller = new AbortController();
+  let restIdleHandle: ReturnType<typeof setTimeout> | null = null;
+  const armRestIdleTimer = () => {
+    if (restIdleHandle) clearTimeout(restIdleHandle);
+    restIdleHandle = setTimeout(() => {
+      restIdleHandle = null;
+      restAbortReason =
+        `no data for ${REST_INACTIVITY_TIMEOUT_MS / 1000}s at stage=${restStage}`;
+      console.error(`REST fallback stalled: ${restAbortReason}`);
+      try {
+        controller.abort();
+      } catch (e) {
+        /* ignore */
+      }
+    }, REST_INACTIVITY_TIMEOUT_MS);
+  };
+  const noteBytes = (byteLength: number) => {
+    restBytesReceived += byteLength;
+    restLastByteAtMs = Date.now();
+    armRestIdleTimer();
+  };
+
+  armRestIdleTimer();
   try {
     const response = await fetch(url, {
       method: 'POST',
@@ -859,17 +994,27 @@ async function fetchFallback(url: string, data: object, csrfToken: string): Prom
         'X-CSRFToken': csrfToken,
       },
       body: JSON.stringify(data),
+      signal: controller.signal,
     });
+
+    restStage = 'headers';
+    restHttpStatus = response.status;
+    restTimeToHeadersMs = Date.now() - restStartedAtMs;
+    restLastByteAtMs = Date.now();
+    armRestIdleTimer();
 
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}: ${response.statusText}`);
     }
 
+    restStage = 'streaming';
     if (!response.body) {
       // No streaming body available — read entire response as text
       const text = await response.text();
+      noteBytes(text.length);
       for (const line of text.split('\n')) {
         if (line.trim()) {
+          restFramesReceived++;
           processResponseChunk(line + '\n');
         }
       }
@@ -881,27 +1026,38 @@ async function fetchFallback(url: string, data: object, csrfToken: string): Prom
       while (true) {
         const { done: streamDone, value } = await reader.read();
         if (streamDone) break;
+        noteBytes(value?.byteLength ?? 0);
         buffer += decoder.decode(value, { stream: true });
         // Process complete lines
         while (buffer.includes('\n')) {
           const idx = buffer.indexOf('\n');
           const line = buffer.slice(0, idx + 1);
           buffer = buffer.slice(idx + 1);
+          if (line.trim()) {
+            restFramesReceived++;
+          }
           processResponseChunk(line);
         }
       }
       // Process any remaining data
       if (buffer.trim()) {
+        restFramesReceived++;
         processResponseChunk(buffer + '\n');
       }
     }
+    restStage = 'complete';
     updateStatusIndicator('done', appealsSoFar.length);
   } catch (error) {
     console.error("REST fallback error:", error);
-    lastRestErrorMessage = (error as any)?.message || String(error);
+    lastRestErrorMessage = describeFetchError(error);
     if (statusMessage) {
       statusMessage.textContent = 'Connection failed. Please try refreshing the page.';
       statusMessage.style.color = '#dc3545';
+    }
+  } finally {
+    if (restIdleHandle) {
+      clearTimeout(restIdleHandle);
+      restIdleHandle = null;
     }
   }
   // Record REST attempt duration before reporting / hiding UI.
@@ -1321,6 +1477,18 @@ export function doQuery(backend_url: string, data: Map<string, string>, rest_fal
   // own generation_id, so a stale id would mis-join the server trace.
   wsEndReason = 'none';
   serverGenerationId = '';
+  // Same reasoning for the REST leg's counters: the external-models rerun
+  // goes back to the WebSocket, so leaving the previous pass's stage/bytes
+  // latched would attribute a stale transport failure to the new attempt.
+  restStage = 'none';
+  restHttpStatus = -1;
+  restTimeToHeadersMs = -1;
+  restBytesReceived = 0;
+  restFramesReceived = 0;
+  restStartedAtMs = 0;
+  restLastByteAtMs = 0;
+  restAbortReason = '';
+  lastRestErrorMessage = '';
   // Start the aggregate wait clock only on the first call. doQuery
   // recurses on retry via done(), and we want the total to span the
   // entire user-visible wait, not just the latest retry.

--- a/tests/async-unit/test_websocket_diagnostics.py
+++ b/tests/async-unit/test_websocket_diagnostics.py
@@ -683,7 +683,8 @@ async def test_rest_fallback_disconnect_idle_excludes_generation_gap():
     elapsed, idle = float(match.group(1)), float(match.group(2))
     # Two generation gaps have elapsed, but we were writing at the moment of
     # the disconnect, so the idle window must not include either of them.
-    assert elapsed >= gap, message
+    # The 0.1s slack on elapsed is the log's formatting granularity.
+    assert elapsed >= 2 * gap - 0.1, message
     assert idle < gap / 2, message
 
 

--- a/tests/async-unit/test_websocket_diagnostics.py
+++ b/tests/async-unit/test_websocket_diagnostics.py
@@ -13,6 +13,7 @@ don't accidentally collapse the lookup-failed case back into the
 "generation produced nothing" bucket.
 """
 
+import asyncio
 import json
 import re
 from unittest.mock import patch, AsyncMock, MagicMock
@@ -623,6 +624,67 @@ async def test_rest_fallback_disconnect_log_includes_stream_timing():
     assert messages, "expected a client-disconnect WARNING"
     assert "client disconnected mid-stream" in messages[-1]
     assert re.search(r"elapsed=\d+\.\d+s idle=\d+\.\d+s", messages[-1]), messages[-1]
+
+
+@pytest.mark.asyncio
+async def test_rest_fallback_disconnect_idle_excludes_generation_gap():
+    """`idle` measures silence since the last frame WE sent, not since the last
+    frame we finished bookkeeping for.
+
+    A hangup injects GeneratorExit at whichever `yield` the stream is suspended
+    on, so the idle timestamp has to be stamped before each yield. Stamped
+    after, a disconnect immediately following a slow-to-produce frame reports
+    the whole generation gap as idle -- which would point triage at an idle
+    proxy timeout when the server was writing right up to the disconnect.
+    """
+    from rest_framework.test import APIRequestFactory
+
+    from fighthealthinsurance import rest_views
+
+    # Comfortably wider than the log's 0.1s formatting granularity, so the
+    # buggy (stamp-after-yield) reading of ~1 gap can't round into the passing
+    # band and make this flaky.
+    gap = 0.4
+
+    async def _slow_between_frames(_data):
+        for _ in range(2):
+            await asyncio.sleep(gap)
+            yield json.dumps({"type": "status", "phase": "generating"}) + "\n"
+
+    request = APIRequestFactory().post(
+        "/ziggy/rest/appeals/streaming_fallback",
+        {"denial_id": 42, "email": "a@b.com", "semi_sekret": "s"},
+        format="json",
+    )
+
+    fake_logger = MagicMock()
+    with patch.object(
+        rest_views.common_view_logic,
+        "get_denial_for_action",
+        return_value=MagicMock(),
+    ), patch.object(
+        rest_views.common_view_logic.AppealsBackendHelper,
+        "generate_appeals",
+        _slow_between_frames,
+    ), patch.object(
+        rest_views, "logger", fake_logger
+    ):
+        response = rest_views.streaming_appeals_rest_fallback(request)
+        stream = response._iterator
+        # Stop on the second record: the stream has just produced a frame after
+        # a `gap`-long wait, so a hangup here is the "died mid-write" case.
+        for _ in range(4):
+            await stream.__anext__()
+        await stream.aclose()
+
+    message = fake_logger.warning.call_args_list[-1].args[0]
+    match = re.search(r"elapsed=(\d+\.\d+)s idle=(\d+\.\d+)s", message)
+    assert match, message
+    elapsed, idle = float(match.group(1)), float(match.group(2))
+    # Two generation gaps have elapsed, but we were writing at the moment of
+    # the disconnect, so the idle window must not include either of them.
+    assert elapsed >= gap, message
+    assert idle < gap / 2, message
 
 
 @pytest.mark.asyncio

--- a/tests/async-unit/test_websocket_diagnostics.py
+++ b/tests/async-unit/test_websocket_diagnostics.py
@@ -14,6 +14,7 @@ don't accidentally collapse the lookup-failed case back into the
 """
 
 import json
+import re
 from unittest.mock import patch, AsyncMock, MagicMock
 
 import pytest
@@ -569,6 +570,59 @@ async def test_rest_fallback_wires_error_from_send_false():
     assert errors, "expected a zero-appeal ERROR from the REST fallback"
     assert "Generation produced nothing" in errors[-1]
     assert reset_error in errors[-1]
+
+
+@pytest.mark.asyncio
+async def test_rest_fallback_disconnect_log_includes_stream_timing():
+    """A REST client hanging up mid-stream logs how long the stream ran and
+    how long it had been silent.
+
+    The client can only report "the connection dropped"; the server-side
+    elapsed/idle pair is what tells triage whether an intermediary reaped an
+    idle stream (long idle gap) or the connection died while we were actively
+    writing (idle near zero).
+    """
+    from rest_framework.test import APIRequestFactory
+
+    from fighthealthinsurance import rest_views
+
+    async def _two_status_frames(_data):
+        yield json.dumps({"type": "status", "phase": "generating"}) + "\n"
+        yield json.dumps({"type": "status", "phase": "generating"}) + "\n"
+
+    request = APIRequestFactory().post(
+        "/ziggy/rest/appeals/streaming_fallback",
+        {"denial_id": 42, "email": "a@b.com", "semi_sekret": "s"},
+        format="json",
+    )
+
+    fake_logger = MagicMock()
+    with patch.object(
+        rest_views.common_view_logic,
+        "get_denial_for_action",
+        return_value=MagicMock(),
+    ), patch.object(
+        rest_views.common_view_logic.AppealsBackendHelper,
+        "generate_appeals",
+        _two_status_frames,
+    ), patch.object(
+        rest_views, "logger", fake_logger
+    ):
+        response = rest_views.streaming_appeals_rest_fallback(request)
+        # Drive the view's own generator (not the `streaming_content`
+        # wrapper): closing it is what delivers GeneratorExit to the
+        # disconnect branch, exactly as an ASGI client hangup does.
+        stream = response._iterator
+        # Leading "\n", first record, its framing "\n", then the second
+        # record -- leaving the generator suspended on a yield, mid-stream.
+        for _ in range(4):
+            await stream.__anext__()
+        await stream.aclose()
+
+    messages = [call.args[0] for call in fake_logger.warning.call_args_list]
+    assert messages, "expected a client-disconnect WARNING"
+    assert "client disconnected mid-stream" in messages[-1]
+    assert re.search(r"elapsed=\d+\.\d+s idle=\d+\.\d+s", messages[-1]), messages[-1]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Adds comprehensive diagnostics to the REST fallback transport layer to help triage connection failures. When the REST fallback fails, the client now reports detailed timing, stream progress, and connection state information that distinguishes between different failure modes (idle timeout, mid-stream disconnect, network unavailable, etc.).

## Key Changes

**Client-side (TypeScript):**
- Added REST fallback stage tracking (`restStage`: none → connecting → headers → streaming → complete) to identify where the connection failed
- Added stream timing metrics: time-to-first-byte, bytes received, frames received, and idle time since last byte
- Implemented inactivity watchdog (`REST_INACTIVITY_TIMEOUT_MS = 90s`) that aborts stalled fetches with explicit reason
- Enhanced error reporting with `describeFetchError()` that interprets browser fetch errors and provides plain-English context (e.g., "connection dropped mid-response" vs "request never got a response")
- Updated error report to include: `rest_stage`, `rest_status`, `rest_ttfb_ms`, `rest_bytes`, `rest_frames`, `rest_idle_ms`, `net_online`, `page_hidden`
- Improved error headline to show REST outcome inline: `[stage=... frames=... bytes=... err=...]`
- Reset all REST diagnostics on retry to avoid stale data from previous attempts

**Server-side (Python):**
- Added server-side stream timing (`elapsed` and `idle` since last frame) to mirror client diagnostics
- Increased error message field size (500 → 800 chars) and diagnostics field size (1000 → 1600 chars) to accommodate new counters
- Updated disconnect and error logging to include timing information for triage correlation

**Tests:**
- Added `test_rest_fallback_disconnect_log_includes_stream_timing()` to verify server logs include elapsed/idle timing on client disconnect

## Implementation Details

The REST fallback now tracks:
- **Stage progression**: Identifies whether the server was reached (headers received) and how far the response streaming got
- **Timing metrics**: Time-to-first-byte distinguishes DNS/TLS/connect failures from mid-stream drops; idle time reveals idle timeouts (round numbers like 60s, 100s) vs active connection loss (near zero)
- **Stream progress**: Byte and frame counts show whether the server was actively producing before failure
- **Client environment**: Reports `navigator.onLine` and `document.visibilityState` to catch offline/backgrounded scenarios

The inactivity watchdog uses the same 90-second budget as the WebSocket layer, since the REST fallback streams the same generator with identical keep-alive cadence.

Error interpretation handles browser-specific wording (Chrome "network error" vs Safari "connection was lost" vs Firefox "NetworkError") and maps them to actionable categories for log readers.

https://claude.ai/code/session_01TURuv93AcPCA9vaEM4t9Pp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved REST fallback behavior for stalled/interrupted streams with inactivity detection and stage-aware error reporting.
  * Added more accurate streaming progress, timing, and byte/frame tracking.
  * Prevented stale REST diagnostics from persisting across retries.
  * Enhanced client-disconnection logging to include stream timing (and avoid misattributing idle time).
* **Diagnostics**
  * Expanded client error details with REST stage, HTTP status, time-to-headers, network/page visibility indicators, and idle/byte/frame metrics.
* **Tests**
  * Added coverage for REST fallback disconnect and idle/timing attribution in streaming logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->