### PR TITLE
Serve the speculative reserve mid-flight once a run passes 30s

### DIFF
--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -2627,6 +2627,24 @@ class AppealsBackendHelper:
     nice = NICETools()
     clinical_trials = ClinicalTrialsTools()
 
+    # How many delivered appeals count as "enough" for this denial. Below it we
+    # top up from the reduced-context rows (the speculative reserve + the shed
+    # tiers); at or above it we leave them held back, because padding a
+    # sufficient result with weaker drafts adds no value.
+    ENOUGH_APPEALS = 3
+
+    # Deadline, measured from the start of the generation flow, after which a
+    # still-underdelivering run starts serving the speculative reserve instead
+    # of holding it to the very end. Research + make_appeals routinely run for
+    # minutes, and a reserve that only lands after all of it leaves the user
+    # staring at a spinner while a usable appeal sits in the DB. Past this mark
+    # every checkpoint in the flow (context gathering, the generating-phase
+    # heartbeats, the streaming loop) flushes what the reserve has, up to
+    # ENOUGH_APPEALS. Live drafts are unaffected: they are full-context rows and
+    # are always streamed as they arrive, so this only ever adds to what the
+    # user gets -- it never trades a good appeal for a speculative one.
+    SPECULATIVE_FALLBACK_SECONDS = 30.0
+
     @classmethod
     async def generate_appeals(cls, parameters) -> AsyncIterator[str]:
         """
@@ -2662,6 +2680,12 @@ class AppealsBackendHelper:
         # done frame. Lets a client-side ReportClientError be tied back to the
         # server-side generation trace. See APPEAL_GEN_DIAG logging below.
         generation_id = uuid.uuid4().hex[:12]
+
+        # Start of the user's wait. The speculative-reserve deadline is measured
+        # from here (not from the generating phase) because what the user
+        # experiences is one uninterrupted wait: research/enrichment happens
+        # before generation and can eat the whole budget on its own.
+        flow_started = time.monotonic()
 
         # Instrumentation captured during the generating phase and surfaced in
         # the done frame + zero-appeal diagnostics.
@@ -2874,8 +2898,14 @@ class AppealsBackendHelper:
         existing_appeals = ProposedAppeal.objects.filter(
             for_denial=denial, speculative=False
         ).all()
+        # Everything already delivered to this client, by normalized raw text.
+        # Grown by every path that ships an appeal (existing rows, streamed
+        # drafts, the early reserve flush, synthesis, the end-of-flow
+        # reconciliation) so no path can send the same text twice.
+        served_texts: set[str] = set()
         # Yield the existing appeals first
         old = 0
+        new = 0
         async for appeal in existing_appeals:
             # Enforce the minimum-length rule on previously-saved appeals too:
             # the DB may hold short drafts saved before this threshold existed
@@ -2884,6 +2914,7 @@ class AppealsBackendHelper:
             if is_real_appeal(appeal.appeal_text):
                 old = old + 1
                 logger.debug(f"Found existing appeal {appeal}, yielding")
+                served_texts.add(str(appeal.appeal_text).strip())
                 existing_appeal_dict = await sub_in_appeals(
                     {"id": str(appeal.id), "content": appeal.appeal_text}
                 )
@@ -2892,6 +2923,87 @@ class AppealsBackendHelper:
                 warn_too_short_appeal(
                     appeal.appeal_text,
                     f"saved appeal id={appeal.id} for denial {denial_id}",
+                )
+
+        # --- Early speculative fallback ---
+        # Rows served early by serve_reserve_if_stalled, tracked by normalized
+        # text: they are promoted to speculative=False, so without this they
+        # would look like ordinary live drafts to the synthesis input query.
+        early_reserve_texts: set[str] = set()
+        reserve_served = 0
+        reserve_notice_sent = False
+
+        async def serve_reserve_if_stalled() -> AsyncIterator[str]:
+            """Flush the speculative reserve once the run is over its deadline.
+
+            A no-op until SPECULATIVE_FALLBACK_SECONDS have passed, and a no-op
+            whenever the user already has ENOUGH_APPEALS -- so a run that is
+            delivering keeps its reserve held back exactly as before. Past the
+            deadline it serves the held-back precompute (oldest first), promoting
+            each row to speculative=False so it persists as a real appeal and a
+            later call serves it as existing -- the same promotion the end-of-flow
+            reconciliation does, just early enough to matter to someone watching
+            a spinner.
+
+            Callers invoke it at the checkpoints where the flow is already
+            yielding (context gathering, generating-phase heartbeats, the
+            streaming loop), so it costs one indexed query per checkpoint and
+            only once the deadline is behind us.
+
+            Best-effort like the reconciliation: never raises, because a DB
+            hiccup here must not kill a stream that is otherwise fine.
+            """
+            nonlocal new, reserve_served, reserve_notice_sent
+            if (new + old) >= cls.ENOUGH_APPEALS:
+                return
+            if (time.monotonic() - flow_started) < cls.SPECULATIVE_FALLBACK_SECONDS:
+                return
+            try:
+                # chosen=False: never hand the user their own pick back as a
+                # new appeal (see the same filter in the reconciliation).
+                async for row in ProposedAppeal.objects.filter(
+                    for_denial=denial, speculative=True, chosen=False
+                ).order_by("id"):
+                    if (new + old) >= cls.ENOUGH_APPEALS:
+                        break
+                    if not is_real_appeal(row.appeal_text):
+                        continue
+                    normalized = str(row.appeal_text).strip()
+                    if normalized in served_texts:
+                        continue
+                    row.speculative = False
+                    await row.asave(update_fields=["speculative"])
+                    if not reserve_notice_sent:
+                        reserve_notice_sent = True
+                        yield json.dumps(
+                            {
+                                "type": "status",
+                                "phase": "generating",
+                                "message": (
+                                    "Sending a draft appeal now while the "
+                                    "full version keeps generating..."
+                                ),
+                            }
+                        ) + "\n"
+                    row_dict = await sub_in_appeals(
+                        {"id": str(row.id), "content": row.appeal_text}
+                    )
+                    yield await format_response(row_dict)
+                    served_texts.add(normalized)
+                    early_reserve_texts.add(normalized)
+                    new += 1
+                    reserve_served += 1
+                    logger.info(
+                        f"[gen_id={generation_id}] served speculative reserve "
+                        f"appeal {row.id} for denial {denial_id} after "
+                        f"{time.monotonic() - flow_started:.1f}s "
+                        f"(new={new}, old={old})"
+                    )
+            except Exception:
+                logger.opt(exception=True).warning(
+                    f"[gen_id={generation_id}] early speculative fallback failed "
+                    f"for denial {denial_id}; the end-of-flow reconciliation "
+                    f"remains as the backstop"
                 )
 
         # Yield status after any previously saved appeals have been sent
@@ -3485,6 +3597,13 @@ class AppealsBackendHelper:
                 }
             ) + "\n"
 
+        # Research/enrichment is the first stretch that can blow the reserve
+        # deadline on its own (each source is individually bounded, but they
+        # add up), so check here -- before the generating phase even starts --
+        # rather than making the user wait out generation too.
+        async for _spec in serve_reserve_if_stalled():
+            yield _spec
+
         # Get microsite context if available (optional, non-blocking)
         microsite_context: Optional[str] = None
         if denial.microsite_slug:
@@ -3542,6 +3661,11 @@ class AppealsBackendHelper:
                 pass
             passed = time.time() - t
             logger.debug(f"Saved appeal ({len(appeal_text)} chars) in {passed:.1f}s")
+            # Mark it served as soon as it is on its way out, so the early
+            # reserve flush running between streamed drafts can't ship a
+            # speculative row whose text matches one already sent.
+            if appeal_text:
+                served_texts.add(str(appeal_text).strip())
             return {"id": id, "content": appeal_text}
 
         # Yield status: generating appeals
@@ -3629,6 +3753,11 @@ class AppealsBackendHelper:
             + "\n",
         ):
             yield _hb
+            # Piggyback on the heartbeat cadence: every beat past the deadline
+            # is a chance to hand over the reserve instead of another "still
+            # working" frame.
+            async for _spec in serve_reserve_if_stalled():
+                yield _spec
         denial_text_override: Optional[str] = None
         if summarize_task.done():
             try:
@@ -3688,6 +3817,11 @@ class AppealsBackendHelper:
             make_heartbeat=_generating_heartbeat,
         ):
             yield _hb
+            # The longest blocking stretch of the whole flow, and the one the
+            # reserve was built for: check on every beat so a stalled backend
+            # costs the user at most one heartbeat interval past the deadline.
+            async for _spec in serve_reserve_if_stalled():
+                yield _spec
 
         make_appeals_seconds = time.monotonic() - gen_started
         appeals: Iterator[GeneratedAppeal]
@@ -3780,7 +3914,9 @@ class AppealsBackendHelper:
             appeals_json
         )
 
-        new = 0
+        # NB: `new` is NOT reset here -- the early speculative fallback may
+        # already have delivered rows, and they count toward both the done
+        # frame's totals and the ENOUGH_APPEALS gate.
         async for i in interleaved:
             # Interleave keep-alives are bare newlines; real appeals exceed
             # MIN_APPEAL_CHARS (same threshold as the generation-side filter).
@@ -3790,6 +3926,11 @@ class AppealsBackendHelper:
             else:
                 logger.debug("Sending keep alive....")
             yield i
+            # Also a checkpoint: draining this iterator blocks on the next model
+            # future, so a run that streams one draft and then stalls for
+            # minutes still gets the reserve at the deadline.
+            async for _spec in serve_reserve_if_stalled():
+                yield _spec
         logger.debug(f"Normal appeals sent {new} and {old} (runt_count={runts})")
         yield json.dumps(
             {
@@ -3808,24 +3949,29 @@ class AppealsBackendHelper:
         # frames.
         # Exclude speculative rows: synthesis should combine the live drafts,
         # not the held-back precompute (which could also spuriously push a
-        # 1-real-draft denial to the >=2 synthesis gate).
+        # 1-real-draft denial to the >=2 synthesis gate). Rows the early
+        # fallback served are excluded by text: promotion already flipped them
+        # to speculative=False, so the filter alone would no longer catch them
+        # -- and reaching the synthesis gate on the strength of the reserve is
+        # exactly what that filter is there to prevent.
         saved_appeal_texts: list[str] = [
             str(pa.appeal_text)
             async for pa in ProposedAppeal.objects.filter(
                 for_denial=denial, speculative=False
             )
             if is_real_appeal(pa.appeal_text)
+            and str(pa.appeal_text).strip() not in early_reserve_texts
         ]
         # Everything streamed so far this run persists as speculative=False
-        # (existing rows + drafts saved during streaming), so this doubles as the
-        # set already sent. Track it by normalized raw text and grow it as
-        # synthesis / the end-of-flow reconciliation serve more, so nothing is
-        # shipped twice. Caveat: save_appeal deliberately swallows a failed
-        # asave and still streams the draft, so a draft whose write failed is
-        # absent here -- the reconciliation may then re-serve an identical row.
-        # Harmless (the client dedupes by content) and preferable to dropping a
-        # generated appeal because its row could not be written.
-        served_texts: set[str] = {s.strip() for s in saved_appeal_texts if s}
+        # (existing rows + drafts saved during streaming), so this doubles as
+        # the set already sent. served_texts is tracked from the top of the flow
+        # (and grown by synthesis / the end-of-flow reconciliation below), so
+        # this only fills in anything a row landed for that no yield path saw.
+        # Caveat: save_appeal deliberately swallows a failed asave and still
+        # streams the draft; such a draft has no row here, but the streaming
+        # path already recorded its text, so the reconciliation still won't
+        # re-serve it.
+        served_texts.update({s.strip() for s in saved_appeal_texts if s})
         # Synthesis requires >=2 drafts to be meaningful: with a single
         # input, models often regurgitate it verbatim. The client dedupes
         # by content, so a verbatim copy gets silently dropped, which then
@@ -3929,7 +4075,7 @@ class AppealsBackendHelper:
         # as real appeals and later calls serve them as existing. Runs before
         # the zero/underdelivery logging and the done frame so the counts stay
         # truthful. Dedup is by normalized raw text via served_texts.
-        ENOUGH_APPEALS = 3
+        ENOUGH_APPEALS = cls.ENOUGH_APPEALS
         MINI_LEVELS = {
             CONTEXT_LEVEL_SPECULATIVE,
             CONTEXT_LEVEL_TIER1_SHED,
@@ -3941,8 +4087,10 @@ class AppealsBackendHelper:
         # otherwise a run where generation produced nothing but the reserve
         # covered it reports new=3 and neither branch fires, so a total backend
         # failure becomes invisible to alerting -- exactly the incident this
-        # instrumentation exists to catch.
-        live_new = new
+        # instrumentation exists to catch. reserve_served is subtracted for the
+        # same reason: rows the early fallback shipped mid-flight are already in
+        # `new`, and counting them as live delivery would hide the same failure.
+        live_new = new - reserve_served
         # Best-effort, like the synthesis block above: a failure here (e.g. a
         # promotion asave hitting DB lock contention -- save_appeal wraps its own
         # asave for exactly this reason) must NOT propagate, or the done frame
@@ -3999,10 +4147,15 @@ class AppealsBackendHelper:
         models_tried = make_appeals_diag.get("models_tried") or "none"
         # Keyed on live_new (pre-reserve), so a reserve that rescued the user
         # still reports the backend failure. reserve_note says whether the user
-        # was actually left empty-handed or the fallback covered it.
+        # was actually left empty-handed or the fallback covered it -- counting
+        # both routes the reserve can take: the mid-flight deadline flush and
+        # the end-of-flow reconciliation.
+        from_reserve = reconciled + reserve_served
         reserve_note = (
-            f" served_from_reserve={reconciled} (user was NOT left empty-handed)"
-            if reconciled
+            f" served_from_reserve={from_reserve} "
+            f"(early={reserve_served}, end_of_flow={reconciled}) "
+            f"(user was NOT left empty-handed)"
+            if from_reserve
             else ""
         )
         if gen_error:
@@ -4044,6 +4197,11 @@ class AppealsBackendHelper:
                 "first_model": first_model or "none",
                 "shed_tier": shed_tier,
                 "models_tried": models_tried,
+                # How many of new_appeals came from the speculative reserve
+                # rather than this run's live generation (early flush +
+                # end-of-flow reconciliation), so a client report can be read
+                # without guessing which path filled the stream.
+                "speculative_appeals": from_reserve,
             }
         ) + "\n"
 

--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -2926,6 +2926,29 @@ class AppealsBackendHelper:
                 )
 
         # --- Early speculative fallback ---
+        # What the precompute had ready before this run started. Logged here so
+        # a trace shows, from the first frames, whether there was ever a safety
+        # net -- and so the "we served the reserve" logs below can say whether
+        # those rows were waiting all along or landed while we generated (the
+        # precompute is a detached actor and finishes on its own schedule).
+        # Best-effort: a failed count must not take the generation down with it.
+        reserve_at_start = -1
+        try:
+            reserve_at_start = await ProposedAppeal.objects.filter(
+                for_denial=denial, speculative=True
+            ).acount()
+        except Exception:
+            logger.opt(exception=True).warning(
+                f"[gen_id={generation_id}] could not count the speculative "
+                f"reserve for denial {denial_id}"
+            )
+        logger.info(
+            f"[gen_id={generation_id}] starting appeal generation for denial "
+            f"{denial_id}: speculative reserve available at start="
+            f"{reserve_at_start} (existing appeals={old}, deadline="
+            f"{cls.SPECULATIVE_FALLBACK_SECONDS:.0f}s)"
+        )
+
         # Rows served early by serve_reserve_if_stalled, tracked by normalized
         # text: they are promoted to speculative=False, so without this they
         # would look like ordinary live drafts to the synthesis input query.
@@ -2994,10 +3017,11 @@ class AppealsBackendHelper:
                     new += 1
                     reserve_served += 1
                     logger.info(
-                        f"[gen_id={generation_id}] served speculative reserve "
+                        f"[gen_id={generation_id}] picked speculative reserve "
                         f"appeal {row.id} for denial {denial_id} after "
                         f"{time.monotonic() - flow_started:.1f}s "
-                        f"(new={new}, old={old})"
+                        f"(new={new}, old={old}, "
+                        f"{'available at start' if reserve_at_start > 0 else 'arrived mid-generation'})"
                     )
             except Exception:
                 logger.opt(exception=True).warning(
@@ -3876,13 +3900,35 @@ class AppealsBackendHelper:
         # zero-appeal diagnostic can distinguish "models silent" from
         # "models producing only short strings".
         runts = 0
+        dupes = 0
 
         def keep(item: Optional[GeneratedAppeal]) -> bool:
-            nonlocal runts
+            nonlocal runts, dupes
             if item is None:
                 return False
             text = item.text
             if is_real_appeal(text):
+                # A live model can land on text we already sent -- most likely
+                # the reserve draft the early fallback just served, since the
+                # precompute runs the same internal models on the same denial.
+                # Drop it rather than stream a known duplicate: the client
+                # dedupes by content, so shipping it would make the done frame's
+                # count exceed what the user can see, which is precisely what
+                # trips the "partial delivery" error path in appeal_fetcher.ts.
+                # (Same reasoning as the verbatim-copy guard on synthesis.)
+                # This runs on the sync_iterator_to_async worker thread while the
+                # event loop may be adding to served_texts; a set membership test
+                # is a single atomic lookup, and the only cost of racing one is
+                # an occasional duplicate slipping through -- exactly today's
+                # behavior.
+                if str(text).strip() in served_texts:
+                    dupes += 1
+                    logger.info(
+                        f"[gen_id={generation_id}] dropping a live draft "
+                        f"(model={item.model_name!r}) for denial {denial_id} "
+                        f"that duplicates an appeal already sent"
+                    )
+                    return False
                 return True
             if isinstance(text, str) and text.strip():
                 runts += 1
@@ -3931,7 +3977,10 @@ class AppealsBackendHelper:
             # minutes still gets the reserve at the deadline.
             async for _spec in serve_reserve_if_stalled():
                 yield _spec
-        logger.debug(f"Normal appeals sent {new} and {old} (runt_count={runts})")
+        logger.debug(
+            f"Normal appeals sent {new} and {old} "
+            f"(runt_count={runts}, dupe_count={dupes})"
+        )
         yield json.dumps(
             {
                 "type": "status",
@@ -4082,6 +4131,10 @@ class AppealsBackendHelper:
             CONTEXT_LEVEL_TIER2_SHED,
         }
         reconciled = 0
+        # Subset of `reconciled` that actually came from the speculative
+        # precompute. The rest are late live drafts, which the reserve counters
+        # must not claim.
+        reconciled_from_reserve = 0
         # Snapshot the LIVE delivery count before the reserve tops it up. The
         # zero-appeal diagnostics below key off this, not the final total:
         # otherwise a run where generation produced nothing but the reserve
@@ -4118,6 +4171,17 @@ class AppealsBackendHelper:
                 # Re-evaluate the threshold each iteration: serving increments new.
                 if is_mini and (new + old) >= ENOUGH_APPEALS:
                     continue
+                # Attribution for the reserve counters below, taken BEFORE the
+                # promotion clears the flag. context_level is part of the test
+                # so a reserve row promoted by an earlier run still counts as
+                # precompute output; a late FULL-context draft (also served
+                # here) is live generation and must not be credited to the
+                # reserve, or the diagnostics would report a fallback that
+                # never happened.
+                from_precompute = (
+                    bool(row.speculative)
+                    or row.context_level == CONTEXT_LEVEL_SPECULATIVE
+                )
                 if row.speculative:
                     # Promote to a real appeal so it persists and later calls
                     # serve it as existing.
@@ -4128,6 +4192,8 @@ class AppealsBackendHelper:
                 served_texts.add(normalized)
                 new += 1
                 reconciled += 1
+                if from_precompute:
+                    reconciled_from_reserve += 1
         except Exception:
             logger.opt(exception=True).warning(
                 f"[gen_id={generation_id}] end-of-flow reconciliation failed for "
@@ -4150,10 +4216,31 @@ class AppealsBackendHelper:
         # was actually left empty-handed or the fallback covered it -- counting
         # both routes the reserve can take: the mid-flight deadline flush and
         # the end-of-flow reconciliation.
-        from_reserve = reconciled + reserve_served
+        from_reserve = reconciled_from_reserve + reserve_served
+        # Unconditional counterpart to the start-of-generation line above: every
+        # run that ends up leaning on the precompute says so exactly once,
+        # including runs the zero/underdelivery branches below never fire for
+        # (e.g. the live models returned one draft and the reserve filled the
+        # rest). reserve_at_start distinguishes a reserve that was waiting from
+        # one that landed mid-flight, which is the difference between "the
+        # precompute got ahead of the user" and "it barely kept up".
+        if from_reserve:
+            logger.info(
+                f"[gen_id={generation_id}] picked {from_reserve} appeal(s) from "
+                f"the speculative reserve for denial {denial_id} "
+                f"(early={reserve_served}, end_of_flow={reconciled_from_reserve}, "
+                f"available_at_start={reserve_at_start}, "
+                f"live_generated={live_new}, existing={old})"
+            )
+        elif reserve_at_start > 0:
+            logger.info(
+                f"[gen_id={generation_id}] did NOT need the speculative reserve "
+                f"for denial {denial_id} ({reserve_at_start} row(s) still held "
+                f"back, live_generated={live_new}, existing={old})"
+            )
         reserve_note = (
             f" served_from_reserve={from_reserve} "
-            f"(early={reserve_served}, end_of_flow={reconciled}) "
+            f"(early={reserve_served}, end_of_flow={reconciled_from_reserve}) "
             f"(user was NOT left empty-handed)"
             if from_reserve
             else ""
@@ -4165,6 +4252,7 @@ class AppealsBackendHelper:
                 f"APPEAL_GEN_DIAG [gen_id={generation_id}] Zero appeals "
                 f"generated for denial {denial_id}, "
                 f"gen_attempts={denial.gen_attempts}, runt_count={runts}, "
+                f"dupe_count={dupes}, "
                 f"make_appeals_s={make_appeals_seconds:.1f}, "
                 f"first_model={first_model}, winning_stage={winning_stage}, "
                 f"shed_tier={shed_tier}, models_tried=[{models_tried}], "
@@ -4176,6 +4264,7 @@ class AppealsBackendHelper:
                 f"generated for denial {denial_id} "
                 f"(but {old} existing appeals found), "
                 f"gen_attempts={denial.gen_attempts}, runt_count={runts}, "
+                f"dupe_count={dupes}, "
                 f"make_appeals_s={make_appeals_seconds:.1f}, "
                 f"first_model={first_model}, winning_stage={winning_stage}, "
                 f"models_tried=[{models_tried}]{reserve_note}"

--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -2633,17 +2633,27 @@ class AppealsBackendHelper:
     # sufficient result with weaker drafts adds no value.
     ENOUGH_APPEALS = 3
 
-    # Deadline, measured from the start of the generation flow, after which a
-    # still-underdelivering run starts serving the speculative reserve instead
-    # of holding it to the very end. Research + make_appeals routinely run for
-    # minutes, and a reserve that only lands after all of it leaves the user
-    # staring at a spinner while a usable appeal sits in the DB. Past this mark
-    # every checkpoint in the flow (context gathering, the generating-phase
-    # heartbeats, the streaming loop) flushes what the reserve has, up to
-    # ENOUGH_APPEALS. Live drafts are unaffected: they are full-context rows and
-    # are always streamed as they arrive, so this only ever adds to what the
-    # user gets -- it never trades a good appeal for a speculative one.
-    SPECULATIVE_FALLBACK_SECONDS = 30.0
+    # Deadlines, measured from the start of the generation flow, after which a
+    # run starts serving the speculative reserve instead of holding it to the
+    # very end. Research + make_appeals routinely run for minutes, and a reserve
+    # that only lands after all of it leaves the user staring at a spinner while
+    # a usable appeal sits in the DB. Past the applicable mark, every checkpoint
+    # in the flow (context gathering, the generating-phase heartbeats, the
+    # streaming loop) flushes what the reserve has, up to ENOUGH_APPEALS.
+    #
+    # Two marks, because "nothing at all" and "fewer than we aim for" are
+    # different problems. Someone with an empty screen is rescued first; someone
+    # who already has an appeal in hand can afford to wait longer for the
+    # full-context drafts, which are better than anything the reserve holds.
+    #
+    # Live drafts are unaffected either way: they are full-context rows and are
+    # always streamed as they arrive, so this only ever adds to what the user
+    # gets -- it never trades a good appeal for a speculative one.
+    #
+    # No appeal delivered at all yet:
+    SPECULATIVE_FALLBACK_NO_APPEAL_SECONDS = 45.0
+    # At least one delivered, but still short of ENOUGH_APPEALS:
+    SPECULATIVE_FALLBACK_UNDER_TARGET_SECONDS = 90.0
 
     @classmethod
     async def generate_appeals(cls, parameters) -> AsyncIterator[str]:
@@ -2945,8 +2955,10 @@ class AppealsBackendHelper:
         logger.info(
             f"[gen_id={generation_id}] starting appeal generation for denial "
             f"{denial_id}: speculative reserve available at start="
-            f"{reserve_at_start} (existing appeals={old}, deadline="
-            f"{cls.SPECULATIVE_FALLBACK_SECONDS:.0f}s)"
+            f"{reserve_at_start} (existing appeals={old}, deadlines: "
+            f"{cls.SPECULATIVE_FALLBACK_NO_APPEAL_SECONDS:.0f}s with nothing "
+            f"delivered / {cls.SPECULATIVE_FALLBACK_UNDER_TARGET_SECONDS:.0f}s "
+            f"under {cls.ENOUGH_APPEALS})"
         )
 
         # Rows served early by serve_reserve_if_stalled, tracked by normalized
@@ -2959,27 +2971,40 @@ class AppealsBackendHelper:
         async def serve_reserve_if_stalled() -> AsyncIterator[str]:
             """Flush the speculative reserve once the run is over its deadline.
 
-            A no-op until SPECULATIVE_FALLBACK_SECONDS have passed, and a no-op
-            whenever the user already has ENOUGH_APPEALS -- so a run that is
-            delivering keeps its reserve held back exactly as before. Past the
-            deadline it serves the held-back precompute (oldest first), promoting
-            each row to speculative=False so it persists as a real appeal and a
-            later call serves it as existing -- the same promotion the end-of-flow
-            reconciliation does, just early enough to matter to someone watching
-            a spinner.
+            Which deadline applies depends on what the user is looking at right
+            now: with nothing delivered they are rescued at
+            SPECULATIVE_FALLBACK_NO_APPEAL_SECONDS; with at least one appeal in
+            hand but fewer than ENOUGH_APPEALS they can wait until
+            SPECULATIVE_FALLBACK_UNDER_TARGET_SECONDS for the full-context
+            drafts, which beat anything the reserve holds. At or above
+            ENOUGH_APPEALS this is a no-op, so a run that is delivering keeps
+            its reserve held back exactly as before.
+
+            Past the applicable mark it serves the held-back precompute (oldest
+            first), promoting each row to speculative=False so it persists as a
+            real appeal and a later call serves it as existing -- the same
+            promotion the end-of-flow reconciliation does, just early enough to
+            matter to someone watching a spinner.
 
             Callers invoke it at the checkpoints where the flow is already
             yielding (context gathering, generating-phase heartbeats, the
             streaming loop), so it costs one indexed query per checkpoint and
-            only once the deadline is behind us.
+            only once a deadline is behind us.
 
             Best-effort like the reconciliation: never raises, because a DB
             hiccup here must not kill a stream that is otherwise fine.
             """
             nonlocal new, reserve_served, reserve_notice_sent
-            if (new + old) >= cls.ENOUGH_APPEALS:
+            delivered = new + old
+            if delivered >= cls.ENOUGH_APPEALS:
                 return
-            if (time.monotonic() - flow_started) < cls.SPECULATIVE_FALLBACK_SECONDS:
+            if delivered == 0:
+                deadline = cls.SPECULATIVE_FALLBACK_NO_APPEAL_SECONDS
+                rule = f"no-appeal@{deadline:.0f}s"
+            else:
+                deadline = cls.SPECULATIVE_FALLBACK_UNDER_TARGET_SECONDS
+                rule = f"under-target@{deadline:.0f}s"
+            if (time.monotonic() - flow_started) < deadline:
                 return
             try:
                 # chosen=False: never hand the user their own pick back as a
@@ -3020,7 +3045,7 @@ class AppealsBackendHelper:
                         f"[gen_id={generation_id}] picked speculative reserve "
                         f"appeal {row.id} for denial {denial_id} after "
                         f"{time.monotonic() - flow_started:.1f}s "
-                        f"(new={new}, old={old}, "
+                        f"(rule={rule}, new={new}, old={old}, "
                         f"{'available at start' if reserve_at_start > 0 else 'arrived mid-generation'})"
                     )
             except Exception:

--- a/tests/async-unit/test_appeals_backend_citations.py
+++ b/tests/async-unit/test_appeals_backend_citations.py
@@ -107,31 +107,52 @@ def _make_empty_proposed_appeal_query():
     return mock_queryset
 
 
-def _make_proposed_appeal_query_with_texts(texts):
+def _make_proposed_appeal_query_with_texts(texts, existing_texts=None):
     """Create a queryset-like object that yields ProposedAppeal-like mocks
     each carrying one of the given appeal texts. Supports both:
       - `qs.all()` (used at common_view_logic.py:~2410)
       - `async for pa in qs` (used in the synthesis branch)
+
+    ``existing_texts`` overrides what `qs.all()` (the previously-saved appeals
+    served as `old` at the top of the flow) yields; it defaults to ``texts``,
+    i.e. every row was already there when the run started. Pass ``[]`` to model
+    a denial with no prior appeals, where ``texts`` are drafts this run saved
+    while streaming -- otherwise those drafts look like text already served and
+    the generator drops them as duplicates.
     """
-    pa_mocks = []
-    for text in texts:
-        pa = MagicMock()
-        pa.appeal_text = text
-        pa_mocks.append(pa)
+
+    def _mocks(values):
+        out = []
+        for text in values:
+            pa = MagicMock()
+            pa.appeal_text = text
+            out.append(pa)
+        return out
+
+    pa_mocks = _mocks(texts)
+    existing_mocks = pa_mocks if existing_texts is None else _mocks(existing_texts)
 
     class _Queryset:
-        def __init__(self, items):
+        def __init__(self, items, existing):
             self._items = items
+            self._existing = existing
 
-        def _gen(self):
+        def _gen(self, items=None):
             async def gen():
-                for item in self._items:
+                for item in self._items if items is None else items:
                     yield item
 
             return gen()
 
         def all(self):
-            return self._gen()
+            return self._gen(self._existing)
+
+        async def acount(self):
+            # The reserve-availability count at the start of generation. This
+            # fake ignores filter kwargs, so it cannot tell the speculative
+            # query from any other; none of these tests set up speculative
+            # rows, so report an empty reserve.
+            return 0
 
         def order_by(self, *args, **kwargs):
             # Mock ignores the sort key; the reconciliation query uses
@@ -141,7 +162,7 @@ def _make_proposed_appeal_query_with_texts(texts):
         def __aiter__(self):
             return self._gen()
 
-    return _Queryset(pa_mocks)
+    return _Queryset(pa_mocks, existing_mocks)
 
 
 def _sync_to_async_router(pa_wrapper, make_appeals_wrapper, uspstf_wrapper=None):
@@ -767,8 +788,10 @@ async def test_synthesis_skips_verbatim_duplicate():
             AsyncMock(return_value=[_ga(t) for t in saved_texts]),
         )
         mock_pa_cls.return_value = MagicMock(id=1, asave=AsyncMock())
+        # No prior appeals: saved_texts are the drafts THIS run streams, so the
+        # synthesis-input query sees them but the existing-appeals loop does not.
         mock_pa_cls.objects.filter.return_value = (
-            _make_proposed_appeal_query_with_texts(saved_texts)
+            _make_proposed_appeal_query_with_texts(saved_texts, existing_texts=[])
         )
         # Synthesizer returns a verbatim copy of the first saved draft —
         # the server must NOT yield it as a "new" appeal.

--- a/tests/async-unit/test_common_view_logic.py
+++ b/tests/async-unit/test_common_view_logic.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import io
+from contextlib import contextmanager
 from asgiref.sync import async_to_sync
 from unittest.mock import Mock, patch, AsyncMock
 from typing import AsyncIterator, List
@@ -43,6 +44,19 @@ class TestCommonViewLogic(TestCase):
             gen_attempts=gen_attempts,
         )
         return email, denial
+
+    @staticmethod
+    @contextmanager
+    def _capture_logs(level="INFO"):
+        """Capture loguru output for the duration of the block."""
+        from loguru import logger as loguru_logger
+
+        sink = io.StringIO()
+        handler_id = loguru_logger.add(sink, level=level)
+        try:
+            yield sink
+        finally:
+            loguru_logger.remove(handler_id)
 
     @staticmethod
     def _fast_keepalive():
@@ -1015,6 +1029,238 @@ class TestCommonViewLogic(TestCase):
                 self.assertEqual(done["new_appeals"], 1)
             finally:
                 await Denial.objects.filter(denial_id=23).adelete()
+
+        async_to_sync(test)()
+
+    @pytest.mark.django_db
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_logs_reserve_availability_at_start_and_when_picked(
+        self, mock_appeal_generator
+    ):
+        """A trace must show, up front, whether a reserve was available, and
+        again at the end whether the run actually leaned on it."""
+        email, denial = self._create_test_denial(26, gen_attempts=3)
+        ProposedAppeal.objects.create(
+            for_denial=denial,
+            appeal_text="The reserve draft this run is going to fall back on.",
+            speculative=True,
+            context_level="speculative",
+        )
+        mock_appeal_generator.make_appeals.return_value = iter([])
+
+        async def test():
+            try:
+                with self._capture_logs() as sink:
+                    await self.collect_appeal_responses(
+                        {
+                            "denial_id": 26,
+                            "email": email,
+                            "semi_sekret": denial.semi_sekret,
+                        }
+                    )
+                logs = sink.getvalue()
+                self.assertIn("speculative reserve available at start=1", logs)
+                self.assertIn("picked 1 appeal(s) from the speculative reserve", logs)
+                self.assertIn("available_at_start=1", logs)
+            finally:
+                await Denial.objects.filter(denial_id=26).adelete()
+
+        async_to_sync(test)()
+
+    @pytest.mark.django_db
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_logs_a_reserve_that_arrives_mid_generation(self, mock_appeal_generator):
+        """The precompute is a detached actor, so a reserve can land after the
+        run starts. That case must log start=0 and still report the pick."""
+        email, denial = self._create_test_denial(27, gen_attempts=3)
+
+        async def land_a_reserve_row(*args, **kwargs):
+            # Runs on the event loop after the start-of-generation count and
+            # before generation -- i.e. the precompute finishing mid-flight.
+            await ProposedAppeal.objects.acreate(
+                for_denial=denial,
+                appeal_text="A reserve draft that landed while we generated.",
+                speculative=True,
+                context_level="speculative",
+            )
+            return None
+
+        mock_appeal_generator.make_appeals.return_value = iter([])
+
+        async def test():
+            try:
+                with self._capture_logs() as sink, patch(
+                    "fighthealthinsurance.common_view_logic."
+                    "MLAppealContextHelper.maybe_summarize_denial_text",
+                    side_effect=land_a_reserve_row,
+                ), patch.object(
+                    AppealsBackendHelper, "SPECULATIVE_FALLBACK_SECONDS", 0.0
+                ):
+                    _, appeal_contents, _ = await self.collect_appeal_responses(
+                        {
+                            "denial_id": 27,
+                            "email": email,
+                            "semi_sekret": denial.semi_sekret,
+                        }
+                    )
+                logs = sink.getvalue()
+                self.assertIn("speculative reserve available at start=0", logs)
+                self.assertIn("arrived mid-generation", logs)
+                self.assertIn(
+                    "A reserve draft that landed while we generated.",
+                    appeal_contents,
+                )
+            finally:
+                await Denial.objects.filter(denial_id=27).adelete()
+
+        async_to_sync(test)()
+
+    @pytest.mark.django_db
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_logs_when_the_reserve_was_available_but_not_needed(
+        self, mock_appeal_generator
+    ):
+        """A held-back reserve on a run that delivered is worth saying out loud
+        too -- otherwise the only reserve signal in the logs is failure."""
+        email, denial = self._create_test_denial(28, gen_attempts=3)
+        ProposedAppeal.objects.create(
+            for_denial=denial,
+            appeal_text="A reserve draft this run will never need to use.",
+            speculative=True,
+            context_level="speculative",
+        )
+        mock_appeal_generator.make_appeals.return_value = iter(
+            self._live_drafts(
+                [
+                    f"A live appeal letter number {i} of sufficient length here."
+                    for i in range(3)
+                ]
+            )
+        )
+
+        async def test():
+            try:
+                with self._capture_logs() as sink:
+                    await self.collect_appeal_responses(
+                        {
+                            "denial_id": 28,
+                            "email": email,
+                            "semi_sekret": denial.semi_sekret,
+                        }
+                    )
+                logs = sink.getvalue()
+                self.assertIn("did NOT need the speculative reserve", logs)
+                self.assertIn("1 row(s) still held back", logs)
+            finally:
+                await Denial.objects.filter(denial_id=28).adelete()
+
+        async_to_sync(test)()
+
+    @pytest.mark.django_db
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_live_draft_matching_an_early_served_reserve_is_dropped(
+        self, mock_appeal_generator
+    ):
+        """The precompute runs the same internal models on the same denial, so a
+        live draft can come back identical to a reserve row already served. It
+        must not be streamed again: the client dedupes by content, so counting
+        it would make the done frame promise more appeals than are on screen."""
+        email, denial = self._create_test_denial(24, gen_attempts=3)
+        shared_text = "An appeal letter both the reserve and the live run produce."
+        ProposedAppeal.objects.create(
+            for_denial=denial,
+            appeal_text=shared_text,
+            speculative=True,
+            context_level="speculative",
+        )
+        mock_appeal_generator.make_appeals.return_value = iter(
+            self._live_drafts([shared_text])
+        )
+
+        async def test():
+            try:
+                with patch.object(
+                    AppealsBackendHelper, "SPECULATIVE_FALLBACK_SECONDS", 0.0
+                ):
+                    status_messages, appeal_contents, _ = (
+                        await self.collect_appeal_responses(
+                            {
+                                "denial_id": 24,
+                                "email": email,
+                                "semi_sekret": denial.semi_sekret,
+                            }
+                        )
+                    )
+                self.assertEqual(appeal_contents.count(shared_text), 1)
+                done = [m for m in status_messages if m.get("phase") == "done"][0]
+                self.assertEqual(
+                    done["new_appeals"],
+                    1,
+                    "the count must match what the client can actually show",
+                )
+            finally:
+                await Denial.objects.filter(denial_id=24).adelete()
+
+        async_to_sync(test)()
+
+    @pytest.mark.django_db
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_late_live_draft_is_not_counted_as_a_speculative_appeal(
+        self, mock_appeal_generator
+    ):
+        """The reconciliation also serves late FULL-context drafts. Those are
+        live generation, so they must not be attributed to the reserve in the
+        done frame's speculative_appeals count."""
+        email, denial = self._create_test_denial(25, gen_attempts=3)
+        late_text = "A late live draft that missed the streaming window here."
+        # Two existing drafts so the run reaches the synthesis step, which is
+        # where the late row is landed below.
+        for i in range(2):
+            ProposedAppeal.objects.create(
+                for_denial=denial,
+                appeal_text=f"An existing appeal draft number {i} of real length.",
+                speculative=False,
+                context_level="full",
+            )
+        mock_appeal_generator.make_appeals.return_value = iter([])
+
+        async def land_a_late_full_context_row(*args, **kwargs):
+            # Synthesis runs after the flow has snapshotted what it sent and
+            # before the reconciliation, so a row written here is one no yield
+            # path saw -- the late full-context draft the reconciliation's
+            # non-mini branch exists to pick up. Returns None (no synthesized
+            # text) so nothing else is added to the stream.
+            await ProposedAppeal.objects.acreate(
+                for_denial=denial,
+                appeal_text=late_text,
+                speculative=False,
+                context_level="full",
+            )
+            return None
+
+        mock_appeal_generator.synthesize_appeals = AsyncMock(
+            side_effect=land_a_late_full_context_row
+        )
+
+        async def test():
+            try:
+                status_messages, appeal_contents, _ = (
+                    await self.collect_appeal_responses(
+                        {
+                            "denial_id": 25,
+                            "email": email,
+                            "semi_sekret": denial.semi_sekret,
+                        }
+                    )
+                )
+                # The reconciliation served it (it is a real appeal nobody sent)...
+                self.assertIn(late_text, appeal_contents)
+                done = [m for m in status_messages if m.get("phase") == "done"][0]
+                self.assertEqual(done["new_appeals"], 1)
+                # ...but it is live generation, not reserve output.
+                self.assertEqual(done["speculative_appeals"], 0)
+            finally:
+                await Denial.objects.filter(denial_id=25).adelete()
 
         async_to_sync(test)()
 

--- a/tests/async-unit/test_common_view_logic.py
+++ b/tests/async-unit/test_common_view_logic.py
@@ -45,6 +45,53 @@ class TestCommonViewLogic(TestCase):
         return email, denial
 
     @staticmethod
+    def _fast_keepalive():
+        """Patch the generating-phase heartbeat cadence from 15s down to 50ms.
+
+        Returns a context manager. The real ``keepalive_frames`` still runs --
+        only the interval shrinks -- so tests that depend on heartbeat-driven
+        behavior (heartbeat frames, the speculative-fallback checkpoints that
+        ride on them) exercise the production code path without a 15s sleep.
+        """
+        from fighthealthinsurance import utils as _fhi_utils
+
+        real_keepalive = _fhi_utils.keepalive_frames
+
+        def fast_keepalive(task, *, interval=15.0, overall_timeout=None, **kwargs):
+            return real_keepalive(
+                task, interval=0.05, overall_timeout=overall_timeout, **kwargs
+            )
+
+        return patch(
+            "fighthealthinsurance.common_view_logic.keepalive_frames",
+            fast_keepalive,
+        )
+
+    @staticmethod
+    def _live_drafts(texts: List[str]) -> List[GeneratedAppeal]:
+        """Wrap plain strings as the GeneratedAppeal drafts make_appeals emits."""
+        return [
+            GeneratedAppeal(text=t, model_name="fhi-internal", context_level="full")
+            for t in texts
+        ]
+
+    @classmethod
+    def _slow_make_appeals(cls, seconds: float, texts: List[str]):
+        """A make_appeals side effect that blocks ``seconds`` then yields ``texts``.
+
+        The sleep runs in the database_sync_to_async threadpool, so it does NOT
+        block the event loop -- the generating-phase keepalive loop (and the
+        checkpoints on it) keep running meanwhile.
+        """
+        import time as _time
+
+        def slow_make_appeals(*args, **kwargs):
+            _time.sleep(seconds)
+            return iter(cls._live_drafts(texts))
+
+        return slow_make_appeals
+
+    @staticmethod
     async def collect_appeal_responses(data):
         """Collect all responses from generate_appeals into categorized lists."""
         status_messages = []
@@ -515,37 +562,15 @@ class TestCommonViewLogic(TestCase):
         """Regression for the silent-generation bug: while the blocking
         make_appeals runs, the generating phase must keep emitting status
         frames so the client's 90s inactivity watchdog never fires."""
-        import time as _time
-
-        from fighthealthinsurance import utils as _fhi_utils
-
         email, denial = self._create_test_denial(14, gen_attempts=3)
-
-        def slow_make_appeals(*args, **kwargs):
-            # Runs in a database_sync_to_async threadpool, so this sleep does
-            # NOT block the event loop -- the keepalive loop runs meanwhile.
-            _time.sleep(1.0)
-            return iter(
-                ["Dear Insurance Company, this is a sufficiently long appeal letter."]
-            )
-
-        mock_appeal_generator.make_appeals.side_effect = slow_make_appeals
-
-        real_keepalive = _fhi_utils.keepalive_frames
-
-        def fast_keepalive(task, *, interval=15.0, overall_timeout=None, **kwargs):
-            # Shrink the 15s cadence so the test doesn't have to sleep that long
-            # while still exercising the real keepalive_frames behavior.
-            return real_keepalive(
-                task, interval=0.05, overall_timeout=overall_timeout, **kwargs
-            )
+        mock_appeal_generator.make_appeals.side_effect = self._slow_make_appeals(
+            1.0,
+            ["Dear Insurance Company, this is a sufficiently long appeal letter."],
+        )
 
         async def test():
             try:
-                with patch(
-                    "fighthealthinsurance.common_view_logic.keepalive_frames",
-                    fast_keepalive,
-                ):
+                with self._fast_keepalive():
                     status_messages, _, _ = await self.collect_appeal_responses(
                         {
                             "denial_id": 14,
@@ -810,6 +835,186 @@ class TestCommonViewLogic(TestCase):
                 self.assertEqual(held, 2)
             finally:
                 await Denial.objects.filter(denial_id=18).adelete()
+
+        async_to_sync(test)()
+
+    @pytest.mark.django_db
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_reserve_is_served_before_a_slow_live_draft_past_the_deadline(
+        self, mock_appeal_generator
+    ):
+        """Once the run passes SPECULATIVE_FALLBACK_SECONDS while still short of
+        ENOUGH_APPEALS, the reserve is handed over mid-flight -- ahead of a live
+        draft that is still generating -- instead of being held to the end."""
+        email, denial = self._create_test_denial(20, gen_attempts=3)
+        spec = ProposedAppeal.objects.create(
+            for_denial=denial,
+            appeal_text="A reserve draft the user should get without waiting.",
+            speculative=True,
+            context_level="speculative",
+        )
+        live_text = "A slow live appeal letter that finishes much later on."
+        mock_appeal_generator.make_appeals.side_effect = self._slow_make_appeals(
+            1.5, [live_text]
+        )
+
+        async def test():
+            try:
+                with self._fast_keepalive(), patch.object(
+                    AppealsBackendHelper, "SPECULATIVE_FALLBACK_SECONDS", 0.5
+                ):
+                    status_messages, appeal_contents, _ = (
+                        await self.collect_appeal_responses(
+                            {
+                                "denial_id": 20,
+                                "email": email,
+                                "semi_sekret": denial.semi_sekret,
+                            }
+                        )
+                    )
+                reserve_text = "A reserve draft the user should get without waiting."
+                self.assertIn(reserve_text, appeal_contents)
+                self.assertIn(live_text, appeal_contents)
+                self.assertLess(
+                    appeal_contents.index(reserve_text),
+                    appeal_contents.index(live_text),
+                    f"reserve must arrive first, got: {appeal_contents}",
+                )
+                # Served rows are promoted, exactly as the end-of-flow path does.
+                await spec.arefresh_from_db()
+                self.assertFalse(spec.speculative)
+                done = [m for m in status_messages if m.get("phase") == "done"][0]
+                self.assertEqual(done["new_appeals"], 2)
+                self.assertEqual(done["speculative_appeals"], 1)
+            finally:
+                await Denial.objects.filter(denial_id=20).adelete()
+
+        async_to_sync(test)()
+
+    @pytest.mark.django_db
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_reserve_stays_held_back_before_the_deadline(self, mock_appeal_generator):
+        """A run that is still inside its deadline keeps the reserve held back:
+        the early fallback only fires for runs that are actually stalling."""
+        email, denial = self._create_test_denial(21, gen_attempts=3)
+        ProposedAppeal.objects.create(
+            for_denial=denial,
+            appeal_text="A reserve draft that must not be served early here.",
+            speculative=True,
+            context_level="speculative",
+        )
+        live_texts = [
+            f"A live appeal letter number {i} of sufficient length here."
+            for i in range(3)
+        ]
+        mock_appeal_generator.make_appeals.return_value = iter(
+            self._live_drafts(live_texts)
+        )
+
+        async def test():
+            try:
+                # The default 30s deadline is far beyond this fast run, so the
+                # reserve is never reached: the live drafts cover the user.
+                _, appeal_contents, _ = await self.collect_appeal_responses(
+                    {
+                        "denial_id": 21,
+                        "email": email,
+                        "semi_sekret": denial.semi_sekret,
+                    }
+                )
+                self.assertNotIn(
+                    "A reserve draft that must not be served early here.",
+                    appeal_contents,
+                )
+                spec = await ProposedAppeal.objects.aget(
+                    for_denial=denial, speculative=True
+                )
+                self.assertTrue(spec.speculative)
+            finally:
+                await Denial.objects.filter(denial_id=21).adelete()
+
+        async_to_sync(test)()
+
+    @pytest.mark.django_db
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_early_served_reserve_is_not_fed_to_synthesis(self, mock_appeal_generator):
+        """Promotion flips an early-served reserve row to speculative=False, but
+        it must still not count toward the >=2 synthesis gate -- synthesizing
+        the reduced-context precompute with itself is what that gate excludes."""
+        email, denial = self._create_test_denial(22, gen_attempts=3)
+        for i in range(2):
+            ProposedAppeal.objects.create(
+                for_denial=denial,
+                appeal_text=f"Reserve draft number {i} with plenty of length here.",
+                speculative=True,
+                context_level="speculative",
+            )
+        # Live generation delivers nothing, so the only rows are the reserve.
+        mock_appeal_generator.make_appeals.return_value = iter([])
+
+        async def test():
+            try:
+                with patch.object(
+                    AppealsBackendHelper, "SPECULATIVE_FALLBACK_SECONDS", 0.0
+                ):
+                    status_messages, _, _ = await self.collect_appeal_responses(
+                        {
+                            "denial_id": 22,
+                            "email": email,
+                            "semi_sekret": denial.semi_sekret,
+                        }
+                    )
+                mock_appeal_generator.synthesize_appeals.assert_not_called()
+                self.assertEqual(
+                    [m for m in status_messages if m.get("phase") == "synthesizing"],
+                    [],
+                )
+            finally:
+                await Denial.objects.filter(denial_id=22).adelete()
+
+        async_to_sync(test)()
+
+    @pytest.mark.django_db
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_early_served_reserve_is_not_re_served_at_end_of_flow(
+        self, mock_appeal_generator
+    ):
+        """The end-of-flow reconciliation must not ship a reserve row the early
+        fallback already sent (both paths dedupe through the same served set)."""
+        email, denial = self._create_test_denial(23, gen_attempts=3)
+        ProposedAppeal.objects.create(
+            for_denial=denial,
+            appeal_text="The one and only reserve draft for this denial here.",
+            speculative=True,
+            context_level="speculative",
+        )
+        mock_appeal_generator.make_appeals.return_value = iter([])
+
+        async def test():
+            try:
+                with patch.object(
+                    AppealsBackendHelper, "SPECULATIVE_FALLBACK_SECONDS", 0.0
+                ):
+                    status_messages, appeal_contents, _ = (
+                        await self.collect_appeal_responses(
+                            {
+                                "denial_id": 23,
+                                "email": email,
+                                "semi_sekret": denial.semi_sekret,
+                            }
+                        )
+                    )
+                self.assertEqual(
+                    appeal_contents.count(
+                        "The one and only reserve draft for this denial here."
+                    ),
+                    1,
+                    f"reserve draft sent more than once: {appeal_contents}",
+                )
+                done = [m for m in status_messages if m.get("phase") == "done"][0]
+                self.assertEqual(done["new_appeals"], 1)
+            finally:
+                await Denial.objects.filter(denial_id=23).adelete()
 
         async_to_sync(test)()
 

--- a/tests/async-unit/test_common_view_logic.py
+++ b/tests/async-unit/test_common_view_logic.py
@@ -857,7 +857,7 @@ class TestCommonViewLogic(TestCase):
     def test_reserve_is_served_before_a_slow_live_draft_past_the_deadline(
         self, mock_appeal_generator
     ):
-        """Once the run passes SPECULATIVE_FALLBACK_SECONDS while still short of
+        """Once a run with nothing delivered passes the no-appeal deadline while short of
         ENOUGH_APPEALS, the reserve is handed over mid-flight -- ahead of a live
         draft that is still generating -- instead of being held to the end."""
         email, denial = self._create_test_denial(20, gen_attempts=3)
@@ -875,7 +875,7 @@ class TestCommonViewLogic(TestCase):
         async def test():
             try:
                 with self._fast_keepalive(), patch.object(
-                    AppealsBackendHelper, "SPECULATIVE_FALLBACK_SECONDS", 0.5
+                    AppealsBackendHelper, "SPECULATIVE_FALLBACK_NO_APPEAL_SECONDS", 0.5
                 ):
                     status_messages, appeal_contents, _ = (
                         await self.collect_appeal_responses(
@@ -907,6 +907,121 @@ class TestCommonViewLogic(TestCase):
 
     @pytest.mark.django_db
     @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_reserve_lands_under_target_once_the_longer_deadline_passes(
+        self, mock_appeal_generator
+    ):
+        """A user holding one appeal is not empty-handed, so the reserve waits
+        for the longer under-target deadline -- but once that passes while still
+        short of ENOUGH_APPEALS, it lands rather than waiting out the run."""
+        email, denial = self._create_test_denial(29, gen_attempts=3)
+        # One appeal already on screen -> the no-appeal rule does not apply.
+        ProposedAppeal.objects.create(
+            for_denial=denial,
+            appeal_text="The one appeal this user already has in hand now.",
+            speculative=False,
+            context_level="full",
+        )
+        ProposedAppeal.objects.create(
+            for_denial=denial,
+            appeal_text="A reserve draft for a run that stays under target.",
+            speculative=True,
+            context_level="speculative",
+        )
+        live_text = "A slow live appeal letter that finishes much later on."
+        mock_appeal_generator.make_appeals.side_effect = self._slow_make_appeals(
+            1.5, [live_text]
+        )
+
+        async def test():
+            try:
+                with self._fast_keepalive(), patch.object(
+                    AppealsBackendHelper,
+                    "SPECULATIVE_FALLBACK_UNDER_TARGET_SECONDS",
+                    0.5,
+                ):
+                    status_messages, appeal_contents, _ = (
+                        await self.collect_appeal_responses(
+                            {
+                                "denial_id": 29,
+                                "email": email,
+                                "semi_sekret": denial.semi_sekret,
+                            }
+                        )
+                    )
+                reserve_text = "A reserve draft for a run that stays under target."
+                self.assertIn(reserve_text, appeal_contents)
+                self.assertLess(
+                    appeal_contents.index(reserve_text),
+                    appeal_contents.index(live_text),
+                    f"reserve must arrive before the slow live draft, got: "
+                    f"{appeal_contents}",
+                )
+                done = [m for m in status_messages if m.get("phase") == "done"][0]
+                self.assertEqual(done["speculative_appeals"], 1)
+            finally:
+                await Denial.objects.filter(denial_id=29).adelete()
+
+        async_to_sync(test)()
+
+    @pytest.mark.django_db
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_no_appeal_deadline_does_not_apply_once_one_appeal_is_in_hand(
+        self, mock_appeal_generator
+    ):
+        """The short deadline is the empty-screen rescue only. With an appeal
+        already delivered, passing it must NOT flush the reserve -- that run
+        waits for the longer under-target deadline instead."""
+        email, denial = self._create_test_denial(30, gen_attempts=3)
+        ProposedAppeal.objects.create(
+            for_denial=denial,
+            appeal_text="The one appeal this user already has in hand now.",
+            speculative=False,
+            context_level="full",
+        )
+        ProposedAppeal.objects.create(
+            for_denial=denial,
+            appeal_text="A reserve draft that the short deadline must not send.",
+            speculative=True,
+            context_level="speculative",
+        )
+        mock_appeal_generator.make_appeals.side_effect = self._slow_make_appeals(
+            1.0, []
+        )
+
+        async def test():
+            try:
+                # Short deadline already past, long deadline unreachable.
+                with self._fast_keepalive(), patch.object(
+                    AppealsBackendHelper, "SPECULATIVE_FALLBACK_NO_APPEAL_SECONDS", 0.0
+                ), patch.object(
+                    AppealsBackendHelper,
+                    "SPECULATIVE_FALLBACK_UNDER_TARGET_SECONDS",
+                    3600.0,
+                ):
+                    status_messages, _, _ = await self.collect_appeal_responses(
+                        {
+                            "denial_id": 30,
+                            "email": email,
+                            "semi_sekret": denial.semi_sekret,
+                        }
+                    )
+                # The mid-flight flush announces itself; the end-of-flow
+                # reconciliation (which still serves the reserve) does not.
+                self.assertEqual(
+                    [
+                        m
+                        for m in status_messages
+                        if "Sending a draft appeal now" in m.get("message", "")
+                    ],
+                    [],
+                )
+            finally:
+                await Denial.objects.filter(denial_id=30).adelete()
+
+        async_to_sync(test)()
+
+    @pytest.mark.django_db
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
     def test_reserve_stays_held_back_before_the_deadline(self, mock_appeal_generator):
         """A run that is still inside its deadline keeps the reserve held back:
         the early fallback only fires for runs that are actually stalling."""
@@ -927,7 +1042,7 @@ class TestCommonViewLogic(TestCase):
 
         async def test():
             try:
-                # The default 30s deadline is far beyond this fast run, so the
+                # The default deadlines are far beyond this fast run, so the
                 # reserve is never reached: the live drafts cover the user.
                 _, appeal_contents, _ = await self.collect_appeal_responses(
                     {
@@ -969,7 +1084,7 @@ class TestCommonViewLogic(TestCase):
         async def test():
             try:
                 with patch.object(
-                    AppealsBackendHelper, "SPECULATIVE_FALLBACK_SECONDS", 0.0
+                    AppealsBackendHelper, "SPECULATIVE_FALLBACK_NO_APPEAL_SECONDS", 0.0
                 ):
                     status_messages, _, _ = await self.collect_appeal_responses(
                         {
@@ -1007,7 +1122,7 @@ class TestCommonViewLogic(TestCase):
         async def test():
             try:
                 with patch.object(
-                    AppealsBackendHelper, "SPECULATIVE_FALLBACK_SECONDS", 0.0
+                    AppealsBackendHelper, "SPECULATIVE_FALLBACK_NO_APPEAL_SECONDS", 0.0
                 ):
                     status_messages, appeal_contents, _ = (
                         await self.collect_appeal_responses(
@@ -1094,7 +1209,7 @@ class TestCommonViewLogic(TestCase):
                     "MLAppealContextHelper.maybe_summarize_denial_text",
                     side_effect=land_a_reserve_row,
                 ), patch.object(
-                    AppealsBackendHelper, "SPECULATIVE_FALLBACK_SECONDS", 0.0
+                    AppealsBackendHelper, "SPECULATIVE_FALLBACK_NO_APPEAL_SECONDS", 0.0
                 ):
                     _, appeal_contents, _ = await self.collect_appeal_responses(
                         {
@@ -1180,7 +1295,7 @@ class TestCommonViewLogic(TestCase):
         async def test():
             try:
                 with patch.object(
-                    AppealsBackendHelper, "SPECULATIVE_FALLBACK_SECONDS", 0.0
+                    AppealsBackendHelper, "SPECULATIVE_FALLBACK_NO_APPEAL_SECONDS", 0.0
                 ):
                     status_messages, appeal_contents, _ = (
                         await self.collect_appeal_responses(


### PR DESCRIPTION
The speculative precompute was only ever reachable at the very end of
generate_appeals, after research, make_appeals (up to a 360s budget) and
synthesis had all run. A user whose live generation stalled therefore sat
on a spinner for minutes while a usable appeal was already sitting in the
DB, held back by design.

Add a deadline: SPECULATIVE_FALLBACK_SECONDS (30s), measured from the
start of the flow, after which any run still under ENOUGH_APPEALS flushes
the held-back reserve as it goes. The check runs at the points where the
flow already yields -- after research/enrichment, on each generating-phase
heartbeat, and between streamed drafts -- so a stalled backend costs the
user at most one heartbeat interval past the mark, and a reserve that
lands mid-flight is picked up as soon as it exists.

Rows served this way are promoted to speculative=False exactly as the
end-of-flow reconciliation promotes them. Live drafts are unaffected:
full-context rows still stream as they arrive, so this only ever adds to
what the user gets.

Supporting changes:
- served_texts is now tracked from the top of the flow (existing rows,
  streamed drafts, early flush) instead of being rebuilt from the DB at
  synthesis time, so no path can ship the same text twice -- including a
  draft whose row write failed.
- Early-served reserve rows are excluded from the synthesis inputs by
  text, since promotion would otherwise let the precompute reach the >=2
  synthesis gate that the speculative filter exists to prevent.
- live_new subtracts the early-served count so the zero-appeal
  APPEAL_GEN_DIAG still fires when the reserve rescued a failed run, and
  the done frame reports speculative_appeals.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01K39Ke9Z2GNBpLvB3zJSHvJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Speculative appeals can now be delivered earlier when generating live appeals takes too long.
  * Streaming results are deduplicated to prevent repeated appeals.
  * Final status information now more accurately reports appeals delivered from the reserve.

* **Bug Fixes**
  * Prevented reserve appeals from being resent during synthesis or final reconciliation.
  * Improved delivery reliability during slow generation and streaming periods.

* **Tests**
  * Added coverage for reserve timing, deduplication, synthesis handling, and reconciliation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->