### PR TITLE
Gate PostInferedForm's captcha on settings, not import-time env

### DIFF
--- a/fighthealthinsurance/forms/__init__.py
+++ b/fighthealthinsurance/forms/__init__.py
@@ -409,14 +409,16 @@ class BasePostInferedForm(DenialRefForm):
     )
 
 
-class PostInferedForm(BasePostInferedForm):
+class PostInferedForm(ReCaptchaOptionalMixin, BasePostInferedForm):
+    """Public appeal form with conditionally-enforced reCAPTCHA.
+
+    Previously decided at import time from ``os.environ``, which made the
+    captcha depend on process-wide state rather than the active
+    configuration. See ReCaptchaOptionalMixin for how the field is
+    conditionally enforced from ``django.conf.settings`` instead.
+    """
+
     captcha = forms.CharField(required=False, widget=forms.HiddenInput())
-    # Instead of the default behaviour we skip the recaptcha field entirely for dev.
-    if "RECAPTCHA_PUBLIC_KEY" in os.environ and (
-        "RECAPTCHA_TESTING" not in os.environ
-        or os.environ["RECAPTCHA_TESTING"].lower() != "true"
-    ):
-        captcha = ReCaptchaField(widget=ReCaptchaV2Checkbox())
 
 
 class ProPostInferedForm(BasePostInferedForm):


### PR DESCRIPTION
PostInferedForm decided at class-definition time whether to attach a real ReCaptchaField, reading os.environ directly. Two problems:

- It ran at import, so the decision came from process-wide state rather than the active configuration.
- RECAPTCHA_TESTING is unreliable as an env var. Every class body in settings.py executes on import regardless of which configuration is selected, and Prod is declared last, so its os.environ["RECAPTCHA_TESTING"] = "False" overwrote the "True" that Dev sets -- meaning Dev and the Test configs saw "False" and would attach a live captcha whenever RECAPTCHA_PUBLIC_KEY happened to be set.

ReCaptchaOptionalMixin already solves this and is used by PublicDeleteDataForm; its docstring explains the reasoning (single source of truth, testable via override_settings). This switches PostInferedForm to the same pattern.

Prod behaviour is unchanged: settings.RECAPTCHA_TESTING is False there and both keys are configured, so the captcha is enforced exactly as before. Dev and Test now correctly skip it.

Verified against the real image with override_settings:
  RECAPTCHA_TESTING=True  + keys -> no ReCaptchaField
  RECAPTCHA_TESTING=False + keys -> ReCaptchaField attached
  RECAPTCHA_TESTING=False, no keys -> no ReCaptchaField

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CAPTCHA handling on the insurance post form.
  * CAPTCHA validation now adapts automatically to the application’s configuration, providing a smoother form submission experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->