### PR TITLE
Add fhi-pg-main-9 backup reconciliation runbook and health checks

### DIFF
--- a/docs/pg-backup-reconciliation-runbook-2026-07.md
+++ b/docs/pg-backup-reconciliation-runbook-2026-07.md
@@ -279,6 +279,14 @@ Likely causes, in rough order:
    primary then drains as the backlog uploads. This fix is INDEPENDENT of
    the plugin Service/reconciliation repair — archiving resumes even before
    the reinstall, because the WAL path is instance → local sidecar → B2.
+
+   **RESOLVED 2026-08-04:** the blocking content was 8 objects on timeline
+   4 (`wals/0000000400000003/…`) dated 2026-01-05 — a January incarnation
+   archiving under the same serverName — now parked in
+   `graveyard/fhi-pg-main-9-stale-wals/`. Archiving started within a minute
+   of the move (`archived_count` rising from 0, fresh `last_archived_time`).
+   `failed_count` ≈ 100k is the 24-day retry history — it is a lifetime
+   counter and never resets; only a rising trend is a problem.
    **Never "fix" this by deleting the `.check-empty-wal-archive` marker or
    otherwise skipping the check** — it exists to stop two clusters from
    interleaving WAL in one archive, which silently corrupts the restore

--- a/docs/pg-backup-reconciliation-runbook-2026-07.md
+++ b/docs/pg-backup-reconciliation-runbook-2026-07.md
@@ -254,16 +254,35 @@ kubectl -n totallylegitco logs fhi-pg-main-9-1 -c plugin-barman-cloud --since=30
 
 Likely causes, in rough order:
 
-1. **Empty-WAL-archive check failing.** On first archive the plugin verifies
+1. **Empty-WAL-archive check failing — CONFIRMED live 2026-08-04** (sidecar
+   log: `ERROR: WAL archive check failed for server fhi-pg-main-9: Expected
+   empty archive`, retried every ~60s). On first archive the plugin verifies
    the `wals/` prefix for `serverName: fhi-pg-main-9` is EMPTY (that is what
-   the `.check-empty-wal-archive` marker in PGDATA is about). If an earlier
-   `-9` incarnation or a restore-drill cluster (`pg-copy.yaml` /
-   `pg-recover.yaml`) ever archived under the same serverName, the check
-   fails forever. Inspect:
-   `aws --endpoint-url https://s3.us-west-004.backblazeb2.com s3 ls s3://fhi-pg-backup-second/fhi-pg-main-9/wals/ | head`
-   If foreign WAL is there with timestamps predating 2026-07-11, move/delete
-   ONLY that `wals/` prefix (leave `base/`); archiving proceeds on the next
-   retry.
+   the `.check-empty-wal-archive` marker in PGDATA is about). An earlier
+   `-9` incarnation or restore-drill cluster (`pg-copy.yaml` /
+   `pg-recover.yaml`) archived under the same serverName before this
+   cluster's 2026-07-11 birth, so the check fails forever. Fix by clearing
+   ONLY the `wals/` prefix (leave `base/`):
+
+   ```bash
+   B2="--endpoint-url https://s3.us-west-004.backblazeb2.com"
+   # sanity: size + dates — the content must all predate 2026-07-11
+   aws $B2 s3 ls --recursive --summarize s3://fhi-pg-backup-second/fhi-pg-main-9/wals/ | tail -5
+   # preferred: park it rather than destroy it
+   aws $B2 s3 mv --recursive s3://fhi-pg-backup-second/fhi-pg-main-9/wals/ \
+     s3://fhi-pg-backup-second/graveyard/fhi-pg-main-9-stale-wals/
+   # (aws s3 rm --recursive on wals/ is fine too once the dates are confirmed)
+   ```
+
+   The next ~60s retry passes the check — watch the sidecar log flip to
+   success and `pg_stat_archiver.archived_count` start rising; pg_wal on the
+   primary then drains as the backlog uploads. This fix is INDEPENDENT of
+   the plugin Service/reconciliation repair — archiving resumes even before
+   the reinstall, because the WAL path is instance → local sidecar → B2.
+   **Never "fix" this by deleting the `.check-empty-wal-archive` marker or
+   otherwise skipping the check** — it exists to stop two clusters from
+   interleaving WAL in one archive, which silently corrupts the restore
+   lineage.
 2. **B2 checksum env vars missing from the RUNNING sidecars.** The
    ObjectStore sets `AWS_REQUEST_CHECKSUM_CALCULATION` /
    `AWS_RESPONSE_CHECKSUM_VALIDATION`, but sidecar env is baked at pod

--- a/docs/pg-backup-reconciliation-runbook-2026-07.md
+++ b/docs/pg-backup-reconciliation-runbook-2026-07.md
@@ -1,0 +1,279 @@
+# July 2026 — fhi-pg-main-9 reconciliation blocked + backups stale: runbook
+
+Live remediation for the state observed 2026-07-30:
+
+| Symptom | Evidence |
+|---|---|
+| `fhi-pg-main-9` status: *"Cluster cannot proceed to reconciliation due to an error while interacting with plugins"* | `kubectl get cluster -A` (DB itself is up, 3/3) |
+| **Two** barman-cloud plugin installs in `cnpg-system` | deploy `barman-cloud` (manifest-based, 1/1, holds the leader lease) **and** deploy `barman-cloud-plugin-barman-cloud` (helm, **0/1 for 12d**, log stuck at *"Attempting to acquire leader lease"* on `822e3f5c.cnpg.io`) |
+| Newest `-9` base backup 19d old; no ScheduledBackup exists for `-9` | `kubectl -n totallylegitco get backup` |
+| ~240 forever-`pending` `backup-example-*` Backups + a `backup-example` ScheduledBackup in `default`, all targeting the **dead** `fhi-pg-main-7` | `kubectl get backup -A`; operator webhook log still shows create-attempts for months-old `backup-example-*` names **today** |
+| **Zero** ScheduledBackup-created Backups cluster-wide since `20260718000000` (both `backup-example-*` and `pcfweb-pg-nightly-*` stop there) | `kubectl get backup -A` |
+| `pcfweb-pg` (PG **18**, in-tree `barmanObjectStore`) stuck `walArchivingFailing`; its nightlies all `pending` | `kubectl -n pcfweb describe backup pcfweb-pg-backup-manual` |
+
+## What happened
+
+1. **~Jul 10–11**: plugin-barman-cloud **v0.13.0** installed via the release
+   *manifest* (`kubectl apply -f .../manifest.yaml`) → deployment/Service named
+   `barman-cloud` in `cnpg-system`. `-9` was created Jul 11 and its manual
+   backup completed through this install.
+2. **Jul 18 ~19:00 UTC**: `colo-scripts/playbooks/cluster-setup.yaml` ran. Its
+   two CNPG helm tasks were **unpinned**, so it (a) upgraded the operator to
+   chart 0.29.0 / **operator 1.30.0** (new `cnpg-cloudnative-pg` pod), and
+   (b) installed a **second copy of the plugin** as helm release `barman-cloud`
+   (chart 0.7.0 / app v0.13.0 — helm names it `barman-cloud-plugin-barman-cloud`).
+3. The helm pod can never acquire the plugin's leader-election Lease
+   (`822e3f5c.cnpg.io`) — the manifest pod holds it — so it sits **0/1**
+   (readiness follows leadership), and with **two Services claiming plugin name
+   `barman-cloud.cloudnative-pg.io`** the operator's plugin discovery/gRPC is
+   broken → reconciliation blocked ever since. This is a **recurrence of the -8
+   outage pattern** (see `docs/pg-reliability-hardening.md`, Fault A: duplicate
+   installs + stale lease + dead Service endpoints), just without the cert break.
+4. Independently, the `backup-example` ScheduledBackup (a CNPG docs example
+   applied ~Nov 2025, targeting the long-dead `fhi-pg-main-7`) has left the new
+   operator in a **catch-up storm**: every reconcile re-attempts creation of
+   ~240 already-existing daily Backups (visible in the webhook log). Since the
+   Jul 18 operator restart, **no ScheduledBackup anywhere has produced a new
+   Backup** — the storm/wedge starves the scheduling controller. This is why
+   pcfweb's nightlies stopped on exactly Jul 18.
+5. `-9` itself never had a ScheduledBackup: `k8s/fhi-pg-main-9-alerts.yaml`
+   pages on backup age >26h *assuming* a daily schedule that was never created
+   (only the migration's manual Phase-3 backup existed).
+
+Root causes: **(a)** duplicate plugin installs (manifest + helm), **(b)**
+unpinned helm charts in the cluster playbook, **(c)** orphaned docs-example
+ScheduledBackup aimed at a dead cluster, with no owner-refs on its Backups,
+**(d)** missing `-9` ScheduledBackup.
+
+Fixes in-repo: `k8s/fhi-pg-main-9-scheduledbackup.yaml` (new),
+`scripts/check-pg9-backup-health.sh` (new), and in `colo-scripts`: pinned
+chart versions + `cleanupbooks/cnpg-backup-cruft.yaml`.
+
+---
+
+## Fast path (if you already know the story)
+
+```bash
+# 1. cruft (dead fhi-pg-main-7 backups — unstarves the scheduling controller)
+kubectl -n default delete scheduledbackup backup-example
+kubectl -n default delete backup --all                      # all target dead -7; CRs only, no bucket data
+
+# 2. converge to ONE plugin install (keep helm, drop the manifest one)
+kubectl -n cnpg-system delete deployment barman-cloud service barman-cloud
+kubectl -n cnpg-system delete lease 822e3f5c.cnpg.io       # frees leadership immediately
+kubectl -n cnpg-system get pods -w                          # helm pod -> 1/1
+
+# 3. reconciliation clears (restart operator only if it doesn't within ~3m)
+kubectl -n totallylegitco get cluster fhi-pg-main-9 -w
+
+# 4. backups: prove once, then schedule daily
+kubectl apply -f k8s/fhi-pg-main-9-scheduledbackup.yaml     # immediate: true takes one now
+./scripts/check-pg9-backup-health.sh
+```
+
+Details, guards, and validation below — use the phases if anything deviates.
+
+---
+
+## Phase 0 — capture state, assess urgency (read-only)
+
+```bash
+kubectl -n cnpg-system get deploy,pods,svc,lease -o wide
+kubectl -n cnpg-system get lease 822e3f5c.cnpg.io -o jsonpath='{.spec.holderIdentity}{"\n"}'
+kubectl -n totallylegitco get cluster fhi-pg-main-9 -o jsonpath='{.status.phase}: {.status.phaseReason}{"\n"}'
+# Is WAL actually piling up / is the disk at risk? (archiving may still work --
+# the instance SIDECARS archive; it is the operator<->plugin channel that broke)
+kubectl -n totallylegitco exec fhi-pg-main-9-1 -c postgres -- psql -U postgres -xc \
+  "SELECT archived_count, failed_count, last_archived_time, last_failed_wal FROM pg_stat_archiver;"
+for p in fhi-pg-main-9-1 fhi-pg-main-9-2 fhi-pg-main-9-3; do
+  kubectl -n totallylegitco exec "$p" -c postgres -- sh -c \
+    'echo "$HOSTNAME: $(ls /var/lib/postgresql/data/pgdata/pg_wal | grep -Ec "^[0-9A-F]{24}$") segments"; df -h /var/lib/postgresql/data | tail -1'
+done
+```
+
+**Read it like this:** `last_archived_time` recent + `failed_count` flat ⇒ WAL
+archiving is fine and this is "only" a reconciliation/backup outage. WAL
+segments climbing toward 640 (10GiB) / 1280 (20GiB) or volume ≥70% ⇒ move
+straight to Phase 2 now. **Never hand-delete anything in `pg_wal`.**
+
+## Phase 1 — delete the dead-cluster backup cruft in `default`
+
+Why first: it is zero-risk (CR deletion never touches object-store data, and
+`fhi-pg-main-7` is dead anyway) and it unstarves the ScheduledBackup
+controller, which you need working in Phase 3.
+
+```bash
+# guard: every Backup in default must target fhi-pg-main-7
+kubectl -n default get backup \
+  -o custom-columns='NAME:.metadata.name,CLUSTER:.spec.cluster.name' --no-headers \
+  | awk '$2!="fhi-pg-main-7"{print "UNEXPECTED:", $0}'
+# expect NO output; then:
+kubectl -n default delete scheduledbackup backup-example
+kubectl -n default delete backup --all        # ~241 objects, takes a minute
+```
+
+**VALIDATION:** operator log goes quiet on `backup-example`:
+`kubectl -n cnpg-system logs deploy/cnpg-cloudnative-pg --since=10m | grep -c backup-example` → `0`.
+
+## Phase 2 — converge to ONE plugin install (keep helm, remove manifest)
+
+We keep the **helm** release: it is what git (`colo-scripts`) manages, it is
+the same app version (v0.13.0) as the manifest install, and future upgrades
+become a reviewable one-line pin bump.
+
+```bash
+# GUARDS (all must hold before deleting anything):
+helm -n cnpg-system list                                   # releases: cnpg, barman-cloud
+helm -n cnpg-system get manifest barman-cloud | grep -B2 -A6 '^kind: \(Deployment\|Service\)$' \
+  | grep -E 'kind:|name:'
+#   -> the release must own barman-cloud-plugin-barman-cloud, and must NOT own
+#      the plain names deleted below.
+kubectl -n cnpg-system get deploy barman-cloud \
+  -o jsonpath='helm-owner={.metadata.annotations.meta\.helm\.sh/release-name}{"\n"}'
+#   -> must print 'helm-owner=' (EMPTY: manifest-based, safe to delete)
+
+kubectl -n cnpg-system delete deployment barman-cloud service barman-cloud
+kubectl -n cnpg-system delete lease 822e3f5c.cnpg.io       # just a lock; recreated on acquire
+kubectl -n cnpg-system get pods -w
+```
+
+**GATE:** `barman-cloud-plugin-barman-cloud-*` reaches **1/1**; its log shows
+`successfully acquired lease`; and its Service has ready endpoints (the -8
+selector-break check):
+
+```bash
+kubectl -n cnpg-system logs deploy/barman-cloud-plugin-barman-cloud | tail -5
+kubectl -n cnpg-system get endpointslices -l kubernetes.io/service-name=barman-cloud-plugin-barman-cloud
+```
+
+Then reconciliation should clear on its own:
+
+```bash
+kubectl -n totallylegitco get cluster fhi-pg-main-9 -w    # -> "Cluster in healthy state"
+# only if still plugin-errored after ~3 minutes:
+kubectl -n cnpg-system rollout restart deploy cnpg-cloudnative-pg
+```
+
+Leftover manifest RBAC/certs are inert; clean them in Phase 6, **never** the
+`barmancloud.cnpg.io` CRDs (deleting the ObjectStore CRD would cascade-delete
+`fhi-backup-store-9`).
+
+## Phase 3 — re-prove `-9` backups end-to-end, then schedule them
+
+Same proof as migration runbook Phase 3, now with real data:
+
+```bash
+kubectl -n totallylegitco exec fhi-pg-main-9-1 -c postgres -- psql -U postgres -c 'SELECT pg_switch_wal();'
+sleep 30
+kubectl -n totallylegitco exec fhi-pg-main-9-1 -c postgres -- psql -U postgres -xc \
+  "SELECT archived_count, failed_count, last_archived_time FROM pg_stat_archiver;"   # rising / flat / fresh
+
+kubectl apply -f k8s/fhi-pg-main-9-scheduledbackup.yaml
+# immediate: true -> a Backup appears right away:
+kubectl -n totallylegitco get backup -l cnpg.io/cluster=fhi-pg-main-9 \
+  --sort-by=.metadata.creationTimestamp -w                                            # -> completed
+aws --endpoint-url https://s3.us-west-004.backblazeb2.com s3 ls \
+  s3://fhi-pg-backup-second/fhi-pg-main-9/base/ | tail
+./scripts/check-pg9-backup-health.sh                                                  # ALL CHECKS PASSED
+```
+
+If archiving is broken at the instance level even though the plugin is
+healthy, the sidecars may need re-injection: restart instances one at a time,
+replicas first (`primaryUpdateStrategy: supervised` means nothing rolls
+without you): `kubectl cnpg restart fhi-pg-main-9 -n totallylegitco` — or
+plugin-free, delete pods `-2`/`-3` one at a time, then switchover, then the
+old primary.
+
+## Phase 4 — pcfweb-pg: dead in-tree backup path (separate fix)
+
+`pcfweb-pg` is PG **18** using the **in-tree** `barmanObjectStore` — deprecated
+since CNPG 1.26 and removed in 1.28+ (the operator is now **1.30**), and the
+PG18 operand images no longer ship the barman-cloud binaries. Its
+`walArchivingFailing` has been failing **since creation** (first manual backup
+Jul 11 already hit it): it has **zero working backups and no WAL archive**.
+
+```bash
+# confirm the archive failure mode:
+kubectl -n pcfweb logs pcfweb-pg-1 | grep -iE 'archive|barman' | tail -20
+kubectl -n pcfweb exec pcfweb-pg-1 -c postgres -- psql -U postgres -xc \
+  "SELECT archived_count, failed_count, last_failed_wal FROM pg_stat_archiver;"
+# stop the nightly from minting new doomed Backups until migrated:
+kubectl -n pcfweb patch scheduledbackup pcfweb-pg-nightly --type=merge -p '{"spec":{"suspend":true}}'
+```
+
+**Fix = migrate it to the plugin**, exactly like `-9` (its manifests live
+outside this repo — apply these, then commit them wherever pcfweb is managed):
+
+```yaml
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: pcfweb-backup-store
+  namespace: pcfweb
+spec:
+  configuration:
+    destinationPath: s3://pcfweb-pg-backup/          # same bucket it always pointed at
+    endpointURL: https://s3.us-west-004.backblazeb2.com
+    s3Credentials:
+      accessKeyId: {name: pg-backup, key: PG_ACCESS_KEY_ID}
+      secretAccessKey: {name: pg-backup, key: PG_ACCESS_SECRET_KEY}
+    data: {compression: gzip}
+    wal: {compression: gzip, maxParallel: 4}
+  retentionPolicy: "30d"
+  # B2 rejects the AWS SDK's newer default checksums -- REQUIRED, same as -9:
+  instanceSidecarConfiguration:
+    env:
+      - {name: AWS_REQUEST_CHECKSUM_CALCULATION, value: when_required}
+      - {name: AWS_RESPONSE_CHECKSUM_VALIDATION, value: when_required}
+```
+
+Cluster edit (in pcfweb's manifest): **remove** `spec.backup.barmanObjectStore`,
+add:
+
+```yaml
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: pcfweb-backup-store
+        serverName: pcfweb-pg
+```
+
+Then: delete the stale `pending`/`walArchivingFailing` pcfweb Backups, take a
+manual `method: plugin` Backup to `completed`, and recreate
+`pcfweb-pg-nightly` with `method: plugin` + `pluginConfiguration` +
+`backupOwnerReference: self` (schedule `"0 0 9 * * *"` keeps it off `-9`'s
+08:00 slot).
+
+## Phase 5 — `mautrix-discord-db` has no backups at all
+
+`matrix/mautrix-discord-db` (144d) has **zero** Backup/ScheduledBackup
+configured. Decide deliberately: if losing the Discord-bridge state is
+acceptable, record that; otherwise give it the same ObjectStore+plugin+
+ScheduledBackup treatment (its own bucket prefix / serverName).
+
+## Phase 6 — cosmetic cleanup + keeping it fixed
+
+```bash
+# leftover manifest-install RBAC/certs (inert; delete only what is NOT
+# helm-annotated and NOT a CRD):
+kubectl -n cnpg-system get sa,role,rolebinding,certificate,issuer,secret -o name | grep -i barman
+kubectl get clusterrole,clusterrolebinding -o name | grep -i barman
+#   check each:  -o jsonpath='{.metadata.annotations.meta\.helm\.sh/release-name}'
+#   empty -> manifest leftover -> deletable.  NEVER delete the
+#   barmancloud.cnpg.io CRDs (cascade-deletes fhi-backup-store-9).
+
+kubectl -n totallylegitco get prometheusrule fhi-pg-main-9-backup-wal   # alerts actually applied?
+```
+
+- `colo-scripts` now pins `cloudnative-pg` **0.29.0** and `plugin-barman-cloud`
+  **0.7.0** with `wait: yes` (an install stuck 0/1 fails the playbook loudly
+  instead of rotting for 12 days). Upgrades are deliberate pin bumps: check the
+  plugin release notes for sidecar/selector changes first (the v0.9→v0.13
+  break), and bump plugin + operator separately.
+- **Never** `kubectl apply` the plugin's release `manifest.yaml` again — that
+  is how the duplicate was born. Helm (via the playbook) is the only installer.
+- `./scripts/check-pg9-backup-health.sh` is the one-shot health probe for all
+  of the above; run it after any operator/plugin change and whenever backups
+  feel doubtful. The 26h-backup-age and WAL alerts in
+  `k8s/fhi-pg-main-9-alerts.yaml` are the always-on version.

--- a/docs/pg-backup-reconciliation-runbook-2026-07.md
+++ b/docs/pg-backup-reconciliation-runbook-2026-07.md
@@ -299,9 +299,12 @@ Likely causes, in rough order:
    If absent, restart instances one at a time (supervised) to re-inject.
 3. **Credentials** (`pg-backup2`) — the sidecar log will show S3 403s.
 
-After the fix, `pg_stat_archiver.archived_count` must RISE with
-`last_failed_wal` clearing; then take the fresh backup (Phase 3 above) and
-run a restore drill before trusting it.
+After the fix, validate recovery by `pg_stat_archiver.archived_count` RISING
+with a fresh `last_archived_time`. Do NOT wait for `last_failed_wal` /
+`failed_count` to clear — they persist until an explicit stats reset and
+never clear on success; only their RECENCY vs the last success matters.
+Then take the fresh backup (Phase 3 above) and run a restore drill before
+trusting it.
 
 ## Phase 4 — pcfweb-pg: dead in-tree backup path (separate fix)
 

--- a/docs/pg-backup-reconciliation-runbook-2026-07.md
+++ b/docs/pg-backup-reconciliation-runbook-2026-07.md
@@ -24,11 +24,15 @@ Live remediation for the state observed 2026-07-30:
    (chart 0.7.0 / app v0.13.0 — helm names it `barman-cloud-plugin-barman-cloud`).
 3. The helm pod can never acquire the plugin's leader-election Lease
    (`822e3f5c.cnpg.io`) — the manifest pod holds it — so it sits **0/1**
-   (readiness follows leadership), and with **two Services claiming plugin name
-   `barman-cloud.cloudnative-pg.io`** the operator's plugin discovery/gRPC is
-   broken → reconciliation blocked ever since. This is a **recurrence of the -8
-   outage pattern** (see `docs/pg-reliability-hardening.md`, Fault A: duplicate
-   installs + stale lease + dead Service endpoints), just without the cert break.
+   (readiness follows leadership). Worse, the two install methods **share
+   resource names**: the chart hardcodes Service `barman-cloud` (*"DO NOT
+   CHANGE THE SERVICE NAME"* — it must match the serving cert), so the Jul 18
+   helm install re-pointed the ONE existing `barman-cloud` Service at its own
+   — not-ready — pod, leaving the operator's gRPC/mTLS plugin channel with no
+   ready backend → reconciliation blocked ever since. This is a **recurrence
+   of the -8 outage pattern** (see `docs/pg-reliability-hardening.md`, Fault
+   A: duplicate installs + stale lease + a Service selecting zero ready pods),
+   just without the cert break.
 4. Independently, the `backup-example` ScheduledBackup (a CNPG docs example
    applied ~Nov 2025, targeting the long-dead `fhi-pg-main-7`) has left the new
    operator in a **catch-up storm**: every reconcile re-attempts creation of
@@ -46,8 +50,9 @@ ScheduledBackup aimed at a dead cluster, with no owner-refs on its Backups,
 **(d)** missing `-9` ScheduledBackup.
 
 Fixes in-repo: `k8s/fhi-pg-main-9-scheduledbackup.yaml` (new),
-`scripts/check-pg9-backup-health.sh` (new), and in `colo-scripts`: pinned
-chart versions + `cleanupbooks/cnpg-backup-cruft.yaml`.
+`scripts/check-pg9-backup-health.sh` (new), `scripts/build.sh` (now re-asserts
+the schedule on every deploy), and in `colo-scripts`: pinned chart versions +
+`cleanupbooks/cnpg-backup-cruft.yaml` (convergent cleanup + reinstall).
 
 ---
 
@@ -58,10 +63,14 @@ chart versions + `cleanupbooks/cnpg-backup-cruft.yaml`.
 kubectl -n default delete scheduledbackup backup-example
 kubectl -n default delete backup --all                      # all target dead -7; CRs only, no bucket data
 
-# 2. converge to ONE plugin install (keep helm, drop the manifest one)
-kubectl -n cnpg-system delete deployment barman-cloud service barman-cloud
-kubectl -n cnpg-system delete lease 822e3f5c.cnpg.io       # frees leadership immediately
-kubectl -n cnpg-system get pods -w                          # helm pod -> 1/1
+# 2. converge to ONE plugin install: uninstall + purge + clean pinned reinstall.
+#    Do NOT delete piecemeal by name — Service/Certificate/ConfigMap names are
+#    SHARED between the install methods (Phase 2 explains what that broke).
+helm -n cnpg-system uninstall barman-cloud || true
+for r in $(kubectl -n cnpg-system get deploy,svc,cm,sa,role,rolebinding,certificate,issuer -o name | grep -i barman); do kubectl -n cnpg-system delete "$r"; done
+for r in $(kubectl get clusterrole,clusterrolebinding -o name | grep -i barman); do kubectl delete "$r"; done
+helm repo update cnpg
+helm -n cnpg-system install barman-cloud cnpg/plugin-barman-cloud --version 0.7.0 --wait --timeout 5m
 
 # 3. reconciliation clears (restart operator only if it doesn't within ~3m)
 kubectl -n totallylegitco get cluster fhi-pg-main-9 -w
@@ -115,35 +124,59 @@ kubectl -n default delete backup --all        # ~241 objects, takes a minute
 **VALIDATION:** operator log goes quiet on `backup-example`:
 `kubectl -n cnpg-system logs deploy/cnpg-cloudnative-pg --since=10m | grep -c backup-example` → `0`.
 
-## Phase 2 — converge to ONE plugin install (keep helm, remove manifest)
+## Phase 2 — converge to ONE plugin install (helm-managed, reinstalled clean)
 
 We keep the **helm** release: it is what git (`colo-scripts`) manages, it is
 the same app version (v0.13.0) as the manifest install, and future upgrades
 become a reviewable one-line pin bump.
 
-```bash
-# GUARDS (all must hold before deleting anything):
-helm -n cnpg-system list                                   # releases: cnpg, barman-cloud
-helm -n cnpg-system get manifest barman-cloud | grep -B2 -A6 '^kind: \(Deployment\|Service\)$' \
-  | grep -E 'kind:|name:'
-#   -> the release must own barman-cloud-plugin-barman-cloud, and must NOT own
-#      the plain names deleted below.
-kubectl -n cnpg-system get deploy barman-cloud \
-  -o jsonpath='helm-owner={.metadata.annotations.meta\.helm\.sh/release-name}{"\n"}'
-#   -> must print 'helm-owner=' (EMPTY: manifest-based, safe to delete)
+**Do NOT delete the manifest install piecemeal by name** — several names are
+IDENTICAL across the two install methods: the chart hardcodes Service
+`barman-cloud` (its values.yaml: *"DO NOT CHANGE THE SERVICE NAME as it is
+currently used to generate the certificate"*), Certificates
+`barman-cloud-client`/`barman-cloud-server`, ConfigMap
+`plugin-barman-cloud-config`. Name-based deletion takes out shared objects the
+survivor needs. As executed on 2026-07-30 this is exactly what bit us:
+deleting `deployment/barman-cloud` freed the lease and the helm pod went
+Ready, but `service/barman-cloud` was the ONE shared discovery Service — with
+it gone the operator had no plugin endpoint at all, and the cluster stayed
+plugin-errored even with a perfectly healthy plugin pod (leader, gRPC up,
+ObjectStores reconciling).
 
-kubectl -n cnpg-system delete deployment barman-cloud service barman-cloud
-kubectl -n cnpg-system delete lease 822e3f5c.cnpg.io       # just a lock; recreated on acquire
-kubectl -n cnpg-system get pods -w
+Safe convergence = uninstall + purge + clean pinned reinstall. Safety facts:
+the ObjectStore **CRD carries `helm.sh/resource-policy: keep`**, so neither
+`helm uninstall` nor this purge can cascade-delete `fhi-backup-store-9`; the
+purge also skips CRDs and Secrets explicitly (cert-manager re-issues the TLS
+secrets from the fresh Certificates).
+
+```bash
+helm -n cnpg-system uninstall barman-cloud || true
+
+# purge every remaining plugin resource EXCEPT CRDs + Secrets:
+for r in $(kubectl -n cnpg-system get deploy,svc,cm,sa,role,rolebinding,certificate,issuer -o name | grep -i barman); do
+  kubectl -n cnpg-system delete "$r"; done
+for r in $(kubectl get clusterrole,clusterrolebinding -o name | grep -i barman); do
+  kubectl delete "$r"; done
+
+kubectl get crd objectstores.barmancloud.cnpg.io      # still present (resource-policy: keep)
+kubectl -n totallylegitco get objectstore             # fhi-backup-store + fhi-backup-store-9 intact
+
+helm repo update cnpg
+helm -n cnpg-system install barman-cloud cnpg/plugin-barman-cloud --version 0.7.0 --wait --timeout 5m
+# if helm refuses over ownership of the pre-existing CRDs: add --set crds.create=false
 ```
 
-**GATE:** `barman-cloud-plugin-barman-cloud-*` reaches **1/1**; its log shows
-`successfully acquired lease`; and its Service has ready endpoints (the -8
-selector-break check):
+(Codified equivalent: `ansible-playbook cleanupbooks/cnpg-backup-cruft.yaml`
+in colo-scripts — idempotent; converges from any of this incident's
+intermediate states.)
+
+**GATE:** plugin deployment **1/1**, and the discovery Service is back with
+ready endpoints (the -8 selector-break check):
 
 ```bash
-kubectl -n cnpg-system logs deploy/barman-cloud-plugin-barman-cloud | tail -5
-kubectl -n cnpg-system get endpointslices -l kubernetes.io/service-name=barman-cloud-plugin-barman-cloud
+kubectl -n cnpg-system get deploy barman-cloud-plugin-barman-cloud
+kubectl -n cnpg-system get svc barman-cloud --show-labels   # cnpg.io/pluginName=barman-cloud.cloudnative-pg.io
+kubectl -n cnpg-system get endpointslices -l kubernetes.io/service-name=barman-cloud
 ```
 
 Then reconciliation should clear on its own:
@@ -154,9 +187,11 @@ kubectl -n totallylegitco get cluster fhi-pg-main-9 -w    # -> "Cluster in healt
 kubectl -n cnpg-system rollout restart deploy cnpg-cloudnative-pg
 ```
 
-Leftover manifest RBAC/certs are inert; clean them in Phase 6, **never** the
-`barmancloud.cnpg.io` CRDs (deleting the ObjectStore CRD would cascade-delete
-`fhi-backup-store-9`).
+No cluster-spec change is needed afterwards: `spec.plugins[].name:
+barman-cloud.cloudnative-pg.io` is the plugin's *protocol* name — the operator
+matches it against the Service's `cnpg.io/pluginName` label, which is
+identical under both install methods — and `barmanObjectName`/`serverName`
+reference the ObjectStore CR, which the reinstall never touches.
 
 ## Phase 3 — re-prove `-9` backups end-to-end, then schedule them
 
@@ -255,13 +290,11 @@ ScheduledBackup treatment (its own bucket prefix / serverName).
 ## Phase 6 — cosmetic cleanup + keeping it fixed
 
 ```bash
-# leftover manifest-install RBAC/certs (inert; delete only what is NOT
-# helm-annotated and NOT a CRD):
-kubectl -n cnpg-system get sa,role,rolebinding,certificate,issuer,secret -o name | grep -i barman
-kubectl get clusterrole,clusterrolebinding -o name | grep -i barman
-#   check each:  -o jsonpath='{.metadata.annotations.meta\.helm\.sh/release-name}'
-#   empty -> manifest leftover -> deletable.  NEVER delete the
-#   barmancloud.cnpg.io CRDs (cascade-deletes fhi-backup-store-9).
+# after Phase 2's purge + reinstall, every plugin resource left in cnpg-system
+# must carry meta.helm.sh/release-name=barman-cloud; anything without it is a
+# leftover -> deletable. NEVER delete the barmancloud.cnpg.io CRDs
+# (cascade-deletes fhi-backup-store-9).
+kubectl -n cnpg-system get deploy,svc,cm,sa,role,rolebinding,certificate,issuer,secret -o name | grep -i barman
 
 kubectl -n totallylegitco get prometheusrule fhi-pg-main-9-backup-wal   # alerts actually applied?
 ```
@@ -277,3 +310,23 @@ kubectl -n totallylegitco get prometheusrule fhi-pg-main-9-backup-wal   # alerts
   of the above; run it after any operator/plugin change and whenever backups
   feel doubtful. The 26h-backup-age and WAL alerts in
   `k8s/fhi-pg-main-9-alerts.yaml` are the always-on version.
+
+### Redeploy idempotency — a redeploy can never mint a second install
+
+- **colo-scripts** `playbooks/cluster-setup.yaml`: the plugin is exactly ONE
+  pinned helm release (`barman-cloud`, chart 0.7.0). Re-running the playbook
+  `helm upgrade`s that release in place — it cannot create a second copy — and
+  `wait: yes` fails the run loudly if the rollout wedges (a 0/1 pod would have
+  failed the Jul 18 run instead of rotting for 12 days). The only path back to
+  two installs is hand-applying the GitHub release `manifest.yaml` — don't;
+  the health script (checks 1–3) and `cleanupbooks/cnpg-backup-cruft.yaml`
+  both detect and converge that state.
+- **fighthealthinsurance** `scripts/build.sh`: never touches the plugin. It
+  re-asserts `k8s/db-config.yaml` and `k8s/fhi-pg-main-9-scheduledbackup.yaml`
+  on every deploy (idempotent applies), so an app redeploy self-heals the
+  backup schedule and cannot affect the plugin install.
+- The `-9` cluster spec needs no per-install-method changes ever:
+  `spec.plugins[].name` is the plugin's protocol name (matched via the
+  Service's `cnpg.io/pluginName` label, identical under both install methods)
+  and `barmanObjectName`/`serverName` reference the ObjectStore CR, which
+  installs/uninstalls never touch.

--- a/docs/pg-backup-reconciliation-runbook-2026-07.md
+++ b/docs/pg-backup-reconciliation-runbook-2026-07.md
@@ -75,7 +75,8 @@ helm -n cnpg-system install barman-cloud cnpg/plugin-barman-cloud --version 0.7.
 # 3. reconciliation clears (restart operator only if it doesn't within ~3m)
 kubectl -n totallylegitco get cluster fhi-pg-main-9 -w
 
-# 4. backups: prove once, then schedule daily
+# 4. backups: prove once, then schedule daily. If the archiver is stuck on
+#    000000010000000000000001 / archived_count=0 -> Phase 3a (never worked).
 kubectl apply -f k8s/fhi-pg-main-9-scheduledbackup.yaml     # immediate: true takes one now
 ./scripts/check-pg9-backup-health.sh
 ```
@@ -166,9 +167,11 @@ helm -n cnpg-system install barman-cloud cnpg/plugin-barman-cloud --version 0.7.
 # if helm refuses over ownership of the pre-existing CRDs: add --set crds.create=false
 ```
 
-(Codified equivalent: `ansible-playbook cleanupbooks/cnpg-backup-cruft.yaml`
-in colo-scripts — idempotent; converges from any of this incident's
-intermediate states.)
+(Codified: `ansible-playbook cleanupbooks/cnpg-backup-cruft.yaml` does the
+teardown half — default-ns cruft + TOTAL plugin removal (helm release +
+leftovers; never CRDs/Secrets). It deliberately installs nothing: re-run
+`playbooks/cluster-setup.yaml` afterwards, whose pinned helm task performs
+the same clean install as above.)
 
 **GATE:** plugin deployment **1/1**, and the discovery Service is back with
 ready endpoints (the -8 selector-break check):
@@ -218,6 +221,60 @@ replicas first (`primaryUpdateStrategy: supervised` means nothing rolls
 without you): `kubectl cnpg restart fhi-pg-main-9 -n totallylegitco` — or
 plugin-free, delete pods `-2`/`-3` one at a time, then switchover, then the
 old primary.
+
+### Phase 3a — the archiver has NEVER worked (stuck on `…0001`)
+
+Observed live 2026-07-31 in the `fhi-pg-main-9-1` instance log:
+
+```
+Error while calling ArchiveWAL … unexpected failure invoking barman-cloud-wal-archive: exit status 1
+The failed archive command was: /controller/manager wal-archive … pg_wal/000000010000000000000001
+```
+
+`000000010000000000000001` is the **first segment of timeline 1**. Postgres
+archives strictly in order, so still failing on segment #1 means `-9` has
+archived **zero WAL since its Jul 11 birth** — independent of (and predating)
+the duplicate-install outage: the WAL path is instance manager → **local
+sidecar** → B2 and never touches the central plugin deployment. Consequences:
+
+- **pg_wal grows without bound.** Unarchived WAL is exempt from
+  `max_slot_wal_keep_size`; this is the exact mechanism that filled and
+  killed `-8-1`. Run the Phase 0 WAL-count/df block IMMEDIATELY.
+- The Jul 11 "completed" base backup is **probably not restorable**: a
+  barman base backup needs the archived WALs spanning its start/stop to
+  reach consistency, and the archive has none. Treat `-9` as having NO
+  usable backup until archiving works, a fresh backup completes, AND a
+  restore drill passes.
+
+The real error text lives in the sidecar container on the primary:
+
+```bash
+kubectl -n totallylegitco logs fhi-pg-main-9-1 -c plugin-barman-cloud --since=30m | tail -30
+```
+
+Likely causes, in rough order:
+
+1. **Empty-WAL-archive check failing.** On first archive the plugin verifies
+   the `wals/` prefix for `serverName: fhi-pg-main-9` is EMPTY (that is what
+   the `.check-empty-wal-archive` marker in PGDATA is about). If an earlier
+   `-9` incarnation or a restore-drill cluster (`pg-copy.yaml` /
+   `pg-recover.yaml`) ever archived under the same serverName, the check
+   fails forever. Inspect:
+   `aws --endpoint-url https://s3.us-west-004.backblazeb2.com s3 ls s3://fhi-pg-backup-second/fhi-pg-main-9/wals/ | head`
+   If foreign WAL is there with timestamps predating 2026-07-11, move/delete
+   ONLY that `wals/` prefix (leave `base/`); archiving proceeds on the next
+   retry.
+2. **B2 checksum env vars missing from the RUNNING sidecars.** The
+   ObjectStore sets `AWS_REQUEST_CHECKSUM_CALCULATION` /
+   `AWS_RESPONSE_CHECKSUM_VALIDATION`, but sidecar env is baked at pod
+   creation — pods older than the ObjectStore change never picked them up:
+   `kubectl -n totallylegitco get pod fhi-pg-main-9-1 -o jsonpath='{.spec.containers[?(@.name=="plugin-barman-cloud")].env}'`
+   If absent, restart instances one at a time (supervised) to re-inject.
+3. **Credentials** (`pg-backup2`) — the sidecar log will show S3 403s.
+
+After the fix, `pg_stat_archiver.archived_count` must RISE with
+`last_failed_wal` clearing; then take the fresh backup (Phase 3 above) and
+run a restore drill before trusting it.
 
 ## Phase 4 — pcfweb-pg: dead in-tree backup path (separate fix)
 
@@ -319,8 +376,9 @@ kubectl -n totallylegitco get prometheusrule fhi-pg-main-9-backup-wal   # alerts
   `wait: yes` fails the run loudly if the rollout wedges (a 0/1 pod would have
   failed the Jul 18 run instead of rotting for 12 days). The only path back to
   two installs is hand-applying the GitHub release `manifest.yaml` — don't;
-  the health script (checks 1–3) and `cleanupbooks/cnpg-backup-cruft.yaml`
-  both detect and converge that state.
+  the health script (checks 1–3) detects that state, and
+  `cleanupbooks/cnpg-backup-cruft.yaml` (total teardown) + a
+  `cluster-setup.yaml` re-run converge it.
 - **fighthealthinsurance** `scripts/build.sh`: never touches the plugin. It
   re-asserts `k8s/db-config.yaml` and `k8s/fhi-pg-main-9-scheduledbackup.yaml`
   on every deploy (idempotent applies), so an app redeploy self-heals the

--- a/k8s/fhi-pg-main-9-scheduledbackup.yaml
+++ b/k8s/fhi-pg-main-9-scheduledbackup.yaml
@@ -1,0 +1,60 @@
+# =============================================================================
+# ScheduledBackup for fhi-pg-main-9 -- the DAILY base backup the alerting
+# already assumes exists.
+#
+# WHY THIS FILE EXISTS
+# --------------------
+# k8s/fhi-pg-main-9-alerts.yaml pages on backup age > 26h ("daily schedule ->
+# anything older than 26h is a missed/failed backup") -- but until July 2026 no
+# ScheduledBackup was ever created for -9: only the initial manual Backup from
+# the migration's Phase 3 existed, so the newest base backup silently aged from
+# day one. This manifest is the daily schedule those alerts describe.
+#
+# FIELD SHAPES (postgresql.cnpg.io/v1 ScheduledBackup):
+#   spec.schedule  -- SIX-field cron WITH SECONDS (robfig/cron), NOT the
+#                     5-field Kubernetes CronJob format. "0 0 8 * * *" is
+#                     daily at 08:00:00 UTC (= midnight PST, low traffic for a
+#                     US-focused app; deliberately NOT 00:00 UTC, where the old
+#                     backup-example ScheduledBackup fired and where pcfweb's
+#                     nightly runs -- spreads B2 load).
+#   spec.method    -- MUST be "plugin" + pluginConfiguration.name. -9 has no
+#                     spec.backup section (in-tree barmanObjectStore was
+#                     removed); method: barmanObjectStore fails with "cluster
+#                     has no backup section" (see migration runbook Phase 3).
+#   spec.immediate -- take one backup as soon as this is applied, so applying
+#                     the manifest is self-proving (don't wait for 08:00 UTC).
+#
+# backupOwnerReference: self makes every Backup CR this schedule creates OWNED
+# by this ScheduledBackup, so the CRs are garbage-collected if the schedule is
+# ever deleted. This is a direct lesson from the July 2026 incident: the
+# orphaned `backup-example` ScheduledBackup in the `default` namespace left
+# ~240 forever-pending Backup CRs for the dead fhi-pg-main-7 cluster, and the
+# operator's catch-up re-create storm on those starved scheduling for every
+# OTHER ScheduledBackup in the cluster. Owner-refs keep that graveyard from
+# ever forming again. (Deleting Backup CRs never deletes object-store data;
+# on-disk retention is governed by the ObjectStore's retentionPolicy, 30d.)
+#
+# Verification after apply (see docs/pg-backup-reconciliation-runbook-2026-07.md
+# and scripts/check-pg9-backup-health.sh):
+#   kubectl -n totallylegitco get scheduledbackup fhi-pg-main-9-nightly
+#   kubectl -n totallylegitco get backup -l cnpg.io/cluster=fhi-pg-main-9 \
+#     --sort-by=.metadata.creationTimestamp | tail   # immediate backup -> completed
+# =============================================================================
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: fhi-pg-main-9-nightly
+  namespace: totallylegitco
+  labels:
+    app: fight-health-insurance
+    cnpg.io/cluster: fhi-pg-main-9
+spec:
+  # Six fields: sec min hour day-of-month month day-of-week.
+  schedule: "0 0 8 * * *"
+  cluster:
+    name: fhi-pg-main-9
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
+  immediate: true
+  backupOwnerReference: self

--- a/k8s/fhi-pg-main-9-scheduledbackup.yaml
+++ b/k8s/fhi-pg-main-9-scheduledbackup.yaml
@@ -58,3 +58,8 @@ spec:
     name: barman-cloud.cloudnative-pg.io
   immediate: true
   backupOwnerReference: self
+  # Explicit false is load-bearing: build.sh re-applies this manifest on every
+  # deploy, but a field ABSENT from the manifest survives kubectl apply's
+  # three-way merge -- a manual `kubectl patch ... suspend: true` would stick
+  # forever. Declared here, the next deploy reverts it.
+  suspend: false

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -116,6 +116,15 @@ esac
 kubectl apply -f k8s/db-config.yaml
 echo "PDBHOST now set to: $(kubectl -n totallylegitco get configmap fhi-db-config -o jsonpath='{.data.PDBHOST}')"
 
+# Backup schedule for fhi-pg-main-9 -- re-asserted on every deploy (same
+# pattern as db-config above) so a deleted/suspended schedule self-heals and
+# the 26h backup-age alert in k8s/fhi-pg-main-9-alerts.yaml always has a real
+# schedule behind it. Idempotent. NOTE: the barman-cloud plugin INSTALL is
+# deliberately NOT managed here -- colo-scripts owns it as a single pinned
+# helm release; this script must never apply a second copy (July 2026
+# incident: two plugin installs deadlocked reconciliation for 12 days).
+kubectl apply -f k8s/fhi-pg-main-9-scheduledbackup.yaml
+
 # The raycluster operator doesn't handle upgrades well so delete + recreate instead.
 kubectl delete raycluster -n totallylegitco raycluster-kuberay || echo "No raycluster present"
 envsubst < k8s/ray/cluster.yaml | kubectl apply -f -

--- a/scripts/check-pg9-backup-health.sh
+++ b/scripts/check-pg9-backup-health.sh
@@ -21,7 +21,7 @@
 #   6. pg_wal segment count bounded on every instance (matches 10/20GB alerts)
 #   7. PGDATA volume headroom on every instance
 #   8. newest completed base backup younger than 26h (matches FhiPg9BackupTooOld)
-#   9. ScheduledBackup exists and is not suspended
+#   9. ScheduledBackup exists, is not suspended, and matches the manifest spec
 #  10. cluster-wide cruft scan: ScheduledBackups aimed at dead clusters,
 #      long-pending Backup CRs (the backup-example failure mode)
 #
@@ -47,6 +47,7 @@ WAL_WARN_SEGS="${WAL_WARN_SEGS:-640}"              # 10GiB @ 16MB
 WAL_FAIL_SEGS="${WAL_FAIL_SEGS:-1280}"             # 20GiB @ 16MB
 MAX_BACKUP_AGE_S="${MAX_BACKUP_AGE_S:-93600}"      # 26h, FhiPg9BackupTooOld
 SCHEDULED_BACKUP="${SCHEDULED_BACKUP:-fhi-pg-main-9-nightly}"
+EXPECTED_SCHEDULE="${EXPECTED_SCHEDULE:-0 0 8 * * *}"  # must match the manifest
 PENDING_CRUFT_AGE_S="${PENDING_CRUFT_AGE_S:-172800}"  # pending >48h = cruft
 
 info() { printf '\033[0;36m[INFO]\033[0m %s\n' "$*"; }
@@ -76,20 +77,21 @@ else
   if [ "${PLUGIN_DEPLOYS[0]}" = "$PLUGIN_DEPLOY" ]; then
     pass "exactly one plugin deployment: ${PLUGIN_DEPLOYS[0]}"
   else
-    warn "single plugin deployment is '${PLUGIN_DEPLOYS[0]}' (expected '$PLUGIN_DEPLOY' from the helm release)"
+    # a lone NON-helm install still violates the runbook end-state: the next
+    # cluster-setup.yaml run would recreate the duplicate-install deadlock
+    fail "single plugin deployment is '${PLUGIN_DEPLOYS[0]}' (expected helm-managed '$PLUGIN_DEPLOY')"
   fi
 fi
 for d in "${PLUGIN_DEPLOYS[@]}"; do
   READY="$(kubectl -n "$PLUGIN_NS" get deploy "$d" \
     -o jsonpath='{.status.readyReplicas}/{.status.replicas}' 2>/dev/null || echo '?/?')"
-  case "$READY" in
-    */*)
-      if [ "${READY%/*}" = "${READY#*/}" ] && [ "${READY%/*}" != "" ]; then
-        pass "deployment $d ready: $READY"
-      else
-        fail "deployment $d NOT ready ($READY) -- likely waiting on the leader lease"
-      fi ;;
-  esac
+  if [ "$READY" = "?/?" ]; then
+    fail "deployment $d: could not read readiness (kubectl error)"
+  elif [ "${READY%/*}" = "${READY#*/}" ] && [ -n "${READY%/*}" ]; then
+    pass "deployment $d ready: $READY"
+  else
+    fail "deployment $d NOT ready ($READY) -- likely waiting on the leader lease"
+  fi
 done
 
 # --- 2. leader lease held by a live pod of the surviving deployment ----------
@@ -161,9 +163,10 @@ psql_primary() { kubectl -n "$NAMESPACE" exec -i "$PRIMARY" -c "$PG_CONTAINER" -
 info "=== [5] WAL archiver on $PRIMARY ==="
 ARCH="$(psql_primary "SELECT archived_count, failed_count,
   COALESCE(EXTRACT(EPOCH FROM (now()-last_archived_time))::bigint, -1),
-  COALESCE(last_archived_wal,''), COALESCE(last_failed_wal,'')
+  COALESCE(last_archived_wal,''), COALESCE(last_failed_wal,''),
+  COALESCE(EXTRACT(EPOCH FROM (now()-last_failed_time))::bigint, -1)
   FROM pg_stat_archiver;")"
-IFS='|' read -r ARCHIVED FAILED_N SINCE LAST_OK LAST_BAD <<<"$ARCH"
+IFS='|' read -r ARCHIVED FAILED_N SINCE LAST_OK LAST_BAD SINCE_FAIL <<<"$ARCH"
 info "archived_count=$ARCHIVED failed_count=$FAILED_N last_ok=$LAST_OK last_failed=$LAST_BAD"
 if [ "$ARCHIVED" -eq 0 ]; then
   fail "archiver has NEVER succeeded on this timeline (archived_count=0)"
@@ -171,6 +174,11 @@ elif [ "$SINCE" -lt 0 ]; then
   fail "no last_archived_time reported"
 elif [ "$SINCE" -gt "$MAX_ARCHIVE_AGE_S" ]; then
   fail "last successful archive was ${SINCE}s ago (> ${MAX_ARCHIVE_AGE_S}s) -- PITR coverage is stalled"
+elif [ "$SINCE_FAIL" -ge 0 ] && [ "$SINCE_FAIL" -lt "$SINCE" ]; then
+  # a failure NEWER than the last success = the archiver's most recent attempt
+  # failed; postgres retries the same segment, so this is a live stall even if
+  # the last success is only minutes old
+  fail "archiver is CURRENTLY failing: last failure ${SINCE_FAIL}s ago (newer than last success ${SINCE}s ago), failing on '$LAST_BAD'"
 else
   pass "last successful archive ${SINCE}s ago"
 fi
@@ -238,42 +246,62 @@ if ! kubectl -n "$NAMESPACE" get scheduledbackup "$SCHEDULED_BACKUP" >/dev/null 
 else
   SUSPENDED="$(kubectl -n "$NAMESPACE" get scheduledbackup "$SCHEDULED_BACKUP" \
     -o jsonpath='{.spec.suspend}' 2>/dev/null || true)"
+  SB_GOT="$(kubectl -n "$NAMESPACE" get scheduledbackup "$SCHEDULED_BACKUP" \
+    -o jsonpath='{.spec.cluster.name}|{.spec.method}|{.spec.pluginConfiguration.name}|{.spec.backupOwnerReference}|{.spec.schedule}' 2>/dev/null || true)"
+  SB_WANT="$CLUSTER|plugin|$PLUGIN_NAME|self|$EXPECTED_SCHEDULE"
   if [ "$SUSPENDED" = "true" ]; then
     fail "ScheduledBackup $SCHEDULED_BACKUP is SUSPENDED"
+  elif [ "$SB_GOT" != "$SB_WANT" ]; then
+    fail "ScheduledBackup $SCHEDULED_BACKUP spec drift (cluster|method|plugin|ownerRef|schedule): got '$SB_GOT', want '$SB_WANT' -- re-apply k8s/fhi-pg-main-9-scheduledbackup.yaml"
   else
-    pass "ScheduledBackup $SCHEDULED_BACKUP present and active"
+    pass "ScheduledBackup $SCHEDULED_BACKUP present, active, and matching the manifest"
   fi
 fi
 
 # --- 10. cluster-wide cruft scan (the backup-example failure mode) -----------
 info "=== [10] cluster-wide ScheduledBackup/Backup cruft ==="
 CRUFT=0
-while IFS=' ' read -r SNS SNAME SCLUSTER; do
-  [ -n "$SNS" ] || continue
-  if ! kubectl -n "$SNS" get cluster "$SCLUSTER" >/dev/null 2>&1; then
-    fail "ScheduledBackup $SNS/$SNAME targets NON-EXISTENT cluster '$SCLUSTER' -- delete it (its catch-up storm can starve ALL scheduled backups)"
-    CRUFT=1
-  fi
-done < <(kubectl get scheduledbackup -A \
+if ! SB_LIST="$(kubectl get scheduledbackup -A \
   -o custom-columns='NS:.metadata.namespace,NAME:.metadata.name,CLUSTER:.spec.cluster.name' \
-  --no-headers 2>/dev/null || true)
+  --no-headers 2>/dev/null)"; then
+  fail "could not list ScheduledBackups cluster-wide (RBAC/API?) -- dead-cluster scan did NOT run"
+  CRUFT=-1
+else
+  while IFS=' ' read -r SNS SNAME SCLUSTER; do
+    [ -n "$SNS" ] || continue
+    if ! kubectl -n "$SNS" get cluster "$SCLUSTER" >/dev/null 2>&1; then
+      fail "ScheduledBackup $SNS/$SNAME targets NON-EXISTENT cluster '$SCLUSTER' -- delete it (its catch-up storm can starve ALL scheduled backups)"
+      CRUFT=1
+    fi
+  done <<<"$SB_LIST"
+fi
 
 NOW_S="$(date +%s)"
 PENDING_OLD=0
-while IFS=' ' read -r BNS BNAME BPHASE BCREATED; do
-  [ -n "$BNS" ] || continue
-  case "$BPHASE" in pending|walArchivingFailing) ;; *) continue ;; esac
-  AGE=$(( NOW_S - $(date -d "$BCREATED" +%s) ))
-  [ "$AGE" -gt "$PENDING_CRUFT_AGE_S" ] && PENDING_OLD=$((PENDING_OLD+1))
-done < <(kubectl get backup -A \
+if ! B_LIST="$(kubectl get backup -A \
   -o custom-columns='NS:.metadata.namespace,NAME:.metadata.name,PHASE:.status.phase,CREATED:.metadata.creationTimestamp' \
-  --no-headers 2>/dev/null || true)
-if [ "$PENDING_OLD" -gt 0 ]; then
-  warn "$PENDING_OLD Backup CR(s) cluster-wide stuck pending/walArchivingFailing for >48h -- investigate/delete (kubectl get backup -A)"
+  --no-headers 2>/dev/null)"; then
+  fail "could not list Backups cluster-wide (RBAC/API?) -- pending-cruft scan did NOT run"
 else
-  pass "no long-pending Backup CRs cluster-wide"
+  while IFS=' ' read -r BNS BNAME BPHASE BCREATED; do
+    [ -n "$BNS" ] || continue
+    case "$BPHASE" in pending|walArchivingFailing) ;; *) continue ;; esac
+    AGE=$(( NOW_S - $(date -d "$BCREATED" +%s) ))
+    if [ "$AGE" -gt "$PENDING_CRUFT_AGE_S" ]; then
+      PENDING_OLD=$((PENDING_OLD+1))
+    fi
+  done <<<"$B_LIST"
+  if [ "$PENDING_OLD" -gt 0 ]; then
+    # fail, not warn: long-pending Backup CRs are the exact failure mode that
+    # starved ScheduledBackup processing cluster-wide in July 2026
+    fail "$PENDING_OLD Backup CR(s) cluster-wide stuck pending/walArchivingFailing for >48h -- investigate/delete (kubectl get backup -A)"
+  else
+    pass "no long-pending Backup CRs cluster-wide"
+  fi
 fi
-[ "$CRUFT" -eq 0 ] && pass "every ScheduledBackup targets a live cluster"
+if [ "$CRUFT" -eq 0 ]; then
+  pass "every ScheduledBackup targets a live cluster"
+fi
 
 # --- verdict -----------------------------------------------------------------
 echo

--- a/scripts/check-pg9-backup-health.sh
+++ b/scripts/check-pg9-backup-health.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+# =============================================================================
+# check-pg9-backup-health.sh
+# Verify the ENTIRE fhi-pg-main-9 backup path is healthy: exactly one
+# barman-cloud plugin install, operator<->plugin channel up, archiver
+# advancing, WAL bounded, base backups fresh, and no ScheduledBackup cruft.
+#
+# Encodes the lessons of BOTH incidents:
+#   - the -8 outage (v0.9->v0.13: duplicate plugin installs, stale leader
+#     lease, empty Service endpoints -> reconciliation stalled), and
+#   - the July 2026 -9 recurrence (helm release + manifest install both
+#     present; `backup-example` ScheduledBackup graveyard in `default`
+#     starving scheduling cluster-wide).
+#
+# Checks (all READ-ONLY):
+#   1. exactly ONE plugin-barman-cloud deployment in cnpg-system, fully ready
+#   2. the plugin leader lease is held by a pod of that deployment
+#   3. plugin Service discoverable + endpoints non-empty (the -8 selector break)
+#   4. cluster status is healthy (not "error while interacting with plugins")
+#   5. WAL archiver advancing on the primary (matches FhiPg9ArchiverStalled)
+#   6. pg_wal segment count bounded on every instance (matches 10/20GB alerts)
+#   7. PGDATA volume headroom on every instance
+#   8. newest completed base backup younger than 26h (matches FhiPg9BackupTooOld)
+#   9. ScheduledBackup exists and is not suspended
+#  10. cluster-wide cruft scan: ScheduledBackups aimed at dead clusters,
+#      long-pending Backup CRs (the backup-example failure mode)
+#
+# Usage: ./scripts/check-pg9-backup-health.sh
+#   (kube-context must point at the prod cluster; all knobs env-overridable)
+# =============================================================================
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-totallylegitco}"
+CLUSTER="${CLUSTER:-fhi-pg-main-9}"
+PG_CONTAINER="${PG_CONTAINER:-postgres}"
+PLUGIN_NS="${PLUGIN_NS:-cnpg-system}"
+PLUGIN_NAME="${PLUGIN_NAME:-barman-cloud.cloudnative-pg.io}"
+# Deployment the *helm release* owns (release "barman-cloud" x chart
+# "plugin-barman-cloud" -> fullname below). Anything ELSE running the plugin
+# image is a duplicate install.
+PLUGIN_DEPLOY="${PLUGIN_DEPLOY:-barman-cloud-plugin-barman-cloud}"
+# Leader-election lock the plugin hardcodes (visible in its logs).
+LEASE_NAME="${LEASE_NAME:-822e3f5c.cnpg.io}"
+PGDATA="${PGDATA:-/var/lib/postgresql/data/pgdata}"
+MAX_ARCHIVE_AGE_S="${MAX_ARCHIVE_AGE_S:-3600}"     # FhiPg9ArchiverStalled
+WAL_WARN_SEGS="${WAL_WARN_SEGS:-640}"              # 10GiB @ 16MB
+WAL_FAIL_SEGS="${WAL_FAIL_SEGS:-1280}"             # 20GiB @ 16MB
+MAX_BACKUP_AGE_S="${MAX_BACKUP_AGE_S:-93600}"      # 26h, FhiPg9BackupTooOld
+SCHEDULED_BACKUP="${SCHEDULED_BACKUP:-fhi-pg-main-9-nightly}"
+PENDING_CRUFT_AGE_S="${PENDING_CRUFT_AGE_S:-172800}"  # pending >48h = cruft
+
+info() { printf '\033[0;36m[INFO]\033[0m %s\n' "$*"; }
+pass() { printf '\033[0;32m[PASS]\033[0m %s\n' "$*"; }
+warn() { printf '\033[0;33m[WARN]\033[0m %s\n' "$*"; }
+fail() { printf '\033[0;31m[FAIL]\033[0m %s\n' "$*"; FAILED=$((FAILED+1)); }
+die()  { printf '\033[0;31m[FAIL]\033[0m %s\n' "$*"; exit 1; }
+
+FAILED=0
+
+command -v kubectl >/dev/null 2>&1 || die "kubectl not found on PATH"
+CTX="$(kubectl config current-context 2>/dev/null || true)"
+[ -n "$CTX" ] || die "no active kube-context"
+info "kube-context : $CTX"
+info "cluster      : $NAMESPACE/$CLUSTER   plugin ns: $PLUGIN_NS"
+
+# --- 1. exactly ONE plugin deployment, fully ready ---------------------------
+info "=== [1] single plugin-barman-cloud deployment ==="
+mapfile -t PLUGIN_DEPLOYS < <(kubectl -n "$PLUGIN_NS" get deploy \
+  -o custom-columns='NAME:.metadata.name,IMG:.spec.template.spec.containers[*].image' \
+  --no-headers 2>/dev/null | awk '/plugin-barman-cloud/{print $1}')
+if [ "${#PLUGIN_DEPLOYS[@]}" -eq 0 ]; then
+  fail "no plugin-barman-cloud deployment found in $PLUGIN_NS"
+elif [ "${#PLUGIN_DEPLOYS[@]}" -gt 1 ]; then
+  fail "DUPLICATE plugin installs: ${PLUGIN_DEPLOYS[*]} -- they fight over the leader lease (the July 2026 reconciliation outage). Keep only the helm-managed '$PLUGIN_DEPLOY'; see docs/pg-backup-reconciliation-runbook-2026-07.md"
+else
+  [ "${PLUGIN_DEPLOYS[0]}" = "$PLUGIN_DEPLOY" ] \
+    && pass "exactly one plugin deployment: ${PLUGIN_DEPLOYS[0]}" \
+    || warn "single plugin deployment is '${PLUGIN_DEPLOYS[0]}' (expected '$PLUGIN_DEPLOY' from the helm release)"
+fi
+for d in "${PLUGIN_DEPLOYS[@]}"; do
+  READY="$(kubectl -n "$PLUGIN_NS" get deploy "$d" \
+    -o jsonpath='{.status.readyReplicas}/{.status.replicas}' 2>/dev/null || echo '?/?')"
+  case "$READY" in
+    */*) [ "${READY%/*}" = "${READY#*/}" ] && [ "${READY%/*}" != "" ] \
+           && pass "deployment $d ready: $READY" \
+           || fail "deployment $d NOT ready ($READY) -- likely waiting on the leader lease" ;;
+  esac
+done
+
+# --- 2. leader lease held by a live pod of the surviving deployment ----------
+info "=== [2] plugin leader lease ==="
+HOLDER="$(kubectl -n "$PLUGIN_NS" get lease "$LEASE_NAME" \
+  -o jsonpath='{.spec.holderIdentity}' 2>/dev/null || true)"
+if [ -z "$HOLDER" ]; then
+  warn "lease $LEASE_NAME not found (ok only if the plugin was just reinstalled)"
+else
+  HOLDER_POD="${HOLDER%%_*}"
+  if kubectl -n "$PLUGIN_NS" get pod "$HOLDER_POD" >/dev/null 2>&1; then
+    pass "lease held by live pod $HOLDER_POD"
+  else
+    fail "lease $LEASE_NAME held by NON-EXISTENT pod '$HOLDER_POD' -- stale lock is blocking the plugin; kubectl -n $PLUGIN_NS delete lease $LEASE_NAME"
+  fi
+fi
+
+# --- 3. plugin Service discovery + endpoints (the -8 selector break) ---------
+info "=== [3] plugin Service + endpoints ==="
+mapfile -t PLUGIN_SVCS < <(kubectl -n "$PLUGIN_NS" get svc \
+  -l "cnpg.io/pluginName=$PLUGIN_NAME" -o name 2>/dev/null | sed 's|service/||')
+if [ "${#PLUGIN_SVCS[@]}" -eq 0 ]; then
+  # fall back to name-based discovery in case the label key changed upstream
+  mapfile -t PLUGIN_SVCS < <(kubectl -n "$PLUGIN_NS" get svc -o name 2>/dev/null \
+    | sed 's|service/||' | grep -i barman || true)
+  [ "${#PLUGIN_SVCS[@]}" -gt 0 ] \
+    && warn "no Service labeled cnpg.io/pluginName=$PLUGIN_NAME; found by name: ${PLUGIN_SVCS[*]} -- verify the operator can discover the plugin" \
+    || fail "no plugin Service found in $PLUGIN_NS at all"
+elif [ "${#PLUGIN_SVCS[@]}" -gt 1 ]; then
+  fail "MULTIPLE Services claim plugin '$PLUGIN_NAME': ${PLUGIN_SVCS[*]} -- operator discovery is ambiguous (duplicate install)"
+else
+  pass "one plugin Service: ${PLUGIN_SVCS[0]}"
+fi
+for s in "${PLUGIN_SVCS[@]}"; do
+  READY_EPS="$(kubectl -n "$PLUGIN_NS" get endpointslices \
+    -l "kubernetes.io/service-name=$s" \
+    -o jsonpath='{range .items[*]}{range .endpoints[*]}{.conditions.ready}{"\n"}{end}{end}' \
+    2>/dev/null | grep -c true || true)"
+  [ "${READY_EPS:-0}" -ge 1 ] \
+    && pass "service $s has $READY_EPS ready endpoint(s)" \
+    || fail "service $s has NO ready endpoints -- operator gRPC to the plugin has no backend (exact -8 failure)"
+done
+
+# --- 4. cluster reconciliation status ---------------------------------------
+info "=== [4] cluster status ==="
+PHASE="$(kubectl -n "$NAMESPACE" get cluster "$CLUSTER" \
+  -o jsonpath='{.status.phase}' 2>/dev/null || true)"
+PHASE_REASON="$(kubectl -n "$NAMESPACE" get cluster "$CLUSTER" \
+  -o jsonpath='{.status.phaseReason}' 2>/dev/null || true)"
+if [ "$PHASE" = "Cluster in healthy state" ]; then
+  pass "cluster phase: $PHASE"
+else
+  fail "cluster phase: ${PHASE:-<none>} ${PHASE_REASON:+-- $PHASE_REASON}"
+fi
+
+PRIMARY="$(kubectl -n "$NAMESPACE" get cluster "$CLUSTER" \
+  -o jsonpath='{.status.currentPrimary}' 2>/dev/null || true)"
+[ -n "$PRIMARY" ] || die "cannot determine current primary for $CLUSTER"
+info "primary      : $PRIMARY"
+
+psql_primary() { kubectl -n "$NAMESPACE" exec -i "$PRIMARY" -c "$PG_CONTAINER" -- \
+  psql -U postgres -d postgres -At -v ON_ERROR_STOP=1 -c "$1"; }
+
+# --- 5. archiver advancing on the primary -----------------------------------
+info "=== [5] WAL archiver on $PRIMARY ==="
+ARCH="$(psql_primary "SELECT archived_count, failed_count,
+  COALESCE(EXTRACT(EPOCH FROM (now()-last_archived_time))::bigint, -1),
+  COALESCE(last_archived_wal,''), COALESCE(last_failed_wal,'')
+  FROM pg_stat_archiver;")"
+IFS='|' read -r ARCHIVED FAILED_N SINCE LAST_OK LAST_BAD <<<"$ARCH"
+info "archived_count=$ARCHIVED failed_count=$FAILED_N last_ok=$LAST_OK last_failed=$LAST_BAD"
+if [ "$ARCHIVED" -eq 0 ]; then
+  fail "archiver has NEVER succeeded on this timeline (archived_count=0)"
+elif [ "$SINCE" -lt 0 ]; then
+  fail "no last_archived_time reported"
+elif [ "$SINCE" -gt "$MAX_ARCHIVE_AGE_S" ]; then
+  fail "last successful archive was ${SINCE}s ago (> ${MAX_ARCHIVE_AGE_S}s) -- PITR coverage is stalled"
+else
+  pass "last successful archive ${SINCE}s ago"
+fi
+
+# --- 6. pg_wal bounded on every instance ------------------------------------
+info "=== [6] pg_wal segment count per instance ==="
+mapfile -t PODS < <(kubectl -n "$NAMESPACE" get pods \
+  -l "cnpg.io/cluster=$CLUSTER" -o name 2>/dev/null | sed 's|pod/||')
+[ "${#PODS[@]}" -ge 1 ] || die "no pods found for cluster $CLUSTER"
+for p in "${PODS[@]}"; do
+  SEGS="$(kubectl -n "$NAMESPACE" exec "$p" -c "$PG_CONTAINER" -- \
+    sh -c "ls '$PGDATA/pg_wal' 2>/dev/null | grep -Ec '^[0-9A-F]{24}\$'" || echo -1)"
+  if [ "$SEGS" -lt 0 ]; then
+    warn "$p: could not count WAL segments"
+  elif [ "$SEGS" -gt "$WAL_FAIL_SEGS" ]; then
+    fail "$p: $SEGS WAL segments (>20GiB) -- the -8-1 disk-full pattern; check archiver + stuck slots NOW"
+  elif [ "$SEGS" -gt "$WAL_WARN_SEGS" ]; then
+    warn "$p: $SEGS WAL segments (>10GiB early warning)"
+  else
+    pass "$p: $SEGS WAL segments"
+  fi
+done
+
+# --- 7. PGDATA volume headroom ----------------------------------------------
+info "=== [7] PGDATA volume usage per instance ==="
+for p in "${PODS[@]}"; do
+  USEP="$(kubectl -n "$NAMESPACE" exec "$p" -c "$PG_CONTAINER" -- \
+    sh -c "df -P '$PGDATA' | awk 'NR==2{gsub(/%/,\"\",\$5); print \$5}'" 2>/dev/null || echo -1)"
+  if [ "$USEP" -lt 0 ]; then
+    warn "$p: could not read df for $PGDATA"
+  elif [ "$USEP" -ge 85 ]; then
+    fail "$p: PGDATA volume ${USEP}% full"
+  elif [ "$USEP" -ge 70 ]; then
+    warn "$p: PGDATA volume ${USEP}% full"
+  else
+    pass "$p: PGDATA volume ${USEP}% full"
+  fi
+done
+
+# --- 8. newest completed base backup fresh enough ----------------------------
+info "=== [8] base backup freshness ==="
+NEWEST_DONE=""
+while IFS=' ' read -r BNAME BPHASE BSTOP; do
+  [ "$BPHASE" = "completed" ] && [ -n "$BSTOP" ] && [ "$BSTOP" != "<none>" ] && NEWEST_DONE="$BNAME $BSTOP"
+done < <(kubectl -n "$NAMESPACE" get backup -l "cnpg.io/cluster=$CLUSTER" \
+  --sort-by=.metadata.creationTimestamp \
+  -o custom-columns='NAME:.metadata.name,PHASE:.status.phase,STOP:.status.stoppedAt' \
+  --no-headers 2>/dev/null || true)
+if [ -z "$NEWEST_DONE" ]; then
+  fail "no COMPLETED backup exists for $CLUSTER"
+else
+  BNAME="${NEWEST_DONE% *}"; BSTOP="${NEWEST_DONE#* }"
+  AGE_S=$(( $(date +%s) - $(date -d "$BSTOP" +%s) ))
+  if [ "$AGE_S" -gt "$MAX_BACKUP_AGE_S" ]; then
+    fail "newest completed backup '$BNAME' is ${AGE_S}s old (> ${MAX_BACKUP_AGE_S}s / 26h)"
+  else
+    pass "newest completed backup '$BNAME' is ${AGE_S}s old"
+  fi
+fi
+
+# --- 9. ScheduledBackup present + active ------------------------------------
+info "=== [9] ScheduledBackup ==="
+if ! kubectl -n "$NAMESPACE" get scheduledbackup "$SCHEDULED_BACKUP" >/dev/null 2>&1; then
+  fail "ScheduledBackup $SCHEDULED_BACKUP missing -- apply k8s/fhi-pg-main-9-scheduledbackup.yaml"
+else
+  SUSPENDED="$(kubectl -n "$NAMESPACE" get scheduledbackup "$SCHEDULED_BACKUP" \
+    -o jsonpath='{.spec.suspend}' 2>/dev/null || true)"
+  [ "$SUSPENDED" = "true" ] \
+    && fail "ScheduledBackup $SCHEDULED_BACKUP is SUSPENDED" \
+    || pass "ScheduledBackup $SCHEDULED_BACKUP present and active"
+fi
+
+# --- 10. cluster-wide cruft scan (the backup-example failure mode) -----------
+info "=== [10] cluster-wide ScheduledBackup/Backup cruft ==="
+CRUFT=0
+while IFS=' ' read -r SNS SNAME SCLUSTER; do
+  [ -n "$SNS" ] || continue
+  if ! kubectl -n "$SNS" get cluster "$SCLUSTER" >/dev/null 2>&1; then
+    fail "ScheduledBackup $SNS/$SNAME targets NON-EXISTENT cluster '$SCLUSTER' -- delete it (its catch-up storm can starve ALL scheduled backups)"
+    CRUFT=1
+  fi
+done < <(kubectl get scheduledbackup -A \
+  -o custom-columns='NS:.metadata.namespace,NAME:.metadata.name,CLUSTER:.spec.cluster.name' \
+  --no-headers 2>/dev/null || true)
+
+NOW_S="$(date +%s)"
+PENDING_OLD=0
+while IFS=' ' read -r BNS BNAME BPHASE BCREATED; do
+  [ -n "$BNS" ] || continue
+  case "$BPHASE" in pending|walArchivingFailing) ;; *) continue ;; esac
+  AGE=$(( NOW_S - $(date -d "$BCREATED" +%s) ))
+  [ "$AGE" -gt "$PENDING_CRUFT_AGE_S" ] && PENDING_OLD=$((PENDING_OLD+1))
+done < <(kubectl get backup -A \
+  -o custom-columns='NS:.metadata.namespace,NAME:.metadata.name,PHASE:.status.phase,CREATED:.metadata.creationTimestamp' \
+  --no-headers 2>/dev/null || true)
+if [ "$PENDING_OLD" -gt 0 ]; then
+  warn "$PENDING_OLD Backup CR(s) cluster-wide stuck pending/walArchivingFailing for >48h -- investigate/delete (kubectl get backup -A)"
+else
+  pass "no long-pending Backup CRs cluster-wide"
+fi
+[ "$CRUFT" -eq 0 ] && pass "every ScheduledBackup targets a live cluster"
+
+# --- verdict -----------------------------------------------------------------
+echo
+if [ "$FAILED" -eq 0 ]; then
+  pass "ALL CHECKS PASSED -- $CLUSTER backup path is healthy"
+else
+  die "$FAILED check(s) FAILED -- see docs/pg-backup-reconciliation-runbook-2026-07.md"
+fi

--- a/scripts/check-pg9-backup-health.sh
+++ b/scripts/check-pg9-backup-health.sh
@@ -73,17 +73,22 @@ if [ "${#PLUGIN_DEPLOYS[@]}" -eq 0 ]; then
 elif [ "${#PLUGIN_DEPLOYS[@]}" -gt 1 ]; then
   fail "DUPLICATE plugin installs: ${PLUGIN_DEPLOYS[*]} -- they fight over the leader lease (the July 2026 reconciliation outage). Keep only the helm-managed '$PLUGIN_DEPLOY'; see docs/pg-backup-reconciliation-runbook-2026-07.md"
 else
-  [ "${PLUGIN_DEPLOYS[0]}" = "$PLUGIN_DEPLOY" ] \
-    && pass "exactly one plugin deployment: ${PLUGIN_DEPLOYS[0]}" \
-    || warn "single plugin deployment is '${PLUGIN_DEPLOYS[0]}' (expected '$PLUGIN_DEPLOY' from the helm release)"
+  if [ "${PLUGIN_DEPLOYS[0]}" = "$PLUGIN_DEPLOY" ]; then
+    pass "exactly one plugin deployment: ${PLUGIN_DEPLOYS[0]}"
+  else
+    warn "single plugin deployment is '${PLUGIN_DEPLOYS[0]}' (expected '$PLUGIN_DEPLOY' from the helm release)"
+  fi
 fi
 for d in "${PLUGIN_DEPLOYS[@]}"; do
   READY="$(kubectl -n "$PLUGIN_NS" get deploy "$d" \
     -o jsonpath='{.status.readyReplicas}/{.status.replicas}' 2>/dev/null || echo '?/?')"
   case "$READY" in
-    */*) [ "${READY%/*}" = "${READY#*/}" ] && [ "${READY%/*}" != "" ] \
-           && pass "deployment $d ready: $READY" \
-           || fail "deployment $d NOT ready ($READY) -- likely waiting on the leader lease" ;;
+    */*)
+      if [ "${READY%/*}" = "${READY#*/}" ] && [ "${READY%/*}" != "" ]; then
+        pass "deployment $d ready: $READY"
+      else
+        fail "deployment $d NOT ready ($READY) -- likely waiting on the leader lease"
+      fi ;;
   esac
 done
 
@@ -110,9 +115,11 @@ if [ "${#PLUGIN_SVCS[@]}" -eq 0 ]; then
   # fall back to name-based discovery in case the label key changed upstream
   mapfile -t PLUGIN_SVCS < <(kubectl -n "$PLUGIN_NS" get svc -o name 2>/dev/null \
     | sed 's|service/||' | grep -i barman || true)
-  [ "${#PLUGIN_SVCS[@]}" -gt 0 ] \
-    && warn "no Service labeled cnpg.io/pluginName=$PLUGIN_NAME; found by name: ${PLUGIN_SVCS[*]} -- verify the operator can discover the plugin" \
-    || fail "no plugin Service found in $PLUGIN_NS at all"
+  if [ "${#PLUGIN_SVCS[@]}" -gt 0 ]; then
+    warn "no Service labeled cnpg.io/pluginName=$PLUGIN_NAME; found by name: ${PLUGIN_SVCS[*]} -- verify the operator can discover the plugin"
+  else
+    fail "no plugin Service found in $PLUGIN_NS at all"
+  fi
 elif [ "${#PLUGIN_SVCS[@]}" -gt 1 ]; then
   fail "MULTIPLE Services claim plugin '$PLUGIN_NAME': ${PLUGIN_SVCS[*]} -- operator discovery is ambiguous (duplicate install)"
 else
@@ -123,9 +130,11 @@ for s in "${PLUGIN_SVCS[@]}"; do
     -l "kubernetes.io/service-name=$s" \
     -o jsonpath='{range .items[*]}{range .endpoints[*]}{.conditions.ready}{"\n"}{end}{end}' \
     2>/dev/null | grep -c true || true)"
-  [ "${READY_EPS:-0}" -ge 1 ] \
-    && pass "service $s has $READY_EPS ready endpoint(s)" \
-    || fail "service $s has NO ready endpoints -- operator gRPC to the plugin has no backend (exact -8 failure)"
+  if [ "${READY_EPS:-0}" -ge 1 ]; then
+    pass "service $s has $READY_EPS ready endpoint(s)"
+  else
+    fail "service $s has NO ready endpoints -- operator gRPC to the plugin has no backend (exact -8 failure)"
+  fi
 done
 
 # --- 4. cluster reconciliation status ---------------------------------------
@@ -229,9 +238,11 @@ if ! kubectl -n "$NAMESPACE" get scheduledbackup "$SCHEDULED_BACKUP" >/dev/null 
 else
   SUSPENDED="$(kubectl -n "$NAMESPACE" get scheduledbackup "$SCHEDULED_BACKUP" \
     -o jsonpath='{.spec.suspend}' 2>/dev/null || true)"
-  [ "$SUSPENDED" = "true" ] \
-    && fail "ScheduledBackup $SCHEDULED_BACKUP is SUSPENDED" \
-    || pass "ScheduledBackup $SCHEDULED_BACKUP present and active"
+  if [ "$SUSPENDED" = "true" ]; then
+    fail "ScheduledBackup $SCHEDULED_BACKUP is SUSPENDED"
+  else
+    pass "ScheduledBackup $SCHEDULED_BACKUP present and active"
+  fi
 fi
 
 # --- 10. cluster-wide cruft scan (the backup-example failure mode) -----------


### PR DESCRIPTION
## Summary

Adds comprehensive documentation and tooling to prevent and remediate the July 2026 PostgreSQL backup outage affecting `fhi-pg-main-9`. The incident was caused by duplicate barman-cloud plugin installations (manifest + helm), a stale leader lease blocking reconciliation, and orphaned ScheduledBackup CRs from a dead cluster starving the scheduling controller.

## Key Changes

- **docs/pg-backup-reconciliation-runbook-2026-07.md** (417 lines)
  - Complete incident postmortem with root cause analysis (duplicate plugin installs, unpinned helm charts, orphaned backup CRs)
  - Six-phase remediation runbook with guards and validation steps
  - Fast-path summary for operators familiar with the incident
  - Phase 3a deep-dive on WAL archiver failures (the empty-archive-check blocker resolved 2026-08-04)
  - Phase 4–6 covering pcfweb-pg migration to plugin-based backups and long-term prevention

- **k8s/fhi-pg-main-9-scheduledbackup.yaml** (new)
  - Daily ScheduledBackup for `fhi-pg-main-9` at 08:00 UTC (low-traffic window, spreads B2 load)
  - Uses plugin-based backup method (in-tree barmanObjectStore removed in CNPG 1.28+)
  - `immediate: true` for self-proving on apply
  - `backupOwnerReference: self` to prevent orphaned Backup CRs (the July 2026 failure mode)

- **scripts/check-pg9-backup-health.sh** (273 lines, new)
  - Read-only health probe covering the entire backup path
  - 10 checks: single plugin deployment, leader lease, Service discovery, cluster reconciliation, archiver advancement, WAL bounds, volume headroom, backup freshness, ScheduledBackup presence, cluster-wide cruft scan
  - Detects the -8 and July 2026 failure patterns (duplicate installs, stale leases, empty Service endpoints, long-pending Backup CRs)
  - Env-overridable thresholds; used by both runbook and CI

- **scripts/build.sh** (modified)
  - Re-asserts `k8s/fhi-pg-main-9-scheduledbackup.yaml` on every deploy (idempotent)
  - Ensures the backup schedule self-heals if deleted/suspended
  - Mirrors the existing `db-config.yaml` pattern

## Implementation Details

- The runbook encodes lessons from **two incidents**: the -8 outage (v0.9→v0.13 plugin upgrade, duplicate installs, stale lease, empty Service endpoints) and the July 2026 -9 recurrence (same pattern + orphaned `backup-example` ScheduledBackup starving the scheduling controller)
- Phase 2 emphasizes **safe convergence** to a single helm-managed plugin install: uninstall + purge + clean reinstall, never piecemeal deletion (Service/Certificate/ConfigMap names are shared between install methods)
- Phase 3a documents the empty-WAL-archive-check blocker (confirmed live 2026-08-04): stale WAL from a prior `-9` incarnation or restore-drill cluster under the same serverName must be parked/cleared before archiving resumes
- The health script is designed to be run by operators, CI, and the runbook itself; all thresholds match the alerting rules in `k8s/fhi-pg-main-9-alerts.yaml` (26h backup age, 3600s archiver staleness, 10/20GiB WAL bounds)
- `colo-scripts` pinning (mentioned in the runbook) is a separate change: chart versions are now pinned with `wait: yes` to fail loudly on stuck rollouts instead of rotting for 12 days

## Prevention

- Helm chart versions in `colo-scripts/playbooks/cluster-setup.yaml` are now pinned (cloudnative-pg 0.29.0, plugin-barman

https://claude.ai/code/session_016bc6m6fpgLH82EzSNTVXMg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added daily automated backups for the PostgreSQL 9 cluster using the Barman Cloud plugin.
  * Added deployment safeguards to restore the backup schedule automatically.
  * Added a read-only health check covering backup readiness, scheduling, archiving, storage, and backup completion.

* **Documentation**
  * Added a comprehensive runbook for diagnosing and resolving PostgreSQL backup and reconciliation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->