### PR TITLE
Fix Sentry initialization gate to prevent local dev noise

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,7 +80,10 @@ DEFF_PASSWORD=your-encryption-password
 # =============================================================================
 # MONITORING & LOGGING
 # =============================================================================
-# Sentry error tracking (optional)
+# Sentry error tracking (optional). Only reports from real deployments:
+# requires DEBUG off AND a deployment marker -- KUBERNETES_SERVICE_HOST
+# (present in every k8s pod) or FHI_DEPLOYED=1 in the process environment.
+# A real DSN here is therefore safe for local dev; nothing reports.
 SENTRY_ENDPOINT=https://xxxxx@sentry.io/xxxxx
 
 # Enable audit logging for compliance

--- a/fighthealthinsurance/asgi.py
+++ b/fighthealthinsurance/asgi.py
@@ -10,7 +10,7 @@ https://docs.djangoproject.com/en/4.1/howto/deployment/asgi/
 import os
 import sys
 
-from fighthealthinsurance.env_utils import get_env_variable
+from fighthealthinsurance.env_utils import get_env_variable, should_enable_sentry
 
 # Use stderr for startup messages since logging may not be configured yet
 print("Setting default envs", file=sys.stderr)
@@ -59,7 +59,14 @@ application = ProtocolTypeRouter(
 
 from django.conf import settings
 
-if settings.SENTRY_ENDPOINT and not settings.DEBUG:
+# Sentry only fires from real (non-local) deployments. "endpoint set and
+# DEBUG off" is not enough: dev machines routinely carry the production
+# SENTRY_ENDPOINT plus a Prod DJANGO_CONFIGURATION (copied .env files, and
+# editors like Cursor export .env into the process env), which used to tag
+# every local hiccup as a production error. should_enable_sentry additionally
+# requires a deployment marker: KUBERNETES_SERVICE_HOST (present in every
+# k8s pod) or an explicit FHI_DEPLOYED=1.
+if should_enable_sentry(settings.SENTRY_ENDPOINT, settings.DEBUG):
     import sentry_sdk
     from sentry_sdk.integrations.django import DjangoIntegration
 
@@ -125,6 +132,18 @@ if settings.SENTRY_ENDPOINT and not settings.DEBUG:
             # possible.
             "continuous_profiling_auto_start": True,
         },
+    )
+elif settings.SENTRY_ENDPOINT:
+    # Startup-visible breadcrumb for "why aren't my errors in Sentry?"
+    print(
+        "SENTRY_ENDPOINT is set but Sentry stays off: "
+        + (
+            "DEBUG is on"
+            if settings.DEBUG
+            else "not a deployed environment "
+            "(no KUBERNETES_SERVICE_HOST; set FHI_DEPLOYED=1 to override)"
+        ),
+        file=sys.stderr,
     )
 
 # Optional Azure Log Analytics shipping. Activates only when both workspace

--- a/fighthealthinsurance/env_utils.py
+++ b/fighthealthinsurance/env_utils.py
@@ -25,3 +25,35 @@ def get_env_variable(var_name: str, default: Optional[str] = None) -> str:
             raise RuntimeError(
                 f"Critical environment variable {var_name} is missing. Ensure it is set securely."
             )
+
+
+def is_deployed_environment() -> bool:
+    """True when this process runs in a real (non-local) deployment.
+
+    Every real deployment of this app runs in Kubernetes, and the kubelet
+    injects KUBERNETES_SERVICE_HOST into every container it starts, so its
+    presence distinguishes cluster pods from laptops with zero configuration.
+    FHI_DEPLOYED=1 opts a non-Kubernetes deployment in. Both are read from
+    the process environment only (not .env): copied-around .env files are
+    exactly how local machines end up looking like prod in the first place.
+    """
+    if os.getenv("KUBERNETES_SERVICE_HOST"):
+        return True
+    return (os.getenv("FHI_DEPLOYED") or "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
+def should_enable_sentry(sentry_endpoint: Optional[str], debug: bool) -> bool:
+    """Gate for sentry_sdk.init (see asgi.py): report only from real deployments.
+
+    DEBUG alone is not enough of a guard: a dev shell carrying the production
+    SENTRY_ENDPOINT plus a Prod DJANGO_CONFIGURATION (common when poking at
+    prod settings locally, and editors auto-export .env into the process env)
+    passed the old ``endpoint and not DEBUG`` check and flooded Sentry with
+    local-editing noise tagged as production.
+    """
+    return bool(sentry_endpoint) and not debug and is_deployed_environment()

--- a/tests/async-unit/test_sentry_deployment_gating.py
+++ b/tests/async-unit/test_sentry_deployment_gating.py
@@ -1,0 +1,81 @@
+"""Sentry must only initialize for real (non-local) deployments.
+
+Dev machines routinely carry the production SENTRY_ENDPOINT plus a Prod
+DJANGO_CONFIGURATION (copied .env files; editors like Cursor export .env
+into the process env), so the old ``SENTRY_ENDPOINT and not DEBUG`` gate in
+asgi.py reported every local hiccup to Sentry tagged as production. The gate
+now also requires a deployment marker: KUBERNETES_SERVICE_HOST (the kubelet
+injects it into every pod) or an explicit FHI_DEPLOYED opt-in.
+"""
+
+import pytest
+
+from fighthealthinsurance.env_utils import (
+    is_deployed_environment,
+    should_enable_sentry,
+)
+
+_ENV_VARS = ["KUBERNETES_SERVICE_HOST", "FHI_DEPLOYED"]
+
+_DSN = "https://key@sentry.example/1"
+
+
+def _clear_env(monkeypatch):
+    for var in _ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+class TestIsDeployedEnvironment:
+    def test_local_machine_is_not_deployed(self, monkeypatch):
+        _clear_env(monkeypatch)
+        assert is_deployed_environment() is False
+
+    def test_kubernetes_pod_is_deployed(self, monkeypatch):
+        _clear_env(monkeypatch)
+        monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
+        assert is_deployed_environment() is True
+
+    def test_empty_kubernetes_host_is_not_deployed(self, monkeypatch):
+        """Templating can materialize unset env vars as empty strings."""
+        _clear_env(monkeypatch)
+        monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "")
+        assert is_deployed_environment() is False
+
+    @pytest.mark.parametrize("value", ["1", "true", "True", "yes", "on"])
+    def test_explicit_opt_in_counts_as_deployed(self, monkeypatch, value):
+        _clear_env(monkeypatch)
+        monkeypatch.setenv("FHI_DEPLOYED", value)
+        assert is_deployed_environment() is True
+
+    @pytest.mark.parametrize("value", ["", "0", "false", "no"])
+    def test_falsy_opt_in_is_not_deployed(self, monkeypatch, value):
+        _clear_env(monkeypatch)
+        monkeypatch.setenv("FHI_DEPLOYED", value)
+        assert is_deployed_environment() is False
+
+
+class TestShouldEnableSentry:
+    def test_deployed_non_debug_enables_sentry(self, monkeypatch):
+        _clear_env(monkeypatch)
+        monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
+        assert should_enable_sentry(_DSN, debug=False) is True
+
+    def test_local_machine_with_prod_env_stays_silent(self, monkeypatch):
+        """The incident case: real DSN + DEBUG off on a laptop must not report."""
+        _clear_env(monkeypatch)
+        assert should_enable_sentry(_DSN, debug=False) is False
+
+    def test_debug_stays_silent_even_when_deployed(self, monkeypatch):
+        _clear_env(monkeypatch)
+        monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
+        assert should_enable_sentry(_DSN, debug=True) is False
+
+    def test_missing_endpoint_stays_silent_when_deployed(self, monkeypatch):
+        _clear_env(monkeypatch)
+        monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
+        assert should_enable_sentry(None, debug=False) is False
+
+    def test_fhi_deployed_opt_in_enables_sentry_off_kubernetes(self, monkeypatch):
+        _clear_env(monkeypatch)
+        monkeypatch.setenv("FHI_DEPLOYED", "1")
+        assert should_enable_sentry(_DSN, debug=False) is True


### PR DESCRIPTION
## Summary
Prevents Sentry from reporting errors from local development machines that happen to have production environment variables set. The old gate (`SENTRY_ENDPOINT and not DEBUG`) was insufficient because dev machines routinely carry copied `.env` files with production settings, causing local editing noise to be tagged as production errors in Sentry.

## Changes
- **New `env_utils.py` functions:**
  - `is_deployed_environment()` - Detects real deployments via `KUBERNETES_SERVICE_HOST` (injected by kubelet into every pod) or explicit `FHI_DEPLOYED=1` opt-in
  - `should_enable_sentry()` - Comprehensive gate requiring: valid endpoint, DEBUG off, AND deployed environment marker

- **Updated `asgi.py`:**
  - Replaced simple `SENTRY_ENDPOINT and not DEBUG` check with `should_enable_sentry()` call
  - Added diagnostic stderr message when Sentry endpoint is set but initialization is skipped (helps debug "why aren't my errors in Sentry?")

- **Updated `.env.example`:**
  - Clarified that real DSN is safe for local dev since nothing will report without deployment markers

- **New test suite** (`test_sentry_deployment_gating.py`):
  - Comprehensive unit tests for both `is_deployed_environment()` and `should_enable_sentry()`
  - Covers edge cases: empty env vars, various truthy/falsy values, all combinations of conditions

## Implementation Details
- Reads deployment markers only from process environment (not `.env`), avoiding the circular problem of copied `.env` files making local machines look deployed
- Supports both Kubernetes (zero-config) and non-Kubernetes deployments (explicit opt-in)
- Handles templating edge case where unset env vars materialize as empty strings
- Provides clear diagnostic output for operators troubleshooting Sentry connectivity

https://claude.ai/code/session_011MaFP7TsuBbv5gCyR3PXZ9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error-reporting safeguards so Sentry activates only when configured, debugging is disabled, and the application is running in a detected deployed environment.
  * Added startup diagnostics when Sentry is configured but intentionally disabled.

* **Documentation**
  * Expanded environment configuration guidance with the conditions required to enable Sentry.

* **Tests**
  * Added coverage for deployment detection and error-reporting enablement, including local and invalid configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->