### PR TITLE
Add a staff direct-query link for each model on the status page

### DIFF
--- a/fighthealthinsurance/ml/health_status.py
+++ b/fighthealthinsurance/ml/health_status.py
@@ -432,6 +432,17 @@ def compute_model_health_details(timeout_seconds: int = 8) -> List[Dict[str, Any
     if not candidates:
         return results
 
+    # Cross-process reference so the status page can link each row to a direct
+    # staff query of that exact backend. Best-effort: a backend we cannot label
+    # still gets a health row, just without the query link.
+    try:
+        from fighthealthinsurance.ml.model_query import model_refs_by_identity
+
+        ref_by_id = model_refs_by_identity()
+    except Exception:
+        logger.opt(exception=True).debug("Could not build model query references")
+        ref_by_id = {}
+
     ex = concurrent.futures.ThreadPoolExecutor(max_workers=min(8, len(candidates)))
     try:
         future_map = {ex.submit(m.model_is_ok): m for m in candidates}
@@ -453,7 +464,13 @@ def compute_model_health_details(timeout_seconds: int = 8) -> List[Dict[str, Any
             else:
                 err = f"timeout>{timeout_seconds}s"
             results.append(
-                {"name": name, "ok": ok, "external": is_external, "error": err}
+                {
+                    "name": name,
+                    "ok": ok,
+                    "external": is_external,
+                    "error": err,
+                    "ref": ref_by_id.get(id(m)),
+                }
             )
     finally:
         # Return at the deadline rather than blocking on stragglers. Exiting a

--- a/fighthealthinsurance/ml/model_query.py
+++ b/fighthealthinsurance/ml/model_query.py
@@ -43,7 +43,16 @@ DEFAULT_SYSTEM_PROMPT = (
 DEFAULT_TEMPERATURE = 0.7
 DEFAULT_TIMEOUT = 60.0
 # Bounds for staff-supplied values; a direct query is a debugging tool, not a
-# way to pin a web worker to a backend indefinitely.
+# way to wait on a backend indefinitely.
+#
+# MAX_TIMEOUT matches ``RemoteOpenLike._timeout`` (300s), the backend's own
+# per-inference ceiling: past that the model layer gives up on its own, so a
+# larger value here would buy nothing. It sits well inside the ingress
+# ``proxy-read-timeout`` (3600s in k8s/deploy*.yaml), so a query that runs to
+# the ceiling still returns a real answer rather than a gateway error. Only a
+# staff user who deliberately raises the field gets near it -- the default is
+# a minute -- and the sync view runs in the ASGI thread pool, so a long query
+# holds one thread rather than blocking its uvicorn worker.
 MIN_TIMEOUT = 1.0
 MAX_TIMEOUT = 300.0
 MAX_PROMPT_LENGTH = 20000

--- a/fighthealthinsurance/ml/model_query.py
+++ b/fighthealthinsurance/ml/model_query.py
@@ -1,0 +1,249 @@
+"""Address and directly query one specific ML model backend.
+
+The staff system-status page lists every registered backend and whether it
+answers a liveness check. When a row looks wrong the next question is always
+"what does it actually say?", so this module lets staff send an arbitrary
+prompt straight at one backend and capture the raw response -- bypassing the
+router's selection and fan-out so the answer is attributable to that backend
+alone.
+
+Backends are addressed by a **reference string** rather than a Python object
+id (as ``health_status._model_key`` uses): several web pods each build their
+own ``MLRouter``, so a link generated while rendering the status page on one
+pod has to resolve on whichever pod serves the follow-up request. The
+reference is therefore built from stable configuration -- implementation
+class, router-stamped friendly name, configured wire model id -- plus an
+occurrence index that keeps genuinely identical replicas apart. The router's
+pools are cost-sorted from the same configuration in every process, so that
+index means the same thing everywhere.
+
+Queries reuse ``_infer_no_context`` (the same entry point as the startup
+``probe``) with ``raise_http_errors=True`` so auth/quota/model-not-found
+failures surface as a real HTTP status instead of being flattened into
+"empty response".
+"""
+
+import asyncio
+import time
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from asgiref.sync import async_to_sync
+from loguru import logger
+
+from fighthealthinsurance.ml import ml_router as ml_router_module
+from fighthealthinsurance.ml.ml_models import RemoteModelLike, describe_model_error
+
+# Field separator inside a reference string. Neither a class name, a friendly
+# model name nor a wire model id contains it, so no escaping is needed.
+_REF_SEP = "|"
+
+DEFAULT_SYSTEM_PROMPT = (
+    "You are a helpful assistant. Answer the question directly and concisely."
+)
+DEFAULT_TEMPERATURE = 0.7
+DEFAULT_TIMEOUT = 60.0
+# Bounds for staff-supplied values; a direct query is a debugging tool, not a
+# way to pin a web worker to a backend indefinitely.
+MIN_TIMEOUT = 1.0
+MAX_TIMEOUT = 300.0
+MAX_PROMPT_LENGTH = 20000
+
+
+def _base_ref(model: Any) -> str:
+    """Configuration-derived (not yet unique) reference for ``model``."""
+    name = getattr(model, "name", None) or ""
+    wire = getattr(model, "model", None) or ""
+    return _REF_SEP.join([type(model).__name__, str(name), str(wire)])
+
+
+def build_refs(models: Sequence[Any]) -> List[str]:
+    """Reference string for each model in ``models``, positionally aligned.
+
+    Identical configurations (e.g. internal replicas of one model on several
+    hosts) share a base reference, so each gets the index of its occurrence
+    appended. Because the caller always passes the pools in their stable
+    cost-sorted order, the same backend gets the same reference in every
+    process.
+    """
+    seen: Dict[str, int] = {}
+    refs: List[str] = []
+    for model in models:
+        base = _base_ref(model)
+        occurrence = seen.get(base, 0)
+        seen[base] = occurrence + 1
+        refs.append(f"{base}{_REF_SEP}{occurrence}")
+    return refs
+
+
+def registered_models() -> List[RemoteModelLike]:
+    """Every backend a staff query can target, deduplicated by identity.
+
+    Context-only backends (e.g. Perplexity for citations) are included and
+    appended last: they never take part in generation, but they are exactly
+    the ones whose quota/credential failures are worth poking at by hand.
+    Appending them keeps the occurrence indices of the generation pools
+    unchanged, so a reference stays valid whether or not the context-only
+    pool is reachable.
+    """
+    router = ml_router_module.ml_router
+    models: List[RemoteModelLike] = list(router.all_models_by_cost)
+    try:
+        context_only = list(router.context_only_models_by_cost)
+    except Exception:
+        # A router that cannot enumerate its context-only pool should still
+        # let staff query the generation backends.
+        logger.opt(exception=True).debug(
+            "Could not enumerate context-only models for direct query"
+        )
+        context_only = []
+    seen = {id(m) for m in models}
+    for m in context_only:
+        if id(m) not in seen:
+            seen.add(id(m))
+            models.append(m)
+    return models
+
+
+def enumerate_queryable_models() -> List[Tuple[str, RemoteModelLike]]:
+    """``(reference, model)`` for every backend, in stable pool order."""
+    models = registered_models()
+    return list(zip(build_refs(models), models))
+
+
+def model_refs_by_identity() -> Dict[int, str]:
+    """``id(model) -> reference`` for the current process's backends.
+
+    Lets a caller that already holds model instances (the health sweep) label
+    them without re-deriving the ordering rules.
+    """
+    return {id(model): ref for ref, model in enumerate_queryable_models()}
+
+
+def find_model_by_ref(ref: Optional[str]) -> Optional[RemoteModelLike]:
+    """Resolve a reference string to a live backend, or ``None``."""
+    if not ref:
+        return None
+    for candidate_ref, model in enumerate_queryable_models():
+        if candidate_ref == ref:
+            return model
+    return None
+
+
+def describe_model(model: Any, ref: Optional[str] = None) -> Dict[str, Any]:
+    """Template-friendly summary of a backend.
+
+    ``dual_mode``/``backup_model`` are surfaced because they change how a
+    response should be read: a dual-mode backend races a backup endpoint, so
+    the text may have come from the backup rather than the primary.
+    """
+    backup_model = getattr(model, "backup_model", None)
+    dual_mode = bool(getattr(model, "dual_mode", False)) and bool(
+        getattr(model, "backup_api_base", None)
+    )
+    return {
+        "ref": ref if ref is not None else _base_ref(model) + f"{_REF_SEP}0",
+        "label": str(model),
+        "class_name": type(model).__name__,
+        "name": getattr(model, "name", None),
+        "wire_model": getattr(model, "model", None),
+        "api_base": getattr(model, "api_base", None),
+        "external": bool(getattr(model, "external", True)),
+        "context_only": bool(getattr(model, "context_only", False)),
+        "dual_mode": dual_mode,
+        "backup_model": backup_model if dual_mode else None,
+        "backup_api_base": (
+            getattr(model, "backup_api_base", None) if dual_mode else None
+        ),
+    }
+
+
+def clamp_timeout(raw: Any, default: float = DEFAULT_TIMEOUT) -> float:
+    """Parse a staff-supplied timeout, falling back to the default."""
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return default
+    return max(MIN_TIMEOUT, min(MAX_TIMEOUT, value))
+
+
+def clamp_temperature(raw: Any, default: float = DEFAULT_TEMPERATURE) -> float:
+    """Parse a staff-supplied temperature, falling back to the default."""
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return default
+    return max(0.0, min(2.0, value))
+
+
+async def aquery_model(
+    model: Any,
+    prompt: str,
+    *,
+    system_prompt: Optional[str] = None,
+    temperature: float = DEFAULT_TEMPERATURE,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> Dict[str, Any]:
+    """Send ``prompt`` to ``model`` and capture what comes back.
+
+    Returns ``{"ok", "response", "error", "elapsed"}``. Never raises: a
+    failure is reported as ``ok=False`` with a one-line reason, since the
+    reason is the point of running this from a status page.
+    """
+    # ``_infer`` loops over the system prompts, so an empty list would return
+    # None without ever calling the backend -- always send at least one.
+    system_prompts = [(system_prompt or "").strip() or DEFAULT_SYSTEM_PROMPT]
+    start = time.monotonic()
+    try:
+        response = await asyncio.wait_for(
+            model._infer_no_context(
+                system_prompts=system_prompts,
+                prompt=prompt,
+                temperature=temperature,
+                raise_http_errors=True,
+            ),
+            timeout=timeout,
+        )
+    except asyncio.TimeoutError:
+        return {
+            "ok": False,
+            "response": None,
+            "error": f"timeout>{timeout:g}s",
+            "elapsed": time.monotonic() - start,
+        }
+    except Exception as e:
+        logger.warning(
+            f"Staff direct query to {model} failed: {describe_model_error(e)}"
+        )
+        return {
+            "ok": False,
+            "response": None,
+            "error": describe_model_error(e),
+            "elapsed": time.monotonic() - start,
+        }
+    elapsed = time.monotonic() - start
+    if response is None or not response.strip():
+        return {
+            "ok": False,
+            "response": response,
+            "error": "empty or no response",
+            "elapsed": elapsed,
+        }
+    return {"ok": True, "response": response, "error": None, "elapsed": elapsed}
+
+
+def query_model(
+    model: Any,
+    prompt: str,
+    *,
+    system_prompt: Optional[str] = None,
+    temperature: float = DEFAULT_TEMPERATURE,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> Dict[str, Any]:
+    """Synchronous wrapper around :func:`aquery_model` for the staff view."""
+    return async_to_sync(aquery_model)(
+        model,
+        prompt,
+        system_prompt=system_prompt,
+        temperature=temperature,
+        timeout=timeout,
+    )

--- a/fighthealthinsurance/staff_views.py
+++ b/fighthealthinsurance/staff_views.py
@@ -41,6 +41,7 @@ from fighthealthinsurance.models import (
 )
 from fighthealthinsurance.email_utils import is_sendable_email
 from fighthealthinsurance.business_hours import describe_send_window
+from fighthealthinsurance.ml import model_query
 from fighthealthinsurance.ml.model_identity import (
     LEGACY_UNATTRIBUTED_LABEL,
     normalize_model_label,
@@ -284,6 +285,135 @@ class AdminStatusView(generic.TemplateView):
             logger.opt(exception=True).warning("External storage health check failed")
             out["error"] = str(e)
         return out
+
+
+class AdminModelQueryView(View):
+    """Staff page to send an ad-hoc prompt at one specific model backend.
+
+    Reached from the "query" link on each row of the system status page. The
+    status page answers "is this backend up?"; this answers the follow-up
+    question, "what does it actually say?" -- useful for telling a backend
+    that is merely slow apart from one returning refusals, empty text, or a
+    credentials error, without waiting for a real appeal to route to it.
+
+    The prompt goes straight to the chosen backend via
+    ``model_query.query_model``: no router selection, no fan-out, no
+    fallback to a different model, so the captured response is attributable
+    to that backend. It makes a real (billable) inference call, hence
+    staff-only and never triggered by simply loading the page.
+    """
+
+    template_name = "admin_model_query.html"
+    unknown_ref_error = (
+        "Unknown model reference. It may be from an older deployment "
+        "-- pick a backend below and try again."
+    )
+
+    def get(self, request):
+        ref = request.GET.get("ref") or ""
+        return self._render(request, ref=ref)
+
+    def post(self, request):
+        ref = request.POST.get("ref") or ""
+        prompt = (request.POST.get("prompt") or "").strip()
+        system_prompt = (request.POST.get("system_prompt") or "").strip()
+        temperature = model_query.clamp_temperature(request.POST.get("temperature"))
+        timeout = model_query.clamp_timeout(request.POST.get("timeout"))
+
+        result: Optional[Dict[str, Any]] = None
+        error: Optional[str] = None
+        model = self._lookup(ref)
+        if model is None:
+            error = self.unknown_ref_error
+        elif not prompt:
+            error = "Enter a prompt to send."
+        elif len(prompt) > model_query.MAX_PROMPT_LENGTH:
+            error = (
+                f"Prompt is too long ({len(prompt)} characters); "
+                f"the limit is {model_query.MAX_PROMPT_LENGTH}."
+            )
+        else:
+            logger.info(
+                f"Staff user {request.user.username} sending a direct query to "
+                f"model {model} ({len(prompt)} chars, timeout {timeout:g}s)"
+            )
+            result = model_query.query_model(
+                model,
+                prompt,
+                system_prompt=system_prompt,
+                temperature=temperature,
+                timeout=timeout,
+            )
+
+        return render(
+            request,
+            self.template_name,
+            self._context(
+                ref=ref,
+                prompt=prompt,
+                system_prompt=system_prompt,
+                temperature=temperature,
+                timeout=timeout,
+                result=result,
+                error=error,
+            ),
+        )
+
+    @staticmethod
+    def _lookup(ref: str):
+        """Resolve a model reference, treating a broken router as "not found"
+        so the page renders an error row instead of a 500."""
+        try:
+            return model_query.find_model_by_ref(ref)
+        except Exception:
+            logger.opt(exception=True).error("Error resolving model reference")
+            return None
+
+    def _render(self, request, **kwargs):
+        return render(request, self.template_name, self._context(**kwargs))
+
+    def _context(
+        self,
+        ref: str = "",
+        prompt: str = "",
+        system_prompt: str = "",
+        temperature: float = model_query.DEFAULT_TEMPERATURE,
+        timeout: float = model_query.DEFAULT_TIMEOUT,
+        result: Optional[Dict[str, Any]] = None,
+        error: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        available: List[Dict[str, Any]] = []
+        selected: Optional[Dict[str, Any]] = None
+        enumeration_error: Optional[str] = None
+        try:
+            for candidate_ref, candidate in model_query.enumerate_queryable_models():
+                described = model_query.describe_model(candidate, ref=candidate_ref)
+                available.append(described)
+                if candidate_ref == ref:
+                    selected = described
+        except Exception as e:
+            logger.opt(exception=True).error("Error enumerating model backends")
+            enumeration_error = str(e)
+
+        if ref and selected is None and error is None and enumeration_error is None:
+            error = self.unknown_ref_error
+
+        return {
+            "title": "Query a Model Backend",
+            "ref": ref,
+            "selected": selected,
+            "available": available,
+            "enumeration_error": enumeration_error,
+            "prompt": prompt,
+            "system_prompt": system_prompt,
+            "temperature": temperature,
+            "timeout": timeout,
+            "default_system_prompt": model_query.DEFAULT_SYSTEM_PROMPT,
+            "max_prompt_length": model_query.MAX_PROMPT_LENGTH,
+            "max_timeout": model_query.MAX_TIMEOUT,
+            "result": result,
+            "error": error,
+        }
 
 
 class ScheduleFollowUps(View):

--- a/fighthealthinsurance/templates/admin_model_query.html
+++ b/fighthealthinsurance/templates/admin_model_query.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>{{ title }}</title>
+  <style>
+    body { font-family: Arial, sans-serif; max-width: 1100px; margin: 0 auto; padding: 20px; background: #f5f5f5; color: #222; }
+    h1 { color: #333; border-bottom: 2px solid #007bff; padding-bottom: 10px; }
+    h2 { color: #555; margin-top: 0; border-left: 4px solid #007bff; padding-left: 10px; }
+    .status-section { background: white; padding: 20px; border-radius: 8px; margin-bottom: 20px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+    .nav-back { display: inline-block; margin-bottom: 14px; margin-right: 14px; color: #007bff; text-decoration: none; }
+    .nav-back:hover { text-decoration: underline; }
+    .meta { color: #666; font-size: 0.9em; margin-bottom: 18px; }
+    .badge { display: inline-block; padding: 2px 10px; border-radius: 12px; font-size: 0.82em; font-weight: bold; color: white; }
+    .badge.ok { background: #28a745; }
+    .badge.bad { background: #dc3545; }
+    .badge.warn { background: #f0ad4e; color: #333; }
+    .pill { display: inline-block; padding: 1px 8px; border-radius: 10px; font-size: 0.78em; background: #e9ecef; color: #555; }
+    .error-text { color: #dc3545; }
+    table.status { width: 100%; border-collapse: collapse; margin-top: 8px; }
+    table.status th, table.status td { padding: 6px 10px; text-align: left; border-bottom: 1px solid #eee; vertical-align: top; }
+    table.status th { background: #f0f4f8; }
+    table.status td.key { width: 180px; color: #666; }
+    label { display: block; font-weight: bold; margin: 12px 0 4px 0; font-size: 0.9em; color: #444; }
+    textarea, input[type=text], input[type=number] { width: 100%; box-sizing: border-box; padding: 8px; border: 1px solid #ced4da; border-radius: 4px; font-family: inherit; font-size: 0.95em; }
+    textarea { font-family: monospace; }
+    .field-row { display: flex; gap: 16px; }
+    .field-row > div { flex: 1; }
+    .hint { font-size: 0.8em; color: #777; font-weight: normal; }
+    button { margin-top: 14px; padding: 10px 22px; background: #007bff; color: white; border: none; border-radius: 4px; font-size: 1em; cursor: pointer; }
+    button:hover { background: #0069d9; }
+    pre.response { background: #f8f9fa; border: 1px solid #dee2e6; border-radius: 6px; padding: 14px; white-space: pre-wrap; word-wrap: break-word; max-height: 640px; overflow-y: auto; }
+    .warn-box { background: #fff8e6; border: 1px solid #f0ad4e; border-radius: 6px; padding: 10px 14px; font-size: 0.9em; }
+  </style>
+</head>
+<body>
+  <a class="nav-back" href="{% url 'staff_dashboard' %}">&laquo; Back to Staff Dashboard</a>
+  <a class="nav-back" href="{% url 'admin_status' %}">&laquo; Back to System Status</a>
+  <h1>{{ title }}</h1>
+  <p class="meta">
+    Sends your prompt straight to one backend &mdash; no router selection, no fan-out, no fallback
+    to another model &mdash; so the response below came from that backend. This makes a real
+    (billable) inference call.
+  </p>
+
+  {% if error %}
+    <div class="status-section">
+      <p><span class="badge bad">ERROR</span> <span class="error-text">{{ error }}</span></p>
+    </div>
+  {% endif %}
+
+  {% if enumeration_error %}
+    <div class="status-section">
+      <p><span class="badge bad">ERROR</span>
+        <span class="error-text">Could not enumerate model backends: {{ enumeration_error }}</span></p>
+    </div>
+  {% endif %}
+
+  {% if selected %}
+  <div class="status-section">
+    <h2>🧠 {{ selected.label }}</h2>
+    <table class="status">
+      <tbody>
+        <tr><td class="key">Class</td><td>{{ selected.class_name }}</td></tr>
+        <tr><td class="key">Tracking name</td><td>{{ selected.name|default:"—" }}</td></tr>
+        <tr><td class="key">Wire model id</td><td>{{ selected.wire_model|default:"—" }}</td></tr>
+        <tr><td class="key">API base</td><td>{{ selected.api_base|default:"—" }}</td></tr>
+        <tr>
+          <td class="key">Kind</td>
+          <td>
+            <span class="pill">{% if selected.external %}external{% else %}internal{% endif %}</span>
+            {% if selected.context_only %}<span class="pill">context-only</span>{% endif %}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    {% if selected.dual_mode %}
+      <p class="warn-box" style="margin-top: 14px;">
+        This backend runs in <strong>dual mode</strong>: it races
+        <code>{{ selected.wire_model }}</code> against
+        <code>{{ selected.backup_model|default:"a backup model" }}</code>
+        at <code>{{ selected.backup_api_base }}</code> and returns whichever answers first,
+        so the response may have come from the backup endpoint.
+      </p>
+    {% endif %}
+  </div>
+
+  <div class="status-section">
+    <h2>✉️ Send a Query</h2>
+    <form method="post">
+      {% csrf_token %}
+      <input type="hidden" name="ref" value="{{ selected.ref }}">
+      <label for="prompt">Prompt <span class="hint">(max {{ max_prompt_length }} characters)</span></label>
+      <textarea id="prompt" name="prompt" rows="8" required
+                maxlength="{{ max_prompt_length }}">{{ prompt }}</textarea>
+      <label for="system_prompt">System prompt <span class="hint">(optional; defaults to &ldquo;{{ default_system_prompt }}&rdquo;)</span></label>
+      <input type="text" id="system_prompt" name="system_prompt" value="{{ system_prompt }}">
+      <div class="field-row">
+        <div>
+          <label for="temperature">Temperature <span class="hint">(0&ndash;2)</span></label>
+          <input type="number" id="temperature" name="temperature" step="0.1" min="0" max="2"
+                 value="{{ temperature }}">
+        </div>
+        <div>
+          <label for="timeout">Timeout <span class="hint">(seconds, max {{ max_timeout|floatformat:0 }})</span></label>
+          <input type="number" id="timeout" name="timeout" step="1" min="1" max="{{ max_timeout|floatformat:0 }}"
+                 value="{{ timeout|floatformat:0 }}">
+        </div>
+      </div>
+      <button type="submit">Send to {{ selected.label }}</button>
+    </form>
+  </div>
+  {% endif %}
+
+  {% if result %}
+  <div class="status-section">
+    <h2>📥 Response</h2>
+    <p>
+      {% if result.ok %}
+        <span class="badge ok">RESPONDED</span>
+      {% else %}
+        <span class="badge bad">FAILED</span>
+      {% endif %}
+      <span class="pill">{{ result.elapsed|floatformat:2 }}s</span>
+      {% if result.error %}<span class="error-text">&nbsp;{{ result.error }}</span>{% endif %}
+    </p>
+    {% if result.response %}
+      <pre class="response">{{ result.response }}</pre>
+    {% endif %}
+  </div>
+  {% endif %}
+
+  <div class="status-section">
+    <h2>📋 Registered Backends</h2>
+    {% if available %}
+    <table class="status">
+      <thead><tr><th>Model</th><th>Class</th><th>Wire model id</th><th>Kind</th><th></th></tr></thead>
+      <tbody>
+      {% for m in available %}
+        <tr>
+          <td>{{ m.label }}</td>
+          <td>{{ m.class_name }}</td>
+          <td>{{ m.wire_model|default:"—" }}</td>
+          <td>
+            <span class="pill">{% if m.external %}external{% else %}internal{% endif %}</span>
+            {% if m.context_only %}<span class="pill">context-only</span>{% endif %}
+          </td>
+          <td>
+            {% if m.ref == ref %}
+              <span class="pill">selected</span>
+            {% else %}
+              <a href="{% url 'admin_model_query' %}?ref={{ m.ref|urlencode }}">query</a>
+            {% endif %}
+          </td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+    {% elif not enumeration_error %}
+      <p class="meta">No model backends registered.</p>
+    {% endif %}
+  </div>
+</body>
+</html>

--- a/fighthealthinsurance/templates/admin_status.html
+++ b/fighthealthinsurance/templates/admin_status.html
@@ -59,7 +59,7 @@
       </p>
       {% if models.details %}
       <table class="status">
-        <thead><tr><th>Model</th><th>Type</th><th>Status</th><th>Error</th></tr></thead>
+        <thead><tr><th>Model</th><th>Type</th><th>Status</th><th>Error</th><th>Query</th></tr></thead>
         <tbody>
         {% for d in models.details %}
           <tr>
@@ -67,10 +67,20 @@
             <td><span class="pill">{% if d.external %}external{% else %}internal{% endif %}</span></td>
             <td>{% if d.ok %}<span class="badge ok">up</span>{% else %}<span class="badge bad">down</span>{% endif %}</td>
             <td class="error-text">{{ d.error|default:"" }}</td>
+            <td>
+              {% if d.ref %}
+                <a href="{% url 'admin_model_query' %}?ref={{ d.ref|urlencode }}"
+                   title="Send a prompt straight to this backend and capture the response">query</a>
+              {% endif %}
+            </td>
           </tr>
         {% endfor %}
         </tbody>
       </table>
+      <p class="meta" style="margin-top: 10px;">
+        &ldquo;query&rdquo; sends an ad-hoc prompt to that one backend (no router fan-out or fallback)
+        and shows the raw response &mdash; a real, billable inference call.
+      </p>
       {% else %}
         <p class="meta">No model backends registered.</p>
       {% endif %}

--- a/fighthealthinsurance/templates/staff_dashboard.html
+++ b/fighthealthinsurance/templates/staff_dashboard.html
@@ -84,6 +84,12 @@
           <div class="link-description">Live health: ML models up, Ray actors, Sonic fax, queued faxes, and storage</div>
         </a>
       </li>
+      <li>
+        <a href="{% url 'admin_model_query' %}">
+          <strong>Query a Model Backend</strong>
+          <div class="link-description">Send an ad-hoc prompt to one specific ML backend (no router fan-out or fallback) and capture the raw response</div>
+        </a>
+      </li>
     </ul>
   </div>
 

--- a/fighthealthinsurance/urls.py
+++ b/fighthealthinsurance/urls.py
@@ -78,6 +78,11 @@ urlpatterns: List[Union[URLPattern, URLResolver]] = [
         name="admin_status",
     ),
     path(
+        "timbit/help/model_query",
+        staff_member_required(staff_views.AdminModelQueryView.as_view()),
+        name="admin_model_query",
+    ),
+    path(
         "timbit/help/followup_sched",
         staff_member_required(staff_views.ScheduleFollowUps.as_view()),
     ),

--- a/tests/sync/test_admin_model_query.py
+++ b/tests/sync/test_admin_model_query.py
@@ -1,0 +1,386 @@
+"""Tests for the staff direct-model-query page (AdminModelQueryView) and the
+``model_query`` helpers that address and call a single backend."""
+
+import asyncio
+from unittest import mock
+
+import aiohttp
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from fighthealthinsurance.ml import model_query
+
+User = get_user_model()
+
+_ROUTER = "fighthealthinsurance.ml.ml_router.ml_router"
+
+
+class FakeModel:
+    """Minimal stand-in for a RemoteModelLike backend."""
+
+    external = True
+    context_only = False
+    dual_mode = False
+    backup_api_base = None
+    backup_model = None
+    api_base = "https://example.invalid/v1"
+
+    def __init__(self, name="fhi-test", model="vendor/test-model", response="hi there"):
+        self.name = name
+        self.model = model
+        self._response = response
+        self.calls = []
+
+    def __str__(self):
+        return self.name
+
+    async def _infer_no_context(self, system_prompts, prompt, **kwargs):
+        self.calls.append(
+            {"system_prompts": system_prompts, "prompt": prompt, **kwargs}
+        )
+        if isinstance(self._response, Exception):
+            raise self._response
+        return self._response
+
+
+def _fake_router(models, context_only=None):
+    router = mock.MagicMock()
+    router.all_models_by_cost = models
+    router.context_only_models_by_cost = context_only or []
+    return router
+
+
+class ModelRefTest(TestCase):
+    def test_ref_is_derived_from_configuration_not_object_identity(self):
+        """A ref built on one pod must resolve on another, so it must not
+        depend on the in-process object address."""
+        first = FakeModel()
+        second = FakeModel()
+        self.assertNotEqual(id(first), id(second))
+        with mock.patch(_ROUTER, _fake_router([first])):
+            ref_a = model_query.enumerate_queryable_models()[0][0]
+        with mock.patch(_ROUTER, _fake_router([second])):
+            ref_b = model_query.enumerate_queryable_models()[0][0]
+        self.assertEqual(ref_a, ref_b)
+
+    def test_identically_configured_replicas_get_distinct_refs(self):
+        replicas = [FakeModel(), FakeModel()]
+        with mock.patch(_ROUTER, _fake_router(replicas)):
+            refs = [ref for ref, _ in model_query.enumerate_queryable_models()]
+        self.assertEqual(len(set(refs)), 2)
+
+    def test_context_only_models_are_queryable(self):
+        generation = FakeModel(name="fhi-gen")
+        citations = FakeModel(name="perplexity")
+        citations.context_only = True
+        with mock.patch(_ROUTER, _fake_router([generation], [citations])):
+            found = model_query.enumerate_queryable_models()
+        self.assertEqual([str(m) for _, m in found], ["fhi-gen", "perplexity"])
+
+    def test_context_only_models_do_not_shift_generation_refs(self):
+        """Refs must stay valid whether or not the context-only pool loads,
+        so the context-only models are enumerated last."""
+        generation = FakeModel(name="fhi-gen")
+        citations = FakeModel(name="perplexity")
+        with mock.patch(_ROUTER, _fake_router([generation])):
+            without = model_query.enumerate_queryable_models()[0][0]
+        with mock.patch(_ROUTER, _fake_router([generation], [citations])):
+            with_context = model_query.enumerate_queryable_models()[0][0]
+        self.assertEqual(without, with_context)
+
+    def test_find_model_by_ref_round_trips(self):
+        wanted = FakeModel(name="wanted", model="vendor/wanted")
+        other = FakeModel(name="other", model="vendor/other")
+        with mock.patch(_ROUTER, _fake_router([other, wanted])):
+            ref = dict(
+                (str(m), r) for r, m in model_query.enumerate_queryable_models()
+            )["wanted"]
+            self.assertIs(model_query.find_model_by_ref(ref), wanted)
+
+    def test_find_model_by_unknown_ref_returns_none(self):
+        with mock.patch(_ROUTER, _fake_router([FakeModel()])):
+            self.assertIsNone(model_query.find_model_by_ref("Nope|nope|nope|0"))
+
+    def test_unreachable_context_only_pool_still_lists_generation_models(self):
+        router = mock.MagicMock()
+        router.all_models_by_cost = [FakeModel()]
+        type(router).context_only_models_by_cost = mock.PropertyMock(
+            side_effect=RuntimeError("pool not ready")
+        )
+        with mock.patch(_ROUTER, router):
+            self.assertEqual(len(model_query.enumerate_queryable_models()), 1)
+
+
+class QueryModelTest(TestCase):
+    def test_successful_query_captures_response_and_elapsed(self):
+        model = FakeModel(response="the appeal letter")
+        result = model_query.query_model(model, "hello?")
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["response"], "the appeal letter")
+        self.assertIsNone(result["error"])
+        self.assertGreaterEqual(result["elapsed"], 0)
+
+    def test_query_passes_prompt_and_surfaces_http_errors(self):
+        """raise_http_errors must be set so a 401 reads as an auth failure
+        rather than being flattened into "empty response"."""
+        model = FakeModel(
+            response=aiohttp.ClientResponseError(
+                request_info=mock.Mock(), history=(), status=401, message="Unauthorized"
+            )
+        )
+        result = model_query.query_model(model, "hello?")
+        self.assertFalse(result["ok"])
+        self.assertIn("401", result["error"])
+        self.assertTrue(model.calls[0]["raise_http_errors"])
+        self.assertEqual(model.calls[0]["prompt"], "hello?")
+
+    def test_empty_system_prompt_falls_back_to_default(self):
+        """``_infer`` loops over system prompts, so an empty list would never
+        reach the backend."""
+        model = FakeModel()
+        model_query.query_model(model, "hello?", system_prompt="   ")
+        self.assertEqual(
+            model.calls[0]["system_prompts"], [model_query.DEFAULT_SYSTEM_PROMPT]
+        )
+
+    def test_custom_system_prompt_and_temperature_are_forwarded(self):
+        model = FakeModel()
+        model_query.query_model(
+            model, "hello?", system_prompt="Be terse.", temperature=0.1
+        )
+        self.assertEqual(model.calls[0]["system_prompts"], ["Be terse."])
+        self.assertEqual(model.calls[0]["temperature"], 0.1)
+
+    def test_empty_response_is_reported_as_failure(self):
+        result = model_query.query_model(FakeModel(response="  "), "hello?")
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["error"], "empty or no response")
+
+    def test_timeout_is_enforced_and_reported(self):
+        class Hanging(FakeModel):
+            async def _infer_no_context(self, system_prompts, prompt, **kwargs):
+                await asyncio.sleep(30)
+                return "too late"
+
+        result = model_query.query_model(Hanging(), "hello?", timeout=0.1)
+        self.assertFalse(result["ok"])
+        self.assertIn("timeout", result["error"])
+
+    def test_unexpected_exception_does_not_propagate(self):
+        model = FakeModel(response=RuntimeError("backend exploded"))
+        result = model_query.query_model(model, "hello?")
+        self.assertFalse(result["ok"])
+        self.assertIn("backend exploded", result["error"])
+
+    def test_clamp_helpers_bound_and_default_staff_input(self):
+        self.assertEqual(model_query.clamp_timeout("9999"), model_query.MAX_TIMEOUT)
+        self.assertEqual(model_query.clamp_timeout("0"), model_query.MIN_TIMEOUT)
+        self.assertEqual(model_query.clamp_timeout("abc"), model_query.DEFAULT_TIMEOUT)
+        self.assertEqual(model_query.clamp_temperature("7"), 2.0)
+        self.assertEqual(model_query.clamp_temperature("-1"), 0.0)
+        self.assertEqual(
+            model_query.clamp_temperature(None), model_query.DEFAULT_TEMPERATURE
+        )
+
+
+class AdminModelQueryAccessTest(TestCase):
+    def test_anonymous_user_redirected(self):
+        response = self.client.get(reverse("admin_model_query"))
+        self.assertEqual(response.status_code, 302)
+
+    def test_authenticated_non_staff_user_redirected(self):
+        User.objects.create_user(username="plain", password="pw123", is_staff=False)
+        self.client.login(username="plain", password="pw123")
+        self.assertEqual(self.client.get(reverse("admin_model_query")).status_code, 302)
+
+    def test_non_staff_user_cannot_post_a_query(self):
+        """The expensive path must be gated too, not just the page render."""
+        model = FakeModel()
+        User.objects.create_user(username="plain", password="pw123", is_staff=False)
+        self.client.login(username="plain", password="pw123")
+        with mock.patch(_ROUTER, _fake_router([model])):
+            ref = model_query.enumerate_queryable_models()[0][0]
+            response = self.client.post(
+                reverse("admin_model_query"), {"ref": ref, "prompt": "hello?"}
+            )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(model.calls, [])
+
+
+class AdminModelQueryViewTest(TestCase):
+    def setUp(self):
+        User.objects.create_user(username="staff", password="pw123", is_staff=True)
+        self.client.login(username="staff", password="pw123")
+
+    @staticmethod
+    def _ref_for(models, index=0):
+        with mock.patch(_ROUTER, _fake_router(models)):
+            return model_query.enumerate_queryable_models()[index][0]
+
+    def test_get_lists_backends_without_calling_any(self):
+        model = FakeModel(name="fhi-listed")
+        with mock.patch(_ROUTER, _fake_router([model])):
+            response = self.client.get(reverse("admin_model_query"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "fhi-listed")
+        self.assertEqual(model.calls, [], "listing must not invoke the backend")
+
+    def test_get_with_ref_selects_the_backend_and_shows_the_form(self):
+        model = FakeModel(name="fhi-selected")
+        ref = self._ref_for([model])
+        with mock.patch(_ROUTER, _fake_router([model])):
+            response = self.client.get(reverse("admin_model_query"), {"ref": ref})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["selected"]["label"], "fhi-selected")
+        self.assertContains(response, "Send a Query")
+        self.assertEqual(model.calls, [])
+
+    def test_post_queries_only_the_selected_backend(self):
+        wanted = FakeModel(name="wanted", model="vendor/wanted", response="I answered")
+        other = FakeModel(name="other", model="vendor/other", response="not me")
+        ref = self._ref_for([other, wanted], index=1)
+        with mock.patch(_ROUTER, _fake_router([other, wanted])):
+            response = self.client.post(
+                reverse("admin_model_query"),
+                {"ref": ref, "prompt": "Why was this denied?"},
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "I answered")
+        self.assertEqual(len(wanted.calls), 1)
+        self.assertEqual(wanted.calls[0]["prompt"], "Why was this denied?")
+        self.assertEqual(other.calls, [], "only the selected backend may be called")
+
+    def test_post_renders_backend_failure_instead_of_erroring(self):
+        model = FakeModel(response=RuntimeError("connection refused"))
+        ref = self._ref_for([model])
+        with mock.patch(_ROUTER, _fake_router([model])):
+            response = self.client.post(
+                reverse("admin_model_query"), {"ref": ref, "prompt": "hello?"}
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context["result"]["ok"])
+        self.assertContains(response, "connection refused")
+
+    def test_post_without_prompt_does_not_call_the_backend(self):
+        model = FakeModel()
+        ref = self._ref_for([model])
+        with mock.patch(_ROUTER, _fake_router([model])):
+            response = self.client.post(
+                reverse("admin_model_query"), {"ref": ref, "prompt": "   "}
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.context["result"])
+        self.assertIn("Enter a prompt", response.context["error"])
+        self.assertEqual(model.calls, [])
+
+    def test_post_with_overlong_prompt_is_rejected(self):
+        model = FakeModel()
+        ref = self._ref_for([model])
+        with mock.patch(_ROUTER, _fake_router([model])):
+            response = self.client.post(
+                reverse("admin_model_query"),
+                {"ref": ref, "prompt": "x" * (model_query.MAX_PROMPT_LENGTH + 1)},
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("too long", response.context["error"])
+        self.assertEqual(model.calls, [])
+
+    def test_post_with_stale_ref_reports_error_without_querying(self):
+        model = FakeModel()
+        with mock.patch(_ROUTER, _fake_router([model])):
+            response = self.client.post(
+                reverse("admin_model_query"),
+                {"ref": "Gone|gone|gone|0", "prompt": "hello?"},
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Unknown model reference", response.context["error"])
+        self.assertEqual(model.calls, [])
+
+    def test_staff_supplied_timeout_and_temperature_are_clamped(self):
+        model = FakeModel()
+        ref = self._ref_for([model])
+        with mock.patch(_ROUTER, _fake_router([model])):
+            response = self.client.post(
+                reverse("admin_model_query"),
+                {
+                    "ref": ref,
+                    "prompt": "hello?",
+                    "timeout": "99999",
+                    "temperature": "11",
+                },
+            )
+        self.assertEqual(response.context["timeout"], model_query.MAX_TIMEOUT)
+        self.assertEqual(model.calls[0]["temperature"], 2.0)
+
+    def test_broken_router_renders_error_row_not_a_500(self):
+        broken = mock.MagicMock()
+        type(broken).all_models_by_cost = mock.PropertyMock(
+            side_effect=RuntimeError("router not ready")
+        )
+        with mock.patch(_ROUTER, broken):
+            response = self.client.get(reverse("admin_model_query"))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("router not ready", response.context["enumeration_error"])
+
+
+class AdminStatusModelQueryLinkTest(TestCase):
+    """The status page's model rows must carry a working query link."""
+
+    _MODELS = "fighthealthinsurance.ml.health_status.compute_model_health_details"
+    _ACTORS = "fighthealthinsurance.actor_health_status.check_actor_health"
+    _FAX = "fighthealthinsurance.fax_health_status.check_fax_backends_health"
+
+    def setUp(self):
+        User.objects.create_user(username="staff", password="pw123", is_staff=True)
+        self.client.login(username="staff", password="pw123")
+
+    def test_health_details_include_a_resolvable_ref(self):
+        from fighthealthinsurance.ml.health_status import compute_model_health_details
+
+        class Backend(FakeModel):
+            def model_is_ok(self):
+                return True
+
+        model = Backend(name="fhi-linked")
+        with mock.patch(_ROUTER, _fake_router([model])):
+            details = compute_model_health_details(timeout_seconds=2)
+            self.assertIsNotNone(details[0]["ref"])
+            self.assertIs(model_query.find_model_by_ref(details[0]["ref"]), model)
+
+    def test_status_page_links_each_model_to_the_query_page(self):
+        with mock.patch(self._FAX) as mock_fax, mock.patch(
+            self._ACTORS
+        ) as mock_actors, mock.patch(self._MODELS) as mock_models:
+            mock_models.return_value = [
+                {
+                    "name": "fhi-2025",
+                    "ok": True,
+                    "external": False,
+                    "error": None,
+                    "ref": "NewRemoteInternal|fhi-2025|fhi-2025|0",
+                }
+            ]
+            mock_actors.return_value = {
+                "alive_actors": 1,
+                "total_actors": 1,
+                "details": [],
+            }
+            mock_fax.return_value = {
+                "backends": [],
+                "total_backends": 0,
+                "sonic": {
+                    "configured": False,
+                    "active": False,
+                    "ok": False,
+                    "error": None,
+                },
+            }
+            response = self.client.get(reverse("admin_status"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            f"{reverse('admin_model_query')}?ref="
+            "NewRemoteInternal%7Cfhi-2025%7Cfhi-2025%7C0",
+        )


### PR DESCRIPTION
The system status page answers "is this backend up?"; the next question
on-call always has is "what does it actually say?" -- a backend that is
merely slow looks the same as one returning refusals, empty text, or a
credentials error until you get a real response out of it.

Each ML model row on /timbit/help/status now carries a "query" link to a
new staff-only page that sends an ad-hoc prompt straight at that one
backend and shows the raw response, latency, and any error. The call
bypasses router selection, fan-out and fallback, so the captured response
is attributable to that backend alone. Both pages sit behind
staff_member_required, and the expensive path only runs on POST.

Backends are addressed by a configuration-derived reference string
(class, tracking name, wire model id, occurrence index) rather than an
in-process object id, so a link rendered on one web pod resolves on
whichever pod serves the follow-up request. Queries reuse
_infer_no_context with raise_http_errors=True -- the same entry point as
the startup probe -- so auth/quota/model-not-found failures surface as a
real HTTP status instead of "empty response". Staff-supplied timeout and
temperature are clamped, prompt length is bounded, and only the prompt's
length is logged.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BL9kMms2V4qkfg35x3TsiJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a staff-only “Query a Model Backend” page to run an ad-hoc prompt against a single ML backend and display the raw response, elapsed time, and any errors.
  * Introduced stable backend references for selecting targets, plus configurable (clamped) system prompt, temperature, and timeout controls.
  * Added navigation/action links from the staff dashboard, admin status table, and a dedicated admin-only route.
* **Bug Fixes**
  * Admin ML health results now include backend references when available.
* **Tests**
  * Added extensive coverage for view behavior, reference building/lookup, input validation, error handling, timeouts, and link rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->