### PR TITLE
Filter scanner 404s from sentry

### DIFF
--- a/fighthealthinsurance/asgi.py
+++ b/fighthealthinsurance/asgi.py
@@ -8,7 +8,6 @@ https://docs.djangoproject.com/en/4.1/howto/deployment/asgi/
 """
 
 import os
-import re
 import sys
 
 from fighthealthinsurance.env_utils import get_env_variable, should_enable_sentry
@@ -129,11 +128,13 @@ if should_enable_sentry(settings.SENTRY_ENDPOINT, settings.DEBUG):
         # own 404 mail; this is the equivalent for Sentry.
         for exc in exception_values:
             if exc.get("type") == "Resolver404":
-                path = ""
-                match = re.search(r"'path':\s*'([^']*)'", exc.get("value", "") or "")
-                if match:
-                    path = match.group(1)
-                logger.info(f"Unrouted path (filtered from Sentry): {path[:100]!r}")
+                # The attempted path is deliberately NOT recorded here. It is
+                # client-controlled and can carry sensitive segments (a
+                # mistyped follow-up link still contains its token and hashed
+                # email), and uvicorn already logs every request path via
+                # --access-log in scripts/start-server.sh -- so probe activity
+                # stays greppable without writing untrusted input a second time.
+                logger.info("Unrouted path (filtered from Sentry)")
                 return None
 
         return event

--- a/fighthealthinsurance/asgi.py
+++ b/fighthealthinsurance/asgi.py
@@ -8,6 +8,7 @@ https://docs.djangoproject.com/en/4.1/howto/deployment/asgi/
 """
 
 import os
+import re
 import sys
 
 from fighthealthinsurance.env_utils import get_env_variable, should_enable_sentry
@@ -113,6 +114,26 @@ if should_enable_sentry(settings.SENTRY_ENDPOINT, settings.DEBUG):
                 logger.warning(
                     f"Ray gRPC channel error (filtered from Sentry): {exc_value[:200]}"
                 )
+                return None
+
+        # Drop URL-resolution 404s. These are internet background noise:
+        # scanners probing for exposed secrets (.bashrc, api/.env, key.pem,
+        # wp-login.php...). Django refuses them correctly, so there is nothing
+        # to action -- but each novel probe path is a NEW Sentry issue, which
+        # means a fresh alert for something nobody can or should fix.
+        #
+        # Deliberately narrow: only the resolver's "no route matched" error.
+        # A 404 raised deliberately inside a view (a missing appeal, an expired
+        # link) is a different class and still reports, because that one can
+        # indicate a real bug. IGNORABLE_404_URLS in settings covers Django's
+        # own 404 mail; this is the equivalent for Sentry.
+        for exc in exception_values:
+            if exc.get("type") == "Resolver404":
+                path = ""
+                match = re.search(r"'path':\s*'([^']*)'", exc.get("value", "") or "")
+                if match:
+                    path = match.group(1)
+                logger.info(f"Unrouted path (filtered from Sentry): {path[:100]!r}")
                 return None
 
         return event

--- a/fighthealthinsurance/asgi.py
+++ b/fighthealthinsurance/asgi.py
@@ -11,6 +11,7 @@ import os
 import sys
 
 from fighthealthinsurance.env_utils import get_env_variable, should_enable_sentry
+from fighthealthinsurance.sentry_filters import is_only_unrouted
 
 # Use stderr for startup messages since logging may not be configured yet
 print("Setting default envs", file=sys.stderr)
@@ -126,16 +127,15 @@ if should_enable_sentry(settings.SENTRY_ENDPOINT, settings.DEBUG):
         # link) is a different class and still reports, because that one can
         # indicate a real bug. IGNORABLE_404_URLS in settings covers Django's
         # own 404 mail; this is the equivalent for Sentry.
-        for exc in exception_values:
-            if exc.get("type") == "Resolver404":
-                # The attempted path is deliberately NOT recorded here. It is
-                # client-controlled and can carry sensitive segments (a
-                # mistyped follow-up link still contains its token and hashed
-                # email), and uvicorn already logs every request path via
-                # --access-log in scripts/start-server.sh -- so probe activity
-                # stays greppable without writing untrusted input a second time.
-                logger.info("Unrouted path (filtered from Sentry)")
-                return None
+        if is_only_unrouted(exception_values):
+            # The attempted path is deliberately NOT recorded here. It is
+            # client-controlled and can carry sensitive segments (a mistyped
+            # follow-up link still contains its token and hashed email), and
+            # uvicorn already logs every request path via --access-log in
+            # scripts/start-server.sh -- so probe activity stays greppable
+            # without writing untrusted input a second time.
+            logger.info("Unrouted path (filtered from Sentry)")
+            return None
 
         return event
 

--- a/fighthealthinsurance/sentry_filters.py
+++ b/fighthealthinsurance/sentry_filters.py
@@ -1,0 +1,32 @@
+"""Decisions used by Sentry's before_send filter.
+
+asgi.py defines ``before_send_filter`` inside a settings-dependent block, which
+makes it awkward to import from a test. The decisions that need coverage live
+here as plain functions instead.
+"""
+
+from typing import Any, Dict, List, Optional
+
+# Django raises this when no URL pattern matches at all.
+UNROUTED_EXCEPTION_TYPE = "Resolver404"
+
+
+def is_only_unrouted(exception_values: Optional[List[Dict[str, Any]]]) -> bool:
+    """True when an event is *nothing but* URL-resolution 404s.
+
+    Scanner probes (``/.env``, ``/key.pem``) produce a lone Resolver404, and
+    those are pure noise -- Django refused them, and each new probe path
+    fingerprints as a brand-new Sentry issue.
+
+    Sentry reports chained exceptions as several entries in ``values``, so a
+    real failure that merely passed through URL resolution would also carry a
+    Resolver404. Requiring EVERY entry to be Resolver404 keeps those events:
+    dropping on "any" would silently swallow the genuine error alongside it.
+
+    An empty or missing list is never suppressed. ``all([])`` is True, so
+    checking emptiness first is what stops message-only events (no exception
+    at all) from being mistaken for a 404.
+    """
+    if not exception_values:
+        return False
+    return all(exc.get("type") == UNROUTED_EXCEPTION_TYPE for exc in exception_values)

--- a/tests/sync/test_sensitive_paths_not_served.py
+++ b/tests/sync/test_sensitive_paths_not_served.py
@@ -12,8 +12,10 @@ normally happen: a new static-file route, a catch-all handler, or a
 misconfigured storage backend that quietly starts answering for paths nobody
 audited.
 
-Deliberately asserts "not successful" rather than "== 404" -- a 403 or a
-redirect to a login page is also fine. Serving the bytes is not.
+Asserts an allow-list of outcomes rather than "not 2xx": 404, 403, and
+redirects are all acceptable ways of not serving a file. Anything else --
+including a 5xx -- fails, because a server error on these paths can mask a
+routing problem rather than prove the path is safe.
 """
 
 from django.test import Client, SimpleTestCase
@@ -48,6 +50,17 @@ SENSITIVE_PATHS = [
 ]
 
 
+def _is_safe_response(status_code: int) -> bool:
+    """Outcomes that prove we did not serve the file.
+
+    404 and 403 are the expected refusals; a redirect (to a login page, or a
+    canonical URL) is also fine. Everything else fails -- notably 5xx, which
+    would mean the request reached something that broke rather than something
+    that refused, and could hide a routing bug behind an apparent "not served".
+    """
+    return status_code in (403, 404) or 300 <= status_code < 400
+
+
 class SensitivePathsNotServedTest(SimpleTestCase):
     """None of these may return a successful response.
 
@@ -60,15 +73,13 @@ class SensitivePathsNotServedTest(SimpleTestCase):
         served = []
         for path in SENSITIVE_PATHS:
             response = client.get(f"/{path}")
-            # 2xx means we handed the caller content. Anything else -- 404,
-            # 403, a redirect to login -- means we did not.
-            if 200 <= response.status_code < 300:
+            if not _is_safe_response(response.status_code):
                 served.append((path, response.status_code))
         self.assertEqual(
             served,
             [],
-            "These paths returned a successful response and may be exposing "
-            f"configuration or credentials: {served}. If a route legitimately "
+            "These paths did not cleanly refuse (expected 404/403/redirect) and "
+            f"may be exposing configuration or credentials: {served}. If a route legitimately "
             "needs one of these names, rename the route -- do not remove the "
             "path from this list.",
         )
@@ -79,6 +90,6 @@ class SensitivePathsNotServedTest(SimpleTestCase):
         served = []
         for path in (".ENV", ".Env", ".env?x=1", "static/.env", "media/.env"):
             response = client.get(f"/{path}")
-            if 200 <= response.status_code < 300:
+            if not _is_safe_response(response.status_code):
                 served.append((path, response.status_code))
-        self.assertEqual(served, [], f"Variant paths served content: {served}")
+        self.assertEqual(served, [], f"Variant paths did not cleanly refuse: {served}")

--- a/tests/sync/test_sensitive_paths_not_served.py
+++ b/tests/sync/test_sensitive_paths_not_served.py
@@ -1,0 +1,84 @@
+"""Sensitive filenames must never resolve to a real response.
+
+Scanners probe every public site for config and credential files -- .env,
+key.pem, settings.json, .git/config -- and four such probes reached Sentry in
+a single week. Every one 404'd, which is the *good* outcome: an actual
+exposure would return 200 and raise nothing at all, so error monitoring is
+silent on precisely the case that matters.
+
+This test inverts that. It stays quiet while these paths are unroutable and
+fails the moment one starts serving content, which is how such exposures
+normally happen: a new static-file route, a catch-all handler, or a
+misconfigured storage backend that quietly starts answering for paths nobody
+audited.
+
+Deliberately asserts "not successful" rather than "== 404" -- a 403 or a
+redirect to a login page is also fine. Serving the bytes is not.
+"""
+
+from django.test import Client, SimpleTestCase
+
+# Paths taken from probes actually observed against production, plus the
+# usual suspects from scanner wordlists. Add to this list, never trim it.
+SENSITIVE_PATHS = [
+    # observed in production Sentry, Aug 2026
+    ".bashrc",
+    "api/.env",
+    "key.pem",
+    "settings.json",
+    # standard scanner fare
+    ".env",
+    ".env.local",
+    ".env.production",
+    ".git/config",
+    ".git/HEAD",
+    "config.json",
+    "credentials.json",
+    "secrets.json",
+    ".aws/credentials",
+    "id_rsa",
+    "private.pem",
+    "backup.sql",
+    "dump.sql",
+    "docker-compose.yml",
+    "Dockerfile",
+    ".npmrc",
+    ".dockercfg",
+    "wp-config.php",
+]
+
+
+class SensitivePathsNotServedTest(SimpleTestCase):
+    """None of these may return a successful response.
+
+    SimpleTestCase: this exercises URL routing only, so it needs no database
+    and stays fast enough to never be the reason someone skips the suite.
+    """
+
+    def test_sensitive_paths_are_not_served(self):
+        client = Client()
+        served = []
+        for path in SENSITIVE_PATHS:
+            response = client.get(f"/{path}")
+            # 2xx means we handed the caller content. Anything else -- 404,
+            # 403, a redirect to login -- means we did not.
+            if 200 <= response.status_code < 300:
+                served.append((path, response.status_code))
+        self.assertEqual(
+            served,
+            [],
+            "These paths returned a successful response and may be exposing "
+            f"configuration or credentials: {served}. If a route legitimately "
+            "needs one of these names, rename the route -- do not remove the "
+            "path from this list.",
+        )
+
+    def test_sensitive_paths_are_not_served_with_query_or_case_variants(self):
+        """Same guarantee for the trivial evasions scanners actually try."""
+        client = Client()
+        served = []
+        for path in (".ENV", ".Env", ".env?x=1", "static/.env", "media/.env"):
+            response = client.get(f"/{path}")
+            if 200 <= response.status_code < 300:
+                served.append((path, response.status_code))
+        self.assertEqual(served, [], f"Variant paths served content: {served}")

--- a/tests/sync/test_sentry_unrouted_filter.py
+++ b/tests/sync/test_sentry_unrouted_filter.py
@@ -1,0 +1,56 @@
+"""The Sentry filter must drop scanner probes without swallowing real errors.
+
+Background: bots probe every public site for exposed config (/.env, /key.pem),
+Django refuses them with Resolver404, and each novel path fingerprints as a
+NEW Sentry issue -- so "new issue" alerts fire for something nobody can fix.
+asgi.before_send_filter drops those.
+
+The risk in doing so is over-matching. Sentry reports chained exceptions as
+several entries in ``exception.values``, so an event can legitimately contain
+a Resolver404 *alongside* the real failure. Suppressing on "any entry is a
+Resolver404" would discard the real error too; these tests pin the "every
+entry" behaviour.
+"""
+
+from django.test import SimpleTestCase
+
+from fighthealthinsurance.sentry_filters import is_only_unrouted
+
+
+def _exc(*types):
+    return [{"type": t, "value": "..."} for t in types]
+
+
+class IsOnlyUnroutedTest(SimpleTestCase):
+    def test_lone_scanner_probe_is_suppressed(self):
+        self.assertTrue(is_only_unrouted(_exc("Resolver404")))
+
+    def test_several_unrouted_entries_are_suppressed(self):
+        self.assertTrue(is_only_unrouted(_exc("Resolver404", "Resolver404")))
+
+    def test_mixed_chain_is_kept(self):
+        """The regression this file exists for.
+
+        A real error that passed through URL resolution carries both types.
+        Dropping it would hide the failure that actually matters.
+        """
+        self.assertFalse(is_only_unrouted(_exc("Resolver404", "OperationalError")))
+        self.assertFalse(is_only_unrouted(_exc("OperationalError", "Resolver404")))
+
+    def test_ordinary_errors_are_kept(self):
+        self.assertFalse(is_only_unrouted(_exc("OperationalError")))
+        self.assertFalse(is_only_unrouted(_exc("Http404")))
+
+    def test_deliberate_http404_is_kept(self):
+        """Http404 raised inside a view (missing appeal, expired link) is a
+        different class from "no route matched" and can indicate a real bug."""
+        self.assertFalse(is_only_unrouted(_exc("Http404", "Resolver404")))
+
+    def test_empty_and_missing_are_kept(self):
+        """all([]) is True, so emptiness must be checked first -- otherwise
+        message-only events (no exception at all) would be suppressed."""
+        self.assertFalse(is_only_unrouted([]))
+        self.assertFalse(is_only_unrouted(None))
+
+    def test_entries_without_a_type_are_kept(self):
+        self.assertFalse(is_only_unrouted([{"value": "no type key"}]))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented Sentry from reporting local or debug-mode errors unless the application is explicitly running in a deployed environment.
  * Reduced noise by excluding unrouted URL errors from Sentry reports.
  * Added safeguards to prevent sensitive configuration, credential, private-key, and database files from being served.

* **Documentation**
  * Clarified the environment requirements for enabling Sentry error reporting.

* **Tests**
  * Added coverage for deployment detection, Sentry activation rules, and sensitive-path protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->