### PR TITLE
Add Cofactor AI contact to intro email CC line

### DIFF
--- a/fighthealthinsurance/proconnector.py
+++ b/fighthealthinsurance/proconnector.py
@@ -21,7 +21,7 @@ Wording constraints (enforced by ``_is_safe_intro_draft``):
 
 import re
 import urllib.parse
-from typing import Optional
+from typing import Iterable, Optional
 
 from asgiref.sync import async_to_sync
 from django.conf import settings
@@ -45,6 +45,11 @@ DEFAULT_PROFESSIONAL_CC_EMAIL = "professional@fighthealthinsurance.com"
 # The intro copy tells the recipient Cofactor AI is "cc'd here", so this address
 # is CC'd on every intro email alongside the professional contact address.
 DEFAULT_COFACTOR_CC_EMAIL = "rmorales@cofactorai.com"
+
+# COFACTOR_CC_EMAIL value that explicitly disables the Cofactor AI CC. A blank
+# setting can't mean "off" -- an unset/empty env var has to keep falling back to
+# the default -- so opting out is spelled out (see get_cofactor_cc_email).
+CC_DISABLED_SENTINEL = "none"
 
 # Obvious test / spam signups we never introduce. These are filtered out of the
 # processing queue and the CSV export entirely (never shown, never counted)
@@ -191,11 +196,23 @@ def get_professional_cc_email() -> str:
     return str(value) if value else DEFAULT_PROFESSIONAL_CC_EMAIL
 
 
-def get_cofactor_cc_email() -> str:
-    """Cofactor AI's CC address for intro emails: the configured
-    ``COFACTOR_CC_EMAIL`` setting if set, otherwise the known contact."""
+def get_cofactor_cc_email() -> Optional[str]:
+    """Cofactor AI's CC address for intro emails, or ``None`` when turned off.
+
+    Uses the configured ``COFACTOR_CC_EMAIL`` setting, falling back to the known
+    contact. Setting it to ``"none"`` (any case) is an explicit opt-out and
+    returns ``None`` -- an unset or empty value means "not configured" and gets
+    the default instead, so switching the CC off takes the sentinel rather than a
+    blank. With it off, the base email's "who are cc'd here" line no longer
+    matches what is sent, so staff need to edit that out of the draft.
+    """
     value = getattr(settings, "COFACTOR_CC_EMAIL", None)
-    return str(value) if value else DEFAULT_COFACTOR_CC_EMAIL
+    cleaned = str(value).strip() if value is not None else ""
+    if not cleaned:
+        return DEFAULT_COFACTOR_CC_EMAIL
+    if cleaned.lower() == CC_DISABLED_SENTINEL:
+        return None
+    return cleaned
 
 
 def _greeting_name(pro: InterestedProfessional) -> str:
@@ -424,8 +441,8 @@ def generate_intro_email(pro: InterestedProfessional) -> str:
     return async_to_sync(agenerate_intro_email)(pro)
 
 
-def _dedup_addresses(addresses: list[str]) -> list[str]:
-    """Drop blanks and case-insensitive duplicates, preserving order."""
+def _dedup_addresses(addresses: Iterable[Optional[str]]) -> list[str]:
+    """Drop blanks/``None`` and case-insensitive duplicates, preserving order."""
     recipients: list[str] = []
     seen: set[str] = set()
     for addr in addresses:
@@ -444,7 +461,8 @@ def default_intro_cc_recipients() -> list[str]:
     actually be on the CC line for the email to match the copy. Both are
     configurable (see :func:`get_professional_cc_email` /
     :func:`get_cofactor_cc_email`), so they're deduplicated in case a deployment
-    points both settings at the same address.
+    points both settings at the same address, and the Cofactor CC drops out
+    entirely when it is explicitly disabled.
     """
     return _dedup_addresses([get_professional_cc_email(), get_cofactor_cc_email()])
 

--- a/fighthealthinsurance/proconnector.py
+++ b/fighthealthinsurance/proconnector.py
@@ -8,8 +8,9 @@ workflows.
 
 This module builds the introduction email -- optionally personalized by an
 (external) LLM and always falling back to a safe approved base template -- and
-sends it with the professional contact address CC'd. Staff review and edit every
-draft before it is sent; nothing here sends automatically.
+sends it with the professional contact address and Cofactor AI's contact CC'd
+(the copy tells the recipient Cofactor AI is "cc'd here"). Staff review and edit
+every draft before it is sent; nothing here sends automatically.
 
 Wording constraints (enforced by ``_is_safe_intro_draft``):
   * Never describe Cofactor AI as a "partner" or say FHI "partnered" with them.
@@ -39,6 +40,11 @@ from fighthealthinsurance.utils import send_fallback_email
 
 # Fallback CC address when no professional/support email setting is configured.
 DEFAULT_PROFESSIONAL_CC_EMAIL = "professional@fighthealthinsurance.com"
+
+# Fallback Cofactor AI contact when no COFACTOR_CC_EMAIL setting is configured.
+# The intro copy tells the recipient Cofactor AI is "cc'd here", so this address
+# is CC'd on every intro email alongside the professional contact address.
+DEFAULT_COFACTOR_CC_EMAIL = "rmorales@cofactorai.com"
 
 # Obvious test / spam signups we never introduce. These are filtered out of the
 # processing queue and the CSV export entirely (never shown, never counted)
@@ -183,6 +189,13 @@ def get_professional_cc_email() -> str:
     setting if set, otherwise the ``professional@`` default."""
     value = getattr(settings, "PROFESSIONAL_CC_EMAIL", None)
     return str(value) if value else DEFAULT_PROFESSIONAL_CC_EMAIL
+
+
+def get_cofactor_cc_email() -> str:
+    """Cofactor AI's CC address for intro emails: the configured
+    ``COFACTOR_CC_EMAIL`` setting if set, otherwise the known contact."""
+    value = getattr(settings, "COFACTOR_CC_EMAIL", None)
+    return str(value) if value else DEFAULT_COFACTOR_CC_EMAIL
 
 
 def _greeting_name(pro: InterestedProfessional) -> str:
@@ -411,17 +424,36 @@ def generate_intro_email(pro: InterestedProfessional) -> str:
     return async_to_sync(agenerate_intro_email)(pro)
 
 
-def _intro_cc_recipients(extra_cc: Optional[list[str]] = None) -> list[str]:
-    """CC list for an intro email: the professional contact address first, then
-    any caller-supplied extras, deduplicated case-insensitively in order."""
-    professional_cc = get_professional_cc_email()
-    recipients = [professional_cc]
-    seen = {professional_cc.lower()}
-    for addr in extra_cc or []:
-        if addr.lower() not in seen:
-            seen.add(addr.lower())
-            recipients.append(addr)
+def _dedup_addresses(addresses: list[str]) -> list[str]:
+    """Drop blanks and case-insensitive duplicates, preserving order."""
+    recipients: list[str] = []
+    seen: set[str] = set()
+    for addr in addresses:
+        cleaned = (addr or "").strip()
+        if cleaned and cleaned.lower() not in seen:
+            seen.add(cleaned.lower())
+            recipients.append(cleaned)
     return recipients
+
+
+def default_intro_cc_recipients() -> list[str]:
+    """Addresses always CC'd on an intro email.
+
+    The FHI professional contact address plus Cofactor AI's contact -- the intro
+    copy tells the recipient Cofactor AI is "cc'd here", so their address has to
+    actually be on the CC line for the email to match the copy. Both are
+    configurable (see :func:`get_professional_cc_email` /
+    :func:`get_cofactor_cc_email`), so they're deduplicated in case a deployment
+    points both settings at the same address.
+    """
+    return _dedup_addresses([get_professional_cc_email(), get_cofactor_cc_email()])
+
+
+def _intro_cc_recipients(extra_cc: Optional[list[str]] = None) -> list[str]:
+    """CC list for an intro email: the always-CC'd defaults (professional
+    contact, Cofactor AI) first, then any caller-supplied extras, deduplicated
+    case-insensitively in order."""
+    return _dedup_addresses([*default_intro_cc_recipients(), *(extra_cc or [])])
 
 
 def send_proconnector_intro_email(
@@ -431,9 +463,10 @@ def send_proconnector_intro_email(
     cc: Optional[list[str]] = None,
 ) -> None:
     """Send the (edited) intro email to ``pro`` now, always CC'ing the
-    professional address.
+    professional address and Cofactor AI.
 
-    The professional/support address is always included; any caller-supplied
+    The professional/support address and Cofactor AI's contact are always
+    included (see :func:`default_intro_cc_recipients`); any caller-supplied
     ``cc`` is treated as *additional* recipients, deduplicated while preserving
     order. Raises on send failure -- including a blocked/unsendable recipient,
     which ``send_fallback_email`` would otherwise skip silently -- so the caller
@@ -462,11 +495,12 @@ def send_proconnector_test_email(
 
     Lets staff preview exactly how the (edited) draft renders in a real inbox
     before committing to the real send. Unlike the real send it goes only to
-    the test address (the professional is NOT emailed and the professional
-    contact address is NOT CC'd), the subject and body are clearly marked as a
-    test, and -- critically -- nothing is written to the record: the intro is
-    not marked attempted/sent, so it stays in the queue. Raises on a blocked
-    test address or send failure so the caller can surface the problem.
+    the test address (the professional is NOT emailed and neither the
+    professional contact address nor Cofactor AI is CC'd), the subject and body
+    are clearly marked as a test, and -- critically -- nothing is written to the
+    record: the intro is not marked attempted/sent, so it stays in the queue.
+    Raises on a blocked test address or send failure so the caller can surface
+    the problem.
     """
     if is_blocked_email(test_email):
         raise ValueError("Test email address is blocked or unsendable")

--- a/fighthealthinsurance/proconnector.py
+++ b/fighthealthinsurance/proconnector.py
@@ -31,7 +31,7 @@ from django.utils import timezone
 
 from loguru import logger
 
-from fighthealthinsurance.email_utils import is_blocked_email
+from fighthealthinsurance.email_utils import is_blocked_email, is_sendable_email
 from fighthealthinsurance.ml.ml_inference import infer_with_fallback
 from fighthealthinsurance.ml.ml_router import ml_router
 from fighthealthinsurance.models import InterestedProfessional, ScheduledEmail
@@ -213,6 +213,28 @@ def get_cofactor_cc_email() -> Optional[str]:
     if cleaned.lower() == CC_DISABLED_SENTINEL:
         return None
     return cleaned
+
+
+def cofactor_cc_problem() -> Optional[str]:
+    """Reason the configured Cofactor CC address is unusable, or ``None``.
+
+    A typo'd (no ``@``) or blocked-domain ``COFACTOR_CC_EMAIL`` is *silently*
+    dropped from the CC list by ``send_fallback_email``, which then reports a
+    successful send -- so the intro would go out telling the recipient Cofactor AI
+    is "cc'd here", and be recorded as sent, while Cofactor never received it.
+    Real sends fail closed on this instead (see :func:`_intro_cc_recipients`).
+    Deliberately disabling the CC with the ``"none"`` sentinel is a choice, not a
+    problem, so it returns ``None``.
+    """
+    address = get_cofactor_cc_email()
+    if address is None or is_sendable_email(address):
+        return None
+    return (
+        f"COFACTOR_CC_EMAIL is set to '{address}', which is not a sendable "
+        f"address, so Cofactor AI would be silently dropped from the CC. Fix the "
+        f"setting, or set it to '{CC_DISABLED_SENTINEL}' to send intros without "
+        f"CC'ing Cofactor AI."
+    )
 
 
 def _greeting_name(pro: InterestedProfessional) -> str:
@@ -470,7 +492,16 @@ def default_intro_cc_recipients() -> list[str]:
 def _intro_cc_recipients(extra_cc: Optional[list[str]] = None) -> list[str]:
     """CC list for an intro email: the always-CC'd defaults (professional
     contact, Cofactor AI) first, then any caller-supplied extras, deduplicated
-    case-insensitively in order."""
+    case-insensitively in order.
+
+    Raises ``ValueError`` when the configured Cofactor address is unusable (see
+    :func:`cofactor_cc_problem`). Every real send path goes through here to build
+    its CC list, so this is the chokepoint that keeps a misconfigured setting from
+    quietly turning into an intro that claims a CC it doesn't have.
+    """
+    problem = cofactor_cc_problem()
+    if problem:
+        raise ValueError(problem)
     return _dedup_addresses([*default_intro_cc_recipients(), *(extra_cc or [])])
 
 

--- a/fighthealthinsurance/settings.py
+++ b/fighthealthinsurance/settings.py
@@ -167,7 +167,10 @@ class Base(Configuration):
     # Cofactor AI's contact address, CC'd on pro-connector intro emails alongside
     # PROFESSIONAL_CC_EMAIL -- the intro copy says Cofactor AI is "cc'd here", so
     # they have to actually be on the CC line. Configurable via env so a change
-    # of contact doesn't require a code change.
+    # of contact doesn't require a code change. Set it to "none" to turn the
+    # Cofactor CC off entirely (an empty value falls back to the default instead,
+    # so the opt-out has to be spelled out); with it off, staff need to edit the
+    # "cc'd here" line out of the draft.
     COFACTOR_CC_EMAIL = os.getenv("COFACTOR_CC_EMAIL", "rmorales@cofactorai.com")
 
     # Demo-request notifications always go to support42@; additional recipients

--- a/fighthealthinsurance/settings.py
+++ b/fighthealthinsurance/settings.py
@@ -164,6 +164,12 @@ class Base(Configuration):
         "PROFESSIONAL_CC_EMAIL", "professional@fighthealthinsurance.com"
     )
 
+    # Cofactor AI's contact address, CC'd on pro-connector intro emails alongside
+    # PROFESSIONAL_CC_EMAIL -- the intro copy says Cofactor AI is "cc'd here", so
+    # they have to actually be on the CC line. Configurable via env so a change
+    # of contact doesn't require a code change.
+    COFACTOR_CC_EMAIL = os.getenv("COFACTOR_CC_EMAIL", "rmorales@cofactorai.com")
+
     # Demo-request notifications always go to support42@; additional recipients
     # can be configured via the DEMO_REQUEST_EXTRA_NOTIFICATION_EMAILS env var
     # (comma-separated).

--- a/fighthealthinsurance/staff_views.py
+++ b/fighthealthinsurance/staff_views.py
@@ -53,6 +53,7 @@ from fighthealthinsurance.proconnector import (
     claim_email_for_send,
     default_intro_cc_recipients,
     generate_intro_email,
+    get_cofactor_cc_email,
     get_next_interested_professional,
     get_professional_cc_email,
     intro_wording_problem,
@@ -1055,7 +1056,10 @@ class ProConnectorProcessView(View):
             "subject": subject or PROCONNECTOR_INTRO_SUBJECT,
             # The email CCs both the professional contact address and Cofactor
             # AI; the printable letter can only name the professional contact.
+            # cofactor_cc_email is None when the Cofactor CC is disabled, so the
+            # template doesn't promise a CC that isn't happening.
             "cc_emails": default_intro_cc_recipients(),
+            "cofactor_cc_email": get_cofactor_cc_email(),
             "contact_email": get_professional_cc_email(),
             "google_search_url": links["google"],
             "linkedin_search_url": links["linkedin"],

--- a/fighthealthinsurance/staff_views.py
+++ b/fighthealthinsurance/staff_views.py
@@ -51,6 +51,7 @@ from fighthealthinsurance.proconnector import (
     build_base_intro_letter,
     build_search_links,
     claim_email_for_send,
+    cofactor_cc_problem,
     default_intro_cc_recipients,
     generate_intro_email,
     get_cofactor_cc_email,
@@ -1060,6 +1061,7 @@ class ProConnectorProcessView(View):
             # template doesn't promise a CC that isn't happening.
             "cc_emails": default_intro_cc_recipients(),
             "cofactor_cc_email": get_cofactor_cc_email(),
+            "cofactor_cc_problem": cofactor_cc_problem(),
             "contact_email": get_professional_cc_email(),
             "google_search_url": links["google"],
             "linkedin_search_url": links["linkedin"],
@@ -1212,6 +1214,12 @@ class ProConnectorProcessView(View):
         error = self._intro_form_problem(body, subject)
         if error is None and not is_sendable_email(pro.email):
             error = f"{pro.email} is not a sendable address; cannot send."
+        # A misconfigured Cofactor CC makes the send helpers raise. Catch it here
+        # -- before the record is claimed -- so staff get the actual reason instead
+        # of a generic failure, and the record stays in the queue for a retry once
+        # the setting is fixed.
+        if error is None:
+            error = cofactor_cc_problem()
         if error:
             return self._render_record(
                 request,

--- a/fighthealthinsurance/staff_views.py
+++ b/fighthealthinsurance/staff_views.py
@@ -51,6 +51,7 @@ from fighthealthinsurance.proconnector import (
     build_base_intro_letter,
     build_search_links,
     claim_email_for_send,
+    default_intro_cc_recipients,
     generate_intro_email,
     get_next_interested_professional,
     get_professional_cc_email,
@@ -1052,7 +1053,10 @@ class ProConnectorProcessView(View):
             "pro": pro,
             "email_body": draft,
             "subject": subject or PROCONNECTOR_INTRO_SUBJECT,
-            "cc_email": get_professional_cc_email(),
+            # The email CCs both the professional contact address and Cofactor
+            # AI; the printable letter can only name the professional contact.
+            "cc_emails": default_intro_cc_recipients(),
+            "contact_email": get_professional_cc_email(),
             "google_search_url": links["google"],
             "linkedin_search_url": links["linkedin"],
             "google_address_search_url": links["google_address"],

--- a/fighthealthinsurance/templates/proconnector.html
+++ b/fighthealthinsurance/templates/proconnector.html
@@ -216,10 +216,18 @@
 
         <label>CC</label>
         <input type="text" class="readonly" value="{{ cc_emails|join:', ' }}" readonly>
-        <p class="hint">
-          Cofactor AI is CC'd alongside the FHI professional address &mdash; the
-          email tells the recipient they are cc'd here.
-        </p>
+        {% if cofactor_cc_email %}
+          <p class="hint">
+            Cofactor AI is CC'd alongside the FHI professional address &mdash; the
+            email tells the recipient they are cc'd here.
+          </p>
+        {% else %}
+          <p class="hint">
+            The Cofactor AI CC is turned off in this deployment's configuration
+            &mdash; please edit the &ldquo;who are cc'd here&rdquo; wording out of
+            the draft below before sending.
+          </p>
+        {% endif %}
 
         <label for="subject">Subject</label>
         <input type="text" id="subject" name="subject" value="{{ subject }}">

--- a/fighthealthinsurance/templates/proconnector.html
+++ b/fighthealthinsurance/templates/proconnector.html
@@ -216,7 +216,9 @@
 
         <label>CC</label>
         <input type="text" class="readonly" value="{{ cc_emails|join:', ' }}" readonly>
-        {% if cofactor_cc_email %}
+        {% if cofactor_cc_problem %}
+          <p class="error">⚠️ {{ cofactor_cc_problem }}</p>
+        {% elif cofactor_cc_email %}
           <p class="hint">
             Cofactor AI is CC'd alongside the FHI professional address &mdash; the
             email tells the recipient they are cc'd here.

--- a/fighthealthinsurance/templates/proconnector.html
+++ b/fighthealthinsurance/templates/proconnector.html
@@ -126,6 +126,11 @@
       border: 1px solid #d9c9f7;
       border-radius: 4px;
     }
+    .hint {
+      font-size: 0.88em;
+      color: #555;
+      margin: 6px 0 0;
+    }
     .test-send label { margin-top: 0; }
     .test-send .hint {
       font-size: 0.88em;
@@ -185,7 +190,7 @@
         For professionals worth reaching by mail as well as email, print a
         physical introduction letter to send by post. The printed letter uses
         different wording &mdash; it can't CC Cofactor AI, so it asks the
-        recipient to email <strong>{{ cc_email }}</strong> for the introduction.
+        recipient to email <strong>{{ contact_email }}</strong> for the introduction.
         Use the <em>Google address</em> link above to find or verify a mailing
         address.
       </p>
@@ -210,7 +215,11 @@
         <input type="text" class="readonly" value="{{ pro.email }}" readonly>
 
         <label>CC</label>
-        <input type="text" class="readonly" value="{{ cc_email }}" readonly>
+        <input type="text" class="readonly" value="{{ cc_emails|join:', ' }}" readonly>
+        <p class="hint">
+          Cofactor AI is CC'd alongside the FHI professional address &mdash; the
+          email tells the recipient they are cc'd here.
+        </p>
 
         <label for="subject">Subject</label>
         <input type="text" id="subject" name="subject" value="{{ subject }}">

--- a/tests/sync/test_proconnector.py
+++ b/tests/sync/test_proconnector.py
@@ -617,6 +617,20 @@ class ProcessPageCCDisplayTest(_ProcessViewTestCase):
         self.assertContains(response, get_professional_cc_email())
         self.assertContains(response, get_cofactor_cc_email())
 
+    @patch(
+        "fighthealthinsurance.staff_views.generate_intro_email",
+        return_value="A draft body with compensation disclosure.",
+    )
+    @override_settings(COFACTOR_CC_EMAIL="none")
+    def test_disabled_cofactor_cc_warns_instead_of_promising_a_cc(self, _mock_gen):
+        # With the CC off the page must not claim Cofactor AI is CC'd; it warns
+        # staff to edit the "cc'd here" wording out of the draft instead.
+        _make_pro(email="jane@janeclinic.com")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "cofactorai.com")
+        self.assertContains(response, "Cofactor AI CC is turned off")
+
 
 # ---------------------------------------------------------------------------
 # Send flow
@@ -1047,6 +1061,33 @@ class SendHelperTest(TestCase):
         self.assertEqual(
             default_intro_cc_recipients(), ["shared@fighthealthinsurance.com"]
         )
+
+    @override_settings(COFACTOR_CC_EMAIL="none")
+    def test_cofactor_cc_disabled_by_none_sentinel(self):
+        self.assertIsNone(get_cofactor_cc_email())
+        self.assertEqual(default_intro_cc_recipients(), [get_professional_cc_email()])
+
+    @override_settings(COFACTOR_CC_EMAIL="  NoNe  ")
+    def test_cofactor_cc_none_sentinel_ignores_case_and_whitespace(self):
+        self.assertIsNone(get_cofactor_cc_email())
+
+    @override_settings(COFACTOR_CC_EMAIL="none")
+    def test_send_omits_cofactor_cc_when_disabled(self):
+        pro = _make_pro(email="jane@janeclinic.com")
+        proconnector.send_proconnector_intro_email(
+            pro,
+            subject="Intro",
+            body="Body with compensation disclosure.",
+        )
+        msg = mail.outbox[0]
+        self.assertEqual(msg.cc, [get_professional_cc_email()])
+        self.assertNotIn("cofactorai.com", " ".join(msg.cc))
+
+    @override_settings(COFACTOR_CC_EMAIL="")
+    def test_empty_cofactor_setting_falls_back_to_default(self):
+        # Only the explicit sentinel disables the CC; an unset / empty env var
+        # means "not configured" and keeps the known contact.
+        self.assertEqual(get_cofactor_cc_email(), "rmorales@cofactorai.com")
 
     def test_plaintext_body_is_not_html_escaped(self):
         # The .txt template must not HTML-escape the body, or apostrophes and

--- a/tests/sync/test_proconnector.py
+++ b/tests/sync/test_proconnector.py
@@ -25,8 +25,10 @@ from fighthealthinsurance.proconnector import (
     build_base_intro_email,
     build_base_intro_letter,
     build_search_links,
+    default_intro_cc_recipients,
     describe_known_info,
     generate_intro_email,
+    get_cofactor_cc_email,
     get_next_interested_professional,
     get_professional_cc_email,
     partner_framing_problem,
@@ -603,6 +605,19 @@ class _ProcessViewTestCase(TestCase):
         return self.client.post(self.url, {"action": action, **fields})
 
 
+class ProcessPageCCDisplayTest(_ProcessViewTestCase):
+    @patch(
+        "fighthealthinsurance.staff_views.generate_intro_email",
+        return_value="A draft body with compensation disclosure.",
+    )
+    def test_cc_field_shows_professional_and_cofactor(self, _mock_gen):
+        _make_pro(email="jane@janeclinic.com")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, get_professional_cc_email())
+        self.assertContains(response, get_cofactor_cc_email())
+
+
 # ---------------------------------------------------------------------------
 # Send flow
 # ---------------------------------------------------------------------------
@@ -990,10 +1005,10 @@ class SkipFlowTest(_ProcessViewTestCase):
 
 
 # ---------------------------------------------------------------------------
-# Email send helper (CC professional@)
+# Email send helper (CC professional@ + Cofactor AI)
 # ---------------------------------------------------------------------------
 class SendHelperTest(TestCase):
-    def test_send_proconnector_intro_email_ccs_professional(self):
+    def test_send_proconnector_intro_email_ccs_professional_and_cofactor(self):
         pro = _make_pro(email="jane@janeclinic.com")
         proconnector.send_proconnector_intro_email(
             pro,
@@ -1003,13 +1018,35 @@ class SendHelperTest(TestCase):
         self.assertGreaterEqual(len(mail.outbox), 1)
         msg = mail.outbox[0]
         self.assertIn("jane@janeclinic.com", msg.to)
-        self.assertEqual(msg.cc, [get_professional_cc_email()])
+        self.assertEqual(msg.cc, [get_professional_cc_email(), get_cofactor_cc_email()])
         self.assertEqual(msg.subject, "Intro to Cofactor AI")
         self.assertIn("compensation disclosure", msg.body)
+
+    def test_cofactor_contact_is_cced_so_the_email_matches_the_copy(self):
+        # The base email tells the recipient Cofactor AI is "cc'd here", so their
+        # contact has to actually be on the CC line by default.
+        self.assertIn("cc'd here", BASE_INTRO_EMAIL)
+        self.assertEqual(get_cofactor_cc_email(), "rmorales@cofactorai.com")
+        self.assertIn("rmorales@cofactorai.com", default_intro_cc_recipients())
 
     @override_settings(PROFESSIONAL_CC_EMAIL="custom-pro@example-host.com")
     def test_cc_uses_configured_setting(self):
         self.assertEqual(get_professional_cc_email(), "custom-pro@example-host.com")
+
+    @override_settings(COFACTOR_CC_EMAIL="someone-else@cofactorai.com")
+    def test_cofactor_cc_uses_configured_setting(self):
+        self.assertEqual(get_cofactor_cc_email(), "someone-else@cofactorai.com")
+        self.assertIn("someone-else@cofactorai.com", default_intro_cc_recipients())
+        self.assertNotIn("rmorales@cofactorai.com", default_intro_cc_recipients())
+
+    @override_settings(
+        PROFESSIONAL_CC_EMAIL="shared@fighthealthinsurance.com",
+        COFACTOR_CC_EMAIL="SHARED@fighthealthinsurance.com",
+    )
+    def test_default_cc_dedups_when_both_settings_match(self):
+        self.assertEqual(
+            default_intro_cc_recipients(), ["shared@fighthealthinsurance.com"]
+        )
 
     def test_plaintext_body_is_not_html_escaped(self):
         # The .txt template must not HTML-escape the body, or apostrophes and
@@ -1163,7 +1200,9 @@ class QueueHelperTest(TestCase):
         self.assertEqual(se.purpose, "proconnector_intro")
         self.assertEqual(se.send_timezone, "America/New_York")
         self.assertTrue(se.timezone_is_specific)
+        # Queued sends carry the same default CC list as immediate sends.
         self.assertIn(get_professional_cc_email(), se.cc)
+        self.assertIn(get_cofactor_cc_email(), se.cc)
         self.assertEqual(se.context["body"], "Body with compensation disclosure.")
         self.assertFalse(se.sent)
 

--- a/tests/sync/test_proconnector.py
+++ b/tests/sync/test_proconnector.py
@@ -25,6 +25,7 @@ from fighthealthinsurance.proconnector import (
     build_base_intro_email,
     build_base_intro_letter,
     build_search_links,
+    cofactor_cc_problem,
     default_intro_cc_recipients,
     describe_known_info,
     generate_intro_email,
@@ -621,6 +622,39 @@ class ProcessPageCCDisplayTest(_ProcessViewTestCase):
         "fighthealthinsurance.staff_views.generate_intro_email",
         return_value="A draft body with compensation disclosure.",
     )
+    @override_settings(COFACTOR_CC_EMAIL="rmorales-at-cofactorai.com")
+    def test_misconfigured_cofactor_cc_is_flagged_on_the_page(self, _mock_gen):
+        _make_pro(email="jane@janeclinic.com")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "not a sendable address")
+
+    @patch(
+        "fighthealthinsurance.staff_views.generate_intro_email",
+        return_value="A draft body with compensation disclosure.",
+    )
+    @override_settings(COFACTOR_CC_EMAIL="rmorales-at-cofactorai.com")
+    def test_send_blocked_by_misconfigured_cofactor_cc_keeps_record_queued(
+        self, _mock_gen
+    ):
+        # Staff get the config reason (not a generic failure) and the record is
+        # never claimed, so it can be retried once the setting is fixed.
+        pro = _make_pro(email="jane@janeclinic.com")
+        response = self._post(
+            "send",
+            interested_professional_id=pro.id,
+            email_body="Body with compensation disclosure.",
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertContains(response, "COFACTOR_CC_EMAIL", status_code=400)
+        pro.refresh_from_db()
+        self.assertFalse(pro.proconnector_attempted)
+        self.assertEqual(len(mail.outbox), 0)
+
+    @patch(
+        "fighthealthinsurance.staff_views.generate_intro_email",
+        return_value="A draft body with compensation disclosure.",
+    )
     @override_settings(COFACTOR_CC_EMAIL="none")
     def test_disabled_cofactor_cc_warns_instead_of_promising_a_cc(self, _mock_gen):
         # With the CC off the page must not claim Cofactor AI is CC'd; it warns
@@ -1088,6 +1122,52 @@ class SendHelperTest(TestCase):
         # Only the explicit sentinel disables the CC; an unset / empty env var
         # means "not configured" and keeps the known contact.
         self.assertEqual(get_cofactor_cc_email(), "rmorales@cofactorai.com")
+
+
+# ---------------------------------------------------------------------------
+# Misconfigured COFACTOR_CC_EMAIL (send_fallback_email would silently drop it)
+# ---------------------------------------------------------------------------
+class CofactorCCMisconfigurationTest(TestCase):
+    def test_no_problem_for_the_default_contact(self):
+        self.assertIsNone(cofactor_cc_problem())
+
+    @override_settings(COFACTOR_CC_EMAIL="none")
+    def test_no_problem_when_explicitly_disabled(self):
+        # Turning the CC off is a deliberate choice, not a misconfiguration.
+        self.assertIsNone(cofactor_cc_problem())
+
+    @override_settings(COFACTOR_CC_EMAIL="rmorales-at-cofactorai.com")
+    def test_malformed_address_is_reported(self):
+        problem = cofactor_cc_problem()
+        self.assertIsNotNone(problem)
+        assert problem is not None  # for mypy
+        self.assertIn("COFACTOR_CC_EMAIL", problem)
+        self.assertIn("rmorales-at-cofactorai.com", problem)
+
+    @override_settings(COFACTOR_CC_EMAIL="cofactor@example.com")
+    def test_blocked_domain_address_is_reported(self):
+        # example.com is a blocked domain, so this CC would never be delivered.
+        self.assertIsNotNone(cofactor_cc_problem())
+
+    @override_settings(COFACTOR_CC_EMAIL="rmorales-at-cofactorai.com")
+    def test_send_raises_rather_than_silently_dropping_the_cc(self):
+        # Without this the email goes out claiming Cofactor AI is "cc'd here"
+        # while send_fallback_email quietly filters the malformed CC address.
+        pro = _make_pro(email="jane@janeclinic.com")
+        with self.assertRaises(ValueError):
+            proconnector.send_proconnector_intro_email(
+                pro, subject="Intro", body="Body with compensation disclosure."
+            )
+        self.assertEqual(len(mail.outbox), 0)
+
+    @override_settings(COFACTOR_CC_EMAIL="rmorales-at-cofactorai.com")
+    def test_queue_raises_and_enqueues_nothing(self):
+        pro = _make_pro(email="jane@janeclinic.com")
+        with self.assertRaises(ValueError):
+            queue_proconnector_intro_email(
+                pro, subject="Intro", body="Body with compensation disclosure."
+            )
+        self.assertEqual(ScheduledEmail.objects.count(), 0)
 
     def test_plaintext_body_is_not_html_escaped(self):
         # The .txt template must not HTML-escape the body, or apostrophes and


### PR DESCRIPTION
## Summary
Adds Cofactor AI's contact address to the CC line of professional introduction emails, alongside the existing FHI professional contact address. The intro email copy already states "Cofactor AI is cc'd here", so this change ensures the email matches its own copy. The Cofactor AI CC is configurable and can be disabled via a sentinel value.

## Key Changes

- **New configuration setting**: `COFACTOR_CC_EMAIL` environment variable (defaults to `rmorales@cofactorai.com`) with opt-out via `"none"` sentinel value
- **New helper functions**:
  - `get_cofactor_cc_email()` - Retrieves the Cofactor AI contact, respecting the sentinel opt-out
  - `default_intro_cc_recipients()` - Returns the standard CC list (professional + Cofactor AI)
  - `_dedup_addresses()` - Utility for case-insensitive deduplication of email addresses
- **Updated email sending**: `send_proconnector_intro_email()` now includes Cofactor AI in the CC line by default
- **Staff UI improvements**: 
  - Process page now displays both CC addresses
  - Shows a hint when Cofactor AI CC is enabled (explaining the CC)
  - Shows a warning when Cofactor AI CC is disabled (prompting staff to edit the "cc'd here" wording)
- **Comprehensive test coverage**: Added tests for configuration, deduplication, opt-out behavior, and email sending with the new CC

## Implementation Details

- The sentinel value `"none"` (case-insensitive, whitespace-tolerant) explicitly disables the Cofactor AI CC; an empty/unset env var falls back to the default instead, ensuring deployments don't accidentally lose the contact
- Email addresses are deduplicated case-insensitively in order, so if both settings point to the same address, it appears only once
- When the Cofactor AI CC is disabled, the template warns staff to remove the "who are cc'd here" wording from the draft before sending
- Queued email sends (via `queue_proconnector_intro_email`) carry the same default CC list as immediate sends

https://claude.ai/code/session_01G2vkM2Z7WCvAdB9UbXmR6V

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pro-connector introduction emails now include both the professional contact and Cofactor AI in CC by default.
  * Staff can view/edit a complete CC list before sending, with clearer warnings when Cofactor AI CC is off.
* **Bug Fixes**
  * Prevents sending when Cofactor AI CC is misconfigured; the record remains queued for retry.
  * Queued and immediate sends now use the same CC recipients.
* **Documentation**
  * Updated staff guidance clarifies CC behavior and test-email expectations.
* **Tests**
  * Expanded coverage for default behavior, overrides, deduplication, opt-out, and misconfiguration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->