### PR TITLE
Dev parity: boot in-process Ray cluster at startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,9 @@ coverage.xml
 local_settings.py
 db.sqlite3
 db.sqlite3-journal
+# WAL-mode sidecars (dev runs sqlite in journal_mode=WAL; see settings.py)
+db.sqlite3-wal
+db.sqlite3-shm
 
 # Flask stuff:
 instance/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,15 @@ python manage.py loaddata initial followup plan_source insurance_companies pa_re
 
 ### Async Processing
 - Ray actors (`*_actor.py`) for distributed background tasks
+- **Local dev runs the same Ray paths as production:** the Dev config boots an
+  in-process Ray cluster at server startup (`local_ray.maybe_init_local_ray`,
+  called from `asgi.py`/`wsgi.py`), so per-task dispatches (UCR refresh,
+  speculative appeals, denied-items analysis, fax, staff mail) go through real
+  actors instead of their inline/thread fallbacks. `FHI_LOCAL_RAY=false`
+  disables it (fallback paths return); `FHI_LOCAL_RAY_POLLING=true`
+  additionally launches the polling-actor fleet. Setting `RAY_ADDRESS` makes
+  startup attach to that cluster instead of booting one. Test* configs keep it
+  off — don't turn it on in tests.
 - WebSocket streaming for long-running ML operations
 - async/await patterns with sync-to-async bridges. **In async code, reach for
   Django's native async ORM first** — `aget`/`acreate`/`asave`/`adelete`/

--- a/fighthealthinsurance/asgi.py
+++ b/fighthealthinsurance/asgi.py
@@ -59,6 +59,14 @@ application = ProtocolTypeRouter(
 
 from django.conf import settings
 
+# Dev parity: deliberately bring up Ray once at startup (Dev boots an
+# in-process cluster; a set RAY_ADDRESS attaches instead) so the per-task
+# dispatch sites take the same actor paths locally as in production. No-op
+# in Test*/Prod configs; never raises. See local_ray for the gates.
+from fighthealthinsurance.local_ray import maybe_init_local_ray
+
+maybe_init_local_ray()
+
 if settings.SENTRY_ENDPOINT and not settings.DEBUG:
     import sentry_sdk
     from sentry_sdk.integrations.django import DjangoIntegration

--- a/fighthealthinsurance/base_actor_ref.py
+++ b/fighthealthinsurance/base_actor_ref.py
@@ -24,6 +24,14 @@ def ray_cluster_available() -> bool:
     take their fallback instead. Polling actors don't need it: they're launched
     once by the dedicated ``launch_polling_actors`` command, which runs on the
     cluster and waits for Ray to come up.
+
+    Dev servers pass this gate the same way production does: ``local_ray.
+    maybe_init_local_ray()`` deliberately boots an in-process cluster once at
+    startup (Dev config only), so ``ray.is_initialized()`` is True and the
+    dispatch sites take their Ray paths locally too. That startup boot is the
+    sanctioned counterpart of the per-dispatch auto-init this guard blocks;
+    the fallbacks below each gate remain for Test* configs and for dev runs
+    with ``FHI_LOCAL_RAY=false``.
     """
     try:
         if ray.is_initialized():

--- a/fighthealthinsurance/local_ray.py
+++ b/fighthealthinsurance/local_ray.py
@@ -20,14 +20,21 @@ Gating:
     background actor DB writes, and the Selenium suite historically died to
     exactly this kind of cluster boot.
   * ``FHI_LOCAL_RAY`` env var -- explicit "true"/"false" overrides the
-    setting either way (kill switch for slow reload cycles; force-on for a
-    one-off shell).
+    setting either way (kill switch for slow reload cycles). It only takes
+    effect where the entrypoints call this function; a ``manage.py shell``
+    never imports asgi/wsgi, so there you call ``maybe_init_local_ray()``
+    yourself.
 
-The polling-actor fleet (email/fax/chooser/IMR/UCR/PA) is launched by a
-dedicated command in production, not by web processes, so it is NOT started
-here by default. Set ``FHI_LOCAL_RAY_POLLING=true`` to launch it into the
-local cluster too, or hit the staff "relaunch actors" endpoint -- both go
-through ``actor_health_status.relaunch_actors``.
+The dedicated polling-actor FLEET launch (email/fax/chooser/IMR/UCR/PA --
+production runs it via ``launch_polling_actors``, never from web processes)
+is opt-in here: set ``FHI_LOCAL_RAY_POLLING=true``, or hit the staff
+"relaunch actors" endpoint -- both go through
+``actor_health_status.relaunch_actors``. Note that individual actors can
+still start their own loops without the fleet launch, exactly as in
+production: ``BaseActorRef`` fires ``run.remote()`` on first use for actors
+that have one, so e.g. the first UCR-eligible denial starts the UCR
+actor's continuous source-refresh loop (which in Dev downloads real CMS
+data).
 
 Dev-lifecycle notes: the cluster lives inside the server process, so each
 autoreload restart reboots it and detached actors restart lazily on next use.
@@ -36,6 +43,7 @@ For a cluster that survives reloads, run ``ray start --head`` once and export
 """
 
 import os
+import sys
 
 import ray
 from loguru import logger
@@ -63,6 +71,14 @@ def local_ray_enabled() -> bool:
         return True
     if env in _FALSY:
         return False
+    if env:
+        # A mistyped kill switch (FHI_LOCAL_RAY=n, =flase, ...) must not be
+        # silently ignored -- the dev who set it believes the boot is off.
+        logger.warning(
+            f"Unrecognized {LOCAL_RAY_ENV_VAR}={env!r}; expected one of "
+            f"{_TRUTHY} or {_FALSY}. Falling back to "
+            "settings.RAY_LOCAL_DEV_CLUSTER."
+        )
 
     from django.conf import settings
 
@@ -86,11 +102,24 @@ def maybe_init_local_ray() -> bool:
     if not local_ray_enabled():
         return False
 
+    if _in_reloader_watcher_process():
+        logger.debug(
+            "Reloader watcher process detected; leaving the Ray boot to the "
+            "serving child"
+        )
+        return False
+
     address = (os.environ.get("RAY_ADDRESS") or "").strip()
     # A real RAY_ADDRESS means "attach to that cluster" (ray.init reads the
     # env var itself); sizing kwargs are only legal when starting a new local
-    # cluster. Ray spells "start a new local cluster" as address "local" or
-    # unset -- mirror base_actor_ref.ray_cluster_available's reading of it.
+    # cluster. The boot branch passes address="local" EXPLICITLY: with the
+    # address left unset, ray.init auto-attaches to whatever address a past
+    # `ray start` recorded in /tmp/ray/ray_current_cluster (no liveness
+    # check), and on that path the sizing kwargs raise -- so a stale file
+    # from a crashed `ray start` would silently kill the boot. "local"
+    # always means a fresh cluster (ray services.canonicalize_bootstrap_
+    # address). Attaching to a `ray start` cluster is spelled RAY_ADDRESS,
+    # as the module docstring says.
     attaching = bool(address) and address.lower() != "local"
     try:
         if attaching:
@@ -98,6 +127,7 @@ def maybe_init_local_ray() -> bool:
             logger.info(f"Attached to Ray cluster at RAY_ADDRESS={address} at startup")
         else:
             ray.init(
+                address="local",
                 namespace="fhi",
                 ignore_reinit_error=True,
                 include_dashboard=False,
@@ -116,6 +146,25 @@ def maybe_init_local_ray() -> bool:
 
     _maybe_launch_polling_actors()
     return True
+
+
+def _in_reloader_watcher_process() -> bool:
+    """True in runserver_plus's werkzeug watcher parent.
+
+    django-extensions' runserver_plus builds the WSGI handler (importing
+    wsgi.py) BEFORE werkzeug forks the serving child, and the watcher parent
+    then only watches files -- booting Ray there would leave a second,
+    permanently idle cluster running for the whole session. The serving
+    child re-executes with WERKZEUG_RUN_MAIN=true, and --noreload serves
+    directly from the first process, so both of those must boot. Plain
+    `manage.py runserver`'s autoreload parent never imports the handler, so
+    it needs no guard.
+    """
+    if "runserver_plus" not in sys.argv:
+        return False
+    if "--noreload" in sys.argv:
+        return False
+    return os.environ.get("WERKZEUG_RUN_MAIN") != "true"
 
 
 def _maybe_launch_polling_actors() -> None:

--- a/fighthealthinsurance/local_ray.py
+++ b/fighthealthinsurance/local_ray.py
@@ -1,0 +1,141 @@
+"""Deliberate in-process Ray boot so dev runs the same code paths as prod.
+
+In production ``RAY_ADDRESS`` points at the k8s RayCluster, so every per-task
+dispatch site (UCR refresh, speculative appeals, denied-items analysis, fax
+send, staff mailing) takes the Ray-actor path. Without a cluster those sites
+either fall back to inline/thread work or skip entirely (see
+``base_actor_ref.ray_cluster_available``), which means local development
+exercises different code than production.
+
+``maybe_init_local_ray()`` closes that gap: called once at server startup
+(``asgi.py`` / ``wsgi.py``), it boots a small in-process local Ray cluster --
+or eagerly attaches when ``RAY_ADDRESS`` names a real cluster -- so
+``ray_cluster_available()`` passes and the production dispatch paths run
+locally. This is the *deliberate, once-per-process* version of the accidental
+per-dispatch auto-init that gate exists to prevent.
+
+Gating:
+  * ``settings.RAY_LOCAL_DEV_CLUSTER`` -- True in Dev, False in Test*/Prod.
+    The Test* configs must stay off: TestCase-transaction teardown races
+    background actor DB writes, and the Selenium suite historically died to
+    exactly this kind of cluster boot.
+  * ``FHI_LOCAL_RAY`` env var -- explicit "true"/"false" overrides the
+    setting either way (kill switch for slow reload cycles; force-on for a
+    one-off shell).
+
+The polling-actor fleet (email/fax/chooser/IMR/UCR/PA) is launched by a
+dedicated command in production, not by web processes, so it is NOT started
+here by default. Set ``FHI_LOCAL_RAY_POLLING=true`` to launch it into the
+local cluster too, or hit the staff "relaunch actors" endpoint -- both go
+through ``actor_health_status.relaunch_actors``.
+
+Dev-lifecycle notes: the cluster lives inside the server process, so each
+autoreload restart reboots it and detached actors restart lazily on next use.
+For a cluster that survives reloads, run ``ray start --head`` once and export
+``RAY_ADDRESS`` -- this module then just attaches, same as production.
+"""
+
+import os
+
+import ray
+from loguru import logger
+
+LOCAL_RAY_ENV_VAR = "FHI_LOCAL_RAY"
+LOCAL_RAY_POLLING_ENV_VAR = "FHI_LOCAL_RAY_POLLING"
+
+_TRUTHY = ("true", "1", "yes", "on")
+_FALSY = ("false", "0", "no", "off")
+
+# The dispatch sites ship ids and small strings, not datasets, so Ray's
+# default object store (a percentage of system RAM) would be pure waste on a
+# dev machine. Ray's floor is ~75MB; 200MB leaves comfortable headroom.
+LOCAL_RAY_OBJECT_STORE_BYTES = 200 * 1024 * 1024
+
+
+def local_ray_enabled() -> bool:
+    """Should this process deliberately bring up Ray at startup?
+
+    ``FHI_LOCAL_RAY`` wins when it says anything recognizable; otherwise the
+    ``RAY_LOCAL_DEV_CLUSTER`` setting decides (Dev on, Test*/Prod off).
+    """
+    env = (os.environ.get(LOCAL_RAY_ENV_VAR) or "").strip().lower()
+    if env in _TRUTHY:
+        return True
+    if env in _FALSY:
+        return False
+
+    from django.conf import settings
+
+    return bool(getattr(settings, "RAY_LOCAL_DEV_CLUSTER", False))
+
+
+def maybe_init_local_ray() -> bool:
+    """Boot (or attach) Ray once at startup when enabled; never raise.
+
+    Returns True when Ray is initialized in this process afterwards --
+    whether this call did it or it already was. A failed boot logs and
+    returns False so the server still starts; the dispatch sites then fall
+    back exactly as they do today without a cluster.
+    """
+    try:
+        if ray.is_initialized():
+            return True
+    except Exception:
+        logger.opt(exception=True).debug("ray.is_initialized() check failed")
+
+    if not local_ray_enabled():
+        return False
+
+    address = (os.environ.get("RAY_ADDRESS") or "").strip()
+    # A real RAY_ADDRESS means "attach to that cluster" (ray.init reads the
+    # env var itself); sizing kwargs are only legal when starting a new local
+    # cluster. Ray spells "start a new local cluster" as address "local" or
+    # unset -- mirror base_actor_ref.ray_cluster_available's reading of it.
+    attaching = bool(address) and address.lower() != "local"
+    try:
+        if attaching:
+            ray.init(namespace="fhi", ignore_reinit_error=True)
+            logger.info(f"Attached to Ray cluster at RAY_ADDRESS={address} at startup")
+        else:
+            ray.init(
+                namespace="fhi",
+                ignore_reinit_error=True,
+                include_dashboard=False,
+                object_store_memory=LOCAL_RAY_OBJECT_STORE_BYTES,
+            )
+            logger.info(
+                "Booted in-process local Ray cluster for dev/prod code-path "
+                f"parity (disable with {LOCAL_RAY_ENV_VAR}=false)"
+            )
+    except Exception:
+        logger.opt(exception=True).warning(
+            "Local Ray boot failed; continuing without a cluster (dispatch "
+            "sites will use their non-Ray fallbacks)"
+        )
+        return False
+
+    _maybe_launch_polling_actors()
+    return True
+
+
+def _maybe_launch_polling_actors() -> None:
+    """Opt-in launch of the polling-actor fleet into the local cluster.
+
+    Off by default: in production these are launched by the dedicated
+    ``launch_polling_actors`` command, not by web processes, and locally they
+    poll external services (IMAP, fax backends) that usually aren't
+    configured -- so starting them unasked would just spam error logs.
+    """
+    env = (os.environ.get(LOCAL_RAY_POLLING_ENV_VAR) or "").strip().lower()
+    if env not in _TRUTHY:
+        return
+    try:
+        from fighthealthinsurance.actor_health_status import relaunch_actors
+
+        results = relaunch_actors(force=False)
+        statuses = {name: info.get("status") for name, info in results.items()}
+        logger.info(f"Local Ray polling actors launched: {statuses}")
+    except Exception:
+        logger.opt(exception=True).warning(
+            "Failed to launch polling actors on the local Ray cluster"
+        )

--- a/fighthealthinsurance/ray.py
+++ b/fighthealthinsurance/ray.py
@@ -1,2 +1,0 @@
-# Optional we could setup a runtime env here
-# ray.init(runtime_env=runtime_env)

--- a/fighthealthinsurance/settings.py
+++ b/fighthealthinsurance/settings.py
@@ -80,14 +80,20 @@ def _sqlite_shared_file_options(timeout_seconds: int) -> dict:
       write; if another writer committed in between, sqlite must fail the
       upgrade *immediately* (the read snapshot is stale, so the busy handler
       never runs). IMMEDIATE takes the write lock at BEGIN, turning that
-      hard failure into a plain wait.
+      hard failure into a plain wait. The known cost: EVERY outermost atomic
+      block takes the write lock, including read-only ones and the wrapper
+      transactions of Django ``TestCase`` -- so a sync-actor test written as
+      plain ``TestCase`` holds the write lock for its whole run and any
+      actor write against the shared file will time out. Actor-facing tests
+      there must keep using ``TransactionTestCase`` (they already do).
     * ``timeout`` -- passed to ``sqlite3.connect``; sets the busy handler so
       lock waits block up to this long instead of raising at once.
     * ``journal_mode=WAL`` -- readers stop blocking the writer (and vice
       versa), which is the steady state of a dev server: actors write in the
       background while requests read. Sticky per database file; harmless to
-      re-run per connection. (Would misbehave on a network mount, but dev
-      DB files live in the repo checkout.)
+      re-run per connection. (WAL is unsafe on network filesystems -- fine
+      for the default in-repo dev DB and the container paths, but don't
+      point ``DEV_DB_LOC`` at an NFS mount.)
     * ``synchronous=NORMAL`` -- the standard WAL pairing; loses at most the
       final transactions on power loss, never consistency. Fine for dev and
       throwaway test databases.
@@ -812,7 +818,6 @@ class Test(Dev):
     DATABASES = {
         "default": {
             "ENGINE": "django.db.backends.sqlite3",
-            "TIMEOUT": 30,
             "CONN_MAX_AGE": 0,
             "NAME": "memory",
         },
@@ -845,7 +850,6 @@ class TestSync(Dev):
     DATABASES = {
         "default": {
             "ENGINE": "django.db.backends.sqlite3",
-            "TIMEOUT": 4,
             "NAME": "memory",
         },
     }

--- a/fighthealthinsurance/settings.py
+++ b/fighthealthinsurance/settings.py
@@ -68,6 +68,40 @@ def _env_flag(name: str, default: str = "0") -> bool:
     return (os.getenv(name) or default).strip().lower() in ("1", "true", "yes", "on")
 
 
+def _sqlite_shared_file_options(timeout_seconds: int) -> dict:
+    """sqlite OPTIONS for a database FILE shared by several processes at once.
+
+    Dev and the sync-actor suite both run the web/test process plus Ray actor
+    workers (each booting its own Django) against one sqlite file. Stock
+    sqlite makes that combination flake with "database is locked":
+
+    * ``transaction_mode: IMMEDIATE`` -- Django's default DEFERRED begins a
+      write transaction as a reader and upgrades to writer at the first
+      write; if another writer committed in between, sqlite must fail the
+      upgrade *immediately* (the read snapshot is stale, so the busy handler
+      never runs). IMMEDIATE takes the write lock at BEGIN, turning that
+      hard failure into a plain wait.
+    * ``timeout`` -- passed to ``sqlite3.connect``; sets the busy handler so
+      lock waits block up to this long instead of raising at once.
+    * ``journal_mode=WAL`` -- readers stop blocking the writer (and vice
+      versa), which is the steady state of a dev server: actors write in the
+      background while requests read. Sticky per database file; harmless to
+      re-run per connection. (Would misbehave on a network mount, but dev
+      DB files live in the repo checkout.)
+    * ``synchronous=NORMAL`` -- the standard WAL pairing; loses at most the
+      final transactions on power loss, never consistency. Fine for dev and
+      throwaway test databases.
+
+    Returns a fresh dict per call: Django mutates settings_dict in place, so
+    sharing one literal between configuration classes would couple them.
+    """
+    return {
+        "transaction_mode": "IMMEDIATE",
+        "timeout": timeout_seconds,
+        "init_command": "PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL;",
+    }
+
+
 class Base(Configuration):
     SENTRY_ENDPOINT = os.getenv("SENTRY_ENDPOINT")
     COOKIE_CONSENT_ENABLED = False
@@ -690,6 +724,11 @@ class Dev(Base):
         "default": {
             "ENGINE": "django.db.backends.sqlite3",
             "NAME": os.getenv("DEV_DB_LOC", BASE_DIR / "db.sqlite3"),
+            # The dev server shares this file with the in-process Ray
+            # cluster's actor workers (see local_ray), so it needs the
+            # multi-process options or concurrent actor writes surface as
+            # "database is locked" errors in the web process.
+            "OPTIONS": _sqlite_shared_file_options(timeout_seconds=20),
             "TEST": {
                 "NAME": BASE_DIR / "test.db.sqlite3",
             },
@@ -842,7 +881,12 @@ class TestActor(Dev):
     DATABASES = {
         "default": {
             "ENGINE": "django.db.backends.sqlite3",
-            "TIMEOUT": 10,
+            # Same shared-file shape as Dev: the test process and Ray actor
+            # workers hit this one file concurrently. (This replaces a
+            # top-level "TIMEOUT" key, which is not a Django database
+            # setting -- it was silently ignored, leaving the stock 5s
+            # busy handler.)
+            "OPTIONS": _sqlite_shared_file_options(timeout_seconds=10),
             "NAME": dbname,
             "TEST": {
                 "NAME": dbname,

--- a/fighthealthinsurance/settings.py
+++ b/fighthealthinsurance/settings.py
@@ -485,6 +485,14 @@ class Base(Configuration):
     # transaction.
     WS_PER_CONNECTION_THREAD_SENSITIVE = True
 
+    # Deliberately boot an in-process local Ray cluster at server startup so
+    # the per-task dispatch sites take the same actor paths as production
+    # (see local_ray.maybe_init_local_ray). Off in Base/Prod -- production
+    # attaches to the real cluster via RAY_ADDRESS -- and on in Dev.
+    # Test* configs (which subclass Dev) must override this back off:
+    # background actor DB writes race TestCase transaction teardown.
+    RAY_LOCAL_DEV_CLUSTER = False
+
     # Static files (CSS, JavaScript, Images)
     # https://docs.djangoproject.com/en/4.0/howto/static-files/
 
@@ -618,6 +626,10 @@ class Dev(Base):
     # Keep the (production-closed) professional signup flow testable locally
     # and in the Test* configurations that subclass Dev.
     NEW_PROFESSIONAL_SIGNUP_ENABLED = True
+    # Dev servers boot an in-process Ray cluster at startup so local runs
+    # exercise the production actor-dispatch paths (see local_ray). The Test*
+    # subclasses turn this back off; FHI_LOCAL_RAY=false is the kill switch.
+    RAY_LOCAL_DEV_CLUSTER = True
     CSRF_TRUSTED_ORIGINS = [
         "https://fightpaperwork.com",
         "https://localhost:3000",
@@ -778,6 +790,8 @@ class Test(Dev):
     SPECULATIVE_APPEALS_PRECOMPUTE = False
     # Keep thread-sensitive bridge routing on the test thread (see Base).
     WS_PER_CONNECTION_THREAD_SENSITIVE = False
+    # No startup Ray boot in tests (see Base).
+    RAY_LOCAL_DEV_CLUSTER = False
 
 
 class TestSync(Dev):
@@ -808,6 +822,8 @@ class TestSync(Dev):
     SPECULATIVE_APPEALS_PRECOMPUTE = False
     # Keep thread-sensitive bridge routing on the test thread (see Base).
     WS_PER_CONNECTION_THREAD_SENSITIVE = False
+    # No startup Ray boot in tests (see Base).
+    RAY_LOCAL_DEV_CLUSTER = False
 
 
 class TestActor(Dev):
@@ -845,6 +861,9 @@ class TestActor(Dev):
     SPECULATIVE_APPEALS_PRECOMPUTE = False
     # Keep thread-sensitive bridge routing on the test thread (see Base).
     WS_PER_CONNECTION_THREAD_SENSITIVE = False
+    # No startup Ray boot in tests (see Base). The sync-actor suite manages
+    # ray.init/shutdown itself in each test's setUp/tearDown.
+    RAY_LOCAL_DEV_CLUSTER = False
 
 
 class Prod(Base):

--- a/fighthealthinsurance/wsgi.py
+++ b/fighthealthinsurance/wsgi.py
@@ -20,3 +20,11 @@ os.environ.setdefault(
 os.environ.setdefault("DJANGO_CONFIGURATION", get_env_variable("ENVIRONMENT", "Dev"))
 
 application = get_wsgi_application()
+
+# Dev parity: deliberately bring up Ray once at startup, mirroring asgi.py --
+# `manage.py runserver` serves through this module (WSGI_APPLICATION), so the
+# hook has to live here too or runserver-based dev would keep the divergent
+# non-Ray fallbacks. No-op in Test*/Prod configs; never raises.
+from fighthealthinsurance.local_ray import maybe_init_local_ray
+
+maybe_init_local_ray()

--- a/k8s/deploy_dev.yaml
+++ b/k8s/deploy_dev.yaml
@@ -32,6 +32,15 @@ spec:
           env:
             - name: DEV_DB_LOC
               value: "/tmp/db.sqlite3"
+            # This pod runs the Dev configuration, whose default now boots an
+            # in-process Ray cluster per server process for laptop parity
+            # (see local_ray.py) -- here that would mean one cluster per
+            # uvicorn worker (start-server.sh defaults to 2) in a pod with no
+            # resource limits. Keep the pod on its pre-existing no-cluster
+            # behavior; to give it real parity instead, point RAY_ADDRESS at
+            # a dev RayCluster (or set UVICORN_WORKERS=1 and drop this).
+            - name: FHI_LOCAL_RAY
+              value: "false"
           imagePullPolicy: Always
           ports:
             - containerPort: 80

--- a/scripts/test_setup.sh
+++ b/scripts/test_setup.sh
@@ -4,6 +4,16 @@ set -ex
 
 SCRIPT_DIR="$(dirname "$0")"
 
+# A hard-killed prior run can leave WAL sidecars beside a pinned DBNAME
+# (TestActor runs sqlite in journal_mode=WAL; see settings.py). Django's
+# test-DB creation removes only the main file, and sqlite would replay the
+# stale -wal into the freshly created database at the same path. Safe to do
+# here: nothing has opened the database yet. Only the explicit DBNAME pin
+# needs this -- the default name is timestamped per run.
+if [ -n "${DBNAME:-}" ]; then
+  rm -f "${DBNAME}-wal" "${DBNAME}-shm"
+fi
+
 "${SCRIPT_DIR}/"build_static.sh &> logs || (echo "ERROR building"; cat logs; exit 1)
 
 echo "Tests ready to run."

--- a/tests/sync-actor/test_local_ray_boot.py
+++ b/tests/sync-actor/test_local_ray_boot.py
@@ -1,0 +1,36 @@
+"""Real-boot test for the dev-parity in-process Ray cluster.
+
+The gating logic is covered with mocks in tests/sync/test_local_ray.py; this
+suite pays for actual Ray startup anyway, so here we verify the exact
+ray.init call maybe_init_local_ray makes (namespace, dashboard off, small
+object store) is accepted by the pinned Ray version and yields a cluster the
+dispatch gate recognizes.
+"""
+
+import os
+from unittest.mock import patch
+
+import ray
+from django.test import SimpleTestCase
+
+from fighthealthinsurance.base_actor_ref import ray_cluster_available
+from fighthealthinsurance.local_ray import LOCAL_RAY_ENV_VAR, maybe_init_local_ray
+
+
+class TestLocalRayBoot(SimpleTestCase):
+    def tearDown(self):
+        if ray.is_initialized():
+            ray.shutdown()
+
+    def test_boot_passes_dispatch_gate_and_is_idempotent(self):
+        # TestActor keeps RAY_LOCAL_DEV_CLUSTER off; force-enable via the env
+        # override -- which also exercises that override path for real.
+        with patch.dict(os.environ, {LOCAL_RAY_ENV_VAR: "true"}, clear=False):
+            os.environ.pop("RAY_ADDRESS", None)
+            self.assertTrue(maybe_init_local_ray())
+            self.assertTrue(ray.is_initialized())
+            # The per-task dispatch sites gate on this: after the deliberate
+            # boot they must take the same actor paths as production.
+            self.assertTrue(ray_cluster_available())
+            # Second call short-circuits on the running cluster.
+            self.assertTrue(maybe_init_local_ray())

--- a/tests/sync-actor/test_local_ray_boot.py
+++ b/tests/sync-actor/test_local_ray_boot.py
@@ -14,7 +14,11 @@ import ray
 from django.test import SimpleTestCase
 
 from fighthealthinsurance.base_actor_ref import ray_cluster_available
-from fighthealthinsurance.local_ray import LOCAL_RAY_ENV_VAR, maybe_init_local_ray
+from fighthealthinsurance.local_ray import (
+    LOCAL_RAY_ENV_VAR,
+    LOCAL_RAY_POLLING_ENV_VAR,
+    maybe_init_local_ray,
+)
 
 
 class TestLocalRayBoot(SimpleTestCase):
@@ -27,6 +31,10 @@ class TestLocalRayBoot(SimpleTestCase):
         # override -- which also exercises that override path for real.
         with patch.dict(os.environ, {LOCAL_RAY_ENV_VAR: "true"}, clear=False):
             os.environ.pop("RAY_ADDRESS", None)
+            # tox runs with passenv = *: a developer's exported
+            # FHI_LOCAL_RAY_POLLING would otherwise make this real boot
+            # launch the actual polling-actor fleet mid-suite.
+            os.environ.pop(LOCAL_RAY_POLLING_ENV_VAR, None)
             self.assertTrue(maybe_init_local_ray())
             self.assertTrue(ray.is_initialized())
             # The per-task dispatch sites gate on this: after the deliberate

--- a/tests/sync-actor/test_sqlite_shared_file.py
+++ b/tests/sync-actor/test_sqlite_shared_file.py
@@ -1,0 +1,33 @@
+"""Live-connection proof that the shared-file sqlite options take effect.
+
+The sync-actor suite runs under TestActor against a real sqlite FILE (the
+same file Ray actor workers open), so the pragmas that matter for
+multi-process safety can be asserted on the actual Django connection here --
+unlike the in-memory Test/TestSync suites, where journal_mode is always
+"memory" no matter what the options say.
+"""
+
+from django.db import connection
+from django.test import TestCase
+
+
+class SharedFileSqlitePragmasTest(TestCase):
+    def _pragma(self, name):
+        with connection.cursor() as cursor:
+            cursor.execute(f"PRAGMA {name}")
+            return cursor.fetchone()[0]
+
+    def test_journal_mode_is_wal(self):
+        self.assertEqual(self._pragma("journal_mode"), "wal")
+
+    def test_busy_timeout_matches_options(self):
+        # OPTIONS["timeout"] (seconds) becomes the sqlite busy handler (ms).
+        expected_ms = connection.settings_dict["OPTIONS"]["timeout"] * 1000
+        self.assertEqual(self._pragma("busy_timeout"), expected_ms)
+
+    def test_synchronous_is_normal(self):
+        # 1 == NORMAL (0 OFF, 2 FULL, 3 EXTRA)
+        self.assertEqual(self._pragma("synchronous"), 1)
+
+    def test_write_transactions_begin_immediate(self):
+        self.assertEqual(connection.transaction_mode, "IMMEDIATE")

--- a/tests/sync/test_dev_sqlite_options.py
+++ b/tests/sync/test_dev_sqlite_options.py
@@ -1,0 +1,41 @@
+"""The shared-file sqlite configs must carry the multi-process options.
+
+Dev and TestActor point several processes (server/test process + Ray actor
+workers, each booting its own Django) at one sqlite file; without WAL +
+IMMEDIATE transactions + a busy timeout that shape flakes with "database is
+locked". These are plain class-attribute checks -- the live-connection proof
+(the pragmas actually taking effect on the shared file) lives in
+tests/sync-actor/test_sqlite_shared_file.py where the file-backed database
+is the active one.
+"""
+
+from django.test import SimpleTestCase
+
+from fighthealthinsurance.settings import Dev, TestActor
+
+
+class SharedFileSqliteOptionsTest(SimpleTestCase):
+    def _options(self, config_class):
+        return config_class.DATABASES["default"]["OPTIONS"]
+
+    def test_dev_uses_immediate_transactions(self):
+        self.assertEqual(self._options(Dev)["transaction_mode"], "IMMEDIATE")
+
+    def test_dev_enables_wal_and_normal_sync(self):
+        init_command = self._options(Dev)["init_command"]
+        self.assertIn("journal_mode=WAL", init_command)
+        self.assertIn("synchronous=NORMAL", init_command)
+
+    def test_dev_sets_a_busy_timeout(self):
+        self.assertGreaterEqual(self._options(Dev)["timeout"], 5)
+
+    def test_testactor_gets_the_same_shared_file_options(self):
+        options = self._options(TestActor)
+        self.assertEqual(options["transaction_mode"], "IMMEDIATE")
+        self.assertIn("journal_mode=WAL", options["init_command"])
+        self.assertGreaterEqual(options["timeout"], 5)
+
+    def test_options_dicts_are_not_shared_between_configs(self):
+        # Django mutates settings_dict in place; a shared literal would
+        # couple the configurations (see _sqlite_shared_file_options).
+        self.assertIsNot(self._options(Dev), self._options(TestActor))

--- a/tests/sync/test_local_ray.py
+++ b/tests/sync/test_local_ray.py
@@ -1,0 +1,158 @@
+"""Gating tests for the deliberate dev-parity Ray boot (local_ray).
+
+These never boot a real cluster -- ray is mocked throughout. The real boot is
+exercised by tests/sync-actor/test_local_ray_boot.py, where paying for Ray
+startup is the suite's normal cost.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+from django.conf import settings
+from django.test import TestCase, override_settings
+
+from fighthealthinsurance.local_ray import (
+    LOCAL_RAY_ENV_VAR,
+    LOCAL_RAY_POLLING_ENV_VAR,
+    local_ray_enabled,
+    maybe_init_local_ray,
+)
+
+_RAY = "fighthealthinsurance.local_ray.ray"
+_RELAUNCH = "fighthealthinsurance.actor_health_status.relaunch_actors"
+
+
+def _clean_env():
+    """patch.dict context with the three relevant vars removed.
+
+    tox runs with passenv = *, so FHI_LOCAL_RAY / FHI_LOCAL_RAY_POLLING /
+    RAY_ADDRESS could leak in from the host and flip a branch under test;
+    patch.dict restores the original environment on exit even for keys
+    popped inside the block.
+    """
+    ctx = patch.dict(os.environ, {}, clear=False)
+    ctx.start()
+    os.environ.pop(LOCAL_RAY_ENV_VAR, None)
+    os.environ.pop(LOCAL_RAY_POLLING_ENV_VAR, None)
+    os.environ.pop("RAY_ADDRESS", None)
+    return ctx
+
+
+class LocalRayGatingTest(TestCase):
+    """maybe_init_local_ray must boot only when deliberately enabled."""
+
+    def setUp(self):
+        self._env = _clean_env()
+        self.addCleanup(self._env.stop)
+
+    def _mock_ray(self, initialized=False):
+        mock_ray = MagicMock()
+        mock_ray.is_initialized.return_value = initialized
+        return patch(_RAY, mock_ray)
+
+    def test_test_configs_keep_the_startup_boot_off(self):
+        # The suite runs under a Test* configuration; the Dev default must
+        # not leak through the subclass chain (Test* subclass Dev).
+        self.assertFalse(settings.RAY_LOCAL_DEV_CLUSTER)
+        self.assertFalse(local_ray_enabled())
+
+    def test_disabled_makes_no_ray_calls(self):
+        with self._mock_ray() as mock_ray:
+            self.assertFalse(maybe_init_local_ray())
+        mock_ray.init.assert_not_called()
+
+    @override_settings(RAY_LOCAL_DEV_CLUSTER=True)
+    def test_dev_setting_boots_local_cluster(self):
+        with self._mock_ray() as mock_ray:
+            self.assertTrue(maybe_init_local_ray())
+        mock_ray.init.assert_called_once()
+        kwargs = mock_ray.init.call_args.kwargs
+        self.assertEqual(kwargs["namespace"], "fhi")
+        # Local boot passes the dev sizing args (vs. the attach branch).
+        self.assertIn("object_store_memory", kwargs)
+
+    def test_env_var_true_overrides_test_setting(self):
+        os.environ[LOCAL_RAY_ENV_VAR] = "true"
+        with self._mock_ray() as mock_ray:
+            self.assertTrue(maybe_init_local_ray())
+        mock_ray.init.assert_called_once()
+
+    @override_settings(RAY_LOCAL_DEV_CLUSTER=True)
+    def test_env_var_false_is_a_kill_switch_over_dev_setting(self):
+        os.environ[LOCAL_RAY_ENV_VAR] = "false"
+        with self._mock_ray() as mock_ray:
+            self.assertFalse(maybe_init_local_ray())
+        mock_ray.init.assert_not_called()
+
+    def test_already_initialized_short_circuits_without_reinit(self):
+        # Truthful even when the gate is off (e.g. a sync-actor test already
+        # attached this process): Ray is up, so report it and touch nothing.
+        with self._mock_ray(initialized=True) as mock_ray:
+            self.assertTrue(maybe_init_local_ray())
+        mock_ray.init.assert_not_called()
+
+    @override_settings(RAY_LOCAL_DEV_CLUSTER=True)
+    def test_real_ray_address_attaches_without_local_sizing_args(self):
+        # Sizing kwargs are only legal when starting a new local cluster;
+        # with a real address ray.init must be left to attach.
+        os.environ["RAY_ADDRESS"] = "ray://cluster:10001"
+        with self._mock_ray() as mock_ray:
+            self.assertTrue(maybe_init_local_ray())
+        kwargs = mock_ray.init.call_args.kwargs
+        self.assertEqual(kwargs["namespace"], "fhi")
+        self.assertNotIn("object_store_memory", kwargs)
+        self.assertNotIn("include_dashboard", kwargs)
+
+    @override_settings(RAY_LOCAL_DEV_CLUSTER=True)
+    def test_ray_address_local_takes_the_boot_branch(self):
+        # "local" is Ray's spelling of "start a brand-new local cluster"
+        # (mirrors base_actor_ref.ray_cluster_available), so the dev sizing
+        # args apply.
+        os.environ["RAY_ADDRESS"] = "local"
+        with self._mock_ray() as mock_ray:
+            self.assertTrue(maybe_init_local_ray())
+        self.assertIn("object_store_memory", mock_ray.init.call_args.kwargs)
+
+    @override_settings(RAY_LOCAL_DEV_CLUSTER=True)
+    def test_boot_failure_is_swallowed_and_reports_false(self):
+        # The server must still start without a cluster; dispatch sites then
+        # use their non-Ray fallbacks.
+        with self._mock_ray() as mock_ray:
+            mock_ray.init.side_effect = RuntimeError("no cluster for you")
+            self.assertFalse(maybe_init_local_ray())
+
+
+class LocalRayPollingOptInTest(TestCase):
+    """The polling-actor fleet launches only on explicit opt-in."""
+
+    def setUp(self):
+        self._env = _clean_env()
+        self.addCleanup(self._env.stop)
+        os.environ[LOCAL_RAY_ENV_VAR] = "true"
+
+    def _boot(self):
+        mock_ray = MagicMock()
+        mock_ray.is_initialized.return_value = False
+        with patch(_RAY, mock_ray), patch(_RELAUNCH) as mock_relaunch:
+            mock_relaunch.return_value = {
+                "email_polling_actor": {"status": "launched"}
+            }
+            self.assertTrue(maybe_init_local_ray())
+        return mock_relaunch
+
+    def test_polling_actors_not_launched_by_default(self):
+        self._boot().assert_not_called()
+
+    def test_polling_actors_launched_when_opted_in(self):
+        os.environ[LOCAL_RAY_POLLING_ENV_VAR] = "true"
+        mock_relaunch = self._boot()
+        mock_relaunch.assert_called_once_with(force=False)
+
+    def test_polling_launch_failure_does_not_fail_the_boot(self):
+        os.environ[LOCAL_RAY_POLLING_ENV_VAR] = "true"
+        mock_ray = MagicMock()
+        mock_ray.is_initialized.return_value = False
+        with patch(_RAY, mock_ray), patch(
+            _RELAUNCH, side_effect=RuntimeError("actors sad")
+        ):
+            self.assertTrue(maybe_init_local_ray())

--- a/tests/sync/test_local_ray.py
+++ b/tests/sync/test_local_ray.py
@@ -6,6 +6,7 @@ startup is the suite's normal cost.
 """
 
 import os
+import sys
 from unittest.mock import MagicMock, patch
 
 from django.conf import settings
@@ -70,6 +71,11 @@ class LocalRayGatingTest(TestCase):
         self.assertEqual(kwargs["namespace"], "fhi")
         # Local boot passes the dev sizing args (vs. the attach branch).
         self.assertIn("object_store_memory", kwargs)
+        # address="local" must be explicit: left unset, ray.init would
+        # auto-attach to any (possibly stale) /tmp/ray/ray_current_cluster
+        # address recorded by a past `ray start`, where the sizing kwargs
+        # raise and the boot silently dies.
+        self.assertEqual(kwargs["address"], "local")
 
     def test_env_var_true_overrides_test_setting(self):
         os.environ[LOCAL_RAY_ENV_VAR] = "true"
@@ -94,7 +100,8 @@ class LocalRayGatingTest(TestCase):
     @override_settings(RAY_LOCAL_DEV_CLUSTER=True)
     def test_real_ray_address_attaches_without_local_sizing_args(self):
         # Sizing kwargs are only legal when starting a new local cluster;
-        # with a real address ray.init must be left to attach.
+        # with a real address ray.init must be left to attach (it reads
+        # RAY_ADDRESS itself, so no address kwarg either).
         os.environ["RAY_ADDRESS"] = "ray://cluster:10001"
         with self._mock_ray() as mock_ray:
             self.assertTrue(maybe_init_local_ray())
@@ -102,6 +109,7 @@ class LocalRayGatingTest(TestCase):
         self.assertEqual(kwargs["namespace"], "fhi")
         self.assertNotIn("object_store_memory", kwargs)
         self.assertNotIn("include_dashboard", kwargs)
+        self.assertNotIn("address", kwargs)
 
     @override_settings(RAY_LOCAL_DEV_CLUSTER=True)
     def test_ray_address_local_takes_the_boot_branch(self):
@@ -120,6 +128,38 @@ class LocalRayGatingTest(TestCase):
         with self._mock_ray() as mock_ray:
             mock_ray.init.side_effect = RuntimeError("no cluster for you")
             self.assertFalse(maybe_init_local_ray())
+
+    def test_unrecognized_env_value_warns_and_uses_setting(self):
+        # A mistyped kill switch (=n, =flase) must not silently boot anyway.
+        os.environ[LOCAL_RAY_ENV_VAR] = "n"
+        with patch("fighthealthinsurance.local_ray.logger") as mock_logger:
+            self.assertFalse(local_ray_enabled())
+        mock_logger.warning.assert_called_once()
+
+    @override_settings(RAY_LOCAL_DEV_CLUSTER=True)
+    def test_runserver_plus_watcher_parent_skips_boot(self):
+        # runserver_plus imports wsgi.py in the werkzeug watcher parent
+        # before forking the serving child; booting there would leave an
+        # idle second cluster for the whole session.
+        argv = ["manage.py", "runserver_plus", "0.0.0.0:8000"]
+        with patch.object(sys, "argv", argv), self._mock_ray() as mock_ray:
+            os.environ.pop("WERKZEUG_RUN_MAIN", None)
+            self.assertFalse(maybe_init_local_ray())
+            mock_ray.init.assert_not_called()
+            # The serving child (WERKZEUG_RUN_MAIN=true) must boot.
+            os.environ["WERKZEUG_RUN_MAIN"] = "true"
+            self.assertTrue(maybe_init_local_ray())
+            mock_ray.init.assert_called_once()
+
+    @override_settings(RAY_LOCAL_DEV_CLUSTER=True)
+    def test_runserver_plus_noreload_boots_directly(self):
+        # With --noreload the first process serves, so it must boot despite
+        # WERKZEUG_RUN_MAIN never being set.
+        argv = ["manage.py", "runserver_plus", "--noreload"]
+        with patch.object(sys, "argv", argv), self._mock_ray() as mock_ray:
+            os.environ.pop("WERKZEUG_RUN_MAIN", None)
+            self.assertTrue(maybe_init_local_ray())
+        mock_ray.init.assert_called_once()
 
 
 class LocalRayPollingOptInTest(TestCase):


### PR DESCRIPTION
## Summary

Adds deliberate in-process Ray cluster initialization at server startup in Dev configuration, ensuring local development exercises the same actor-dispatch code paths as production. This closes a gap where Dev would fall back to inline/thread work while production uses Ray actors.

## Key Changes

- **New `local_ray.py` module**: Implements `maybe_init_local_ray()` to boot (or attach to) Ray once at startup with careful gating:
  - Enabled by `RAY_LOCAL_DEV_CLUSTER` setting (True in Dev, False in Test*/Prod)
  - Overridable via `FHI_LOCAL_RAY` env var ("true"/"false" kill switch)
  - Detects and skips the werkzeug reloader watcher process to avoid idle second cluster
  - Distinguishes between local cluster boot (with dev sizing args) and attachment to real clusters
  - Opt-in polling-actor fleet launch via `FHI_LOCAL_RAY_POLLING=true`

- **Settings configuration**:
  - Added `RAY_LOCAL_DEV_CLUSTER` setting (False in Base, True in Dev, False in Test*/Prod)
  - New `_sqlite_shared_file_options()` helper for multi-process sqlite safety (WAL mode, IMMEDIATE transactions, busy timeout)
  - Applied shared-file options to Dev and TestActor database configs to prevent "database is locked" errors when Ray actors write concurrently

- **Entry point integration**:
  - `asgi.py` and `wsgi.py` call `maybe_init_local_ray()` at module load to boot Ray once per process
  - Ensures both ASGI and WSGI servers (runserver, uvicorn, etc.) initialize Ray

- **Comprehensive test coverage**:
  - `tests/sync/test_local_ray.py`: 198 lines of gating logic tests with mocked Ray (no real cluster startup)
  - `tests/sync-actor/test_local_ray_boot.py`: Real Ray boot verification that the cluster passes the dispatch gate
  - `tests/sync/test_dev_sqlite_options.py`: Validates sqlite multi-process options are present
  - `tests/sync-actor/test_sqlite_shared_file.py`: Live-connection proof that WAL/IMMEDIATE/timeout pragmas take effect

- **Documentation and cleanup**:
  - Updated `CLAUDE.md` with local Ray dev parity explanation
  - Updated `k8s/deploy_dev.yaml` to disable Ray boot in containerized Dev (pod has no resource limits)
  - Updated `.gitignore` for WAL sidecars (`db.sqlite3-wal`, `db.sqlite3-shm`)
  - Updated `scripts/test_setup.sh` to clean stale WAL sidecars before test runs
  - Removed unused `fighthealthinsurance/ray.py`

## Implementation Details

- **Gating hierarchy**: `FHI_LOCAL_RAY` env var > `RAY_LOCAL_DEV_CLUSTER` setting, with unrecognized env values logged as warnings
- **Reloader detection**: Checks for `runserver_plus` in `sys.argv` and `WERKZEUG_RUN_MAIN` env var to skip the watcher parent
- **Address handling**: Explicit `address="local"` for new clusters (prevents auto-attach to stale `/tmp/ray/ray_current_cluster`); no address kwarg when attaching to real clusters
- **Error resilience**: Boot failures are logged and return False; dispatch sites fall back gracefully
- **Sqlite safety**: IMMEDIATE transaction mode takes write lock at BEGIN (prevents stale-snapshot upgrade failures); WAL mode allows concurrent readers/writers; NORMAL synchronous mode is safe with WAL
- **Idempotency**: Second calls to `maybe_init_local_ray()` short-circuit on `ray.is_initialized()`

https://claude.ai/code/session_016jf4EpXatrgymCXUuw3tix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Local development can automatically start an in-process Ray cluster for supported background tasks.
  * Developers can enable optional polling workers or connect to an existing Ray cluster.
  * SQLite development and actor workflows now better support concurrent processes.

* **Bug Fixes**
  * Improved recovery from stale SQLite sidecar files after interrupted runs.
  * Ray startup failures no longer prevent the application from starting.

* **Documentation**
  * Updated local asynchronous processing and Ray configuration guidance.

* **Tests**
  * Added coverage for local Ray startup options and shared SQLite behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->