### PR TITLE
Fix dev storage to use local paths instead of container-only /external_data

### DIFF
--- a/fighthealthinsurance/combined_storage.py
+++ b/fighthealthinsurance/combined_storage.py
@@ -2,13 +2,11 @@ from typing import IO, Any, List, Optional
 
 from django.core.files.base import File
 from django.core.files.storage import Storage
-from django.utils.deconstruct import deconstructible
 
 from loguru import logger
 from stopit import ThreadingTimeout as Timeout
 
 
-@deconstructible(path="fighthealthinsurance.combined_storage.CombinedStorage")
 class CombinedStorage(Storage):
     """A combined storage backend that uses timeouts."""
 
@@ -16,6 +14,20 @@ class CombinedStorage(Storage):
 
     def __init__(self, *args: Optional[Storage]):
         self.backends = [x for x in args if x is not None]
+
+    def deconstruct(self):
+        """Serialize into migrations without the wrapped backends.
+
+        Written by hand rather than via @deconstructible, whose generated
+        deconstruct() replays the constructor args -- that recorded each
+        backend's root in every migration that touches a FileField
+        (``FileSystemStorage(location="/external_data")``). Storage roots are
+        deployment configuration, not schema, so pointing dev at a directory
+        that exists there made makemigrations believe all twelve file fields
+        had changed. The backends come from settings at runtime; migration
+        state only needs to know the field uses this storage.
+        """
+        return ("fighthealthinsurance.combined_storage.CombinedStorage", [], {})
 
     def open(self, name: str, mode: str = "rb") -> File:
         last_error: Optional[BaseException] = None

--- a/fighthealthinsurance/settings.py
+++ b/fighthealthinsurance/settings.py
@@ -622,6 +622,34 @@ class Dev(Base):
     EMAIL_BACKEND = "django.core.mail.backends.filebased.EmailBackend"
     EMAIL_FILE_PATH = os.path.join(BASE_DIR, "sent_emails")
 
+    # Base points the external storage at /external_data, which only exists
+    # inside the container images that create it (see k8s/Dockerfile) or where
+    # the shared PVC is mounted. On a dev machine that path is absent, so
+    # listing it -- the staff status page's storage check and the
+    # check_storage REST endpoint both do -- raised FileNotFoundError, and
+    # every CombinedStorage save silently failed for that backend. Point dev at
+    # gitignored directories inside the repo and create them on first use.
+    EXTERNAL_STORAGE_LOCATION = os.getenv(
+        "EXTERNAL_STORAGE_LOCATION", os.path.join(BASE_DIR, "external_data")
+    )
+    EXTERNAL_STORAGE_LOCATION_B = os.getenv(
+        "EXTERNAL_STORAGE_LOCATION_B", os.path.join(BASE_DIR, "external_data_b")
+    )
+
+    @cached_property
+    def EXTERNAL_STORAGE(self) -> Optional[Storage]:
+        from django.core.files.storage import FileSystemStorage
+
+        os.makedirs(self.EXTERNAL_STORAGE_LOCATION, exist_ok=True)
+        return FileSystemStorage(location=self.EXTERNAL_STORAGE_LOCATION)
+
+    @cached_property
+    def EXTERNAL_STORAGE_B(self) -> Optional[Storage]:
+        from django.core.files.storage import FileSystemStorage
+
+        os.makedirs(self.EXTERNAL_STORAGE_LOCATION_B, exist_ok=True)
+        return FileSystemStorage(location=self.EXTERNAL_STORAGE_LOCATION_B)
+
     DATABASES = {
         "default": {
             "ENGINE": "django.db.backends.sqlite3",

--- a/fighthealthinsurance/settings.py
+++ b/fighthealthinsurance/settings.py
@@ -629,11 +629,16 @@ class Dev(Base):
     # check_storage REST endpoint both do -- raised FileNotFoundError, and
     # every CombinedStorage save silently failed for that backend. Point dev at
     # gitignored directories inside the repo and create them on first use.
+    # The defaults are their own constants so the fallback stays assertable
+    # without depending on the ambient environment (tox runs with passenv = *,
+    # so a host EXTERNAL_STORAGE_LOCATION would otherwise leak into the suite).
+    DEFAULT_EXTERNAL_STORAGE_LOCATION = os.path.join(BASE_DIR, "external_data")
+    DEFAULT_EXTERNAL_STORAGE_LOCATION_B = os.path.join(BASE_DIR, "external_data_b")
     EXTERNAL_STORAGE_LOCATION = os.getenv(
-        "EXTERNAL_STORAGE_LOCATION", os.path.join(BASE_DIR, "external_data")
+        "EXTERNAL_STORAGE_LOCATION", DEFAULT_EXTERNAL_STORAGE_LOCATION
     )
     EXTERNAL_STORAGE_LOCATION_B = os.getenv(
-        "EXTERNAL_STORAGE_LOCATION_B", os.path.join(BASE_DIR, "external_data_b")
+        "EXTERNAL_STORAGE_LOCATION_B", DEFAULT_EXTERNAL_STORAGE_LOCATION_B
     )
 
     @cached_property

--- a/fighthealthinsurance/staff_views.py
+++ b/fighthealthinsurance/staff_views.py
@@ -261,17 +261,25 @@ class AdminStatusView(generic.TemplateView):
     @staticmethod
     def _storage_status() -> Dict[str, Any]:
         """Whether the external (encrypted) storage backend is reachable."""
-        out: Dict[str, Any] = {"ok": False, "error": None}
+        out: Dict[str, Any] = {"ok": False, "error": None, "location": None}
         try:
             from django.conf import settings
             from stopit import ThreadingTimeout as Timeout
 
             es = settings.EXTERNAL_STORAGE
+            out["location"] = getattr(es, "location", None)
             with Timeout(3.0):
                 es.listdir("./")
                 out["ok"] = True
                 return out
             out["error"] = "timeout"
+        except FileNotFoundError as e:
+            # The storage root itself is missing: in prod that means the shared
+            # volume isn't mounted, locally it usually means the directory was
+            # never created. A full traceback adds nothing over the path, so
+            # log a one-liner instead of dumping a stack on every page load.
+            logger.warning(f"External storage location missing: {e}")
+            out["error"] = f"storage location does not exist: {e.filename}"
         except Exception as e:
             logger.opt(exception=True).warning("External storage health check failed")
             out["error"] = str(e)

--- a/fighthealthinsurance/templates/admin_status.html
+++ b/fighthealthinsurance/templates/admin_status.html
@@ -191,6 +191,7 @@
       {% else %}
         <span class="badge bad">UNREACHABLE</span>
       {% endif %}
+      {% if storage.location %}<span class="pill">{{ storage.location }}</span>{% endif %}
       {% if storage.error %}<span class="error-text">&nbsp;{{ storage.error }}</span>{% endif %}
     </p>
   </div>

--- a/tests/async-unit/test_dev_storage_settings.py
+++ b/tests/async-unit/test_dev_storage_settings.py
@@ -1,0 +1,41 @@
+"""Unit tests for Dev's external-storage locations.
+
+Base points EXTERNAL_STORAGE at ``/external_data``, which only exists inside
+the container images that create it (k8s/Dockerfile) or where the shared PVC
+is mounted. Pointing dev at it meant every listing (the staff status page's
+storage check, the check_storage REST endpoint) raised FileNotFoundError and
+every CombinedStorage save silently dropped that backend.
+"""
+
+import os
+
+from fighthealthinsurance import settings as fhi_settings
+
+
+def _dev_storage(tmp_path, attr, location_attr):
+    """Build one of Dev's storage backends rooted under tmp_path."""
+    cfg = fhi_settings.Dev()
+    setattr(cfg, location_attr, os.path.join(str(tmp_path), "storage"))
+    return getattr(cfg, attr)
+
+
+class TestDevExternalStorageLocations:
+    def test_dev_does_not_use_the_container_only_root_path(self):
+        assert fhi_settings.Dev.EXTERNAL_STORAGE_LOCATION != "/external_data"
+        assert fhi_settings.Prod.EXTERNAL_STORAGE_LOCATION == "/external_data"
+
+    def test_dev_locations_are_absolute_so_cwd_does_not_move_them(self):
+        assert os.path.isabs(fhi_settings.Dev.EXTERNAL_STORAGE_LOCATION)
+        assert os.path.isabs(fhi_settings.Dev.EXTERNAL_STORAGE_LOCATION_B)
+
+    def test_external_storage_is_created_and_listable(self, tmp_path):
+        storage = _dev_storage(
+            tmp_path, "EXTERNAL_STORAGE", "EXTERNAL_STORAGE_LOCATION"
+        )
+        assert storage.listdir("./") == ([], [])
+
+    def test_external_storage_b_is_created_and_listable(self, tmp_path):
+        storage = _dev_storage(
+            tmp_path, "EXTERNAL_STORAGE_B", "EXTERNAL_STORAGE_LOCATION_B"
+        )
+        assert storage.listdir("./") == ([], [])

--- a/tests/async-unit/test_dev_storage_settings.py
+++ b/tests/async-unit/test_dev_storage_settings.py
@@ -20,13 +20,36 @@ def _dev_storage(tmp_path, attr, location_attr):
 
 
 class TestDevExternalStorageLocations:
-    def test_dev_does_not_use_the_container_only_root_path(self):
-        assert fhi_settings.Dev.EXTERNAL_STORAGE_LOCATION != "/external_data"
+    """The DEFAULT_* constants are asserted rather than the effective
+    locations: the latter are read from the environment at import time and tox
+    runs with ``passenv = *``, so a host EXTERNAL_STORAGE_LOCATION would
+    otherwise decide whether these pass."""
+
+    def test_dev_default_is_not_the_container_only_root_path(self):
+        assert fhi_settings.Dev.DEFAULT_EXTERNAL_STORAGE_LOCATION != "/external_data"
         assert fhi_settings.Prod.EXTERNAL_STORAGE_LOCATION == "/external_data"
 
-    def test_dev_locations_are_absolute_so_cwd_does_not_move_them(self):
-        assert os.path.isabs(fhi_settings.Dev.EXTERNAL_STORAGE_LOCATION)
-        assert os.path.isabs(fhi_settings.Dev.EXTERNAL_STORAGE_LOCATION_B)
+    def test_dev_defaults_are_absolute_so_cwd_does_not_move_them(self):
+        assert os.path.isabs(fhi_settings.Dev.DEFAULT_EXTERNAL_STORAGE_LOCATION)
+        assert os.path.isabs(fhi_settings.Dev.DEFAULT_EXTERNAL_STORAGE_LOCATION_B)
+
+    def test_locations_take_the_env_override_and_fall_back_to_the_defaults(self):
+        for env_var, default_attr, location_attr in (
+            (
+                "EXTERNAL_STORAGE_LOCATION",
+                "DEFAULT_EXTERNAL_STORAGE_LOCATION",
+                "EXTERNAL_STORAGE_LOCATION",
+            ),
+            (
+                "EXTERNAL_STORAGE_LOCATION_B",
+                "DEFAULT_EXTERNAL_STORAGE_LOCATION_B",
+                "EXTERNAL_STORAGE_LOCATION_B",
+            ),
+        ):
+            expected = os.environ.get(
+                env_var, getattr(fhi_settings.Dev, default_attr)
+            )
+            assert getattr(fhi_settings.Dev, location_attr) == expected
 
     def test_external_storage_is_created_and_listable(self, tmp_path):
         storage = _dev_storage(

--- a/tests/sync/test_admin_status.py
+++ b/tests/sync/test_admin_status.py
@@ -3,13 +3,14 @@ fax/model health helpers it relies on."""
 
 import datetime
 import os
+import tempfile
 import threading
 import time
 from unittest import mock
 
 import requests
 from django.contrib.auth import get_user_model
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 
@@ -155,6 +156,36 @@ class AdminStatusFaxQueueTest(TestCase):
         self.assertEqual(q["awaiting_confirmation"], 1)  # C
         self.assertEqual(q["in_flight"], 1)  # D
         self.assertEqual(q["failures_recent"], 1)  # E
+
+
+class AdminStatusStorageTest(TestCase):
+    """_storage_status must degrade to an error row, never raise."""
+
+    @staticmethod
+    def _status_for(location):
+        from django.core.files.storage import FileSystemStorage
+
+        from fighthealthinsurance.staff_views import AdminStatusView
+
+        with override_settings(EXTERNAL_STORAGE=FileSystemStorage(location=location)):
+            return AdminStatusView._storage_status()
+
+    def test_reachable_storage_reports_ok_and_location(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            status = self._status_for(tmp)
+        self.assertTrue(status["ok"])
+        self.assertIsNone(status["error"])
+        self.assertEqual(status["location"], tmp)
+
+    def test_missing_storage_location_reports_error_without_raising(self):
+        """The dev/unmounted case: /external_data (or any absent root) must
+        render as UNREACHABLE naming the path, not blow up the status page."""
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = os.path.join(tmp, "not-mounted")
+        status = self._status_for(missing)
+        self.assertFalse(status["ok"])
+        self.assertIn(missing, status["error"])
+        self.assertEqual(status["location"], missing)
 
 
 class ComputeModelHealthDetailsTest(TestCase):


### PR DESCRIPTION
## Summary
The Dev configuration was pointing `EXTERNAL_STORAGE` at `/external_data`, a path that only exists inside container images or where a shared PVC is mounted. On local dev machines, this caused `FileNotFoundError` when listing storage (staff status page, REST endpoints) and silently dropped saves in `CombinedStorage`. This change redirects dev storage to gitignored local directories that are created on first use.

## Key Changes

- **settings.py (Dev class)**: 
  - Added `EXTERNAL_STORAGE_LOCATION` and `EXTERNAL_STORAGE_LOCATION_B` that default to `external_data/` and `external_data_b/` subdirectories in the repo (configurable via env vars)
  - Converted `EXTERNAL_STORAGE` and `EXTERNAL_STORAGE_B` to `@cached_property` methods that create directories on first access using `os.makedirs(..., exist_ok=True)`
  - Kept Prod pointing to `/external_data` as before

- **staff_views.py (_storage_status method)**:
  - Added `location` field to status dict to expose the storage path in the UI
  - Added explicit `FileNotFoundError` handling that logs a one-liner instead of a full traceback (avoids spam on every page load when storage is unreachable)
  - Extracts and returns the storage location for display

- **admin_status.html**:
  - Added display of storage location path when available: `<span class="pill">{{ storage.location }}</span>`

- **tests/sync/test_admin_status.py (AdminStatusStorageTest)**:
  - New test class verifying `_storage_status()` degrades gracefully to error rows instead of raising
  - `test_reachable_storage_reports_ok_and_location`: confirms accessible storage reports success with location
  - `test_missing_storage_location_reports_error_without_raising`: confirms missing paths render as UNREACHABLE with the path named, not exceptions

- **tests/async-unit/test_dev_storage_settings.py** (new file):
  - Unit tests for Dev's external storage configuration
  - Verifies Dev doesn't use the container-only `/external_data` path
  - Confirms storage locations are absolute paths (immune to cwd changes)
  - Tests that both storage backends are created and listable when configured with temp directories

https://claude.ai/code/session_01Hs7TMjD29th5d74UAFbAkk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - External storage locations can now be configured through environment settings.
  - Required storage directories are created automatically when needed.
  - Admin status now displays the configured external storage location.

- **Bug Fixes**
  - Development storage no longer depends on container-only paths.
  - Storage health checks provide clearer messages for missing locations and timeouts.
  - Missing storage directories no longer cause storage checks or saves to fail unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->