### PR TITLE
Add a subscriber cleanup flow for junk/suspicious mailing list signups

### DIFF
--- a/fighthealthinsurance/email_utils.py
+++ b/fighthealthinsurance/email_utils.py
@@ -17,6 +17,29 @@ BLOCKED_EMAIL_DOMAINS: frozenset[str] = frozenset(
 )
 
 
+# Internal / obvious-test addresses. These are real rows in our tables (staff
+# testing the forms, joke signups) but never real contacts, so outreach and the
+# subscriber cleanup queue treat them separately from genuine signups. Lives
+# here rather than in a workflow module so every consumer shares one list.
+INTERNAL_TEST_EMAILS: frozenset[str] = frozenset(
+    {
+        "testing@example.com",
+        "farts@farts.com",
+        "holden@pigscanfly.ca",
+        # Also on charts' consumer-analytics exclusion list; without these an
+        # internal tester's signup would land (business domains even sort to the
+        # FRONT of the pro-connector queue) and get a real Cofactor intro.
+        "holden.karau@gmail.com",
+        "holden@fighthealthinsurance.com",
+        "warrick@fighthealthinsurance.com",
+        "test@test.com",
+    }
+)
+
+# Signups on these TLDs are treated as spam / out of scope.
+SPAM_EMAIL_TLDS: tuple[str, ...] = (".ru", ".ua")
+
+
 def get_email_domain(email: Optional[str]) -> Optional[str]:
     """Return the lowercased domain of an email address, or None if unparseable.
 

--- a/fighthealthinsurance/mailing_list_actor.py
+++ b/fighthealthinsurance/mailing_list_actor.py
@@ -65,9 +65,20 @@ class MailingListActor:
             # For test email, we don't include unsubscribe link
             recipients: list[tuple[str, Optional[str]]] = [(test_email, None)]
         else:
-            # Get all subscribers with their unsubscribe URLs
-            subscribers = MailingListSubscriber.objects.all().iterator()
-            recipients = [(sub.email, sub.get_unsubscribe_url()) for sub in subscribers]
+            # Get all subscribers with their unsubscribe URLs, one send per
+            # mailbox: the list can hold case-variant duplicates of the same
+            # address (the signup paths match on an exact email), and mailing
+            # somebody twice is both rude and a spam signal. The newest row wins
+            # -- that's the one the signup paths keep updated -- and the cleanup
+            # flow (see subscriber_hygiene.py) removes the older copies for good.
+            subscribers = MailingListSubscriber.objects.order_by("id").iterator()
+            by_mailbox: dict[str, tuple[str, Optional[str]]] = {}
+            for sub in subscribers:
+                by_mailbox[(sub.email or "").strip().lower()] = (
+                    sub.email,
+                    sub.get_unsubscribe_url(),
+                )
+            recipients = list(by_mailbox.values())
 
         # Use connection reuse for better performance
         connection = get_connection()

--- a/fighthealthinsurance/management/commands/cleanup_subscribers.py
+++ b/fighthealthinsurance/management/commands/cleanup_subscribers.py
@@ -1,0 +1,162 @@
+"""Management command to find (and optionally delete) junk mailing list subscribers.
+
+Reports by default -- nothing is deleted without ``--apply``. See
+``fighthealthinsurance/subscriber_hygiene.py`` for what each reason code means.
+
+Examples::
+
+    # What's wrong with the list?
+    python manage.py cleanup_subscribers
+
+    # ...including the other inbound-contact tables (report only, never deleted)
+    python manage.py cleanup_subscribers --all-sources
+
+    # Delete the unambiguous junk (unmailable, invalid, duplicate, spam markup)
+    python manage.py cleanup_subscribers --apply
+
+    # Delete only exact duplicates
+    python manage.py cleanup_subscribers --apply --reasons duplicate_email
+"""
+
+from typing import Any, List
+
+from django.core.management.base import BaseCommand, CommandError, CommandParser
+
+from fighthealthinsurance import subscriber_hygiene as hygiene
+from fighthealthinsurance.utils import mask_email_for_logging
+
+
+class Command(BaseCommand):
+    help = (
+        "Report on suspicious/junk mailing list subscribers and, with --apply, "
+        "delete them."
+    )
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument(
+            "--apply",
+            action="store_true",
+            help="Actually delete the matching subscribers (default: report only)",
+        )
+        parser.add_argument(
+            "--reasons",
+            type=str,
+            default="",
+            help=(
+                "Comma-separated reason codes to act on. Defaults to every "
+                "auto-cleanable reason: "
+                + ", ".join(sorted(hygiene.AUTO_CLEANABLE_CODES))
+            ),
+        )
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help=(
+                "Allow --apply with review-only reasons (spam TLDs, role "
+                "accounts, alias duplicates, ...). Use with care."
+            ),
+        )
+        parser.add_argument(
+            "--include-reviewed",
+            action="store_true",
+            help="Also consider rows staff already reviewed and chose to keep",
+        )
+        parser.add_argument(
+            "--all-sources",
+            action="store_true",
+            help=(
+                "Also report on chat leads, demo requests and interested "
+                "professionals (report only -- these are never deleted here)"
+            ),
+        )
+        parser.add_argument(
+            "--limit",
+            type=int,
+            default=10,
+            help="How many example rows to print per reason (default: 10)",
+        )
+
+    def handle(self, *args: str, **options: Any) -> None:
+        apply_changes: bool = options["apply"]
+        force: bool = options["force"]
+        limit: int = options["limit"]
+        requested = [
+            code.strip() for code in options["reasons"].split(",") if code.strip()
+        ]
+
+        unknown = [code for code in requested if code not in hygiene.REASONS]
+        if unknown:
+            raise CommandError(
+                f"Unknown reason code(s): {', '.join(unknown)}. "
+                f"Known codes: {', '.join(sorted(hygiene.REASONS))}"
+            )
+
+        codes = set(requested) if requested else set(hygiene.AUTO_CLEANABLE_CODES)
+        risky = sorted(codes - hygiene.AUTO_CLEANABLE_CODES)
+        if apply_changes and risky and not force:
+            raise CommandError(
+                f"{', '.join(risky)} are review-only reasons -- a human should "
+                "look at those rows (staff page: /timbit/help/subscriber_cleanup). "
+                "Pass --force to delete on them anyway."
+            )
+
+        result = hygiene.scan_subscribers(
+            include_reviewed=options["include_reviewed"],
+        )
+        self._report(result, limit=limit)
+
+        if options["all_sources"]:
+            for other in hygiene.scan_other_contact_tables():
+                self._report(other, limit=limit)
+
+        targets: List[int] = [
+            finding.record.pk
+            for finding in result.findings
+            if codes.intersection(finding.codes)
+        ]
+
+        if not targets:
+            self.stdout.write(self.style.SUCCESS("Nothing to clean up."))
+            return
+
+        if not apply_changes:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"\n{len(targets)} subscriber(s) match {', '.join(sorted(codes))}. "
+                    "Re-run with --apply to delete them."
+                )
+            )
+            return
+
+        deleted = hygiene.delete_subscribers(targets, actor="cleanup_subscribers")
+        self.stdout.write(self.style.SUCCESS(f"\nDeleted {deleted} subscriber row(s)."))
+
+    def _report(self, result: hygiene.ScanResult, limit: int) -> None:
+        self.stdout.write(
+            f"\n=== {result.source}: {result.flagged_count} flagged of "
+            f"{result.scanned} scanned ==="
+        )
+        if not result.findings:
+            self.stdout.write("  (clean)")
+            return
+
+        counts = result.counts_by_code()
+        for code, count in counts.items():
+            reason = hygiene.REASONS[code]
+            bucket = "auto-cleanable" if reason.auto_cleanable else "review only"
+            self.stdout.write(f"\n  {code}: {count} ({bucket}) -- {reason.description}")
+            for finding in result.findings_with_code(code)[:limit]:
+                record = finding.record
+                # Addresses are masked: this output lands in terminals and logs.
+                self.stdout.write(
+                    f"    #{record.pk} {mask_email_for_logging(record.email)}"
+                    f" [{finding.details.get(code, '')}]"
+                )
+            if count > limit:
+                self.stdout.write(f"    ... and {count - limit} more")
+
+        auto = len(result.auto_cleanable_findings)
+        self.stdout.write(
+            f"\n  {auto} row(s) carry at least one auto-cleanable reason; "
+            f"{result.flagged_count - auto} need human review."
+        )

--- a/fighthealthinsurance/migrations/0198_mailinglistsubscriber_cleanup_review.py
+++ b/fighthealthinsurance/migrations/0198_mailinglistsubscriber_cleanup_review.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("fighthealthinsurance", "0197_denial_candidate_denial_text_summary"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="mailinglistsubscriber",
+            name="cleanup_reviewed_at",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="mailinglistsubscriber",
+            name="cleanup_reviewed_by",
+            field=models.CharField(blank=True, default="", max_length=150),
+        ),
+    ]

--- a/fighthealthinsurance/models.py
+++ b/fighthealthinsurance/models.py
@@ -279,6 +279,14 @@ class MailingListSubscriber(models.Model):
     )
     referral_source_details = models.TextField(default="", blank=True, null=True)
 
+    # Subscriber cleanup flow (see subscriber_hygiene.py). Our signup forms are
+    # open, so the list collects bot submissions and junk rows. Staff review
+    # flagged rows and either delete them or mark them kept; a non-null
+    # reviewed_at means "a human looked and this row stays", which takes it out
+    # of the cleanup queue for good.
+    cleanup_reviewed_at = models.DateTimeField(null=True, blank=True)
+    cleanup_reviewed_by = models.CharField(max_length=150, default="", blank=True)
+
     def __str__(self):
         return self.email
 

--- a/fighthealthinsurance/proconnector.py
+++ b/fighthealthinsurance/proconnector.py
@@ -31,7 +31,12 @@ from django.utils import timezone
 
 from loguru import logger
 
-from fighthealthinsurance.email_utils import is_blocked_email, is_sendable_email
+from fighthealthinsurance.email_utils import (
+    INTERNAL_TEST_EMAILS,
+    SPAM_EMAIL_TLDS,
+    is_blocked_email,
+    is_sendable_email,
+)
 from fighthealthinsurance.ml.ml_inference import infer_with_fallback
 from fighthealthinsurance.ml.ml_router import ml_router
 from fighthealthinsurance.models import InterestedProfessional, ScheduledEmail
@@ -55,23 +60,9 @@ CC_DISABLED_SENTINEL = "none"
 # processing queue and the CSV export entirely (never shown, never counted)
 # rather than skipped, so they don't clutter the staff workflow. Includes FHI's
 # own internal test accounts (mirroring charts' signup-analytics exclusion) so
-# outreach and the export never target ourselves.
-FILTERED_EMAILS: frozenset[str] = frozenset(
-    {
-        "testing@example.com",
-        "farts@farts.com",
-        "holden@pigscanfly.ca",
-        # Also on charts' consumer-analytics exclusion list; without these an
-        # internal tester's signup would land (business domains even sort to the
-        # FRONT of the queue) and get a real Cofactor intro.
-        "holden.karau@gmail.com",
-        "holden@fighthealthinsurance.com",
-        "warrick@fighthealthinsurance.com",
-        "test@test.com",
-    }
-)
-# Signups on these TLDs are treated as spam / out of scope and filtered out.
-SPAM_EMAIL_TLDS: tuple[str, ...] = (".ru", ".ua")
+# outreach and the export never target ourselves. The lists themselves live in
+# email_utils so the subscriber cleanup flow flags the same addresses/TLDs.
+FILTERED_EMAILS: frozenset[str] = INTERNAL_TEST_EMAILS
 
 # Known personal / free-email provider domains. Professionals using a business
 # or organizational domain tend to be the strongest fit for Cofactor AI, so the

--- a/fighthealthinsurance/staff_views.py
+++ b/fighthealthinsurance/staff_views.py
@@ -69,6 +69,7 @@ from fighthealthinsurance.proconnector import (
     send_proconnector_intro_email,
     send_proconnector_test_email,
 )
+from fighthealthinsurance import subscriber_hygiene
 from fighthealthinsurance.type_utils import User
 from fighthealthinsurance.utils import mask_email_for_logging
 
@@ -1333,6 +1334,175 @@ class ProConnectorLetterView(View):
             "today": timezone.now().date(),
         }
         return render(request, self.template_name, context)
+
+
+class SubscriberCleanupView(View):
+    """Staff review queue for junk / suspicious mailing list subscribers.
+
+    Our signup forms are open, so the list collects bot submissions (URLs in the
+    name field), unmailable addresses, and case-variant duplicates of the same
+    mailbox. This page shows every flagged row with the reasons it was flagged,
+    and offers three actions:
+
+      * delete the checked rows,
+      * keep the checked rows (marks them reviewed so they stop showing up), or
+      * delete every row carrying an auto-cleanable reason (needs the confirm box).
+
+    Only unambiguous junk is auto-cleanable; review-only signals (spam TLD, role
+    account, alias duplicate, ...) are never part of the bulk delete. The
+    analysis is shared with ``python manage.py cleanup_subscribers``.
+
+    Lead tables (chat leads, demo requests, interested professionals) are scanned
+    too when asked, but strictly read-only -- those rows belong to other flows.
+    """
+
+    template_name = "subscriber_cleanup.html"
+    page_size = 100
+
+    def get(self, request) -> HttpResponse:
+        return self._render(request)
+
+    def post(self, request) -> HttpResponse:
+        action = request.POST.get("action")
+        actor = getattr(request.user, "username", "") or ""
+        selected = self._selected_ids(request)
+
+        if action == "delete_selected":
+            if not selected:
+                return self._render(request, error="No subscribers were selected.")
+            deleted = subscriber_hygiene.delete_subscribers(selected, actor=actor)
+            logger.info(
+                f"Staff user {actor} deleted {deleted} mailing list subscriber(s) "
+                "from the cleanup queue"
+            )
+            return self._render(request, notice=f"Deleted {deleted} subscriber(s).")
+
+        if action == "keep_selected":
+            if not selected:
+                return self._render(request, error="No subscribers were selected.")
+            kept = subscriber_hygiene.mark_subscribers_reviewed(selected, actor=actor)
+            return self._render(
+                request,
+                notice=f"Marked {kept} subscriber(s) as reviewed; they will stay.",
+            )
+
+        if action == "delete_auto":
+            if request.POST.get("confirm") != "yes":
+                return self._render(
+                    request,
+                    error="Check the confirmation box to delete every "
+                    "auto-cleanable row.",
+                )
+            # Re-scan rather than trusting ids from the form: the page may be
+            # stale, and this action is a bulk delete.
+            result = subscriber_hygiene.scan_subscribers()
+            ids = [f.record.pk for f in result.auto_cleanable_findings]
+            deleted = subscriber_hygiene.delete_subscribers(ids, actor=actor)
+            logger.info(
+                f"Staff user {actor} bulk-deleted {deleted} auto-cleanable "
+                "mailing list subscriber(s)"
+            )
+            return self._render(request, notice=f"Deleted {deleted} subscriber(s).")
+
+        return self._render(request, error=f"Unknown action: {action}", status=400)
+
+    @staticmethod
+    def _selected_ids(request) -> List[int]:
+        ids = []
+        for raw in request.POST.getlist("subscriber_id"):
+            try:
+                ids.append(int(raw))
+            except (TypeError, ValueError):
+                continue
+        return ids
+
+    def _render(
+        self,
+        request,
+        *,
+        notice: Optional[str] = None,
+        error: Optional[str] = None,
+        status: int = 200,
+    ) -> HttpResponse:
+        include_leads = request.GET.get("include_leads") == "1"
+        result = subscriber_hygiene.scan_subscribers()
+        # Auto-cleanable rows first so the deletable junk is what staff sees on
+        # page one, then oldest-first within each bucket.
+        findings = sorted(
+            result.findings, key=lambda f: (not f.auto_cleanable, f.record.pk)
+        )
+        try:
+            page_number = max(1, int(request.GET.get("page", 1)))
+        except (TypeError, ValueError):
+            page_number = 1
+        start = (page_number - 1) * self.page_size
+        page = findings[start : start + self.page_size]
+        total_pages = max(1, -(-len(findings) // self.page_size))
+
+        context: Dict[str, Any] = {
+            "title": "Subscriber Cleanup",
+            "notice": notice,
+            "error": error,
+            "scanned": result.scanned,
+            "flagged_count": result.flagged_count,
+            "auto_cleanable_count": len(result.auto_cleanable_findings),
+            "summary": [
+                {
+                    "code": code,
+                    "label": subscriber_hygiene.REASONS[code].label,
+                    "description": subscriber_hygiene.REASONS[code].description,
+                    "auto_cleanable": subscriber_hygiene.REASONS[code].auto_cleanable,
+                    "count": count,
+                }
+                for code, count in result.counts_by_code().items()
+            ],
+            "rows": [
+                {
+                    "id": f.record.pk,
+                    "email": f.record.email,
+                    "name": f.record.name,
+                    "phone": f.record.phone,
+                    "comments": f.record.comments,
+                    "signup_date": f.record.created,
+                    "auto_cleanable": f.auto_cleanable,
+                    "reasons": [
+                        {
+                            "code": code,
+                            "label": subscriber_hygiene.REASONS[code].label,
+                            "detail": f.details.get(code, ""),
+                            "auto_cleanable": code
+                            in subscriber_hygiene.AUTO_CLEANABLE_CODES,
+                        }
+                        for code in f.codes
+                    ],
+                }
+                for f in page
+            ],
+            "page_number": page_number,
+            "total_pages": total_pages,
+            "include_leads": include_leads,
+            "lead_results": (
+                [
+                    {
+                        "source": other.source,
+                        "scanned": other.scanned,
+                        "flagged": other.flagged_count,
+                        "counts": [
+                            {
+                                "code": code,
+                                "label": subscriber_hygiene.REASONS[code].label,
+                                "count": count,
+                            }
+                            for code, count in other.counts_by_code().items()
+                        ],
+                    }
+                    for other in subscriber_hygiene.scan_other_contact_tables()
+                ]
+                if include_leads
+                else []
+            ),
+        }
+        return render(request, self.template_name, context, status=status)
 
 
 class _CSVEcho:

--- a/fighthealthinsurance/subscriber_hygiene.py
+++ b/fighthealthinsurance/subscriber_hygiene.py
@@ -1,0 +1,612 @@
+"""Subscriber list hygiene: find junk/suspicious signups and clean them up.
+
+Our signup paths are open forms (denial flow, chat leads, explain-denial, the
+REST API), so the mailing list accumulates rows nobody should ever be mailed:
+bot submissions with URLs stuffed into the name field, addresses at reserved
+domains, case-variant duplicates of the same mailbox (``get_or_create(email=...)``
+is case-sensitive), and internal test signups.
+
+This module is the shared brain for that cleanup. It only *analyzes* -- callers
+decide what to do:
+
+  * ``python manage.py cleanup_subscribers`` -- report, and delete with ``--apply``
+  * the staff Subscriber Cleanup page -- review one screen of flagged rows and
+    either delete them or mark them reviewed (kept)
+
+Every finding carries a reason code (see :data:`REASONS`). Reasons are split
+into two buckets:
+
+  * ``auto_cleanable`` -- unambiguous junk (unmailable, malformed, duplicate,
+    URL-in-name spam, header-injection attempts). Bulk deletion targets only
+    these.
+  * review-only -- a *signal*, not a verdict (spam-associated TLD, internal test
+    address, role account, alias-duplicate, suspicious unicode). A human decides;
+    nothing bulk-deletes these.
+
+The same analysis runs over the other inbound-contact tables (chat leads, demo
+requests, interested professionals) so staff can *see* suspicious rows there,
+but this flow never deletes from them -- those are sales/lead records with their
+own workflows (see ``proconnector.py``).
+"""
+
+from dataclasses import dataclass, field
+from datetime import date
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from django.core.exceptions import ValidationError
+from django.core.validators import validate_email
+from django.db.models import QuerySet
+from django.utils import timezone
+
+from loguru import logger
+
+from fighthealthinsurance.chat.message_preprocessor import has_suspicious_unicode
+from fighthealthinsurance.email_utils import (
+    INTERNAL_TEST_EMAILS,
+    SPAM_EMAIL_TLDS,
+    get_email_domain,
+    is_blocked_email,
+)
+from fighthealthinsurance.models import (
+    ChatLeads,
+    DemoRequests,
+    InterestedProfessional,
+    MailingListSubscriber,
+)
+from fighthealthinsurance.utils import mask_email_for_logging
+
+
+@dataclass(frozen=True)
+class Reason:
+    """One kind of problem we can find on a contact row.
+
+    ``auto_cleanable`` means "safe to delete in bulk without a human looking at
+    the individual row". Everything else is a review signal only.
+    """
+
+    code: str
+    label: str
+    description: str
+    auto_cleanable: bool
+
+
+UNSENDABLE = "unsendable_email"
+INVALID_EMAIL = "invalid_email"
+DUPLICATE = "duplicate_email"
+LINK_IN_FIELDS = "link_in_fields"
+HEADER_INJECTION = "header_injection"
+CONTROL_IN_EMAIL = "control_chars_in_email"
+SPAM_TLD = "spam_tld"
+INTERNAL_TEST = "internal_test_address"
+ROLE_ADDRESS = "role_address"
+ALIAS_DUPLICATE = "alias_duplicate"
+SUSPICIOUS_UNICODE = "suspicious_unicode"
+OVERLONG_FIELD = "overlong_field"
+
+REASONS: Dict[str, Reason] = {
+    r.code: r
+    for r in (
+        Reason(
+            UNSENDABLE,
+            "Unmailable address",
+            "Blocked/reserved domain or malformed address -- mail to it can never "
+            "be delivered (see email_utils.is_blocked_email).",
+            auto_cleanable=True,
+        ),
+        Reason(
+            INVALID_EMAIL,
+            "Invalid address",
+            "Fails Django's email validation, so it was never a working mailbox.",
+            auto_cleanable=True,
+        ),
+        Reason(
+            DUPLICATE,
+            "Duplicate of a newer row",
+            "Another row holds the same address (case-insensitively). The newest "
+            "row is the one our signup paths keep updating, so older copies are "
+            "dropped -- they also break unsubscribe, which only deletes the row "
+            "matching the token.",
+            auto_cleanable=True,
+        ),
+        Reason(
+            LINK_IN_FIELDS,
+            "URL / markup in name or comments",
+            "Links or BBCode/HTML in a name, phone, or comments field: the "
+            "signature of an automated form-spam submission.",
+            auto_cleanable=True,
+        ),
+        Reason(
+            HEADER_INJECTION,
+            "Header-injection attempt",
+            "Newlines or mail headers (bcc:, content-type:) embedded in a field "
+            "-- an attempt to inject extra headers into outgoing mail.",
+            auto_cleanable=True,
+        ),
+        Reason(
+            CONTROL_IN_EMAIL,
+            "Control characters in address",
+            "The address itself contains control/zero-width characters.",
+            auto_cleanable=True,
+        ),
+        Reason(
+            SPAM_TLD,
+            "Spam-associated TLD",
+            f"Address on one of {', '.join(SPAM_EMAIL_TLDS)} -- treated as spam "
+            "or out of scope elsewhere in the codebase.",
+            auto_cleanable=False,
+        ),
+        Reason(
+            INTERNAL_TEST,
+            "Internal / test address",
+            "One of our own test accounts or an obvious joke signup.",
+            auto_cleanable=False,
+        ),
+        Reason(
+            ROLE_ADDRESS,
+            "Role account",
+            "postmaster@, noreply@, abuse@ and friends: nobody reads these, and "
+            "mailing them hurts sender reputation.",
+            auto_cleanable=False,
+        ),
+        Reason(
+            ALIAS_DUPLICATE,
+            "Possible alias duplicate",
+            "Another row normalizes to the same mailbox (gmail dots, +tag "
+            "addressing). Usually the same person twice, but not certain enough "
+            "to delete automatically.",
+            auto_cleanable=False,
+        ),
+        Reason(
+            SUSPICIOUS_UNICODE,
+            "Suspicious unicode",
+            "Zero-width, bidi-override or control characters in a field -- used "
+            "to disguise spam text.",
+            auto_cleanable=False,
+        ),
+        Reason(
+            OVERLONG_FIELD,
+            "Implausibly long field",
+            "A name or phone far longer than any real value, typically a pasted "
+            "spam payload.",
+            auto_cleanable=False,
+        ),
+    )
+}
+
+AUTO_CLEANABLE_CODES: frozenset[str] = frozenset(
+    code for code, reason in REASONS.items() if reason.auto_cleanable
+)
+
+# Markers that mean "there is a link here". Checked against the *name*, *phone*
+# and *comments* fields, never the email address. Our own code only ever writes
+# fixed strings like "From appeal flow" into comments, so any link there came
+# from a bot. "http" is deliberately bare (it catches http:// and https:// and
+# obfuscated variants) and matches the existing pro-connector spam filter.
+_LINK_MARKERS: Tuple[str, ...] = (
+    "http",
+    "www.",
+    "[url",
+    "[/url]",
+    "<a ",
+    "href=",
+    "://",
+)
+
+# Mail headers that should never appear inside a submitted field.
+_HEADER_MARKERS: Tuple[str, ...] = (
+    "bcc:",
+    "cc:",
+    "content-type:",
+    "mime-version:",
+    "content-transfer-encoding:",
+)
+
+# Local parts that are automated mailboxes rather than people.
+_ROLE_LOCAL_PARTS: frozenset[str] = frozenset(
+    {
+        "abuse",
+        "admin",
+        "administrator",
+        "bounce",
+        "bounces",
+        "donotreply",
+        "do-not-reply",
+        "hostmaster",
+        "mailer-daemon",
+        "no-reply",
+        "noreply",
+        "postmaster",
+        "root",
+        "webmaster",
+    }
+)
+
+# Local parts that mean somebody was testing the form.
+_TEST_LOCAL_PARTS: frozenset[str] = frozenset(
+    {"test", "testing", "test1", "test123", "asdf", "aaaa", "qwerty"}
+)
+
+# Domains where a "." in the local part is not significant, so
+# ``f.oo@gmail.com`` and ``foo@gmail.com`` are the same mailbox.
+_DOT_INSENSITIVE_DOMAINS: frozenset[str] = frozenset({"gmail.com", "googlemail.com"})
+
+# Longest plausible values; anything past these is a pasted payload, not a name.
+_MAX_NAME_LEN = 200
+_MAX_PHONE_LEN = 40
+
+
+@dataclass(frozen=True)
+class ContactRecord:
+    """A normalized view of one inbound-contact row, whatever table it came from.
+
+    Keeping the analysis on this small struct (rather than on a model) is what
+    lets the same checks run over subscribers, chat leads, demo requests and
+    interested professionals.
+    """
+
+    pk: int
+    email: str
+    name: str = ""
+    phone: str = ""
+    comments: str = ""
+    created: Optional[date] = None
+    source: str = "MailingListSubscriber"
+
+
+@dataclass
+class Finding:
+    """Everything we found wrong with a single row."""
+
+    record: ContactRecord
+    codes: List[str] = field(default_factory=list)
+    # code -> short human-readable evidence ("duplicate of #12", "name contains 'http'")
+    details: Dict[str, str] = field(default_factory=dict)
+
+    def add(self, code: str, detail: str = "") -> None:
+        if code not in self.codes:
+            self.codes.append(code)
+        if detail:
+            self.details[code] = detail
+
+    @property
+    def auto_cleanable(self) -> bool:
+        """True when at least one reason is safe to bulk-delete on."""
+        return any(code in AUTO_CLEANABLE_CODES for code in self.codes)
+
+    @property
+    def reasons(self) -> List[Reason]:
+        return [REASONS[code] for code in self.codes]
+
+    def describe(self) -> str:
+        """One-line summary for CLI output. Never includes the raw address."""
+        parts = []
+        for code in self.codes:
+            detail = self.details.get(code)
+            parts.append(f"{code} ({detail})" if detail else code)
+        return (
+            f"#{self.record.pk} {mask_email_for_logging(self.record.email)}: "
+            + ", ".join(parts)
+        )
+
+
+@dataclass
+class ScanResult:
+    """Findings for one table, plus the counts needed to render a summary."""
+
+    source: str
+    scanned: int
+    findings: List[Finding] = field(default_factory=list)
+
+    @property
+    def flagged_count(self) -> int:
+        return len(self.findings)
+
+    @property
+    def auto_cleanable_findings(self) -> List[Finding]:
+        return [f for f in self.findings if f.auto_cleanable]
+
+    def counts_by_code(self) -> Dict[str, int]:
+        """How many rows carry each reason, ordered by :data:`REASONS`."""
+        counts = {code: 0 for code in REASONS}
+        for finding in self.findings:
+            for code in finding.codes:
+                counts[code] += 1
+        return {code: count for code, count in counts.items() if count}
+
+    def findings_with_code(self, code: str) -> List[Finding]:
+        return [f for f in self.findings if code in f.codes]
+
+
+def normalized_email(email: str) -> str:
+    """Lowercased/trimmed address -- our notion of "the same subscriber"."""
+    return (email or "").strip().lower()
+
+
+def mailbox_key(email: str) -> str:
+    """Best-effort "same mailbox" key: drops +tags, and dots on gmail.
+
+    Used only to *suggest* alias duplicates for human review; it is deliberately
+    never used to delete, because +tag addressing is legitimately distinct at
+    some providers.
+    """
+    normalized = normalized_email(email)
+    domain = get_email_domain(normalized)
+    if not domain:
+        return normalized
+    local = normalized.rsplit("@", 1)[0]
+    local = local.split("+", 1)[0]
+    if domain in _DOT_INSENSITIVE_DOMAINS:
+        local = local.replace(".", "")
+    return f"{local}@{domain}"
+
+
+def _contains(text: str, markers: Sequence[str]) -> Optional[str]:
+    """Return the first marker present in ``text`` (case-insensitively)."""
+    lowered = (text or "").lower()
+    for marker in markers:
+        if marker in lowered:
+            return marker
+    return None
+
+
+def _check_email(record: ContactRecord, finding: Finding) -> None:
+    email = record.email or ""
+    stripped = email.strip()
+
+    if any(ch in email for ch in ("\n", "\r", "\t")) or has_suspicious_unicode(email):
+        finding.add(CONTROL_IN_EMAIL, "control/zero-width characters in address")
+
+    if is_blocked_email(stripped):
+        domain = get_email_domain(stripped)
+        finding.add(UNSENDABLE, f"domain {domain}" if domain else "unparseable address")
+    else:
+        try:
+            validate_email(stripped)
+        except ValidationError:
+            finding.add(INVALID_EMAIL, "fails email validation")
+
+    lowered = normalized_email(email)
+    if lowered in INTERNAL_TEST_EMAILS:
+        finding.add(INTERNAL_TEST, "known internal/test address")
+    elif "@" in lowered:
+        local = lowered.rsplit("@", 1)[0]
+        if local in _TEST_LOCAL_PARTS:
+            finding.add(INTERNAL_TEST, f"test-looking local part {local}@")
+        if local in _ROLE_LOCAL_PARTS:
+            finding.add(ROLE_ADDRESS, f"role mailbox {local}@")
+
+    if lowered.endswith(SPAM_EMAIL_TLDS):
+        finding.add(SPAM_TLD, f"TLD {lowered.rsplit('.', 1)[-1]}")
+
+
+def _check_text_fields(record: ContactRecord, finding: Finding) -> None:
+    fields = (
+        ("name", record.name),
+        ("phone", record.phone),
+        ("comments", record.comments),
+    )
+    for label, value in fields:
+        if not value:
+            continue
+        marker = _contains(value, _LINK_MARKERS)
+        if marker:
+            finding.add(LINK_IN_FIELDS, f"{label} contains {marker!r}")
+        header = _contains(value, _HEADER_MARKERS)
+        if header or "\n" in value or "\r" in value:
+            finding.add(
+                HEADER_INJECTION,
+                (
+                    f"{label} contains {header!r}"
+                    if header
+                    else f"{label} contains a newline"
+                ),
+            )
+        if has_suspicious_unicode(value):
+            finding.add(SUSPICIOUS_UNICODE, f"{label} has hidden/bidi characters")
+
+    if len(record.name or "") > _MAX_NAME_LEN:
+        finding.add(OVERLONG_FIELD, f"name is {len(record.name)} chars")
+    if len(record.phone or "") > _MAX_PHONE_LEN:
+        finding.add(OVERLONG_FIELD, f"phone is {len(record.phone)} chars")
+
+
+def analyze_record(record: ContactRecord) -> Finding:
+    """Run every single-row check. Cross-row checks live in :func:`scan_records`."""
+    finding = Finding(record=record)
+    _check_email(record, finding)
+    _check_text_fields(record, finding)
+    return finding
+
+
+def _add_duplicate_findings(
+    records: Sequence[ContactRecord], findings: Dict[int, Finding]
+) -> None:
+    """Flag exact duplicates (delete-safe) and alias duplicates (review-only).
+
+    For exact duplicates we keep the highest pk: the signup paths look up the
+    newest row for an address and update it in place, so that row holds the
+    freshest name/referral data.
+    """
+    by_email: Dict[str, List[ContactRecord]] = {}
+    by_mailbox: Dict[str, List[ContactRecord]] = {}
+    for record in records:
+        email = normalized_email(record.email)
+        if not email:
+            continue
+        by_email.setdefault(email, []).append(record)
+        by_mailbox.setdefault(mailbox_key(record.email), []).append(record)
+
+    for group in by_email.values():
+        if len(group) < 2:
+            continue
+        ordered = sorted(group, key=lambda r: r.pk)
+        keeper = ordered[-1]
+        for record in ordered[:-1]:
+            findings.setdefault(record.pk, Finding(record=record)).add(
+                DUPLICATE, f"same address as newer row #{keeper.pk}"
+            )
+
+    for group in by_mailbox.values():
+        distinct = {normalized_email(r.email) for r in group}
+        if len(distinct) < 2:
+            # Either a single row or an exact-duplicate group already handled above.
+            continue
+        for record in group:
+            others = sorted(r.pk for r in group if r.pk != record.pk)
+            findings.setdefault(record.pk, Finding(record=record)).add(
+                ALIAS_DUPLICATE,
+                "same mailbox as " + ", ".join(f"#{pk}" for pk in others),
+            )
+
+
+def scan_records(
+    records: Sequence[ContactRecord], source: str = "MailingListSubscriber"
+) -> ScanResult:
+    """Analyze a batch of rows, including the cross-row duplicate checks.
+
+    Duplicate detection is only correct over a *complete* set of rows, so pass
+    the whole table (or a whole address-space slice of it), not a page.
+    """
+    findings: Dict[int, Finding] = {}
+    for record in records:
+        finding = analyze_record(record)
+        if finding.codes:
+            findings[record.pk] = finding
+    _add_duplicate_findings(records, findings)
+    ordered = sorted(findings.values(), key=lambda f: f.record.pk)
+    return ScanResult(source=source, scanned=len(records), findings=ordered)
+
+
+def subscriber_records(
+    queryset: Optional["QuerySet[MailingListSubscriber]"] = None,
+) -> Tuple[List[ContactRecord], List[int]]:
+    """Load mailing list subscribers as records, plus the reviewed-row ids.
+
+    Reviewed rows are returned too -- they are only dropped *after* the scan (see
+    :func:`scan_subscribers`), because removing them first would hide the fact
+    that an unreviewed row duplicates a reviewed one, leaving the older copy
+    looking unique and surviving cleanup.
+    """
+    qs = MailingListSubscriber.objects.all() if queryset is None else queryset
+    records: List[ContactRecord] = []
+    reviewed: List[int] = []
+    for sub in qs.iterator():
+        if sub.cleanup_reviewed_at is not None:
+            reviewed.append(sub.id)
+        records.append(
+            ContactRecord(
+                pk=sub.id,
+                email=sub.email or "",
+                name=sub.name or "",
+                phone=sub.phone or "",
+                comments=sub.comments or "",
+                created=sub.signup_date,
+                source="MailingListSubscriber",
+            )
+        )
+    return records, reviewed
+
+
+def scan_subscribers(
+    queryset: Optional["QuerySet[MailingListSubscriber]"] = None,
+    include_reviewed: bool = False,
+) -> ScanResult:
+    """Scan the mailing list. This is the table the cleanup flow can delete from.
+
+    Rows staff already reviewed and chose to keep are scanned (so duplicate
+    detection stays correct) but reported only with ``include_reviewed``.
+    """
+    records, reviewed = subscriber_records(queryset=queryset)
+    result = scan_records(records, source="MailingListSubscriber")
+    if include_reviewed:
+        return result
+    reviewed_ids = set(reviewed)
+    return ScanResult(
+        source=result.source,
+        scanned=result.scanned - len(reviewed_ids),
+        findings=[f for f in result.findings if f.record.pk not in reviewed_ids],
+    )
+
+
+def _lead_records(model: Any, source: str, **field_map: str) -> List[ContactRecord]:
+    records = []
+    for obj in model.objects.all().iterator():
+        records.append(
+            ContactRecord(
+                pk=obj.pk,
+                email=getattr(obj, "email", "") or "",
+                name=(getattr(obj, field_map.get("name", "name"), "") or ""),
+                phone=(getattr(obj, field_map.get("phone", "phone"), "") or ""),
+                comments=(
+                    getattr(obj, field_map.get("comments", "comments"), "") or ""
+                ),
+                created=getattr(obj, field_map.get("created", "signup_date"), None),
+                source=source,
+            )
+        )
+    return records
+
+
+def scan_other_contact_tables() -> List[ScanResult]:
+    """Report-only scans of the other inbound-contact tables.
+
+    Nothing in this flow deletes from these -- they are sales/lead records with
+    their own workflows -- but the same signals are worth surfacing.
+    """
+    results = []
+    results.append(
+        scan_records(
+            _lead_records(
+                ChatLeads, "ChatLeads", comments="company", created="created_at"
+            ),
+            source="ChatLeads",
+        )
+    )
+    results.append(
+        scan_records(
+            _lead_records(DemoRequests, "DemoRequests", comments="company"),
+            source="DemoRequests",
+        )
+    )
+    results.append(
+        scan_records(
+            _lead_records(
+                InterestedProfessional,
+                "InterestedProfessional",
+                phone="phone_number",
+            ),
+            source="InterestedProfessional",
+        )
+    )
+    return results
+
+
+def delete_subscribers(ids: Iterable[int], actor: str = "") -> int:
+    """Delete mailing list subscribers by id. Returns the number deleted.
+
+    Deletion is the correct "cleanup" here: unsubscribing is already modelled as
+    deleting the row (see UnsubscribeView), and RemoveDataHelper deletes these
+    rows too, so there is no soft-delete state to respect.
+    """
+    id_list = list(ids)
+    if not id_list:
+        return 0
+    qs = MailingListSubscriber.objects.filter(id__in=id_list)
+    # Log what goes away (masked) so a bad cleanup is at least reconstructible.
+    for sub in qs:
+        logger.info(
+            f"Subscriber cleanup: deleting #{sub.id} "
+            f"{mask_email_for_logging(sub.email)}" + (f" (by {actor})" if actor else "")
+        )
+    deleted, _ = qs.delete()
+    return deleted
+
+
+def mark_subscribers_reviewed(ids: Iterable[int], actor: str = "") -> int:
+    """Mark rows as reviewed-and-kept so they leave the cleanup queue."""
+    id_list = list(ids)
+    if not id_list:
+        return 0
+    return MailingListSubscriber.objects.filter(id__in=id_list).update(
+        cleanup_reviewed_at=timezone.now(), cleanup_reviewed_by=(actor or "")[:150]
+    )

--- a/fighthealthinsurance/templates/staff_dashboard.html
+++ b/fighthealthinsurance/templates/staff_dashboard.html
@@ -103,6 +103,12 @@
         </a>
       </li>
       <li>
+        <a href="{% url 'subscriber_cleanup' %}">
+          <strong>Subscriber Cleanup</strong>
+          <div class="link-description">Review junk/suspicious mailing list signups — bot submissions, unmailable addresses, duplicates — and delete or keep them</div>
+        </a>
+      </li>
+      <li>
         <a href="{% url 'proconnector_process' %}">
           <strong>Pro Connector Introductions (Cofactor AI)</strong>
           <div class="link-description">Review interested professionals one at a time and send an AI-drafted introduction to Cofactor AI under our sourcing agreement</div>

--- a/fighthealthinsurance/templates/subscriber_cleanup.html
+++ b/fighthealthinsurance/templates/subscriber_cleanup.html
@@ -1,0 +1,248 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>{{ title|default:"Subscriber Cleanup" }}</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 20px;
+      background-color: #f5f5f5;
+    }
+    h1 {
+      color: #333;
+      border-bottom: 2px solid #007bff;
+      padding-bottom: 10px;
+    }
+    .card {
+      background: white;
+      padding: 20px;
+      border-radius: 8px;
+      margin-bottom: 20px;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+    th, td {
+      text-align: left;
+      padding: 8px;
+      border-bottom: 1px solid #eee;
+      vertical-align: top;
+      font-size: 0.9em;
+    }
+    th {
+      background-color: #f8f9fa;
+    }
+    .tag {
+      display: inline-block;
+      padding: 2px 6px;
+      border-radius: 3px;
+      font-size: 0.8em;
+      margin: 1px 2px 1px 0;
+      white-space: nowrap;
+    }
+    .tag.auto {
+      background-color: #f8d7da;
+      color: #721c24;
+    }
+    .tag.review {
+      background-color: #fff3cd;
+      color: #856404;
+    }
+    .muted {
+      color: #666;
+      font-size: 0.85em;
+    }
+    .notice {
+      padding: 12px;
+      border-radius: 4px;
+      background-color: #d4edda;
+      color: #155724;
+      margin-bottom: 15px;
+    }
+    .error {
+      padding: 12px;
+      border-radius: 4px;
+      background-color: #f8d7da;
+      color: #721c24;
+      margin-bottom: 15px;
+    }
+    button {
+      padding: 10px 16px;
+      border: none;
+      border-radius: 4px;
+      color: white;
+      cursor: pointer;
+      margin-right: 8px;
+      font-size: 0.95em;
+    }
+    button.danger { background-color: #dc3545; }
+    button.keep { background-color: #28a745; }
+    button.bulk { background-color: #6c757d; }
+    .actions { margin: 15px 0; }
+    .pager a { margin-right: 10px; }
+    .wrap { max-width: 320px; overflow-wrap: anywhere; }
+  </style>
+</head>
+<body>
+  <h1>🧹 Subscriber Cleanup</h1>
+  <p class="muted">
+    <a href="{% url 'staff_dashboard' %}">&larr; Staff dashboard</a>
+  </p>
+
+  {% if notice %}<div class="notice">{{ notice }}</div>{% endif %}
+  {% if error %}<div class="error">{{ error }}</div>{% endif %}
+
+  <div class="card">
+    <h2>Summary</h2>
+    <p>
+      Scanned <strong>{{ scanned }}</strong> unreviewed subscriber(s):
+      <strong>{{ flagged_count }}</strong> flagged,
+      <strong>{{ auto_cleanable_count }}</strong> carrying an auto-cleanable reason.
+    </p>
+    {% if summary %}
+    <table>
+      <tr><th>Reason</th><th>Rows</th><th>Bucket</th><th>What it means</th></tr>
+      {% for row in summary %}
+      <tr>
+        <td><strong>{{ row.label }}</strong><div class="muted">{{ row.code }}</div></td>
+        <td>{{ row.count }}</td>
+        <td>
+          {% if row.auto_cleanable %}
+            <span class="tag auto">auto-cleanable</span>
+          {% else %}
+            <span class="tag review">review only</span>
+          {% endif %}
+        </td>
+        <td class="muted">{{ row.description }}</td>
+      </tr>
+      {% endfor %}
+    </table>
+    {% else %}
+    <p>Nothing flagged — the list is clean. 🎉</p>
+    {% endif %}
+  </div>
+
+  {% if rows %}
+  <form method="post">
+    {% csrf_token %}
+    <div class="card">
+      <h2>Flagged subscribers (page {{ page_number }} of {{ total_pages }})</h2>
+      <table>
+        <tr>
+          <th></th>
+          <th>ID</th>
+          <th>Email</th>
+          <th>Name</th>
+          <th>Phone</th>
+          <th>Comments</th>
+          <th>Signed up</th>
+          <th>Flags</th>
+        </tr>
+        {% for row in rows %}
+        <tr>
+          <td><input type="checkbox" name="subscriber_id" value="{{ row.id }}"
+                     {% if row.auto_cleanable %}checked{% endif %}></td>
+          <td>{{ row.id }}</td>
+          <td class="wrap">{{ row.email }}</td>
+          <td class="wrap">{{ row.name }}</td>
+          <td class="wrap">{{ row.phone }}</td>
+          <td class="wrap">{{ row.comments|truncatechars:120 }}</td>
+          <td>{{ row.signup_date|default:"—" }}</td>
+          <td>
+            {% for reason in row.reasons %}
+              <span class="tag {% if reason.auto_cleanable %}auto{% else %}review{% endif %}"
+                    title="{{ reason.detail }}">{{ reason.label }}</span>
+            {% endfor %}
+            {% for reason in row.reasons %}
+              {% if reason.detail %}<div class="muted">{{ reason.detail }}</div>{% endif %}
+            {% endfor %}
+          </td>
+        </tr>
+        {% endfor %}
+      </table>
+
+      <div class="actions">
+        <button type="submit" name="action" value="delete_selected" class="danger">
+          Delete checked
+        </button>
+        <button type="submit" name="action" value="keep_selected" class="keep">
+          Keep checked (mark reviewed)
+        </button>
+      </div>
+      <p class="muted">
+        Auto-cleanable rows are pre-checked. "Keep" marks a row reviewed so it
+        never appears in this queue again; deletion is permanent (the same thing
+        unsubscribing does).
+      </p>
+    </div>
+
+    <div class="card">
+      <h2>Bulk cleanup</h2>
+      <p>
+        Delete <strong>every</strong> row carrying an auto-cleanable reason
+        ({{ auto_cleanable_count }} row(s) across all pages). Review-only rows are
+        never touched by this button.
+      </p>
+      <label>
+        <input type="checkbox" name="confirm" value="yes">
+        Yes, delete all {{ auto_cleanable_count }} auto-cleanable rows
+      </label>
+      <div class="actions">
+        <button type="submit" name="action" value="delete_auto" class="bulk">
+          Delete all auto-cleanable
+        </button>
+      </div>
+    </div>
+  </form>
+
+  {% if total_pages > 1 %}
+  <div class="card pager">
+    {% if page_number > 1 %}
+      <a href="?page={{ page_number|add:"-1" }}{% if include_leads %}&include_leads=1{% endif %}">&larr; Previous</a>
+    {% endif %}
+    {% if page_number < total_pages %}
+      <a href="?page={{ page_number|add:"1" }}{% if include_leads %}&include_leads=1{% endif %}">Next &rarr;</a>
+    {% endif %}
+  </div>
+  {% endif %}
+  {% endif %}
+
+  <div class="card">
+    <h2>Other inbound-contact tables</h2>
+    {% if include_leads %}
+      <p class="muted">
+        Read-only: these rows belong to the sales / lead workflows and are never
+        deleted from this page.
+      </p>
+      {% for lead in lead_results %}
+        <h3>{{ lead.source }}</h3>
+        <p>{{ lead.flagged }} flagged of {{ lead.scanned }} scanned.</p>
+        {% if lead.counts %}
+        <table>
+          <tr><th>Reason</th><th>Rows</th></tr>
+          {% for row in lead.counts %}
+          <tr><td>{{ row.label }} <span class="muted">({{ row.code }})</span></td><td>{{ row.count }}</td></tr>
+          {% endfor %}
+        </table>
+        {% endif %}
+      {% endfor %}
+    {% else %}
+      <p>
+        <a href="?include_leads=1">Also scan chat leads, demo requests and interested professionals</a>
+        <span class="muted">(read-only, slower)</span>
+      </p>
+    {% endif %}
+  </div>
+
+  <div class="card">
+    <h2>From the command line</h2>
+    <pre class="muted">python manage.py cleanup_subscribers                  # report
+python manage.py cleanup_subscribers --all-sources    # include lead tables
+python manage.py cleanup_subscribers --apply          # delete auto-cleanable rows</pre>
+  </div>
+</body>
+</html>

--- a/fighthealthinsurance/urls.py
+++ b/fighthealthinsurance/urls.py
@@ -114,6 +114,11 @@ urlpatterns: List[Union[URLPattern, URLResolver]] = [
         name="send_mailing_list_mail",
     ),
     path(
+        "timbit/help/subscriber_cleanup",
+        staff_member_required(staff_views.SubscriberCleanupView.as_view()),
+        name="subscriber_cleanup",
+    ),
+    path(
         "timbit/help/delete_user_data",
         staff_member_required(staff_views.AdminDeleteDataView.as_view()),
         name="admin_delete_user_data",

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -2606,7 +2606,12 @@ class UnsubscribeView(View):
                 unsubscribe_token=token
             )
             email = subscriber.email
-            subscriber.delete()
+            # Remove every row for this address, not just the one holding the
+            # token. The signup paths can create case-variant duplicates
+            # (get_or_create matches the email exactly), and deleting a single
+            # row would leave the others subscribed -- the person clicks
+            # unsubscribe and keeps getting mail.
+            models.MailingListSubscriber.objects.filter(email__iexact=email).delete()
             return render(
                 request,
                 "unsubscribed.html",

--- a/tests/sync/test_subscriber_cleanup.py
+++ b/tests/sync/test_subscriber_cleanup.py
@@ -1,0 +1,335 @@
+"""Tests for the subscriber cleanup flow: the hygiene analysis, the
+``cleanup_subscribers`` management command, and the staff review page."""
+
+from io import StringIO
+
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+from django.urls import reverse
+
+from fighthealthinsurance import subscriber_hygiene as hygiene
+from fighthealthinsurance.models import MailingListSubscriber
+
+User = get_user_model()
+
+
+def make_subscriber(email, **kwargs):
+    return MailingListSubscriber.objects.create(email=email, **kwargs)
+
+
+class AnalyzeRecordTest(TestCase):
+    """Single-row checks."""
+
+    @staticmethod
+    def _codes(email="person@example.org", **kwargs):
+        record = hygiene.ContactRecord(pk=1, email=email, **kwargs)
+        return hygiene.analyze_record(record).codes
+
+    def test_ordinary_subscriber_is_not_flagged(self):
+        self.assertEqual(
+            self._codes(
+                email="jane@hospital.org", name="Jane Doe", comments="From appeal flow"
+            ),
+            [],
+        )
+
+    def test_reserved_domain_is_unsendable(self):
+        self.assertIn(hygiene.UNSENDABLE, self._codes(email="someone@example.com"))
+
+    def test_malformed_address_is_flagged_once_as_unsendable(self):
+        codes = self._codes(email="not-an-email")
+        self.assertIn(hygiene.UNSENDABLE, codes)
+        # is_blocked_email already rejects it; don't double-report it as invalid.
+        self.assertNotIn(hygiene.INVALID_EMAIL, codes)
+
+    def test_address_with_spaces_is_invalid(self):
+        self.assertIn(
+            hygiene.INVALID_EMAIL, self._codes(email="two words@realdomain.org")
+        )
+
+    def test_url_in_name_is_form_spam(self):
+        codes = self._codes(name="Buy now http://spam.example")
+        self.assertIn(hygiene.LINK_IN_FIELDS, codes)
+
+    def test_url_in_comments_is_form_spam(self):
+        self.assertIn(
+            hygiene.LINK_IN_FIELDS, self._codes(comments="check www.spam.example")
+        )
+
+    def test_newline_in_name_is_header_injection(self):
+        self.assertIn(
+            hygiene.HEADER_INJECTION, self._codes(name="Jane\nBcc: victim@example.org")
+        )
+
+    def test_mail_header_in_comments_is_header_injection(self):
+        self.assertIn(
+            hygiene.HEADER_INJECTION, self._codes(comments="Content-Type: text/html")
+        )
+
+    def test_zero_width_character_in_name_is_suspicious_unicode(self):
+        self.assertIn(hygiene.SUSPICIOUS_UNICODE, self._codes(name="Ja​ne"))
+
+    def test_control_character_in_address_is_flagged(self):
+        self.assertIn(hygiene.CONTROL_IN_EMAIL, self._codes(email="jane​@hospital.org"))
+
+    def test_spam_tld_is_review_only(self):
+        codes = self._codes(email="someone@vendor.ru")
+        self.assertEqual(codes, [hygiene.SPAM_TLD])
+        self.assertFalse(hygiene.REASONS[hygiene.SPAM_TLD].auto_cleanable)
+
+    def test_known_internal_address_is_flagged_as_test(self):
+        self.assertIn(hygiene.INTERNAL_TEST, self._codes(email="test@test.com"))
+
+    def test_role_account_is_flagged(self):
+        self.assertIn(hygiene.ROLE_ADDRESS, self._codes(email="noreply@hospital.org"))
+
+    def test_overlong_name_is_flagged(self):
+        self.assertIn(hygiene.OVERLONG_FIELD, self._codes(name="x" * 500))
+
+
+class MailboxKeyTest(TestCase):
+    def test_gmail_dots_and_tags_collapse(self):
+        self.assertEqual(hygiene.mailbox_key("Ja.ne+news@GMAIL.com"), "jane@gmail.com")
+
+    def test_dots_are_significant_off_gmail(self):
+        self.assertEqual(
+            hygiene.mailbox_key("ja.ne@hospital.org"), "ja.ne@hospital.org"
+        )
+
+
+class ScanSubscribersTest(TestCase):
+    """Cross-row checks and queryset handling."""
+
+    def test_case_variant_duplicate_flags_the_older_row_only(self):
+        older = make_subscriber("Jane@Hospital.org")
+        newer = make_subscriber("jane@hospital.org")
+
+        result = hygiene.scan_subscribers()
+        flagged = {f.record.pk: f for f in result.findings}
+
+        self.assertIn(older.id, flagged)
+        self.assertNotIn(newer.id, flagged)
+        self.assertIn(hygiene.DUPLICATE, flagged[older.id].codes)
+        self.assertIn(f"#{newer.id}", flagged[older.id].details[hygiene.DUPLICATE])
+
+    def test_duplicate_is_auto_cleanable(self):
+        make_subscriber("jane@hospital.org")
+        make_subscriber("JANE@hospital.org")
+        result = hygiene.scan_subscribers()
+        self.assertEqual(len(result.auto_cleanable_findings), 1)
+
+    def test_alias_duplicates_are_review_only(self):
+        make_subscriber("jane@gmail.com")
+        make_subscriber("ja.ne@gmail.com")
+
+        result = hygiene.scan_subscribers()
+
+        self.assertEqual(result.flagged_count, 2)
+        for finding in result.findings:
+            self.assertEqual(finding.codes, [hygiene.ALIAS_DUPLICATE])
+            self.assertFalse(finding.auto_cleanable)
+
+    def test_reviewed_rows_are_excluded_from_the_queue(self):
+        subscriber = make_subscriber("someone@example.com")
+        self.assertEqual(hygiene.scan_subscribers().flagged_count, 1)
+
+        hygiene.mark_subscribers_reviewed([subscriber.id], actor="staffer")
+
+        self.assertEqual(hygiene.scan_subscribers().flagged_count, 0)
+        self.assertEqual(
+            hygiene.scan_subscribers(include_reviewed=True).flagged_count, 1
+        )
+
+    def test_reviewed_row_still_counts_as_the_duplicate_keeper(self):
+        """A reviewed row must not vanish before the duplicate pass, or an older
+        unreviewed copy would look unique and survive."""
+        older = make_subscriber("jane@hospital.org")
+        newer = make_subscriber("Jane@Hospital.org")
+        hygiene.mark_subscribers_reviewed([newer.id])
+
+        result = hygiene.scan_subscribers()
+
+        self.assertEqual([f.record.pk for f in result.findings], [older.id])
+        self.assertIn(hygiene.DUPLICATE, result.findings[0].codes)
+
+    def test_counts_by_code_only_reports_present_reasons(self):
+        make_subscriber("someone@example.com")
+        counts = hygiene.scan_subscribers().counts_by_code()
+        self.assertEqual(counts, {hygiene.UNSENDABLE: 1})
+
+    def test_clean_list_produces_no_findings(self):
+        make_subscriber("jane@hospital.org", name="Jane Doe")
+        make_subscriber("bob@clinic.org", name="Bob Roberts")
+        self.assertEqual(hygiene.scan_subscribers().findings, [])
+
+
+class DeleteSubscribersTest(TestCase):
+    def test_delete_removes_only_the_given_ids(self):
+        doomed = make_subscriber("someone@example.com")
+        kept = make_subscriber("jane@hospital.org")
+
+        deleted = hygiene.delete_subscribers([doomed.id], actor="tester")
+
+        self.assertEqual(deleted, 1)
+        self.assertFalse(MailingListSubscriber.objects.filter(id=doomed.id).exists())
+        self.assertTrue(MailingListSubscriber.objects.filter(id=kept.id).exists())
+
+    def test_delete_with_no_ids_is_a_no_op(self):
+        make_subscriber("jane@hospital.org")
+        self.assertEqual(hygiene.delete_subscribers([]), 0)
+        self.assertEqual(MailingListSubscriber.objects.count(), 1)
+
+
+class CleanupSubscribersCommandTest(TestCase):
+    def setUp(self):
+        self.junk = make_subscriber("someone@example.com")
+        self.spammy = make_subscriber(
+            "seo@vendor.org", name="Cheap pills http://spam.example"
+        )
+        self.review_only = make_subscriber("someone@vendor.ru")
+        self.good = make_subscriber("jane@hospital.org", name="Jane Doe")
+
+    def _run(self, *args):
+        out = StringIO()
+        call_command("cleanup_subscribers", *args, stdout=out)
+        return out.getvalue()
+
+    def test_report_does_not_delete_anything(self):
+        output = self._run()
+        self.assertEqual(MailingListSubscriber.objects.count(), 4)
+        self.assertIn("--apply", output)
+        self.assertIn(hygiene.UNSENDABLE, output)
+
+    def test_report_masks_email_addresses(self):
+        output = self._run()
+        self.assertNotIn("someone@example.com", output)
+
+    def test_apply_deletes_auto_cleanable_rows_only(self):
+        self._run("--apply")
+
+        remaining = set(MailingListSubscriber.objects.values_list("id", flat=True))
+        self.assertEqual(remaining, {self.review_only.id, self.good.id})
+
+    def test_apply_with_explicit_reason_only_deletes_that_reason(self):
+        self._run("--apply", "--reasons", hygiene.LINK_IN_FIELDS)
+
+        remaining = set(MailingListSubscriber.objects.values_list("id", flat=True))
+        self.assertEqual(remaining, {self.junk.id, self.review_only.id, self.good.id})
+
+    def test_apply_refuses_review_only_reasons_without_force(self):
+        with self.assertRaises(CommandError):
+            self._run("--apply", "--reasons", hygiene.SPAM_TLD)
+        self.assertEqual(MailingListSubscriber.objects.count(), 4)
+
+    def test_force_allows_deleting_on_a_review_only_reason(self):
+        self._run("--apply", "--force", "--reasons", hygiene.SPAM_TLD)
+        self.assertFalse(
+            MailingListSubscriber.objects.filter(id=self.review_only.id).exists()
+        )
+
+    def test_unknown_reason_code_is_rejected(self):
+        with self.assertRaises(CommandError):
+            self._run("--reasons", "not_a_real_reason")
+
+    def test_all_sources_reports_other_tables(self):
+        output = self._run("--all-sources")
+        self.assertIn("ChatLeads", output)
+        self.assertIn("DemoRequests", output)
+        self.assertIn("InterestedProfessional", output)
+
+
+class SubscriberCleanupViewTest(TestCase):
+    def setUp(self):
+        self.url = reverse("subscriber_cleanup")
+        User.objects.create_user(username="staff", password="pw123", is_staff=True)
+        self.junk = make_subscriber("someone@example.com")
+        self.review_only = make_subscriber("someone@vendor.ru")
+        self.good = make_subscriber("jane@hospital.org", name="Jane Doe")
+
+    def login(self):
+        self.assertTrue(self.client.login(username="staff", password="pw123"))
+
+    def test_non_staff_are_redirected(self):
+        User.objects.create_user(username="plain", password="pw123", is_staff=False)
+        self.client.login(username="plain", password="pw123")
+        response = self.client.get(self.url)
+        self.assertIn(response.status_code, (302, 403))
+
+    def test_page_lists_flagged_rows_only(self):
+        self.login()
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "someone@example.com")
+        self.assertContains(response, "someone@vendor.ru")
+        self.assertNotContains(response, "jane@hospital.org")
+
+    def test_delete_selected_removes_the_checked_rows(self):
+        self.login()
+        response = self.client.post(
+            self.url,
+            {"action": "delete_selected", "subscriber_id": [str(self.junk.id)]},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(MailingListSubscriber.objects.filter(id=self.junk.id).exists())
+        self.assertTrue(MailingListSubscriber.objects.filter(id=self.good.id).exists())
+
+    def test_keep_selected_marks_reviewed_and_clears_the_queue(self):
+        self.login()
+        self.client.post(
+            self.url,
+            {"action": "keep_selected", "subscriber_id": [str(self.review_only.id)]},
+        )
+        self.review_only.refresh_from_db()
+        self.assertIsNotNone(self.review_only.cleanup_reviewed_at)
+        self.assertEqual(self.review_only.cleanup_reviewed_by, "staff")
+        self.assertNotIn(
+            self.review_only.id,
+            [f.record.pk for f in hygiene.scan_subscribers().findings],
+        )
+
+    def test_bulk_delete_requires_confirmation(self):
+        self.login()
+        response = self.client.post(self.url, {"action": "delete_auto"})
+        self.assertContains(response, "confirmation box")
+        self.assertTrue(MailingListSubscriber.objects.filter(id=self.junk.id).exists())
+
+    def test_bulk_delete_spares_review_only_rows(self):
+        self.login()
+        self.client.post(self.url, {"action": "delete_auto", "confirm": "yes"})
+
+        remaining = set(MailingListSubscriber.objects.values_list("id", flat=True))
+        self.assertEqual(remaining, {self.review_only.id, self.good.id})
+
+    def test_delete_with_nothing_selected_reports_an_error(self):
+        self.login()
+        response = self.client.post(self.url, {"action": "delete_selected"})
+        self.assertContains(response, "No subscribers were selected.")
+        self.assertEqual(MailingListSubscriber.objects.count(), 3)
+
+    def test_include_leads_scans_the_other_tables(self):
+        self.login()
+        response = self.client.get(self.url, {"include_leads": "1"})
+        self.assertContains(response, "ChatLeads")
+
+
+class UnsubscribeDuplicateTest(TestCase):
+    """Unsubscribing has to clear every row for the address, not just the one
+    holding the token, or duplicates keep the person subscribed."""
+
+    def test_unsubscribe_removes_case_variant_duplicates(self):
+        first = make_subscriber("jane@hospital.org")
+        make_subscriber("Jane@Hospital.org")
+
+        response = self.client.get(
+            reverse("unsubscribe", kwargs={"token": first.unsubscribe_token})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            MailingListSubscriber.objects.filter(
+                email__iexact="jane@hospital.org"
+            ).count(),
+            0,
+        )


### PR DESCRIPTION
Our signup forms are open, so MailingListSubscriber accumulates rows nobody
should ever be mailed: bot submissions with URLs in the name field, addresses
at reserved domains, case-variant duplicates of the same mailbox, and internal
test signups. There was no way to see or clear any of it.

subscriber_hygiene.py is the shared analysis: each row gets reason codes split
into auto-cleanable (unmailable, invalid, exact duplicate, URL/markup in a
field, header-injection attempt, control chars in the address) and review-only
signals (spam TLD, internal/test address, role account, alias duplicate,
suspicious unicode, implausibly long field). Bulk deletion only ever targets
the auto-cleanable bucket.

Two front ends over it:
  * `python manage.py cleanup_subscribers` -- reports by default, deletes with
    --apply, --reasons to narrow, --all-sources to also report on chat leads /
    demo requests / interested professionals (never deleted here). Addresses
    are masked in output since it lands in logs.
  * a staff Subscriber Cleanup page (/timbit/help/subscriber_cleanup) that
    lists flagged rows with their reasons and lets staff delete them, mark them
    reviewed-and-kept, or bulk-delete the auto-cleanable set behind a confirm
    box. New cleanup_reviewed_at/by fields keep reviewed rows out of the queue.

Two duplicate-related fixes found along the way:
  * unsubscribing now deletes every row for the address, not just the one
    holding the token -- with a duplicate row the person kept getting mail.
  * the mailing list actor sends once per mailbox instead of once per row.

Also moves the pro-connector test-address / spam-TLD lists into email_utils so
both flows share one list.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019N4BZqfZCvyEH9ej1RACPX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added staff tools to review, classify, and clean up suspicious mailing-list subscribers.
  * Added filtering, pagination, review tracking, selective deletion, and bulk cleanup options.
  * Added optional reporting for suspicious contacts in other tables.
  * Added unsubscribe handling that removes all matching case variants.

* **Bug Fixes**
  * Improved recipient deduplication and selection of the latest subscriber details.
  * Centralized detection of internal, test, and spam email addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->