### PR TITLE
Fix trailing-slash /media-references/ 404 by adding redirect and test

### DIFF
--- a/fighthealthinsurance/urls.py
+++ b/fighthealthinsurance/urls.py
@@ -260,6 +260,14 @@ urlpatterns: List[Union[URLPattern, URLResolver]] = [
         views.MediaReferencesView.as_view(),
         name="media-references",
     ),
+    # Accept the conventional trailing-slash spelling too. APPEND_SLASH only
+    # redirects in the opposite direction (slashless -> slash), so without an
+    # explicit alias links to /media-references/ end in a 404.
+    path(
+        "media-references/",
+        RedirectView.as_view(pattern_name="media-references", permanent=True),
+        name="media-references-trailing-slash",
+    ),
     path(
         "bingo",
         views.BingoView.as_view(),

--- a/tests/sync/test_media_references.py
+++ b/tests/sync/test_media_references.py
@@ -27,6 +27,16 @@ class TestMediaReferencesPage(TestCase):
         self.assertTemplateUsed(response, "media_references.html")
         self.assertTemplateUsed(response, "base.html")
 
+    def test_trailing_slash_url_redirects_to_media_references_page(self):
+        response = self.client.get("/media-references/")
+
+        self.assertRedirects(
+            response,
+            reverse("media-references"),
+            status_code=301,
+            fetch_redirect_response=False,
+        )
+
     def test_media_references_page_is_cached_like_other_static_ish_pages(self):
         response = self.client.get(reverse("media-references"))
         cache_control = response["Cache-Control"]


### PR DESCRIPTION
### Motivation
- Users linking to `/media-references/` (trailing slash) were getting a 404 because the canonical route is registered without the trailing slash and `APPEND_SLASH` only redirects in the opposite direction.

### Description
- Add an explicit permanent redirect route from `media-references/` to the canonical `media-references` route using `RedirectView` in `fighthealthinsurance/urls.py`.
- Add a regression test `test_trailing_slash_url_redirects_to_media_references_page` in `tests/sync/test_media_references.py` that asserts a `301` from `/media-references/` to `reverse("media-references")`.
- Small commit updating the URL table and test file to prevent the trailing-slash variant from returning 404 in the future.

### Testing
- Ran `DJANGO_CONFIGURATION=TestSync pytest tests/sync/test_media_references.py -q`, and all tests passed (`10 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67041c46808322811a9b1222d87edc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for trailing-slash media references URLs.
  * Requests now receive a permanent redirect to the canonical media references page instead of a 404 error.

* **Tests**
  * Added coverage to verify the redirect behavior and destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->