### PR TITLE
Filter wordless appeals alongside too-short ones

### DIFF
--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -91,7 +91,7 @@ from fighthealthinsurance.utils import (
     keepalive_frames,
     MIN_APPEAL_CHARS,
     sync_iterator_to_async,
-    warn_too_short_appeal,
+    warn_unusable_appeal,
 )
 from .clinicaltrials_tools import ClinicalTrialsTools
 from .pubmed_tools import PubMedTools
@@ -2917,10 +2917,10 @@ class AppealsBackendHelper:
         old = 0
         new = 0
         async for appeal in existing_appeals:
-            # Enforce the minimum-length rule on previously-saved appeals too:
-            # the DB may hold short drafts saved before this threshold existed
-            # (or by paths that skipped the filter), and we must not re-deliver
-            # them.
+            # Enforce the deliverability rules on previously-saved appeals too:
+            # the DB may hold short or letterless drafts saved before those
+            # checks existed (or by paths that skipped the filter), and we must
+            # not re-deliver them.
             if is_real_appeal(appeal.appeal_text):
                 old = old + 1
                 logger.debug(f"Found existing appeal {appeal}, yielding")
@@ -2930,7 +2930,7 @@ class AppealsBackendHelper:
                 )
                 yield await format_response(existing_appeal_dict)
             elif appeal.appeal_text is not None and str(appeal.appeal_text).strip():
-                warn_too_short_appeal(
+                warn_unusable_appeal(
                     appeal.appeal_text,
                     f"saved appeal id={appeal.id} for denial {denial_id}",
                 )
@@ -3921,9 +3921,9 @@ class AppealsBackendHelper:
                 f"{summarize_denial_context_tokens(denial)}"
             )
             appeals = iter([])
-        # Drop None / empty / whitespace / runt outputs. Track runts so the
-        # zero-appeal diagnostic can distinguish "models silent" from
-        # "models producing only short strings".
+        # Drop None / empty / whitespace / runt / letterless outputs. Track the
+        # rejects so the zero-appeal diagnostic can distinguish "models silent"
+        # from "models producing only undeliverable strings".
         runts = 0
         dupes = 0
 
@@ -3957,7 +3957,7 @@ class AppealsBackendHelper:
                 return True
             if isinstance(text, str) and text.strip():
                 runts += 1
-                warn_too_short_appeal(
+                warn_unusable_appeal(
                     text,
                     f"model={item.model_name!r} for denial {denial_id}",
                 )
@@ -4094,10 +4094,11 @@ class AppealsBackendHelper:
                 else:
                     synthesized = synthesis_task.result()
                     if synthesized and not is_real_appeal(synthesized):
-                        # Non-empty but below the deliverable threshold: filter
-                        # it out so synthesis can't bypass the minimum-length
-                        # rule that the streaming path enforces.
-                        warn_too_short_appeal(
+                        # Non-empty but not deliverable (too short, or nothing
+                        # but numbers and punctuation): filter it out so
+                        # synthesis can't bypass the rules the streaming path
+                        # enforces.
+                        warn_unusable_appeal(
                             synthesized,
                             f"synthesis output for denial {denial_id}",
                         )
@@ -4231,8 +4232,9 @@ class AppealsBackendHelper:
                 f"(new={new}, old={old})"
             )
 
-        # runt_count=0 means models were silent; >0 means models produced
-        # only too-short outputs — different root causes for incident review.
+        # runt_count=0 means models were silent; >0 means models produced only
+        # undeliverable outputs (too short, or nothing but numbers and
+        # punctuation) — different root causes for incident review.
         shed_tier = make_appeals_diag.get("shed_tier")
         winning_stage = make_appeals_diag.get("winning_stage")
         models_tried = make_appeals_diag.get("models_tried") or "none"

--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -3091,8 +3091,19 @@ class AppealsBackendHelper:
                     normalized = str(row.appeal_text).strip()
                     if normalized in served_texts:
                         continue
+                    # Claim the row atomically. served_texts is per-run, so it
+                    # cannot dedupe against a concurrent flow -- and a reconnect
+                    # makes exactly that overlap likely, since the dropped
+                    # socket's generator can still be draining server-side while
+                    # the replacement flushes the reserve. Both would otherwise
+                    # select and serve the same held-back draft; the client
+                    # dedupes by content, so the done frame would promise more
+                    # appeals than are on screen. The loser of the race skips.
+                    if not await ProposedAppeal.objects.filter(
+                        pk=row.pk, speculative=True, chosen=False
+                    ).aupdate(speculative=False):
+                        continue
                     row.speculative = False
-                    await row.asave(update_fields=["speculative"])
                     if not reserve_notice_sent:
                         reserve_notice_sent = True
                         yield json.dumps(
@@ -4110,8 +4121,8 @@ class AppealsBackendHelper:
         # exactly what that filter is there to prevent.
         saved_appeal_texts: list[str] = [
             str(pa.appeal_text)
-            async for pa in ProposedAppeal.objects.filter(
-                for_denial=denial, speculative=False
+            async for pa in deliverable_candidates(
+                ProposedAppeal.objects.filter(for_denial=denial, speculative=False)
             )
             if is_real_appeal(pa.appeal_text)
             and str(pa.appeal_text).strip() not in early_reserve_texts
@@ -4290,9 +4301,14 @@ class AppealsBackendHelper:
                 )
                 if row.speculative:
                     # Promote to a real appeal so it persists and later calls
-                    # serve it as existing.
+                    # serve it as existing. Claimed atomically for the same
+                    # reason as the early flush above: a concurrent run must not
+                    # serve the same held-back draft, and the loser skips it.
+                    if not await ProposedAppeal.objects.filter(
+                        pk=row.pk, speculative=True, chosen=False
+                    ).aupdate(speculative=False):
+                        continue
                     row.speculative = False
-                    await row.asave(update_fields=["speculative"])
                 row_dict = await sub_in_appeals({"id": str(row.id), "content": text})
                 yield await format_response(row_dict)
                 served_texts.add(normalized)

--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -2918,7 +2918,7 @@ class AppealsBackendHelper:
         new = 0
         async for appeal in existing_appeals:
             # Enforce the deliverability rules on previously-saved appeals too:
-            # the DB may hold short or letterless drafts saved before those
+            # the DB may hold short or wordless drafts saved before those
             # checks existed (or by paths that skipped the filter), and we must
             # not re-deliver them.
             if is_real_appeal(appeal.appeal_text):
@@ -3921,7 +3921,7 @@ class AppealsBackendHelper:
                 f"{summarize_denial_context_tokens(denial)}"
             )
             appeals = iter([])
-        # Drop None / empty / whitespace / runt / letterless outputs. Track the
+        # Drop None / empty / whitespace / runt / wordless outputs. Track the
         # rejects so the zero-appeal diagnostic can distinguish "models silent"
         # from "models producing only undeliverable strings".
         runts = 0
@@ -4094,8 +4094,8 @@ class AppealsBackendHelper:
                 else:
                     synthesized = synthesis_task.result()
                     if synthesized and not is_real_appeal(synthesized):
-                        # Non-empty but not deliverable (too short, or nothing
-                        # but numbers and punctuation): filter it out so
+                        # Non-empty but not deliverable (too short, or not
+                        # made of words): filter it out so
                         # synthesis can't bypass the rules the streaming path
                         # enforces.
                         warn_unusable_appeal(
@@ -4233,8 +4233,8 @@ class AppealsBackendHelper:
             )
 
         # runt_count=0 means models were silent; >0 means models produced only
-        # undeliverable outputs (too short, or nothing but numbers and
-        # punctuation) — different root causes for incident review.
+        # undeliverable outputs (too short, or not made of words) —
+        # different root causes for incident review.
         shed_tier = make_appeals_diag.get("shed_tier")
         winning_stage = make_appeals_diag.get("winning_stage")
         models_tried = make_appeals_diag.get("models_tried") or "none"

--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -36,6 +36,7 @@ from django.core.files import File
 from django.core.mail import send_mail
 from django.core.validators import validate_email
 from django.db.models import F, Q, QuerySet
+from django.db.models.functions import Length
 from django.forms import Form
 from django.template.loader import render_to_string
 from django.urls import reverse
@@ -2621,6 +2622,31 @@ def _uspstf_context_getter_factory() -> typing.Callable[[Any], Optional[str]]:
     return get_uspstf_context_for_denial
 
 
+def deliverable_candidates(qs: QuerySet) -> QuerySet:
+    """Narrow a ProposedAppeal queryset to rows that could be deliverable.
+
+    The DB-side half of the deliverability rule, applied BEFORE anything
+    counts, gates on, or decides what to do with these rows -- so a reserve
+    holding nothing but junk reads as the empty reserve it effectively is,
+    rather than as rows we are about to serve.
+
+    Only the cheap half pushes into SQL: a raw character count is an upper
+    bound on ``meaningful_appeal_length`` (whitespace and control characters
+    only ever subtract), so anything shorter than ``MIN_APPEAL_CHARS`` raw can
+    never pass and is not worth fetching. The word rule can't be expressed in
+    SQL, so ``is_real_appeal`` stays the authority and still runs on every row
+    AFTER this, immediately before it is served.
+    """
+    # Annotated rather than returned directly: django-stubs types the alias()
+    # chain as Any, which trips --warn-return-any.
+    narrowed: QuerySet = (
+        qs.exclude(appeal_text__isnull=True)
+        .alias(_appeal_len=Length("appeal_text"))
+        .filter(_appeal_len__gte=MIN_APPEAL_CHARS)
+    )
+    return narrowed
+
+
 class AppealsBackendHelper:
     regex_denial_processor = ProcessDenialRegex()
     pmt = PubMedTools()
@@ -2941,13 +2967,24 @@ class AppealsBackendHelper:
         # net -- and so the "we served the reserve" logs below can say whether
         # those rows were waiting all along or landed while we generated (the
         # precompute is a detached actor and finishes on its own schedule).
+        #
+        # Counts only rows that could actually be served: a reserve of runts or
+        # identifier-echo junk is no safety net at all, and reporting it as one
+        # would send an incident review looking for a fallback that could never
+        # have fired. The reserve caps at MAX_SPECULATIVE_APPEALS rows, so
+        # applying the full is_real_appeal rule here costs a handful of short
+        # reads rather than a COUNT(*).
         # Best-effort: a failed count must not take the generation down with it.
         reserve_at_start = -1
         try:
-            reserve_at_start = await ProposedAppeal.objects.filter(
-                for_denial=denial, speculative=True
-            ).acount()
+            reserve_at_start = 0
+            async for _row in deliverable_candidates(
+                ProposedAppeal.objects.filter(for_denial=denial, speculative=True)
+            ).only("appeal_text"):
+                if is_real_appeal(_row.appeal_text):
+                    reserve_at_start += 1
         except Exception:
+            reserve_at_start = -1
             logger.opt(exception=True).warning(
                 f"[gen_id={generation_id}] could not count the speculative "
                 f"reserve for denial {denial_id}"
@@ -3009,8 +3046,14 @@ class AppealsBackendHelper:
             try:
                 # chosen=False: never hand the user their own pick back as a
                 # new appeal (see the same filter in the reconciliation).
-                async for row in ProposedAppeal.objects.filter(
-                    for_denial=denial, speculative=True, chosen=False
+                # deliverable_candidates keeps junk out of the loop entirely, so
+                # it can't reach the ENOUGH_APPEALS check below and can't be the
+                # row we stop on; is_real_appeal then re-checks each survivor,
+                # since the word rule doesn't fit in SQL.
+                async for row in deliverable_candidates(
+                    ProposedAppeal.objects.filter(
+                        for_denial=denial, speculative=True, chosen=False
+                    )
                 ).order_by("id"):
                     if (new + old) >= cls.ENOUGH_APPEALS:
                         break
@@ -4184,8 +4227,8 @@ class AppealsBackendHelper:
             # another request mid-stream lands a chosen row (for an editted one,
             # text the user wrote, which was never a draft) in between that
             # query and this one, leaving it absent from served_texts.
-            async for row in ProposedAppeal.objects.filter(
-                for_denial=denial, chosen=False
+            async for row in deliverable_candidates(
+                ProposedAppeal.objects.filter(for_denial=denial, chosen=False)
             ).order_by("id"):
                 text = row.appeal_text
                 if not is_real_appeal(text):

--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -2697,6 +2697,15 @@ class AppealsBackendHelper:
         hashed_email = Denial.get_hashed_email(email)
         # Extract the professional_to_finish parameter from the input, default to False
         professional_to_finish = parameters.get("professional_to_finish", False)
+        # Set by the JS client when this socket replaces one that dropped (see
+        # ws.onopen in appeal_fetcher.ts). Such a user has already waited out a
+        # broken connection on top of whatever generation has cost so far, and
+        # a fresh flow restarts flow_started at zero -- so the reserve's
+        # deadlines would make them wait the full 45s/90s all over again. On a
+        # reconnect the reserve goes out as soon as we know they are short of
+        # ENOUGH_APPEALS. Absent (REST, older clients) means False, i.e. the
+        # deadline behaviour is unchanged.
+        is_reconnect = bool(parameters.get("reconnect", False))
         # Medical reason provided?
         medical_reasons = set()
         if (
@@ -2993,9 +3002,17 @@ class AppealsBackendHelper:
             f"[gen_id={generation_id}] starting appeal generation for denial "
             f"{denial_id}: speculative reserve available at start="
             f"{reserve_at_start} (existing appeals={old}, deadlines: "
-            f"{cls.SPECULATIVE_FALLBACK_NO_APPEAL_SECONDS:.0f}s with nothing "
-            f"delivered / {cls.SPECULATIVE_FALLBACK_UNDER_TARGET_SECONDS:.0f}s "
-            f"under {cls.ENOUGH_APPEALS})"
+            + (
+                "waived, reconnect"
+                if is_reconnect
+                else (
+                    f"{cls.SPECULATIVE_FALLBACK_NO_APPEAL_SECONDS:.0f}s with "
+                    f"nothing delivered / "
+                    f"{cls.SPECULATIVE_FALLBACK_UNDER_TARGET_SECONDS:.0f}s "
+                    f"under {cls.ENOUGH_APPEALS}"
+                )
+            )
+            + ")"
         )
 
         # Rows served early by serve_reserve_if_stalled, tracked by normalized
@@ -3017,6 +3034,12 @@ class AppealsBackendHelper:
             ENOUGH_APPEALS this is a no-op, so a run that is delivering keeps
             its reserve held back exactly as before.
 
+            On a WS reconnect neither deadline applies: the wait this run
+            measures started when the replacement socket opened, so honouring
+            it would make someone who already lost a connection start their
+            45s/90s over. There, being under ENOUGH_APPEALS is the whole
+            condition and the reserve goes out at the first checkpoint.
+
             Past the applicable mark it serves the held-back precompute (oldest
             first), promoting each row to speculative=False so it persists as a
             real appeal and a later call serves it as existing -- the same
@@ -3035,14 +3058,20 @@ class AppealsBackendHelper:
             delivered = new + old
             if delivered >= cls.ENOUGH_APPEALS:
                 return
-            if delivered == 0:
-                deadline = cls.SPECULATIVE_FALLBACK_NO_APPEAL_SECONDS
-                rule = f"no-appeal@{deadline:.0f}s"
+            if is_reconnect:
+                # No deadline on a reconnect: this run's clock started when the
+                # replacement socket opened, but the user's wait didn't. Being
+                # under ENOUGH_APPEALS is the whole condition.
+                rule = "reconnect"
             else:
-                deadline = cls.SPECULATIVE_FALLBACK_UNDER_TARGET_SECONDS
-                rule = f"under-target@{deadline:.0f}s"
-            if (time.monotonic() - flow_started) < deadline:
-                return
+                if delivered == 0:
+                    deadline = cls.SPECULATIVE_FALLBACK_NO_APPEAL_SECONDS
+                    rule = f"no-appeal@{deadline:.0f}s"
+                else:
+                    deadline = cls.SPECULATIVE_FALLBACK_UNDER_TARGET_SECONDS
+                    rule = f"under-target@{deadline:.0f}s"
+                if (time.monotonic() - flow_started) < deadline:
+                    return
             try:
                 # chosen=False: never hand the user their own pick back as a
                 # new appeal (see the same filter in the reconciliation).
@@ -3097,6 +3126,14 @@ class AppealsBackendHelper:
                     f"for denial {denial_id}; the end-of-flow reconciliation "
                     f"remains as the backstop"
                 )
+
+        # First checkpoint, placed before research/generation rather than after
+        # them: on a reconnect this fires immediately (no deadline to wait out),
+        # so a user whose socket dropped gets the reserve in their first frames
+        # instead of sitting through the whole flow again. On an ordinary run
+        # nothing is past its deadline this early, so it is a no-op.
+        async for _spec in serve_reserve_if_stalled():
+            yield _spec
 
         # Yield status after any previously saved appeals have been sent
         yield json.dumps(

--- a/fighthealthinsurance/generate_appeal.py
+++ b/fighthealthinsurance/generate_appeal.py
@@ -60,7 +60,12 @@ from .payer_policy_helper import (
 )
 from .process_denial import ProcessDenialRegex
 from .pubmed_tools import PubMedTools
-from .utils import as_available_nested, best_within_timelimit, is_real_appeal
+from .utils import (
+    as_available_nested,
+    best_within_timelimit,
+    describe_unusable_appeal,
+    is_real_appeal,
+)
 
 
 class AppealTemplateGenerator(object):
@@ -1240,15 +1245,15 @@ def _peek_real_or_none(
     it: Iterator["GeneratedAppeal"], denial_id: Any, stage: str
 ) -> Tuple[Optional["GeneratedAppeal"], Iterator["GeneratedAppeal"]]:
     """Like _peek_or_none, but returns (None, _) when the first item is
-    non-None but fails is_real_appeal. Without this, a runt first item
+    non-None but fails is_real_appeal. Without this, an unusable first item
     would suppress the fallback path even though downstream filtering
     drops it — leading to zero deliverable appeals."""
     first, it = _peek_or_none(it)
     if first is not None and not is_real_appeal(first.text):
-        first_len = len(first.text.strip()) if isinstance(first.text, str) else 0
         logger.warning(
-            f"make_appeals: {stage} first item is a runt (len={first_len}) "
-            f"for denial {denial_id}; treating as empty to trigger fallback"
+            f"make_appeals: {stage} first item is unusable "
+            f"({describe_unusable_appeal(first.text)}) for denial {denial_id}; "
+            f"treating as empty to trigger fallback"
         )
         return None, it
     return first, it

--- a/fighthealthinsurance/static/js/appeal_fetcher.ts
+++ b/fighthealthinsurance/static/js/appeal_fetcher.ts
@@ -1388,7 +1388,13 @@ function connectWebSocket(
     ws.onopen = () => {
       console.log("WebSocket connection opened");
       updateStatusIndicator('connected', appealsSoFar.length);
-      ws.send(JSON.stringify(data));
+      // Tell the server this socket is a reconnect (retries is only non-zero
+      // after scheduleReconnect, and resets for a fresh query). Someone who
+      // has already lost a socket has been waiting through a dropped
+      // connection on top of the generation itself, so the server hands over
+      // the speculative reserve immediately instead of holding it for its
+      // usual deadline -- as long as they are still short of a full set.
+      ws.send(JSON.stringify({ ...data, reconnect: retries > 0 }));
       // Arm the inactivity timer now, not just on the first message: a
       // socket the server accepts but never replies on would otherwise
       // have no timeout, no error and no close — i.e. spin forever.

--- a/fighthealthinsurance/static/js/appeal_fetcher.ts
+++ b/fighthealthinsurance/static/js/appeal_fetcher.ts
@@ -431,8 +431,16 @@ function hideLoading(): void {
   }
 }
 
+// The payload appeals.html hands to doQuery: a plain object built from the
+// form context, NOT a Map. It was typed as Map<string, string> while every
+// consumer read it as an object through `as any` -- a real Map would have
+// broken the wire long ago, since JSON.stringify(new Map()) is "{}" and the
+// server would see no denial_id. Typing it honestly keeps the object spread in
+// ws.onopen (and the reads below) checked rather than cast away.
+type AppealQueryData = Record<string, string>;
+
 // Hacky, TODO: Fix this.
-let my_data: Map<string, string> = new Map<string, string>();
+let my_data: AppealQueryData = {};
 let my_backend_url = "";
 let my_rest_fallback_url = "";
 let usingRestFallback = false;
@@ -1468,7 +1476,7 @@ function connectWebSocket(
   startWebSocket();
 }
 
-export function doQuery(backend_url: string, data: Map<string, string>, rest_fallback_url?: string): void {
+export function doQuery(backend_url: string, data: AppealQueryData, rest_fallback_url?: string): void {
   showLoading();
   my_backend_url = backend_url;
   my_data = data;

--- a/fighthealthinsurance/utils.py
+++ b/fighthealthinsurance/utils.py
@@ -74,14 +74,32 @@ def meaningful_appeal_length(text: Optional[str]) -> int:
     )
 
 
+def appeal_has_letters(text: Optional[str]) -> bool:
+    """True when ``text`` contains at least one alphabetic character.
+
+    Text made up entirely of digits, punctuation, and symbols is not an
+    appeal letter no matter how long it is -- a model that echoes back a
+    claim number, a date, a dollar amount, or a row of dashes has produced
+    nothing deliverable, and such an output would otherwise sail past the
+    ``MIN_APPEAL_CHARS`` length check. ``str.isalpha`` is Unicode-aware, so
+    appeals written in non-Latin scripts still pass.
+    """
+    return isinstance(text, str) and any(ch.isalpha() for ch in text)
+
+
 def is_real_appeal(x: Optional[str]) -> TypeGuard[str]:
     """True when ``x`` is a deliverable appeal: a string with at least
-    ``MIN_APPEAL_CHARS`` non-whitespace, non-control characters.
+    ``MIN_APPEAL_CHARS`` non-whitespace, non-control characters, at least
+    one of which is a letter (see ``appeal_has_letters``).
 
     Typed as a ``TypeGuard[str]`` so callers narrow ``Optional[str]`` to
     ``str`` inside the truthy branch (e.g. when building the streamed
     appeal payload)."""
-    return isinstance(x, str) and meaningful_appeal_length(x) >= MIN_APPEAL_CHARS
+    return (
+        isinstance(x, str)
+        and meaningful_appeal_length(x) >= MIN_APPEAL_CHARS
+        and appeal_has_letters(x)
+    )
 
 
 import asyncstdlib
@@ -102,20 +120,30 @@ pubmed_fetcher = (
 )
 
 
-def warn_too_short_appeal(text: Optional[str], context: str) -> None:
-    """Log a warning that a too-short appeal is being filtered out.
+def describe_unusable_appeal(text: Optional[str]) -> str:
+    """Describe why ``text`` fails ``is_real_appeal``, for logging.
 
-    Centralizes the message format shared by the generation, streaming, and
-    synthesis drop sites so a runt appeal is reported consistently wherever
-    it is dropped. ``context`` identifies the source (e.g. the model name,
-    a saved-appeal id, or "synthesis output") plus the denial id. The logged
-    length is the meaningful (non-whitespace, non-control) count actually
-    used by the filter.
+    The reported length is the meaningful (non-whitespace, non-control)
+    count actually used by the filter. Called only on text already known to
+    be unusable, so it always names one of the two rejection reasons -- too
+    short, or long enough but carrying no letters at all.
     """
     length = meaningful_appeal_length(text)
+    if length < MIN_APPEAL_CHARS:
+        return f"too-short (len={length} < {MIN_APPEAL_CHARS} chars)"
+    return f"numbers-and-punctuation-only (len={length})"
+
+
+def warn_unusable_appeal(text: Optional[str], context: str) -> None:
+    """Log a warning that an undeliverable appeal is being filtered out.
+
+    Centralizes the message format shared by the generation, streaming, and
+    synthesis drop sites so a rejected appeal is reported consistently
+    wherever it is dropped. ``context`` identifies the source (e.g. the model
+    name, a saved-appeal id, or "synthesis output") plus the denial id.
+    """
     logger.warning(
-        f"Filtering out too-short appeal "
-        f"(len={length} < {MIN_APPEAL_CHARS} chars): {context}"
+        f"Filtering out unusable appeal -- {describe_unusable_appeal(text)}: {context}"
     )
 
 

--- a/fighthealthinsurance/utils.py
+++ b/fighthealthinsurance/utils.py
@@ -54,6 +54,20 @@ if TYPE_CHECKING:
 # user gets nothing, so fall back.
 MIN_APPEAL_CHARS = 15
 
+# Minimum number of word-like tokens (see appeal_word_count) an appeal must
+# have. Denials are often word-sparse -- a claim number, a date, a CPT code,
+# a dollar amount -- but an appeal is a letter, so it has to say something.
+# Deliberately a floor for the worst-of-the-worst (a model echoing back the
+# denial's identifiers instead of writing), NOT a quality bar: real appeals
+# run to a couple hundred words, so anything with fewer than two words is
+# junk by any measure.
+MIN_APPEAL_WORDS = 2
+
+# A word-like token: a run of two or more letters. Digits, punctuation, and
+# lone letters are excluded, so "99213", "$1,250.00", "11/02/2026" and the
+# "A" in "Plan A" contribute nothing.
+_APPEAL_WORD_RE = re.compile(r"[^\W\d_]{2,}")
+
 
 def meaningful_appeal_length(text: Optional[str]) -> int:
     """Count the characters in ``text`` that actually carry content.
@@ -74,23 +88,37 @@ def meaningful_appeal_length(text: Optional[str]) -> int:
     )
 
 
-def appeal_has_letters(text: Optional[str]) -> bool:
-    """True when ``text`` contains at least one alphabetic character.
+def appeal_word_count(text: Optional[str]) -> int:
+    """Count the word-like tokens in ``text`` (runs of two or more letters).
 
-    Text made up entirely of digits, punctuation, and symbols is not an
-    appeal letter no matter how long it is -- a model that echoes back a
-    claim number, a date, a dollar amount, or a row of dashes has produced
-    nothing deliverable, and such an output would otherwise sail past the
-    ``MIN_APPEAL_CHARS`` length check. ``str.isalpha`` is Unicode-aware, so
-    appeals written in non-Latin scripts still pass.
+    The regex is Unicode-aware, so words in non-Latin scripts count too. A
+    non-string returns 0.
     """
-    return isinstance(text, str) and any(ch.isalpha() for ch in text)
+    if not isinstance(text, str):
+        return 0
+    return len(_APPEAL_WORD_RE.findall(text))
+
+
+def appeal_has_words(text: Optional[str]) -> bool:
+    """True when ``text`` says something rather than just listing values.
+
+    An output made only of digits, punctuation, and symbols -- a model
+    echoing back the claim number, the date of service, the billed amount,
+    or a row of dashes -- is not a letter no matter how long it is, and
+    would otherwise sail past the ``MIN_APPEAL_CHARS`` length check.
+    """
+    words = _APPEAL_WORD_RE.findall(text) if isinstance(text, str) else []
+    if len(words) >= MIN_APPEAL_WORDS:
+        return True
+    # Scripts written without spaces (Chinese, Japanese, Thai) put a whole
+    # clause in a single run, so one long run of letters is prose as well.
+    return any(len(w) >= MIN_APPEAL_CHARS for w in words)
 
 
 def is_real_appeal(x: Optional[str]) -> TypeGuard[str]:
     """True when ``x`` is a deliverable appeal: a string with at least
-    ``MIN_APPEAL_CHARS`` non-whitespace, non-control characters, at least
-    one of which is a letter (see ``appeal_has_letters``).
+    ``MIN_APPEAL_CHARS`` non-whitespace, non-control characters that also
+    contains actual words (see ``appeal_has_words``).
 
     Typed as a ``TypeGuard[str]`` so callers narrow ``Optional[str]`` to
     ``str`` inside the truthy branch (e.g. when building the streamed
@@ -98,7 +126,7 @@ def is_real_appeal(x: Optional[str]) -> TypeGuard[str]:
     return (
         isinstance(x, str)
         and meaningful_appeal_length(x) >= MIN_APPEAL_CHARS
-        and appeal_has_letters(x)
+        and appeal_has_words(x)
     )
 
 
@@ -126,12 +154,15 @@ def describe_unusable_appeal(text: Optional[str]) -> str:
     The reported length is the meaningful (non-whitespace, non-control)
     count actually used by the filter. Called only on text already known to
     be unusable, so it always names one of the two rejection reasons -- too
-    short, or long enough but carrying no letters at all.
+    short, or long enough but not made of words.
     """
     length = meaningful_appeal_length(text)
     if length < MIN_APPEAL_CHARS:
         return f"too-short (len={length} < {MIN_APPEAL_CHARS} chars)"
-    return f"numbers-and-punctuation-only (len={length})"
+    return (
+        f"not-words (words={appeal_word_count(text)} "
+        f"< {MIN_APPEAL_WORDS}, len={length})"
+    )
 
 
 def warn_unusable_appeal(text: Optional[str], context: str) -> None:

--- a/fighthealthinsurance/utils.py
+++ b/fighthealthinsurance/utils.py
@@ -93,21 +93,42 @@ def meaningful_appeal_length(text: Optional[str]) -> int:
     )
 
 
-def _appeal_word_tokens(text: Optional[str]) -> List[str]:
-    """Split ``text`` into word-like tokens (see ``_APPEAL_WORD_RE``).
+def _appeal_word_tokens(text: Optional[str]) -> List[Tuple[str, int]]:
+    """Split ``text`` into word-like tokens (see ``_APPEAL_WORD_RE``), as
+    ``(token, width)`` pairs where ``width`` is the token's length in the
+    original text.
 
-    Combining marks are dropped first. A mark (Unicode category M) attaches to
-    the letter before it rather than being a letter itself -- Thai and Indic
-    vowel and tone signs, for instance -- so leaving them in would break
-    "ที่นี่ดี" into single-letter runs and score a perfectly ordinary appeal as
-    wordless. Removing them leaves the base letters, which is all a token count
-    needs. Text without marks (including English) tokenizes identically either
-    way.
+    Combining marks are dropped before matching. A mark (Unicode category M)
+    attaches to the letter before it rather than being a letter itself -- Thai
+    and Indic vowel and tone signs, for instance -- so leaving them in would
+    break "ที่นี่ดี" into single-letter runs and score a perfectly ordinary
+    appeal as wordless.
+
+    ``width`` counts each dropped mark back onto the letter it belonged to, so
+    the caller can measure a token as it was actually written. Without it the
+    unspaced-script check below would shortchange exactly the scripts the mark
+    handling is here for: a 24-character Thai clause strips to 9 base letters.
+    Text without marks (including all English) is unaffected either way --
+    every width is then the token's own length.
     """
     if not isinstance(text, str):
         return []
-    unmarked = "".join(ch for ch in text if unicodedata.category(ch)[0] != "M")
-    return _APPEAL_WORD_RE.findall(unmarked)
+    chars: List[str] = []
+    widths: List[int] = []
+    for ch in text:
+        if unicodedata.category(ch)[0] == "M":
+            # A mark with no letter before it (malformed text) has nothing to
+            # attach to, so it is simply dropped.
+            if widths:
+                widths[-1] += 1
+        else:
+            chars.append(ch)
+            widths.append(1)
+    unmarked = "".join(chars)
+    return [
+        (m.group(), sum(widths[m.start() : m.end()]))
+        for m in _APPEAL_WORD_RE.finditer(unmarked)
+    ]
 
 
 def appeal_word_count(text: Optional[str]) -> int:
@@ -132,7 +153,8 @@ def appeal_has_words(text: Optional[str]) -> bool:
         return True
     # Scripts written without spaces (Chinese, Japanese, Thai) put a whole
     # clause in a single run, so one long run of letters is prose as well.
-    return any(len(w) >= MIN_APPEAL_CHARS for w in words)
+    # Measured on the width, i.e. the run as written, marks included.
+    return any(width >= MIN_APPEAL_CHARS for _, width in words)
 
 
 def is_real_appeal(x: Optional[str]) -> TypeGuard[str]:

--- a/fighthealthinsurance/utils.py
+++ b/fighthealthinsurance/utils.py
@@ -63,10 +63,15 @@ MIN_APPEAL_CHARS = 15
 # junk by any measure.
 MIN_APPEAL_WORDS = 2
 
-# A word-like token: a run of two or more letters. Digits, punctuation, and
-# lone letters are excluded, so "99213", "$1,250.00", "11/02/2026" and the
-# "A" in "Plan A" contribute nothing.
-_APPEAL_WORD_RE = re.compile(r"[^\W\d_]{2,}")
+# A word-like token: a run of two or more letters that is not welded to a
+# digit or underscore on either side. Digits, punctuation, and lone letters
+# are excluded, so "99213", "$1,250.00", "11/02/2026" and the "A" in "Plan A"
+# contribute nothing -- and neither do the letter prefixes inside claim,
+# member, and authorization identifiers ("AB123456789", "H5521-001"), which
+# would otherwise read as words in exactly the identifier-echo output this
+# filter exists to reject. Ordinary hyphenated and possessive prose is
+# unaffected: "well-documented" is two tokens, "patient's" is one.
+_APPEAL_WORD_RE = re.compile(r"(?<!\w)[^\W\d_]{2,}(?!\w)")
 
 
 def meaningful_appeal_length(text: Optional[str]) -> int:

--- a/fighthealthinsurance/utils.py
+++ b/fighthealthinsurance/utils.py
@@ -93,15 +93,30 @@ def meaningful_appeal_length(text: Optional[str]) -> int:
     )
 
 
+def _appeal_word_tokens(text: Optional[str]) -> List[str]:
+    """Split ``text`` into word-like tokens (see ``_APPEAL_WORD_RE``).
+
+    Combining marks are dropped first. A mark (Unicode category M) attaches to
+    the letter before it rather than being a letter itself -- Thai and Indic
+    vowel and tone signs, for instance -- so leaving them in would break
+    "ที่นี่ดี" into single-letter runs and score a perfectly ordinary appeal as
+    wordless. Removing them leaves the base letters, which is all a token count
+    needs. Text without marks (including English) tokenizes identically either
+    way.
+    """
+    if not isinstance(text, str):
+        return []
+    unmarked = "".join(ch for ch in text if unicodedata.category(ch)[0] != "M")
+    return _APPEAL_WORD_RE.findall(unmarked)
+
+
 def appeal_word_count(text: Optional[str]) -> int:
     """Count the word-like tokens in ``text`` (runs of two or more letters).
 
-    The regex is Unicode-aware, so words in non-Latin scripts count too. A
-    non-string returns 0.
+    Unicode-aware, so words in non-Latin scripts count too. A non-string
+    returns 0.
     """
-    if not isinstance(text, str):
-        return 0
-    return len(_APPEAL_WORD_RE.findall(text))
+    return len(_appeal_word_tokens(text))
 
 
 def appeal_has_words(text: Optional[str]) -> bool:
@@ -112,7 +127,7 @@ def appeal_has_words(text: Optional[str]) -> bool:
     or a row of dashes -- is not a letter no matter how long it is, and
     would otherwise sail past the ``MIN_APPEAL_CHARS`` length check.
     """
-    words = _APPEAL_WORD_RE.findall(text) if isinstance(text, str) else []
+    words = _appeal_word_tokens(text)
     if len(words) >= MIN_APPEAL_WORDS:
         return True
     # Scripts written without spaces (Chinese, Japanese, Thai) put a whole

--- a/tests/async-unit/test_appeals_backend_citations.py
+++ b/tests/async-unit/test_appeals_backend_citations.py
@@ -915,9 +915,9 @@ async def test_synthesis_too_short_output_is_filtered():
 
 
 @pytest.mark.asyncio
-async def test_synthesis_numbers_and_punctuation_output_is_filtered():
+async def test_synthesis_wordless_output_is_filtered():
     """A synthesized "appeal" of nothing but numbers and punctuation is long
-    enough to clear MIN_APPEAL_CHARS but is not a letter, so it must be
+    enough to clear MIN_APPEAL_CHARS but says nothing, so it must be
     filtered out rather than delivered."""
     junk = "1234-5678-90, 11/02/2026: $1,250.00 (99213)"
     chunks, output = await _run_generate_appeals_over_saved(
@@ -929,7 +929,7 @@ async def test_synthesis_numbers_and_punctuation_output_is_filtered():
     assert junk not in contents
     for c in chunks:
         assert '"synthesized": "true"' not in c
-    assert "unusable appeal -- numbers-and-punctuation-only" in output
+    assert "unusable appeal -- not-words" in output
     assert "synthesis output for denial 12345" in output
 
 
@@ -952,7 +952,7 @@ async def test_existing_too_short_appeal_is_skipped():
 
 
 @pytest.mark.asyncio
-async def test_existing_numbers_and_punctuation_appeal_is_skipped():
+async def test_existing_wordless_appeal_is_skipped():
     """A previously-saved row holding only numbers and punctuation must not
     be re-delivered, however long it is."""
     junk = "1234-5678-90 / 11-02-2026 / $1,250.00 / 99213"
@@ -963,5 +963,5 @@ async def test_existing_numbers_and_punctuation_appeal_is_skipped():
     contents = _collect_appeal_contents(chunks)
     assert junk not in contents
     assert "a valid existing appeal body" in contents
-    assert "unusable appeal -- numbers-and-punctuation-only" in output
+    assert "unusable appeal -- not-words" in output
     assert "saved appeal id=" in output

--- a/tests/async-unit/test_appeals_backend_citations.py
+++ b/tests/async-unit/test_appeals_backend_citations.py
@@ -195,6 +195,75 @@ def _sync_to_async_router(pa_wrapper, make_appeals_wrapper, uspstf_wrapper=None)
     return route
 
 
+async def _run_generate_appeals_over_saved(saved_texts, synthesized=None):
+    """Drive ``generate_appeals`` with ``saved_texts`` already in the DB and
+    no newly generated appeals, with the synthesis step returning
+    ``synthesized``.
+
+    Returns ``(chunks, warning_log_output)`` so callers can assert on both
+    what was delivered and what was logged.
+    """
+    mock_denial = _make_mock_denial()
+    parameters = {
+        "denial_id": "12345",
+        "email": "test@example.com",
+        "semi_sekret": "test-secret",
+    }
+
+    with (
+        patch(
+            "fighthealthinsurance.common_view_logic.Denial.objects.filter",
+            return_value=_make_mock_denial_query(mock_denial),
+        ),
+        patch(
+            "fighthealthinsurance.common_view_logic.Denial.get_hashed_email",
+            return_value="hashed",
+        ),
+        patch.object(AppealsBackendHelper, "regex_denial_processor") as mock_regex,
+        patch(
+            "fighthealthinsurance.common_view_logic.MLCitationsHelper.generate_citations_for_denial",
+            new_callable=AsyncMock,
+            return_value="",
+        ),
+        patch.object(
+            AppealsBackendHelper.pmt,
+            "find_context_for_denial",
+            new_callable=AsyncMock,
+            return_value="",
+        ),
+        patch(
+            "fighthealthinsurance.common_view_logic.database_sync_to_async",
+        ) as mock_sync_to_async,
+        patch(
+            "fighthealthinsurance.common_view_logic.interleave_iterator_for_keep_alive",
+            side_effect=passthrough_interleave,
+        ),
+        patch(
+            "fighthealthinsurance.common_view_logic.ProposedAppeal",
+        ) as mock_pa_cls,
+        patch(
+            "fighthealthinsurance.common_view_logic.appealGenerator"
+        ) as mock_appeal_gen,
+    ):
+        mock_regex.get_appeal_templates = AsyncMock(return_value=[])
+        mock_sync_to_async.side_effect = _sync_to_async_router(
+            AsyncMock(return_value=""),
+            AsyncMock(return_value=[]),  # no newly generated appeals
+        )
+        mock_pa_cls.return_value = MagicMock(id=1, asave=AsyncMock())
+        mock_pa_cls.objects.filter.return_value = (
+            _make_proposed_appeal_query_with_texts(saved_texts)
+        )
+        mock_appeal_gen.synthesize_appeals = AsyncMock(return_value=synthesized)
+
+        with _loguru_capture() as sink:
+            chunks = []
+            async for chunk in AppealsBackendHelper.generate_appeals(parameters):
+                chunks.append(chunk)
+
+    return chunks, sink.getvalue()
+
+
 class TestAppealsBackendHelperWithCitations:
     """Tests for the AppealsBackendHelper class with ML citations integration.
 
@@ -828,67 +897,12 @@ async def test_synthesis_too_short_output_is_filtered():
     """A synthesized appeal below MIN_APPEAL_CHARS must not be yielded — it
     would otherwise bypass the minimum-length rule the streaming path
     enforces — and the drop must be logged as a warning."""
-    mock_denial = _make_mock_denial()
-    parameters = {
-        "denial_id": "12345",
-        "email": "test@example.com",
-        "semi_sekret": "test-secret",
-    }
-    saved_texts = ["draft one text body", "draft two text body"]
-
-    with (
-        patch(
-            "fighthealthinsurance.common_view_logic.Denial.objects.filter",
-            return_value=_make_mock_denial_query(mock_denial),
-        ),
-        patch(
-            "fighthealthinsurance.common_view_logic.Denial.get_hashed_email",
-            return_value="hashed",
-        ),
-        patch.object(AppealsBackendHelper, "regex_denial_processor") as mock_regex,
-        patch(
-            "fighthealthinsurance.common_view_logic.MLCitationsHelper.generate_citations_for_denial",
-            new_callable=AsyncMock,
-            return_value="",
-        ),
-        patch.object(
-            AppealsBackendHelper.pmt,
-            "find_context_for_denial",
-            new_callable=AsyncMock,
-            return_value="",
-        ),
-        patch(
-            "fighthealthinsurance.common_view_logic.database_sync_to_async",
-        ) as mock_sync_to_async,
-        patch(
-            "fighthealthinsurance.common_view_logic.interleave_iterator_for_keep_alive",
-            side_effect=passthrough_interleave,
-        ),
-        patch(
-            "fighthealthinsurance.common_view_logic.ProposedAppeal",
-        ) as mock_pa_cls,
-        patch(
-            "fighthealthinsurance.common_view_logic.appealGenerator"
-        ) as mock_appeal_gen,
-    ):
-        mock_regex.get_appeal_templates = AsyncMock(return_value=[])
-        # make_appeals returns nothing new so the only synthesis candidate is
-        # the (too-short) synthesizer output under test.
-        mock_sync_to_async.side_effect = _sync_to_async_router(
-            AsyncMock(return_value=""),
-            AsyncMock(return_value=[]),
-        )
-        mock_pa_cls.return_value = MagicMock(id=1, asave=AsyncMock())
-        mock_pa_cls.objects.filter.return_value = (
-            _make_proposed_appeal_query_with_texts(saved_texts)
-        )
-        # Synthesizer returns a non-empty but too-short letter (< 15 chars).
-        mock_appeal_gen.synthesize_appeals = AsyncMock(return_value="too short")
-
-        with _loguru_capture() as sink:
-            chunks = []
-            async for chunk in AppealsBackendHelper.generate_appeals(parameters):
-                chunks.append(chunk)
+    # make_appeals returns nothing new so the only synthesis candidate is
+    # the (too-short) synthesizer output under test.
+    chunks, output = await _run_generate_appeals_over_saved(
+        ["draft one text body", "draft two text body"],
+        synthesized="too short",
+    )
 
     # The too-short synthesis must never be delivered.
     contents = _collect_appeal_contents(chunks)
@@ -896,8 +910,26 @@ async def test_synthesis_too_short_output_is_filtered():
     for c in chunks:
         assert '"synthesized": "true"' not in c
     # And the drop is logged as a warning naming the denial.
-    output = sink.getvalue()
-    assert "too-short appeal" in output
+    assert "unusable appeal -- too-short" in output
+    assert "synthesis output for denial 12345" in output
+
+
+@pytest.mark.asyncio
+async def test_synthesis_numbers_and_punctuation_output_is_filtered():
+    """A synthesized "appeal" of nothing but numbers and punctuation is long
+    enough to clear MIN_APPEAL_CHARS but is not a letter, so it must be
+    filtered out rather than delivered."""
+    junk = "1234-5678-90, 11/02/2026: $1,250.00 (99213)"
+    chunks, output = await _run_generate_appeals_over_saved(
+        ["draft one text body", "draft two text body"],
+        synthesized=junk,
+    )
+
+    contents = _collect_appeal_contents(chunks)
+    assert junk not in contents
+    for c in chunks:
+        assert '"synthesized": "true"' not in c
+    assert "unusable appeal -- numbers-and-punctuation-only" in output
     assert "synthesis output for denial 12345" in output
 
 
@@ -905,71 +937,31 @@ async def test_synthesis_too_short_output_is_filtered():
 async def test_existing_too_short_appeal_is_skipped():
     """Previously-saved appeals below MIN_APPEAL_CHARS (e.g. saved before the
     threshold existed) must not be re-delivered, and the skip is warned."""
-    mock_denial = _make_mock_denial()
-    parameters = {
-        "denial_id": "12345",
-        "email": "test@example.com",
-        "semi_sekret": "test-secret",
-    }
     # One runt (4 chars) and one deliverable existing appeal.
-    existing_texts = ["tiny", "a valid existing appeal body"]
-
-    with (
-        patch(
-            "fighthealthinsurance.common_view_logic.Denial.objects.filter",
-            return_value=_make_mock_denial_query(mock_denial),
-        ),
-        patch(
-            "fighthealthinsurance.common_view_logic.Denial.get_hashed_email",
-            return_value="hashed",
-        ),
-        patch.object(AppealsBackendHelper, "regex_denial_processor") as mock_regex,
-        patch(
-            "fighthealthinsurance.common_view_logic.MLCitationsHelper.generate_citations_for_denial",
-            new_callable=AsyncMock,
-            return_value="",
-        ),
-        patch.object(
-            AppealsBackendHelper.pmt,
-            "find_context_for_denial",
-            new_callable=AsyncMock,
-            return_value="",
-        ),
-        patch(
-            "fighthealthinsurance.common_view_logic.database_sync_to_async",
-        ) as mock_sync_to_async,
-        patch(
-            "fighthealthinsurance.common_view_logic.interleave_iterator_for_keep_alive",
-            side_effect=passthrough_interleave,
-        ),
-        patch(
-            "fighthealthinsurance.common_view_logic.ProposedAppeal",
-        ) as mock_pa_cls,
-        patch(
-            "fighthealthinsurance.common_view_logic.appealGenerator"
-        ) as mock_appeal_gen,
-    ):
-        mock_regex.get_appeal_templates = AsyncMock(return_value=[])
-        mock_sync_to_async.side_effect = _sync_to_async_router(
-            AsyncMock(return_value=""),
-            AsyncMock(return_value=[]),  # no newly generated appeals
-        )
-        mock_pa_cls.return_value = MagicMock(id=1, asave=AsyncMock())
-        mock_pa_cls.objects.filter.return_value = (
-            _make_proposed_appeal_query_with_texts(existing_texts)
-        )
-        mock_appeal_gen.synthesize_appeals = AsyncMock(return_value=None)
-
-        with _loguru_capture() as sink:
-            chunks = []
-            async for chunk in AppealsBackendHelper.generate_appeals(parameters):
-                chunks.append(chunk)
+    chunks, output = await _run_generate_appeals_over_saved(
+        ["tiny", "a valid existing appeal body"]
+    )
 
     contents = _collect_appeal_contents(chunks)
     # The runt is dropped; the valid existing appeal is delivered.
     assert "tiny" not in contents
     assert "a valid existing appeal body" in contents
     # The drop is logged as a warning identifying it as a saved appeal.
-    output = sink.getvalue()
-    assert "too-short appeal" in output
+    assert "unusable appeal -- too-short" in output
+    assert "saved appeal id=" in output
+
+
+@pytest.mark.asyncio
+async def test_existing_numbers_and_punctuation_appeal_is_skipped():
+    """A previously-saved row holding only numbers and punctuation must not
+    be re-delivered, however long it is."""
+    junk = "1234-5678-90 / 11-02-2026 / $1,250.00 / 99213"
+    chunks, output = await _run_generate_appeals_over_saved(
+        [junk, "a valid existing appeal body"]
+    )
+
+    contents = _collect_appeal_contents(chunks)
+    assert junk not in contents
+    assert "a valid existing appeal body" in contents
+    assert "unusable appeal -- numbers-and-punctuation-only" in output
     assert "saved appeal id=" in output

--- a/tests/async-unit/test_appeals_backend_citations.py
+++ b/tests/async-unit/test_appeals_backend_citations.py
@@ -225,6 +225,13 @@ async def _run_generate_appeals_over_saved(saved_texts, synthesized=None):
             new_callable=AsyncMock,
             return_value="",
         ),
+        # generate_appeals awaits the RAG service (default http://localhost:8001)
+        # under a 30s wait_for; stub it so this unit test does no network I/O.
+        patch(
+            "fighthealthinsurance.common_view_logic.get_rag_context_for_denial",
+            new_callable=AsyncMock,
+            return_value="",
+        ),
         patch.object(
             AppealsBackendHelper.pmt,
             "find_context_for_denial",
@@ -748,6 +755,13 @@ async def test_synthesis_threshold(saved_texts, synthesis_should_run):
             new_callable=AsyncMock,
             return_value="",
         ),
+        # generate_appeals awaits the RAG service (default http://localhost:8001)
+        # under a 30s wait_for; stub it so this unit test does no network I/O.
+        patch(
+            "fighthealthinsurance.common_view_logic.get_rag_context_for_denial",
+            new_callable=AsyncMock,
+            return_value="",
+        ),
         patch.object(
             AppealsBackendHelper.pmt,
             "find_context_for_denial",
@@ -828,6 +842,13 @@ async def test_synthesis_skips_verbatim_duplicate():
         patch.object(AppealsBackendHelper, "regex_denial_processor") as mock_regex,
         patch(
             "fighthealthinsurance.common_view_logic.MLCitationsHelper.generate_citations_for_denial",
+            new_callable=AsyncMock,
+            return_value="",
+        ),
+        # generate_appeals awaits the RAG service (default http://localhost:8001)
+        # under a 30s wait_for; stub it so this unit test does no network I/O.
+        patch(
+            "fighthealthinsurance.common_view_logic.get_rag_context_for_denial",
             new_callable=AsyncMock,
             return_value="",
         ),

--- a/tests/async-unit/test_appeals_backend_citations.py
+++ b/tests/async-unit/test_appeals_backend_citations.py
@@ -147,12 +147,18 @@ def _make_proposed_appeal_query_with_texts(texts, existing_texts=None):
         def all(self):
             return self._gen(self._existing)
 
-        async def acount(self):
-            # The reserve-availability count at the start of generation. This
-            # fake ignores filter kwargs, so it cannot tell the speculative
-            # query from any other; none of these tests set up speculative
-            # rows, so report an empty reserve.
-            return 0
+        def exclude(self, *args, **kwargs):
+            # deliverable_candidates() narrows the reserve/reconciliation
+            # querysets DB-side (exclude -> alias -> filter) before anything
+            # counts or serves them. This fake holds rows in memory with no
+            # SQL to push down to, so the chain is a passthrough and
+            # is_real_appeal -- which production runs on every row anyway --
+            # does the filtering these tests exercise.
+            return self
+
+        alias = exclude
+        filter = exclude
+        only = exclude
 
         def order_by(self, *args, **kwargs):
             # Mock ignores the sort key; the reconciliation query uses

--- a/tests/async-unit/test_common_view_logic.py
+++ b/tests/async-unit/test_common_view_logic.py
@@ -1592,6 +1592,10 @@ class TestCommonViewLogic(TestCase):
         (".,;:!?()[]{}<>/\\-_=+*&^%$#@~", False),
         # One word among the identifiers is still not a letter.
         ("Denied. 99213 11/02/2026 -- $1,250.00", False),
+        # Letter prefixes welded to identifiers are not words: this is the
+        # identifier-echo output the filter exists to reject.
+        ("AB123456789 CD987654321", False),
+        ("H5521-001 BCBS12345 99213 $1,250.00", False),
         # Two words clears the floor: it is deliberately a worst-of-the-worst
         # bar, not a quality bar (real appeals run to hundreds of words).
         ("Claim #1234-5678-90 denied 11/02/2026 -- $1,250.00", True),
@@ -1635,6 +1639,14 @@ def test_appeal_has_words(value, expected):
         ("Plan A 1234", 1),  # the lone "A" is not a token
         ("Claim 1234 denied", 2),
         ("this is a long enough appeal text for delivery", 8),  # "a" excluded
+        # Letters welded to digits are identifier fragments, not words.
+        ("AB123456789 CD987654321", 0),
+        ("H5521-001 BCBS12345", 0),
+        # ...but ordinary hyphenated and possessive prose still counts.
+        ("well-documented", 2),
+        # the / patient / rays; the possessive "s" and the lone "X" don't count
+        ("the patient's X-rays", 3),
+        ("COVID-19 treatment", 2),
     ],
 )
 def test_appeal_word_count(value, expected):

--- a/tests/async-unit/test_common_view_logic.py
+++ b/tests/async-unit/test_common_view_logic.py
@@ -13,9 +13,10 @@ from fighthealthinsurance.common_view_logic import (
 )
 from fighthealthinsurance.utils import (
     MIN_APPEAL_CHARS,
+    appeal_has_letters,
     is_real_appeal,
     meaningful_appeal_length,
-    warn_too_short_appeal,
+    warn_unusable_appeal,
 )
 from fighthealthinsurance.generate_appeal import GeneratedAppeal
 from fighthealthinsurance.helpers import SendFaxHelper, RemoveDataHelper
@@ -1583,10 +1584,40 @@ class TestCommonViewLogic(TestCase):
         ("a" * MIN_APPEAL_CHARS + "\x07" * 20, True),
         # Tabs/newlines between letters are ignored (only 12 real letters).
         ("a\tb\nc d e f g h i j k l", False),
+        # Long enough, but nothing except digits and punctuation: not a letter.
+        ("1234-5678-90, 11/02/2026: $1,250.00", False),
+        ("1" * 500, False),
+        ("-" * 80, False),
+        (".,;:!?()[]{}<>/\\-_=+*&^%$#@~", False),
+        # A single letter among the digits/punctuation is still too little to
+        # be a letter in practice, but the letter rule is deliberately a floor,
+        # not a ratio -- length is what keeps this class of junk out.
+        ("Claim #1234-5678-90 denied 11/02/2026 -- $1,250.00", True),
+        # Non-Latin scripts count as letters.
+        ("这是一封足够长的申诉信正文内容示例。", True),
     ],
 )
 def test_is_real_appeal(value, expected):
     assert is_real_appeal(value) is expected
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (None, False),
+        (123, False),
+        ("", False),
+        ("   ", False),
+        ("1234567890", False),
+        ("$1,250.00 (11/02/2026)", False),
+        ("---===---", False),
+        ("a", True),
+        ("Claim 1234 denied", True),
+        ("申诉", True),  # non-Latin script
+    ],
+)
+def test_appeal_has_letters(value, expected):
+    assert appeal_has_letters(value) is expected
 
 
 @pytest.mark.parametrize(
@@ -1608,7 +1639,7 @@ def test_meaningful_appeal_length(value, expected):
     assert meaningful_appeal_length(value) == expected
 
 
-def test_warn_too_short_appeal_logs_length_and_context():
+def test_warn_unusable_appeal_logs_length_and_context():
     """The shared drop-site warning reports the measured length, the
     threshold, and the caller-supplied context. The reported length is the
     meaningful (non-whitespace) count, so internal spaces are not counted."""
@@ -1617,24 +1648,43 @@ def test_warn_too_short_appeal_logs_length_and_context():
     sink = io.StringIO()
     handler_id = loguru_logger.add(sink, level="WARNING")
     try:
-        warn_too_short_appeal("a b c", "model='m' for denial 7")
+        warn_unusable_appeal("a b c", "model='m' for denial 7")
     finally:
         loguru_logger.remove(handler_id)
     output = sink.getvalue()
-    assert "too-short appeal" in output
+    assert "too-short" in output
     assert "len=3" in output  # 3 letters, the 2 spaces are excluded
     assert f"< {MIN_APPEAL_CHARS} chars" in output
     assert "model='m' for denial 7" in output
 
 
-def test_warn_too_short_appeal_handles_non_string():
+def test_warn_unusable_appeal_reports_letterless_reason():
+    """A long-enough but letterless appeal is reported as numbers-and-
+    punctuation-only rather than as too short."""
+    from loguru import logger as loguru_logger
+
+    sink = io.StringIO()
+    handler_id = loguru_logger.add(sink, level="WARNING")
+    try:
+        warn_unusable_appeal(
+            "1234-5678-90, 11/02/2026: $1,250.00", "model='m' for denial 7"
+        )
+    finally:
+        loguru_logger.remove(handler_id)
+    output = sink.getvalue()
+    assert "numbers-and-punctuation-only" in output
+    assert "too-short" not in output
+    assert "model='m' for denial 7" in output
+
+
+def test_warn_unusable_appeal_handles_non_string():
     """A non-string (e.g. None) is reported as length 0 without raising."""
     from loguru import logger as loguru_logger
 
     sink = io.StringIO()
     handler_id = loguru_logger.add(sink, level="WARNING")
     try:
-        warn_too_short_appeal(None, "some context")
+        warn_unusable_appeal(None, "some context")
     finally:
         loguru_logger.remove(handler_id)
     output = sink.getvalue()

--- a/tests/async-unit/test_common_view_logic.py
+++ b/tests/async-unit/test_common_view_logic.py
@@ -13,7 +13,8 @@ from fighthealthinsurance.common_view_logic import (
 )
 from fighthealthinsurance.utils import (
     MIN_APPEAL_CHARS,
-    appeal_has_letters,
+    appeal_has_words,
+    appeal_word_count,
     is_real_appeal,
     meaningful_appeal_length,
     warn_unusable_appeal,
@@ -1584,16 +1585,17 @@ class TestCommonViewLogic(TestCase):
         ("a" * MIN_APPEAL_CHARS + "\x07" * 20, True),
         # Tabs/newlines between letters are ignored (only 12 real letters).
         ("a\tb\nc d e f g h i j k l", False),
-        # Long enough, but nothing except digits and punctuation: not a letter.
+        # Long enough, but nothing except digits and punctuation: not words.
         ("1234-5678-90, 11/02/2026: $1,250.00", False),
         ("1" * 500, False),
         ("-" * 80, False),
         (".,;:!?()[]{}<>/\\-_=+*&^%$#@~", False),
-        # A single letter among the digits/punctuation is still too little to
-        # be a letter in practice, but the letter rule is deliberately a floor,
-        # not a ratio -- length is what keeps this class of junk out.
+        # One word among the identifiers is still not a letter.
+        ("Denied. 99213 11/02/2026 -- $1,250.00", False),
+        # Two words clears the floor: it is deliberately a worst-of-the-worst
+        # bar, not a quality bar (real appeals run to hundreds of words).
         ("Claim #1234-5678-90 denied 11/02/2026 -- $1,250.00", True),
-        # Non-Latin scripts count as letters.
+        # Non-Latin scripts count: one unspaced run of letters is prose.
         ("这是一封足够长的申诉信正文内容示例。", True),
     ],
 )
@@ -1611,13 +1613,32 @@ def test_is_real_appeal(value, expected):
         ("1234567890", False),
         ("$1,250.00 (11/02/2026)", False),
         ("---===---", False),
-        ("a", True),
+        ("a", False),  # a lone letter is not a word
+        ("Plan A 1234", False),  # only one word-like token
         ("Claim 1234 denied", True),
-        ("申诉", True),  # non-Latin script
+        # Unspaced script: one run of MIN_APPEAL_CHARS+ letters counts as prose.
+        ("这是一封足够长的申诉信正文内容示例", True),
+        ("申诉信", False),  # one short run is not enough
     ],
 )
-def test_appeal_has_letters(value, expected):
-    assert appeal_has_letters(value) is expected
+def test_appeal_has_words(value, expected):
+    assert appeal_has_words(value) is expected
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (None, 0),
+        (123, 0),
+        ("", 0),
+        ("1234-5678-90, 11/02/2026: $1,250.00", 0),
+        ("Plan A 1234", 1),  # the lone "A" is not a token
+        ("Claim 1234 denied", 2),
+        ("this is a long enough appeal text for delivery", 8),  # "a" excluded
+    ],
+)
+def test_appeal_word_count(value, expected):
+    assert appeal_word_count(value) == expected
 
 
 @pytest.mark.parametrize(
@@ -1658,9 +1679,9 @@ def test_warn_unusable_appeal_logs_length_and_context():
     assert "model='m' for denial 7" in output
 
 
-def test_warn_unusable_appeal_reports_letterless_reason():
-    """A long-enough but letterless appeal is reported as numbers-and-
-    punctuation-only rather than as too short."""
+def test_warn_unusable_appeal_reports_wordless_reason():
+    """A long-enough but wordless appeal is reported as not-words rather
+    than as too short."""
     from loguru import logger as loguru_logger
 
     sink = io.StringIO()
@@ -1672,7 +1693,8 @@ def test_warn_unusable_appeal_reports_letterless_reason():
     finally:
         loguru_logger.remove(handler_id)
     output = sink.getvalue()
-    assert "numbers-and-punctuation-only" in output
+    assert "not-words" in output
+    assert "words=0" in output
     assert "too-short" not in output
     assert "model='m' for denial 7" in output
 

--- a/tests/async-unit/test_common_view_logic.py
+++ b/tests/async-unit/test_common_view_logic.py
@@ -1830,6 +1830,11 @@ def test_is_real_appeal(value, expected):
         # still tokenize into words.
         ("ที่นี่ดี ที่นี่ดี ที่นี่ดี", True),
         ("नमस्ते दुनिया यह एक अपील है", True),
+        # Unspaced AND mark-heavy: one token, whose length has to be measured
+        # as written (24 characters) rather than on its 9 base letters.
+        ("ที่นี่ดีที่นี่ดีที่นี่ดี", True),
+        # ...but the length bar still applies: 8 characters is not prose.
+        ("ที่นี่ดี", False),
     ],
 )
 def test_appeal_has_words(value, expected):

--- a/tests/async-unit/test_common_view_logic.py
+++ b/tests/async-unit/test_common_view_logic.py
@@ -1068,6 +1068,66 @@ class TestCommonViewLogic(TestCase):
 
     @pytest.mark.django_db
     @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_undeliverable_reserve_rows_are_not_counted_or_served(
+        self, mock_appeal_generator
+    ):
+        """A reserve of junk is no safety net. Rows that fail the deliverability
+        rule must be filtered out before the availability count and the serving
+        gate see them, and must never reach the user -- covering both halves:
+        the runt is dropped DB-side, the long identifier-echo row survives that
+        and is caught by is_real_appeal at serve time."""
+        email, denial = self._create_test_denial(31, gen_attempts=3)
+        runt = "$1,250"
+        wordless = "AB123456789 CD987654321 99213 11/02/2026 $1,250.00"
+        real = "A reserve draft with real words the user should receive."
+        for text in (runt, wordless, real):
+            ProposedAppeal.objects.create(
+                for_denial=denial,
+                appeal_text=text,
+                speculative=True,
+                context_level="speculative",
+            )
+        mock_appeal_generator.make_appeals.side_effect = self._slow_make_appeals(
+            1.5, []
+        )
+
+        async def test():
+            try:
+                with self._capture_logs() as sink, self._fast_keepalive(), patch.object(
+                    AppealsBackendHelper,
+                    "SPECULATIVE_FALLBACK_NO_APPEAL_SECONDS",
+                    0.5,
+                ):
+                    _, appeal_contents, _ = await self.collect_appeal_responses(
+                        {
+                            "denial_id": 31,
+                            "email": email,
+                            "semi_sekret": denial.semi_sekret,
+                        }
+                    )
+
+                self.assertIn(real, appeal_contents)
+                self.assertNotIn(runt, appeal_contents)
+                self.assertNotIn(wordless, appeal_contents)
+                # Undeliverable rows are never promoted: promotion is what makes
+                # a row persist as a real appeal for every later call.
+                for text in (runt, wordless):
+                    row = await ProposedAppeal.objects.aget(
+                        for_denial=denial, appeal_text=text
+                    )
+                    self.assertTrue(row.speculative, f"{text!r} must stay held back")
+                # The availability figure counts the one row that could be
+                # served, not all three.
+                self.assertIn(
+                    "speculative reserve available at start=1", sink.getvalue()
+                )
+            finally:
+                await Denial.objects.filter(denial_id=31).adelete()
+
+        async_to_sync(test)()
+
+    @pytest.mark.django_db
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
     def test_early_served_reserve_is_not_fed_to_synthesis(self, mock_appeal_generator):
         """Promotion flips an early-served reserve row to speculative=False, but
         it must still not count toward the >=2 synthesis gate -- synthesizing

--- a/tests/async-unit/test_common_view_logic.py
+++ b/tests/async-unit/test_common_view_logic.py
@@ -33,8 +33,25 @@ import pytest
 from django.test import TestCase
 
 
+@contextmanager
+def capture_logs(level="INFO"):
+    """Capture loguru output for the duration of the block."""
+    from loguru import logger as loguru_logger
+
+    sink = io.StringIO()
+    handler_id = loguru_logger.add(sink, level=level)
+    try:
+        yield sink
+    finally:
+        loguru_logger.remove(handler_id)
+
+
 class TestCommonViewLogic(TestCase):
     fixtures = ["fighthealthinsurance/fixtures/initial.yaml"]
+
+    # Module-level helper, exposed on the class so the existing `self.` call
+    # sites keep working.
+    _capture_logs = staticmethod(capture_logs)
 
     def _create_test_denial(self, denial_id, gen_attempts=0):
         """Helper to create a test denial with specified gen_attempts."""
@@ -46,19 +63,6 @@ class TestCommonViewLogic(TestCase):
             gen_attempts=gen_attempts,
         )
         return email, denial
-
-    @staticmethod
-    @contextmanager
-    def _capture_logs(level="INFO"):
-        """Capture loguru output for the duration of the block."""
-        from loguru import logger as loguru_logger
-
-        sink = io.StringIO()
-        handler_id = loguru_logger.add(sink, level=level)
-        try:
-            yield sink
-        finally:
-            loguru_logger.remove(handler_id)
 
     @staticmethod
     def _fast_keepalive():
@@ -1106,6 +1110,63 @@ class TestCommonViewLogic(TestCase):
 
     @pytest.mark.django_db
     @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_a_reserve_row_another_run_already_claimed_is_not_re_served(
+        self, mock_appeal_generator
+    ):
+        """Promotion claims the row atomically. A row that a concurrent flow
+        promoted after this one selected it (the overlap a reconnect makes
+        likely, since the dropped socket's generator may still be draining)
+        must not be served twice."""
+        email, denial = self._create_test_denial(34, gen_attempts=3)
+        reserve_text = "A reserve draft that two overlapping runs both found."
+        spec = ProposedAppeal.objects.create(
+            for_denial=denial,
+            appeal_text=reserve_text,
+            speculative=True,
+            context_level="speculative",
+        )
+        mock_appeal_generator.make_appeals.return_value = iter([])
+
+        async def test():
+            try:
+                # Stand in for the concurrent run: the row is selected as
+                # speculative, then claimed by someone else before this flow
+                # promotes it. Patching aupdate to report "no rows updated" is
+                # exactly what the losing side of that race observes.
+                real_filter = ProposedAppeal.objects.filter
+
+                def filter_with_lost_claim(*args, **kwargs):
+                    qs = real_filter(*args, **kwargs)
+                    if "pk" in kwargs:
+                        qs.aupdate = AsyncMock(return_value=0)
+                    return qs
+
+                with patch.object(
+                    AppealsBackendHelper, "SPECULATIVE_FALLBACK_NO_APPEAL_SECONDS", 0.0
+                ), patch.object(
+                    ProposedAppeal.objects,
+                    "filter",
+                    side_effect=filter_with_lost_claim,
+                ):
+                    _, appeal_contents, _ = await self.collect_appeal_responses(
+                        {
+                            "denial_id": 34,
+                            "email": email,
+                            "semi_sekret": denial.semi_sekret,
+                        }
+                    )
+                self.assertNotIn(reserve_text, appeal_contents)
+                # The row is left exactly as the claim found it, for the run
+                # that actually won it.
+                await spec.arefresh_from_db()
+                self.assertTrue(spec.speculative)
+            finally:
+                await Denial.objects.filter(denial_id=34).adelete()
+
+        async_to_sync(test)()
+
+    @pytest.mark.django_db
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
     def test_reconnect_holds_the_reserve_once_enough_appeals_are_in_hand(
         self, mock_appeal_generator
     ):
@@ -1764,6 +1825,11 @@ def test_is_real_appeal(value, expected):
         # Unspaced script: one run of MIN_APPEAL_CHARS+ letters counts as prose.
         ("这是一封足够长的申诉信正文内容示例", True),
         ("申诉信", False),  # one short run is not enough
+        # Combining marks attach to the letter before them rather than being
+        # letters themselves, so scripts that use them (Thai, Devanagari) must
+        # still tokenize into words.
+        ("ที่นี่ดี ที่นี่ดี ที่นี่ดี", True),
+        ("नमस्ते दुनिया यह एक अपील है", True),
     ],
 )
 def test_appeal_has_words(value, expected):
@@ -1788,6 +1854,8 @@ def test_appeal_has_words(value, expected):
         # the / patient / rays; the possessive "s" and the lone "X" don't count
         ("the patient's X-rays", 3),
         ("COVID-19 treatment", 2),
+        # Combining marks don't split a word: three Thai words, not zero.
+        ("ที่นี่ดี ที่นี่ดี ที่นี่ดี", 3),
     ],
 )
 def test_appeal_word_count(value, expected):
@@ -1817,14 +1885,8 @@ def test_warn_unusable_appeal_logs_length_and_context():
     """The shared drop-site warning reports the measured length, the
     threshold, and the caller-supplied context. The reported length is the
     meaningful (non-whitespace) count, so internal spaces are not counted."""
-    from loguru import logger as loguru_logger
-
-    sink = io.StringIO()
-    handler_id = loguru_logger.add(sink, level="WARNING")
-    try:
+    with capture_logs(level="WARNING") as sink:
         warn_unusable_appeal("a b c", "model='m' for denial 7")
-    finally:
-        loguru_logger.remove(handler_id)
     output = sink.getvalue()
     assert "too-short" in output
     assert "len=3" in output  # 3 letters, the 2 spaces are excluded
@@ -1835,16 +1897,10 @@ def test_warn_unusable_appeal_logs_length_and_context():
 def test_warn_unusable_appeal_reports_wordless_reason():
     """A long-enough but wordless appeal is reported as not-words rather
     than as too short."""
-    from loguru import logger as loguru_logger
-
-    sink = io.StringIO()
-    handler_id = loguru_logger.add(sink, level="WARNING")
-    try:
+    with capture_logs(level="WARNING") as sink:
         warn_unusable_appeal(
             "1234-5678-90, 11/02/2026: $1,250.00", "model='m' for denial 7"
         )
-    finally:
-        loguru_logger.remove(handler_id)
     output = sink.getvalue()
     assert "not-words" in output
     assert "words=0" in output
@@ -1854,14 +1910,8 @@ def test_warn_unusable_appeal_reports_wordless_reason():
 
 def test_warn_unusable_appeal_handles_non_string():
     """A non-string (e.g. None) is reported as length 0 without raising."""
-    from loguru import logger as loguru_logger
-
-    sink = io.StringIO()
-    handler_id = loguru_logger.add(sink, level="WARNING")
-    try:
+    with capture_logs(level="WARNING") as sink:
         warn_unusable_appeal(None, "some context")
-    finally:
-        loguru_logger.remove(handler_id)
     output = sink.getvalue()
     assert "len=0" in output
 

--- a/tests/async-unit/test_common_view_logic.py
+++ b/tests/async-unit/test_common_view_logic.py
@@ -1068,6 +1068,87 @@ class TestCommonViewLogic(TestCase):
 
     @pytest.mark.django_db
     @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_reconnect_serves_the_reserve_without_waiting_out_a_deadline(
+        self, mock_appeal_generator
+    ):
+        """A reconnecting socket restarts this run's clock, but not the user's
+        wait. With the default (far-off) deadlines a first connect holds the
+        reserve back; reconnect=True hands it over in the first frames."""
+        email, denial = self._create_test_denial(32, gen_attempts=3)
+        reserve_text = "A reserve draft owed to a user whose socket dropped."
+        ProposedAppeal.objects.create(
+            for_denial=denial,
+            appeal_text=reserve_text,
+            speculative=True,
+            context_level="speculative",
+        )
+        mock_appeal_generator.make_appeals.side_effect = self._slow_make_appeals(
+            1.0, []
+        )
+
+        async def test():
+            try:
+                # Deadlines left at their defaults, so nothing here is "stalled"
+                # by the usual rule -- only the reconnect flag can flush this.
+                _, appeal_contents, _ = await self.collect_appeal_responses(
+                    {
+                        "denial_id": 32,
+                        "email": email,
+                        "semi_sekret": denial.semi_sekret,
+                        "reconnect": True,
+                    }
+                )
+                self.assertIn(reserve_text, appeal_contents)
+            finally:
+                await Denial.objects.filter(denial_id=32).adelete()
+
+        async_to_sync(test)()
+
+    @pytest.mark.django_db
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_reconnect_holds_the_reserve_once_enough_appeals_are_in_hand(
+        self, mock_appeal_generator
+    ):
+        """The reconnect waiver drops the deadline, not the ENOUGH_APPEALS
+        condition: a user who already has a full set keeps their reserve held
+        back even on a reconnect."""
+        email, denial = self._create_test_denial(33, gen_attempts=3)
+        for i in range(AppealsBackendHelper.ENOUGH_APPEALS):
+            ProposedAppeal.objects.create(
+                for_denial=denial,
+                appeal_text=f"An appeal this user already has in hand, no {i}.",
+                speculative=False,
+                context_level="full",
+            )
+        reserve_text = "A reserve draft that a full set must keep held back."
+        spec = ProposedAppeal.objects.create(
+            for_denial=denial,
+            appeal_text=reserve_text,
+            speculative=True,
+            context_level="speculative",
+        )
+        mock_appeal_generator.make_appeals.return_value = iter([])
+
+        async def test():
+            try:
+                _, appeal_contents, _ = await self.collect_appeal_responses(
+                    {
+                        "denial_id": 33,
+                        "email": email,
+                        "semi_sekret": denial.semi_sekret,
+                        "reconnect": True,
+                    }
+                )
+                self.assertNotIn(reserve_text, appeal_contents)
+                await spec.arefresh_from_db()
+                self.assertTrue(spec.speculative)
+            finally:
+                await Denial.objects.filter(denial_id=33).adelete()
+
+        async_to_sync(test)()
+
+    @pytest.mark.django_db
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
     def test_undeliverable_reserve_rows_are_not_counted_or_served(
         self, mock_appeal_generator
     ):

--- a/tests/async-unit/test_dev_storage_settings.py
+++ b/tests/async-unit/test_dev_storage_settings.py
@@ -46,9 +46,7 @@ class TestDevExternalStorageLocations:
                 "EXTERNAL_STORAGE_LOCATION_B",
             ),
         ):
-            expected = os.environ.get(
-                env_var, getattr(fhi_settings.Dev, default_attr)
-            )
+            expected = os.environ.get(env_var, getattr(fhi_settings.Dev, default_attr))
             assert getattr(fhi_settings.Dev, location_attr) == expected
 
     def test_external_storage_is_created_and_listable(self, tmp_path):

--- a/tests/async-unit/test_generate_appeal.py
+++ b/tests/async-unit/test_generate_appeal.py
@@ -1177,9 +1177,10 @@ class TestPeekRealOrNone:
         assert "primary first item is unusable" in output
         assert "denial 999" in output
 
-    def test_numbers_and_punctuation_first_returns_none(self):
-        """A long letterless first item (e.g. a model echoing a claim number)
-        must trigger fallback just like a runt does."""
+    def test_wordless_first_returns_none(self):
+        """A long but wordless first item (e.g. a model echoing back the claim
+        number and date of service) must trigger fallback just like a runt
+        does."""
         first, _ = _peek_real_or_none(
             iter([_ga("1234-5678-90, 11/02/2026: $1,250.00")]),
             denial_id=1,

--- a/tests/async-unit/test_generate_appeal.py
+++ b/tests/async-unit/test_generate_appeal.py
@@ -1174,5 +1174,15 @@ class TestPeekRealOrNone:
         with _loguru_capture() as sink:
             _peek_real_or_none(iter([_ga("short")]), denial_id=999, stage="primary")
         output = sink.getvalue()
-        assert "primary first item is a runt" in output
+        assert "primary first item is unusable" in output
         assert "denial 999" in output
+
+    def test_numbers_and_punctuation_first_returns_none(self):
+        """A long letterless first item (e.g. a model echoing a claim number)
+        must trigger fallback just like a runt does."""
+        first, _ = _peek_real_or_none(
+            iter([_ga("1234-5678-90, 11/02/2026: $1,250.00")]),
+            denial_id=1,
+            stage="primary",
+        )
+        assert first is None


### PR DESCRIPTION
## Summary
Extends appeal validation to reject not just short appeals, but also appeals that are long enough but contain no actual words—e.g., a model echoing back claim numbers, dates, and dollar amounts. This prevents junk output from bypassing the minimum-length check.

## Key Changes

- **New utility functions in `utils.py`:**
  - `appeal_word_count()` — counts word-like tokens (runs of 2+ letters) in text
  - `appeal_has_words()` — checks if text contains enough words to be a real letter
  - `describe_unusable_appeal()` — explains why text fails validation (too-short vs. not-words)
  - Renamed `warn_too_short_appeal()` → `warn_unusable_appeal()` to cover both rejection reasons

- **Updated `is_real_appeal()` validation:**
  - Now requires both minimum length AND actual words (via `appeal_has_words()`)
  - Handles unspaced scripts (Chinese, Japanese, Thai) by accepting one long run of letters as prose

- **Consistent filtering across all appeal sources:**
  - Streaming generation path (`common_view_logic.py`)
  - Synthesis output (`common_view_logic.py`)
  - Fallback detection in `generate_appeal.py`
  - Previously-saved appeals in the database

- **Improved logging:**
  - Single warning format for all rejection reasons
  - Distinguishes "too-short" from "not-words" in output
  - Reports word count alongside character count for wordless rejects

## Implementation Details

- Word detection uses a Unicode-aware regex (`[^\W\d_]{2,}`) that excludes digits, punctuation, and lone letters
- Minimum word threshold is deliberately low (2 words) to catch worst-case junk while allowing legitimate short appeals
- Non-Latin scripts are supported: a single unspaced run of 15+ letters (e.g., Chinese text) counts as prose
- All appeal validation now goes through `is_real_appeal()`, ensuring consistent behavior across generation, synthesis, and database retrieval

## Tests Added
- `test_synthesis_wordless_output_is_filtered()` — synthesized junk is rejected
- `test_existing_wordless_appeal_is_skipped()` — saved junk is not re-delivered
- `test_wordless_first_returns_none()` — fallback triggers on wordless first item
- Parametrized tests for `appeal_has_words()` and `appeal_word_count()` with edge cases
- Refactored test helper `_run_generate_appeals_over_saved()` to reduce duplication

https://claude.ai/code/session_01Xrb3ZyBDnQcWrDbC9pvvXj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened appeal validation to reject outputs that are too short or have no meaningful word-like content (including punctuation- and number-only text).
  * Prevented undeliverable/invalid generated and previously saved appeals from being returned.
  * Improved generation fallback when the first proposed appeal is unusable.
  * Enhanced reconnect handling so speculative/preview items flush and are served without duplicates when applicable.
* **Diagnostics**
  * Updated warnings to consistently distinguish “too-short” vs “not-words” unusable appeals with clearer context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->