### PR TITLE
Tune Temporal Postgres pool to stop idle-session churn

### DIFF
--- a/k8s/temporal/README.md
+++ b/k8s/temporal/README.md
@@ -153,6 +153,30 @@ back to plain TLS.
    (`launch_polling_actors --force` relaunch excludes it under Temporal, but
    does not kill a live one).
 
+## Applying a values.yaml change
+
+Editing `values.yaml` does **not** change anything by itself, and neither does
+restarting the Temporal pods — Kubernetes re-reads the ConfigMap Helm already
+rendered, not this file. Changes land only via `helm upgrade`:
+
+```sh
+TEMPORAL_PG_HOST=fhi-pg-main-9-rw.totallylegitco.svc \
+TEMPORAL_PG_USER=temporal \
+envsubst '${TEMPORAL_PG_HOST} ${TEMPORAL_PG_USER}' < values.yaml > /tmp/temporal-values.yaml
+helm upgrade temporal temporal/temporal --version 1.6.0 \
+  -n totallylegitco -f /tmp/temporal-values.yaml
+```
+
+Datastore changes restart the four Temporal server pods, so the cluster is
+briefly unavailable (~30-60s). FHI's own pods (web, `fhi-fax-worker`) are not
+restarted, but a fax dispatched during that window fails over to the Ray path
+— pick a quiet moment. Verify after:
+
+```sh
+kubectl -n totallylegitco exec -i deploy/temporal-admintools -- \
+  temporal operator cluster health --address temporal-frontend:7233
+```
+
 ## Rollback
 
 Set `TEMPORAL_ENABLED=false` (or scale the worker to 0). Fax dispatch falls

--- a/k8s/temporal/values.yaml
+++ b/k8s/temporal/values.yaml
@@ -29,11 +29,16 @@ server:
             existingSecret: "temporal-postgres"  # key: password
             maxConns: 20
             # Tuned 2026-08-10: stock chart example was maxIdleConns 20 /
-            # maxConnLifetime 1h, which parks 20 idle connections until pg's
-            # 30-min idle_session_timeout reaps them (~46 kills/6h in the
-            # pg log). Lifetime under 30m lets Temporal recycle first, and
-            # this workload never needs 20 idle. maxConns unchanged, so
-            # burst capacity is untouched.
+            # maxConnLifetime 1h, which parks 20 idle connections until pg
+            # reaps them on idle_session_timeout -- measured on the primary,
+            # 46 "terminating connection due to idle-session timeout" entries
+            # for temporal@temporal in 6h. Note the timeout differs between
+            # config and cluster: k8s/fhi-pg-main-9-cluster.yaml declares
+            # 90min, but the running server reports 30min (the parameter
+            # needs a Postgres restart, deferred by primaryUpdateStrategy:
+            # supervised). 25m sits below both, so Temporal recycles first
+            # either way. This workload never needs 20 idle connections;
+            # maxConns is unchanged, so burst capacity is untouched.
             maxIdleConns: 5
             maxConnLifetime: "25m"
             manageSchema: true

--- a/k8s/temporal/values.yaml
+++ b/k8s/temporal/values.yaml
@@ -28,8 +28,14 @@ server:
             user: "${TEMPORAL_PG_USER}"
             existingSecret: "temporal-postgres"  # key: password
             maxConns: 20
-            maxIdleConns: 20
-            maxConnLifetime: "1h"
+            # Tuned 2026-08-10: stock chart example was maxIdleConns 20 /
+            # maxConnLifetime 1h, which parks 20 idle connections until pg's
+            # 30-min idle_session_timeout reaps them (~46 kills/6h in the
+            # pg log). Lifetime under 30m lets Temporal recycle first, and
+            # this workload never needs 20 idle. maxConns unchanged, so
+            # burst capacity is untouched.
+            maxIdleConns: 5
+            maxConnLifetime: "25m"
             manageSchema: true
         visibility:
           sql:
@@ -41,8 +47,8 @@ server:
             user: "${TEMPORAL_PG_USER}"
             existingSecret: "temporal-postgres"
             maxConns: 10
-            maxIdleConns: 10
-            maxConnLifetime: "1h"
+            maxIdleConns: 2
+            maxConnLifetime: "25m"
             manageSchema: true
 
 # We bring our own Postgres. Chart >= 1.0 no longer bundles Cassandra/ES/

--- a/k8s/temporal/values.yaml
+++ b/k8s/temporal/values.yaml
@@ -28,17 +28,14 @@ server:
             user: "${TEMPORAL_PG_USER}"
             existingSecret: "temporal-postgres"  # key: password
             maxConns: 20
-            # Tuned 2026-08-10: stock chart example was maxIdleConns 20 /
-            # maxConnLifetime 1h, which parks 20 idle connections until pg
-            # reaps them on idle_session_timeout -- measured on the primary,
-            # 46 "terminating connection due to idle-session timeout" entries
-            # for temporal@temporal in 6h. Note the timeout differs between
-            # config and cluster: k8s/fhi-pg-main-9-cluster.yaml declares
-            # 90min, but the running server reports 30min (the parameter
-            # needs a Postgres restart, deferred by primaryUpdateStrategy:
-            # supervised). 25m sits below both, so Temporal recycles first
-            # either way. This workload never needs 20 idle connections;
-            # maxConns is unchanged, so burst capacity is untouched.
+            # Tuned off the chart's stock example (20 / 20 / 1h). Parking
+            # 20 idle connections is far more than this workload needs, and
+            # a lifetime longer than pg's idle_session_timeout means the
+            # server severs connections before Temporal recycles them. 25m
+            # stays under that timeout whether it is the 30min the server
+            # currently reports or the 90min fhi-pg-main-9-cluster.yaml
+            # declares. maxConns is unchanged: burst capacity is identical,
+            # only the idle pool shrinks.
             maxIdleConns: 5
             maxConnLifetime: "25m"
             manageSchema: true


### PR DESCRIPTION
The datastore blocks carried the Temporal Helm chart's stock example values (maxConns 20 / maxIdleConns 20 / maxConnLifetime 1h). maxIdleConns 20 parks 20 idle connections per store, and a 1h lifetime is longer than pg9's 30-min idle_session_timeout, so Postgres always won the race and severed them: ~46 'terminating connection due to idle-session timeout' entries per 6h in the pg log, all temporal@temporal.

Recycle before the server reaps (25m lifetime) and stop parking connections this workload never needs (idle 5 / 2). maxConns is unchanged at 20 / 10, so burst capacity is identical -- only the idle pool shrinks.

Also document how to apply a values.yaml change: editing the file (or restarting pods) does nothing without helm upgrade, which restarts the Temporal server pods.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added operational guidance for applying Temporal deployment configuration changes.
  * Documented temporary service unavailability during datastore updates, unaffected FHI pods, fax fallback behavior, and post-upgrade health checks.

* **Bug Fixes**
  * Improved Temporal datastore connection management by reducing idle connection limits and connection lifetimes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->