### PR TITLE
Chat loop prevention: hard rejection + anti-repeat retry ladder

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,37 @@ default), every configured model is enabled.
 export ENABLED_REMOTE_MODELS="azure-anthropic/claude-opus-4-8,azure-openai/gpt-5"
 ```
 
+### GeoIP (chat state guessing + ASN tracking)
+
+The chat can seed the model with a *best-effort, unconfirmed* guess of the
+user's US state from their connection IP (so Medicaid questions can start with
+"it looks like you might be in California — is that right?" instead of a cold
+"which state are you in?"), and request tracking can record network-level ASN
+info. Both need a [geoip2fast](https://github.com/rabuchaim/geoip2fast)
+city-level database, switched on by **one key**:
+
+```bash
+export FHI_GEOIP_CITY_DB=/path/to/geoip2fast-city-asn-ipv6.dat.gz
+```
+
+The `geoip2fast` package itself is installed via `requirements.txt`, but it
+only bundles country/ASN databases — state (subdivision) data requires a
+city-level file downloaded from the geoip2fast releases. Use the
+`-city-asn-ipv6` variant so ASN lookups work too:
+
+```bash
+curl -L -o geoip2fast-city-asn-ipv6.dat.gz \
+  https://github.com/rabuchaim/geoip2fast/releases/download/LATEST/geoip2fast-city-asn-ipv6.dat.gz
+export FHI_GEOIP_CITY_DB="$PWD/geoip2fast-city-asn-ipv6.dat.gz"
+```
+
+**Soft fail:** when `FHI_GEOIP_CITY_DB` is unset (or the file is missing /
+unreadable, or the package isn't installed) nothing breaks — the state guess
+and ASN lookups simply return nothing, and a single warning naming
+`FHI_GEOIP_CITY_DB` is logged at startup so the misconfiguration is visible.
+The guess is transient by design: it is fed to the model as unconfirmed
+context each turn and is never persisted for anonymous users.
+
 ### Model backend health checks
 
 Every deployment runs an end-to-end health check of all **enabled** model

--- a/README.md
+++ b/README.md
@@ -151,10 +151,26 @@ city-level file downloaded from the geoip2fast releases. Use the
 `-city-asn-ipv6` variant so ASN lookups work too:
 
 ```bash
+# Pin a specific release tag, never the moving `LATEST`.
+GEOIP2FAST_RELEASE=v1.2.2
 curl -L -o geoip2fast-city-asn-ipv6.dat.gz \
-  https://github.com/rabuchaim/geoip2fast/releases/download/LATEST/geoip2fast-city-asn-ipv6.dat.gz
+  "https://github.com/rabuchaim/geoip2fast/releases/download/${GEOIP2FAST_RELEASE}/geoip2fast-city-asn-ipv6.dat.gz"
+
+# Record the checksum the first time, then VERIFY it on every later fetch and
+# in your deploy pipeline:
+sha256sum geoip2fast-city-asn-ipv6.dat.gz | tee geoip2fast-city-asn-ipv6.dat.gz.sha256
+sha256sum -c geoip2fast-city-asn-ipv6.dat.gz.sha256
+
 export FHI_GEOIP_CITY_DB="$PWD/geoip2fast-city-asn-ipv6.dat.gz"
 ```
+
+> **Treat this file as trusted code, not data.** geoip2fast loads the database
+> with `pickle.load()`, so anything that can replace the file (a swapped
+> release asset, a MITM on a build box, write access to the deployment volume)
+> can execute code inside the web process — which holds DB credentials and the
+> PHI field-encryption keys. Pin the release, verify the checksum before the
+> file reaches a server, and give the mounted path the same write protections
+> you give application code.
 
 **Soft fail:** when `FHI_GEOIP_CITY_DB` is unset (or the file is missing /
 unreadable, or the package isn't installed) nothing breaks — the state guess

--- a/README.md
+++ b/README.md
@@ -156,10 +156,15 @@ GEOIP2FAST_RELEASE=v1.2.2
 curl -L -o geoip2fast-city-asn-ipv6.dat.gz \
   "https://github.com/rabuchaim/geoip2fast/releases/download/${GEOIP2FAST_RELEASE}/geoip2fast-city-asn-ipv6.dat.gz"
 
-# Record the checksum the first time, then VERIFY it on every later fetch and
-# in your deploy pipeline:
-sha256sum geoip2fast-city-asn-ipv6.dat.gz | tee geoip2fast-city-asn-ipv6.dat.gz.sha256
-sha256sum -c geoip2fast-city-asn-ipv6.dat.gz.sha256
+# Verify against a digest you already trust. GEOIP2FAST_SHA256 must come from
+# somewhere INDEPENDENT of this download -- the value published by the project
+# for this tag, or one you recorded on a trusted machine and then stored in
+# the repo / your secrets manager. Deriving it from the file you just fetched
+# (sha256sum file > file.sha256 && sha256sum -c) verifies nothing: a swapped
+# asset passes its own checksum.
+GEOIP2FAST_SHA256=<expected-digest-for-${GEOIP2FAST_RELEASE}>
+echo "${GEOIP2FAST_SHA256}  geoip2fast-city-asn-ipv6.dat.gz" | sha256sum -c - \
+  || { echo "GeoIP database failed checksum -- refusing to install"; exit 1; }
 
 export FHI_GEOIP_CITY_DB="$PWD/geoip2fast-city-asn-ipv6.dat.gz"
 ```

--- a/docs/chat-pipeline.md
+++ b/docs/chat-pipeline.md
@@ -9,7 +9,7 @@ next.
 
 ## 1. End-to-end flow of one turn
 
-```
+```text
 Browser (React chat_interface.tsx)
   │  scrub PII client-side ({{FIRST_NAME}}, {{Your Email Address}}, ...)
   │  ws frame: {content, chat_id, use_external_models, debug, ...}

--- a/docs/chat-pipeline.md
+++ b/docs/chat-pipeline.md
@@ -165,7 +165,9 @@ get_chat_backends_with_fallback builds the fan-out:
   this change; the old cost-sort quietly picked the cheapest end,
 * when external models are enabled: the best <= 3 externals
   (quality-sorted, health-gated, one Groq max) now join the PRIMARY
-  fan-out too, plus serve as the retry-pass fallback list.
+  fan-out. The separate fallback list then carries only externals NOT
+  already there — normally none, since the retry pass fans out over both
+  lists and a backend in each would get four identical requests.
 
 Why externals in the primary pass: with externals only in the fallback,
 an internal-loop turn had to burn the full 30+30s primary window before an

--- a/docs/chat-pipeline.md
+++ b/docs/chat-pipeline.md
@@ -1,0 +1,296 @@
+# Chat pipeline: architecture, failure modes, and roadmap
+
+A detailed think-through of the chat stack as of the loop-prevention work
+(PR #934). Written to be the reference for "why does chat behave this way"
+questions: the end-to-end flow, the scoring math with real numbers, every
+anti-loop defense and where it sits, how models are chosen, what we
+deliberately did not build, and the prioritized list of what should come
+next.
+
+## 1. End-to-end flow of one turn
+
+```
+Browser (React chat_interface.tsx)
+  │  scrub PII client-side ({{FIRST_NAME}}, {{Your Email Address}}, ...)
+  │  ws frame: {content, chat_id, use_external_models, debug, ...}
+  ▼
+OngoingChatConsumer (websockets.py)
+  │  auth/session resolution, IP -> state hint (guess_us_state, geoip2fast)
+  │  debug gating (settings.DEBUG or staff)
+  ▼
+ChatInterface.handle_chat_message (chat_interface.py)
+  │  crisis check -> early resources reply
+  │  EARLY pre-persist of the user message (disconnect safety)
+  │  prepare_history_for_llm (context_manager.py): truncate to last 20,
+  │    summarize dropped prefix once per 10-message band, bound the
+  │    accreted summary to FHI_CHAT_MAX_SUMMARY_CHARS (6000)
+  │  prepare_user_message_variants (message_preprocessor.py)
+  │  state hint injected into the summary context as an UNCONFIRMED guess
+  ▼
+_call_llm_with_actions
+  │  allow_repeat = user_requested_repeat(RAW message)   <- before wrapping
+  │  build_llm_calls[_for_variants] (llm_client.py):
+  │    one call per backend x {truncated, full} history x message variant,
+  │    base score = quality()^2 // divisor, call -> label map
+  │  create_response_scorer: content bonuses/penalties, HARD -inf rejection
+  │    of (near-)repeats, per-session repeat-offender decay
+  │  best_two_within_timelimit (utils.py): 30s + 30s overtime, returns
+  │    best + runner-up + scores + originating calls
+  │  [if unusable] retry_llm_with_fallback (retry_handler.py): shortened
+  │    history, anti-repeat note + temperature 0.85 when repeats were
+  │    rejected, fallback backends, 35s + 40s; repeats get a finite
+  │    last-resort penalty here instead of -inf
+  │  alternate answer: runner-up kept only when scores are CLOSELY TIED
+  │  debug_llm_input / debug_llm_result frames when debug is on
+  │  tool handlers (appeal, prior auth, medicaid, pubmed, doc fetcher, ...)
+  │    -- recursive tools re-enter _call_llm_with_actions at depth+1
+  ▼
+persistence (chat_persistence.py): transactional turn persist with
+  tail-dedup, summary list capped at 20; panda-summary placeholder swap
+  happens in the background when the model omitted its summary
+  ▼
+ws frames out: status heartbeats, content (+ alternate_content), metrics
+```
+
+Everything in the fan-out is concurrent; the serial spine of a turn is
+summarization (when it fires) -> fan-out window -> optional retry window ->
+tool processing. The whole turn runs under FHI_CHAT_TURN_BUDGET (150s
+default), and the fan-out windows were sized (30+30, 35+40) so the ladder
+fits inside it.
+
+## 2. The scoring system, with real numbers
+
+Selection is score-based, not ordered fallback. Each call starts from a
+base score derived from the model's self-reported quality():
+
+| backend                      | quality | primary base (q^2//5) | full-history (q^2//4) |
+|------------------------------|---------|------------------------|------------------------|
+| AlphaRemoteInternal (fhi)    | 210     | 8820                   | 11025                  |
+| NewRemoteInternal (fhi)      | 200     | 8000                   | 10000                  |
+| RemoteHealthInsurance legacy | 101     | 2040                   | 2550                   |
+| paid external, premium tier  | 98      | 1920                   | 2401                   |
+| DeepInfra DeepSeek-V4-Pro    | 92      | 1692                   | 2116                   |
+
+Content signals then adjust: +100 primary-variant bonus, +100 substantial
+response, +10 context, +100 tool-call bonus, +150 mentions an uploaded
+document, -75 system-prompt leak, -200 false promise, -200 asks for the
+patient's name, repetition penalties (-500 exact / -400 near / -75
+bag-of-words vs recent messages), internal-repetition penalty up to -200.
+
+Two consequences worth internalizing:
+
+* **Base scores dominate content signals across tiers.** An internal model
+  beats an external on base score by ~6000; no combination of content
+  signals (max swing well under 1500) flips that. Cross-tier selection
+  therefore only changes hands when the higher tier is *invalid* — which
+  is exactly what hard rejection provides.
+* **Within a tier, content signals decide.** Two internal calls differ by
+  0–2000 base (trunc vs full history), so repeats, leaks, and document
+  mentions actually matter there.
+
+The -inf hard rejection (a candidate that nearly repeats one of the last 3
+assistant replies, unless the user asked for a repeat or it's a mandated
+canned reply) is what turned the scorer from "prefers not to loop" into
+"cannot deliver a loop from the primary pass". The old -500 soft penalty
+was invisible next to an 8000+ base — that was the production loop.
+
+## 3. The anti-loop ladder (all layers)
+
+Defenses stack from the inside out, so any single layer failing still
+leaves the loop broken:
+
+1. **Prompting** (ml_models.py): the system prompt tells the model to never
+   repeat an earlier reply and explains the client-side privacy
+   placeholders ({{STATE}} etc.) — the original trigger was the model
+   receiving `{{STATE}}` with no explanation, concluding it still didn't
+   know the state, and re-asking forever. The client no longer scrubs
+   state at all (a state name isn't identifying enough to justify breaking
+   the model's ability to use the answer).
+2. **Per-backend self-heal** (generate_chat_response): a fresh generation
+   that nearly repeats the last assistant reply gets ONE corrective retry
+   with feedback text and +0.15 temperature before the caller ever sees
+   it. Skipped for canned replies and user-requested repeats
+   (allow_repeated_reply, derived from the RAW message upstream).
+3. **Hard rejection in scoring** (-inf): a repeat cannot win the primary
+   fan-out. rejection_stats counts what was rejected.
+4. **Repeat-offender decay** (create_response_scorer): each hard-rejected
+   repeat adds a per-session strike to that backend's label; strikes decay
+   its BASE score by 0.7^strikes (capped at 4). A persistently looping
+   internal backend slides toward external-tier preference within the
+   session, so the fan-out stops re-electing it on raw quality. In-memory
+   only; resets with the WebSocket session.
+5. **Anti-repeat retry** (retry_llm_with_fallback): when everything usable
+   was rejected as a repeat, the retry appends an explicit
+   system-injected do-not-repeat note (also changes prompt bytes ->
+   busts upstream response caches) and samples at 0.85.
+6. **Last-resort delivery**: the retry scorer penalizes repeats by -1e6
+   (finite) instead of -inf — a repeat beats an error frame, but only when
+   literally nothing else came back.
+7. **Terse-reply bridge**: a short user reply (<= 60 chars) right after an
+   assistant question gets a bridging note telling the model the reply
+   answers that question — the "CA" case that models previously ignored.
+8. **Metrics** (ml_metrics.py): fhi_chat_repeated_responses_total
+   {action=rejected_candidates|delivered_repeat} makes the ladder's
+   behavior observable in production.
+
+## 4. Model selection (and why external models are now default-on)
+
+get_chat_backends_with_fallback builds the fan-out:
+
+* the primary fhi backend, doubled (redundancy against a slow pod),
+* the strongest 6 *available* internal backends — quality-sorted since
+  this change; the old cost-sort quietly picked the cheapest end,
+* when external models are enabled: the best <= 3 externals
+  (quality-sorted, health-gated, one Groq max) now join the PRIMARY
+  fan-out too, plus serve as the retry-pass fallback list.
+
+Why externals in the primary pass: with externals only in the fallback,
+an internal-loop turn had to burn the full 30+30s primary window before an
+external got a chance. In the primary fan-out, the external answer is
+already in hand at rejection time — the quadratic base score still prefers
+internals whenever they produce a valid reply, so the privacy/cost
+preference is intact; the external answer only surfaces when the internals
+loop or fail.
+
+Why default-on: chat messages are PII-scrubbed client-side before they
+leave the browser, the consent form's toggle has defaulted to checked for
+a while, and the failure mode it prevents (turn fails entirely because the
+internal pool is down or looping) is much worse for users than the
+marginal exposure of scrubbed text to a vetted external provider. Users
+can still opt out — the toggle stores an explicit "false" and the server
+respects it; the server also treats an ABSENT key as on, which is what
+actually changed (the old code treated absent as off, so anyone who never
+went through the consent form silently lost fallback).
+
+What we deliberately did NOT build for selection:
+
+* **Learned/persistent routing weights.** The feedback loop (below) should
+  produce data first; hand-tuning quality() numbers against real win/loss
+  and preference metrics is cheap and auditable. A learned router is
+  premature while the metric volume is small.
+* **Latency-aware scoring.** best_two_within_timelimit already gives fast
+  models an edge (slow ones miss the window); double-counting latency in
+  scores would bias toward terse models.
+* **Cross-session offender persistence.** A backend that loops for one
+  user is usually a backend+context interaction, not a global property;
+  persisting strikes would punish it everywhere for one bad conversation
+  and add a writer to a hot path. Session scope + metrics is enough to
+  see a globally sick backend.
+
+## 5. Choosing between answers: alternates as a product feature
+
+best_two_within_timelimit returns (best, runner_up, both scores, both
+originating calls). The runner-up becomes a side-by-side alternate answer
+("🔀 See an alternate answer") ONLY when:
+
+* the two scores are closely tied — runner_up >= 0.8 * best with both
+  positive (scores_closely_tied). Given the quadratic tiers this means
+  "same tier, comparable content" (e.g. the same model's truncated- vs
+  full-history calls at 8000 vs 10000 base, or two same-tier backends);
+  a cross-tier runner-up never qualifies, and
+* it's presentable (no tool/action tokens, not a near-duplicate of the
+  primary, not itself a repeat, no safety flags), and
+* tool processing didn't rewrite the primary reply.
+
+The tie requirement is what makes the feature honest: when the scorer has
+a clear winner, showing a second answer is noise; when the race was
+genuinely close, the user is the right tiebreaker — and their choice is
+recorded (fhi_chat_answer_feedback_total{preferred=primary|alternate})
+without starting an LLM turn. Only the primary is persisted; replays show
+one answer.
+
+**This is also the model-selection feedback loop**: close ties are exactly
+the cases where quality() can't separate two backends, and the preference
+metric accumulates evidence about which one users actually prefer. When
+that data disagrees with the quality map, adjust the map.
+
+## 6. Context management ("context shedding")
+
+* Histories <= 20 messages go to the model verbatim (plus the full history
+  variant for large-context models when it fits their window minus 8k).
+* Beyond 20, the dropped prefix is summarized once per 10-message band
+  (`% SUMMARIZATION_INTERVAL <= 1` — the <= 1 exists because same-role
+  merging changes parity; a rare double-fire produces byte-identical
+  output because _summarize_history REPLACES the previous summary block
+  instead of nesting it).
+* The accreted summary context is bounded (bound_summary_context, 6000
+  chars, keeps the tail) — an unbounded blob was crowding the actual
+  conversation out of attention, which is one of the ways replies degraded
+  into replaying earlier turns.
+* The per-turn "panda" summary (model-provided context for the next call)
+  is stored in summary_for_next_call, capped at MAX_STORED_SUMMARIES=20;
+  a missing panda gets a placeholder that a background summarization task
+  swaps out transactionally.
+* Summarization is hard-bounded at 90s and degrades to "keep existing
+  context" — it must never stall the interactive turn.
+
+## 7. Debuggability
+
+Three levels, in increasing detail:
+
+1. **Always-on INFO log line per LLM pass**: picked backend + score,
+   runner-up + score + tied?, candidate count, rejected-repeat count,
+   retry usage, elapsed ms. This is the production triage record.
+2. **Prometheus metrics**: repeats (rejected/delivered), alternates
+   offered, answer feedback, turn outcomes.
+3. **Debug frames** (localStorage `fhi_chat_debug = "true"`, honored only
+   for DEBUG deployments and staff accounts): per turn the server sends
+   - `debug_llm_input` — the EXACT wrapped message, context summary,
+     history counts, variants, state hint;
+   - `debug_llm_result` — picked/runner-up models and scores, per-candidate
+     score log, closely_tied, alternate_offered, rejected repeats, current
+     repeat-offender strikes, retry path, allow_repeated_reply, elapsed.
+   The frontend logs both to the console AND renders them as a collapsed
+   "🔧 Debug" panel under the assistant message they produced, so
+   debugging no longer requires devtools open before the turn.
+
+## 8. Known gaps and roadmap (prioritized)
+
+1. **Ship the city DB in k8s.** guess_us_state and ASN tracking soft-fail
+   without FHI_GEOIP_CITY_DB (startup warns exactly this); the chart
+   doesn't yet mount a geoip2fast city database. Low effort, unlocks the
+   state hint in prod.
+2. **Streaming responses.** The infra streams status heartbeats but final
+   answers arrive whole. Token streaming from the winning backend would
+   cut perceived latency drastically — but it collides with fan-out
+   scoring (you can't score a stream you haven't finished). A pragmatic
+   shape: keep the fan-out for the first N seconds, then stream the
+   leader's remainder. Biggest UX win, medium-large effort.
+3. **Legacy backend prompt shape.** RemoteHealthInsurance
+   (supports_system=False) receives the system prompt folded into the
+   final user message. It's quality 101 so it rarely wins, but its calls
+   burn capacity; consider dropping it from the chat pool entirely.
+4. **Retry-button double turns.** The client retry sends the same message
+   again; the server merges duplicates at persist time (serial + deduped)
+   but the second LLM turn still runs. An in-flight turn-id (client echoes
+   it, server drops re-submits of a live turn) would make retry free.
+5. **Per-model win/lose metrics.** The debug frame reports the picked
+   model; promote that to a bounded-cardinality counter
+   (fhi_chat_model_wins_total{model}) so the quality map can be tuned
+   from dashboards, not log greps. (Deliberately deferred: needs a label
+   allowlist to keep cardinality bounded.)
+6. **Summarization model diversity.** summarize_chat_history routes to one
+   summarizer; a bad summary quietly poisons every later turn's context.
+   Cheap guard: score summaries with the repetition detector before
+   storing (a summary that mostly repeats the raw history is fine; one
+   that repeats the model's last REPLY is the poison case).
+7. **Evaluation harness.** The loop bug shipped because nothing exercised
+   multi-turn conversations against scripted "sticky" backends. The test
+   suite now covers the ladder with RecordingChatModel; a nightly
+   scripted-conversation eval against the real internal backends (no
+   users) would catch regressions the unit layer can't.
+
+## 9. Invariants to preserve (change these knowingly or not at all)
+
+* The scorer may only hard-reject (-inf) candidates that are REPEATS or
+  invalid — never for style. The last-resort path must stay finite.
+* allow_repeated_reply / repeat exemptions are derived from the RAW user
+  message, never from the wrapped prompt (wrapper text contains the word
+  "repeat").
+* The alternate answer is ephemeral: never persisted, never replayed.
+* The state hint is transient and UNCONFIRMED: injected per turn, never
+  stored on the chat.
+* Summarization and geo lookups soft-fail; nothing on the turn path is
+  allowed to hard-block the reply.
+* Every wait on the turn path has an explicit bound that fits inside
+  FHI_CHAT_TURN_BUDGET.

--- a/docs/chat-pipeline.md
+++ b/docs/chat-pipeline.md
@@ -94,6 +94,29 @@ canned reply) is what turned the scorer from "prefers not to loop" into
 "cannot deliver a loop from the primary pass". The old -500 soft penalty
 was invisible next to an 8000+ base — that was the production loop.
 
+### Similarity detection: two non-obvious constraints
+
+`response_similarity.py` is small but has two properties that must not be
+"cleaned up":
+
+* **`autojunk=False` is required for correctness.** difflib's default
+  autojunk heuristic marks any element appearing in >1% of a 200+ element
+  sequence as junk and refuses to match on it. On character-level natural
+  language that is every space and every common letter, so `ratio()`
+  collapses: two 430-char replies differing by one reworded sentence
+  measured **0.33 with autojunk vs 0.96 without**, against a 0.9 threshold.
+  With the default, every long near-verbatim repeat — precisely what the
+  detector exists for — scored as unrelated.
+* **The cheap gates in front of `ratio()` are load-bearing, not premature
+  optimization.** Scoring runs inline on the event loop inside the fan-out,
+  several comparisons per candidate, ~20 candidates per turn. With
+  `autojunk=False`, `ratio()` is genuinely O(n·m). Two exact upper bounds run
+  first — the length bound `2·min/(la+lb)`, then word-set Jaccard against a
+  loose 0.35 floor — so unrelated pairs (the overwhelming majority) cost
+  ~0.1ms instead of 15-60ms, and only plausible repeats pay the full
+  comparison. `quick_ratio` is *not* a useful gate here: it compares
+  character multisets and reads ~0.98 for two unrelated English texts.
+
 ## 3. The anti-loop ladder (all layers)
 
 Defenses stack from the inside out, so any single layer failing still
@@ -294,3 +317,27 @@ Three levels, in increasing detail:
   allowed to hard-block the reply.
 * Every wait on the turn path has an explicit bound that fits inside
   FHI_CHAT_TURN_BUDGET.
+* `user_requested_repeat` is the master switch that disables the whole
+  ladder, so it must match an explicit REQUEST ("repeat that", "say that
+  again"), never the topic. "repeat MRI", "repeat colonoscopy", "repeat
+  prescription" and "repeat denial" are ordinary vocabulary here, and a bare
+  `\brepeat\b` turned every one of those conversations into an unprotected
+  one. Erring toward not-matching is the safe direction.
+* `is_canned_reply` must require the WHOLE mandated block, not a marker
+  phrase: the system prompt tells the model to link the Medicaid FAQ on any
+  work-requirements answer, so a marker-only test exempted every ordinary
+  Medicaid reply — including the looping ones.
+* Anything that screens a reply for tool calls must use
+  `patterns.contains_tool_call` (the handlers' own flags). Several tool
+  patterns are `^...$`-anchored, so a flag-less `re.search` only matches a
+  call at the very start of a reply.
+* Compare like with like: a raw generation still carries its trailing
+  `🐼<summary>` while history stores the split answer. Comparing the two
+  shapes put a byte-identical repeat at ~0.76 similarity, under threshold.
+* Externals may appear in the primary fan-out OR the retry fallback list,
+  never both — `build_retry_calls` iterates both, so a backend in each got
+  four identical paid requests per retry.
+* Internal (LLM-context-only) history entries are identified by their
+  `internal` flag, not by a content prefix a user could type, and every view
+  of the history — WebSocket replay, REST listing, chat titles, previews —
+  must filter them the same way.

--- a/fhi_users/audit.py
+++ b/fhi_users/audit.py
@@ -12,6 +12,8 @@ Design goals:
 - Optional: Controlled by ENABLE_AUDIT_LOGGING setting
 """
 
+import os
+import threading
 from dataclasses import dataclass
 from enum import Enum
 from typing import Optional, Union, Protocol, Any
@@ -361,6 +363,169 @@ def get_asn_info(ip_address: Optional[str]) -> tuple[str, str]:
         pass
 
     return ("", "")
+
+
+# --- IP -> US state guess (for chat context, transient only) ---
+
+# 2-letter postal code -> full state name, used to normalize whatever the geo
+# database returns into the full name the chat/Medicaid tooling expects.
+_US_STATE_NAMES_BY_CODE = {
+    "AL": "Alabama",
+    "AK": "Alaska",
+    "AZ": "Arizona",
+    "AR": "Arkansas",
+    "CA": "California",
+    "CO": "Colorado",
+    "CT": "Connecticut",
+    "DE": "Delaware",
+    "DC": "District of Columbia",
+    "FL": "Florida",
+    "GA": "Georgia",
+    "HI": "Hawaii",
+    "ID": "Idaho",
+    "IL": "Illinois",
+    "IN": "Indiana",
+    "IA": "Iowa",
+    "KS": "Kansas",
+    "KY": "Kentucky",
+    "LA": "Louisiana",
+    "ME": "Maine",
+    "MD": "Maryland",
+    "MA": "Massachusetts",
+    "MI": "Michigan",
+    "MN": "Minnesota",
+    "MS": "Mississippi",
+    "MO": "Missouri",
+    "MT": "Montana",
+    "NE": "Nebraska",
+    "NV": "Nevada",
+    "NH": "New Hampshire",
+    "NJ": "New Jersey",
+    "NM": "New Mexico",
+    "NY": "New York",
+    "NC": "North Carolina",
+    "ND": "North Dakota",
+    "OH": "Ohio",
+    "OK": "Oklahoma",
+    "OR": "Oregon",
+    "PA": "Pennsylvania",
+    "RI": "Rhode Island",
+    "SC": "South Carolina",
+    "SD": "South Dakota",
+    "TN": "Tennessee",
+    "TX": "Texas",
+    "UT": "Utah",
+    "VT": "Vermont",
+    "VA": "Virginia",
+    "WA": "Washington",
+    "WV": "West Virginia",
+    "WI": "Wisconsin",
+    "WY": "Wyoming",
+}
+_US_STATE_NAMES = {name.lower(): name for name in _US_STATE_NAMES_BY_CODE.values()}
+
+# Lazily-created, cached geo reader (loading the database per lookup would be
+# far too slow for a per-message call). _geo_reader_failed remembers a failed
+# init so we don't retry the import/load on every chat message.
+_geo_reader: Any = None
+_geo_reader_failed = False
+_geo_reader_lock = threading.Lock()
+
+
+def _get_geo_reader() -> Any:
+    global _geo_reader, _geo_reader_failed
+    if _geo_reader is not None or _geo_reader_failed:
+        return _geo_reader
+    with _geo_reader_lock:
+        if _geo_reader is not None or _geo_reader_failed:
+            return _geo_reader
+        try:
+            from geoip2fast import GeoIP2Fast
+
+            # Subdivision (state) data needs a city-level database; the
+            # default country-level file yields no state and guesses stay
+            # None. Point FHI_GEOIP_CITY_DB at a city .dat.gz to enable.
+            db_path = os.environ.get("FHI_GEOIP_CITY_DB")
+            if db_path:
+                _geo_reader = GeoIP2Fast(geoip2fast_data_file=db_path)
+            else:
+                _geo_reader = GeoIP2Fast()
+        except Exception:
+            # geoip2fast not installed / database missing: state guessing is
+            # an optional enhancement (same posture as get_asn_info above).
+            _geo_reader_failed = True
+            _geo_reader = None
+    return _geo_reader
+
+
+def _reset_geo_reader_cache_for_tests() -> None:
+    """Test hook: clear the cached geo reader / failure flag."""
+    global _geo_reader, _geo_reader_failed
+    with _geo_reader_lock:
+        _geo_reader = None
+        _geo_reader_failed = False
+
+
+def _normalize_state_guess(value: str) -> Optional[str]:
+    """Map a raw subdivision value (code or name) to a full US state name."""
+    cleaned = value.strip()
+    if not cleaned:
+        return None
+    # Some databases prefix subdivision codes with the country ("US-CA").
+    if "-" in cleaned:
+        cleaned = cleaned.rsplit("-", 1)[-1].strip()
+    if len(cleaned) == 2:
+        return _US_STATE_NAMES_BY_CODE.get(cleaned.upper())
+    return _US_STATE_NAMES.get(cleaned.lower())
+
+
+def guess_us_state(ip_address: Optional[str]) -> Optional[str]:
+    """Best-effort guess of the US state for an IP address, or None.
+
+    Used to seed the chat with an UNCONFIRMED location hint so the model can
+    ask "it looks like you might be in California, is that right?" instead of
+    a cold "which state are you in?". Requires geoip2fast with a city-level
+    database (see _get_geo_reader); returns None (never raises) when the
+    dependency, the database, or subdivision data is unavailable, when the IP
+    isn't clearly US, or on any lookup error. Callers must treat the value as
+    a transient guess: present it to the model as unconfirmed and never
+    persist it for anonymous users.
+    """
+    if not ip_address:
+        return None
+    reader = _get_geo_reader()
+    if reader is None:
+        return None
+    try:
+        result = reader.lookup(str(ip_address).strip())
+    except Exception:
+        return None
+    if result is None:
+        return None
+    country = str(getattr(result, "country_code", "") or "").strip().upper()
+    if country and country != "US":
+        return None
+    # Probe the field shapes different geoip2fast versions/databases use for
+    # subdivision info, on both the result and its nested city object.
+    city_obj = getattr(result, "city", None)
+    for source in (result, city_obj):
+        if source is None:
+            continue
+        for attr in (
+            "subdivision_code",
+            "subdivision_name",
+            "region_code",
+            "region_name",
+            "state",
+            "state_code",
+            "state_name",
+        ):
+            raw = getattr(source, attr, None)
+            if isinstance(raw, str) and raw.strip():
+                state = _normalize_state_guess(raw)
+                if state:
+                    return state
+    return None
 
 
 def tracking_metadata_for_request(

--- a/fhi_users/audit.py
+++ b/fhi_users/audit.py
@@ -338,31 +338,30 @@ def get_asn_info(ip_address: Optional[str]) -> tuple[str, str]:
     Returns:
         Tuple of (asn_number, asn_name). Both empty strings if lookup fails.
 
-    Note: This is a placeholder that can be enhanced with geoip2fast or similar.
-    For now, returns empty strings. To enable ASN lookup, install geoip2fast
-    and download the ASN database.
+    Uses the shared cached geoip2fast reader (see _get_geo_reader), which is
+    only constructed when FHI_GEOIP_CITY_DB is set. Point it at an ASN-bearing
+    database (geoip2fast-city-asn-ipv6.dat.gz) to get ASN data alongside the
+    state guess; with the key unset this returns empty strings — the
+    pre-geoip2fast behavior.
     """
     if not ip_address:
         return ("", "")
 
+    reader = _get_geo_reader()
+    if reader is None:
+        return ("", "")
     try:
-        # Try to import geoip2fast if available
-        from geoip2fast import GeoIP2Fast
-
-        geoip = GeoIP2Fast()
-        result = geoip.lookup(ip_address)
-        if result and hasattr(result, "asn"):
-            asn_num = str(result.asn) if result.asn else ""
-            asn_name = str(result.asn_name)[:200] if result.asn_name else ""
-            return (asn_num, asn_name)
-    except ImportError:
-        # geoip2fast not installed, that's fine
-        pass
+        result = reader.lookup(str(ip_address).strip())
+        if result is None:
+            return ("", "")
+        # geoip2fast exposes asn_name (and asn_cidr); some builds/forks also
+        # expose a numeric asn. Probe defensively.
+        asn_num = str(getattr(result, "asn", "") or "")
+        asn_name = str(getattr(result, "asn_name", "") or "")[:200]
+        return (asn_num, asn_name)
     except Exception:
         # Any lookup failure, return empty
-        pass
-
-    return ("", "")
+        return ("", "")
 
 
 # --- IP -> US state guess (for chat context, transient only) ---
@@ -424,9 +423,19 @@ _US_STATE_NAMES_BY_CODE = {
 }
 _US_STATE_NAMES = {name.lower(): name for name in _US_STATE_NAMES_BY_CODE.values()}
 
+# The configuration key that switches IP geo lookups on: path to a
+# geoip2fast CITY-level database (state guessing needs subdivision data,
+# which the package's bundled country/ASN databases do not carry). Use
+# geoip2fast-city-asn-ipv6.dat.gz to also get ASN data for get_asn_info.
+# See README "GeoIP" section. Without it, guess_us_state and get_asn_info
+# soft-fail to None/empty — a startup warning names this key.
+GEOIP_CITY_DB_ENV = "FHI_GEOIP_CITY_DB"
+
 # Lazily-created, cached geo reader (loading the database per lookup would be
-# far too slow for a per-message call). _geo_reader_failed remembers a failed
-# init so we don't retry the import/load on every chat message.
+# far too slow for a per-message call: the city database takes seconds to
+# load). _geo_reader_failed remembers a failed init so we don't retry the
+# import/load on every chat message. The FIRST call still pays the load, so
+# async callers must wrap lookups in a thread (the chat consumer does).
 _geo_reader: Any = None
 _geo_reader_failed = False
 _geo_reader_lock = threading.Lock()
@@ -439,20 +448,26 @@ def _get_geo_reader() -> Any:
     with _geo_reader_lock:
         if _geo_reader is not None or _geo_reader_failed:
             return _geo_reader
+        # Deliberately gated on the env key rather than falling back to the
+        # package's bundled country database: without city data the state
+        # guess can never work, and silently loading a database that can't
+        # serve the feature just hides the misconfiguration (the startup
+        # check warns instead).
+        db_path = os.environ.get(GEOIP_CITY_DB_ENV)
+        if not db_path:
+            _geo_reader_failed = True
+            return None
         try:
             from geoip2fast import GeoIP2Fast
 
-            # Subdivision (state) data needs a city-level database; the
-            # default country-level file yields no state and guesses stay
-            # None. Point FHI_GEOIP_CITY_DB at a city .dat.gz to enable.
-            db_path = os.environ.get("FHI_GEOIP_CITY_DB")
-            if db_path:
-                _geo_reader = GeoIP2Fast(geoip2fast_data_file=db_path)
-            else:
-                _geo_reader = GeoIP2Fast()
+            _geo_reader = GeoIP2Fast(geoip2fast_data_file=db_path)
         except Exception:
-            # geoip2fast not installed / database missing: state guessing is
-            # an optional enhancement (same posture as get_asn_info above).
+            # Missing package or unreadable database file: geo features are
+            # an optional enhancement and must never break request handling.
+            logger.opt(exception=True).warning(
+                f"Failed to load GeoIP database from {GEOIP_CITY_DB_ENV}="
+                f"{db_path!r}; IP state guessing and ASN lookups disabled."
+            )
             _geo_reader_failed = True
             _geo_reader = None
     return _geo_reader
@@ -464,6 +479,61 @@ def _reset_geo_reader_cache_for_tests() -> None:
     with _geo_reader_lock:
         _geo_reader = None
         _geo_reader_failed = False
+
+
+def geo_lookup_status() -> tuple[bool, Optional[str]]:
+    """Whether IP geo lookups (state guess + ASN) are available, and why not.
+
+    Cheap enough for startup: it checks the key and the package import but
+    does NOT load the database (that happens lazily on first lookup).
+
+    Returns:
+        (enabled, reason) — reason is None when enabled, otherwise a short
+        human-readable explanation naming the fix.
+    """
+    db_path = os.environ.get(GEOIP_CITY_DB_ENV)
+    if not db_path:
+        return (
+            False,
+            f"{GEOIP_CITY_DB_ENV} is not set (path to a geoip2fast city-level "
+            f"database, e.g. geoip2fast-city-asn-ipv6.dat.gz)",
+        )
+    try:
+        import geoip2fast  # noqa: F401
+    except ImportError:
+        return (False, "the geoip2fast package is not installed")
+    if not os.path.exists(db_path):
+        return (False, f"{GEOIP_CITY_DB_ENV}={db_path!r} does not exist")
+    return (True, None)
+
+
+_geo_startup_warning_emitted = False
+
+
+def warn_if_geo_lookups_disabled() -> None:
+    """Log a one-line startup warning when geo lookups are disabled.
+
+    Soft fail by design: the chat state guess and ASN tracking silently
+    degrade without the database, and this warning is the only signal — so
+    it names the exact key to set. Called from AppConfig.ready(); guarded so
+    repeat ready() calls (tests, autoreload) warn once per process.
+    """
+    global _geo_startup_warning_emitted
+    if _geo_startup_warning_emitted:
+        return
+    _geo_startup_warning_emitted = True
+    enabled, reason = geo_lookup_status()
+    if enabled:
+        logger.info(
+            f"GeoIP lookups enabled ({GEOIP_CITY_DB_ENV}="
+            f"{os.environ.get(GEOIP_CITY_DB_ENV)!r})"
+        )
+        return
+    logger.warning(
+        f"GeoIP lookups disabled: {reason}. Chat IP-based state guessing "
+        f"and ASN tracking will soft-fail (return nothing). See the README "
+        f"'GeoIP' section for setup."
+    )
 
 
 def _normalize_state_guess(value: str) -> Optional[str]:

--- a/fhi_users/audit.py
+++ b/fhi_users/audit.py
@@ -354,8 +354,9 @@ def get_asn_info(ip_address: Optional[str]) -> tuple[str, str]:
         result = reader.lookup(str(ip_address).strip())
         if result is None:
             return ("", "")
-        # geoip2fast exposes asn_name (and asn_cidr); some builds/forks also
-        # expose a numeric asn. Probe defensively.
+        # geoip2fast (1.2.x) exposes asn_name and asn_cidr but NO numeric
+        # ASN field, so the numeric slot stays empty with this library (as it
+        # always has); the probe is kept for forks/builds that add one.
         asn_num = str(getattr(result, "asn", "") or "")
         asn_name = str(getattr(result, "asn_name", "") or "")[:200]
         return (asn_num, asn_name)
@@ -504,6 +505,16 @@ def geo_lookup_status() -> tuple[bool, Optional[str]]:
         return (False, "the geoip2fast package is not installed")
     if not os.path.exists(db_path):
         return (False, f"{GEOIP_CITY_DB_ENV}={db_path!r} does not exist")
+    # Cheap sanity only -- a full parse would load the multi-second database
+    # in every management command's ready(). A corrupt-but-nonempty file is
+    # still caught (and warned about) lazily by _get_geo_reader on first use.
+    if not os.access(db_path, os.R_OK):
+        return (False, f"{GEOIP_CITY_DB_ENV}={db_path!r} is not readable")
+    try:
+        if os.path.getsize(db_path) == 0:
+            return (False, f"{GEOIP_CITY_DB_ENV}={db_path!r} is an empty file")
+    except OSError as e:
+        return (False, f"{GEOIP_CITY_DB_ENV}={db_path!r} is not accessible: {e}")
     return (True, None)
 
 
@@ -572,8 +583,10 @@ def guess_us_state(ip_address: Optional[str]) -> Optional[str]:
         return None
     if result is None:
         return None
+    # Require an explicit US result: a missing/empty country code with a
+    # subdivision present is unconfirmed data, not a US state.
     country = str(getattr(result, "country_code", "") or "").strip().upper()
-    if country and country != "US":
+    if country != "US":
         return None
     # Probe the field shapes different geoip2fast versions/databases use for
     # subdivision info, on both the result and its nested city object.

--- a/fhi_users/audit.py
+++ b/fhi_users/audit.py
@@ -12,6 +12,7 @@ Design goals:
 - Optional: Controlled by ENABLE_AUDIT_LOGGING setting
 """
 
+import ipaddress
 import os
 import threading
 from dataclasses import dataclass
@@ -547,6 +548,32 @@ def warn_if_geo_lookups_disabled() -> None:
     )
 
 
+def warm_geo_reader_in_background() -> None:
+    """Load the GeoIP database off the request path, at startup.
+
+    The city database takes seconds to parse and the load is serialized on a
+    process-global lock. Left lazy, that cost landed on whichever request
+    touched geo first -- and one of those call sites
+    (extract_tracking_info_from_scope -> get_asn_info) is a plain synchronous
+    call inside the async WebSocket consumer, so the parse ran ON the event
+    loop and stalled every other socket on the worker.
+
+    Daemon thread so it never delays or blocks process shutdown; failures are
+    already logged (and latched) by _get_geo_reader.
+    """
+    enabled, _ = geo_lookup_status()
+    if not enabled:
+        return
+
+    def _warm() -> None:
+        try:
+            _get_geo_reader()
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning(f"GeoIP warm-up failed: {type(e).__name__}: {e}")
+
+    threading.Thread(target=_warm, name="geoip-warmup", daemon=True).start()
+
+
 def _normalize_state_guess(value: str) -> Optional[str]:
     """Map a raw subdivision value (code or name) to a full US state name."""
     cleaned = value.strip()
@@ -574,11 +601,22 @@ def guess_us_state(ip_address: Optional[str]) -> Optional[str]:
     """
     if not ip_address:
         return None
+    # The caller derives this from X-Forwarded-For / X-Real-IP, which are
+    # client-supplied and never validated upstream, so reject anything that
+    # is not a literal IP address before it reaches the third-party parser
+    # (and bound the work an arbitrary header value can cause).
+    candidate = str(ip_address).strip()
+    if len(candidate) > 45:  # longest possible IPv6 form
+        return None
+    try:
+        ipaddress.ip_address(candidate)
+    except ValueError:
+        return None
     reader = _get_geo_reader()
     if reader is None:
         return None
     try:
-        result = reader.lookup(str(ip_address).strip())
+        result = reader.lookup(candidate)
     except Exception:
         return None
     if result is None:

--- a/fighthealthinsurance/apps.py
+++ b/fighthealthinsurance/apps.py
@@ -12,3 +12,10 @@ class FightHealthInsuranceConfig(AppConfig):
         from fighthealthinsurance.db_pool_metrics import register_pool_stats_collector
 
         register_pool_stats_collector()
+
+        # Soft-fail visibility for IP geo lookups (chat state guessing +
+        # ASN tracking): warn once, naming FHI_GEOIP_CITY_DB, when they are
+        # disabled — otherwise the features silently return nothing.
+        from fhi_users.audit import warn_if_geo_lookups_disabled
+
+        warn_if_geo_lookups_disabled()

--- a/fighthealthinsurance/apps.py
+++ b/fighthealthinsurance/apps.py
@@ -16,6 +16,14 @@ class FightHealthInsuranceConfig(AppConfig):
         # Soft-fail visibility for IP geo lookups (chat state guessing +
         # ASN tracking): warn once, naming FHI_GEOIP_CITY_DB, when they are
         # disabled — otherwise the features silently return nothing.
-        from fhi_users.audit import warn_if_geo_lookups_disabled
+        from fhi_users.audit import (
+            warm_geo_reader_in_background,
+            warn_if_geo_lookups_disabled,
+        )
 
         warn_if_geo_lookups_disabled()
+        # Parse the (multi-second) city database at startup in a daemon
+        # thread, so no request — including the synchronous ASN lookup that
+        # runs inside the async chat consumer — pays the load on the event
+        # loop.
+        warm_geo_reader_in_background()

--- a/fighthealthinsurance/chat/chat_persistence.py
+++ b/fighthealthinsurance/chat/chat_persistence.py
@@ -13,6 +13,7 @@ row lock fully serializes writers; on sqlite (tests) ``select_for_update`` is
 a no-op but sqlite serializes writes anyway and the merge logic still runs.
 """
 
+import re
 import uuid
 from typing import Any, Dict, List, Optional
 
@@ -21,6 +22,39 @@ from django.db import transaction
 from django.utils import timezone
 
 from loguru import logger
+
+# Legacy shape of the LLM-context-only link notes, from before they carried an
+# explicit `internal` flag. Deliberately anchored to the FULL generated shape
+# ("... Appeal #12", "... Prior Auth Request #3") rather than the bare prefix:
+# the prefix alone is text a user can type, and matching it hid their own
+# message from their own replay while every server-side view still had it.
+_LEGACY_INTERNAL_NOTE_RE = re.compile(
+    r"^(?:Linked this chat to|This chat is already linked to)\s+"
+    r"(?:Appeal|Prior Auth Request)\s+#\d+",
+)
+
+
+def is_internal_history_message(message: Dict[str, Any]) -> bool:
+    """Whether a stored history entry is LLM-context-only.
+
+    Internal notes are persisted with role=user so the model sees them, but
+    they were never typed by the user and must not be shown as user messages
+    -- in replay OR in any other view of the history (REST listings, chat
+    titles, previews).
+    """
+    if message.get("internal"):
+        return True
+    if message.get("role") != "user":
+        return False
+    content = message.get("content") or ""
+    return bool(_LEGACY_INTERNAL_NOTE_RE.match(content))
+
+
+def visible_history(
+    history: Optional[List[Dict[str, Any]]],
+) -> List[Dict[str, Any]]:
+    """History with LLM-context-only messages removed."""
+    return [m for m in (history or []) if not is_internal_history_message(m)]
 
 
 def merge_new_messages(
@@ -44,7 +78,19 @@ def merge_new_messages(
             last = history[-1]
             if last.get("role") == role and last.get("content") == content:
                 continue
-            if role == "user" and last.get("role") == "user":
+            if (
+                role == "user"
+                and last.get("role") == "user"
+                # Only merge messages of the same internal-ness. This branch
+                # returns before the internal flag is applied below, so
+                # merging an internal LLM-context note into a user-authored
+                # message silently dropped the flag -- and the merged text no
+                # longer started with a known internal prefix either, so
+                # replay rendered the system note inside the user's own
+                # bubble. A failed turn leaves a user-role tail, which is
+                # exactly when the next internal note would hit this path.
+                and bool(last.get("internal")) == bool(msg.get("internal"))
+            ):
                 last["content"] = f"{last.get('content')} {content}"
                 last["timestamp"] = timezone.now().isoformat()
                 continue

--- a/fighthealthinsurance/chat/chat_persistence.py
+++ b/fighthealthinsurance/chat/chat_persistence.py
@@ -24,7 +24,7 @@ from loguru import logger
 
 
 def merge_new_messages(
-    history: List[Dict[str, Any]], new_messages: List[Dict[str, str]]
+    history: List[Dict[str, Any]], new_messages: List[Dict[str, Any]]
 ) -> List[Dict[str, Any]]:
     """Append messages to a history list with tail-dedupe and user-merge.
 
@@ -48,19 +48,31 @@ def merge_new_messages(
                 last["content"] = f"{last.get('content')} {content}"
                 last["timestamp"] = timezone.now().isoformat()
                 continue
-        history.append(
-            {
-                "role": role,
-                "content": content,
-                "timestamp": timezone.now().isoformat(),
-            }
-        )
+        entry: Dict[str, Any] = {
+            "role": role,
+            "content": content,
+            "timestamp": timezone.now().isoformat(),
+        }
+        # LLM-context-only messages (e.g. appeal-link notes stored with
+        # role=user) carry an internal flag so history replay can skip them.
+        if msg.get("internal"):
+            entry["internal"] = True
+        history.append(entry)
     return history
+
+
+# Upper bound on stored context summaries. Only the last two are ever read
+# (chat_interface builds the LLM context from them), but every turn appends
+# one -- long chats used to accrete hundreds of KB-sized entries onto the
+# row, bloating each read/write of the chat. Placeholders trimmed away
+# before their background summary lands are fine: the replacement helper
+# no-ops when the tag is gone.
+MAX_STORED_SUMMARIES = 20
 
 
 def _persist_chat_turn_sync(
     chat_id: uuid.UUID,
-    new_messages: List[Dict[str, str]],
+    new_messages: List[Dict[str, Any]],
     new_summaries: List[Optional[str]],
 ):
     from fighthealthinsurance.models import OngoingChat
@@ -80,6 +92,8 @@ def _persist_chat_turn_sync(
                 if not entry or (summary and summary[-1] == entry):
                     continue
                 summary.append(entry)
+            if len(summary) > MAX_STORED_SUMMARIES:
+                summary = summary[-MAX_STORED_SUMMARIES:]
             fresh.summary_for_next_call = summary
             update_fields.append("summary_for_next_call")
         fresh.save(update_fields=update_fields)
@@ -89,7 +103,7 @@ def _persist_chat_turn_sync(
 async def apersist_chat_turn(
     chat,
     *,
-    new_messages: Optional[List[Dict[str, str]]] = None,
+    new_messages: Optional[List[Dict[str, Any]]] = None,
     new_summaries: Optional[List[Optional[str]]] = None,
 ):
     """Persist a turn's additions against the fresh row; return the fresh row.

--- a/fighthealthinsurance/chat/context_manager.py
+++ b/fighthealthinsurance/chat/context_manager.py
@@ -30,6 +30,52 @@ MISSING_CONTEXT_PREFIX = "Missing context summary, refer to previous chat histor
 EARLIER_SUMMARY_LABEL = "Earlier conversation summary: "
 ADDITIONAL_CONTEXT_SEPARATOR = "\n\nAdditional context: "
 
+# Wrapper labels chat_interface adds when it hands two stored summaries to the
+# LLM. They must be recognized here so a stale summary block wrapped in them is
+# still stripped (and so a label left dangling by a strip is cleaned up).
+_SUMMARY_WRAPPER_LABELS = (
+    "Previous context summary:",
+    "Most recent context summary:",
+)
+
+
+def strip_previous_summary_blocks(existing_summary: Optional[str]) -> Optional[str]:
+    """Remove already-generated summary blocks, keeping other accreted context.
+
+    A fresh summarization covers the ENTIRE dropped prefix, so any earlier
+    ``EARLIER_SUMMARY_LABEL`` block it contains is superseded and must be
+    dropped rather than nested inside the new one.
+
+    This deliberately searches ANYWHERE in the string rather than testing
+    ``startswith``: the production caller never passes a bare summary. It
+    passes the model's own per-turn summary, or chat_interface's
+    "Previous context summary: ... Most recent context summary: ..." wrapper,
+    optionally prefixed by ``TRIMMED_CONTEXT_PREFIX`` -- so a startswith test
+    never matched and summaries nested on every band.
+    """
+    if not existing_summary:
+        return None
+    index = existing_summary.find(EARLIER_SUMMARY_LABEL)
+    if index < 0:
+        return existing_summary
+    head = existing_summary[:index]
+    # Everything from the label onward is the stale summary, except any
+    # "Additional context:" tail it carried (which may itself nest more).
+    rest = existing_summary[index:].split(ADDITIONAL_CONTEXT_SEPARATOR, 1)
+    tail = strip_previous_summary_blocks(rest[1]) if len(rest) > 1 else None
+    parts = []
+    for part in (head, tail):
+        if not part:
+            continue
+        cleaned = part.strip()
+        # Drop wrapper labels left pointing at content we just removed.
+        for label in _SUMMARY_WRAPPER_LABELS:
+            if cleaned.endswith(label):
+                cleaned = cleaned[: -len(label)].strip()
+        if cleaned and cleaned not in _SUMMARY_WRAPPER_LABELS:
+            parts.append(cleaned)
+    return "\n\n".join(parts) or None
+
 
 def make_placeholder(counter: int) -> str:
     """Create a uniquely-identified placeholder for a missing context summary."""
@@ -52,7 +98,13 @@ def bound_summary_context(context: Optional[str], max_chars: int) -> Optional[st
     """
     if not context or max_chars <= 0 or len(context) <= max_chars:
         return context
-    keep = max(0, max_chars - len(TRIMMED_CONTEXT_PREFIX))
+    keep = max_chars - len(TRIMMED_CONTEXT_PREFIX)
+    if keep <= 0:
+        # No room for the marker plus any content. `context[-0:]` is the WHOLE
+        # string, so returning the marker + slice here produced output LONGER
+        # than the input for any max_chars <= len(TRIMMED_CONTEXT_PREFIX) --
+        # the bound silently inverted. Hard-truncate instead.
+        return context[-max_chars:]
     return f"{TRIMMED_CONTEXT_PREFIX}{context[-keep:]}"
 
 
@@ -161,13 +213,11 @@ async def _summarize_history(
         )
 
         if history_summary:
-            # The fresh summary covers the whole dropped prefix, so a
+            # The fresh summary covers the whole dropped prefix, so any
             # previous full-prefix summary block in existing_summary is
-            # superseded -- keep only the non-summary context that followed
-            # it (microsite/pubmed additions etc.).
-            if existing_summary and existing_summary.startswith(EARLIER_SUMMARY_LABEL):
-                split = existing_summary.split(ADDITIONAL_CONTEXT_SEPARATOR, 1)
-                existing_summary = split[1] if len(split) > 1 else None
+            # superseded -- keep only the non-summary context around it
+            # (microsite/pubmed additions etc.).
+            existing_summary = strip_previous_summary_blocks(existing_summary)
             if existing_summary:
                 return (
                     f"{EARLIER_SUMMARY_LABEL}{history_summary}"

--- a/fighthealthinsurance/chat/context_manager.py
+++ b/fighthealthinsurance/chat/context_manager.py
@@ -20,6 +20,16 @@ SUMMARIZATION_INTERVAL = 10
 
 MISSING_CONTEXT_PREFIX = "Missing context summary, refer to previous chat history"
 
+# Labels used when combining a fresh history summary with accumulated
+# context (see _summarize_history). A previous full-prefix summary is
+# REPLACED, not nested: every summarization call covers the entire dropped
+# prefix, so the fresh summary supersedes the old block. Without the strip,
+# adjacent band triggers (e.g. a failed turn shifting history length from a
+# remainder-0 boundary to remainder 1) nested near-identical summaries
+# inside each other.
+EARLIER_SUMMARY_LABEL = "Earlier conversation summary: "
+ADDITIONAL_CONTEXT_SEPARATOR = "\n\nAdditional context: "
+
 
 def make_placeholder(counter: int) -> str:
     """Create a uniquely-identified placeholder for a missing context summary."""
@@ -88,7 +98,13 @@ async def prepare_history_for_llm(
     # same-role messages get merged (ensure_message_alternation) so the
     # length can change parity -- a strict `% N == 0` then never fires again
     # and dropped messages stop being folded into the summary at all. `<= 1`
-    # fires exactly once per band for both parities.
+    # fires once per band for either parity. When a +1 length step lands
+    # right after a boundary (e.g. a failed turn persisting only its user
+    # message), remainders 0 and 1 can BOTH fire in one band; that costs one
+    # redundant bounded summarization call, and _summarize_history replaces
+    # (never nests) the previous summary block, so the result is identical.
+    # Tracking the exact summarized boundary would need persisted state,
+    # which this rare case doesn't justify.
     messages_over_threshold = len(history_for_llm) - DEFAULT_MESSAGES_TO_KEEP
     should_summarize = messages_over_threshold % SUMMARIZATION_INTERVAL <= 1
 
@@ -145,12 +161,19 @@ async def _summarize_history(
         )
 
         if history_summary:
+            # The fresh summary covers the whole dropped prefix, so a
+            # previous full-prefix summary block in existing_summary is
+            # superseded -- keep only the non-summary context that followed
+            # it (microsite/pubmed additions etc.).
+            if existing_summary and existing_summary.startswith(EARLIER_SUMMARY_LABEL):
+                split = existing_summary.split(ADDITIONAL_CONTEXT_SEPARATOR, 1)
+                existing_summary = split[1] if len(split) > 1 else None
             if existing_summary:
                 return (
-                    f"Earlier conversation summary: {history_summary}\n\n"
-                    f"Additional context: {existing_summary}"
+                    f"{EARLIER_SUMMARY_LABEL}{history_summary}"
+                    f"{ADDITIONAL_CONTEXT_SEPARATOR}{existing_summary}"
                 )
-            return f"Earlier conversation summary: {history_summary}"
+            return f"{EARLIER_SUMMARY_LABEL}{history_summary}"
 
         logger.info("Summarization returned empty, keeping existing context")
         return existing_summary

--- a/fighthealthinsurance/chat/context_manager.py
+++ b/fighthealthinsurance/chat/context_manager.py
@@ -26,6 +26,26 @@ def make_placeholder(counter: int) -> str:
     return f"{MISSING_CONTEXT_PREFIX} [{counter}]"
 
 
+# Marker prepended when bound_summary_context trims accreted context.
+TRIMMED_CONTEXT_PREFIX = "[...earlier context trimmed...]\n"
+
+
+def bound_summary_context(context: Optional[str], max_chars: int) -> Optional[str]:
+    """Bound an accreted summary-context string to ``max_chars``.
+
+    Summaries accrete over long chats ("Earlier conversation summary: ...
+    Additional context: Earlier conversation summary: ..."), and an unbounded
+    blob crowds the actual conversation out of the model's attention -- one
+    of the ways replies degrade into replaying earlier turns. Keeps the TAIL
+    (most recent context lands last in the accreted string) with a marker so
+    the model knows earlier context was dropped.
+    """
+    if not context or max_chars <= 0 or len(context) <= max_chars:
+        return context
+    keep = max(0, max_chars - len(TRIMMED_CONTEXT_PREFIX))
+    return f"{TRIMMED_CONTEXT_PREFIX}{context[-keep:]}"
+
+
 async def prepare_history_for_llm(
     chat_history: Optional[List[Dict[str, str]]],
     existing_summary: Optional[str],
@@ -63,9 +83,14 @@ async def prepare_history_for_llm(
     # Preserve full history for models with large context windows
     full_history_for_llm = list(history_for_llm)
 
-    # Check if we should summarize (every N messages after threshold)
+    # Check if we should summarize (once per N-message band after the
+    # threshold). History normally grows by 2 per turn, but consecutive
+    # same-role messages get merged (ensure_message_alternation) so the
+    # length can change parity -- a strict `% N == 0` then never fires again
+    # and dropped messages stop being folded into the summary at all. `<= 1`
+    # fires exactly once per band for both parities.
     messages_over_threshold = len(history_for_llm) - DEFAULT_MESSAGES_TO_KEEP
-    should_summarize = messages_over_threshold % SUMMARIZATION_INTERVAL == 0
+    should_summarize = messages_over_threshold % SUMMARIZATION_INTERVAL <= 1
 
     if should_summarize:
         summarized_context = await _summarize_history(

--- a/fighthealthinsurance/chat/llm_client.py
+++ b/fighthealthinsurance/chat/llm_client.py
@@ -115,6 +115,20 @@ USER_REQUESTED_REPEAT_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Markers of replies the system prompt REQUIRES to be sent verbatim (e.g. the
+# Medicaid work-requirements block must always be that exact text). Repeating
+# them across turns is by design, so they are exempt from HARD rejection —
+# soft repetition penalties still apply, keeping a fresh non-canned answer
+# preferred when one exists.
+CANNED_REPLY_MARKERS = ("Medicaid Work Requirements FAQ",)
+
+
+def is_canned_reply(text: Optional[str]) -> bool:
+    """Whether the reply is one of the mandated verbatim canned responses."""
+    if not text:
+        return False
+    return any(marker in text for marker in CANNED_REPLY_MARKERS)
+
 
 def user_requested_repeat(message: Optional[str]) -> bool:
     """True when the user's message explicitly asks us to repeat ourselves."""
@@ -139,6 +153,8 @@ def find_repeated_reply(
     repeat still won the fan-out race.
     """
     if not response_text:
+        return None
+    if is_canned_reply(response_text):
         return None
     if current_message and is_mostly_repeated(response_text, current_message):
         return "echoes_user_message"

--- a/fighthealthinsurance/chat/llm_client.py
+++ b/fighthealthinsurance/chat/llm_client.py
@@ -14,14 +14,19 @@ from fighthealthinsurance.chat.safety_filters import detect_false_promises
 from fighthealthinsurance.chat.tools.patterns import ALL_TOOL_PATTERNS as tools_regex
 from fighthealthinsurance.ml.ml_models import RemoteModelLike, repetition_penalty
 
-# Shared similarity helpers (stdlib-only module, importable from both this
-# layer and ml_models without a cycle). normalize_text/bag_of_words are
-# re-exported from here for existing importers/tests.
+# Shared similarity/exemption helpers (stdlib-only module, importable from
+# both this layer and ml_models without a cycle). normalize_text,
+# bag_of_words, is_canned_reply, user_requested_repeat and the exemption
+# constants are re-exported from here for existing importers/tests.
 from fighthealthinsurance.ml.response_similarity import (
+    CANNED_REPLY_MARKERS,
+    USER_REQUESTED_REPEAT_RE,
     bag_of_words,
+    is_canned_reply,
     is_mostly_repeated,
     normalize_text,
     response_similarity,
+    user_requested_repeat,
 )
 from fighthealthinsurance.utils import ensure_message_alternation
 
@@ -107,33 +112,6 @@ OLDER_USER_REPEAT_PENALTY = -10.0
 # HARD repeat rejection (covers both A-A loops and A-B-A alternation loops).
 RECENT_ASSISTANT_REPLIES_TO_CHECK = 3
 
-# When the user explicitly asks for a repeat, repeating is the right answer —
-# skip the hard rejection so the turn can succeed.
-USER_REQUESTED_REPEAT_RE = re.compile(
-    r"\b(repeat|say (?:that|it) again|one more time|once more|again please|"
-    r"re-?send|(?:show|send) (?:that|it) again)\b",
-    re.IGNORECASE,
-)
-
-# Markers of replies the system prompt REQUIRES to be sent verbatim (e.g. the
-# Medicaid work-requirements block must always be that exact text). Repeating
-# them across turns is by design, so they are exempt from HARD rejection —
-# soft repetition penalties still apply, keeping a fresh non-canned answer
-# preferred when one exists.
-CANNED_REPLY_MARKERS = ("Medicaid Work Requirements FAQ",)
-
-
-def is_canned_reply(text: Optional[str]) -> bool:
-    """Whether the reply is one of the mandated verbatim canned responses."""
-    if not text:
-        return False
-    return any(marker in text for marker in CANNED_REPLY_MARKERS)
-
-
-def user_requested_repeat(message: Optional[str]) -> bool:
-    """True when the user's message explicitly asks us to repeat ourselves."""
-    return bool(message and USER_REQUESTED_REPEAT_RE.search(message))
-
 
 def find_repeated_reply(
     response_text: str,
@@ -203,6 +181,11 @@ def compute_repetition_penalty(
     response_bow = bag_of_words(response_text)
 
     # --- Check against the current user message (not yet in history) ---
+    # Severity order: exact > near-verbatim > bag-of-words. The near-repeat
+    # check runs BEFORE bag-of-words equality so a long reply sharing the
+    # exact word set (which IS a near-verbatim reorder) gets the stronger
+    # penalty; short reorders never trip the similarity path and still land
+    # in the mild bag-of-words bucket.
     if current_message:
         normalized_current = normalize_text(current_message)
         if normalized_response == normalized_current:
@@ -210,15 +193,15 @@ def compute_repetition_penalty(
             logger.debug(
                 "Response is exact repeat of current user message, applying heavy penalty"
             )
-        elif response_bow == bag_of_words(current_message):
-            penalty += BAG_OF_WORDS_REPEAT_PENALTY
-            logger.debug(
-                "Response has same bag-of-words as current user message, applying mild penalty"
-            )
         elif is_mostly_repeated(response_text, current_message):
             penalty += NEAR_REPEAT_PENALTY
             logger.debug(
                 "Response is a near-verbatim repeat of current user message, penalizing"
+            )
+        elif response_bow == bag_of_words(current_message):
+            penalty += BAG_OF_WORDS_REPEAT_PENALTY
+            logger.debug(
+                "Response has same bag-of-words as current user message, applying mild penalty"
             )
 
     if not chat_history:
@@ -235,7 +218,9 @@ def compute_repetition_penalty(
         if last_user_msg is not None and last_assistant_msg is not None:
             break
 
-    # Heavy penalties for matching the immediate previous messages in history
+    # Heavy penalties for matching the immediate previous messages in
+    # history. Same severity order as above: exact > near-verbatim >
+    # bag-of-words.
     for prev_text in [last_user_msg, last_assistant_msg]:
         if not prev_text:
             continue
@@ -245,15 +230,15 @@ def compute_repetition_penalty(
             logger.debug(
                 "Response is exact repeat of previous message, applying heavy penalty"
             )
-        elif response_bow == bag_of_words(prev_text):
-            penalty += BAG_OF_WORDS_REPEAT_PENALTY
-            logger.debug(
-                "Response has same bag-of-words as previous message, applying mild penalty"
-            )
         elif is_mostly_repeated(response_text, prev_text):
             penalty += NEAR_REPEAT_PENALTY
             logger.debug(
                 "Response is a near-verbatim repeat of previous message, penalizing"
+            )
+        elif response_bow == bag_of_words(prev_text):
+            penalty += BAG_OF_WORDS_REPEAT_PENALTY
+            logger.debug(
+                "Response has same bag-of-words as previous message, applying mild penalty"
             )
 
     # Lighter penalties for matching older messages

--- a/fighthealthinsurance/chat/llm_client.py
+++ b/fighthealthinsurance/chat/llm_client.py
@@ -13,6 +13,16 @@ from fighthealthinsurance.chat.message_preprocessor import MessageVariant
 from fighthealthinsurance.chat.safety_filters import detect_false_promises
 from fighthealthinsurance.chat.tools.patterns import ALL_TOOL_PATTERNS as tools_regex
 from fighthealthinsurance.ml.ml_models import RemoteModelLike, repetition_penalty
+
+# Shared similarity helpers (stdlib-only module, importable from both this
+# layer and ml_models without a cycle). normalize_text/bag_of_words are
+# re-exported from here for existing importers/tests.
+from fighthealthinsurance.ml.response_similarity import (
+    bag_of_words,
+    is_mostly_repeated,
+    normalize_text,
+    response_similarity,
+)
 from fighthealthinsurance.utils import ensure_message_alternation
 
 # Response patterns that indicate a bad/leaked response
@@ -84,21 +94,66 @@ def _extract_document_names_from_history(
 
 # Penalty for response that exactly matches (normalized) the last user/assistant message
 EXACT_REPEAT_PENALTY = -500.0
+# Penalty for response that is a near-verbatim (but not exact) rewording of a
+# recent message. Between exact and bag-of-words in severity.
+NEAR_REPEAT_PENALTY = -400.0
 # Penalty for response with same bag-of-words as the last user/assistant message
 BAG_OF_WORDS_REPEAT_PENALTY = -75.0
 # Lighter penalties for matching older messages in the history
 OLDER_ASSISTANT_REPEAT_PENALTY = -20.0
 OLDER_USER_REPEAT_PENALTY = -10.0
 
+# How many recent assistant replies a candidate is checked against for the
+# HARD repeat rejection (covers both A-A loops and A-B-A alternation loops).
+RECENT_ASSISTANT_REPLIES_TO_CHECK = 3
 
-def normalize_text(text: str) -> str:
-    """Normalize text for comparison: lowercase, collapse whitespace, strip."""
-    return re.sub(r"\s+", " ", text.lower().strip())
+# When the user explicitly asks for a repeat, repeating is the right answer —
+# skip the hard rejection so the turn can succeed.
+USER_REQUESTED_REPEAT_RE = re.compile(
+    r"\b(repeat|say (?:that|it) again|one more time|once more|again please|"
+    r"re-?send|(?:show|send) (?:that|it) again)\b",
+    re.IGNORECASE,
+)
 
 
-def bag_of_words(text: str) -> set:
-    """Extract a bag of words (lowercased) from text for unordered comparison."""
-    return set(re.findall(r"[a-z0-9]+", text.lower()))
+def user_requested_repeat(message: Optional[str]) -> bool:
+    """True when the user's message explicitly asks us to repeat ourselves."""
+    return bool(message and USER_REQUESTED_REPEAT_RE.search(message))
+
+
+def find_repeated_reply(
+    response_text: str,
+    chat_history: Optional[List[Dict[str, str]]],
+    current_message: Optional[str] = None,
+    max_assistant_messages: int = RECENT_ASSISTANT_REPLIES_TO_CHECK,
+) -> Optional[str]:
+    """Detect a candidate reply that mostly repeats the recent conversation.
+
+    Returns a short reason string ("echoes_user_message" /
+    "repeats_recent_assistant_reply") when the response is (nearly) identical
+    to the current user message or to one of the last few assistant replies,
+    None otherwise. This is the trigger for HARD rejection: the observed chat
+    loops were the model re-sending its previous reply verbatim after the
+    user answered its question, and soft score penalties (-500) were dwarfed
+    by per-model base scores (quality**2 scaling reaches ~8800), so the
+    repeat still won the fan-out race.
+    """
+    if not response_text:
+        return None
+    if current_message and is_mostly_repeated(response_text, current_message):
+        return "echoes_user_message"
+    if not chat_history:
+        return None
+    checked = 0
+    for msg in reversed(chat_history):
+        if msg.get("role") != "assistant":
+            continue
+        if is_mostly_repeated(response_text, msg.get("content", "")):
+            return "repeats_recent_assistant_reply"
+        checked += 1
+        if checked >= max_assistant_messages:
+            break
+    return None
 
 
 def compute_repetition_penalty(
@@ -144,6 +199,11 @@ def compute_repetition_penalty(
             logger.debug(
                 "Response has same bag-of-words as current user message, applying mild penalty"
             )
+        elif is_mostly_repeated(response_text, current_message):
+            penalty += NEAR_REPEAT_PENALTY
+            logger.debug(
+                "Response is a near-verbatim repeat of current user message, penalizing"
+            )
 
     if not chat_history:
         return penalty
@@ -173,6 +233,11 @@ def compute_repetition_penalty(
             penalty += BAG_OF_WORDS_REPEAT_PENALTY
             logger.debug(
                 "Response has same bag-of-words as previous message, applying mild penalty"
+            )
+        elif is_mostly_repeated(response_text, prev_text):
+            penalty += NEAR_REPEAT_PENALTY
+            logger.debug(
+                "Response is a near-verbatim repeat of previous message, penalizing"
             )
 
     # Lighter penalties for matching older messages
@@ -205,6 +270,7 @@ def score_llm_response(
     is_primary_call: bool = True,
     chat_history: Optional[List[Dict[str, str]]] = None,
     current_message: Optional[str] = None,
+    rejection_stats: Optional[Dict[str, int]] = None,
 ) -> float:
     """
     Score an LLM response for quality and safety.
@@ -217,9 +283,15 @@ def score_llm_response(
         current_message: The user message that triggered this response.
             Passed separately because it is not yet in chat_history
             at scoring time.
+        rejection_stats: Optional mutable dict; hard rejections increment
+            its "repeated_rejected" counter so the caller can tell "no
+            usable response" apart from "responses arrived but all repeated
+            earlier replies" and retry with an anti-repeat instruction.
 
     Returns:
-        Float score (higher is better, -inf for invalid responses)
+        Float score (higher is better, -inf for invalid responses).
+        -inf is a HARD rejection: best_within_timelimit never returns a
+        result scored -inf, so repeats can't be delivered from this pass.
     """
     if result is None:
         return float("-inf")
@@ -228,6 +300,27 @@ def score_llm_response(
 
     if not context_part and not response_text:
         return float("-inf")
+
+    # HARD rejection of (near-)repeated replies. Soft penalties are not
+    # enough here: per-model base scores reach ~8800 (quality**2 scaling),
+    # so a -500 nudge still let a verbatim repeat from the favorite backend
+    # win the fan-out race — which is exactly the observed chat loop.
+    # Skipped when the user explicitly asked us to repeat ourselves.
+    if (
+        response_text
+        and len(response_text) > MIN_RESPONSE_LENGTH
+        and not user_requested_repeat(current_message)
+    ):
+        repeat_reason = find_repeated_reply(
+            response_text, chat_history, current_message
+        )
+        if repeat_reason:
+            if rejection_stats is not None:
+                rejection_stats["repeated_rejected"] = (
+                    rejection_stats.get("repeated_rejected", 0) + 1
+                )
+            logger.info(f"Hard-rejecting candidate chat reply: {repeat_reason}")
+            return float("-inf")
 
     score = 0.0
 
@@ -304,6 +397,7 @@ def create_response_scorer(
     primary_calls: Optional[List[Awaitable]] = None,
     chat_history: Optional[List[Dict[str, str]]] = None,
     current_message: Optional[str] = None,
+    rejection_stats: Optional[Dict[str, int]] = None,
 ) -> Callable[[Optional[Tuple[Optional[str], Optional[str]]], Awaitable], float]:
     """
     Create a scoring function for use with best_within_timelimit.
@@ -315,6 +409,8 @@ def create_response_scorer(
         current_message: The user message that triggered this response.
             Passed separately because it is not yet in chat_history
             at scoring time.
+        rejection_stats: Optional mutable dict shared with the caller; see
+            score_llm_response.
 
     Returns:
         Scoring function compatible with best_within_timelimit
@@ -333,6 +429,7 @@ def create_response_scorer(
             is_primary,
             chat_history=chat_history,
             current_message=current_message,
+            rejection_stats=rejection_stats,
         )
 
     return score_fn
@@ -476,6 +573,7 @@ def build_retry_calls(
     is_professional: bool,
     is_logged_in: bool,
     fallback_backends: Optional[List[RemoteModelLike]] = None,
+    temperature: float = 0.7,
 ) -> Tuple[List[Awaitable[Tuple[Optional[str], Optional[str]]]], Dict[Awaitable, int]]:
     """
     Build retry LLM calls with shortened context and fallback backends.
@@ -488,6 +586,8 @@ def build_retry_calls(
         is_professional: Whether user is a professional
         is_logged_in: Whether user is logged in
         fallback_backends: Optional backup model backends
+        temperature: Sampling temperature for the retry calls. Anti-repeat
+            retries pass a higher value to break deterministic loops.
 
     Returns:
         Tuple of (list of call awaitables, dict mapping calls to quality scores)
@@ -507,6 +607,7 @@ def build_retry_calls(
             history=retry_history,
             is_professional=is_professional,
             is_logged_in=is_logged_in,
+            temperature=temperature,
         )
         calls.append(call)
         # Quadratic scaling, reduced for retry (lower priority than primary)
@@ -520,6 +621,7 @@ def build_retry_calls(
             history=history,
             is_professional=is_professional,
             is_logged_in=is_logged_in,
+            temperature=temperature,
         )
         calls.append(call)
         call_scores[call] = (model_backend.quality() ** 2) // 2
@@ -534,6 +636,7 @@ def build_retry_calls(
                 history=retry_history,
                 is_professional=is_professional,
                 is_logged_in=is_logged_in,
+                temperature=temperature,
             )
             calls.append(call)
             call_scores[call] = (model_backend.quality() ** 2) // 7
@@ -545,8 +648,61 @@ def build_retry_calls(
                 history=history,
                 is_professional=is_professional,
                 is_logged_in=is_logged_in,
+                temperature=temperature,
             )
             calls.append(call)
             call_scores[call] = (model_backend.quality() ** 2) // 5
 
     return calls, call_scores
+
+
+# --- Alternate ("side-by-side") answer support ---
+
+# An alternate answer is only offered when it is meaningfully different from
+# the primary one; above this similarity it reads as a reworded duplicate.
+ALTERNATE_MAX_SIMILARITY = 0.7
+# And only when it is a substantial reply on its own.
+ALTERNATE_MIN_CHARS = 30
+
+# Tokens that mean a reply is part of a tool/action flow rather than a plain
+# conversational answer (those flows mutate state; only the winner runs them).
+_ACTION_TOKEN_RE = re.compile(
+    r"\*\*(create_or_update_appeal|create_or_update_prior_auth)\*\*"
+)
+
+
+def alternate_is_presentable(
+    alternate_text: Optional[str],
+    primary_text: str,
+    chat_history: Optional[List[Dict[str, str]]] = None,
+    current_message: Optional[str] = None,
+) -> bool:
+    """Whether a runner-up reply is safe and useful to show side-by-side.
+
+    The alternate is shown raw (no tool processing runs on it), so anything
+    containing tool calls or action tokens is out, as is anything unsafe,
+    near-duplicate of the primary, or itself a repeat of the conversation.
+    """
+    if not alternate_text:
+        return False
+    text = alternate_text.strip()
+    if len(text) < ALTERNATE_MIN_CHARS:
+        return False
+    if "🐼" in text:
+        return False
+    if _ACTION_TOKEN_RE.search(text):
+        return False
+    for pattern in tools_regex:
+        if re.search(pattern, text):
+            return False
+    if BAD_RESPONSE_PATTERNS.search(text):
+        return False
+    if detect_false_promises(text):
+        return False
+    if ASKS_FOR_PATIENT_NAME.search(text):
+        return False
+    if response_similarity(text, primary_text) >= ALTERNATE_MAX_SIMILARITY:
+        return False
+    if find_repeated_reply(text, chat_history, current_message):
+        return False
+    return True

--- a/fighthealthinsurance/chat/llm_client.py
+++ b/fighthealthinsurance/chat/llm_client.py
@@ -12,7 +12,10 @@ from loguru import logger
 
 from fighthealthinsurance.chat.message_preprocessor import MessageVariant
 from fighthealthinsurance.chat.safety_filters import detect_false_promises
-from fighthealthinsurance.chat.tools.patterns import ALL_TOOL_PATTERNS as tools_regex
+from fighthealthinsurance.chat.tools.patterns import (
+    ALL_TOOL_PATTERNS as tools_regex,
+    contains_tool_call,
+)
 from fighthealthinsurance.ml.ml_models import RemoteModelLike, repetition_penalty
 
 # Shared similarity/exemption helpers (stdlib-only module, importable from
@@ -20,7 +23,7 @@ from fighthealthinsurance.ml.ml_models import RemoteModelLike, repetition_penalt
 # bag_of_words, is_canned_reply, user_requested_repeat and the exemption
 # constants are re-exported from here for existing importers/tests.
 from fighthealthinsurance.ml.response_similarity import (
-    CANNED_REPLY_MARKERS,
+    CANNED_REPLY_SIGNATURES,
     USER_REQUESTED_REPEAT_RE,
     bag_of_words,
     is_canned_reply,
@@ -395,13 +398,21 @@ def score_llm_response(
 
 
 # Per-session demotion for backends whose candidates were hard-rejected as
-# repeats earlier in the SAME chat session: each strike multiplies the
-# backend's base score by the decay (capped), so a persistent looper decays
-# from internal-tier preference (~8000 base) toward external-tier (~1900)
-# after ~4 strikes instead of winning every race on raw quality forever.
-# Content-quality signals are unaffected -- only the model-preference prior
-# decays. Strikes are in-memory per ChatInterface (one WebSocket session)
-# and never persisted.
+# repeats on earlier TURNS of the same chat session: each strike multiplies
+# the backend's base score by the decay (capped), so a persistent looper
+# decays from internal-tier preference (~8000 base) toward external-tier
+# (~1900) after ~4 looping turns instead of winning every race on raw quality
+# forever. Content-quality signals are unaffected -- only the model-preference
+# prior decays. Strikes are in-memory per ChatInterface (one WebSocket
+# session) and never persisted.
+#
+# At most ONE strike per backend per scorer (i.e. per turn): the number of
+# candidates a backend contributes to a fan-out is a property of the fan-out
+# shape -- the primary fhi backend is listed twice, each backend may get a
+# truncated- and a full-history call, and each message variant multiplies
+# again -- so counting per candidate ranked backends by how many slots they
+# occupy rather than how often they loop, and saturated the cap inside a
+# single turn.
 REPEAT_OFFENDER_DECAY = 0.7
 REPEAT_OFFENDER_CAP = 4
 
@@ -444,6 +455,9 @@ def create_response_scorer(
         Scoring function compatible with best_within_timelimit
     """
     primary_set = set(primary_calls) if primary_calls else set()
+    # Labels already struck by THIS scorer, so one looping turn costs a
+    # backend one strike no matter how many candidates it contributed.
+    struck_this_turn: set = set()
 
     def score_fn(
         result: Optional[Tuple[Optional[str], Optional[str]]],
@@ -452,7 +466,13 @@ def create_response_scorer(
         call_score = call_scores.get(original_task, 0)
         label = call_labels.get(original_task) if call_labels else None
         if label and repeat_offenders:
-            strikes = min(repeat_offenders.get(label, 0), REPEAT_OFFENDER_CAP)
+            # Strikes earned on EARLIER turns only: struck_this_turn keeps the
+            # current turn's strike from also demoting the candidates being
+            # scored alongside it.
+            earlier_strikes = repeat_offenders.get(label, 0) - (
+                1 if label in struck_this_turn else 0
+            )
+            strikes = min(max(earlier_strikes, 0), REPEAT_OFFENDER_CAP)
             if strikes:
                 call_score = int(call_score * (REPEAT_OFFENDER_DECAY**strikes))
         is_primary = original_task in primary_set
@@ -471,10 +491,12 @@ def create_response_scorer(
         )
         if (
             label
+            and label not in struck_this_turn
             and repeat_offenders is not None
             and rejection_stats is not None
             and rejection_stats.get("repeated_rejected", 0) > rejected_before
         ):
+            struck_this_turn.add(label)
             repeat_offenders[label] = repeat_offenders.get(label, 0) + 1
         if score_log is not None:
             score_log[original_task] = score
@@ -745,12 +767,6 @@ ALTERNATE_MAX_SIMILARITY = 0.7
 # And only when it is a substantial reply on its own.
 ALTERNATE_MIN_CHARS = 30
 
-# Tokens that mean a reply is part of a tool/action flow rather than a plain
-# conversational answer (those flows mutate state; only the winner runs them).
-_ACTION_TOKEN_RE = re.compile(
-    r"\*\*(create_or_update_appeal|create_or_update_prior_auth)\*\*"
-)
-
 
 def alternate_is_presentable(
     alternate_text: Optional[str],
@@ -771,11 +787,12 @@ def alternate_is_presentable(
         return False
     if "🐼" in text:
         return False
-    if _ACTION_TOKEN_RE.search(text):
+    # Screened with the same flags the tool handlers use: a flag-less sweep
+    # over the `^...$`-anchored patterns only caught a tool call at the very
+    # start of the reply, so an alternate whose tool call followed a line of
+    # prose was shown to the user as raw syntax plus its JSON payload.
+    if contains_tool_call(text):
         return False
-    for pattern in tools_regex:
-        if re.search(pattern, text):
-            return False
     if BAD_RESPONSE_PATTERNS.search(text):
         return False
     if detect_false_promises(text):

--- a/fighthealthinsurance/chat/llm_client.py
+++ b/fighthealthinsurance/chat/llm_client.py
@@ -4,6 +4,7 @@ LLM client utilities for chat interface.
 Extracts core LLM calling logic from ChatInterface for reusability and testing.
 """
 
+import math
 import re
 from typing import Awaitable, Callable, Dict, List, Optional, Tuple
 
@@ -393,12 +394,27 @@ def score_llm_response(
     return score
 
 
+# Per-session demotion for backends whose candidates were hard-rejected as
+# repeats earlier in the SAME chat session: each strike multiplies the
+# backend's base score by the decay (capped), so a persistent looper decays
+# from internal-tier preference (~8000 base) toward external-tier (~1900)
+# after ~4 strikes instead of winning every race on raw quality forever.
+# Content-quality signals are unaffected -- only the model-preference prior
+# decays. Strikes are in-memory per ChatInterface (one WebSocket session)
+# and never persisted.
+REPEAT_OFFENDER_DECAY = 0.7
+REPEAT_OFFENDER_CAP = 4
+
+
 def create_response_scorer(
     call_scores: Dict[Awaitable, int],
     primary_calls: Optional[List[Awaitable]] = None,
     chat_history: Optional[List[Dict[str, str]]] = None,
     current_message: Optional[str] = None,
     rejection_stats: Optional[Dict[str, int]] = None,
+    call_labels: Optional[Dict[Awaitable, str]] = None,
+    repeat_offenders: Optional[Dict[str, int]] = None,
+    score_log: Optional[Dict[Awaitable, float]] = None,
 ) -> Callable[[Optional[Tuple[Optional[str], Optional[str]]], Awaitable], float]:
     """
     Create a scoring function for use with best_within_timelimit.
@@ -412,6 +428,17 @@ def create_response_scorer(
             at scoring time.
         rejection_stats: Optional mutable dict shared with the caller; see
             score_llm_response.
+        call_labels: Optional dict mapping call awaitables to backend labels
+            (filled by the build_* helpers). Enables the repeat-offender
+            demotion and the per-candidate score log.
+        repeat_offenders: Optional mutable dict (label -> strike count)
+            owned by the caller and shared across turns of one chat
+            session. Strikes demote the backend's base score (see
+            REPEAT_OFFENDER_DECAY) and each hard-rejected repeat from a
+            labeled call adds a strike.
+        score_log: Optional mutable dict; every scored call's final score is
+            recorded here (keyed by the original awaitable) so the caller
+            can report per-candidate scores in debug output.
 
     Returns:
         Scoring function compatible with best_within_timelimit
@@ -423,8 +450,18 @@ def create_response_scorer(
         original_task: Awaitable,
     ) -> float:
         call_score = call_scores.get(original_task, 0)
+        label = call_labels.get(original_task) if call_labels else None
+        if label and repeat_offenders:
+            strikes = min(repeat_offenders.get(label, 0), REPEAT_OFFENDER_CAP)
+            if strikes:
+                call_score = int(call_score * (REPEAT_OFFENDER_DECAY**strikes))
         is_primary = original_task in primary_set
-        return score_llm_response(
+        rejected_before = (
+            rejection_stats.get("repeated_rejected", 0)
+            if rejection_stats is not None
+            else 0
+        )
+        score = score_llm_response(
             result,
             call_score,
             is_primary,
@@ -432,6 +469,16 @@ def create_response_scorer(
             current_message=current_message,
             rejection_stats=rejection_stats,
         )
+        if (
+            label
+            and repeat_offenders is not None
+            and rejection_stats is not None
+            and rejection_stats.get("repeated_rejected", 0) > rejected_before
+        ):
+            repeat_offenders[label] = repeat_offenders.get(label, 0) + 1
+        if score_log is not None:
+            score_log[original_task] = score
+        return score
 
     return score_fn
 
@@ -445,6 +492,7 @@ def build_llm_calls(
     is_logged_in: bool,
     full_history: Optional[List[Dict[str, str]]] = None,
     allow_repeated_reply: bool = False,
+    call_labels: Optional[Dict[Awaitable, str]] = None,
 ) -> Tuple[List[Awaitable[Tuple[Optional[str], Optional[str]]]], Dict[Awaitable, int]]:
     """
     Build parallel LLM calls for multiple model backends.
@@ -457,12 +505,19 @@ def build_llm_calls(
         is_professional: Whether user is a professional
         is_logged_in: Whether user is logged in
         full_history: Full untruncated history (optional)
+        call_labels: Optional mutable dict filled with call -> backend label
+            (str(backend)); lets the scorer attribute candidates to models
+            for repeat-offender demotion and debug reporting.
 
     Returns:
         Tuple of (list of call awaitables, dict mapping calls to quality scores)
     """
     calls: List[Awaitable[Tuple[Optional[str], Optional[str]]]] = []
     call_scores: Dict[Awaitable, int] = {}
+
+    def _label(call: Awaitable, model_backend: RemoteModelLike) -> None:
+        if call_labels is not None:
+            call_labels[call] = str(model_backend)
 
     for model_backend in model_backends:
         # Try with truncated history
@@ -474,6 +529,7 @@ def build_llm_calls(
             is_logged_in=is_logged_in,
             allow_repeated_reply=allow_repeated_reply,
         )
+        _label(call, model_backend)
         calls.append(call)
         # Quadratic scaling to more aggressively prefer higher-quality models
         call_scores[call] = (model_backend.quality() ** 2) // 5
@@ -494,6 +550,7 @@ def build_llm_calls(
                     is_logged_in=is_logged_in,
                     allow_repeated_reply=allow_repeated_reply,
                 )
+                _label(full_history_call, model_backend)
                 calls.append(full_history_call)
                 # Slightly prefer full history for better context
                 call_scores[full_history_call] = (model_backend.quality() ** 2) // 4
@@ -510,6 +567,7 @@ def build_llm_calls_for_variants(
     is_logged_in: bool,
     full_history: Optional[List[Dict[str, str]]] = None,
     allow_repeated_reply: bool = False,
+    call_labels: Optional[Dict[Awaitable, str]] = None,
 ) -> Tuple[
     List[Awaitable[Tuple[Optional[str], Optional[str]]]],
     Dict[Awaitable, int],
@@ -552,6 +610,7 @@ def build_llm_calls_for_variants(
             is_logged_in=is_logged_in,
             full_history=full_history,
             allow_repeated_reply=allow_repeated_reply,
+            call_labels=call_labels,
         )
         # Apply the variant's score delta to every call it produced.
         for call in calls:
@@ -581,6 +640,7 @@ def build_retry_calls(
     fallback_backends: Optional[List[RemoteModelLike]] = None,
     temperature: float = 0.7,
     allow_repeated_reply: bool = False,
+    call_labels: Optional[Dict[Awaitable, str]] = None,
 ) -> Tuple[List[Awaitable[Tuple[Optional[str], Optional[str]]]], Dict[Awaitable, int]]:
     """
     Build retry LLM calls with shortened context and fallback backends.
@@ -595,12 +655,18 @@ def build_retry_calls(
         fallback_backends: Optional backup model backends
         temperature: Sampling temperature for the retry calls. Anti-repeat
             retries pass a higher value to break deterministic loops.
+        call_labels: Optional mutable dict filled with call -> backend label
+            (see build_llm_calls).
 
     Returns:
         Tuple of (list of call awaitables, dict mapping calls to quality scores)
     """
     calls: List[Awaitable[Tuple[Optional[str], Optional[str]]]] = []
     call_scores: Dict[Awaitable, int] = {}
+
+    def _label(call: Awaitable, model_backend: RemoteModelLike) -> None:
+        if call_labels is not None:
+            call_labels[call] = str(model_backend)
 
     # Use shorter history for retry (Python gracefully handles if len < 5)
     start_idx = max(0, len(history) - 5)
@@ -617,6 +683,7 @@ def build_retry_calls(
             temperature=temperature,
             allow_repeated_reply=allow_repeated_reply,
         )
+        _label(call, model_backend)
         calls.append(call)
         # Quadratic scaling, reduced for retry (lower priority than primary)
         call_scores[call] = (model_backend.quality() ** 2) // 7
@@ -632,6 +699,7 @@ def build_retry_calls(
             temperature=temperature,
             allow_repeated_reply=allow_repeated_reply,
         )
+        _label(call, model_backend)
         calls.append(call)
         call_scores[call] = (model_backend.quality() ** 2) // 2
 
@@ -648,6 +716,7 @@ def build_retry_calls(
                 temperature=temperature,
                 allow_repeated_reply=allow_repeated_reply,
             )
+            _label(call, model_backend)
             calls.append(call)
             call_scores[call] = (model_backend.quality() ** 2) // 7
 
@@ -661,6 +730,7 @@ def build_retry_calls(
                 temperature=temperature,
                 allow_repeated_reply=allow_repeated_reply,
             )
+            _label(call, model_backend)
             calls.append(call)
             call_scores[call] = (model_backend.quality() ** 2) // 5
 
@@ -717,3 +787,33 @@ def alternate_is_presentable(
     if find_repeated_reply(text, chat_history, current_message):
         return False
     return True
+
+
+# Runner-up must score at least this fraction of the winner for the pair to
+# count as "closely tied" (the only case where a side-by-side alternate is
+# offered). Base call scores are quadratic in model quality (internal ~8000
+# vs external ~1900 at //5), so a cross-tier runner-up never comes close and
+# the alternate stays reserved for genuinely comparable answers -- e.g. the
+# same model's truncated- vs full-history variants (8000 vs 10000 base,
+# ratio 0.8) or two same-tier backends split by content-quality signals.
+ALTERNATE_CLOSE_TIE_RATIO = 0.8
+
+
+def scores_closely_tied(
+    best_score: float,
+    runner_up_score: float,
+    ratio: float = ALTERNATE_CLOSE_TIE_RATIO,
+) -> bool:
+    """Whether the fan-out's top two scores are close enough that showing
+    the user both answers (side-by-side alternate) beats auto-picking.
+
+    Both scores must be positive and finite: a non-positive winner means the
+    turn was already degraded (heavy penalties), and -inf/absent runner-ups
+    were never usable. With positive scores the ratio test is monotonic and
+    scale-free against the quadratic base-score tiers.
+    """
+    if not (math.isfinite(best_score) and math.isfinite(runner_up_score)):
+        return False
+    if best_score <= 0 or runner_up_score <= 0:
+        return False
+    return runner_up_score >= best_score * ratio

--- a/fighthealthinsurance/chat/llm_client.py
+++ b/fighthealthinsurance/chat/llm_client.py
@@ -444,6 +444,7 @@ def build_llm_calls(
     is_professional: bool,
     is_logged_in: bool,
     full_history: Optional[List[Dict[str, str]]] = None,
+    allow_repeated_reply: bool = False,
 ) -> Tuple[List[Awaitable[Tuple[Optional[str], Optional[str]]]], Dict[Awaitable, int]]:
     """
     Build parallel LLM calls for multiple model backends.
@@ -471,6 +472,7 @@ def build_llm_calls(
             history=history,
             is_professional=is_professional,
             is_logged_in=is_logged_in,
+            allow_repeated_reply=allow_repeated_reply,
         )
         calls.append(call)
         # Quadratic scaling to more aggressively prefer higher-quality models
@@ -490,6 +492,7 @@ def build_llm_calls(
                     history=full_history,
                     is_professional=is_professional,
                     is_logged_in=is_logged_in,
+                    allow_repeated_reply=allow_repeated_reply,
                 )
                 calls.append(full_history_call)
                 # Slightly prefer full history for better context
@@ -506,6 +509,7 @@ def build_llm_calls_for_variants(
     is_professional: bool,
     is_logged_in: bool,
     full_history: Optional[List[Dict[str, str]]] = None,
+    allow_repeated_reply: bool = False,
 ) -> Tuple[
     List[Awaitable[Tuple[Optional[str], Optional[str]]]],
     Dict[Awaitable, int],
@@ -547,6 +551,7 @@ def build_llm_calls_for_variants(
             is_professional=is_professional,
             is_logged_in=is_logged_in,
             full_history=full_history,
+            allow_repeated_reply=allow_repeated_reply,
         )
         # Apply the variant's score delta to every call it produced.
         for call in calls:
@@ -575,6 +580,7 @@ def build_retry_calls(
     is_logged_in: bool,
     fallback_backends: Optional[List[RemoteModelLike]] = None,
     temperature: float = 0.7,
+    allow_repeated_reply: bool = False,
 ) -> Tuple[List[Awaitable[Tuple[Optional[str], Optional[str]]]], Dict[Awaitable, int]]:
     """
     Build retry LLM calls with shortened context and fallback backends.
@@ -609,6 +615,7 @@ def build_retry_calls(
             is_professional=is_professional,
             is_logged_in=is_logged_in,
             temperature=temperature,
+            allow_repeated_reply=allow_repeated_reply,
         )
         calls.append(call)
         # Quadratic scaling, reduced for retry (lower priority than primary)
@@ -623,6 +630,7 @@ def build_retry_calls(
             is_professional=is_professional,
             is_logged_in=is_logged_in,
             temperature=temperature,
+            allow_repeated_reply=allow_repeated_reply,
         )
         calls.append(call)
         call_scores[call] = (model_backend.quality() ** 2) // 2
@@ -638,6 +646,7 @@ def build_retry_calls(
                 is_professional=is_professional,
                 is_logged_in=is_logged_in,
                 temperature=temperature,
+                allow_repeated_reply=allow_repeated_reply,
             )
             calls.append(call)
             call_scores[call] = (model_backend.quality() ** 2) // 7
@@ -650,6 +659,7 @@ def build_retry_calls(
                 is_professional=is_professional,
                 is_logged_in=is_logged_in,
                 temperature=temperature,
+                allow_repeated_reply=allow_repeated_reply,
             )
             calls.append(call)
             call_scores[call] = (model_backend.quality() ** 2) // 5

--- a/fighthealthinsurance/chat/retry_handler.py
+++ b/fighthealthinsurance/chat/retry_handler.py
@@ -5,7 +5,7 @@ Provides retry logic with fallback strategies for handling LLM failures
 gracefully. Uses parallel calls to multiple backends with quality scoring.
 """
 
-from typing import Awaitable, Callable, Dict, List, Optional, Tuple
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
 
 from loguru import logger
 
@@ -20,7 +20,7 @@ from fighthealthinsurance.chat.llm_client import (
 )
 from fighthealthinsurance.chat.safety_filters import detect_false_promises
 from fighthealthinsurance.ml.ml_models import RemoteModelLike
-from fighthealthinsurance.utils import best_within_timelimit
+from fighthealthinsurance.utils import best_two_within_timelimit
 
 # Decisive (but finite) penalty for a retry candidate that still repeats a
 # recent reply. Retry base scores top out around quality**2 // 2 (~22k), so
@@ -146,6 +146,7 @@ async def retry_llm_with_fallback(
     anti_repeat: bool = False,
     extended_timeout: float = 40.0,
     allow_repeated_reply: bool = False,
+    debug_info: Optional[Dict[str, Any]] = None,
 ) -> Tuple[Optional[str], Optional[str]]:
     """
     Retry LLM call with shortened context and fallback backends.
@@ -179,6 +180,9 @@ async def retry_llm_with_fallback(
             wrapped current_message contains system-injected text mentioning
             "repeat") and forwarded to the backends so their self-heal loop
             doesn't fight the user's request.
+        debug_info: Optional mutable dict; on a successful retry it receives
+            "retry_picked_model" (backend label) and "retry_picked_score"
+            so the caller's debug output can attribute the delivered answer.
 
     Returns:
         Tuple of (response_text, context_part) or (None, None) on failure
@@ -204,6 +208,7 @@ async def retry_llm_with_fallback(
         retry_temperature = ANTI_REPEAT_TEMPERATURE
 
     # Build retry calls with shortened history and fallbacks
+    call_labels: Dict[Awaitable, str] = {}
     retry_calls, retry_scores = build_retry_calls(
         model_backends=model_backends,
         current_message=retry_message,
@@ -214,6 +219,7 @@ async def retry_llm_with_fallback(
         fallback_backends=fallback_backends,
         temperature=retry_temperature,
         allow_repeated_reply=allow_repeated_reply,
+        call_labels=call_labels,
     )
 
     # Create simplified scorer for retries
@@ -222,7 +228,7 @@ async def retry_llm_with_fallback(
     )
 
     try:
-        best_retry = await best_within_timelimit(
+        best_retry = await best_two_within_timelimit(
             retry_calls,
             retry_scorer,
             timeout=timeout,
@@ -232,11 +238,22 @@ async def retry_llm_with_fallback(
             extended_timeout=extended_timeout,
         )
         retry_response, retry_context = (
-            best_retry if best_retry is not None else (None, None)
+            best_retry.best if best_retry.best is not None else (None, None)
         )
 
         if retry_response and len(retry_response.strip()) > MIN_RESPONSE_LENGTH:
-            logger.info("Successfully got response from retry/fallback models")
+            picked = (
+                call_labels.get(best_retry.best_task)
+                if best_retry.best_task is not None
+                else None
+            )
+            if debug_info is not None:
+                debug_info["retry_picked_model"] = picked
+                debug_info["retry_picked_score"] = best_retry.best_score
+            logger.info(
+                "Successfully got response from retry/fallback models "
+                f"(picked {picked or 'unknown'}, score={best_retry.best_score})"
+            )
             return retry_response, retry_context
 
     except Exception as e:

--- a/fighthealthinsurance/chat/retry_handler.py
+++ b/fighthealthinsurance/chat/retry_handler.py
@@ -145,6 +145,7 @@ async def retry_llm_with_fallback(
     user_message_for_scoring: Optional[str] = None,
     anti_repeat: bool = False,
     extended_timeout: float = 40.0,
+    allow_repeated_reply: bool = False,
 ) -> Tuple[Optional[str], Optional[str]]:
     """
     Retry LLM call with shortened context and fallback backends.
@@ -173,6 +174,11 @@ async def retry_llm_with_fallback(
             repeats of a recent reply. Appends an explicit do-not-repeat
             instruction to the message and raises the sampling temperature
             so the retry actually generates something new.
+        allow_repeated_reply: True when the user explicitly asked for a
+            repeat. Derived from the RAW user message by the caller (the
+            wrapped current_message contains system-injected text mentioning
+            "repeat") and forwarded to the backends so their self-heal loop
+            doesn't fight the user's request.
 
     Returns:
         Tuple of (response_text, context_part) or (None, None) on failure
@@ -207,6 +213,7 @@ async def retry_llm_with_fallback(
         is_logged_in=is_logged_in,
         fallback_backends=fallback_backends,
         temperature=retry_temperature,
+        allow_repeated_reply=allow_repeated_reply,
     )
 
     # Create simplified scorer for retries

--- a/fighthealthinsurance/chat/retry_handler.py
+++ b/fighthealthinsurance/chat/retry_handler.py
@@ -144,6 +144,7 @@ async def retry_llm_with_fallback(
     chat_history: Optional[List[Dict[str, str]]] = None,
     user_message_for_scoring: Optional[str] = None,
     anti_repeat: bool = False,
+    extended_timeout: float = 40.0,
 ) -> Tuple[Optional[str], Optional[str]]:
     """
     Retry LLM call with shortened context and fallback backends.
@@ -218,6 +219,10 @@ async def retry_llm_with_fallback(
             retry_calls,
             retry_scorer,
             timeout=timeout,
+            # Bounded overtime so primary (30+30) + retry (35+40) fit inside
+            # the FHI_CHAT_TURN_BUDGET (150s default) instead of the default
+            # 2x-timeout overtime blowing past it mid-retry.
+            extended_timeout=extended_timeout,
         )
         retry_response, retry_context = (
             best_retry if best_retry is not None else (None, None)

--- a/fighthealthinsurance/chat/retry_handler.py
+++ b/fighthealthinsurance/chat/retry_handler.py
@@ -15,10 +15,39 @@ from fighthealthinsurance.chat.llm_client import (
     _extract_document_names_from_history,
     build_retry_calls,
     compute_repetition_penalty,
+    find_repeated_reply,
+    user_requested_repeat,
 )
 from fighthealthinsurance.chat.safety_filters import detect_false_promises
 from fighthealthinsurance.ml.ml_models import RemoteModelLike
 from fighthealthinsurance.utils import best_within_timelimit
+
+# Decisive (but finite) penalty for a retry candidate that still repeats a
+# recent reply. Retry base scores top out around quality**2 // 2 (~22k), so
+# this guarantees any non-repeating candidate outranks every repeat -- while
+# still allowing a repeat to be delivered as the absolute last resort when
+# nothing else came back at all (a repeat beats a hard error frame here; the
+# PRIMARY pass, by contrast, hard-rejects repeats with -inf so this retry
+# pass gets its chance).
+REPEAT_LAST_RESORT_PENALTY = -1_000_000.0
+
+# Higher sampling temperature for anti-repeat retries: the loops this breaks
+# are often near-deterministic generations, and the temperature bump (plus
+# the changed prompt text) shakes the model out of re-emitting the same
+# reply.
+ANTI_REPEAT_TEMPERATURE = 0.85
+
+# Appended to the user message on an anti-repeat retry. Clearly marked as
+# system-injected so the model doesn't attribute it to the user, and the
+# extra text also changes the prompt bytes, which breaks any upstream
+# response caching that could otherwise serve the same reply again.
+ANTI_REPEAT_NOTE = (
+    "[Note from the system, not the user: your earlier draft repeated your "
+    "previous reply, which the user has already read. Do not send it again. "
+    "Answer the user's newest message directly, using the details they have "
+    "already provided in this conversation (for example a state name or a "
+    "yes/no answer), and move the conversation forward.]"
+)
 
 
 def create_simple_retry_scorer(
@@ -85,6 +114,14 @@ def create_simple_retry_scorer(
                     response_text, chat_history or [], current_message
                 )
 
+            # A retry candidate that still (nearly) repeats a recent reply
+            # loses to ANY non-repeating candidate, but stays deliverable
+            # as the absolute last resort (finite penalty, not -inf).
+            if not user_requested_repeat(current_message) and find_repeated_reply(
+                response_text, chat_history, current_message
+            ):
+                score += REPEAT_LAST_RESORT_PENALTY
+
         # Small bonus for context
         if context_part and len(context_part) > MIN_RESPONSE_LENGTH:
             score += 10
@@ -106,6 +143,7 @@ async def retry_llm_with_fallback(
     status_callback: Optional[Callable[[str], Awaitable[None]]] = None,
     chat_history: Optional[List[Dict[str, str]]] = None,
     user_message_for_scoring: Optional[str] = None,
+    anti_repeat: bool = False,
 ) -> Tuple[Optional[str], Optional[str]]:
     """
     Retry LLM call with shortened context and fallback backends.
@@ -130,6 +168,10 @@ async def retry_llm_with_fallback(
             scoring. Distinct from current_message, which may be wrapped with
             intro-template content or the delete-data instruction. Defaults to
             current_message when not provided.
+        anti_repeat: True when the primary pass produced only (rejected)
+            repeats of a recent reply. Appends an explicit do-not-repeat
+            instruction to the message and raises the sampling temperature
+            so the retry actually generates something new.
 
     Returns:
         Tuple of (response_text, context_part) or (None, None) on failure
@@ -137,7 +179,10 @@ async def retry_llm_with_fallback(
     if status_callback:
         await status_callback("Retrying with optimized context...")
 
-    logger.info("Primary attempt failed, retrying with compacted context")
+    logger.info(
+        "Primary attempt failed, retrying with compacted context"
+        + (" and anti-repeat instruction" if anti_repeat else "")
+    )
 
     scoring_message = (
         user_message_for_scoring
@@ -145,15 +190,22 @@ async def retry_llm_with_fallback(
         else current_message
     )
 
+    retry_message = current_message
+    retry_temperature = 0.7
+    if anti_repeat:
+        retry_message = f"{current_message}\n\n{ANTI_REPEAT_NOTE}"
+        retry_temperature = ANTI_REPEAT_TEMPERATURE
+
     # Build retry calls with shortened history and fallbacks
     retry_calls, retry_scores = build_retry_calls(
         model_backends=model_backends,
-        current_message=current_message,
+        current_message=retry_message,
         previous_context_summary=previous_context_summary,
         history=history,
         is_professional=is_professional,
         is_logged_in=is_logged_in,
         fallback_backends=fallback_backends,
+        temperature=retry_temperature,
     )
 
     # Create simplified scorer for retries

--- a/fighthealthinsurance/chat/tools/clinical_trials_tool.py
+++ b/fighthealthinsurance/chat/tools/clinical_trials_tool.py
@@ -123,6 +123,10 @@ class ClinicalTrialsTool(BaseTool):
                 is_professional=is_professional,
                 fallback_backends=kwargs.get("fallback_backends"),
                 full_history=kwargs.get("full_history"),
+                # Raw user message, so repeat detection/exemption in the
+                # recursive pass keys off what the USER said rather than this
+                # tool payload (which routinely contains words like "repeat").
+                user_message_for_scoring=kwargs.get("user_message_for_scoring"),
             )
             cleaned_response = self.merge_strings(cleaned_response, additional_response)
             context = self.merge_strings(context, additional_context)

--- a/fighthealthinsurance/chat/tools/doc_fetcher_tool.py
+++ b/fighthealthinsurance/chat/tools/doc_fetcher_tool.py
@@ -247,6 +247,10 @@ class DocFetcherTool(BaseTool):
                 is_professional=is_professional,
                 fallback_backends=kwargs.get("fallback_backends"),
                 full_history=kwargs.get("full_history"),
+                # Raw user message, so repeat detection/exemption in the
+                # recursive pass keys off what the USER said rather than this
+                # tool payload (which routinely contains words like "repeat").
+                user_message_for_scoring=kwargs.get("user_message_for_scoring"),
             )
 
             if cleaned_response and additional_response:

--- a/fighthealthinsurance/chat/tools/financial_assistance_tool.py
+++ b/fighthealthinsurance/chat/tools/financial_assistance_tool.py
@@ -256,6 +256,10 @@ class FinancialAssistanceTool(BaseTool):
                 is_professional=is_professional,
                 fallback_backends=kwargs.get("fallback_backends"),
                 full_history=kwargs.get("full_history"),
+                # Raw user message, so repeat detection/exemption in the
+                # recursive pass keys off what the USER said rather than this
+                # tool payload (which routinely contains words like "repeat").
+                user_message_for_scoring=kwargs.get("user_message_for_scoring"),
             )
 
             if cleaned_response and additional_response:

--- a/fighthealthinsurance/chat/tools/json_followup_tool.py
+++ b/fighthealthinsurance/chat/tools/json_followup_tool.py
@@ -206,6 +206,10 @@ class JsonFollowupTool(BaseTool):
                 is_professional=is_professional,
                 fallback_backends=kwargs.get("fallback_backends"),
                 full_history=kwargs.get("full_history"),
+                # Raw user message, so repeat detection/exemption in the
+                # recursive pass keys off what the USER said rather than this
+                # tool payload (which routinely contains words like "repeat").
+                user_message_for_scoring=kwargs.get("user_message_for_scoring"),
             )
 
             if cleaned_response and additional_response:

--- a/fighthealthinsurance/chat/tools/medicaid_tool.py
+++ b/fighthealthinsurance/chat/tools/medicaid_tool.py
@@ -149,6 +149,10 @@ class MedicaidInfoTool(BaseTool):
                         is_professional=is_professional,
                         fallback_backends=kwargs.get("fallback_backends"),
                         full_history=kwargs.get("full_history"),
+                        # Raw user message, so repeat detection/exemption in the
+                        # recursive pass keys off what the USER said rather than this
+                        # tool payload (which routinely contains words like "repeat").
+                        user_message_for_scoring=kwargs.get("user_message_for_scoring"),
                     )
 
                     logger.debug(
@@ -346,6 +350,10 @@ class MedicaidEligibilityTool(BaseTool):
                     is_professional=is_professional,
                     fallback_backends=kwargs.get("fallback_backends"),
                     full_history=kwargs.get("full_history"),
+                    # Raw user message, so repeat detection/exemption in the
+                    # recursive pass keys off what the USER said rather than this
+                    # tool payload (which routinely contains words like "repeat").
+                    user_message_for_scoring=kwargs.get("user_message_for_scoring"),
                 )
 
                 if additional_response and len(additional_response) > 1:

--- a/fighthealthinsurance/chat/tools/patterns.py
+++ b/fighthealthinsurance/chat/tools/patterns.py
@@ -6,6 +6,8 @@ responses to indicate it wants to invoke a tool (e.g., search PubMed,
 look up Medicaid info, create/update appeals, etc.)
 """
 
+import re
+
 # PubMed query tool - captures query terms
 # Matches: [pubmed_query: terms], **pubmed query: terms**, etc.
 PUBMED_QUERY_REGEX = r"[\[\*]{0,4}pubmed[ _]?query:?\s*([^*\[\]]+)"
@@ -96,6 +98,23 @@ CLINICAL_TRIALS_QUERY_REGEX = (
 # not via match.group(1).
 FINANCIAL_ASSISTANCE_REGEX = r"(?:\*\*)?financial_assistance\s*(?=\{)"
 
+# Flags the tool HANDLERS use when detecting a call in a reply (each handler
+# sets `detect_flags`). Anything else that screens a reply for tool calls must
+# use the same flags: several patterns are `^...$`-anchored, so a flag-less
+# re.search only ever matches a tool call at the very start of the reply and
+# silently passes one that follows a sentence of prose.
+TOOL_DETECT_FLAGS = re.DOTALL | re.MULTILINE | re.IGNORECASE
+
+# Tokens that mean a reply is part of a tool/action flow rather than a plain
+# conversational answer (those flows mutate state; only the winner runs them).
+# Matches the bare name too -- the handlers tolerate 0-4 asterisks, so
+# requiring `**name**` adjacency missed the unadorned form.
+ACTION_TOKEN_MENTION_RE = re.compile(
+    r"\*{0,4}\b(?:create_or_update_appeal|create_or_update_prior_auth)\b\*{0,4}",
+    re.IGNORECASE,
+)
+
+
 # List of all tool patterns for scoring/detection
 ALL_TOOL_PATTERNS = [
     PUBMED_QUERY_REGEX,
@@ -110,3 +129,18 @@ ALL_TOOL_PATTERNS = [
     CLINICAL_TRIALS_QUERY_REGEX,
     FINANCIAL_ASSISTANCE_REGEX,
 ]
+
+
+def contains_tool_call(text: str) -> bool:
+    """Whether ``text`` contains anything a tool handler would fire on.
+
+    Uses TOOL_DETECT_FLAGS so this agrees with the handlers themselves. Any
+    reply shown to a user WITHOUT running the tool pipeline (the side-by-side
+    alternate answer) must be screened through here, or raw tool syntax and
+    its JSON payload reach the browser.
+    """
+    if not text:
+        return False
+    if ACTION_TOKEN_MENTION_RE.search(text):
+        return True
+    return any(re.search(p, text, TOOL_DETECT_FLAGS) for p in ALL_TOOL_PATTERNS)

--- a/fighthealthinsurance/chat/tools/patterns.py
+++ b/fighthealthinsurance/chat/tools/patterns.py
@@ -131,6 +131,11 @@ ALL_TOOL_PATTERNS = [
 ]
 
 
+# Compiled once: contains_tool_call runs per alternate candidate, and relying
+# on re's bounded internal cache makes that cost implicit.
+_COMPILED_TOOL_PATTERNS = [re.compile(p, TOOL_DETECT_FLAGS) for p in ALL_TOOL_PATTERNS]
+
+
 def contains_tool_call(text: str) -> bool:
     """Whether ``text`` contains anything a tool handler would fire on.
 
@@ -143,4 +148,4 @@ def contains_tool_call(text: str) -> bool:
         return False
     if ACTION_TOKEN_MENTION_RE.search(text):
         return True
-    return any(re.search(p, text, TOOL_DETECT_FLAGS) for p in ALL_TOOL_PATTERNS)
+    return any(p.search(text) for p in _COMPILED_TOOL_PATTERNS)

--- a/fighthealthinsurance/chat/tools/pubmed_tool.py
+++ b/fighthealthinsurance/chat/tools/pubmed_tool.py
@@ -152,6 +152,10 @@ class PubMedTool(BaseTool):
                 is_professional=is_professional,
                 fallback_backends=kwargs.get("fallback_backends"),
                 full_history=kwargs.get("full_history"),
+                # Raw user message, so repeat detection/exemption in the
+                # recursive pass keys off what the USER said rather than this
+                # tool payload (which routinely contains words like "repeat").
+                user_message_for_scoring=kwargs.get("user_message_for_scoring"),
             )
 
             cleaned_response = self.merge_strings(cleaned_response, additional_response)

--- a/fighthealthinsurance/chat/tools/rxnorm_tool.py
+++ b/fighthealthinsurance/chat/tools/rxnorm_tool.py
@@ -78,6 +78,10 @@ class RxNormLookupTool(BaseTool):
                 is_professional=is_professional,
                 fallback_backends=kwargs.get("fallback_backends"),
                 full_history=kwargs.get("full_history"),
+                # Raw user message, so repeat detection/exemption in the
+                # recursive pass keys off what the USER said rather than this
+                # tool payload (which routinely contains words like "repeat").
+                user_message_for_scoring=kwargs.get("user_message_for_scoring"),
             )
 
             cleaned_response = self.merge_strings(cleaned_response, additional_response)

--- a/fighthealthinsurance/chat_interface.py
+++ b/fighthealthinsurance/chat_interface.py
@@ -18,6 +18,8 @@ from fighthealthinsurance import settings
 from fighthealthinsurance.chat.chat_persistence import (
     apersist_chat_turn,
     apersist_microsite_context,
+    is_internal_history_message,
+    visible_history,
 )
 from fighthealthinsurance.chat.context_manager import (
     MISSING_CONTEXT_PREFIX,
@@ -120,6 +122,18 @@ def _detect_policy_analysis_request(text: str) -> bool:
 # the terse-reply bridge note (see handle_chat_message): terse answers are
 # where models historically looped by re-asking instead of using the answer.
 TERSE_REPLY_MAX_CHARS = 60
+
+
+def _clean_reply(text: str) -> str:
+    """Strip the model's self-repetition from a reply before it is shown.
+
+    Shared by the primary answer and the side-by-side alternate: the two are
+    displayed next to each other, so cleaning them differently would make the
+    comparison the feature exists for unfair.
+    """
+    stripped = text.strip()
+    cleaned = remove_repeated_blocks(stripped) or stripped
+    return remove_repeated_sentences(cleaned) or cleaned
 
 
 class ChatInterface:
@@ -435,20 +449,26 @@ class ChatInterface:
 
         response_text = response_text or ""
 
+        # Record rejected repeats for EVERY turn that had them, not only turns
+        # that also needed a retry. The common success case is "an internal
+        # backend looped, its candidates were hard-rejected, another backend's
+        # answer won" -- which needs no retry, and used to leave the counter
+        # flat while the ladder was working hard. That made the metric read as
+        # "loops never happen" exactly when a backend started looping.
+        saw_repeats = bool(rejection_stats.get("repeated_rejected"))
+        if saw_repeats:
+            # Counted once per turn (the stat itself is per candidate).
+            record_chat_repeat("rejected_candidates")
+            logger.info(
+                f"Chat {chat.id}: primary pass rejected "
+                f"{rejection_stats['repeated_rejected']} repeated "
+                f"candidate replies"
+            )
+
         # If primary models failed, use retry handler with fallback
         retry_used = False
-        saw_repeats = False
         retry_debug: Dict[str, Any] = {}
         if should_retry_response(response_text):
-            saw_repeats = bool(rejection_stats.get("repeated_rejected"))
-            if saw_repeats:
-                # Counted once per turn (the stat itself is per candidate).
-                record_chat_repeat("rejected_candidates")
-                logger.info(
-                    f"Chat {chat.id}: primary pass rejected "
-                    f"{rejection_stats['repeated_rejected']} repeated "
-                    f"candidate replies; retrying with anti-repeat instruction"
-                )
             retry_response, retry_context = await retry_llm_with_fallback(
                 model_backends=model_backends,
                 current_message=current_message_for_llm,
@@ -1165,7 +1185,10 @@ class ChatInterface:
                 f"matters for your answer (for example Medicaid questions), "
                 f"confirm it with the user -- for instance 'It looks like "
                 f"you might be in {self.state_hint}, is that right?' -- "
-                f"instead of assuming."
+                f"instead of assuming. Do NOT put this guess in your context "
+                f"summary unless the user confirms it: the summary is stored "
+                f"with the chat, and an unconfirmed network-derived location "
+                f"must not be."
             )
             summarized_context = (
                 f"{summarized_context}\n\n{state_hint_context}"
@@ -1268,8 +1291,7 @@ class ChatInterface:
             )
 
             if response_text and response_text.strip():
-                cleaned = remove_repeated_blocks(response_text.strip())
-                cleaned = remove_repeated_sentences(cleaned) or cleaned
+                cleaned = _clean_reply(response_text)
                 if llm_requested_delete_handoff(cleaned):
                     logger.info(
                         f"LLM emitted delete-data sentinel in chat {chat.id}, swapping in canned response"
@@ -1374,8 +1396,18 @@ class ChatInterface:
             alternate_content = self._candidate_alternate
             self._candidate_alternate = None
             if alternate_content:
-                alt_cleaned = remove_repeated_blocks(alternate_content.strip())
-                alt_cleaned = remove_repeated_sentences(alt_cleaned) or alt_cleaned
+                alt_cleaned = _clean_reply(alternate_content)
+                # A runner-up that also asked for the delete-data handoff must
+                # never be shown: the primary gets swapped for the approved
+                # DELETE_DATA_RESPONSE, so an unswapped alternate would sit
+                # beside it either leaking the raw sentinel or making
+                # model-authored promises about deleting the user's data.
+                if alt_cleaned and llm_requested_delete_handoff(alt_cleaned):
+                    logger.info(
+                        f"Chat {chat.id}: dropping alternate that requested the "
+                        f"delete-data handoff"
+                    )
+                    alt_cleaned = ""
                 if alt_cleaned and alternate_is_presentable(
                     alt_cleaned,
                     final_response_text,
@@ -1439,30 +1471,20 @@ class ChatInterface:
     # Legacy prefixes of internal (LLM-context-only) user-role messages that
     # predate the explicit "internal" flag; matched so old chats don't replay
     # them either.
-    _INTERNAL_MESSAGE_PREFIXES = (
-        "Linked this chat to ",
-        "This chat is already linked to ",
-    )
-
     @classmethod
     def _is_internal_history_message(cls, message: Dict[str, Any]) -> bool:
         """Messages stored purely as LLM context (e.g. the appeal-linking
         notes recorded with role=user) must not replay as user bubbles."""
-        if message.get("internal"):
-            return True
-        content = message.get("content") or ""
-        return message.get("role") == "user" and content.startswith(
-            cls._INTERNAL_MESSAGE_PREFIXES
-        )
+        return is_internal_history_message(message)
 
     async def replay_chat_history(self):
         """Sends the existing chat history to the client, minus internal
         LLM-context-only messages (which would render as user bubbles the
         user never typed)."""
         chat = self.chat
-        history: List[Dict[str, Any]] = chat.chat_history or []
-        visible = [m for m in history if not self._is_internal_history_message(m)]
-        await self.send_json_message_func({"messages": visible})
+        await self.send_json_message_func(
+            {"messages": visible_history(chat.chat_history)}
+        )
 
     async def _handle_policy_analysis(
         self, chat: OngoingChat, user_message: str

--- a/fighthealthinsurance/chat_interface.py
+++ b/fighthealthinsurance/chat_interface.py
@@ -20,14 +20,18 @@ from fighthealthinsurance.chat.chat_persistence import (
 from fighthealthinsurance.chat.context_manager import (
     MISSING_CONTEXT_PREFIX,
     background_generate_summary,
+    bound_summary_context,
     make_placeholder,
     prepare_history_for_llm,
     should_store_summary,
 )
 from fighthealthinsurance.chat.llm_client import (
+    alternate_is_presentable,
     build_llm_calls,
     build_llm_calls_for_variants,
     create_response_scorer,
+    find_repeated_reply,
+    user_requested_repeat,
 )
 from fighthealthinsurance.chat.message_preprocessor import (
     MessageVariant,
@@ -61,7 +65,11 @@ from fighthealthinsurance.chat.tools import (
 )
 from fighthealthinsurance.extralink_context_helper import ExtraLinkContextHelper
 from fighthealthinsurance.rag_client import get_rag_context_for_denial
-from fighthealthinsurance.ml.ml_metrics import record_chat_turn
+from fighthealthinsurance.ml.ml_metrics import (
+    record_chat_alternate_offered,
+    record_chat_repeat,
+    record_chat_turn,
+)
 from fighthealthinsurance.ml.ml_models import (
     RemoteModelLike,
     _env_float,
@@ -86,7 +94,7 @@ from fighthealthinsurance.clinicaltrials_tools import ClinicalTrialsTools
 from fighthealthinsurance.pubmed_tools import PubMedTools
 from fighthealthinsurance.rxnorm_tools import RxNormTools
 from fighthealthinsurance.utils import (
-    best_within_timelimit,
+    best_two_within_timelimit,
     fire_and_forget_in_new_threadpool,
 )
 from fighthealthinsurance.ml.ml_policy_doc_helper import MLPolicyDocHelper
@@ -105,6 +113,12 @@ def _detect_policy_analysis_request(text: str) -> bool:
     return bool(_POLICY_ANALYSIS_REGEX.search(text))
 
 
+# A user message at/below this length right after an assistant question gets
+# the terse-reply bridge note (see handle_chat_message): terse answers are
+# where models historically looped by re-asking instead of using the answer.
+TERSE_REPLY_MAX_CHARS = 60
+
+
 class ChatInterface:
     def __init__(
         self,
@@ -113,6 +127,8 @@ class ChatInterface:
         user: User,
         use_external_models: bool = False,
         server_session_key: Optional[str] = None,
+        state_hint: Optional[str] = None,
+        debug_llm: bool = False,
     ):
         def wrap_send_json_message_func(message: Dict[str, Any]) -> Awaitable[None]:
             """Wraps the send_json_message_func to ensure it's always awaited."""
@@ -135,7 +151,19 @@ class ChatInterface:
         # upload store their artifacts under the Django session, so lookups
         # must try this key first.
         self.server_session_key: Optional[str] = server_session_key
+        # Best-effort US-state guess derived from the connection's IP (see
+        # fhi_users.audit.guess_us_state). Transient by design: it flows into
+        # the LLM context as an UNCONFIRMED hint each turn but is never
+        # persisted with the chat, so anonymous users' location is not stored.
+        self.state_hint: Optional[str] = state_hint
+        # When True (gated upstream to settings.DEBUG or staff users), each
+        # turn also sends a debug_llm_input frame showing exactly what was
+        # sent to the backend model.
+        self.debug_llm: bool = debug_llm
         self._doc_fetch_count: list[int] = [0]
+        # Runner-up answer from the most recent top-level LLM fan-out,
+        # offered to the client as a side-by-side alternate when presentable.
+        self._candidate_alternate: Optional[str] = None
 
     @staticmethod
     def _append_to_history(chat, role: str, content: str):
@@ -200,11 +228,20 @@ class ChatInterface:
         except asyncio.CancelledError:
             pass
 
-    async def send_message_to_client(self, message: str):
-        """Sends a message to the client."""
-        await self.send_json_message_func(
-            {"content": message, "chat_id": str(self.chat.id), "role": "assistant"}
-        )
+    async def send_message_to_client(
+        self, message: str, alternate_content: Optional[str] = None
+    ):
+        """Sends a message to the client, optionally with a side-by-side
+        alternate answer (rendered behind a toggle client-side; only the
+        primary message is persisted in chat history)."""
+        payload: Dict[str, Any] = {
+            "content": message,
+            "chat_id": str(self.chat.id),
+            "role": "assistant",
+        }
+        if alternate_content:
+            payload["alternate_content"] = alternate_content
+        await self.send_json_message_func(payload)
 
     async def _get_user_info(self) -> str:
         """Generates a descriptive string for the user (either professional or patient)."""
@@ -317,16 +354,22 @@ class ChatInterface:
             )
             primary_calls = calls
 
-        # Create scoring function using the extracted module
+        # Create scoring function using the extracted module. rejection_stats
+        # is shared with the scorer so we can tell "no usable response" apart
+        # from "responses arrived but all repeated a recent reply" -- the
+        # latter retries with an explicit anti-repeat instruction.
+        rejection_stats: Dict[str, int] = {}
         score_fn = create_response_scorer(
             call_scores,
             primary_calls=primary_calls,
             chat_history=chat.chat_history,
             current_message=scoring_message,
+            rejection_stats=rejection_stats,
         )
 
+        runner_up_call: Optional[Tuple[Optional[str], Optional[str]]] = None
         try:
-            best_call = await best_within_timelimit(
+            best_call, runner_up_call = await best_two_within_timelimit(
                 calls,
                 score_fn,
                 timeout=30.0,
@@ -343,6 +386,15 @@ class ChatInterface:
 
         # If primary models failed, use retry handler with fallback
         if should_retry_response(response_text):
+            saw_repeats = bool(rejection_stats.get("repeated_rejected"))
+            if saw_repeats:
+                # Counted once per turn (the stat itself is per candidate).
+                record_chat_repeat("rejected_candidates")
+                logger.info(
+                    f"Chat {chat.id}: primary pass rejected "
+                    f"{rejection_stats['repeated_rejected']} repeated "
+                    f"candidate replies; retrying with anti-repeat instruction"
+                )
             retry_response, retry_context = await retry_llm_with_fallback(
                 model_backends=model_backends,
                 current_message=current_message_for_llm,
@@ -355,6 +407,7 @@ class ChatInterface:
                 status_callback=self.send_status_message,
                 chat_history=chat.chat_history,
                 user_message_for_scoring=scoring_message,
+                anti_repeat=saw_repeats,
             )
             if retry_response and len(retry_response.strip()) > 5:
                 response_text = retry_response
@@ -365,6 +418,23 @@ class ChatInterface:
         if not response_text:
             logger.debug("Got empty response from LLM")
             return None, None
+
+        # Capture a presentable runner-up as a side-by-side alternate answer.
+        # Only for the top-level user turn (depth 0); recursive tool calls
+        # must not clobber it. Cleared again below if tool processing changes
+        # the primary response (action flows don't get a raw alternate).
+        if depth == 0:
+            self._candidate_alternate = None
+            if runner_up_call is not None:
+                alternate_text = runner_up_call[0]
+                if alternate_text and alternate_is_presentable(
+                    alternate_text,
+                    response_text,
+                    chat_history=chat.chat_history,
+                    current_message=scoring_message,
+                ):
+                    self._candidate_alternate = alternate_text.strip()
+        response_before_tools = response_text
 
         # Process tool calls via modular tool handlers
         context = context_part or ""
@@ -478,6 +548,11 @@ class ChatInterface:
             response_text, context, **tool_kwargs
         )
 
+        # Tool processing rewrote the reply (an action/tool flow ran): the
+        # raw runner-up no longer corresponds to it, so drop the alternate.
+        if depth == 0 and response_text != response_before_tools:
+            self._candidate_alternate = None
+
         logger.debug(f"Return with context length {len(context) if context else 0}.")
         return response_text, context
 
@@ -494,6 +569,9 @@ class ChatInterface:
         Handles an incoming chat message, interacts with LLMs, and manages chat history.
         """
         chat = self.chat
+        # A stale alternate from a previous turn must never attach to this
+        # turn's reply (early-return paths below don't go through the LLM).
+        self._candidate_alternate = None
 
         # SAFETY: Check for crisis/self-harm indicators in user-authored messages.
         # Skip for document uploads — OCR'd clinical text often contains
@@ -780,6 +858,14 @@ class ChatInterface:
                         f"Previous context summary:\n{prev_summary}\n\n"
                         f"Most recent context summary:\n{current_llm_context}"
                     )
+            # Bound the accreted context: summaries nest labels over long
+            # chats ("Earlier conversation summary: ... Additional context:
+            # ...") and an unbounded blob both crowds out the actual history
+            # and degrades weaker models into replaying old turns.
+            current_llm_context = bound_summary_context(
+                current_llm_context,
+                int(_env_float("FHI_CHAT_MAX_SUMMARY_CHARS", 6000.0)),
+            )
 
         # Build message variants: the original/primary path plus lower-scored
         # long-message and weird-Unicode alternatives. A normal short message
@@ -846,13 +932,41 @@ class ChatInterface:
                 return template.format(user_info=user_info_str, message=text)
 
         else:
+            # Terse-reply bridge: short answers like "CA" or "yes 2 people"
+            # right after we asked a question are exactly where models fell
+            # into re-asking loops -- they'd ignore the terse reply and
+            # re-send the previous message. Make the linkage explicit so the
+            # model treats the reply as the answer to its own question.
+            terse_bridge = ""
+            stripped_message = (user_message or "").strip()
+            if (
+                stripped_message
+                and len(stripped_message) <= TERSE_REPLY_MAX_CHARS
+                and not is_document
+            ):
+                last_assistant_reply = next(
+                    (
+                        m.get("content")
+                        for m in reversed(chat.chat_history or [])
+                        if m.get("role") == "assistant" and m.get("content")
+                    ),
+                    None,
+                )
+                if last_assistant_reply and "?" in last_assistant_reply:
+                    terse_bridge = (
+                        "\n\n[Note from the system, not the user: this short "
+                        "reply answers the question(s) in your previous "
+                        "message. Combine it with the conversation history "
+                        "and take the next step -- do not re-ask questions it "
+                        "answers and do not repeat your previous message.]"
+                    )
 
             def wrap_for_llm(text: str) -> str:
                 # Re-inject the delete-data handoff instruction on every ongoing
                 # turn. The intro template (which contains it) only fires for new
                 # chats, so without this the sentinel fallback would silently
                 # stop working past the first message.
-                return f"{DELETE_DATA_INSTRUCTION}\n\n{text}"
+                return f"{DELETE_DATA_INSTRUCTION}\n\n{text}{terse_bridge}"
 
         llm_message_variants = [
             replace(v, text_for_llm=wrap_for_llm(v.text_for_llm))
@@ -911,6 +1025,26 @@ class ChatInterface:
                 else doc_context_str
             )
 
+        # Transient IP-derived location hint (never persisted): lets the
+        # model skip the "which state are you in?" round-trip when the guess
+        # is right, while the wording keeps it explicitly unconfirmed so the
+        # model verifies rather than assumes when the state matters.
+        if self.state_hint:
+            state_hint_context = (
+                f"Possible user location based on network information "
+                f"(an UNCONFIRMED guess that can be wrong, e.g. VPNs or "
+                f"shared networks): {self.state_hint}. If the user's state "
+                f"matters for your answer (for example Medicaid questions), "
+                f"confirm it with the user -- for instance 'It looks like "
+                f"you might be in {self.state_hint}, is that right?' -- "
+                f"instead of assuming."
+            )
+            summarized_context = (
+                f"{summarized_context}\n\n{state_hint_context}"
+                if summarized_context
+                else state_hint_context
+            )
+
         if self.is_trial_professional:
             await asyncio.sleep(0.5)  # Half a second delay for trial users.
 
@@ -919,6 +1053,31 @@ class ChatInterface:
         # **medicaid_info {"state": "StateName", "topic": "", "limit": 5}**
         # (The double asterisks around the entire tool call are required)
         # USPSTF preventive recommendations: **uspstf_lookup {"query": "...", "grade": "A"}**
+
+        # Debug visibility: show exactly what is being sent to the backend
+        # model for this turn. Gated upstream (settings.DEBUG or staff), and
+        # the content is the requesting user's own conversation, so sending
+        # it back over their socket exposes nothing new. Also logged
+        # server-side (sizes only -- message content is PHI).
+        if self.debug_llm:
+            debug_payload = {
+                "message_for_llm": llm_input_message,
+                "context_summary": summarized_context,
+                "history_message_count": len(history_for_llm),
+                "full_history_message_count": (
+                    len(full_history_for_llm) if full_history_for_llm else 0
+                ),
+                "message_variants": [v.kind for v in llm_message_variants],
+                "state_hint": self.state_hint,
+            }
+            await self.send_json_message_func({"debug_llm_input": debug_payload})
+        logger.debug(
+            f"Chat {chat.id}: sending turn to LLM "
+            f"(message_chars={len(llm_input_message)}, "
+            f"context_chars={len(summarized_context) if summarized_context else 0}, "
+            f"history_msgs={len(history_for_llm)}, "
+            f"full_history_msgs={len(full_history_for_llm) if full_history_for_llm else 0})"
+        )
 
         # Overall wall-clock budget for this turn's LLM + tool work, plus a
         # heartbeat so the user (and any idle-reaping proxy between us) sees
@@ -955,6 +1114,22 @@ class ChatInterface:
                     cleaned = DELETE_DATA_RESPONSE
                 final_response_text = cleaned
                 final_context_part = context_part
+                # Observability for the loop-prevention ladder: a delivered
+                # reply that STILL repeats a recent reply means every rung
+                # (hard rejection, anti-repeat retry) produced only repeats.
+                # Should stay rare -- alert on this counter growing.
+                if (
+                    final_response_text
+                    and not user_requested_repeat(user_message)
+                    and find_repeated_reply(
+                        final_response_text, chat.chat_history, user_message
+                    )
+                ):
+                    record_chat_repeat("delivered_repeat")
+                    logger.warning(
+                        f"Chat {chat.id}: delivering a reply that repeats a "
+                        f"recent reply (all anti-repeat rungs exhausted)"
+                    )
         except asyncio.TimeoutError:
             logger.error(
                 f"Chat turn exceeded its {turn_budget:.0f}s budget for chat "
@@ -1023,7 +1198,29 @@ class ChatInterface:
             if background_summary_task is not None:
                 await fire_and_forget_in_new_threadpool(background_summary_task)
             record_chat_turn("ok")
-            await self.send_message_to_client(final_response_text)
+            # Side-by-side alternate answer (ChatGPT-style "here's another
+            # take"): cleaned like the primary, dropped if cleaning leaves it
+            # too similar to what we're already sending. Ephemeral -- only
+            # the primary reply is persisted, so replays show one answer.
+            alternate_content = self._candidate_alternate
+            self._candidate_alternate = None
+            if alternate_content:
+                alt_cleaned = remove_repeated_blocks(alternate_content.strip())
+                alt_cleaned = remove_repeated_sentences(alt_cleaned) or alt_cleaned
+                if alt_cleaned and alternate_is_presentable(
+                    alt_cleaned,
+                    final_response_text,
+                    chat_history=chat.chat_history,
+                    current_message=user_message,
+                ):
+                    alternate_content = alt_cleaned
+                    record_chat_alternate_offered()
+                    logger.info(f"Chat {chat.id}: offering an alternate answer")
+                else:
+                    alternate_content = None
+            await self.send_message_to_client(
+                final_response_text, alternate_content=alternate_content
+            )
         else:
             # The turn failed after the user already committed their message:
             # persist it anyway so a reconnect/replay doesn't erase what they

--- a/fighthealthinsurance/chat_interface.py
+++ b/fighthealthinsurance/chat_interface.py
@@ -327,6 +327,14 @@ class ChatInterface:
             else current_message_for_llm
         )
 
+        # Did the user explicitly ask for a repeat? Derived from the RAW
+        # message (scoring_message) BEFORE prompt wrapping -- the wrapped
+        # current_message_for_llm contains system-injected text that itself
+        # says "repeat", so testing it there would always match. Forwarded to
+        # the backends so their per-backend self-heal loop doesn't fight the
+        # user's request (the scorers make the same check independently).
+        allow_repeat = user_requested_repeat(scoring_message)
+
         # Build LLM calls using the extracted module. When message variants are
         # supplied (top-level user turn), fan out per variant and apply each
         # variant's score delta; only the primary_original variant's calls keep
@@ -341,6 +349,7 @@ class ChatInterface:
                 is_professional=is_professional,
                 is_logged_in=is_logged_in,
                 full_history=full_history,
+                allow_repeated_reply=allow_repeat,
             )
         else:
             calls, call_scores = build_llm_calls(
@@ -351,6 +360,7 @@ class ChatInterface:
                 is_professional=is_professional,
                 is_logged_in=is_logged_in,
                 full_history=full_history,
+                allow_repeated_reply=allow_repeat,
             )
             primary_calls = calls
 
@@ -414,6 +424,7 @@ class ChatInterface:
                 chat_history=chat.chat_history,
                 user_message_for_scoring=scoring_message,
                 anti_repeat=saw_repeats,
+                allow_repeated_reply=allow_repeat,
             )
             if retry_response and len(retry_response.strip()) > 5:
                 response_text = retry_response

--- a/fighthealthinsurance/chat_interface.py
+++ b/fighthealthinsurance/chat_interface.py
@@ -1,5 +1,7 @@
 import asyncio
+import math
 import re
+import time
 from dataclasses import replace
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple, cast
 
@@ -31,6 +33,7 @@ from fighthealthinsurance.chat.llm_client import (
     build_llm_calls_for_variants,
     create_response_scorer,
     find_repeated_reply,
+    scores_closely_tied,
     user_requested_repeat,
 )
 from fighthealthinsurance.chat.message_preprocessor import (
@@ -125,7 +128,9 @@ class ChatInterface:
         send_json_message_func: Callable[[Dict[str, Any]], Awaitable[None]],
         chat: OngoingChat,
         user: User,
-        use_external_models: bool = False,
+        # External models participate by default (matches the client-side
+        # default; the consent-form toggle sends an explicit opt-out).
+        use_external_models: bool = True,
         server_session_key: Optional[str] = None,
         state_hint: Optional[str] = None,
         debug_llm: bool = False,
@@ -162,8 +167,14 @@ class ChatInterface:
         self.debug_llm: bool = debug_llm
         self._doc_fetch_count: list[int] = [0]
         # Runner-up answer from the most recent top-level LLM fan-out,
-        # offered to the client as a side-by-side alternate when presentable.
+        # offered to the client as a side-by-side alternate when presentable
+        # AND closely tied with the winner (see scores_closely_tied).
         self._candidate_alternate: Optional[str] = None
+        # Per-session strike counts for backends whose candidates were
+        # hard-rejected as repeats (label -> count). Shared with the scorer,
+        # which decays a striking backend's base score so a looping model
+        # stops winning every fan-out this session. In-memory only.
+        self._repeat_offenders: Dict[str, int] = {}
 
     @staticmethod
     def _append_to_history(chat, role: str, content: str):
@@ -340,6 +351,7 @@ class ChatInterface:
         # variant's score delta; only the primary_original variant's calls keep
         # the is-primary scoring bonus. Otherwise (recursive tool calls) fall
         # back to the single wrapped message, preserving existing behavior.
+        call_labels: Dict[Awaitable, str] = {}
         if message_variants:
             calls, call_scores, primary_calls = build_llm_calls_for_variants(
                 model_backends=model_backends,
@@ -350,6 +362,7 @@ class ChatInterface:
                 is_logged_in=is_logged_in,
                 full_history=full_history,
                 allow_repeated_reply=allow_repeat,
+                call_labels=call_labels,
             )
         else:
             calls, call_scores = build_llm_calls(
@@ -361,6 +374,7 @@ class ChatInterface:
                 is_logged_in=is_logged_in,
                 full_history=full_history,
                 allow_repeated_reply=allow_repeat,
+                call_labels=call_labels,
             )
             primary_calls = calls
 
@@ -368,31 +382,52 @@ class ChatInterface:
         # is shared with the scorer so we can tell "no usable response" apart
         # from "responses arrived but all repeated a recent reply" -- the
         # latter retries with an explicit anti-repeat instruction.
+        # call_labels + self._repeat_offenders let the scorer demote backends
+        # that produced hard-rejected repeats earlier in this session, and
+        # score_log records per-candidate final scores for debug reporting.
         rejection_stats: Dict[str, int] = {}
+        score_log: Dict[Awaitable, float] = {}
         score_fn = create_response_scorer(
             call_scores,
             primary_calls=primary_calls,
             chat_history=chat.chat_history,
             current_message=scoring_message,
             rejection_stats=rejection_stats,
+            call_labels=call_labels,
+            repeat_offenders=self._repeat_offenders,
+            score_log=score_log,
         )
 
-        runner_up_call: Optional[Tuple[Optional[str], Optional[str]]] = None
+        llm_pass_started = time.monotonic()
+        picked_model: Optional[str] = None
+        picked_score: Optional[float] = None
+        runner_up_model: Optional[str] = None
+        runner_up_score: Optional[float] = None
+        runner_up_text: Optional[str] = None
         try:
             # Explicit overtime window: with the defaults (2x timeout) the
             # primary pass could take 90s and the retry pass 105s -- past the
             # 150s turn budget, so the budget killed retries that would have
             # succeeded. 30+30 here plus 35+40 in retry_llm_with_fallback
             # keeps the whole ladder inside the budget.
-            best_call, runner_up_call = await best_two_within_timelimit(
+            best_two = await best_two_within_timelimit(
                 calls,
                 score_fn,
                 timeout=30.0,
                 extended_timeout=30.0,
             )
             response_text, context_part = (
-                best_call if best_call is not None else (None, None)
+                best_two.best if best_two.best is not None else (None, None)
             )
+            if best_two.best is not None:
+                picked_score = best_two.best_score
+                if best_two.best_task is not None:
+                    picked_model = call_labels.get(best_two.best_task)
+            if best_two.runner_up is not None:
+                runner_up_text = best_two.runner_up[0]
+                runner_up_score = best_two.runner_up_score
+                if best_two.runner_up_task is not None:
+                    runner_up_model = call_labels.get(best_two.runner_up_task)
         except Exception as e:
             logger.warning(f"Primary models all failed: {e}")
             response_text = None
@@ -401,6 +436,9 @@ class ChatInterface:
         response_text = response_text or ""
 
         # If primary models failed, use retry handler with fallback
+        retry_used = False
+        saw_repeats = False
+        retry_debug: Dict[str, Any] = {}
         if should_retry_response(response_text):
             saw_repeats = bool(rejection_stats.get("repeated_rejected"))
             if saw_repeats:
@@ -425,10 +463,19 @@ class ChatInterface:
                 user_message_for_scoring=scoring_message,
                 anti_repeat=saw_repeats,
                 allow_repeated_reply=allow_repeat,
+                debug_info=retry_debug,
             )
             if retry_response and len(retry_response.strip()) > 5:
                 response_text = retry_response
                 context_part = retry_context
+                retry_used = True
+                picked_model = retry_debug.get("retry_picked_model") or picked_model
+                picked_score = retry_debug.get("retry_picked_score", picked_score)
+                # The retry winner replaced the primary answer; the primary
+                # pass's runner-up no longer describes a comparable pair.
+                runner_up_text = None
+                runner_up_model = None
+                runner_up_score = None
 
         logger.debug(f"Using best result {response_text:.20}...")
 
@@ -436,21 +483,82 @@ class ChatInterface:
             logger.debug("Got empty response from LLM")
             return None, None
 
-        # Capture a presentable runner-up as a side-by-side alternate answer.
-        # Only for the top-level user turn (depth 0); recursive tool calls
-        # must not clobber it. Cleared again below if tool processing changes
-        # the primary response (action flows don't get a raw alternate).
+        # Capture a presentable runner-up as a side-by-side alternate answer
+        # -- but only when the top two scores are CLOSELY TIED (see
+        # scores_closely_tied): when the winner is clearly better, showing a
+        # second answer is noise; when the race was close, the user is the
+        # right tiebreaker. Only for the top-level user turn (depth 0);
+        # recursive tool calls must not clobber it. Cleared again below if
+        # tool processing changes the primary response (action flows don't
+        # get a raw alternate).
+        closely_tied = False
         if depth == 0:
             self._candidate_alternate = None
-            if runner_up_call is not None:
-                alternate_text = runner_up_call[0]
-                if alternate_text and alternate_is_presentable(
-                    alternate_text,
+            closely_tied = (
+                picked_score is not None
+                and runner_up_score is not None
+                and scores_closely_tied(picked_score, runner_up_score)
+            )
+            if runner_up_text and closely_tied:
+                if alternate_is_presentable(
+                    runner_up_text,
                     response_text,
                     chat_history=chat.chat_history,
                     current_message=scoring_message,
                 ):
-                    self._candidate_alternate = alternate_text.strip()
+                    self._candidate_alternate = runner_up_text.strip()
+            elif runner_up_text:
+                logger.debug(
+                    f"Chat {chat.id}: runner-up not closely tied "
+                    f"({runner_up_score} vs {picked_score}); no alternate"
+                )
+
+        # One compact selection line per LLM pass at INFO: this is the
+        # production-debuggable record of which backend won and why the
+        # alternates/retries behaved as they did (the debug frame below
+        # only reaches DEBUG deployments and staff).
+        elapsed_ms = int((time.monotonic() - llm_pass_started) * 1000)
+        logger.info(
+            f"Chat {chat.id}: picked {picked_model or 'unknown'}"
+            f" (score={picked_score}) runner_up={runner_up_model}"
+            f" (score={runner_up_score}, tied={closely_tied})"
+            f" candidates={len(calls)} rejected_repeats="
+            f"{rejection_stats.get('repeated_rejected', 0)}"
+            f" retry_used={retry_used} elapsed_ms={elapsed_ms} depth={depth}"
+        )
+        if depth == 0 and self.debug_llm:
+            # -inf (hard-rejected candidates) is not valid JSON -- json.dumps
+            # emits `-Infinity`, which browser JSON.parse refuses, killing
+            # the whole frame client-side. Map non-finite scores to None and
+            # mark the rejection explicitly instead.
+            scored_candidates = [
+                {
+                    "model": call_labels.get(task, "unknown"),
+                    "score": score if math.isfinite(score) else None,
+                    "rejected": not math.isfinite(score),
+                }
+                for task, score in score_log.items()
+            ]
+            await self.send_json_message_func(
+                {
+                    "debug_llm_result": {
+                        "picked_model": picked_model,
+                        "picked_score": picked_score,
+                        "runner_up_model": runner_up_model,
+                        "runner_up_score": runner_up_score,
+                        "closely_tied": closely_tied,
+                        "alternate_offered": bool(self._candidate_alternate),
+                        "candidate_count": len(calls),
+                        "scored_candidates": scored_candidates,
+                        "rejected_repeats": rejection_stats.get("repeated_rejected", 0),
+                        "repeat_offenders": dict(self._repeat_offenders),
+                        "retry_used": retry_used,
+                        "anti_repeat_retry": saw_repeats and retry_used,
+                        "allow_repeated_reply": allow_repeat,
+                        "elapsed_ms": elapsed_ms,
+                    }
+                }
+            )
         response_before_tools = response_text
 
         # Process tool calls via modular tool handlers

--- a/fighthealthinsurance/chat_interface.py
+++ b/fighthealthinsurance/chat_interface.py
@@ -369,10 +369,16 @@ class ChatInterface:
 
         runner_up_call: Optional[Tuple[Optional[str], Optional[str]]] = None
         try:
+            # Explicit overtime window: with the defaults (2x timeout) the
+            # primary pass could take 90s and the retry pass 105s -- past the
+            # 150s turn budget, so the budget killed retries that would have
+            # succeeded. 30+30 here plus 35+40 in retry_llm_with_fallback
+            # keeps the whole ladder inside the budget.
             best_call, runner_up_call = await best_two_within_timelimit(
                 calls,
                 score_fn,
                 timeout=30.0,
+                extended_timeout=30.0,
             )
             response_text, context_part = (
                 best_call if best_call is not None else (None, None)
@@ -816,11 +822,14 @@ class ChatInterface:
                 user_facing_message = "This chat is already linked to your prior authorization request. How can I help you with it?"
         if link_message and user_facing_message:
             await asyncio.sleep(0.01)
-            # Transactional merge against the fresh row (see apersist_chat_turn)
+            # Transactional merge against the fresh row (see apersist_chat_turn).
+            # The link note is context for the LLM, not something the user
+            # typed: flag it internal so replays don't render it as a user
+            # bubble (see _is_internal_history_message).
             self.chat = chat = await apersist_chat_turn(
                 chat,
                 new_messages=[
-                    {"role": "user", "content": link_message},
+                    {"role": "user", "content": link_message, "internal": True},
                     {"role": "assistant", "content": user_facing_message},
                 ],
             )
@@ -1054,6 +1063,34 @@ class ChatInterface:
         # (The double asterisks around the entire tool call are required)
         # USPSTF preventive recommendations: **uspstf_lookup {"query": "...", "grade": "A"}**
 
+        # Persist the user's message BEFORE generation. Channels cancels the
+        # consumer's coroutine on disconnect, and persistence used to happen
+        # only after the LLM returned -- so a network blip mid-turn silently
+        # erased the user's message from history (CancelledError skips the
+        # failure-path persist too). The final persist below merges against
+        # fresh state with tail-dedup, so this never duplicates the message.
+        # Deliberately NOT rebinding self.chat/chat: scoring and history prep
+        # treat chat.chat_history as the PRE-turn history (the current
+        # message travels separately). Guarded: persistence problems must
+        # not block the turn -- worst case we fall back to the old
+        # persist-at-end behavior.
+        if user_message and user_message.strip():
+            try:
+                await apersist_chat_turn(
+                    chat,
+                    new_messages=[{"role": "user", "content": user_message}],
+                )
+            except OngoingChat.DoesNotExist:
+                logger.warning(
+                    f"Chat {chat.id} vanished before the turn started; "
+                    f"continuing unpersisted"
+                )
+            except Exception:
+                logger.opt(exception=True).warning(
+                    f"Could not pre-persist user message for chat {chat.id}; "
+                    f"continuing (will persist at turn end)"
+                )
+
         # Debug visibility: show exactly what is being sent to the backend
         # model for this turn. Gated upstream (settings.DEBUG or staff), and
         # the content is the requesting user's own conversation, so sending
@@ -1261,11 +1298,33 @@ class ChatInterface:
             )
             await self.send_error_message(err_msg)
 
+    # Legacy prefixes of internal (LLM-context-only) user-role messages that
+    # predate the explicit "internal" flag; matched so old chats don't replay
+    # them either.
+    _INTERNAL_MESSAGE_PREFIXES = (
+        "Linked this chat to ",
+        "This chat is already linked to ",
+    )
+
+    @classmethod
+    def _is_internal_history_message(cls, message: Dict[str, Any]) -> bool:
+        """Messages stored purely as LLM context (e.g. the appeal-linking
+        notes recorded with role=user) must not replay as user bubbles."""
+        if message.get("internal"):
+            return True
+        content = message.get("content") or ""
+        return message.get("role") == "user" and content.startswith(
+            cls._INTERNAL_MESSAGE_PREFIXES
+        )
+
     async def replay_chat_history(self):
-        """Sends the existing chat history to the client."""
+        """Sends the existing chat history to the client, minus internal
+        LLM-context-only messages (which would render as user bubbles the
+        user never typed)."""
         chat = self.chat
-        history: Optional[List[Dict[str, Any]]] = chat.chat_history
-        await self.send_json_message_func({"messages": chat.chat_history})
+        history: List[Dict[str, Any]] = chat.chat_history or []
+        visible = [m for m in history if not self._is_internal_history_message(m)]
+        await self.send_json_message_func({"messages": visible})
 
     async def _handle_policy_analysis(
         self, chat: OngoingChat, user_message: str

--- a/fighthealthinsurance/chat_interface.py
+++ b/fighthealthinsurance/chat_interface.py
@@ -1074,12 +1074,19 @@ class ChatInterface:
         # message travels separately). Guarded: persistence problems must
         # not block the turn -- worst case we fall back to the old
         # persist-at-end behavior.
+        # Once pre-persisted, the end-of-turn persists must NOT resubmit the
+        # user message: with two connections racing on one chat, the other
+        # turn's pre-persist can merge into this message ("A" -> "A B"), and
+        # resubmitting "A" against that merged tail would append it AGAIN
+        # ("A B A") instead of deduping.
+        user_message_prepersisted = False
         if user_message and user_message.strip():
             try:
                 await apersist_chat_turn(
                     chat,
                     new_messages=[{"role": "user", "content": user_message}],
                 )
+                user_message_prepersisted = True
             except OngoingChat.DoesNotExist:
                 logger.warning(
                     f"Chat {chat.id} vanished before the turn started; "
@@ -1216,12 +1223,18 @@ class ChatInterface:
             # Guarded: the chat row can vanish mid-turn (data deletion); the
             # user still gets the generated reply, it just isn't persisted.
             try:
+                # The user message is only resubmitted when the pre-persist
+                # failed -- see user_message_prepersisted above for why.
+                end_of_turn_messages = [
+                    {"role": "assistant", "content": final_response_text}
+                ]
+                if not user_message_prepersisted:
+                    end_of_turn_messages.insert(
+                        0, {"role": "user", "content": user_message}
+                    )
                 self.chat = chat = await apersist_chat_turn(
                     chat,
-                    new_messages=[
-                        {"role": "user", "content": user_message},
-                        {"role": "assistant", "content": final_response_text},
-                    ],
+                    new_messages=end_of_turn_messages,
                     new_summaries=turn_summaries,
                 )
             except OngoingChat.DoesNotExist:
@@ -1261,11 +1274,17 @@ class ChatInterface:
         else:
             # The turn failed after the user already committed their message:
             # persist it anyway so a reconnect/replay doesn't erase what they
-            # typed (previously the whole turn was dropped on failure).
+            # typed (previously the whole turn was dropped on failure). Only
+            # resubmitted when the pre-persist failed -- see
+            # user_message_prepersisted above.
             try:
                 self.chat = chat = await apersist_chat_turn(
                     chat,
-                    new_messages=[{"role": "user", "content": user_message}],
+                    new_messages=(
+                        []
+                        if user_message_prepersisted
+                        else [{"role": "user", "content": user_message}]
+                    ),
                     new_summaries=turn_summaries,
                 )
             except Exception:

--- a/fighthealthinsurance/ml/ml_metrics.py
+++ b/fighthealthinsurance/ml/ml_metrics.py
@@ -47,6 +47,36 @@ CHAT_TURNS_TOTAL = Counter(
     labelnames=("outcome",),
 )
 
+# Loop-prevention visibility: how often candidate chat replies (nearly)
+# repeated a recent reply, and what happened to them. Actions:
+#   rejected_candidates -- a turn hard-rejected at least one repeated
+#       candidate in the primary pass (counted once per turn);
+#   delivered_repeat -- despite the ladder, the reply we delivered still
+#       repeated a recent reply (last-resort delivery; should stay rare).
+CHAT_REPEATED_RESPONSES_TOTAL = Counter(
+    "fhi_chat_repeated_responses_total",
+    "Chat turns where candidate replies repeated a recent reply, by action.",
+    labelnames=("action",),
+)
+
+# Side-by-side alternate answers: how often one was offered, and which
+# answer users said they preferred.
+CHAT_ALTERNATE_ANSWERS_TOTAL = Counter(
+    "fhi_chat_alternate_answers_total",
+    "Chat turns where an alternate (side-by-side) answer was offered.",
+)
+
+CHAT_ANSWER_FEEDBACK_TOTAL = Counter(
+    "fhi_chat_answer_feedback_total",
+    "User feedback on side-by-side answers (preferred=primary/alternate).",
+    labelnames=("preferred",),
+)
+
+# Bounded label set for the feedback counter: the value arrives from the
+# client, so anything unexpected is collapsed to "other" to keep metric
+# cardinality fixed.
+_ANSWER_FEEDBACK_ALLOWED = frozenset({"primary", "alternate"})
+
 
 def _safe_label(value: object, limit: int = 80) -> str:
     return str(value)[:limit] if value else "unknown"
@@ -76,6 +106,36 @@ def record_chat_turn(outcome: str) -> None:
         CHAT_TURNS_TOTAL.labels(outcome=outcome).inc()
     except Exception:  # pragma: no cover
         logger.opt(exception=True).debug("Failed to record chat turn metric")
+
+
+def record_chat_repeat(action: str) -> None:
+    """Record a repeated-reply event (see CHAT_REPEATED_RESPONSES_TOTAL).
+    Never raises."""
+    try:
+        CHAT_REPEATED_RESPONSES_TOTAL.labels(action=action).inc()
+    except Exception:  # pragma: no cover
+        logger.opt(exception=True).debug("Failed to record chat repeat metric")
+
+
+def record_chat_alternate_offered() -> None:
+    """Record that a side-by-side alternate answer was offered. Never raises."""
+    try:
+        CHAT_ALTERNATE_ANSWERS_TOTAL.inc()
+    except Exception:  # pragma: no cover
+        logger.opt(exception=True).debug("Failed to record alternate metric")
+
+
+def record_answer_feedback(preferred: object) -> None:
+    """Record which side-by-side answer the user preferred. The value comes
+    from the client, so it is collapsed to a bounded label set. Never
+    raises."""
+    try:
+        label = str(preferred) if preferred else "other"
+        if label not in _ANSWER_FEEDBACK_ALLOWED:
+            label = "other"
+        CHAT_ANSWER_FEEDBACK_TOTAL.labels(preferred=label).inc()
+    except Exception:  # pragma: no cover
+        logger.opt(exception=True).debug("Failed to record answer feedback metric")
 
 
 class ExecutorQueueCollector(Collector):

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -1287,6 +1287,8 @@ Some important notes:
 
 - Never repeat one of your earlier replies verbatim or near-verbatim. When the user answers a question you asked -- even tersely, like "CA" or "yes" -- treat it as new information: acknowledge it, combine it with the conversation so far, and take the next step instead of re-asking or re-sending your previous message.
 
+- Messages may contain privacy placeholders such as {{{{FIRST_NAME}}}}, {{{{LAST_NAME}}}}, {{{{PATIENT_NAME}}}}, {{{{Your Email Address}}}}, {{{{ADDRESS}}}}, {{{{CITY}}}}, {{{{ZIP_CODE}}}}, or {{{{STATE}}}}. These stand for the user's REAL details: they are redacted before reaching you and restored on the user's screen. Treat a placeholder as information you already have -- you can even write the placeholder in your reply and the user will see their real value -- and NEVER ask the user to re-supply something that already appears as a placeholder. The one exception: when a tool call needs the literal value (for example medicaid_info needs a real state name) and you only have {{{{STATE}}}}, ask the user to confirm just that value once.
+
 - If conversation strays (e.g., pop culture, venting, existential dread), redirect with warmth and focus.
 
 - You do not currently recommend any particular insurance company or health plan, or countries medical system.

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -987,6 +987,7 @@ class RemoteModelLike(DenialBase):
         is_professional: bool = True,
         is_logged_in: bool = True,
         is_medicaid_related: Optional[bool] = None,
+        allow_repeated_reply: bool = False,
     ) -> tuple[Optional[str], Optional[str]]:
         """
         Generate a chat response from the model.
@@ -1000,6 +1001,11 @@ class RemoteModelLike(DenialBase):
             is_logged_in: Whether the user is logged in or anonymous
             is_medicaid_related: Whether the chat involves Medicaid/Medicare topics.
                 If None, will be auto-detected from message and context.
+            allow_repeated_reply: True when the user's RAW message explicitly
+                asked for a repeat (derived by the caller BEFORE prompt
+                wrapping -- the wrapped prompt contains system-injected text
+                that says "repeat" and can't be tested here). Disables the
+                repeat-of-last-reply retry so the model may actually repeat.
 
         Returns:
             Generated response or None
@@ -1325,11 +1331,13 @@ Remember in the last three sentences GLP-1 is just an _example_ check what the u
 
         def _repeats_last_reply(candidate: Optional[str]) -> bool:
             # Mandated verbatim replies (see CANNED_REPLY_MARKERS) repeat by
-            # design -- retrying against them just burns a serial call. The
-            # user-asked-for-a-repeat case is handled by the SCORING layer,
-            # which sees the raw user message; the wrapped prompt available
-            # here contains system-injected text that itself says "repeat"
-            # and would false-positive.
+            # design, and an explicit "please repeat that" from the user
+            # (allow_repeated_reply, derived from the RAW message upstream)
+            # makes repeating the correct answer -- retrying against either
+            # just burns a serial call and steers the model away from what
+            # was asked.
+            if allow_repeated_reply:
+                return False
             if candidate and is_canned_reply(candidate):
                 return False
             return bool(

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -1330,7 +1330,7 @@ Remember in the last three sentences GLP-1 is just an _example_ check what the u
                     break
 
         def _repeats_last_reply(candidate: Optional[str]) -> bool:
-            # Mandated verbatim replies (see CANNED_REPLY_MARKERS) repeat by
+            # Mandated verbatim replies (see CANNED_REPLY_SIGNATURES) repeat by
             # design, and an explicit "please repeat that" from the user
             # (allow_repeated_reply, derived from the RAW message upstream)
             # makes repeating the correct answer -- retrying against either
@@ -1338,15 +1338,24 @@ Remember in the last three sentences GLP-1 is just an _example_ check what the u
             # was asked.
             if allow_repeated_reply:
                 return False
-            if candidate and is_canned_reply(candidate):
+            # Compare like with like: `candidate` is the RAW generation, which
+            # still carries the trailing "🐼<context summary>", while history
+            # stores the split answer. Comparing the two shapes put a
+            # byte-identical repeat at ~0.76 similarity -- under the 0.9
+            # threshold -- so the self-heal never fired on real output.
+            answer = candidate.split("🐼")[0] if candidate else candidate
+            if answer and is_canned_reply(answer):
                 return False
             return bool(
-                candidate
+                answer
                 and last_assistant_reply
-                and is_mostly_repeated(candidate, last_assistant_reply)
+                and is_mostly_repeated(answer, last_assistant_reply)
             )
 
         result: Optional[str] = None
+        # Evaluated once per iteration and reused by the loop condition and
+        # the corrective-feedback branch (the comparison is not free).
+        repeats_last = False
         c = 0
         chat_timeout = ml_task_timeout("chat")
         loop_start = time.monotonic()
@@ -1357,12 +1366,12 @@ Remember in the last three sentences GLP-1 is just an _example_ check what the u
         while (
             result is None
             or result.strip().lower() == current_message.strip().lower()
-            or _repeats_last_reply(result)
+            or repeats_last
             or self.bad_result(result, "chat")
         ) and (c < 2 and time.monotonic() - loop_start < 2 * chat_timeout):
             c = c + 1
             result_extra = ""
-            if _repeats_last_reply(result):
+            if repeats_last:
                 # Corrective feedback + hotter sampling: the repeat is often
                 # near-deterministic, and the changed prompt text also busts
                 # any upstream response cache serving the same reply. Takes
@@ -1386,6 +1395,7 @@ Remember in the last three sentences GLP-1 is just an _example_ check what the u
             )
             if raw_result:
                 result = raw_result[0]
+            repeats_last = _repeats_last_reply(result)
         if result is None:
             return (None, None)
         if "🐼" not in result:

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -30,6 +30,7 @@ def _is_verbose_logging() -> bool:
 
 
 from fighthealthinsurance.ml.ml_metrics import record_ml_call, record_ml_failure
+from fighthealthinsurance.ml.response_similarity import is_mostly_repeated
 from fighthealthinsurance.utils import (
     RateLimiter,
     ensure_message_alternation,
@@ -1000,8 +1001,16 @@ class RemoteModelLike(DenialBase):
         Returns:
             Generated response or None
         """
+        # Clearly-labeled framing: the old "The previous context is: ... And
+        # the active question is:" buried terse replies ("CA") behind the
+        # summary of the model's OWN previous turn, which invited weaker
+        # models to replay that turn instead of using the new answer.
         previous_context_extra = (
-            f"The previous context is: {previous_context_summary}\n\n And the active question is:"
+            f"Context summary of the conversation so far (background for you; "
+            f"the user has not seen this): {previous_context_summary}\n\n"
+            f"Reply to the user's newest message below. Do not repeat an "
+            f"earlier reply and do not re-ask questions the conversation "
+            f"history already answers.\n\nThe user's newest message is: "
             if previous_context_summary
             else ""
         )
@@ -1268,13 +1277,15 @@ If a chat is linked to an appeal or prior authorization record, pay attention to
 
 Don't tell people which tools your using.
 
-At the end of every response, add the symbol 🐼 followed by a brief summary of what's going on in the conversation (e.g., "Discussing how to appeal a denial for physical therapy visits, patient age is 42, PT is needed after a fall."). Or if the chat is regarding medicaid / medicare eligibility it should be the information collected so far (like income etc.). This summary is for internal use only and will not be shown to the user. Use it to maintain continuity in future replies.
+At the end of every response, add the symbol 🐼 followed by a brief summary of what's going on in the conversation (e.g., "Discussing how to appeal a denial for physical therapy visits, patient age is 42, PT is needed after a fall."). Or if the chat is regarding medicaid / medicare eligibility it should be the information collected so far (like income etc.). This summary is for internal use only and will not be shown to the user. Use it to maintain continuity in future replies. Always fold NEW details from the user's latest message into this summary -- their state, age, income, or answers to questions you asked -- so the summary tracks the answers you have collected, not just the questions you asked.
 (Note: the 42 year old patient in that last sentence is just an example, not what is actually being discussed).
 
 
 Some important notes:
 
 - You should not provide medical advice. If asked, gently steer the conversation back to billing/coverage/admin tasks.
+
+- Never repeat one of your earlier replies verbatim or near-verbatim. When the user answers a question you asked -- even tersely, like "CA" or "yes" -- treat it as new information: acknowledge it, combine it with the conversation so far, and take the next step instead of re-asking or re-sending your previous message.
 
 - If conversation strays (e.g., pop culture, venting, existential dread), redirect with warmth and focus.
 
@@ -1294,6 +1305,26 @@ So for example if a user asks a question and you have a follow up (like "How do 
 What reason did they give you for your GLP-1 denied?🐼Helping a patient appeal a GLP-1 denial.
 Remember in the last three sentences GLP-1 is just an _example_ check what the user is actually chatting about. You'll want to include all of the context collected so far in the summary after the panda emoji.
 """
+        # The most recent assistant reply in the history: a fresh generation
+        # that (nearly) repeats it is the chat-loop failure mode, so the
+        # retry loop below treats it like a bad result and asks the model to
+        # try again with corrective feedback and a temperature bump.
+        last_assistant_reply: Optional[str] = None
+        if history:
+            for prior_msg in reversed(history):
+                if prior_msg.get("role") in ("assistant", "agent") and prior_msg.get(
+                    "content"
+                ):
+                    last_assistant_reply = prior_msg.get("content")
+                    break
+
+        def _repeats_last_reply(candidate: Optional[str]) -> bool:
+            return bool(
+                candidate
+                and last_assistant_reply
+                and is_mostly_repeated(candidate, last_assistant_reply)
+            )
+
         result: Optional[str] = None
         c = 0
         chat_timeout = ml_task_timeout("chat")
@@ -1305,11 +1336,25 @@ Remember in the last three sentences GLP-1 is just an _example_ check what the u
         while (
             result is None
             or result.strip().lower() == current_message.strip().lower()
+            or _repeats_last_reply(result)
             or self.bad_result(result, "chat")
         ) and (c < 2 and time.monotonic() - loop_start < 2 * chat_timeout):
             c = c + 1
             result_extra = ""
-            if result and len(result) > 0 and "🐼" not in result:
+            if _repeats_last_reply(result):
+                # Corrective feedback + hotter sampling: the repeat is often
+                # near-deterministic, and the changed prompt text also busts
+                # any upstream response cache serving the same reply. Takes
+                # priority over the missing-panda feedback -- a repeated
+                # reply is the worse failure.
+                result_extra = (
+                    "Your previous draft repeated your last reply, which the "
+                    "user has already seen. Do not repeat it -- respond to "
+                    "the user's newest message directly, using the details "
+                    "they have already provided.\n\n"
+                )
+                temperature = min(1.0, temperature + 0.15)
+            elif result and len(result) > 0 and "🐼" not in result:
                 result_extra = f"Your previous answer -- {result} -- was missing the panda emoji 🐼 and the context information. Please try again.\n\n"
             raw_result = await self._infer(
                 system_prompts=[base_system_prompt],

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -30,7 +30,10 @@ def _is_verbose_logging() -> bool:
 
 
 from fighthealthinsurance.ml.ml_metrics import record_ml_call, record_ml_failure
-from fighthealthinsurance.ml.response_similarity import is_mostly_repeated
+from fighthealthinsurance.ml.response_similarity import (
+    is_canned_reply,
+    is_mostly_repeated,
+)
 from fighthealthinsurance.utils import (
     RateLimiter,
     ensure_message_alternation,
@@ -1321,6 +1324,14 @@ Remember in the last three sentences GLP-1 is just an _example_ check what the u
                     break
 
         def _repeats_last_reply(candidate: Optional[str]) -> bool:
+            # Mandated verbatim replies (see CANNED_REPLY_MARKERS) repeat by
+            # design -- retrying against them just burns a serial call. The
+            # user-asked-for-a-repeat case is handled by the SCORING layer,
+            # which sees the raw user message; the wrapped prompt available
+            # here contains system-injected text that itself says "repeat"
+            # and would false-positive.
+            if candidate and is_canned_reply(candidate):
+                return False
             return bool(
                 candidate
                 and last_assistant_reply

--- a/fighthealthinsurance/ml/ml_router.py
+++ b/fighthealthinsurance/ml/ml_router.py
@@ -630,13 +630,17 @@ class MLRouter(object):
         pass: quadratic base scoring still prefers a healthy internal reply,
         but when the internals loop (hard-rejected repeats) or fail, an
         external answer is already in hand instead of costing a full retry
-        round trip. The same externals are also returned as fallback so the
-        retry pass (shortened context, hotter sampling) can take another
-        shot at them.
+        round trip.
+
+        The fallback list then carries only externals NOT already in the
+        primary list -- normally none. The retry pass fans out over BOTH
+        lists, so a backend appearing in each would receive four identical
+        requests per retry; the externals already get their retry attempt as
+        members of the primary list.
 
         Args:
-            use_external: Whether external models participate (primary and
-                fallback). False keeps chat internal-only with no fallback.
+            use_external: Whether external models participate at all. False
+                keeps chat internal-only with no fallback.
 
         Returns:
             Tuple of (primary_models, fallback_models)

--- a/fighthealthinsurance/ml/ml_router.py
+++ b/fighthealthinsurance/ml/ml_router.py
@@ -579,7 +579,7 @@ class MLRouter(object):
         """
         Return models for handling chat interactions.
         Args:
-            use_external: Whether to include external models as fallback
+            use_external: Whether to include external models in the fan-out
 
         Returns:
             List of RemoteModelLike models suitable for chat tasks
@@ -603,9 +603,15 @@ class MLRouter(object):
             )
         if use_external:
             models += self.best_external_models()
-        internal_to_add = self._filter_available(
+        # Strongest available internals, not cheapest: the cost ordering was
+        # picking the 6 CHEAPEST internal backends for chat, which is the
+        # wrong end of the list when strong and weak internals coexist. The
+        # sort is stable over the cost ordering, so equal-quality models
+        # still resolve cheapest-first.
+        internal_available = self._filter_available(
             self.internal_models_by_cost, "chat-internal"
-        )[:6]
+        )
+        internal_to_add = sorted(internal_available, key=lambda m: -m.quality())[:6]
         models += internal_to_add
         logger.debug(
             f"get_chat_backends(use_external={use_external}): {len(models)} models: "
@@ -617,23 +623,30 @@ class MLRouter(object):
         self, use_external=False
     ) -> tuple[list[RemoteModelLike], list[RemoteModelLike]]:
         """
-        Return primary (FHI) and fallback (external) models for chat interactions.
-        The fallback models are only returned if use_external is True.
+        Return primary and fallback (retry-only) models for chat interactions.
+
+        When ``use_external`` is True the best external models join the
+        PRIMARY fan-out alongside the internal backends, not just the retry
+        pass: quadratic base scoring still prefers a healthy internal reply,
+        but when the internals loop (hard-rejected repeats) or fail, an
+        external answer is already in hand instead of costing a full retry
+        round trip. The same externals are also returned as fallback so the
+        retry pass (shortened context, hotter sampling) can take another
+        shot at them.
 
         Args:
-            use_external: Whether to include external models as fallback
+            use_external: Whether external models participate (primary and
+                fallback). False keeps chat internal-only with no fallback.
 
         Returns:
             Tuple of (primary_models, fallback_models)
-            - primary_models: FHI/internal models to try first
-            - fallback_models: External models to try if primary fails (empty if use_external=False)
         """
         forced_models = self._get_forced_models("for chat", use_external=use_external)
         if forced_models:
             return forced_models, []
 
         # Reuse get_chat_backends for primary models (allows test mocking to work)
-        primary_models = self.get_chat_backends(use_external=False)
+        primary_models = self.get_chat_backends(use_external=use_external)
 
         fallback_models: list[RemoteModelLike] = []
         if use_external:

--- a/fighthealthinsurance/ml/ml_router.py
+++ b/fighthealthinsurance/ml/ml_router.py
@@ -650,8 +650,16 @@ class MLRouter(object):
 
         fallback_models: list[RemoteModelLike] = []
         if use_external:
-            # Prefer the best available external models for chat fallback.
-            fallback_models = self.best_external_models()
+            # Only externals NOT already in the primary fan-out. build_retry_calls
+            # issues two calls per entry of model_backends AND two per entry of
+            # fallback_backends, so a backend present in both lists received
+            # four byte-identical requests per retry -- doubled paid spend and
+            # rate-limit pressure on exactly the turns that already failed,
+            # with no added diversity.
+            already_primary = {id(m) for m in primary_models}
+            fallback_models = [
+                m for m in self.best_external_models() if id(m) not in already_primary
+            ]
 
         return primary_models, fallback_models
 

--- a/fighthealthinsurance/ml/response_similarity.py
+++ b/fighthealthinsurance/ml/response_similarity.py
@@ -1,0 +1,125 @@
+"""Text-similarity helpers for detecting (near-)repeated chat replies.
+
+The chat loop failure mode this supports: the model re-sends its previous
+reply (often verbatim, sometimes lightly reworded) instead of using the
+user's newest answer, so the conversation stops advancing. Detection has to
+be shared by two layers that cannot import each other's home modules --
+``fighthealthinsurance.ml.ml_models`` (per-backend retry loop) and
+``fighthealthinsurance.chat.llm_client`` (candidate scoring), where
+``llm_client`` already imports from ``ml_models`` -- so the helpers live in
+this tiny stdlib-only module both can import without a cycle.
+"""
+
+import re
+from difflib import SequenceMatcher
+from typing import Optional, Set
+
+# A normalized-exact repeat of anything at least this long is a real repeat
+# (below it, short confirmations like "Yes." can legitimately recur).
+EXACT_REPEAT_MIN_CHARS = 20
+
+# Similarity-based ("mostly repeated") detection only applies to texts at
+# least this long -- short strings reach high ratios by accident.
+NEAR_REPEAT_MIN_CHARS = 80
+
+# SequenceMatcher ratio at/above which two long texts count as the same reply.
+NEAR_REPEAT_SIMILARITY = 0.9
+
+# For long texts, a near-total word-set overlap also counts as a repeat even
+# when reordering keeps the sequence ratio lower.
+LONG_TEXT_JACCARD_MIN_CHARS = 200
+LONG_TEXT_JACCARD_THRESHOLD = 0.95
+
+# Cap comparison cost on pathological outputs; the head of a reply is enough
+# to recognize a repeat.
+_MAX_COMPARE_CHARS = 4000
+
+_WORD_RE = re.compile(r"[a-z0-9]+")
+
+
+def normalize_text(text: str) -> str:
+    """Normalize text for comparison: lowercase, collapse whitespace, strip."""
+    return re.sub(r"\s+", " ", text.lower().strip())
+
+
+def bag_of_words(text: str) -> Set[str]:
+    """Extract a bag of words (lowercased) from text for unordered comparison."""
+    return set(_WORD_RE.findall(text.lower()))
+
+
+def jaccard_similarity(a: str, b: str) -> float:
+    """Word-set Jaccard similarity of two texts (0.0-1.0)."""
+    words_a = bag_of_words(a)
+    words_b = bag_of_words(b)
+    if not words_a or not words_b:
+        return 0.0
+    intersection = len(words_a & words_b)
+    union = len(words_a | words_b)
+    return intersection / union if union else 0.0
+
+
+def sequence_similarity(a: str, b: str) -> float:
+    """Order-sensitive similarity of two normalized texts (0.0-1.0).
+
+    ``difflib.SequenceMatcher`` ratio on the normalized, length-capped
+    strings, with the cheap ``quick_ratio`` upper bound short-circuiting
+    clearly-different pairs (ratio can never exceed quick_ratio, and callers
+    only care about values near the repeat thresholds).
+    """
+    na = normalize_text(a)[:_MAX_COMPARE_CHARS]
+    nb = normalize_text(b)[:_MAX_COMPARE_CHARS]
+    if not na or not nb:
+        return 0.0
+    if na == nb:
+        return 1.0
+    matcher = SequenceMatcher(None, na, nb)
+    quick = matcher.quick_ratio()
+    if quick < 0.6:
+        return quick
+    return matcher.ratio()
+
+
+def response_similarity(a: Optional[str], b: Optional[str]) -> float:
+    """Overall similarity of two replies (0.0-1.0): max of the order-sensitive
+    sequence ratio and the word-set Jaccard, so both verbatim repeats and
+    same-content reorderings score high."""
+    if not a or not b:
+        return 0.0
+    return max(sequence_similarity(a, b), jaccard_similarity(a, b))
+
+
+def is_mostly_repeated(
+    candidate: Optional[str],
+    previous: Optional[str],
+    *,
+    similarity_threshold: float = NEAR_REPEAT_SIMILARITY,
+    min_chars: int = NEAR_REPEAT_MIN_CHARS,
+) -> bool:
+    """Whether ``candidate`` is (nearly) the same reply as ``previous``.
+
+    True when the normalized texts match exactly (and are long enough to not
+    be a routine short confirmation), when long texts are near-identical by
+    sequence ratio, or when long texts share almost their whole word set.
+    Short texts never trip the similarity paths, so brief answers ("Yes.",
+    "Which state?") are left to softer scoring penalties instead.
+    """
+    if not candidate or not previous:
+        return False
+    norm_candidate = normalize_text(candidate)
+    norm_previous = normalize_text(previous)
+    if not norm_candidate or not norm_previous:
+        return False
+    if norm_candidate == norm_previous:
+        return len(norm_candidate) >= EXACT_REPEAT_MIN_CHARS
+    if len(norm_candidate) < min_chars or len(norm_previous) < min_chars:
+        return False
+    if sequence_similarity(norm_candidate, norm_previous) >= similarity_threshold:
+        return True
+    if (
+        len(norm_candidate) >= LONG_TEXT_JACCARD_MIN_CHARS
+        and len(norm_previous) >= LONG_TEXT_JACCARD_MIN_CHARS
+        and jaccard_similarity(norm_candidate, norm_previous)
+        >= LONG_TEXT_JACCARD_THRESHOLD
+    ):
+        return True
+    return False

--- a/fighthealthinsurance/ml/response_similarity.py
+++ b/fighthealthinsurance/ml/response_similarity.py
@@ -160,10 +160,12 @@ def _sequence_similarity_normalized(na: str, nb: str, min_useful: float = 0.0) -
     vs 0.96 without, against a 0.9 threshold. Every long near-verbatim repeat
     -- exactly what this module exists to catch -- scored as unrelated.
 
-    Turning autojunk off makes ratio() genuinely O(n*m), so two cheap
-    O(n) upper bounds run first. Both are exact bounds on ratio(), so
-    skipping on them can only avoid work, never change a verdict near the
-    thresholds callers use.
+    Turning autojunk off makes ratio() genuinely O(n*m), so two cheap O(n)
+    gates run first. The LENGTH gate is an exact upper bound on ratio(), so
+    skipping on it can never change a verdict. The word-set gate is a
+    HEURISTIC, not a bound -- it only applies when the caller's threshold
+    sits above the floor, so the surrogate value it returns is still
+    guaranteed to fall below that threshold.
     """
     if not na or not nb:
         return 0.0
@@ -174,8 +176,14 @@ def _sequence_similarity_normalized(na: str, nb: str, min_useful: float = 0.0) -
         length_bound = 2 * min(len(na), len(nb)) / (len(na) + len(nb))
         if length_bound < min_useful:
             return length_bound
-        # Word-set bound: a near-verbatim repeat shares nearly all its words.
-        if jaccard_similarity(na, nb) < _SEQUENCE_JACCARD_FLOOR:
+        # Word-set gate (heuristic): a near-verbatim repeat shares nearly all
+        # its words. Only usable when the caller's threshold is above the
+        # floor -- otherwise the surrogate returned here could itself reach
+        # the threshold and report a repeat that was never measured.
+        if (
+            min_useful > _SEQUENCE_JACCARD_FLOOR
+            and jaccard_similarity(na, nb) < _SEQUENCE_JACCARD_FLOOR
+        ):
             return min(length_bound, _SEQUENCE_JACCARD_FLOOR)
     return SequenceMatcher(None, na, nb, autojunk=False).ratio()
 

--- a/fighthealthinsurance/ml/response_similarity.py
+++ b/fighthealthinsurance/ml/response_similarity.py
@@ -31,36 +31,87 @@ LONG_TEXT_JACCARD_MIN_CHARS = 200
 LONG_TEXT_JACCARD_THRESHOLD = 0.95
 
 # Cap comparison cost on pathological outputs; the head of a reply is enough
-# to recognize a repeat.
-_MAX_COMPARE_CHARS = 4000
+# to recognize a repeat. Kept low deliberately: ratio() is O(n*m) and runs on
+# the event loop inside the fan-out scorer, so the cap is the hard ceiling on
+# per-comparison cost (~30ms at 1200 chars vs ~240ms at 4000).
+_MAX_COMPARE_CHARS = 1200
+
+# Word-set overlap below which two texts CANNOT be a near-verbatim repeat, so
+# the expensive sequence comparison is skipped. A 0.9 character-sequence
+# ratio implies almost the same words in almost the same order; unrelated
+# English replies share only stopwords (Jaccard well under 0.3). Deliberately
+# loose -- this is a cost gate, not a detector.
+_SEQUENCE_JACCARD_FLOOR = 0.35
 
 _WORD_RE = re.compile(r"[a-z0-9]+")
 
-# Markers of replies the system prompt REQUIRES to be sent verbatim (e.g. the
-# Medicaid work-requirements block must always be that exact text). Repeating
-# them across turns is by design, so repeat-rejection layers exempt them --
-# soft scoring penalties still prefer a fresh non-canned answer when one
-# exists. Shared here (not in chat.llm_client) so the model layer's
-# self-heal retry loop can use it without an import cycle.
-CANNED_REPLY_MARKERS = ("Medicaid Work Requirements FAQ",)
+# Replies the system prompt REQUIRES to be sent verbatim (e.g. the Medicaid
+# work-requirements block must always be that exact text). Repeating them
+# across turns is by design, so repeat-rejection layers exempt them -- soft
+# scoring penalties still prefer a fresh non-canned answer when one exists.
+# Shared here (not in chat.llm_client) so the model layer's self-heal retry
+# loop can use it without an import cycle.
+#
+# Each entry is the set of phrases a reply must contain to BE that canned
+# block. A single marker is not enough: the system prompt tells the model to
+# link the Medicaid FAQ whenever work requirements come up, so matching on
+# the link alone exempted every ordinary Medicaid reply -- including the
+# looping ones this module exists to catch -- from the whole ladder.
+CANNED_REPLY_SIGNATURES = (
+    (
+        "Medicaid Work Requirements FAQ",
+        "80 hours per month",
+        "December 31, 2026",
+    ),
+)
 
 # When the user explicitly asks for a repeat, repeating is the right answer --
-# repeat-rejection layers skip themselves so the turn can succeed. NOTE:
-# match this against the user's RAW message only; system-injected wrapper
-# text (anti-repeat notes, bridge notes) legitimately contains the word
-# "repeat" and would false-positive.
+# repeat-rejection layers skip themselves so the turn can succeed.
+#
+# NOTE 1: match this against the user's RAW message only; system-injected
+# wrapper text (anti-repeat notes, bridge notes) legitimately contains the
+# word "repeat" and would false-positive.
+#
+# NOTE 2: a bare \brepeat\b is NOT enough. "repeat MRI", "repeat colonoscopy",
+# "repeat prescription" and "repeat denial" are everyday vocabulary in this
+# product, and this flag is the master switch that disables every rung of the
+# ladder -- so it must match an explicit REQUEST to say something again, not
+# the topic of the conversation. Erring toward not-matching is the safe
+# direction: it keeps loop protection on.
+_REPEAT_VERB = r"(?:repeat|say|send|resend|re-send|show|write|state|tell)"
 USER_REQUESTED_REPEAT_RE = re.compile(
-    r"\b(repeat|say (?:that|it) again|one more time|once more|again please|"
-    r"re-?send|(?:show|send) (?:that|it) again)\b",
+    r"(?:"
+    # "repeat that", "repeat your last reply", "repeat the above"
+    r"\brepeat\s+(?:that|it|this|those|your|the|last|previous|above)\b"
+    # "say that again", "send it again", "show me that one more time"
+    rf"|\b{_REPEAT_VERB}\b[^.?!\n]{{0,40}}?\b(?:again|one more time|once more)\b"
+    # "can you repeat", "could you please repeat"
+    r"|\b(?:can|could|would|will|please|plz)\s+(?:you\s+)?(?:please\s+)?repeat\b"
+    # "resend it", "re-send that" -- but NOT "resend the fax to my doctor",
+    # which asks us to send a document, not to say something again.
+    r"|\bre-?send\s+(?:that|it|this)\b"
+    # A message that is JUST the request. Anchored to the whole message
+    # because mid-sentence these are ordinary phrases ("I filed an appeal
+    # one more time last month").
+    r"|^\s*repeat(?:\s+please)?\s*[.?!]*\s*$"
+    r"|^\s*(?:one more time|once more)(?:\s+please)?\s*[.?!]*\s*$"
+    r")",
     re.IGNORECASE,
 )
 
 
 def is_canned_reply(text: Optional[str]) -> bool:
-    """Whether the reply is one of the mandated verbatim canned responses."""
+    """Whether the reply IS one of the mandated verbatim canned responses.
+
+    Requires every phrase of a signature, so a normal reply that merely
+    links or mentions the canned block is not exempted from repeat checks.
+    """
     if not text:
         return False
-    return any(marker in text for marker in CANNED_REPLY_MARKERS)
+    return any(
+        all(phrase in text for phrase in signature)
+        for signature in CANNED_REPLY_SIGNATURES
+    )
 
 
 def user_requested_repeat(message: Optional[str]) -> bool:
@@ -89,25 +140,57 @@ def jaccard_similarity(a: str, b: str) -> float:
     return intersection / union if union else 0.0
 
 
-def sequence_similarity(a: str, b: str) -> float:
-    """Order-sensitive similarity of two normalized texts (0.0-1.0).
+def _sequence_similarity_normalized(na: str, nb: str, min_useful: float = 0.0) -> float:
+    """``sequence_similarity`` for already-normalized, already-capped text.
 
-    ``difflib.SequenceMatcher`` ratio on the normalized, length-capped
-    strings, with the cheap ``quick_ratio`` upper bound short-circuiting
-    clearly-different pairs (ratio can never exceed quick_ratio, and callers
-    only care about values near the repeat thresholds).
+    With ``min_useful > 0`` the caller declares it only cares whether the
+    result reaches that threshold, which unlocks the cheap gates below; the
+    return is then either the exact ratio or a value guaranteed to be under
+    ``min_useful``. With the default 0.0 the exact ratio is always computed
+    -- callers comparing against a LOWER threshold (the alternate-answer
+    check uses 0.7) would otherwise read an upper bound as a real score and
+    reject a perfectly distinct answer.
+
+    ``autojunk=False`` is REQUIRED for correctness here, not a tuning knob.
+    difflib's default autojunk heuristic treats any element occurring in more
+    than 1% of a sequence of 200+ elements as "popular junk" and refuses to
+    match on it -- on character-level natural language that is every space and
+    every common letter, so ratio() collapses. Measured on two 430-char
+    assistant replies differing by one reworded sentence: 0.33 with autojunk
+    vs 0.96 without, against a 0.9 threshold. Every long near-verbatim repeat
+    -- exactly what this module exists to catch -- scored as unrelated.
+
+    Turning autojunk off makes ratio() genuinely O(n*m), so two cheap
+    O(n) upper bounds run first. Both are exact bounds on ratio(), so
+    skipping on them can only avoid work, never change a verdict near the
+    thresholds callers use.
     """
-    na = normalize_text(a)[:_MAX_COMPARE_CHARS]
-    nb = normalize_text(b)[:_MAX_COMPARE_CHARS]
     if not na or not nb:
         return 0.0
     if na == nb:
         return 1.0
-    matcher = SequenceMatcher(None, na, nb)
-    quick = matcher.quick_ratio()
-    if quick < 0.6:
-        return quick
-    return matcher.ratio()
+    if min_useful > 0.0:
+        # Length bound: ratio() can never exceed 2*min/(len_a+len_b).
+        length_bound = 2 * min(len(na), len(nb)) / (len(na) + len(nb))
+        if length_bound < min_useful:
+            return length_bound
+        # Word-set bound: a near-verbatim repeat shares nearly all its words.
+        if jaccard_similarity(na, nb) < _SEQUENCE_JACCARD_FLOOR:
+            return min(length_bound, _SEQUENCE_JACCARD_FLOOR)
+    return SequenceMatcher(None, na, nb, autojunk=False).ratio()
+
+
+def sequence_similarity(a: str, b: str) -> float:
+    """Order-sensitive similarity of two texts (0.0-1.0).
+
+    Normalizes and length-caps both sides, then compares (see
+    :func:`_sequence_similarity_normalized` for why ``autojunk=False`` is
+    load-bearing and how the cost is bounded).
+    """
+    return _sequence_similarity_normalized(
+        normalize_text(a)[:_MAX_COMPARE_CHARS],
+        normalize_text(b)[:_MAX_COMPARE_CHARS],
+    )
 
 
 def response_similarity(a: Optional[str], b: Optional[str]) -> float:
@@ -144,7 +227,19 @@ def is_mostly_repeated(
         return len(norm_candidate) >= EXACT_REPEAT_MIN_CHARS
     if len(norm_candidate) < min_chars or len(norm_previous) < min_chars:
         return False
-    if sequence_similarity(norm_candidate, norm_previous) >= similarity_threshold:
+    # Already normalized above -- compare without re-normalizing (the public
+    # sequence_similarity would redo the lowercase + whitespace collapse).
+    capped_candidate = norm_candidate[:_MAX_COMPARE_CHARS]
+    capped_previous = norm_previous[:_MAX_COMPARE_CHARS]
+    # This is the hot path (several comparisons per fan-out candidate, on the
+    # event loop), and it only asks "does it reach the threshold?" -- so the
+    # cheap upper-bound gates apply here.
+    if (
+        _sequence_similarity_normalized(
+            capped_candidate, capped_previous, min_useful=similarity_threshold
+        )
+        >= similarity_threshold
+    ):
         return True
     if (
         len(norm_candidate) >= LONG_TEXT_JACCARD_MIN_CHARS

--- a/fighthealthinsurance/ml/response_similarity.py
+++ b/fighthealthinsurance/ml/response_similarity.py
@@ -36,6 +36,37 @@ _MAX_COMPARE_CHARS = 4000
 
 _WORD_RE = re.compile(r"[a-z0-9]+")
 
+# Markers of replies the system prompt REQUIRES to be sent verbatim (e.g. the
+# Medicaid work-requirements block must always be that exact text). Repeating
+# them across turns is by design, so repeat-rejection layers exempt them --
+# soft scoring penalties still prefer a fresh non-canned answer when one
+# exists. Shared here (not in chat.llm_client) so the model layer's
+# self-heal retry loop can use it without an import cycle.
+CANNED_REPLY_MARKERS = ("Medicaid Work Requirements FAQ",)
+
+# When the user explicitly asks for a repeat, repeating is the right answer --
+# repeat-rejection layers skip themselves so the turn can succeed. NOTE:
+# match this against the user's RAW message only; system-injected wrapper
+# text (anti-repeat notes, bridge notes) legitimately contains the word
+# "repeat" and would false-positive.
+USER_REQUESTED_REPEAT_RE = re.compile(
+    r"\b(repeat|say (?:that|it) again|one more time|once more|again please|"
+    r"re-?send|(?:show|send) (?:that|it) again)\b",
+    re.IGNORECASE,
+)
+
+
+def is_canned_reply(text: Optional[str]) -> bool:
+    """Whether the reply is one of the mandated verbatim canned responses."""
+    if not text:
+        return False
+    return any(marker in text for marker in CANNED_REPLY_MARKERS)
+
+
+def user_requested_repeat(message: Optional[str]) -> bool:
+    """True when the user's message explicitly asks us to repeat ourselves."""
+    return bool(message and USER_REQUESTED_REPEAT_RE.search(message))
+
 
 def normalize_text(text: str) -> str:
     """Normalize text for comparison: lowercase, collapse whitespace, strip."""

--- a/fighthealthinsurance/rest_serializers.py
+++ b/fighthealthinsurance/rest_serializers.py
@@ -48,6 +48,7 @@ from fighthealthinsurance.serializers.fields import (
     StringListField,
 )
 from fighthealthinsurance.utils import is_valid_denial_id
+from fighthealthinsurance.chat.chat_persistence import visible_history
 
 # Legacy alias for backwards compatibility (typo in original name)
 NextStepInfoSerizableSerializer = NextStepInfoSerializableSerializer
@@ -780,10 +781,16 @@ class OngoingChatSerializer(serializers.ModelSerializer):
 
     @extend_schema_field(OngoingChatMessageSerializer(many=True))
     def get_messages(self, obj):
-        """Get formatted chat messages."""
+        """Get formatted chat messages.
+
+        LLM-context-only notes (stored with role=user so the model sees them,
+        but never typed by anyone) are filtered out, the same as in WebSocket
+        replay -- otherwise the two views of one chat disagree and this one
+        attributes system text to the user.
+        """
         if not obj.chat_history:
             return []
-        return obj.chat_history
+        return visible_history(obj.chat_history)
 
     @extend_schema_field(serializers.CharField())
     def get_professional_name(self, obj):

--- a/fighthealthinsurance/rest_views.py
+++ b/fighthealthinsurance/rest_views.py
@@ -84,6 +84,7 @@ from fighthealthinsurance.websockets import (
 
 from .common_view_logic import AppealAssemblyHelper
 from .utils import is_convertible_to_int, is_valid_denial_id
+from fighthealthinsurance.chat.chat_persistence import visible_history
 
 appeal_assembly_helper = AppealAssemblyHelper()
 pubmed_tools = PubMedTools()
@@ -130,7 +131,10 @@ class ChatViewSet(viewsets.ViewSet):
             # Extract the first user message (if it exists)
             first_message_preview = ""
             if chat.chat_history and len(chat.chat_history) > 0:
-                for message in chat.chat_history:
+                # Skip LLM-context-only notes: they are stored with role=user
+                # but were never typed, so they made appeal-linked chats show
+                # a preview of internal system text.
+                for message in visible_history(chat.chat_history):
                     if message.get("role") == "user":
                         content = message.get("content", "")
                         first_message_preview = content[:100] + (
@@ -191,8 +195,10 @@ class ChatViewSet(viewsets.ViewSet):
         if not chat.chat_history or len(chat.chat_history) == 0:
             return "New conversation"
 
-        # Try to find the first user message
-        for message in chat.chat_history:
+        # Try to find the first user message (internal LLM-context notes are
+        # stored with role=user but were never typed, so they must not become
+        # the chat's title).
+        for message in visible_history(chat.chat_history):
             if message.get("role") == "user":
                 content = message.get("content", "")
                 # Extract first line or first few words

--- a/fighthealthinsurance/static/js/chat_interface.tsx
+++ b/fighthealthinsurance/static/js/chat_interface.tsx
@@ -782,6 +782,10 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
 
         // Handle different types of messages from the server
         if (data.error) {
+          // Terminal frame for this turn: drop any buffered debug frames so
+          // they can't attach to a LATER assistant message and describe the
+          // wrong turn.
+          pendingDebugRef.current = null;
           // Skip the professional user error message as we're in patient mode
           if (
             data.error.includes("Professional user not found or not active")
@@ -796,6 +800,8 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
             // Keep requestStartTime so retry button remains visible with error
           }));
         } else if (data.messages) {
+          // History replay: same reasoning as the error branch above.
+          pendingDebugRef.current = null;
           // This is a history replay
           // Restore personal info for BOTH roles: user messages are stored
           // scrubbed ({{FIRST_NAME}} etc.), so without restoring them a

--- a/fighthealthinsurance/static/js/chat_interface.tsx
+++ b/fighthealthinsurance/static/js/chat_interface.tsx
@@ -192,14 +192,22 @@ const ChatMessageContent: React.FC<{ content: string }> = ({ content }) => {
 
 // Typing animation component for loading state with elapsed time
 // Collapsible side-by-side alternate answer (like ChatGPT's occasional
-// "which response do you prefer?"). Collapsed by default; the "prefer"
-// button sends lightweight feedback so we learn which answers users like.
+// "which response do you prefer?"). Collapsed by default; the preference
+// buttons send lightweight feedback (either direction) so we learn which
+// answers users like.
 const AlternateAnswer: React.FC<{
   content: string;
-  onPrefer: () => boolean;
+  onPrefer: (preferred: "primary" | "alternate") => boolean;
 }> = ({ content, onPrefer }) => {
   const [expanded, setExpanded] = useState(false);
-  const [preferred, setPreferred] = useState(false);
+  const [picked, setPicked] = useState<"primary" | "alternate" | null>(null);
+
+  const pick = (choice: "primary" | "alternate") => {
+    if (picked) return;
+    if (onPrefer(choice)) {
+      setPicked(choice);
+    }
+  };
 
   return (
     <Box mt="xs" style={{ borderTop: "1px dashed #d1d5db", paddingTop: 6 }}>
@@ -226,19 +234,28 @@ const AlternateAnswer: React.FC<{
           <Box style={messageContentStyle}>
             <ReactMarkdown>{content}</ReactMarkdown>
           </Box>
-          <Button
-            variant="light"
-            size="compact-xs"
-            mt={4}
-            disabled={preferred}
-            onClick={() => {
-              if (onPrefer()) {
-                setPreferred(true);
-              }
-            }}
-          >
-            {preferred ? "Thanks for the feedback!" : "👍 I prefer this answer"}
-          </Button>
+          {picked ? (
+            <MantineText size="xs" c="dimmed" mt={4}>
+              Thanks for the feedback!
+            </MantineText>
+          ) : (
+            <MantineGroup gap="xs" mt={4}>
+              <Button
+                variant="light"
+                size="compact-xs"
+                onClick={() => pick("alternate")}
+              >
+                👍 I prefer this answer
+              </Button>
+              <Button
+                variant="subtle"
+                size="compact-xs"
+                onClick={() => pick("primary")}
+              >
+                The original was better
+              </Button>
+            </MantineGroup>
+          )}
         </Box>
       )}
     </Box>
@@ -453,6 +470,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
           email: userInfo?.email, // Send email if available
           is_patient: true, // Indicate this is a patient session
           microsite_slug: micrositeSlug || undefined, // Include microsite slug if available
+          debug: isChatDebugEnabled() || undefined,
         };
 
         // If we have a chat ID, request the chat history we explicitily refresh from local storage
@@ -522,6 +540,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
                   session_key: getSessionKey(),
                   microsite_slug: micrositeSlug || undefined,
                   use_external_models: useExternalModels,
+                  debug: isChatDebugEnabled() || undefined,
                 }),
               );
             }, 500);
@@ -589,6 +608,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
                   session_key: getSessionKey(),
                   microsite_slug: micrositeSlug || undefined,
                   use_external_models: useExternalModels,
+                  debug: isChatDebugEnabled() || undefined,
                 }),
               );
             }, 500);
@@ -1077,7 +1097,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
                 {!isUser && message.alternate_content && (
                   <AlternateAnswer
                     content={message.alternate_content}
-                    onPrefer={() => sendAnswerFeedback("alternate")}
+                    onPrefer={(preferred) => sendAnswerFeedback(preferred)}
                   />
                 )}
               </>

--- a/fighthealthinsurance/static/js/chat_interface.tsx
+++ b/fighthealthinsurance/static/js/chat_interface.tsx
@@ -112,8 +112,17 @@ const PWYWBanner: React.FC<{ onDismiss: () => void }> = ({ onDismiss }) => {
 // server to echo back exactly what was sent to the backend model; frames
 // arrive as debug_llm_input and are logged to the browser console. The
 // server only honors it for DEBUG deployments and staff accounts.
-const isChatDebugEnabled = (): boolean =>
-  localStorage.getItem("fhi_chat_debug") === "true";
+// Guarded: storage access THROWS (rather than returning null) in an embedded
+// iframe with third-party storage blocked, or under a block-all-cookies
+// policy. This runs inside ws.onopen and the send helpers, so an unguarded
+// throw here stopped the chat from ever sending its first frame.
+const isChatDebugEnabled = (): boolean => {
+  try {
+    return localStorage.getItem("fhi_chat_debug") === "true";
+  } catch {
+    return false;
+  }
+};
 
 // Server debug frames for one turn (only sent when debug is enabled AND the
 // server allows it): the exact LLM input and the model-selection result.
@@ -438,8 +447,9 @@ interface ChatInterfaceProps {
 }
 
 const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, defaultCondition, medicare, micrositeSlug, initialMessage, enableVoiceIntake, enableLocalSTT }) => {
-  // State for our chat interface
-  const [state, setState] = useState<ChatState>({
+  // State for our chat interface. Lazy initializer: the object literal (with
+  // its localStorage reads) would otherwise be rebuilt on every render.
+  const [state, setState] = useState<ChatState>(() => ({
     messages: [],
     isLoading: false,
     input: "",
@@ -455,7 +465,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
     // for anyone who never went through the consent form).
     useExternalModels: getExternalModelsPreference(),
     showVoiceIntake: Boolean(enableVoiceIntake),
-  });
+  }));
 
   // Track when to show retry button (separate state to avoid re-render issues)
   const [showRetryButton, setShowRetryButton] = useState(false);

--- a/fighthealthinsurance/static/js/chat_interface.tsx
+++ b/fighthealthinsurance/static/js/chat_interface.tsx
@@ -659,9 +659,11 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
           }));
         } else if (data.messages) {
           // This is a history replay
-          // Restore personal info in the message content if we have user info
+          // Restore personal info for BOTH roles: user messages are stored
+          // scrubbed ({{FIRST_NAME}} etc.), so without restoring them a
+          // refresh showed placeholder tokens in the user's own bubbles.
           const processedMessages = data.messages.map((msg: ChatMessage) => {
-            if (msg.role === "assistant" && userInfo) {
+            if (userInfo) {
               return {
                 ...msg,
                 content: restorePersonalInfo(msg.content, userInfo),
@@ -682,6 +684,13 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
             return {
               ...prev,
               messages: processedMessages,
+              // A replay only happens on (re)connect; any turn that was in
+              // flight died with the old socket, so clear the loading state
+              // instead of leaving the spinner stuck until the retry button
+              // appears.
+              isLoading: false,
+              requestStartTime: null,
+              statusMessage: null,
             };
           });
         }

--- a/fighthealthinsurance/static/js/chat_interface.tsx
+++ b/fighthealthinsurance/static/js/chat_interface.tsx
@@ -106,12 +106,22 @@ const PWYWBanner: React.FC<{ onDismiss: () => void }> = ({ onDismiss }) => {
 };
 
 // Define types for our chat messages
+// When true (set via localStorage from the console), each turn asks the
+// server to echo back exactly what was sent to the backend model; frames
+// arrive as debug_llm_input and are logged to the browser console. The
+// server only honors it for DEBUG deployments and staff accounts.
+const isChatDebugEnabled = (): boolean =>
+  localStorage.getItem("fhi_chat_debug") === "true";
+
 interface ChatMessage {
   role: "user" | "assistant";
   content: string;
   timestamp?: string;
   status?: "done" | "typing" | "error";
   uid?: string;
+  // Optional side-by-side alternate answer (ephemeral: not persisted
+  // server-side, so it only appears on live turns, not replays).
+  alternate_content?: string;
 }
 
 interface ChatState {
@@ -181,6 +191,60 @@ const ChatMessageContent: React.FC<{ content: string }> = ({ content }) => {
 };
 
 // Typing animation component for loading state with elapsed time
+// Collapsible side-by-side alternate answer (like ChatGPT's occasional
+// "which response do you prefer?"). Collapsed by default; the "prefer"
+// button sends lightweight feedback so we learn which answers users like.
+const AlternateAnswer: React.FC<{
+  content: string;
+  onPrefer: () => boolean;
+}> = ({ content, onPrefer }) => {
+  const [expanded, setExpanded] = useState(false);
+  const [preferred, setPreferred] = useState(false);
+
+  return (
+    <Box mt="xs" style={{ borderTop: "1px dashed #d1d5db", paddingTop: 6 }}>
+      <Button
+        variant="subtle"
+        size="compact-xs"
+        onClick={() => setExpanded((prev) => !prev)}
+      >
+        {expanded ? "Hide alternate answer" : "🔀 See an alternate answer"}
+      </Button>
+      {expanded && (
+        <Box
+          mt="xs"
+          style={{
+            border: "1px solid #e5e7eb",
+            borderRadius: 8,
+            padding: "6px 10px",
+            backgroundColor: "#ffffff",
+          }}
+        >
+          <MantineText size="xs" c="dimmed" mb={4}>
+            Alternate answer
+          </MantineText>
+          <Box style={messageContentStyle}>
+            <ReactMarkdown>{content}</ReactMarkdown>
+          </Box>
+          <Button
+            variant="light"
+            size="compact-xs"
+            mt={4}
+            disabled={preferred}
+            onClick={() => {
+              if (onPrefer()) {
+                setPreferred(true);
+              }
+            }}
+          >
+            {preferred ? "Thanks for the feedback!" : "👍 I prefer this answer"}
+          </Button>
+        </Box>
+      )}
+    </Box>
+  );
+};
+
 const TypingAnimation: React.FC<{ startTime?: number | null }> = ({ startTime }) => {
   const [dots, setDots] = useState(".");
   const [elapsed, setElapsed] = useState(0);
@@ -548,6 +612,13 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
         // Frames carry chat message content (PHI) -- log only the field names.
         console.debug("Received message frame, keys:", Object.keys(data ?? {}));
 
+        // Debug echo of exactly what was sent to the backend model this
+        // turn (only sent when the debug flag was requested AND the server
+        // allows it). Surfaces in the browser console for inspection.
+        if (data.debug_llm_input) {
+          console.log("FHI chat debug — LLM input:", data.debug_llm_input);
+        }
+
         // Get user info for restoring personal info
         const userInfo = getUserInfo();
 
@@ -622,6 +693,14 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
               ? restorePersonalInfo(data.content, userInfo)
               : data.content;
 
+          // Optional side-by-side alternate answer, same restore treatment.
+          let alternateContent: string | undefined = undefined;
+          if (data.role === "assistant" && typeof data.alternate_content === "string") {
+            alternateContent = userInfo
+              ? restorePersonalInfo(data.alternate_content, userInfo)
+              : data.alternate_content;
+          }
+
           setState((prev) => ({
             ...prev,
             messages: [
@@ -629,6 +708,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
               {
                 role: data.role,
                 content: processedContent,
+                alternate_content: alternateContent,
                 timestamp: data.timestamp || new Date().toISOString(),
                 status: "done",
               },
@@ -733,6 +813,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
             is_document: true,
             document_name: file.name,
             use_external_models: state.useExternalModels,
+            debug: isChatDebugEnabled() || undefined,
           };
 
           wsRef.current.send(JSON.stringify(messageToSend));
@@ -767,9 +848,26 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
       session_key: getSessionKey(),
       use_external_models: state.useExternalModels,
       metadata: source ? { intake_source: source } : undefined,
+      debug: isChatDebugEnabled() || undefined,
     };
 
     wsRef.current.send(JSON.stringify(messageToSend));
+    return true;
+  };
+
+  // Lightweight feedback about a side-by-side alternate answer. Returns
+  // whether the frame was actually sent.
+  const sendAnswerFeedback = (preferred: "primary" | "alternate"): boolean => {
+    if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) {
+      return false;
+    }
+    wsRef.current.send(
+      JSON.stringify({
+        chat_id: state.chatId,
+        session_key: getSessionKey(),
+        answer_feedback: { preferred },
+      }),
+    );
     return true;
   };
 
@@ -965,7 +1063,15 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
             {message.status === "typing" ? (
               <TypingAnimation startTime={state.requestStartTime} />
             ) : (
-              <ChatMessageContent content={message.content} />
+              <>
+                <ChatMessageContent content={message.content} />
+                {!isUser && message.alternate_content && (
+                  <AlternateAnswer
+                    content={message.alternate_content}
+                    onPrefer={() => sendAnswerFeedback("alternate")}
+                  />
+                )}
+              </>
             )}
           </Box>
         </Flex>

--- a/fighthealthinsurance/static/js/chat_interface.tsx
+++ b/fighthealthinsurance/static/js/chat_interface.tsx
@@ -26,7 +26,9 @@ import { THEME } from "./theme";
 import ErrorBoundary from "./ErrorBoundary";
 import VoiceIntake from "./VoiceIntake";
 import {
+  getExternalModelsPreference,
   getUserInfo,
+  saveExternalModelsPreference,
   saveUserInfo,
   scrubPersonalInfo,
   restorePersonalInfo,
@@ -113,6 +115,13 @@ const PWYWBanner: React.FC<{ onDismiss: () => void }> = ({ onDismiss }) => {
 const isChatDebugEnabled = (): boolean =>
   localStorage.getItem("fhi_chat_debug") === "true";
 
+// Server debug frames for one turn (only sent when debug is enabled AND the
+// server allows it): the exact LLM input and the model-selection result.
+interface ChatDebugInfo {
+  input?: Record<string, unknown>;
+  result?: Record<string, unknown>;
+}
+
 interface ChatMessage {
   role: "user" | "assistant";
   content: string;
@@ -122,6 +131,9 @@ interface ChatMessage {
   // Optional side-by-side alternate answer (ephemeral: not persisted
   // server-side, so it only appears on live turns, not replays).
   alternate_content?: string;
+  // Debug frames captured for the turn that produced this assistant
+  // message (rendered as a collapsible panel under the bubble).
+  debug_info?: ChatDebugInfo;
 }
 
 interface ChatState {
@@ -262,6 +274,83 @@ const AlternateAnswer: React.FC<{
   );
 };
 
+// One-line summary of a debug_llm_result frame for the panel header.
+const summarizeDebugResult = (result: Record<string, unknown>): string => {
+  const parts: string[] = [];
+  if (typeof result.picked_model === "string") {
+    parts.push(`picked ${result.picked_model}`);
+  }
+  if (typeof result.candidate_count === "number") {
+    parts.push(`${result.candidate_count} candidates`);
+  }
+  if (typeof result.rejected_repeats === "number" && result.rejected_repeats > 0) {
+    parts.push(`${result.rejected_repeats} repeats rejected`);
+  }
+  if (result.retry_used) {
+    parts.push("retry used");
+  }
+  if (typeof result.elapsed_ms === "number") {
+    parts.push(`${(result.elapsed_ms / 1000).toFixed(1)}s`);
+  }
+  return parts.join(" · ");
+};
+
+// Collapsible per-turn debug panel (only rendered when chat debug is on and
+// the server sent debug frames): shows the model-selection summary up front
+// and the raw LLM input/result JSON behind a toggle.
+const DebugPanel: React.FC<{ debugInfo: ChatDebugInfo }> = ({ debugInfo }) => {
+  const [expanded, setExpanded] = useState(false);
+  const summary = debugInfo.result ? summarizeDebugResult(debugInfo.result) : "";
+
+  return (
+    <Box mt="xs" style={{ borderTop: "1px dashed #d1d5db", paddingTop: 6 }}>
+      <Button
+        variant="subtle"
+        size="compact-xs"
+        color="gray"
+        onClick={() => setExpanded((prev) => !prev)}
+      >
+        {expanded ? "Hide debug" : `🔧 Debug${summary ? `: ${summary}` : ""}`}
+      </Button>
+      {expanded && (
+        <Box
+          mt="xs"
+          style={{
+            border: "1px solid #e5e7eb",
+            borderRadius: 8,
+            padding: "6px 10px",
+            backgroundColor: "#f9fafb",
+            fontFamily: "monospace",
+            fontSize: 11,
+            overflowX: "auto",
+          }}
+        >
+          {debugInfo.result && (
+            <>
+              <MantineText size="xs" c="dimmed">
+                Model selection
+              </MantineText>
+              <pre style={{ whiteSpace: "pre-wrap", margin: "4px 0" }}>
+                {JSON.stringify(debugInfo.result, null, 2)}
+              </pre>
+            </>
+          )}
+          {debugInfo.input && (
+            <>
+              <MantineText size="xs" c="dimmed">
+                LLM input
+              </MantineText>
+              <pre style={{ whiteSpace: "pre-wrap", margin: "4px 0" }}>
+                {JSON.stringify(debugInfo.input, null, 2)}
+              </pre>
+            </>
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+};
+
 const TypingAnimation: React.FC<{ startTime?: number | null }> = ({ startTime }) => {
   const [dots, setDots] = useState(".");
   const [elapsed, setElapsed] = useState(0);
@@ -361,7 +450,10 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
     messageCount: 0,
     statusMessage: null,
     requestStartTime: null,
-    useExternalModels: localStorage.getItem("fhi_use_external_models") === "true",
+    // Default-on: getExternalModelsPreference treats a missing key as true
+    // (the raw === "true" read here used to silently disable external models
+    // for anyone who never went through the consent form).
+    useExternalModels: getExternalModelsPreference(),
     showVoiceIntake: Boolean(enableVoiceIntake),
   });
 
@@ -411,6 +503,10 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
 
   const wsRef = useRef<WebSocket | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  // Debug frames (LLM input / selection result) arrive before the assistant
+  // content frame of the same turn; buffer them here so they attach to the
+  // message that they describe.
+  const pendingDebugRef = useRef<ChatDebugInfo | null>(null);
 
   // Initialize chat interface on load
   useEffect(() => {
@@ -476,7 +572,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
         // If we have a chat ID, request the chat history we explicitily refresh from local storage
         // so reconnect does not capture the old state.
         let chatId = localStorage.getItem("fhi_chat_id");
-        const useExternalModels = localStorage.getItem("fhi_use_external_models") === "true";
+        const useExternalModels = getExternalModelsPreference();
 
         // If we have an initial message (e.g., from explain denial page), start a NEW chat
         // even if there's an existing one - the user explicitly started a new denial explanation
@@ -632,11 +728,23 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
         // Frames carry chat message content (PHI) -- log only the field names.
         console.debug("Received message frame, keys:", Object.keys(data ?? {}));
 
-        // Debug echo of exactly what was sent to the backend model this
-        // turn (only sent when the debug flag was requested AND the server
-        // allows it). Surfaces in the browser console for inspection.
+        // Debug echoes (only sent when the debug flag was requested AND the
+        // server allows it): the exact LLM input for the turn and the
+        // model-selection result. Logged to the console and buffered so the
+        // next assistant message renders them as a collapsible panel.
         if (data.debug_llm_input) {
           console.log("FHI chat debug — LLM input:", data.debug_llm_input);
+          pendingDebugRef.current = {
+            ...(pendingDebugRef.current ?? {}),
+            input: data.debug_llm_input,
+          };
+        }
+        if (data.debug_llm_result) {
+          console.log("FHI chat debug — model selection:", data.debug_llm_result);
+          pendingDebugRef.current = {
+            ...(pendingDebugRef.current ?? {}),
+            result: data.debug_llm_result,
+          };
         }
 
         // Get user info for restoring personal info
@@ -730,6 +838,15 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
               : data.alternate_content;
           }
 
+          // Attach any buffered debug frames to the assistant message they
+          // belong to (cleared either way so a later turn can't inherit a
+          // stale panel).
+          let debugInfo: ChatDebugInfo | undefined = undefined;
+          if (data.role === "assistant" && pendingDebugRef.current) {
+            debugInfo = pendingDebugRef.current;
+          }
+          pendingDebugRef.current = null;
+
           setState((prev) => ({
             ...prev,
             messages: [
@@ -738,6 +855,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
                 role: data.role,
                 content: processedContent,
                 alternate_content: alternateContent,
+                debug_info: debugInfo,
                 timestamp: data.timestamp || new Date().toISOString(),
                 status: "done",
               },
@@ -992,7 +1110,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
   };
 // Handle toggling external models
   const handleToggleExternalModels = (checked: boolean) => {
-    localStorage.setItem("fhi_use_external_models", checked.toString());
+    saveExternalModelsPreference(checked);
     setState((prev) => ({ ...prev, useExternalModels: checked }));
   };
 
@@ -1011,7 +1129,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
 
     console.log("Resetting the chat state");
     // Reset the chat state but preserve useExternalModels setting
-    const useExternalModels = localStorage.getItem("fhi_use_external_models") === "true";
+    const useExternalModels = getExternalModelsPreference();
     setState({
       messages: [],
       isLoading: false,
@@ -1099,6 +1217,9 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
                     content={message.alternate_content}
                     onPrefer={(preferred) => sendAnswerFeedback(preferred)}
                   />
+                )}
+                {!isUser && message.debug_info && (
+                  <DebugPanel debugInfo={message.debug_info} />
                 )}
               </>
             )}

--- a/fighthealthinsurance/static/js/user_info_storage.ts
+++ b/fighthealthinsurance/static/js/user_info_storage.ts
@@ -148,13 +148,11 @@ export function scrubPersonalInfo(message: string, userInfo: UserInfo | null): s
     );
   }
 
-  // Replace state
-  if (userInfo.state) {
-    scrubbedMessage = scrubbedMessage.replace(
-      new RegExp(`\\b${escapeRegExp(userInfo.state)}\\b`, "gi"),
-      "{{STATE}}"
-    );
-  }
+  // State is deliberately NOT scrubbed. It is coarse (1 of 50), and the
+  // Medicaid/appeal flows genuinely need it server-side: the assistant asks
+  // "which state are you in?", and when the answer got masked to {{STATE}}
+  // the model could never learn it and re-asked forever — a guaranteed chat
+  // loop. restorePersonalInfo still expands {{STATE}} for legacy history.
 
   // Replace zip code
   if (userInfo.zipCode) {

--- a/fighthealthinsurance/static/js/user_info_storage.ts
+++ b/fighthealthinsurance/static/js/user_info_storage.ts
@@ -73,11 +73,11 @@ export function saveExternalModelsPreference(useExternalModels: boolean): void {
 export function getExternalModelsPreference(): boolean {
   try {
     const stored = localStorage.getItem(EXTERNAL_MODELS_KEY);
-    if (stored === null) {
-      localStorage.setItem(EXTERNAL_MODELS_KEY, "true");
-      return true;
-    }
-    return stored === "true";
+    // Pure read: no key means "no stored choice, use the default", and a read
+    // must not materialize a value. Writing "true" here recorded an explicit
+    // opt-in for anyone who merely opened the chat, which made a real choice
+    // indistinguishable from never having been asked.
+    return stored === null ? true : stored === "true";
   } catch (e) {
     console.error("Error getting external models preference from localStorage:", e);
   }

--- a/fighthealthinsurance/templates/partials/user_consent_form_fields.html
+++ b/fighthealthinsurance/templates/partials/user_consent_form_fields.html
@@ -99,12 +99,15 @@
     <div class="form-check mb-3">
         {{ form.use_external_models }}
         <label for="use_external_models" class="form-check-label">
-            Allow external AI models as fallback (e.g., OpenAI, Google)
+            Allow external AI models (e.g., OpenAI, Google)
         </label>
         <small class="form-text text-muted d-block mt-1">
-            We prefer using our own FHI models when possible. When enabled, external AI providers
-            may be used as a fallback if our models are unavailable. Note that your conversation
-            data will be sent to these third-party services.
+            We prefer our own FHI models and use their answers whenever they respond well.
+            When this is enabled, external AI providers are asked alongside them on each
+            message, so a good answer is ready if our models are slow, unavailable, or stuck
+            repeating themselves. Your conversation is sent to those third-party services
+            (with names and contact details removed in your browser first). Uncheck this to
+            keep your chat on our own models only.
         </small>
     </div>
 </div>

--- a/fighthealthinsurance/utils.py
+++ b/fighthealthinsurance/utils.py
@@ -1338,7 +1338,7 @@ async def best_two_within_timelimit(
                     second_score = score
                     second_result_option = result
             except Exception as e:
-                _log_fanout_task_error(e, "best_within_timelimit")
+                _log_fanout_task_error(e, "best_two_within_timelimit")
 
     try:
         # Main window: wait for everything (or the timeout), take the best.
@@ -1384,7 +1384,7 @@ async def best_two_within_timelimit(
     # "30s + 60s overtime" sends triage hunting for a timeout that never
     # happened instead of for the immediate failure.
     logger.warning(
-        f"best_within_timelimit: no usable result from {len(tasks)} tasks "
+        f"best_two_within_timelimit: no usable result from {len(tasks)} tasks "
         f"after {time.monotonic() - wait_started:.1f}s "
         f"(budget {timeout}s + {extended_timeout}s overtime)"
     )

--- a/fighthealthinsurance/utils.py
+++ b/fighthealthinsurance/utils.py
@@ -1227,9 +1227,15 @@ async def best_within_timelimit(
     Runs a list of async tasks concurrently.
     Returns the best result (per score_fn) that completes before timeout.
     If nothing usable completed in time, keeps waiting up to
-    ``extended_timeout`` extra seconds and takes the first truthy result to
+    ``extended_timeout`` extra seconds and takes the first usable result to
     arrive. Ignores late results; every still-pending task is cancelled on
     every exit path.
+
+    Results scored ``-inf`` are treated as INVALID (like falsy results): they
+    are never returned, even if they are the only thing that completed.
+    Scorers rely on this to hard-reject candidates (e.g. a chat reply that
+    just repeats the previous reply) so a bad-but-fast result can't win by
+    default.
 
     Args:
         tasks: List of awaitable tasks that return results of type T
@@ -1243,9 +1249,38 @@ async def best_within_timelimit(
         The best result according to score_fn, or None if nothing usable
         completes within timeout + extended_timeout.
     """
+    best_and_second = await best_two_within_timelimit(
+        tasks, score_fn, timeout, extended_timeout
+    )
+    return best_and_second[0]
+
+
+async def best_two_within_timelimit(
+    tasks: Sequence[Awaitable[T]],
+    score_fn: Callable[[T, Awaitable[T]], float],
+    timeout: float,
+    extended_timeout: Optional[float] = None,
+) -> Tuple[Optional[T], Optional[T]]:
+    """
+    Like :func:`best_within_timelimit`, but also returns the runner-up.
+
+    Returns ``(best, second_best)`` where ``second_best`` is the
+    highest-scored usable result that DIFFERS (by ``!=``) from the best
+    (None when no such result completed). Equal-valued results are skipped
+    for the runner-up slot: several backends often serve the same model and
+    return identical answers, and an identical "runner-up" is useless to
+    every conceivable caller. The chat interface uses the runner-up to
+    offer an occasional side-by-side alternate answer; every other caller
+    goes through ``best_within_timelimit`` and ignores it.
+
+    Semantics shared with best_within_timelimit: falsy results and results
+    scored ``-inf`` are invalid and never returned; the overtime window
+    stops at the first usable result; pending tasks are cancelled on every
+    exit path, including caller cancellation.
+    """
     # Should not happen :)
     if not tasks:
-        return None
+        return None, None
 
     if extended_timeout is None:
         extended_timeout = min(max(timeout * 2, 60.0), _extended_wait_cap())
@@ -1265,9 +1300,12 @@ async def best_within_timelimit(
 
     best_result_option: Optional[T] = None
     best_score = float("-inf")  # Start with negative infinity for comparison
+    second_result_option: Optional[T] = None
+    second_score = float("-inf")
 
     def _score_done(done_tasks: Set[asyncio.Task[T]]) -> None:
         nonlocal best_result_option, best_score
+        nonlocal second_result_option, second_score
         for task in done_tasks:
             try:
                 result = task.result()
@@ -1278,9 +1316,27 @@ async def best_within_timelimit(
                 # the best slot and block a later truthy result.
                 if not result:
                     continue
+                # -inf means the scorer hard-rejected the result (invalid /
+                # must never be delivered). Before this check a truthy
+                # -inf-scored result could still win via the "nothing better
+                # yet" fallback below -- which let a repeated chat reply
+                # through no matter how it was scored.
+                if score == float("-inf"):
+                    continue
                 if score > best_score or not best_result_option:
+                    # Demote the old best into the runner-up slot -- unless
+                    # the new best is equal-valued, in which case keeping the
+                    # old second avoids a runner-up identical to the best.
+                    if best_result_option is not None and best_result_option != result:
+                        second_score = best_score
+                        second_result_option = best_result_option
                     best_score = score
                     best_result_option = result
+                elif result != best_result_option and (
+                    score > second_score or not second_result_option
+                ):
+                    second_score = score
+                    second_result_option = result
             except Exception as e:
                 _log_fanout_task_error(e, "best_within_timelimit")
 
@@ -1292,9 +1348,9 @@ async def best_within_timelimit(
         _score_done(done)
         if best_result_option:
             _spawn_cancellation(list(pending))
-            return best_result_option
+            return best_result_option, second_result_option
 
-        # Overtime window: bounded, first truthy result wins. This keeps
+        # Overtime window: bounded, first usable result wins. This keeps
         # slow-but-eventually-successful backends useful without the old
         # unbounded ((timeout + 1) * 20) tail, and a falsy first completion no
         # longer aborts the wait while other tasks are still running.
@@ -1321,7 +1377,7 @@ async def best_within_timelimit(
     if pending:
         _spawn_cancellation(list(pending))
     if best_result_option:
-        return best_result_option
+        return best_result_option, second_result_option
     # Report the ACTUAL elapsed wait, not just the configured window: every
     # task failing instantly (no backends configured, connection refused)
     # exits this function in milliseconds, and a message claiming we waited
@@ -1332,7 +1388,7 @@ async def best_within_timelimit(
         f"after {time.monotonic() - wait_started:.1f}s "
         f"(budget {timeout}s + {extended_timeout}s overtime)"
     )
-    return None
+    return None, None
 
 
 async def best_within_timelimit_static(

--- a/fighthealthinsurance/utils.py
+++ b/fighthealthinsurance/utils.py
@@ -23,6 +23,7 @@ from typing import (
     Generic,
     Iterator,
     List,
+    NamedTuple,
     Optional,
     Sequence,
     Set,
@@ -1252,7 +1253,27 @@ async def best_within_timelimit(
     best_and_second = await best_two_within_timelimit(
         tasks, score_fn, timeout, extended_timeout
     )
-    return best_and_second[0]
+    return best_and_second.best
+
+
+class BestTwo(NamedTuple, Generic[T]):
+    """Result of :func:`best_two_within_timelimit`.
+
+    Field order keeps ``result[0]`` == the best result (the shape callers
+    indexed before scores were added). Scores are the ``score_fn`` values
+    the selection used; tasks are the ORIGINAL awaitables from ``tasks``
+    (not the internal wrappers), so callers can map a winner back to
+    whatever they keyed their calls by (the chat layer maps them to model
+    labels for debugging and close-tie detection). Score/task fields are
+    ``-inf``/None when the corresponding result slot is None.
+    """
+
+    best: Optional[T]
+    runner_up: Optional[T]
+    best_score: float
+    runner_up_score: float
+    best_task: Optional[Awaitable[T]]
+    runner_up_task: Optional[Awaitable[T]]
 
 
 async def best_two_within_timelimit(
@@ -1260,18 +1281,19 @@ async def best_two_within_timelimit(
     score_fn: Callable[[T, Awaitable[T]], float],
     timeout: float,
     extended_timeout: Optional[float] = None,
-) -> Tuple[Optional[T], Optional[T]]:
+) -> "BestTwo[T]":
     """
-    Like :func:`best_within_timelimit`, but also returns the runner-up.
+    Like :func:`best_within_timelimit`, but also returns the runner-up,
+    both results' scores, and the originating tasks (see :class:`BestTwo`).
 
-    Returns ``(best, second_best)`` where ``second_best`` is the
-    highest-scored usable result that DIFFERS (by ``!=``) from the best
-    (None when no such result completed). Equal-valued results are skipped
-    for the runner-up slot: several backends often serve the same model and
-    return identical answers, and an identical "runner-up" is useless to
-    every conceivable caller. The chat interface uses the runner-up to
-    offer an occasional side-by-side alternate answer; every other caller
-    goes through ``best_within_timelimit`` and ignores it.
+    ``runner_up`` is the highest-scored usable result that DIFFERS (by
+    ``!=``) from the best (None when no such result completed). Equal-valued
+    results are skipped for the runner-up slot: several backends often serve
+    the same model and return identical answers, and an identical
+    "runner-up" is useless to every conceivable caller. The chat interface
+    uses the runner-up (with the scores, to judge how closely tied the two
+    answers are) to offer an occasional side-by-side alternate answer; every
+    other caller goes through ``best_within_timelimit`` and ignores it.
 
     Semantics shared with best_within_timelimit: falsy results and results
     scored ``-inf`` are invalid and never returned; the overtime window
@@ -1280,7 +1302,7 @@ async def best_two_within_timelimit(
     """
     # Should not happen :)
     if not tasks:
-        return None, None
+        return BestTwo(None, None, float("-inf"), float("-inf"), None, None)
 
     if extended_timeout is None:
         extended_timeout = min(max(timeout * 2, 60.0), _extended_wait_cap())
@@ -1300,12 +1322,14 @@ async def best_two_within_timelimit(
 
     best_result_option: Optional[T] = None
     best_score = float("-inf")  # Start with negative infinity for comparison
+    best_original: Optional[Awaitable[T]] = None
     second_result_option: Optional[T] = None
     second_score = float("-inf")
+    second_original: Optional[Awaitable[T]] = None
 
     def _score_done(done_tasks: Set[asyncio.Task[T]]) -> None:
-        nonlocal best_result_option, best_score
-        nonlocal second_result_option, second_score
+        nonlocal best_result_option, best_score, best_original
+        nonlocal second_result_option, second_score, second_original
         for task in done_tasks:
             try:
                 result = task.result()
@@ -1330,13 +1354,16 @@ async def best_two_within_timelimit(
                     if best_result_option is not None and best_result_option != result:
                         second_score = best_score
                         second_result_option = best_result_option
+                        second_original = best_original
                     best_score = score
                     best_result_option = result
+                    best_original = original_task
                 elif result != best_result_option and (
                     score > second_score or not second_result_option
                 ):
                     second_score = score
                     second_result_option = result
+                    second_original = original_task
             except Exception as e:
                 _log_fanout_task_error(e, "best_two_within_timelimit")
 
@@ -1348,7 +1375,14 @@ async def best_two_within_timelimit(
         _score_done(done)
         if best_result_option:
             _spawn_cancellation(list(pending))
-            return best_result_option, second_result_option
+            return BestTwo(
+                best_result_option,
+                second_result_option,
+                best_score,
+                second_score,
+                best_original,
+                second_original,
+            )
 
         # Overtime window: bounded, first usable result wins. This keeps
         # slow-but-eventually-successful backends useful without the old
@@ -1377,7 +1411,14 @@ async def best_two_within_timelimit(
     if pending:
         _spawn_cancellation(list(pending))
     if best_result_option:
-        return best_result_option, second_result_option
+        return BestTwo(
+            best_result_option,
+            second_result_option,
+            best_score,
+            second_score,
+            best_original,
+            second_original,
+        )
     # Report the ACTUAL elapsed wait, not just the configured window: every
     # task failing instantly (no backends configured, connection refused)
     # exits this function in milliseconds, and a message claiming we waited
@@ -1388,7 +1429,7 @@ async def best_two_within_timelimit(
         f"after {time.monotonic() - wait_started:.1f}s "
         f"(budget {timeout}s + {extended_timeout}s overtime)"
     )
-    return None, None
+    return BestTwo(None, None, float("-inf"), float("-inf"), None, None)
 
 
 async def best_within_timelimit_static(

--- a/fighthealthinsurance/utils.py
+++ b/fighthealthinsurance/utils.py
@@ -1312,13 +1312,22 @@ async def best_two_within_timelimit(
     # Create task objects with Future results and wrap them
     original_to_task: Dict[asyncio.Task[T], Awaitable[T]] = {}
     wrapped_tasks: List[asyncio.Task[T]] = []
+    # Fan-out position of each original task. asyncio.wait hands back an
+    # UNORDERED set, so without this an exact score tie was resolved by set
+    # iteration order -- and exact ties are the normal case (the router lists
+    # the primary backend twice with identical base scores). Which answer got
+    # delivered vs. shown as a throwaway alternate then flipped between runs
+    # of the same conversation, making the preference metric and the
+    # picked-model debug output irreproducible.
+    task_order: Dict[int, int] = {}
 
-    for task in tasks:
+    for position, task in enumerate(tasks):
         # Cast the awaitable to a coroutine to satisfy mypy
         coroutine: Coroutine[Any, Any, T] = cast(Coroutine[Any, Any, T], task)
         wrapped: asyncio.Task[T] = asyncio.create_task(coroutine)
         wrapped_tasks.append(wrapped)
         original_to_task[wrapped] = task
+        task_order[id(task)] = position
 
     best_result_option: Optional[T] = None
     best_score = float("-inf")  # Start with negative infinity for comparison
@@ -1330,7 +1339,11 @@ async def best_two_within_timelimit(
     def _score_done(done_tasks: Set[asyncio.Task[T]]) -> None:
         nonlocal best_result_option, best_score, best_original
         nonlocal second_result_option, second_score, second_original
-        for task in done_tasks:
+        # Deterministic order: earlier-listed tasks win exact score ties.
+        for task in sorted(
+            done_tasks,
+            key=lambda t: task_order.get(id(original_to_task[t]), 0),
+        ):
             try:
                 result = task.result()
                 original_task = original_to_task[task]

--- a/fighthealthinsurance/websockets.py
+++ b/fighthealthinsurance/websockets.py
@@ -1410,9 +1410,11 @@ class OngoingChatConsumer(PerConnectionThreadSensitiveMixin, AsyncWebsocketConsu
         microsite_slug = data.get(
             "microsite_slug", None
         )  # Microsite slug if coming from a microsite
-        # Allow users to opt-in to using external/public models as fallback
-        # Only used when FHI models fail or timeout
-        use_external_models = data.get("use_external_models", False)
+        # External/public models participate in chat by default (both in the
+        # primary fan-out and as retry fallback); users opt OUT via the
+        # consent-form toggle, which sends an explicit false. A frame without
+        # the key (older clients, hand-rolled API callers) gets the default.
+        use_external_models = data.get("use_external_models", True)
         # Document upload flags from frontend
         is_document = data.get("is_document", False)
         document_name = data.get("document_name", None)

--- a/fighthealthinsurance/websockets.py
+++ b/fighthealthinsurance/websockets.py
@@ -1539,10 +1539,12 @@ class OngoingChatConsumer(PerConnectionThreadSensitiveMixin, AsyncWebsocketConsu
                 # guess_us_state): the connection IP is stable per socket so
                 # this is computed once per interface. Plain asgiref
                 # sync_to_async (no ORM): the first lookup loads the geo
-                # database from disk, which must not block the event loop.
-                state_hint = await sync_to_async(guess_us_state)(
-                    _get_client_ip_from_scope(self.scope)
-                )
+                # database from disk, which must not block the event loop --
+                # and thread_sensitive=False keeps that multi-second load off
+                # the thread-sensitive lane the ORM work runs on.
+                state_hint = await sync_to_async(
+                    guess_us_state, thread_sensitive=False
+                )(_get_client_ip_from_scope(self.scope))
                 self.chat_interface = ChatInterface(
                     send_json_message_func=self.send_json_message,
                     chat=chat,

--- a/fighthealthinsurance/websockets.py
+++ b/fighthealthinsurance/websockets.py
@@ -6,7 +6,7 @@ import time
 import uuid
 from typing import AsyncIterator, Callable, Optional, Tuple, cast
 
-from asgiref.sync import ThreadSensitiveContext
+from asgiref.sync import ThreadSensitiveContext, sync_to_async
 
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
@@ -26,7 +26,12 @@ from channels.db import aclose_old_connections, database_sync_to_async
 from channels.generic.websocket import AsyncWebsocketConsumer
 from loguru import logger
 
-from fhi_users.audit import TrackingInfo, extract_tracking_info_from_scope
+from fhi_users.audit import (
+    TrackingInfo,
+    extract_tracking_info_from_scope,
+    guess_us_state,
+)
+from fighthealthinsurance.ml.ml_metrics import record_answer_feedback
 from fighthealthinsurance.reliability_events import capture_reliability_event
 from fighthealthinsurance import common_view_logic
 from fighthealthinsurance.ml.bad_output_utils import strip_boilerplate_service
@@ -1378,6 +1383,22 @@ class OngoingChatConsumer(PerConnectionThreadSensitiveMixin, AsyncWebsocketConsu
         message_raw = data.get("message", data.get("content", None))
         message: str = message_raw if isinstance(message_raw, str) else ""
         chat_id = data.get("chat_id", self.chat_id)
+
+        # Lightweight side-by-side answer feedback: which answer the user
+        # preferred. Metrics + log only (bounded label set) -- no LLM turn.
+        answer_feedback = data.get("answer_feedback")
+        if answer_feedback is not None:
+            preferred = (
+                answer_feedback.get("preferred")
+                if isinstance(answer_feedback, dict)
+                else None
+            )
+            record_answer_feedback(preferred)
+            logger.info(
+                f"chat ws: answer feedback preferred={str(preferred)[:16]!r} "
+                f"chat_id={chat_id}"
+            )
+            return
         replay_requested = data.get("replay", False)
         iterate_on_appeal = data.get("iterate_on_appeal")
         iterate_on_prior_auth = data.get("iterate_on_prior_auth")
@@ -1395,6 +1416,9 @@ class OngoingChatConsumer(PerConnectionThreadSensitiveMixin, AsyncWebsocketConsu
         # Document upload flags from frontend
         is_document = data.get("is_document", False)
         document_name = data.get("document_name", None)
+        # Client asked to see the exact LLM input for each turn (gated below
+        # to DEBUG deployments and staff users).
+        debug_requested = bool(data.get("debug", False))
 
         # Validate microsite_slug if provided
         if microsite_slug:
@@ -1490,6 +1514,15 @@ class OngoingChatConsumer(PerConnectionThreadSensitiveMixin, AsyncWebsocketConsu
                     {"chat_id": str(chat.id), "chat_forked": True}
                 )
             self.chat_id = str(chat.id)
+            # Whether this connection may see the exact LLM inputs: local
+            # DEBUG deployments and staff accounts only.
+            from django.conf import settings as django_settings
+
+            debug_llm = debug_requested and (
+                getattr(django_settings, "DEBUG", False)
+                or (is_authenticated and getattr(user, "is_staff", False))
+            )
+
             if (
                 not hasattr(self, "chat_interface")
                 or self.chat_interface is None
@@ -1502,16 +1535,29 @@ class OngoingChatConsumer(PerConnectionThreadSensitiveMixin, AsyncWebsocketConsu
                 django_session_key = getattr(
                     self.scope.get("session"), "session_key", None
                 )
+                # Transient IP-derived state guess (never persisted; see
+                # guess_us_state): the connection IP is stable per socket so
+                # this is computed once per interface. Plain asgiref
+                # sync_to_async (no ORM): the first lookup loads the geo
+                # database from disk, which must not block the event loop.
+                state_hint = await sync_to_async(guess_us_state)(
+                    _get_client_ip_from_scope(self.scope)
+                )
                 self.chat_interface = ChatInterface(
                     send_json_message_func=self.send_json_message,
                     chat=chat,
                     user=user,
                     use_external_models=use_external_models,
                     server_session_key=django_session_key,
+                    state_hint=state_hint,
+                    debug_llm=debug_llm,
                 )
-            elif use_external_models != self.chat_interface.use_external_models:
-                # User changed their preference for external models mid-chat
-                self.chat_interface.use_external_models = use_external_models
+            else:
+                if use_external_models != self.chat_interface.use_external_models:
+                    # User changed their preference for external models mid-chat
+                    self.chat_interface.use_external_models = use_external_models
+                # Debug preference can be toggled mid-chat.
+                self.chat_interface.debug_llm = debug_llm
 
             if not replay_requested:
                 # Allow empty message when linking an appeal or prior auth

--- a/fighthealthinsurance/websockets.py
+++ b/fighthealthinsurance/websockets.py
@@ -1394,11 +1394,19 @@ class OngoingChatConsumer(PerConnectionThreadSensitiveMixin, AsyncWebsocketConsu
                 else None
             )
             record_answer_feedback(preferred)
+            # chat_id is raw client input: bound and repr it so an
+            # attacker-supplied value can't inject newlines (forged log
+            # records) or flood the log pipeline with one huge line.
             logger.info(
                 f"chat ws: answer feedback preferred={str(preferred)[:16]!r} "
-                f"chat_id={chat_id}"
+                f"chat_id={str(chat_id)[:64]!r}"
             )
-            return
+            # Only short-circuit when the frame carries nothing else. A frame
+            # batching feedback with a real message used to have the message
+            # silently dropped -- no reply, no error, and the client's
+            # spinner never cleared.
+            if not message and not data.get("replay", False):
+                return
         replay_requested = data.get("replay", False)
         iterate_on_appeal = data.get("iterate_on_appeal")
         iterate_on_prior_auth = data.get("iterate_on_prior_auth")
@@ -1557,11 +1565,18 @@ class OngoingChatConsumer(PerConnectionThreadSensitiveMixin, AsyncWebsocketConsu
                     debug_llm=debug_llm,
                 )
             else:
-                if use_external_models != self.chat_interface.use_external_models:
-                    # User changed their preference for external models mid-chat
-                    self.chat_interface.use_external_models = use_external_models
-                # Debug preference can be toggled mid-chat.
-                self.chat_interface.debug_llm = debug_llm
+                # Only frames that actually CARRY a preference may change it.
+                # Applying the default to every frame meant one frame that
+                # omitted the key (an upload, a replay, a hand-rolled client)
+                # silently reset a user's explicit opt-out back to the
+                # default-on value for the rest of the session.
+                if "use_external_models" in data:
+                    if use_external_models != self.chat_interface.use_external_models:
+                        # User changed their preference mid-chat.
+                        self.chat_interface.use_external_models = use_external_models
+                if "debug" in data:
+                    # Debug preference can be toggled mid-chat.
+                    self.chat_interface.debug_llm = debug_llm
 
             if not replay_requested:
                 # Allow empty message when linking an appeal or prior auth

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,6 +46,7 @@ english-words>=2.0.0
 easy_thumbnails
 exceptionite
 flake8-django
+geoip2fast==1.2.2  # IP -> US state guess + ASN for chat; needs FHI_GEOIP_CITY_DB (see README "GeoIP")
 geopy
 git+https://github.com/holdenk/static-thumbnails.git
 git+https://github.com/jazzband/django-cookie-consent.git#egg=django-cookie-consent

--- a/tests/async-unit/test_async_task_utils.py
+++ b/tests/async-unit/test_async_task_utils.py
@@ -212,18 +212,39 @@ class TestAsyncTaskUtils:
         def score_fn(result: str, _: Awaitable[str]) -> float:
             return scores.get(result, 0.0)
 
-        best, second = await best_two_within_timelimit(tasks, score_fn, timeout=2.0)
-        assert best == "best"
-        assert second == "middle"
+        result = await best_two_within_timelimit(tasks, score_fn, timeout=2.0)
+        assert result.best == "best"
+        assert result.runner_up == "middle"
+
+    @pytest.mark.asyncio
+    async def test_best_two_reports_scores_and_tasks(self):
+        """The result carries both scores and the ORIGINAL awaitables, so
+        callers can judge how closely tied the race was and attribute each
+        answer to the call that produced it."""
+        tasks = [
+            self.async_task_with_delay("best", 0.05),
+            self.async_task_with_delay("middle", 0.1),
+        ]
+        scores = {"best": 3.0, "middle": 2.5}
+
+        def score_fn(result: str, _: Awaitable[str]) -> float:
+            return scores.get(result, 0.0)
+
+        result = await best_two_within_timelimit(tasks, score_fn, timeout=2.0)
+        assert result.best_score == 3.0
+        assert result.runner_up_score == 2.5
+        assert result.best_task is tasks[0]
+        assert result.runner_up_task is tasks[1]
+        # Field order keeps index 0 == best (older callers indexed).
+        assert result[0] == "best"
 
     @pytest.mark.asyncio
     async def test_best_two_single_task_has_no_runner_up(self):
         tasks = [self.async_task_with_delay("only", 0.05)]
-        best, second = await best_two_within_timelimit(
-            tasks, lambda r, _: 1.0, timeout=1.0
-        )
-        assert best == "only"
-        assert second is None
+        result = await best_two_within_timelimit(tasks, lambda r, _: 1.0, timeout=1.0)
+        assert result.best == "only"
+        assert result.runner_up is None
+        assert result.runner_up_task is None
 
     @pytest.mark.asyncio
     async def test_best_two_runner_up_never_neg_inf(self):
@@ -236,9 +257,9 @@ class TestAsyncTaskUtils:
         def score_fn(result: str, _: Awaitable[str]) -> float:
             return float("-inf") if result == "rejected" else 1.0
 
-        best, second = await best_two_within_timelimit(tasks, score_fn, timeout=2.0)
-        assert best == "best"
-        assert second is None
+        result = await best_two_within_timelimit(tasks, score_fn, timeout=2.0)
+        assert result.best == "best"
+        assert result.runner_up is None
 
     @pytest.mark.asyncio
     async def test_best_two_runner_up_skips_duplicates_of_best(self):
@@ -254,9 +275,9 @@ class TestAsyncTaskUtils:
         def score_fn(result: str, _: Awaitable[str]) -> float:
             return scores.get(result, 0.0)
 
-        best, second = await best_two_within_timelimit(tasks, score_fn, timeout=2.0)
-        assert best == "same_answer"
-        assert second == "different_answer"
+        result = await best_two_within_timelimit(tasks, score_fn, timeout=2.0)
+        assert result.best == "same_answer"
+        assert result.runner_up == "different_answer"
 
     @pytest.mark.asyncio
     async def test_best_two_all_duplicates_no_runner_up(self):
@@ -264,11 +285,9 @@ class TestAsyncTaskUtils:
             self.async_task_with_delay("same_answer", 0.05),
             self.async_task_with_delay("same_answer", 0.1),
         ]
-        best, second = await best_two_within_timelimit(
-            tasks, lambda r, _: 1.0, timeout=2.0
-        )
-        assert best == "same_answer"
-        assert second is None
+        result = await best_two_within_timelimit(tasks, lambda r, _: 1.0, timeout=2.0)
+        assert result.best == "same_answer"
+        assert result.runner_up is None
 
     @pytest.mark.asyncio
     async def test_best_within_timelimit_with_exceptions(self):

--- a/tests/async-unit/test_async_task_utils.py
+++ b/tests/async-unit/test_async_task_utils.py
@@ -6,6 +6,7 @@ from typing import Awaitable, TypeVar, Any
 
 from fighthealthinsurance.utils import (
     fire_and_forget_in_new_threadpool,
+    best_two_within_timelimit,
     best_within_timelimit,
     best_within_timelimit_static,
     execute_critical_optional_fireandforget,
@@ -144,6 +145,130 @@ class TestAsyncTaskUtils:
         """Test that best_within_timelimit handles empty task list properly"""
         result = await best_within_timelimit([], lambda r, _: 1.0, timeout=0.1)
         assert result is None
+
+    @pytest.mark.asyncio
+    async def test_neg_inf_scored_result_never_wins(self):
+        """A truthy result scored -inf (hard-rejected) must not be returned
+        when a valid result exists — even if the rejected one finishes first.
+
+        Guards the chat loop fix: repeated replies are scored -inf, and
+        before this semantic a truthy -inf result could still occupy the
+        best slot via the "nothing better yet" fallback.
+        """
+        tasks = [
+            self.async_task_with_delay("rejected_repeat", 0.05),
+            self.async_task_with_delay("valid_answer", 0.2),
+        ]
+
+        def score_fn(result: str, _: Awaitable[str]) -> float:
+            return float("-inf") if result == "rejected_repeat" else 1.0
+
+        result = await best_within_timelimit(tasks, score_fn, timeout=2.0)
+        assert result == "valid_answer"
+
+    @pytest.mark.asyncio
+    async def test_all_neg_inf_returns_none(self):
+        """When every completed result is hard-rejected, the caller gets None
+        (so its retry ladder runs) instead of a rejected result."""
+        tasks = [
+            self.async_task_with_delay("repeat_a", 0.05),
+            self.async_task_with_delay("repeat_b", 0.1),
+        ]
+
+        result = await best_within_timelimit(
+            tasks, lambda r, _: float("-inf"), timeout=1.0, extended_timeout=0.2
+        )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_neg_inf_skipped_in_overtime_window(self):
+        """In the overtime window the first USABLE result wins — a rejected
+        (-inf) straggler must not end the wait."""
+        tasks = [
+            self.async_task_with_delay("rejected", 0.3),
+            self.async_task_with_delay("valid_late", 0.6),
+        ]
+
+        def score_fn(result: str, _: Awaitable[str]) -> float:
+            return float("-inf") if result == "rejected" else 1.0
+
+        # Main window (0.1s) sees nothing; overtime sees the rejected result
+        # first and must keep waiting for the valid one.
+        result = await best_within_timelimit(
+            tasks, score_fn, timeout=0.1, extended_timeout=5.0
+        )
+        assert result == "valid_late"
+
+    # Tests for best_two_within_timelimit
+    @pytest.mark.asyncio
+    async def test_best_two_returns_best_and_runner_up(self):
+        tasks = [
+            self.async_task_with_delay("low", 0.05),
+            self.async_task_with_delay("best", 0.1),
+            self.async_task_with_delay("middle", 0.15),
+        ]
+        scores = {"low": 1.0, "best": 3.0, "middle": 2.0}
+
+        def score_fn(result: str, _: Awaitable[str]) -> float:
+            return scores.get(result, 0.0)
+
+        best, second = await best_two_within_timelimit(tasks, score_fn, timeout=2.0)
+        assert best == "best"
+        assert second == "middle"
+
+    @pytest.mark.asyncio
+    async def test_best_two_single_task_has_no_runner_up(self):
+        tasks = [self.async_task_with_delay("only", 0.05)]
+        best, second = await best_two_within_timelimit(
+            tasks, lambda r, _: 1.0, timeout=1.0
+        )
+        assert best == "only"
+        assert second is None
+
+    @pytest.mark.asyncio
+    async def test_best_two_runner_up_never_neg_inf(self):
+        """A hard-rejected result can't be the runner-up either."""
+        tasks = [
+            self.async_task_with_delay("best", 0.05),
+            self.async_task_with_delay("rejected", 0.1),
+        ]
+
+        def score_fn(result: str, _: Awaitable[str]) -> float:
+            return float("-inf") if result == "rejected" else 1.0
+
+        best, second = await best_two_within_timelimit(tasks, score_fn, timeout=2.0)
+        assert best == "best"
+        assert second is None
+
+    @pytest.mark.asyncio
+    async def test_best_two_runner_up_skips_duplicates_of_best(self):
+        """Several backends serving the same model return identical answers;
+        the runner-up must be the best DIFFERENT result, not a duplicate."""
+        tasks = [
+            self.async_task_with_delay("same_answer", 0.05),
+            self.async_task_with_delay("same_answer", 0.1),
+            self.async_task_with_delay("different_answer", 0.15),
+        ]
+        scores = {"same_answer": 3.0, "different_answer": 1.0}
+
+        def score_fn(result: str, _: Awaitable[str]) -> float:
+            return scores.get(result, 0.0)
+
+        best, second = await best_two_within_timelimit(tasks, score_fn, timeout=2.0)
+        assert best == "same_answer"
+        assert second == "different_answer"
+
+    @pytest.mark.asyncio
+    async def test_best_two_all_duplicates_no_runner_up(self):
+        tasks = [
+            self.async_task_with_delay("same_answer", 0.05),
+            self.async_task_with_delay("same_answer", 0.1),
+        ]
+        best, second = await best_two_within_timelimit(
+            tasks, lambda r, _: 1.0, timeout=2.0
+        )
+        assert best == "same_answer"
+        assert second is None
 
     @pytest.mark.asyncio
     async def test_best_within_timelimit_with_exceptions(self):

--- a/tests/async-unit/test_async_task_utils.py
+++ b/tests/async-unit/test_async_task_utils.py
@@ -233,9 +233,30 @@ class TestAsyncTaskUtils:
         result = await best_two_within_timelimit(tasks, score_fn, timeout=2.0)
         assert result.best_score == 3.0
         assert result.runner_up_score == 2.5
+
+    @pytest.mark.asyncio
+    async def test_best_two_reports_originating_tasks(self):
+        """The ORIGINAL awaitables come back, so a caller can map a winner to
+        whatever it keyed its calls by (the chat layer maps them to models)."""
+        tasks = [
+            self.async_task_with_delay("best", 0.05),
+            self.async_task_with_delay("middle", 0.1),
+        ]
+        scores = {"best": 3.0, "middle": 2.5}
+
+        def score_fn(result: str, _: Awaitable[str]) -> float:
+            return scores.get(result, 0.0)
+
+        result = await best_two_within_timelimit(tasks, score_fn, timeout=2.0)
         assert result.best_task is tasks[0]
         assert result.runner_up_task is tasks[1]
-        # Field order keeps index 0 == best (older callers indexed).
+
+    @pytest.mark.asyncio
+    async def test_best_two_keeps_index_zero_as_best(self):
+        """Field order is load-bearing: older callers index result[0]."""
+        tasks = [self.async_task_with_delay("best", 0.05)]
+
+        result = await best_two_within_timelimit(tasks, lambda r, _: 1.0, timeout=2.0)
         assert result[0] == "best"
 
     @pytest.mark.asyncio

--- a/tests/async-unit/test_backend_env_config.py
+++ b/tests/async-unit/test_backend_env_config.py
@@ -21,7 +21,6 @@ from llm_result_utils.cleaner_utils import CleanerUtils
 # CleanerUtils (see _bounded_is_valid_url).
 from fighthealthinsurance.ml.ml_models import RemoteHealthInsurance
 
-
 _ENV_VARS = [
     "HEALTH_BACKEND_HOST",
     "HEALTH_BACKEND_PORT",
@@ -71,9 +70,7 @@ class TestIdenticalBackupDisabled:
 
 
 class TestEmptyStringEnvIsUnset:
-    def test_empty_backup_host_falls_back_to_primary_without_racing(
-        self, monkeypatch
-    ):
+    def test_empty_backup_host_falls_back_to_primary_without_racing(self, monkeypatch):
         _clear_env(monkeypatch)
         monkeypatch.setenv("HEALTH_BACKEND_HOST", "primary.internal")
         monkeypatch.setenv("HEALTH_BACKUP_BACKEND_HOST", "")

--- a/tests/async-unit/test_chat_repeat_self_heal.py
+++ b/tests/async-unit/test_chat_repeat_self_heal.py
@@ -151,3 +151,35 @@ async def test_context_framing_labels_summary_and_newest_message():
     assert "Context summary of the conversation so far" in prompt
     assert "The user's newest message is: CA" in prompt
     assert "Do not repeat an earlier reply" in prompt
+
+
+CANNED_REPLY = (
+    "New federal rules require many adults (ages 19-64) to complete at least "
+    "80 hours per month of work, job training, school, or community service "
+    "to keep Medicaid coverage. For detailed information, visit: "
+    "[Medicaid Work Requirements FAQ](/faq/medicaid/)"
+    "🐼 Provided the mandated work-requirements information."
+)
+
+
+@pytest.mark.asyncio
+async def test_canned_reply_repeat_needs_no_retry():
+    """Mandated verbatim replies repeat by design — the self-heal loop must
+    not burn a serial retry when the model re-sends one."""
+    canned_no_panda = CANNED_REPLY.split("🐼")[0]
+    history = [
+        {"role": "user", "content": "tell me about the medicaid work requirements"},
+        {"role": "assistant", "content": canned_no_panda},
+    ]
+    model = ScriptedModel([CANNED_REPLY])
+
+    response, _ = await model.generate_chat_response(
+        "what about the work requirements again?",
+        previous_context_summary=None,
+        history=history,
+        is_professional=False,
+        is_logged_in=False,
+    )
+
+    assert len(model.infer_calls) == 1
+    assert response == canned_no_panda

--- a/tests/async-unit/test_chat_repeat_self_heal.py
+++ b/tests/async-unit/test_chat_repeat_self_heal.py
@@ -1,0 +1,103 @@
+"""The per-backend self-heal loop in generate_chat_response.
+
+When a fresh generation (nearly) repeats the previous assistant reply from
+the history, the backend retries once with corrective feedback and hotter
+sampling before the caller's scoring/retry ladder ever sees it.
+"""
+
+import pytest
+
+from fighthealthinsurance.ml.ml_models import RemoteOpenLike
+
+LOOPED_REPLY = (
+    "The new Medicaid requirements can be tricky! To help you understand them "
+    "better, could you tell me a bit more about your situation? For example:\n\n"
+    "* What state are you in?\n"
+    "* What is your current income and household size?\n"
+    "* Do you currently have Medicaid coverage?\n"
+    "* What specific requirements are you trying to understand?\n\n"
+    "Once I have this information, I can help you find the relevant resources "
+    "and explain how to navigate the new requirements."
+)
+
+FRESH_REPLY = (
+    "Great — since you're in California, your Medicaid program is Medi-Cal. "
+    "The new federal rules add an 80-hour monthly activity requirement for "
+    "many adults by the end of 2026. Want me to look up the specifics?"
+)
+
+HISTORY = [
+    {"role": "user", "content": "Help me with the new medicaid requirements."},
+    {"role": "assistant", "content": LOOPED_REPLY},
+]
+
+
+class ScriptedModel(RemoteOpenLike):
+    """RemoteOpenLike whose _infer plays back a scripted list of replies."""
+
+    def __init__(self, replies):
+        super().__init__(
+            api_base="http://example.invalid",
+            token="test-token",
+            model="test-model",
+            system_prompts_map={},
+        )
+        self._replies = list(replies)
+        self.infer_calls = []
+
+    async def _infer(
+        self,
+        system_prompts,
+        prompt,
+        patient_context=None,
+        plan_context=None,
+        pubmed_context=None,
+        ml_citations_context=None,
+        history=None,
+        temperature=0.7,
+        raise_http_errors: bool = False,
+        timeout=None,
+    ):
+        self.infer_calls.append({"prompt": prompt, "temperature": temperature})
+        if not self._replies:
+            return None
+        return (self._replies.pop(0), None)
+
+
+@pytest.mark.asyncio
+async def test_repeat_triggers_corrective_retry():
+    model = ScriptedModel([LOOPED_REPLY, f"{FRESH_REPLY}🐼 CA, Medi-Cal question."])
+
+    response, context = await model.generate_chat_response(
+        "CA",
+        previous_context_summary=None,
+        history=HISTORY,
+        is_professional=False,
+        is_logged_in=False,
+    )
+
+    assert len(model.infer_calls) == 2
+    # The retry carried corrective feedback and hotter sampling.
+    retry_call = model.infer_calls[1]
+    assert "repeated your last reply" in retry_call["prompt"]
+    assert retry_call["temperature"] > model.infer_calls[0]["temperature"]
+    # The fresh (non-repeating) reply is what comes back, panda split off.
+    assert response == FRESH_REPLY
+    assert context is not None and "Medi-Cal" in context
+
+
+@pytest.mark.asyncio
+async def test_fresh_reply_needs_no_retry():
+    model = ScriptedModel([f"{FRESH_REPLY}🐼 CA, Medi-Cal question."])
+
+    response, _ = await model.generate_chat_response(
+        "CA",
+        previous_context_summary=None,
+        history=HISTORY,
+        is_professional=False,
+        is_logged_in=False,
+    )
+
+    assert len(model.infer_calls) == 1
+    assert "repeated your last reply" not in model.infer_calls[0]["prompt"]
+    assert response == FRESH_REPLY

--- a/tests/async-unit/test_chat_repeat_self_heal.py
+++ b/tests/async-unit/test_chat_repeat_self_heal.py
@@ -153,10 +153,15 @@ async def test_context_framing_labels_summary_and_newest_message():
     assert "Do not repeat an earlier reply" in prompt
 
 
+# Matches the mandated block in the system prompt. All of its distinctive
+# phrases matter: is_canned_reply requires the WHOLE block, because the prompt
+# also tells the model to link the FAQ on any work-requirements answer and a
+# marker-only match exempted ordinary (including looping) Medicaid replies.
 CANNED_REPLY = (
     "New federal rules require many adults (ages 19-64) to complete at least "
     "80 hours per month of work, job training, school, or community service "
-    "to keep Medicaid coverage. For detailed information, visit: "
+    "to keep Medicaid coverage. These requirements go into effect by "
+    "December 31, 2026. For detailed information, visit: "
     "[Medicaid Work Requirements FAQ](/faq/medicaid/)"
     "🐼 Provided the mandated work-requirements information."
 )
@@ -205,3 +210,46 @@ async def test_canned_reply_repeat_needs_no_retry():
 
     assert len(model.infer_calls) == 1
     assert response == canned_no_panda
+
+
+@pytest.mark.asyncio
+async def test_repeat_detected_when_generation_carries_a_panda_summary():
+    """Real generations end with "🐼<context summary>" while history stores the
+    SPLIT answer. Comparing the two shapes put a byte-identical repeat at ~0.76
+    similarity — under the 0.9 threshold — so the self-heal never fired on
+    production output, only on the panda-less fixtures."""
+    looped_with_panda = f"{LOOPED_REPLY}🐼 User asked about Medicaid requirements."
+    model = ScriptedModel(
+        [looped_with_panda, f"{FRESH_REPLY}🐼 CA, Medi-Cal question."]
+    )
+
+    response, _ = await model.generate_chat_response(
+        "CA",
+        previous_context_summary=None,
+        history=HISTORY,
+        is_professional=False,
+        is_logged_in=False,
+    )
+
+    assert len(model.infer_calls) == 2, "self-heal did not fire on a real repeat"
+    assert "repeated your last reply" in model.infer_calls[1]["prompt"]
+    assert response == FRESH_REPLY
+
+
+@pytest.mark.asyncio
+async def test_explicit_repeat_request_skips_the_self_heal():
+    """When the user asks us to repeat, repeating is the right answer and the
+    serial retry would fight the request."""
+    model = ScriptedModel([f"{LOOPED_REPLY}🐼 repeat as asked."])
+
+    response, _ = await model.generate_chat_response(
+        "can you repeat that?",
+        previous_context_summary=None,
+        history=HISTORY,
+        is_professional=False,
+        is_logged_in=False,
+        allow_repeated_reply=True,
+    )
+
+    assert len(model.infer_calls) == 1
+    assert response == LOOPED_REPLY

--- a/tests/async-unit/test_chat_repeat_self_heal.py
+++ b/tests/async-unit/test_chat_repeat_self_heal.py
@@ -8,22 +8,10 @@ sampling before the caller's scoring/retry ladder ever sees it.
 import pytest
 
 from fighthealthinsurance.ml.ml_models import RemoteOpenLike
-
-LOOPED_REPLY = (
-    "The new Medicaid requirements can be tricky! To help you understand them "
-    "better, could you tell me a bit more about your situation? For example:\n\n"
-    "* What state are you in?\n"
-    "* What is your current income and household size?\n"
-    "* Do you currently have Medicaid coverage?\n"
-    "* What specific requirements are you trying to understand?\n\n"
-    "Once I have this information, I can help you find the relevant resources "
-    "and explain how to navigate the new requirements."
-)
-
-FRESH_REPLY = (
-    "Great — since you're in California, your Medicaid program is Medi-Cal. "
-    "The new federal rules add an 80-hour monthly activity requirement for "
-    "many adults by the end of 2026. Want me to look up the specifics?"
+from tests.chat_fixtures import (
+    CANNED_MEDICAID_REPLY,
+    FRESH_REPLY,
+    LOOPED_REPLY,
 )
 
 HISTORY = [
@@ -153,40 +141,9 @@ async def test_context_framing_labels_summary_and_newest_message():
     assert "Do not repeat an earlier reply" in prompt
 
 
-# Matches the mandated block in the system prompt. All of its distinctive
-# phrases matter: is_canned_reply requires the WHOLE block, because the prompt
-# also tells the model to link the FAQ on any work-requirements answer and a
-# marker-only match exempted ordinary (including looping) Medicaid replies.
 CANNED_REPLY = (
-    "New federal rules require many adults (ages 19-64) to complete at least "
-    "80 hours per month of work, job training, school, or community service "
-    "to keep Medicaid coverage. These requirements go into effect by "
-    "December 31, 2026. For detailed information, visit: "
-    "[Medicaid Work Requirements FAQ](/faq/medicaid/)"
-    "🐼 Provided the mandated work-requirements information."
+    f"{CANNED_MEDICAID_REPLY}🐼 Provided the mandated work-requirements information."
 )
-
-
-@pytest.mark.asyncio
-async def test_allow_repeated_reply_skips_corrective_retry():
-    """When the caller derived an explicit-repeat request from the RAW user
-    message (allow_repeated_reply=True), a repeat of the last reply is what
-    the user wants — the self-heal loop must deliver it without burning a
-    serial corrective retry."""
-    model = ScriptedModel([f"{LOOPED_REPLY}🐼 Repeated as requested."])
-
-    response, _ = await model.generate_chat_response(
-        "can you repeat that?",
-        previous_context_summary=None,
-        history=HISTORY,
-        is_professional=False,
-        is_logged_in=False,
-        allow_repeated_reply=True,
-    )
-
-    assert len(model.infer_calls) == 1
-    assert "repeated your last reply" not in model.infer_calls[0]["prompt"]
-    assert response == LOOPED_REPLY
 
 
 @pytest.mark.asyncio

--- a/tests/async-unit/test_chat_repeat_self_heal.py
+++ b/tests/async-unit/test_chat_repeat_self_heal.py
@@ -58,7 +58,13 @@ class ScriptedModel(RemoteOpenLike):
         raise_http_errors: bool = False,
         timeout=None,
     ):
-        self.infer_calls.append({"prompt": prompt, "temperature": temperature})
+        self.infer_calls.append(
+            {
+                "prompt": prompt,
+                "temperature": temperature,
+                "system_prompts": list(system_prompts or []),
+            }
+        )
         if not self._replies:
             return None
         return (self._replies.pop(0), None)
@@ -101,3 +107,47 @@ async def test_fresh_reply_needs_no_retry():
     assert len(model.infer_calls) == 1
     assert "repeated your last reply" not in model.infer_calls[0]["prompt"]
     assert response == FRESH_REPLY
+
+
+@pytest.mark.asyncio
+async def test_system_prompt_carries_anti_loop_and_placeholder_guidance():
+    """The chat system prompt must teach the model to never repeat itself
+    and to treat client-side privacy placeholders ({{STATE}} etc.) as known
+    values — messages arrive scrubbed and the model previously had no way to
+    know what the tokens meant, so it re-asked for them forever."""
+    model = ScriptedModel([f"{FRESH_REPLY}🐼 ctx"])
+
+    await model.generate_chat_response(
+        "CA",
+        previous_context_summary=None,
+        history=HISTORY,
+        is_professional=False,
+        is_logged_in=False,
+    )
+
+    system_prompt = model.infer_calls[0]["system_prompts"][0]
+    assert "Never repeat one of your earlier replies" in system_prompt
+    assert "{{STATE}}" in system_prompt
+    assert "{{FIRST_NAME}}" in system_prompt
+    assert "privacy placeholders" in system_prompt
+
+
+@pytest.mark.asyncio
+async def test_context_framing_labels_summary_and_newest_message():
+    """The ongoing-turn framing labels the summary as background and points
+    the model at the user's newest message (the old wording buried terse
+    replies behind a summary of the model's own previous turn)."""
+    model = ScriptedModel([f"{FRESH_REPLY}🐼 ctx"])
+
+    await model.generate_chat_response(
+        "CA",
+        previous_context_summary="User is asking about Medicaid requirements.",
+        history=HISTORY,
+        is_professional=False,
+        is_logged_in=False,
+    )
+
+    prompt = model.infer_calls[0]["prompt"]
+    assert "Context summary of the conversation so far" in prompt
+    assert "The user's newest message is: CA" in prompt
+    assert "Do not repeat an earlier reply" in prompt

--- a/tests/async-unit/test_chat_repeat_self_heal.py
+++ b/tests/async-unit/test_chat_repeat_self_heal.py
@@ -163,6 +163,28 @@ CANNED_REPLY = (
 
 
 @pytest.mark.asyncio
+async def test_allow_repeated_reply_skips_corrective_retry():
+    """When the caller derived an explicit-repeat request from the RAW user
+    message (allow_repeated_reply=True), a repeat of the last reply is what
+    the user wants — the self-heal loop must deliver it without burning a
+    serial corrective retry."""
+    model = ScriptedModel([f"{LOOPED_REPLY}🐼 Repeated as requested."])
+
+    response, _ = await model.generate_chat_response(
+        "can you repeat that?",
+        previous_context_summary=None,
+        history=HISTORY,
+        is_professional=False,
+        is_logged_in=False,
+        allow_repeated_reply=True,
+    )
+
+    assert len(model.infer_calls) == 1
+    assert "repeated your last reply" not in model.infer_calls[0]["prompt"]
+    assert response == LOOPED_REPLY
+
+
+@pytest.mark.asyncio
 async def test_canned_reply_repeat_needs_no_retry():
     """Mandated verbatim replies repeat by design — the self-heal loop must
     not burn a serial retry when the model re-sends one."""

--- a/tests/async-unit/test_chat_ws_answer_feedback.py
+++ b/tests/async-unit/test_chat_ws_answer_feedback.py
@@ -1,0 +1,70 @@
+"""The chat WebSocket's side-by-side answer-feedback frame.
+
+A lightweight ``{"answer_feedback": {"preferred": ...}}`` frame records
+which of the two side-by-side answers the user preferred. It must not start
+an LLM turn, must not require message content, and must collapse arbitrary
+client-supplied values into a bounded metric label set.
+"""
+
+import pytest
+from channels.testing import WebsocketCommunicator
+from prometheus_client import REGISTRY
+
+from fighthealthinsurance.websockets import OngoingChatConsumer
+
+
+def _feedback_metric(preferred):
+    return (
+        REGISTRY.get_sample_value(
+            "fhi_chat_answer_feedback_total", {"preferred": preferred}
+        )
+        or 0.0
+    )
+
+
+@pytest.mark.django_db
+@pytest.mark.asyncio
+async def test_answer_feedback_records_metric_without_llm_turn():
+    before = _feedback_metric("alternate")
+    communicator = WebsocketCommunicator(
+        OngoingChatConsumer.as_asgi(), "/ws/ongoing-chat/"
+    )
+    connected, _ = await communicator.connect()
+    assert connected
+    try:
+        await communicator.send_json_to(
+            {
+                "answer_feedback": {"preferred": "alternate"},
+                "session_key": "feedback-test",
+            }
+        )
+        # The branch returns silently: no reply frame and no error frame
+        # ("Message content is required") may be produced.
+        assert await communicator.receive_nothing(timeout=0.5)
+    finally:
+        await communicator.disconnect()
+
+    assert _feedback_metric("alternate") == before + 1
+
+
+@pytest.mark.django_db
+@pytest.mark.asyncio
+async def test_answer_feedback_bounds_unexpected_values():
+    before = _feedback_metric("other")
+    communicator = WebsocketCommunicator(
+        OngoingChatConsumer.as_asgi(), "/ws/ongoing-chat/"
+    )
+    connected, _ = await communicator.connect()
+    assert connected
+    try:
+        await communicator.send_json_to(
+            {
+                "answer_feedback": {"preferred": "x" * 500},
+                "session_key": "feedback-test-2",
+            }
+        )
+        assert await communicator.receive_nothing(timeout=0.5)
+    finally:
+        await communicator.disconnect()
+
+    assert _feedback_metric("other") == before + 1

--- a/tests/async-unit/test_generic_model_caching.py
+++ b/tests/async-unit/test_generic_model_caching.py
@@ -265,9 +265,7 @@ async def test_generic_citation_cache_write_upserts_on_concurrent_miss():
         # Simulate the concurrent-miss race: the read sees no row (another
         # request's write hadn't landed yet at read time), the write must
         # still upsert against the row that exists by write time.
-        mock_gcg.objects.filter.return_value.afirst = mock.AsyncMock(
-            return_value=None
-        )
+        mock_gcg.objects.filter.return_value.afirst = mock.AsyncMock(return_value=None)
         mock_gcg.objects.aupdate_or_create = (
             GenericContextGeneration.objects.aupdate_or_create
         )

--- a/tests/async-unit/test_infer_quality_regressions.py
+++ b/tests/async-unit/test_infer_quality_regressions.py
@@ -127,6 +127,6 @@ class TestProfPovPromptSelection:
 
     def test_patient_pov_unchanged(self):
         m = _model()
-        assert m.get_system_prompts("full", prof_pov=False) == m.system_prompts_map[
-            "full"
-        ]
+        assert (
+            m.get_system_prompts("full", prof_pov=False) == m.system_prompts_map["full"]
+        )

--- a/tests/async-unit/test_ml_router.py
+++ b/tests/async-unit/test_ml_router.py
@@ -126,8 +126,12 @@ class TestMLRouterChatBackends(unittest.TestCase):
         self.assertIsInstance(fallback_models, list)
 
     def test_get_chat_backends_with_fallback_with_external(self):
-        """Test get_chat_backends_with_fallback with use_external=True."""
-        # best_external_models reads external_models_by_cost.
+        """With use_external=True the externals participate in the fan-out.
+
+        They now join the PRIMARY list, and the fallback list carries only
+        externals not already there (so a retry can't issue the same request
+        to the same backend twice).
+        """
         self.router.external_models_by_cost = [
             make_external_mock(quality=80),
             make_external_mock(quality=90),
@@ -138,44 +142,46 @@ class TestMLRouterChatBackends(unittest.TestCase):
             use_external=True
         )
 
-        # Primary models should be returned
         self.assertIsInstance(primary_models, list)
-        # Fallback models should contain external models only
-        self.assertGreater(len(fallback_models), 0)
-        # All fallback models should be external
+        externals_in_primary = [
+            m for m in primary_models if getattr(m, "external", False)
+        ]
+        self.assertGreater(len(externals_in_primary), 0)
+        # Anything left in fallback must be external and not already primary.
+        primary_ids = {id(m) for m in primary_models}
         for model in fallback_models:
             self.assertTrue(model.external)
+            self.assertNotIn(id(model), primary_ids)
 
-    def test_get_chat_backends_with_fallback_sorts_by_quality(self):
-        """Test that fallback models are sorted by quality (highest first)."""
-        # Set up router with external models of differing quality.
+    def test_chat_externals_are_quality_ordered(self):
+        """The externals offered for chat are best-quality first."""
         self.router.external_models_by_cost = [
             make_external_mock(quality=60),
             make_external_mock(quality=95),
             make_external_mock(quality=75),
         ]
 
-        _, fallback_models = self.router.get_chat_backends_with_fallback(
+        primary_models, _ = self.router.get_chat_backends_with_fallback(
             use_external=True
         )
 
-        # Verify models are sorted by quality (highest first)
-        if len(fallback_models) >= 2:
-            qualities = [m.quality() for m in fallback_models]
-            self.assertEqual(qualities, sorted(qualities, reverse=True))
+        qualities = [
+            m.quality() for m in primary_models if getattr(m, "external", False)
+        ]
+        self.assertEqual(qualities, sorted(qualities, reverse=True))
 
-    def test_get_chat_backends_with_fallback_limits_to_three(self):
-        """Test that fallback models are limited to the best ~3 models."""
+    def test_chat_externals_limited_to_three(self):
+        """At most the best ~3 externals join the chat fan-out."""
         self.router.external_models_by_cost = [
             make_external_mock(quality=50 + i) for i in range(10)
         ]
 
-        _, fallback_models = self.router.get_chat_backends_with_fallback(
+        primary_models, _ = self.router.get_chat_backends_with_fallback(
             use_external=True
         )
 
-        # Should limit to the best 3 models
-        self.assertEqual(len(fallback_models), 3)
+        externals = [m for m in primary_models if getattr(m, "external", False)]
+        self.assertEqual(len(externals), 3)
 
     def test_get_chat_backends_with_fallback_no_external_available(self):
         """Test behavior when no external models are available."""
@@ -224,9 +230,31 @@ class TestMLRouterChatBackends(unittest.TestCase):
             use_external=True
         )
 
-        external_in_primary = [m for m in primary_models if getattr(m, "external", False)]
+        external_in_primary = [
+            m for m in primary_models if getattr(m, "external", False)
+        ]
         self.assertEqual(len(external_in_primary), 2)
-        self.assertEqual(len(fallback_models), 2)
+        # They are NOT repeated in the fallback list: build_retry_calls
+        # iterates both, so a backend in each would get four identical
+        # requests per retry.
+        self.assertEqual(fallback_models, [])
+
+    def test_externals_are_not_duplicated_across_primary_and_fallback(self):
+        """build_retry_calls fans out over model_backends AND fallback_backends,
+        so a backend in both lists received four byte-identical requests per
+        retry — doubled paid spend and rate-limit pressure on exactly the turns
+        that already failed."""
+        self.router.external_models_by_cost = [
+            make_external_mock(quality=90),
+            make_external_mock(quality=80),
+        ]
+
+        primary_models, fallback_models = self.router.get_chat_backends_with_fallback(
+            use_external=True
+        )
+
+        overlap = {id(m) for m in primary_models} & {id(m) for m in fallback_models}
+        self.assertEqual(overlap, set(), "externals appear in both fan-out lists")
 
     def test_internal_chat_backends_ordered_by_quality(self):
         """The internal slots go to the STRONGEST available internals, not the

--- a/tests/async-unit/test_ml_router.py
+++ b/tests/async-unit/test_ml_router.py
@@ -211,6 +211,44 @@ class TestMLRouterChatBackends(unittest.TestCase):
             mock_get_chat.assert_called_once_with(use_external=False)
             self.assertEqual(primary_models, ["mock_model"])
 
+    def test_externals_join_primary_fanout_when_enabled(self):
+        """With use_external=True, external models participate in the PRIMARY
+        fan-out (scoring keeps preferring internals when they answer well);
+        they are not only a retry fallback."""
+        self.router.external_models_by_cost = [
+            make_external_mock(quality=90),
+            make_external_mock(quality=80),
+        ]
+
+        primary_models, fallback_models = self.router.get_chat_backends_with_fallback(
+            use_external=True
+        )
+
+        external_in_primary = [m for m in primary_models if getattr(m, "external", False)]
+        self.assertEqual(len(external_in_primary), 2)
+        self.assertEqual(len(fallback_models), 2)
+
+    def test_internal_chat_backends_ordered_by_quality(self):
+        """The internal slots go to the STRONGEST available internals, not the
+        cheapest (stable sort: equal quality keeps cost order)."""
+
+        def make_internal_mock(quality: int) -> MagicMock:
+            model = MagicMock(spec=RemoteModelLike)
+            model.external = False
+            model.quality.return_value = quality
+            model.is_available.return_value = True
+            model.health_checked_live = True
+            return model
+
+        weak_cheap = make_internal_mock(quality=101)
+        strong_pricier = make_internal_mock(quality=200)
+        self.router.internal_models_by_cost = [weak_cheap, strong_pricier]
+        self.router.models_by_name = {}
+
+        models = self.router.get_chat_backends(use_external=False)
+
+        self.assertEqual(models, [strong_pricier, weak_cheap])
+
 
 class TestMLRouterBestExternalModels(unittest.TestCase):
     """Tests for MLRouter.best_external_models (quality + health selection)."""

--- a/tests/async/mock_chat_model.py
+++ b/tests/async/mock_chat_model.py
@@ -1,6 +1,6 @@
 """Mock models for chat testing."""
 
-from typing import Tuple, Optional, Dict, Any
+from typing import Tuple, Optional
 
 
 class MockChatModel:
@@ -49,28 +49,28 @@ class MockChatModel:
     async def generate_chat_response(
         self,
         current_message_for_llm: str,
-        previous_context_summary: Optional[Dict[str, Any]] = None,
+        previous_context_summary: Optional[str] = None,
         history: Optional[list[dict[str, str]]] = None,
+        temperature: float = 0.7,
         is_professional: Optional[bool] = True,
         is_logged_in: Optional[bool] = True,
-        temperature: float = 0.7,
     ) -> Tuple[str, str]:
         """
         Generate a mock response to a chat message.
 
-        The first parameter is named ``current_message_for_llm`` to match
-        ``RemoteModelLike.generate_chat_response`` exactly — callers (like the
-        chooser) pass it by keyword, so a mismatched mock signature would hide
-        real TypeErrors. ``temperature`` likewise mirrors the real signature
-        (anti-repeat retries pass a raised value).
+        The parameter names, order, and types mirror
+        ``RemoteModelLike.generate_chat_response`` — callers (like the
+        chooser) pass them by keyword, so a mismatched mock signature would
+        hide real TypeErrors. ``temperature`` sits before the audience flags
+        for the same reason (anti-repeat retries pass a raised value).
 
         Args:
             current_message_for_llm: The user's message
             previous_context_summary: Optional context from previous interactions
             history: Optional history of messages
+            temperature: Sampling temperature (ignored by the mock)
             is_professional: Optional boolean indicating if the user is a professional
             is_logged_in: Optional boolean indicating if the user is logged in
-            temperature: Sampling temperature (ignored by the mock)
 
         Returns:
             A tuple of (response_text, updated_context)

--- a/tests/async/mock_chat_model.py
+++ b/tests/async/mock_chat_model.py
@@ -54,6 +54,7 @@ class MockChatModel:
         temperature: float = 0.7,
         is_professional: Optional[bool] = True,
         is_logged_in: Optional[bool] = True,
+        is_medicaid_related: Optional[bool] = None,
         allow_repeated_reply: bool = False,
     ) -> Tuple[str, str]:
         """
@@ -72,6 +73,9 @@ class MockChatModel:
             temperature: Sampling temperature (ignored by the mock)
             is_professional: Optional boolean indicating if the user is a professional
             is_logged_in: Optional boolean indicating if the user is logged in
+            is_medicaid_related: Optional Medicaid-topic hint (ignored by the
+                mock; present so the mock accepts every keyword the real
+                signature does)
             allow_repeated_reply: True when the user explicitly asked for a
                 repeat (ignored by the mock; accepted because the call
                 builders always pass it)

--- a/tests/async/mock_chat_model.py
+++ b/tests/async/mock_chat_model.py
@@ -54,6 +54,7 @@ class MockChatModel:
         temperature: float = 0.7,
         is_professional: Optional[bool] = True,
         is_logged_in: Optional[bool] = True,
+        allow_repeated_reply: bool = False,
     ) -> Tuple[str, str]:
         """
         Generate a mock response to a chat message.
@@ -71,6 +72,9 @@ class MockChatModel:
             temperature: Sampling temperature (ignored by the mock)
             is_professional: Optional boolean indicating if the user is a professional
             is_logged_in: Optional boolean indicating if the user is logged in
+            allow_repeated_reply: True when the user explicitly asked for a
+                repeat (ignored by the mock; accepted because the call
+                builders always pass it)
 
         Returns:
             A tuple of (response_text, updated_context)

--- a/tests/async/mock_chat_model.py
+++ b/tests/async/mock_chat_model.py
@@ -53,6 +53,7 @@ class MockChatModel:
         history: Optional[list[dict[str, str]]] = None,
         is_professional: Optional[bool] = True,
         is_logged_in: Optional[bool] = True,
+        temperature: float = 0.7,
     ) -> Tuple[str, str]:
         """
         Generate a mock response to a chat message.
@@ -60,7 +61,8 @@ class MockChatModel:
         The first parameter is named ``current_message_for_llm`` to match
         ``RemoteModelLike.generate_chat_response`` exactly — callers (like the
         chooser) pass it by keyword, so a mismatched mock signature would hide
-        real TypeErrors.
+        real TypeErrors. ``temperature`` likewise mirrors the real signature
+        (anti-repeat retries pass a raised value).
 
         Args:
             current_message_for_llm: The user's message
@@ -68,6 +70,7 @@ class MockChatModel:
             history: Optional history of messages
             is_professional: Optional boolean indicating if the user is a professional
             is_logged_in: Optional boolean indicating if the user is logged in
+            temperature: Sampling temperature (ignored by the mock)
 
         Returns:
             A tuple of (response_text, updated_context)

--- a/tests/async/test_chat_loop_prevention.py
+++ b/tests/async/test_chat_loop_prevention.py
@@ -65,6 +65,9 @@ class _FrameRecorder:
     def debug_frames(self):
         return [f for f in self.frames if "debug_llm_input" in f]
 
+    def debug_result_frames(self):
+        return [f for f in self.frames if "debug_llm_result" in f]
+
 
 class RecordingChatModel:
     """Chat backend stub: records calls; loops until told not to repeat.
@@ -80,12 +83,17 @@ class RecordingChatModel:
         fresh_reply=FRESH_REPLY,
         always_reply=None,
         model_quality=100,
+        name="recording-model",
     ):
         self.calls = []
         self._looped_reply = looped_reply
         self._fresh_reply = fresh_reply
         self._always_reply = always_reply
         self._quality = model_quality
+        self._name = name
+
+    def __str__(self):
+        return self._name
 
     def quality(self):
         return self._quality
@@ -286,6 +294,57 @@ class ChatAlternateAnswerTest(APITestCase):
         assert content_frames
         assert "alternate_content" not in content_frames[-1]
 
+    async def test_wide_score_gap_runner_up_not_offered(self):
+        """A runner-up far below the winner (cross-tier quality gap) is not
+        worth the user's attention: alternates only show on close ties."""
+        user, chat = await _make_chat(
+            "alternate3", "9999930015", chat_history=_seed_history()
+        )
+        recorder = _FrameRecorder()
+        interface = ChatInterface(send_json_message_func=recorder, chat=chat, user=user)
+        strong_model = RecordingChatModel(
+            always_reply=FRESH_REPLY, model_quality=200, name="strong-internal"
+        )
+        weak_model = RecordingChatModel(
+            always_reply=SECOND_OPINION_REPLY, model_quality=100, name="weak-external"
+        )
+
+        with _patched_router([strong_model, weak_model]), _PATCH_FIRE_AND_FORGET:
+            await interface.handle_chat_message("CA")
+
+        content_frames = recorder.content_frames()
+        assert content_frames
+        frame = content_frames[-1]
+        assert frame["content"] == FRESH_REPLY
+        assert "alternate_content" not in frame
+
+
+class ChatRepeatOffenderTest(APITestCase):
+    async def test_looping_backend_gets_session_strikes(self):
+        """A backend whose candidate is hard-rejected as a repeat collects a
+        per-session strike (used to decay its base score on later turns),
+        and the fresh answer from the other backend is delivered."""
+        user, chat = await _make_chat(
+            "offender1", "9999930016", chat_history=_seed_history()
+        )
+        recorder = _FrameRecorder()
+        interface = ChatInterface(send_json_message_func=recorder, chat=chat, user=user)
+        looper = RecordingChatModel(
+            always_reply=LOOPED_REPLY, model_quality=110, name="looping-backend"
+        )
+        fresh = RecordingChatModel(
+            always_reply=FRESH_REPLY, model_quality=100, name="fresh-backend"
+        )
+
+        with _patched_router([looper, fresh]), _PATCH_FIRE_AND_FORGET:
+            await interface.handle_chat_message("CA")
+
+        content_frames = recorder.content_frames()
+        assert content_frames
+        assert content_frames[-1]["content"] == FRESH_REPLY
+        assert interface._repeat_offenders.get("looping-backend", 0) >= 1
+        assert "fresh-backend" not in interface._repeat_offenders
+
 
 class ChatStateHintTest(APITestCase):
     async def test_state_hint_reaches_model_context_as_unconfirmed(self):
@@ -368,6 +427,48 @@ class ChatDebugFrameTest(APITestCase):
             await interface.handle_chat_message("CA")
 
         assert not recorder.debug_frames()
+        assert not recorder.debug_result_frames()
+
+    async def test_debug_result_frame_reports_model_selection(self):
+        """With debug on, each turn also reports WHICH backend won, both
+        scores, and the anti-loop bookkeeping — the fan-out is otherwise a
+        black box when triaging a bad reply."""
+        user, chat = await _make_chat(
+            "chatdebug3", "9999930017", chat_history=_seed_history()
+        )
+        recorder = _FrameRecorder()
+        interface = ChatInterface(
+            send_json_message_func=recorder,
+            chat=chat,
+            user=user,
+            debug_llm=True,
+        )
+        best_model = RecordingChatModel(
+            always_reply=FRESH_REPLY, model_quality=110, name="winner-model"
+        )
+        second_model = RecordingChatModel(
+            always_reply=SECOND_OPINION_REPLY, model_quality=100, name="second-model"
+        )
+
+        with _patched_router([best_model, second_model]), _PATCH_FIRE_AND_FORGET:
+            await interface.handle_chat_message("CA")
+
+        result_frames = recorder.debug_result_frames()
+        assert result_frames, f"expected a debug result frame: {recorder.frames}"
+        result = result_frames[0]["debug_llm_result"]
+        assert result["picked_model"] == "winner-model"
+        assert result["runner_up_model"] == "second-model"
+        assert result["picked_score"] > result["runner_up_score"]
+        assert result["closely_tied"] is True
+        assert result["alternate_offered"] is True
+        assert result["candidate_count"] == 2
+        assert result["rejected_repeats"] == 0
+        assert result["retry_used"] is False
+        assert result["elapsed_ms"] >= 0
+        assert {c["model"] for c in result["scored_candidates"]} == {
+            "winner-model",
+            "second-model",
+        }
 
 
 class ChatDisconnectSafetyTest(APITestCase):

--- a/tests/async/test_chat_loop_prevention.py
+++ b/tests/async/test_chat_loop_prevention.py
@@ -366,3 +366,97 @@ class ChatDebugFrameTest(APITestCase):
             await interface.handle_chat_message("CA")
 
         assert not recorder.debug_frames()
+
+
+class ChatDisconnectSafetyTest(APITestCase):
+    async def test_user_message_survives_mid_turn_cancellation(self):
+        """Channels cancels the consumer's coroutine on disconnect; the
+        user's message must already be persisted by then (persistence used
+        to happen only after generation, so a network blip erased the
+        turn)."""
+        import asyncio
+
+        user, chat = await _make_chat(
+            "cancelmid1", "9999930010", chat_history=_seed_history()
+        )
+        recorder = _FrameRecorder()
+        interface = ChatInterface(send_json_message_func=recorder, chat=chat, user=user)
+
+        with (
+            _patched_router([RecordingChatModel(always_reply=FRESH_REPLY)]),
+            _PATCH_FIRE_AND_FORGET,
+            patch.object(
+                ChatInterface,
+                "_call_llm_with_actions",
+                new=AsyncMock(side_effect=asyncio.CancelledError),
+            ),
+        ):
+            try:
+                await interface.handle_chat_message("CA")
+            except asyncio.CancelledError:
+                pass
+
+        fresh = await OngoingChat.objects.aget(id=chat.id)
+        user_msgs = [
+            m["content"] for m in fresh.chat_history if m.get("role") == "user"
+        ]
+        assert "CA" in user_msgs, f"user message lost: {fresh.chat_history}"
+
+    async def test_completed_turn_has_no_duplicate_user_message(self):
+        """The early persist plus the end-of-turn persist must not double
+        the user's message (tail-dedup in the merge helper)."""
+        user, chat = await _make_chat(
+            "cancelmid2", "9999930011", chat_history=_seed_history()
+        )
+        recorder = _FrameRecorder()
+        interface = ChatInterface(send_json_message_func=recorder, chat=chat, user=user)
+
+        with (
+            _patched_router([RecordingChatModel(always_reply=FRESH_REPLY)]),
+            _PATCH_FIRE_AND_FORGET,
+        ):
+            await interface.handle_chat_message("CA")
+
+        fresh = await OngoingChat.objects.aget(id=chat.id)
+        ca_msgs = [
+            m
+            for m in fresh.chat_history
+            if m.get("role") == "user" and m.get("content") == "CA"
+        ]
+        assert len(ca_msgs) == 1, f"duplicated user message: {fresh.chat_history}"
+        assert fresh.chat_history[-1]["content"] == FRESH_REPLY
+
+
+class ChatReplayFilterTest(APITestCase):
+    async def test_internal_link_messages_do_not_replay(self):
+        """Appeal-link notes are stored as role=user for LLM context; they
+        must not replay as bubbles the user never typed."""
+        seeded = _seed_history() + [
+            {
+                "role": "user",
+                "content": "Linked this chat to Appeal #4 -- help the user iterate",
+                "internal": True,
+            },
+            {"role": "assistant", "content": "I've linked this chat to your appeal."},
+            # Legacy entry from before the internal flag existed.
+            {
+                "role": "user",
+                "content": "This chat is already linked to Appeal #4 -- details",
+            },
+        ]
+        user, chat = await _make_chat("replayfilter1", "9999930012", seeded)
+        recorder = _FrameRecorder()
+        interface = ChatInterface(send_json_message_func=recorder, chat=chat, user=user)
+
+        await interface.replay_chat_history()
+
+        replay_frames = [f for f in recorder.frames if "messages" in f]
+        assert replay_frames
+        contents = [m["content"] for m in replay_frames[0]["messages"]]
+        assert "I've linked this chat to your appeal." in contents
+        assert not any(c.startswith("Linked this chat to ") for c in contents)
+        assert not any(
+            c.startswith("This chat is already linked to ") for c in contents
+        )
+        # Normal user messages still replay.
+        assert "Help me with the new medicaid requirements." in contents

--- a/tests/async/test_chat_loop_prevention.py
+++ b/tests/async/test_chat_loop_prevention.py
@@ -101,11 +101,13 @@ class RecordingChatModel:
         is_professional=True,
         is_logged_in=True,
         temperature=0.7,
+        allow_repeated_reply=False,
     ):
         self.calls.append(
             {
                 "message": current_message_for_llm,
                 "context": previous_context_summary,
+                "allow_repeated_reply": allow_repeated_reply,
                 "history": list(history) if history else [],
                 "temperature": temperature,
             }

--- a/tests/async/test_chat_loop_prevention.py
+++ b/tests/async/test_chat_loop_prevention.py
@@ -460,3 +460,44 @@ class ChatReplayFilterTest(APITestCase):
         )
         # Normal user messages still replay.
         assert "Help me with the new medicaid requirements." in contents
+
+
+class ChatConcurrentPrePersistTest(APITestCase):
+    async def test_concurrent_prepersist_does_not_duplicate_user_message(self):
+        """Two connections racing on one chat: the second turn's pre-persist
+        merges into this turn's pending user message ("CA" -> "CA B"). The
+        end-of-turn persist must not resubmit this turn's user message, or
+        it would append AGAIN against the merged tail ("CA B CA")."""
+        from fighthealthinsurance.chat.chat_persistence import apersist_chat_turn
+
+        user, chat = await _make_chat(
+            "raceturn1", "9999930013", chat_history=_seed_history()
+        )
+        recorder = _FrameRecorder()
+        interface = ChatInterface(send_json_message_func=recorder, chat=chat, user=user)
+
+        class RacingModel(RecordingChatModel):
+            """Simulates the other connection's pre-persist landing while
+            this turn is mid-generation."""
+
+            async def generate_chat_response(self, *args, **kwargs):
+                await apersist_chat_turn(
+                    chat, new_messages=[{"role": "user", "content": "B"}]
+                )
+                return await super().generate_chat_response(*args, **kwargs)
+
+        model = RacingModel(always_reply=FRESH_REPLY)
+        with _patched_router([model]), _PATCH_FIRE_AND_FORGET:
+            await interface.handle_chat_message("CA")
+
+        fresh = await OngoingChat.objects.aget(id=chat.id)
+        user_contents = [
+            m["content"] for m in fresh.chat_history if m.get("role") == "user"
+        ]
+        # The racing message merged into this turn's pending user message,
+        # and this turn's text appears exactly once (no "CA B CA").
+        assert "CA B" in user_contents, f"history: {fresh.chat_history}"
+        assert not any(
+            c.count("CA") > 1 for c in user_contents
+        ), f"duplicated user text: {user_contents}"
+        assert fresh.chat_history[-1]["content"] == FRESH_REPLY

--- a/tests/async/test_chat_loop_prevention.py
+++ b/tests/async/test_chat_loop_prevention.py
@@ -19,37 +19,17 @@ from rest_framework.test import APITestCase
 from fighthealthinsurance.chat.retry_handler import ANTI_REPEAT_NOTE
 from fighthealthinsurance.chat_interface import ChatInterface
 from fighthealthinsurance.models import OngoingChat, ProfessionalUser
+from tests.chat_fixtures import (
+    FRESH_REPLY,
+    LOOPED_REPLY,
+    SECOND_OPINION_REPLY,
+    RecordingChatModel,
+)
 
 if typing.TYPE_CHECKING:
     from django.contrib.auth.models import User
 else:
     User = get_user_model()
-
-
-LOOPED_REPLY = (
-    "The new Medicaid requirements can be tricky! To help you understand them "
-    "better, could you tell me a bit more about your situation? For example:\n\n"
-    "* What state are you in?\n"
-    "* What is your current income and household size?\n"
-    "* Do you currently have Medicaid coverage?\n"
-    "* What specific requirements are you trying to understand?\n\n"
-    "Once I have this information, I can help you find the relevant resources "
-    "and explain how to navigate the new requirements."
-)
-
-FRESH_REPLY = (
-    "Great — since you're in California, your Medicaid program is Medi-Cal. "
-    "The new federal rules add an 80-hour monthly work, school, or "
-    "volunteering requirement for many adults by the end of 2026. Want me to "
-    "look up the Medi-Cal specifics for you?"
-)
-
-SECOND_OPINION_REPLY = (
-    "One way to start: call the Medi-Cal member help line and ask which of "
-    "the new requirements apply to your household, and keep records of any "
-    "qualifying hours. I can also walk you through the rules here if you "
-    "prefer."
-)
 
 
 class _FrameRecorder:
@@ -67,64 +47,6 @@ class _FrameRecorder:
 
     def debug_result_frames(self):
         return [f for f in self.frames if "debug_llm_result" in f]
-
-
-class RecordingChatModel:
-    """Chat backend stub: records calls; loops until told not to repeat.
-
-    Returns ``looped_reply`` for every call whose message does NOT carry the
-    anti-repeat instruction, and ``fresh_reply`` once it does — mimicking a
-    backend that re-emits its previous reply until explicitly steered.
-    """
-
-    def __init__(
-        self,
-        looped_reply=LOOPED_REPLY,
-        fresh_reply=FRESH_REPLY,
-        always_reply=None,
-        model_quality=100,
-        name="recording-model",
-    ):
-        self.calls = []
-        self._looped_reply = looped_reply
-        self._fresh_reply = fresh_reply
-        self._always_reply = always_reply
-        self._quality = model_quality
-        self._name = name
-
-    def __str__(self):
-        return self._name
-
-    def quality(self):
-        return self._quality
-
-    def get_max_context(self) -> int:
-        return 32768
-
-    async def generate_chat_response(
-        self,
-        current_message_for_llm,
-        previous_context_summary=None,
-        history=None,
-        is_professional=True,
-        is_logged_in=True,
-        temperature=0.7,
-        allow_repeated_reply=False,
-    ):
-        self.calls.append(
-            {
-                "message": current_message_for_llm,
-                "context": previous_context_summary,
-                "allow_repeated_reply": allow_repeated_reply,
-                "history": list(history) if history else [],
-                "temperature": temperature,
-            }
-        )
-        if self._always_reply is not None:
-            return (self._always_reply, "mock context summary")
-        if ANTI_REPEAT_NOTE in (current_message_for_llm or ""):
-            return (self._fresh_reply, "mock context summary")
-        return (self._looped_reply, "mock context summary")
 
 
 def _metric(name, labels=None):

--- a/tests/async/test_chat_loop_prevention.py
+++ b/tests/async/test_chat_loop_prevention.py
@@ -1,0 +1,368 @@
+"""End-to-end chat tests for the loop-prevention ladder.
+
+Covers the observed production failure: the model re-sends its previous
+reply verbatim after the user answers its question ("CA"). The ladder is:
+hard rejection of repeated candidates in scoring -> anti-repeat retry with
+an explicit instruction and hotter sampling -> delivery of a fresh reply.
+Also covers the side-by-side alternate answer, the transient IP-derived
+state hint, and the LLM-input debug frame.
+"""
+
+import typing
+from unittest.mock import AsyncMock, patch
+
+from asgiref.sync import sync_to_async
+from django.contrib.auth import get_user_model
+from prometheus_client import REGISTRY
+from rest_framework.test import APITestCase
+
+from fighthealthinsurance.chat.retry_handler import ANTI_REPEAT_NOTE
+from fighthealthinsurance.chat_interface import ChatInterface
+from fighthealthinsurance.models import OngoingChat, ProfessionalUser
+
+if typing.TYPE_CHECKING:
+    from django.contrib.auth.models import User
+else:
+    User = get_user_model()
+
+
+LOOPED_REPLY = (
+    "The new Medicaid requirements can be tricky! To help you understand them "
+    "better, could you tell me a bit more about your situation? For example:\n\n"
+    "* What state are you in?\n"
+    "* What is your current income and household size?\n"
+    "* Do you currently have Medicaid coverage?\n"
+    "* What specific requirements are you trying to understand?\n\n"
+    "Once I have this information, I can help you find the relevant resources "
+    "and explain how to navigate the new requirements."
+)
+
+FRESH_REPLY = (
+    "Great — since you're in California, your Medicaid program is Medi-Cal. "
+    "The new federal rules add an 80-hour monthly work, school, or "
+    "volunteering requirement for many adults by the end of 2026. Want me to "
+    "look up the Medi-Cal specifics for you?"
+)
+
+SECOND_OPINION_REPLY = (
+    "One way to start: call the Medi-Cal member help line and ask which of "
+    "the new requirements apply to your household, and keep records of any "
+    "qualifying hours. I can also walk you through the rules here if you "
+    "prefer."
+)
+
+
+class _FrameRecorder:
+    def __init__(self):
+        self.frames = []
+
+    async def __call__(self, frame):
+        self.frames.append(frame)
+
+    def content_frames(self):
+        return [f for f in self.frames if "content" in f]
+
+    def debug_frames(self):
+        return [f for f in self.frames if "debug_llm_input" in f]
+
+
+class RecordingChatModel:
+    """Chat backend stub: records calls; loops until told not to repeat.
+
+    Returns ``looped_reply`` for every call whose message does NOT carry the
+    anti-repeat instruction, and ``fresh_reply`` once it does — mimicking a
+    backend that re-emits its previous reply until explicitly steered.
+    """
+
+    def __init__(
+        self,
+        looped_reply=LOOPED_REPLY,
+        fresh_reply=FRESH_REPLY,
+        always_reply=None,
+        model_quality=100,
+    ):
+        self.calls = []
+        self._looped_reply = looped_reply
+        self._fresh_reply = fresh_reply
+        self._always_reply = always_reply
+        self._quality = model_quality
+
+    def quality(self):
+        return self._quality
+
+    def get_max_context(self) -> int:
+        return 32768
+
+    async def generate_chat_response(
+        self,
+        current_message_for_llm,
+        previous_context_summary=None,
+        history=None,
+        is_professional=True,
+        is_logged_in=True,
+        temperature=0.7,
+    ):
+        self.calls.append(
+            {
+                "message": current_message_for_llm,
+                "context": previous_context_summary,
+                "history": list(history) if history else [],
+                "temperature": temperature,
+            }
+        )
+        if self._always_reply is not None:
+            return (self._always_reply, "mock context summary")
+        if ANTI_REPEAT_NOTE in (current_message_for_llm or ""):
+            return (self._fresh_reply, "mock context summary")
+        return (self._looped_reply, "mock context summary")
+
+
+def _metric(name, labels=None):
+    return REGISTRY.get_sample_value(name, labels or {}) or 0.0
+
+
+async def _make_chat(username, npi, chat_history=None):
+    user = await sync_to_async(User.objects.create_user)(
+        username=username, password="testpass", email=f"{username}@example.com"
+    )
+    professional = await ProfessionalUser.objects.acreate(
+        user=user, active=True, npi_number=npi
+    )
+    chat = await OngoingChat.objects.acreate(
+        professional_user=professional,
+        chat_history=chat_history or [],
+        summary_for_next_call=[],
+    )
+    return user, chat
+
+
+def _seed_history():
+    return [
+        {"role": "user", "content": "Help me with the new medicaid requirements."},
+        {"role": "assistant", "content": LOOPED_REPLY},
+    ]
+
+
+def _patched_router(models, fallback=None):
+    return patch(
+        "fighthealthinsurance.ml.ml_router.MLRouter.get_chat_backends_with_fallback",
+        return_value=(models, fallback or []),
+    )
+
+
+_PATCH_FIRE_AND_FORGET = patch(
+    "fighthealthinsurance.chat_interface.fire_and_forget_in_new_threadpool",
+    new_callable=AsyncMock,
+)
+
+
+class ChatRepeatRejectionTest(APITestCase):
+    async def test_looping_backend_is_broken_by_anti_repeat_retry(self):
+        """A backend that re-sends its previous reply gets rejected, retried
+        with the anti-repeat instruction, and the fresh reply is delivered."""
+        user, chat = await _make_chat(
+            "loopbreak1", "9999930001", chat_history=_seed_history()
+        )
+        recorder = _FrameRecorder()
+        interface = ChatInterface(send_json_message_func=recorder, chat=chat, user=user)
+        model = RecordingChatModel()
+
+        rejected_before = _metric(
+            "fhi_chat_repeated_responses_total", {"action": "rejected_candidates"}
+        )
+
+        with _patched_router([model]), _PATCH_FIRE_AND_FORGET:
+            await interface.handle_chat_message("CA")
+
+        content_frames = recorder.content_frames()
+        assert content_frames, f"expected a reply frame, got: {recorder.frames}"
+        delivered = content_frames[-1]["content"]
+        assert delivered == FRESH_REPLY, f"delivered the looped reply: {delivered:.80}"
+
+        # The retry actually carried the anti-repeat instruction.
+        assert any(ANTI_REPEAT_NOTE in c["message"] for c in model.calls)
+        # And the rejection was recorded for observability.
+        assert (
+            _metric(
+                "fhi_chat_repeated_responses_total",
+                {"action": "rejected_candidates"},
+            )
+            == rejected_before + 1
+        )
+
+        # The delivered (fresh) turn was persisted, not the looped one.
+        fresh = await OngoingChat.objects.aget(id=chat.id)
+        assistant_msgs = [m for m in fresh.chat_history if m.get("role") == "assistant"]
+        assert assistant_msgs[-1]["content"] == FRESH_REPLY
+
+    async def test_terse_reply_gets_bridge_note(self):
+        """A short answer right after an assistant question carries the
+        system bridge note into the model call."""
+        user, chat = await _make_chat(
+            "loopbreak2", "9999930002", chat_history=_seed_history()
+        )
+        recorder = _FrameRecorder()
+        interface = ChatInterface(send_json_message_func=recorder, chat=chat, user=user)
+        model = RecordingChatModel(always_reply=FRESH_REPLY)
+
+        with _patched_router([model]), _PATCH_FIRE_AND_FORGET:
+            await interface.handle_chat_message("CA")
+
+        assert model.calls
+        assert any(
+            "this short reply answers the question" in c["message"] for c in model.calls
+        ), f"no bridge note in: {model.calls[0]['message'][:400]}"
+
+    async def test_long_message_gets_no_bridge_note(self):
+        """A full-sentence reply doesn't need (or get) the bridge note."""
+        user, chat = await _make_chat(
+            "loopbreak3", "9999930003", chat_history=_seed_history()
+        )
+        recorder = _FrameRecorder()
+        interface = ChatInterface(send_json_message_func=recorder, chat=chat, user=user)
+        model = RecordingChatModel(always_reply=FRESH_REPLY)
+
+        long_message = (
+            "I'm in California, my household is two people, our income is "
+            "about $2,900 a month, and I currently have Medi-Cal coverage."
+        )
+        with _patched_router([model]), _PATCH_FIRE_AND_FORGET:
+            await interface.handle_chat_message(long_message)
+
+        assert model.calls
+        assert not any(
+            "this short reply answers the question" in c["message"] for c in model.calls
+        )
+
+
+class ChatAlternateAnswerTest(APITestCase):
+    async def test_distinct_runner_up_offered_as_alternate(self):
+        user, chat = await _make_chat(
+            "alternate1", "9999930004", chat_history=_seed_history()
+        )
+        recorder = _FrameRecorder()
+        interface = ChatInterface(send_json_message_func=recorder, chat=chat, user=user)
+        best_model = RecordingChatModel(always_reply=FRESH_REPLY, model_quality=110)
+        second_model = RecordingChatModel(
+            always_reply=SECOND_OPINION_REPLY, model_quality=100
+        )
+
+        offered_before = _metric("fhi_chat_alternate_answers_total")
+
+        with _patched_router([best_model, second_model]), _PATCH_FIRE_AND_FORGET:
+            await interface.handle_chat_message("CA")
+
+        content_frames = recorder.content_frames()
+        assert content_frames
+        frame = content_frames[-1]
+        assert frame["content"] == FRESH_REPLY
+        assert frame.get("alternate_content") == SECOND_OPINION_REPLY
+        assert _metric("fhi_chat_alternate_answers_total") == offered_before + 1
+
+        # Only the primary reply is persisted.
+        fresh = await OngoingChat.objects.aget(id=chat.id)
+        contents = [m.get("content") for m in fresh.chat_history]
+        assert FRESH_REPLY in contents
+        assert SECOND_OPINION_REPLY not in contents
+
+    async def test_near_duplicate_runner_up_not_offered(self):
+        user, chat = await _make_chat(
+            "alternate2", "9999930005", chat_history=_seed_history()
+        )
+        recorder = _FrameRecorder()
+        interface = ChatInterface(send_json_message_func=recorder, chat=chat, user=user)
+        best_model = RecordingChatModel(always_reply=FRESH_REPLY, model_quality=110)
+        near_dup_model = RecordingChatModel(
+            always_reply=FRESH_REPLY.replace("Great —", "Good news:"),
+            model_quality=100,
+        )
+
+        with _patched_router([best_model, near_dup_model]), _PATCH_FIRE_AND_FORGET:
+            await interface.handle_chat_message("CA")
+
+        content_frames = recorder.content_frames()
+        assert content_frames
+        assert "alternate_content" not in content_frames[-1]
+
+
+class ChatStateHintTest(APITestCase):
+    async def test_state_hint_reaches_model_context_as_unconfirmed(self):
+        user, chat = await _make_chat(
+            "statehint1", "9999930006", chat_history=_seed_history()
+        )
+        recorder = _FrameRecorder()
+        interface = ChatInterface(
+            send_json_message_func=recorder,
+            chat=chat,
+            user=user,
+            state_hint="California",
+        )
+        model = RecordingChatModel(always_reply=FRESH_REPLY)
+
+        with _patched_router([model]), _PATCH_FIRE_AND_FORGET:
+            await interface.handle_chat_message("Do the new rules apply to me?")
+
+        assert model.calls
+        context = model.calls[0]["context"] or ""
+        assert "California" in context
+        assert "UNCONFIRMED" in context
+
+        # The hint is transient: nothing about it is persisted on the chat.
+        fresh = await OngoingChat.objects.aget(id=chat.id)
+        persisted_blob = str(fresh.chat_history) + str(fresh.summary_for_next_call)
+        assert "UNCONFIRMED guess" not in persisted_blob
+
+    async def test_no_hint_no_context_injection(self):
+        user, chat = await _make_chat(
+            "statehint2", "9999930007", chat_history=_seed_history()
+        )
+        recorder = _FrameRecorder()
+        interface = ChatInterface(send_json_message_func=recorder, chat=chat, user=user)
+        model = RecordingChatModel(always_reply=FRESH_REPLY)
+
+        with _patched_router([model]), _PATCH_FIRE_AND_FORGET:
+            await interface.handle_chat_message("Do the new rules apply to me?")
+
+        assert model.calls
+        context = model.calls[0]["context"] or ""
+        assert "UNCONFIRMED" not in context
+
+
+class ChatDebugFrameTest(APITestCase):
+    async def test_debug_frame_shows_exact_llm_input(self):
+        user, chat = await _make_chat(
+            "chatdebug1", "9999930008", chat_history=_seed_history()
+        )
+        recorder = _FrameRecorder()
+        interface = ChatInterface(
+            send_json_message_func=recorder,
+            chat=chat,
+            user=user,
+            debug_llm=True,
+        )
+        model = RecordingChatModel(always_reply=FRESH_REPLY)
+
+        with _patched_router([model]), _PATCH_FIRE_AND_FORGET:
+            await interface.handle_chat_message("CA")
+
+        debug_frames = recorder.debug_frames()
+        assert debug_frames, f"expected a debug frame, got: {recorder.frames}"
+        debug = debug_frames[0]["debug_llm_input"]
+        # The frame carries the exact wrapped message the model received.
+        assert model.calls
+        assert debug["message_for_llm"] == model.calls[0]["message"]
+        assert "CA" in debug["message_for_llm"]
+        assert debug["history_message_count"] == 2
+
+    async def test_no_debug_frame_by_default(self):
+        user, chat = await _make_chat(
+            "chatdebug2", "9999930009", chat_history=_seed_history()
+        )
+        recorder = _FrameRecorder()
+        interface = ChatInterface(send_json_message_func=recorder, chat=chat, user=user)
+        model = RecordingChatModel(always_reply=FRESH_REPLY)
+
+        with _patched_router([model]), _PATCH_FIRE_AND_FORGET:
+            await interface.handle_chat_message("CA")
+
+        assert not recorder.debug_frames()

--- a/tests/async/test_chooser_external_models.py
+++ b/tests/async/test_chooser_external_models.py
@@ -87,6 +87,7 @@ class FakeModel:
         is_professional=True,
         is_logged_in=True,
         is_medicaid_related=None,
+        allow_repeated_reply=False,
     ):
         self.chat_calls += 1
         return (CHAT_TEXT, "summary")

--- a/tests/async/test_document_processing.py
+++ b/tests/async/test_document_processing.py
@@ -93,7 +93,9 @@ class TestSearchTermExtraction(TestCase):
     """Tests for search term extraction from user queries."""
 
     def test_basic_extraction(self):
-        terms = _extract_search_terms("What does my plan say about prior authorization?")
+        terms = _extract_search_terms(
+            "What does my plan say about prior authorization?"
+        )
         assert "prior" in terms
         assert "authorization" in terms
         assert "what" not in terms
@@ -117,7 +119,9 @@ class TestChunkScoring(TestCase):
     """Tests for chunk relevance scoring."""
 
     def test_matching_terms_increase_score(self):
-        chunk_text = "This plan requires prior authorization for all surgical procedures."
+        chunk_text = (
+            "This plan requires prior authorization for all surgical procedures."
+        )
         score = _score_chunk(chunk_text, ["prior", "authorization"])
         assert score > 0
 

--- a/tests/chat_fixtures.py
+++ b/tests/chat_fixtures.py
@@ -1,0 +1,121 @@
+"""Shared fixtures for the chat loop-prevention tests.
+
+These constants and test doubles were previously copy-pasted across five
+test modules and had already drifted (one copy dropped a paragraph, so it
+exercised the similarity thresholds against different text than the others).
+Defining them once keeps every suite testing the same shapes, and means a
+change to ``RemoteModelLike.generate_chat_response`` only has to be mirrored
+in one place -- the mock signature is what guards against real TypeErrors.
+"""
+
+from typing import Optional
+
+# The reply from the observed production loop: the assistant re-sent this
+# verbatim after the user answered "CA".
+LOOPED_REPLY = (
+    "The new Medicaid requirements can be tricky! To help you understand them "
+    "better, could you tell me a bit more about your situation? For example:\n\n"
+    "* What state are you in?\n"
+    "* What is your current income and household size?\n"
+    "* Do you currently have Medicaid coverage?\n"
+    "* What specific requirements are you trying to understand?\n\n"
+    "Once I have this information, I can help you find the relevant resources "
+    "and explain how to navigate the new requirements."
+)
+
+# A genuinely new reply that uses the user's answer instead of re-asking.
+FRESH_REPLY = (
+    "Great — since you're in California, your Medicaid program is Medi-Cal. "
+    "The new federal rules add an 80-hour monthly work/school/volunteering "
+    "requirement for many adults by the end of 2026. Want me to look up the "
+    "Medi-Cal specifics for you?"
+)
+
+# A distinct, equally valid answer -- used as the side-by-side alternate.
+SECOND_OPINION_REPLY = (
+    "Here's another angle: Medi-Cal renewals now check the 80-hour activity "
+    "rule, so the practical first step is gathering pay stubs or school "
+    "enrollment records before your renewal date. Want a checklist?"
+)
+
+# The block the system prompt REQUIRES verbatim. Every distinctive phrase
+# matters: is_canned_reply demands the whole block, because the prompt also
+# tells the model to link that FAQ on any work-requirements answer.
+CANNED_MEDICAID_REPLY = (
+    "New federal rules require many adults (ages 19-64) to complete at least "
+    "80 hours per month of work, job training, school, or community service "
+    "to keep Medicaid coverage. These requirements go into effect by "
+    "December 31, 2026. For detailed information, visit: "
+    "[Medicaid Work Requirements FAQ](/faq/medicaid/)"
+)
+
+
+def seeded_history(looped_reply: str = LOOPED_REPLY):
+    """History ending in the assistant reply a looping backend re-sends."""
+    return [
+        {"role": "user", "content": "Help me with the new medicaid requirements."},
+        {"role": "assistant", "content": looped_reply},
+    ]
+
+
+class RecordingChatModel:
+    """Chat backend stub: records calls; loops until told not to repeat.
+
+    Returns ``looped_reply`` for every call whose message does NOT carry an
+    anti-repeat instruction, and ``fresh_reply`` once it does — mimicking a
+    backend that re-emits its previous reply until explicitly steered.
+
+    The signature mirrors ``RemoteModelLike.generate_chat_response`` (callers
+    pass by keyword), so a mismatch here would hide a real TypeError.
+    """
+
+    def __init__(
+        self,
+        looped_reply: str = LOOPED_REPLY,
+        fresh_reply: str = FRESH_REPLY,
+        always_reply: Optional[str] = None,
+        model_quality: int = 100,
+        name: str = "recording-model",
+        anti_repeat_marker: str = "repeated your previous reply",
+    ):
+        self.calls: list = []
+        self._looped_reply = looped_reply
+        self._fresh_reply = fresh_reply
+        self._always_reply = always_reply
+        self._quality = model_quality
+        self._name = name
+        self._anti_repeat_marker = anti_repeat_marker
+
+    def __str__(self) -> str:
+        return self._name
+
+    def quality(self) -> int:
+        return self._quality
+
+    def get_max_context(self) -> int:
+        return 32768
+
+    async def generate_chat_response(
+        self,
+        current_message_for_llm,
+        previous_context_summary=None,
+        history=None,
+        temperature: float = 0.7,
+        is_professional=True,
+        is_logged_in=True,
+        allow_repeated_reply: bool = False,
+    ):
+        self.calls.append(
+            {
+                "message": current_message_for_llm,
+                "context": previous_context_summary,
+                "allow_repeated_reply": allow_repeated_reply,
+                "history": list(history) if history else [],
+                "temperature": temperature,
+            }
+        )
+        if self._always_reply is not None:
+            return (self._always_reply, "mock context summary")
+        if self._anti_repeat_marker in (current_message_for_llm or ""):
+            return (self._fresh_reply, "mock context summary")
+        return (self._looped_reply, "mock context summary")

--- a/tests/selenium/test_selenium_chat_flow.py
+++ b/tests/selenium/test_selenium_chat_flow.py
@@ -532,7 +532,9 @@ class SeleniumExistingChatTest(FHISeleniumBase, StaticLiveServerTestCase):
         external_pref = self.execute_script(
             "return localStorage.getItem('fhi_use_external_models');"
         )
-        assert external_pref == "true", "External models preference should be saved as true"
+        assert (
+            external_pref == "true"
+        ), "External models preference should be saved as true"
 
         # Now visit explain denial - preference should persist
         self.open(f"{self.live_server_url}/explain-denial")

--- a/tests/sync/mock_chat_model.py
+++ b/tests/sync/mock_chat_model.py
@@ -1,6 +1,6 @@
 """Mock models for chat testing."""
 
-from typing import Tuple, Optional, Dict, Any
+from typing import Tuple, Optional
 
 
 class MockChatModel:
@@ -49,28 +49,28 @@ class MockChatModel:
     async def generate_chat_response(
         self,
         current_message_for_llm: str,
-        previous_context_summary: Optional[Dict[str, Any]] = None,
+        previous_context_summary: Optional[str] = None,
         history: Optional[list[dict[str, str]]] = None,
+        temperature: float = 0.7,
         is_professional: Optional[bool] = True,
         is_logged_in: Optional[bool] = True,
-        temperature: float = 0.7,
     ) -> Tuple[str, str]:
         """
         Generate a mock response to a chat message.
 
-        The first parameter is named ``current_message_for_llm`` to match
-        ``RemoteModelLike.generate_chat_response`` exactly — callers (like the
-        chooser) pass it by keyword, so a mismatched mock signature would hide
-        real TypeErrors. ``temperature`` likewise mirrors the real signature
-        (anti-repeat retries pass a raised value).
+        The parameter names, order, and types mirror
+        ``RemoteModelLike.generate_chat_response`` — callers (like the
+        chooser) pass them by keyword, so a mismatched mock signature would
+        hide real TypeErrors. ``temperature`` sits before the audience flags
+        for the same reason (anti-repeat retries pass a raised value).
 
         Args:
             current_message_for_llm: The user's message
             previous_context_summary: Optional context from previous interactions
             history: Optional history of messages
+            temperature: Sampling temperature (ignored by the mock)
             is_professional: Optional boolean indicating if the user is a professional
             is_logged_in: Optional boolean indicating if the user is logged in
-            temperature: Sampling temperature (ignored by the mock)
 
         Returns:
             A tuple of (response_text, updated_context)

--- a/tests/sync/mock_chat_model.py
+++ b/tests/sync/mock_chat_model.py
@@ -54,6 +54,7 @@ class MockChatModel:
         temperature: float = 0.7,
         is_professional: Optional[bool] = True,
         is_logged_in: Optional[bool] = True,
+        is_medicaid_related: Optional[bool] = None,
         allow_repeated_reply: bool = False,
     ) -> Tuple[str, str]:
         """
@@ -72,6 +73,9 @@ class MockChatModel:
             temperature: Sampling temperature (ignored by the mock)
             is_professional: Optional boolean indicating if the user is a professional
             is_logged_in: Optional boolean indicating if the user is logged in
+            is_medicaid_related: Optional Medicaid-topic hint (ignored by the
+                mock; present so the mock accepts every keyword the real
+                signature does)
             allow_repeated_reply: True when the user explicitly asked for a
                 repeat (ignored by the mock; accepted because the call
                 builders always pass it)

--- a/tests/sync/mock_chat_model.py
+++ b/tests/sync/mock_chat_model.py
@@ -54,6 +54,7 @@ class MockChatModel:
         temperature: float = 0.7,
         is_professional: Optional[bool] = True,
         is_logged_in: Optional[bool] = True,
+        allow_repeated_reply: bool = False,
     ) -> Tuple[str, str]:
         """
         Generate a mock response to a chat message.
@@ -71,6 +72,9 @@ class MockChatModel:
             temperature: Sampling temperature (ignored by the mock)
             is_professional: Optional boolean indicating if the user is a professional
             is_logged_in: Optional boolean indicating if the user is logged in
+            allow_repeated_reply: True when the user explicitly asked for a
+                repeat (ignored by the mock; accepted because the call
+                builders always pass it)
 
         Returns:
             A tuple of (response_text, updated_context)

--- a/tests/sync/mock_chat_model.py
+++ b/tests/sync/mock_chat_model.py
@@ -53,6 +53,7 @@ class MockChatModel:
         history: Optional[list[dict[str, str]]] = None,
         is_professional: Optional[bool] = True,
         is_logged_in: Optional[bool] = True,
+        temperature: float = 0.7,
     ) -> Tuple[str, str]:
         """
         Generate a mock response to a chat message.
@@ -60,7 +61,8 @@ class MockChatModel:
         The first parameter is named ``current_message_for_llm`` to match
         ``RemoteModelLike.generate_chat_response`` exactly — callers (like the
         chooser) pass it by keyword, so a mismatched mock signature would hide
-        real TypeErrors.
+        real TypeErrors. ``temperature`` likewise mirrors the real signature
+        (anti-repeat retries pass a raised value).
 
         Args:
             current_message_for_llm: The user's message
@@ -68,6 +70,7 @@ class MockChatModel:
             history: Optional history of messages
             is_professional: Optional boolean indicating if the user is a professional
             is_logged_in: Optional boolean indicating if the user is logged in
+            temperature: Sampling temperature (ignored by the mock)
 
         Returns:
             A tuple of (response_text, updated_context)

--- a/tests/sync/test_admin_delete.py
+++ b/tests/sync/test_admin_delete.py
@@ -50,9 +50,7 @@ class TestAdminDeleteDataView(TestCase):
         assert response.status_code == 200
         assert b"Delete User Data" in response.content
 
-    @patch(
-        "fighthealthinsurance.staff_views.RemoveDataHelper.remove_data_for_email"
-    )
+    @patch("fighthealthinsurance.staff_views.RemoveDataHelper.remove_data_for_email")
     def test_staff_can_delete_data(self, mock_remove):
         """Staff POST with valid email should call RemoveDataHelper."""
         self.client.login(username="staffuser", password="testpass123")

--- a/tests/sync/test_audit.py
+++ b/tests/sync/test_audit.py
@@ -590,6 +590,17 @@ class GuessUsStateTest(TestCase):
         with patch.dict("os.environ", self.FAKE_DB):
             self.assertEqual(self.audit.guess_us_state("203.0.113.7"), "Texas")
 
+    def test_empty_country_returns_none(self):
+        # A subdivision without an explicit US country code is unconfirmed
+        # data, not a US state.
+        class Result:
+            country_code = ""
+            subdivision_code = "CA"
+
+        self._install_fake_geoip(Result())
+        with patch.dict("os.environ", self.FAKE_DB):
+            self.assertIsNone(self.audit.guess_us_state("203.0.113.7"))
+
     def test_non_us_ip_returns_none(self):
         class Result:
             country_code = "FR"
@@ -658,9 +669,12 @@ class GetAsnInfoTest(TestCase):
     def test_no_db_key_returns_empty(self):
         import os
 
-        os.environ.pop("FHI_GEOIP_CITY_DB", None)
-        self.audit._reset_geo_reader_cache_for_tests()
-        self.assertEqual(self.audit.get_asn_info("203.0.113.7"), ("", ""))
+        # patch.dict snapshots os.environ and restores it on exit, so the
+        # pop below cannot leak into later tests.
+        with patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("FHI_GEOIP_CITY_DB", None)
+            self.audit._reset_geo_reader_cache_for_tests()
+            self.assertEqual(self.audit.get_asn_info("203.0.113.7"), ("", ""))
 
     def test_asn_name_from_reader(self):
         class Result:
@@ -687,8 +701,9 @@ class GeoLookupStatusTest(TestCase):
     def test_disabled_without_key_names_the_key(self):
         import os
 
-        os.environ.pop("FHI_GEOIP_CITY_DB", None)
-        enabled, reason = self.audit.geo_lookup_status()
+        with patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("FHI_GEOIP_CITY_DB", None)
+            enabled, reason = self.audit.geo_lookup_status()
         self.assertFalse(enabled)
         self.assertIn("FHI_GEOIP_CITY_DB", reason)
 
@@ -702,17 +717,31 @@ class GeoLookupStatusTest(TestCase):
         import tempfile
 
         with tempfile.NamedTemporaryFile(suffix=".dat.gz") as f:
+            f.write(b"not-really-a-db-but-nonempty")
+            f.flush()
             with patch.dict("os.environ", {"FHI_GEOIP_CITY_DB": f.name}):
                 enabled, reason = self.audit.geo_lookup_status()
-        # geoip2fast is an installed dependency, so a present file => enabled.
+        # geoip2fast is an installed dependency, so a present, readable,
+        # non-empty file => enabled (deep validation happens lazily at first
+        # lookup, with its own warning).
         self.assertTrue(enabled)
         self.assertIsNone(reason)
+
+    def test_disabled_when_file_empty(self):
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=".dat.gz") as f:
+            with patch.dict("os.environ", {"FHI_GEOIP_CITY_DB": f.name}):
+                enabled, reason = self.audit.geo_lookup_status()
+        self.assertFalse(enabled)
+        self.assertIn("empty", reason)
 
     def test_warn_helper_never_raises(self):
         import os
 
-        os.environ.pop("FHI_GEOIP_CITY_DB", None)
-        # Reset the once-per-process guard so the warning path actually runs.
-        self.audit._geo_startup_warning_emitted = False
-        self.audit.warn_if_geo_lookups_disabled()
-        self.audit.warn_if_geo_lookups_disabled()  # second call is a no-op
+        with patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("FHI_GEOIP_CITY_DB", None)
+            # Reset the once-per-process guard so the warning path runs.
+            self.audit._geo_startup_warning_emitted = False
+            self.audit.warn_if_geo_lookups_disabled()
+            self.audit.warn_if_geo_lookups_disabled()  # second call: no-op

--- a/tests/sync/test_audit.py
+++ b/tests/sync/test_audit.py
@@ -3,6 +3,7 @@ Tests for the simplified audit logging system.
 """
 
 from typing import Optional
+from unittest.mock import patch
 
 from django.test import TestCase, RequestFactory, override_settings
 from django.contrib.auth import get_user_model
@@ -501,9 +502,12 @@ class DenialTrackingInfoTest(TestCase):
 class GuessUsStateTest(TestCase):
     """Tests for the IP -> US state guess used to seed chat context.
 
-    geoip2fast is an optional dependency, so these tests inject a fake module
-    into sys.modules and reset the cached reader around each case.
+    Lookups are gated on FHI_GEOIP_CITY_DB (state data needs a city-level
+    database); these tests inject a fake geoip2fast module into sys.modules
+    and reset the cached reader around each case.
     """
+
+    FAKE_DB = {"FHI_GEOIP_CITY_DB": "/fake/geoip2fast-city.dat.gz"}
 
     def setUp(self):
         import fhi_users.audit as audit_module
@@ -541,13 +545,19 @@ class GuessUsStateTest(TestCase):
         self.assertIsNone(self.audit.guess_us_state(None))
         self.assertIsNone(self.audit.guess_us_state(""))
 
-    def test_missing_geoip_returns_none(self):
-        # No fake module installed and (in the test env) geoip2fast is not a
-        # real dependency: the guess degrades to None without raising.
-        import sys
+    def test_no_db_key_returns_none(self):
+        # The key is the switch: without FHI_GEOIP_CITY_DB no reader is
+        # built, even with geoip2fast importable.
+        class Result:
+            country_code = "US"
+            subdivision_code = "CA"
 
-        sys.modules.pop("geoip2fast", None)
-        self.assertIsNone(self.audit.guess_us_state("203.0.113.7"))
+        self._install_fake_geoip(Result())
+        with patch.dict("os.environ", {}, clear=False):
+            import os
+
+            os.environ.pop("FHI_GEOIP_CITY_DB", None)
+            self.assertIsNone(self.audit.guess_us_state("203.0.113.7"))
 
     def test_us_subdivision_code_maps_to_state_name(self):
         class Result:
@@ -555,7 +565,8 @@ class GuessUsStateTest(TestCase):
             subdivision_code = "CA"
 
         self._install_fake_geoip(Result())
-        self.assertEqual(self.audit.guess_us_state("203.0.113.7"), "California")
+        with patch.dict("os.environ", self.FAKE_DB):
+            self.assertEqual(self.audit.guess_us_state("203.0.113.7"), "California")
 
     def test_country_prefixed_subdivision_code(self):
         class Result:
@@ -563,9 +574,11 @@ class GuessUsStateTest(TestCase):
             subdivision_code = "US-NY"
 
         self._install_fake_geoip(Result())
-        self.assertEqual(self.audit.guess_us_state("203.0.113.7"), "New York")
+        with patch.dict("os.environ", self.FAKE_DB):
+            self.assertEqual(self.audit.guess_us_state("203.0.113.7"), "New York")
 
     def test_subdivision_name_on_nested_city_object(self):
+        # Matches the real geoip2fast CityDetail shape (city.subdivision_*).
         class City:
             subdivision_name = "Texas"
 
@@ -574,7 +587,8 @@ class GuessUsStateTest(TestCase):
             city = City()
 
         self._install_fake_geoip(Result())
-        self.assertEqual(self.audit.guess_us_state("203.0.113.7"), "Texas")
+        with patch.dict("os.environ", self.FAKE_DB):
+            self.assertEqual(self.audit.guess_us_state("203.0.113.7"), "Texas")
 
     def test_non_us_ip_returns_none(self):
         class Result:
@@ -582,18 +596,21 @@ class GuessUsStateTest(TestCase):
             subdivision_code = "IDF"
 
         self._install_fake_geoip(Result())
-        self.assertIsNone(self.audit.guess_us_state("203.0.113.7"))
+        with patch.dict("os.environ", self.FAKE_DB):
+            self.assertIsNone(self.audit.guess_us_state("203.0.113.7"))
 
-    def test_country_only_database_returns_none(self):
+    def test_country_only_data_returns_none(self):
         class Result:
             country_code = "US"
 
         self._install_fake_geoip(Result())
-        self.assertIsNone(self.audit.guess_us_state("203.0.113.7"))
+        with patch.dict("os.environ", self.FAKE_DB):
+            self.assertIsNone(self.audit.guess_us_state("203.0.113.7"))
 
     def test_lookup_error_returns_none(self):
         self._install_fake_geoip(RuntimeError("boom"))
-        self.assertIsNone(self.audit.guess_us_state("203.0.113.7"))
+        with patch.dict("os.environ", self.FAKE_DB):
+            self.assertIsNone(self.audit.guess_us_state("203.0.113.7"))
 
     def test_unknown_subdivision_returns_none(self):
         class Result:
@@ -601,4 +618,101 @@ class GuessUsStateTest(TestCase):
             subdivision_code = "ZZ"
 
         self._install_fake_geoip(Result())
-        self.assertIsNone(self.audit.guess_us_state("203.0.113.7"))
+        with patch.dict("os.environ", self.FAKE_DB):
+            self.assertIsNone(self.audit.guess_us_state("203.0.113.7"))
+
+
+class GetAsnInfoTest(TestCase):
+    """get_asn_info shares the gated cached reader with guess_us_state."""
+
+    FAKE_DB = {"FHI_GEOIP_CITY_DB": "/fake/geoip2fast-city-asn.dat.gz"}
+
+    def setUp(self):
+        import fhi_users.audit as audit_module
+
+        self.audit = audit_module
+        self.audit._reset_geo_reader_cache_for_tests()
+
+    def tearDown(self):
+        import sys
+
+        sys.modules.pop("geoip2fast", None)
+        self.audit._reset_geo_reader_cache_for_tests()
+
+    def _install_fake_geoip(self, lookup_result):
+        import sys
+        import types
+
+        fake_module = types.ModuleType("geoip2fast")
+
+        class FakeGeoIP2Fast:
+            def __init__(self, geoip2fast_data_file=None):
+                self.data_file = geoip2fast_data_file
+
+            def lookup(self, ip):
+                return lookup_result
+
+        fake_module.GeoIP2Fast = FakeGeoIP2Fast  # type: ignore[attr-defined]
+        sys.modules["geoip2fast"] = fake_module
+
+    def test_no_db_key_returns_empty(self):
+        import os
+
+        os.environ.pop("FHI_GEOIP_CITY_DB", None)
+        self.audit._reset_geo_reader_cache_for_tests()
+        self.assertEqual(self.audit.get_asn_info("203.0.113.7"), ("", ""))
+
+    def test_asn_name_from_reader(self):
+        class Result:
+            asn_name = "EXAMPLE-NET"
+
+        self._install_fake_geoip(Result())
+        with patch.dict("os.environ", self.FAKE_DB):
+            self.assertEqual(
+                self.audit.get_asn_info("203.0.113.7"), ("", "EXAMPLE-NET")
+            )
+
+    def test_none_ip_returns_empty(self):
+        self.assertEqual(self.audit.get_asn_info(None), ("", ""))
+
+
+class GeoLookupStatusTest(TestCase):
+    """The startup soft-fail status/warning helper."""
+
+    def setUp(self):
+        import fhi_users.audit as audit_module
+
+        self.audit = audit_module
+
+    def test_disabled_without_key_names_the_key(self):
+        import os
+
+        os.environ.pop("FHI_GEOIP_CITY_DB", None)
+        enabled, reason = self.audit.geo_lookup_status()
+        self.assertFalse(enabled)
+        self.assertIn("FHI_GEOIP_CITY_DB", reason)
+
+    def test_disabled_when_file_missing(self):
+        with patch.dict("os.environ", {"FHI_GEOIP_CITY_DB": "/nonexistent/geo.dat.gz"}):
+            enabled, reason = self.audit.geo_lookup_status()
+        self.assertFalse(enabled)
+        self.assertIn("does not exist", reason)
+
+    def test_enabled_with_real_file(self):
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=".dat.gz") as f:
+            with patch.dict("os.environ", {"FHI_GEOIP_CITY_DB": f.name}):
+                enabled, reason = self.audit.geo_lookup_status()
+        # geoip2fast is an installed dependency, so a present file => enabled.
+        self.assertTrue(enabled)
+        self.assertIsNone(reason)
+
+    def test_warn_helper_never_raises(self):
+        import os
+
+        os.environ.pop("FHI_GEOIP_CITY_DB", None)
+        # Reset the once-per-process guard so the warning path actually runs.
+        self.audit._geo_startup_warning_emitted = False
+        self.audit.warn_if_geo_lookups_disabled()
+        self.audit.warn_if_geo_lookups_disabled()  # second call is a no-op

--- a/tests/sync/test_audit.py
+++ b/tests/sync/test_audit.py
@@ -528,18 +528,23 @@ class GuessUsStateTest(TestCase):
         import types
 
         fake_module = types.ModuleType("geoip2fast")
+        # Counts reaching the parser, so guard tests can assert an invalid
+        # value was rejected BEFORE the third-party lookup.
+        fake_module.lookup_calls = 0  # type: ignore[attr-defined]
 
         class FakeGeoIP2Fast:
             def __init__(self, geoip2fast_data_file=None):
                 self.data_file = geoip2fast_data_file
 
             def lookup(self, ip):
+                fake_module.lookup_calls += 1  # type: ignore[attr-defined]
                 if isinstance(lookup_result, Exception):
                     raise lookup_result
                 return lookup_result
 
         fake_module.GeoIP2Fast = FakeGeoIP2Fast  # type: ignore[attr-defined]
         sys.modules["geoip2fast"] = fake_module
+        return fake_module
 
     def test_none_ip_returns_none(self):
         self.assertIsNone(self.audit.guess_us_state(None))
@@ -589,6 +594,30 @@ class GuessUsStateTest(TestCase):
         self._install_fake_geoip(Result())
         with patch.dict("os.environ", self.FAKE_DB):
             self.assertEqual(self.audit.guess_us_state("203.0.113.7"), "Texas")
+
+    def test_non_ip_value_is_rejected_before_lookup(self):
+        """The caller derives this from client-controlled X-Forwarded-For, so
+        anything that is not a literal IP must never reach the parser."""
+
+        class Result:
+            country_code = "US"
+            subdivision_code = "CA"
+
+        fake = self._install_fake_geoip(Result())
+        with patch.dict("os.environ", self.FAKE_DB):
+            self.assertIsNone(self.audit.guess_us_state("not-an-ip"))
+            self.assertIsNone(self.audit.guess_us_state("evil.example.com"))
+        self.assertEqual(getattr(fake, "lookup_calls", 0), 0)
+
+    def test_overlong_value_is_rejected_before_lookup(self):
+        class Result:
+            country_code = "US"
+            subdivision_code = "CA"
+
+        fake = self._install_fake_geoip(Result())
+        with patch.dict("os.environ", self.FAKE_DB):
+            self.assertIsNone(self.audit.guess_us_state("1" * 46))
+        self.assertEqual(getattr(fake, "lookup_calls", 0), 0)
 
     def test_empty_country_returns_none(self):
         # A subdivision without an explicit US country code is unconfirmed
@@ -739,6 +768,15 @@ class GeoLookupStatusTest(TestCase):
     def test_warn_helper_never_raises(self):
         import os
 
+        # The guard is process-global: restore whatever it was, or a later
+        # test can silently skip the warning path depending on run order.
+        previous_warning_state = self.audit._geo_startup_warning_emitted
+        self.addCleanup(
+            setattr,
+            self.audit,
+            "_geo_startup_warning_emitted",
+            previous_warning_state,
+        )
         with patch.dict("os.environ", {}, clear=False):
             os.environ.pop("FHI_GEOIP_CITY_DB", None)
             # Reset the once-per-process guard so the warning path runs.

--- a/tests/sync/test_audit.py
+++ b/tests/sync/test_audit.py
@@ -496,3 +496,109 @@ class DenialTrackingInfoTest(TestCase):
         self.assertEqual(denial.user_agent, "RequestBrowser/3.0")
         # IP should not be stored for non-professional
         self.assertIsNone(denial.ip_address)
+
+
+class GuessUsStateTest(TestCase):
+    """Tests for the IP -> US state guess used to seed chat context.
+
+    geoip2fast is an optional dependency, so these tests inject a fake module
+    into sys.modules and reset the cached reader around each case.
+    """
+
+    def setUp(self):
+        import fhi_users.audit as audit_module
+
+        self.audit = audit_module
+        self.audit._reset_geo_reader_cache_for_tests()
+
+    def tearDown(self):
+        import sys
+
+        sys.modules.pop("geoip2fast", None)
+        self.audit._reset_geo_reader_cache_for_tests()
+
+    def _install_fake_geoip(self, lookup_result):
+        """Install a fake geoip2fast module whose lookup returns the given
+        object (or raises it, if it's an exception instance)."""
+        import sys
+        import types
+
+        fake_module = types.ModuleType("geoip2fast")
+
+        class FakeGeoIP2Fast:
+            def __init__(self, geoip2fast_data_file=None):
+                self.data_file = geoip2fast_data_file
+
+            def lookup(self, ip):
+                if isinstance(lookup_result, Exception):
+                    raise lookup_result
+                return lookup_result
+
+        fake_module.GeoIP2Fast = FakeGeoIP2Fast  # type: ignore[attr-defined]
+        sys.modules["geoip2fast"] = fake_module
+
+    def test_none_ip_returns_none(self):
+        self.assertIsNone(self.audit.guess_us_state(None))
+        self.assertIsNone(self.audit.guess_us_state(""))
+
+    def test_missing_geoip_returns_none(self):
+        # No fake module installed and (in the test env) geoip2fast is not a
+        # real dependency: the guess degrades to None without raising.
+        import sys
+
+        sys.modules.pop("geoip2fast", None)
+        self.assertIsNone(self.audit.guess_us_state("203.0.113.7"))
+
+    def test_us_subdivision_code_maps_to_state_name(self):
+        class Result:
+            country_code = "US"
+            subdivision_code = "CA"
+
+        self._install_fake_geoip(Result())
+        self.assertEqual(self.audit.guess_us_state("203.0.113.7"), "California")
+
+    def test_country_prefixed_subdivision_code(self):
+        class Result:
+            country_code = "US"
+            subdivision_code = "US-NY"
+
+        self._install_fake_geoip(Result())
+        self.assertEqual(self.audit.guess_us_state("203.0.113.7"), "New York")
+
+    def test_subdivision_name_on_nested_city_object(self):
+        class City:
+            subdivision_name = "Texas"
+
+        class Result:
+            country_code = "US"
+            city = City()
+
+        self._install_fake_geoip(Result())
+        self.assertEqual(self.audit.guess_us_state("203.0.113.7"), "Texas")
+
+    def test_non_us_ip_returns_none(self):
+        class Result:
+            country_code = "FR"
+            subdivision_code = "IDF"
+
+        self._install_fake_geoip(Result())
+        self.assertIsNone(self.audit.guess_us_state("203.0.113.7"))
+
+    def test_country_only_database_returns_none(self):
+        class Result:
+            country_code = "US"
+
+        self._install_fake_geoip(Result())
+        self.assertIsNone(self.audit.guess_us_state("203.0.113.7"))
+
+    def test_lookup_error_returns_none(self):
+        self._install_fake_geoip(RuntimeError("boom"))
+        self.assertIsNone(self.audit.guess_us_state("203.0.113.7"))
+
+    def test_unknown_subdivision_returns_none(self):
+        class Result:
+            country_code = "US"
+            subdivision_code = "ZZ"
+
+        self._install_fake_geoip(Result())
+        self.assertIsNone(self.audit.guess_us_state("203.0.113.7"))

--- a/tests/sync/test_chat_fallback.py
+++ b/tests/sync/test_chat_fallback.py
@@ -260,6 +260,52 @@ class ChatFallbackTest(APITestCase):
         await communicator.disconnect()
         await self.asyncTearDown()
 
+    async def test_external_models_default_on_when_key_absent(self):
+        """A frame that omits use_external_models gets the default: external
+        models participate. (Older clients and hand-rolled API callers send
+        no key; the consent-form toggle sends an explicit false to opt out.)"""
+        await self.asyncSetUp()
+
+        self.mock_get_backends.return_value = ([self.mock_primary_model], [])
+        self.mock_primary_model.set_next_response("Default response", "Context")
+
+        user = await sync_to_async(User.objects.create_user)(
+            username="testuser5", password="testpass", email="test5@example.com"
+        )
+        professional = await sync_to_async(ProfessionalUser.objects.create)(
+            user=user, active=True, npi_number="5678901234"
+        )
+        chat = await sync_to_async(OngoingChat.objects.create)(
+            professional_user=professional,
+            chat_history=[],
+            summary_for_next_call=[],
+        )
+
+        communicator = WebsocketCommunicator(
+            OngoingChatConsumer.as_asgi(), "/ws/ongoing-chat/"
+        )
+        communicator.scope["user"] = user
+        connected, _ = await communicator.connect()
+        self.assertTrue(connected)
+
+        await communicator.send_json_to(
+            {
+                "chat_id": str(chat.id),
+                "content": "Test message",
+                # use_external_models intentionally absent
+            }
+        )
+
+        response = await communicator.receive_json_from(timeout=15)
+        while "status" in response:
+            response = await communicator.receive_json_from(timeout=15)
+        self.assertIn("content", response)
+
+        self.mock_get_backends.assert_called_with(use_external=True)
+
+        await communicator.disconnect()
+        await self.asyncTearDown()
+
 
 class MLRouterFallbackTest(APITestCase):
     """Test the ML router fallback functionality."""

--- a/tests/sync/test_chat_persistence_bounds.py
+++ b/tests/sync/test_chat_persistence_bounds.py
@@ -4,7 +4,9 @@ from django.test import TestCase
 
 from fighthealthinsurance.chat.chat_persistence import (
     MAX_STORED_SUMMARIES,
+    is_internal_history_message,
     merge_new_messages,
+    visible_history,
 )
 
 
@@ -54,4 +56,85 @@ class SummaryCapTest(TestCase):
         self.assertEqual(
             chat.summary_for_next_call[-1],
             f"summary {MAX_STORED_SUMMARIES + 14}",
+        )
+
+
+class MergeInternalNoteAfterUserTailTest(TestCase):
+    """A failed turn leaves a user-role tail, so the next internal note hits
+    the consecutive-user merge branch. That branch returned before the
+    internal flag was applied, producing an unflagged message whose text no
+    longer matched a known internal prefix — so replay rendered the system
+    note inside the user's own bubble."""
+
+    def test_internal_note_is_not_merged_into_a_user_message(self):
+        history = [{"role": "user", "content": "what about my knee MRI?"}]
+        merged = merge_new_messages(
+            history,
+            [
+                {
+                    "role": "user",
+                    "content": "Linked this chat to Appeal #4 -- help the user iterate",
+                    "internal": True,
+                }
+            ],
+        )
+
+        self.assertEqual(len(merged), 2, f"internal note was merged away: {merged}")
+        self.assertTrue(merged[-1].get("internal"))
+        self.assertEqual(merged[0]["content"], "what about my knee MRI?")
+
+    def test_internal_note_is_hidden_from_replay(self):
+        history = merge_new_messages(
+            [{"role": "user", "content": "what about my knee MRI?"}],
+            [
+                {
+                    "role": "user",
+                    "content": "Linked this chat to Appeal #4 -- help the user iterate",
+                    "internal": True,
+                }
+            ],
+        )
+        visible = visible_history(history)
+        self.assertEqual([m["content"] for m in visible], ["what about my knee MRI?"])
+
+    def test_consecutive_plain_user_messages_still_merge(self):
+        merged = merge_new_messages(
+            [{"role": "user", "content": "first"}],
+            [{"role": "user", "content": "second"}],
+        )
+        self.assertEqual(len(merged), 1)
+        self.assertEqual(merged[0]["content"], "first second")
+
+
+class InternalHistoryDetectionTest(TestCase):
+    def test_flagged_message_is_internal(self):
+        self.assertTrue(
+            is_internal_history_message(
+                {"role": "user", "content": "x", "internal": True}
+            )
+        )
+
+    def test_legacy_generated_note_is_internal(self):
+        self.assertTrue(
+            is_internal_history_message(
+                {
+                    "role": "user",
+                    "content": "Linked this chat to Appeal #12 -- help the user iterate",
+                }
+            )
+        )
+
+    def test_user_text_that_merely_starts_with_the_prefix_is_visible(self):
+        """The bare prefix is text a user can type; matching it hid their own
+        message from their own replay while every server-side view kept it."""
+        self.assertFalse(
+            is_internal_history_message(
+                {
+                    "role": "user",
+                    "content": (
+                        "Linked this chat to my other appeal — here is the "
+                        "member ID 12345, can you compare them?"
+                    ),
+                }
+            )
         )

--- a/tests/sync/test_chat_persistence_bounds.py
+++ b/tests/sync/test_chat_persistence_bounds.py
@@ -1,0 +1,57 @@
+"""Bounds and flags in the transactional chat persistence helpers."""
+
+from django.test import TestCase
+
+from fighthealthinsurance.chat.chat_persistence import (
+    MAX_STORED_SUMMARIES,
+    merge_new_messages,
+)
+
+
+class MergeNewMessagesInternalFlagTest(TestCase):
+    def test_internal_flag_is_preserved(self):
+        history = merge_new_messages(
+            [],
+            [
+                {
+                    "role": "user",
+                    "content": "Linked this chat to Appeal #4 -- details",
+                    "internal": True,
+                },
+                {"role": "assistant", "content": "I've linked this chat."},
+            ],
+        )
+        self.assertTrue(history[0].get("internal"))
+        self.assertNotIn("internal", history[1])
+
+    def test_normal_messages_have_no_internal_key(self):
+        history = merge_new_messages([], [{"role": "user", "content": "hello there"}])
+        self.assertNotIn("internal", history[0])
+
+    def test_tail_dedup_still_applies(self):
+        history = [{"role": "user", "content": "CA", "timestamp": "t"}]
+        merged = merge_new_messages(history, [{"role": "user", "content": "CA"}])
+        self.assertEqual(len(merged), 1)
+
+
+class SummaryCapTest(TestCase):
+    def _persist(self, chat_id, summaries):
+        from fighthealthinsurance.chat.chat_persistence import (
+            _persist_chat_turn_sync,
+        )
+
+        return _persist_chat_turn_sync(chat_id, [], summaries)
+
+    def test_summary_list_is_capped(self):
+        from fighthealthinsurance.models import OngoingChat
+
+        chat = OngoingChat.objects.create(chat_history=[], summary_for_next_call=[])
+        for i in range(MAX_STORED_SUMMARIES + 15):
+            self._persist(chat.id, [f"summary {i}"])
+        chat.refresh_from_db()
+        self.assertEqual(len(chat.summary_for_next_call), MAX_STORED_SUMMARIES)
+        # The most recent summaries are the ones kept.
+        self.assertEqual(
+            chat.summary_for_next_call[-1],
+            f"summary {MAX_STORED_SUMMARIES + 14}",
+        )

--- a/tests/sync/test_chat_tools.py
+++ b/tests/sync/test_chat_tools.py
@@ -218,9 +218,9 @@ class TestPubMedTool(TestCase):
             article_ids = asyncio.run(tool._search_articles("test query"))
 
         self.assertTrue(set(article_ids).issuperset({"1", "2", "3"}))
-        recent_call = mock_pubmed_tools.find_pubmed_article_ids_for_query.call_args_list[
-            0
-        ]
+        recent_call = (
+            mock_pubmed_tools.find_pubmed_article_ids_for_query.call_args_list[0]
+        )
         self.assertEqual(recent_call.kwargs["since"], "2024")
 
     def test_recent_since_year_uses_configurable_window(self):

--- a/tests/sync/test_clinical_trials_prompt.py
+++ b/tests/sync/test_clinical_trials_prompt.py
@@ -6,7 +6,6 @@ Parallel to ``test_uspstf_api.MakeOpenPromptIncludesUSPSTFContextTests`` and
 
 from django.test import TestCase
 
-
 # A realistic rendered block (what ``get_context_for_denial`` would return):
 # self-contained header + one trial row carrying an NCT id.
 SAMPLE_TRIALS_CONTEXT = (

--- a/tests/sync/test_context_manager.py
+++ b/tests/sync/test_context_manager.py
@@ -13,6 +13,7 @@ from fighthealthinsurance.chat.context_manager import (
     make_placeholder,
     prepare_history_for_llm,
     should_store_summary,
+    strip_previous_summary_blocks,
     get_current_context,
     ensure_message_alternation,
     DEFAULT_MESSAGES_TO_KEEP,
@@ -545,3 +546,57 @@ class TestSummaryReplacesInsteadOfNesting:
             "Earlier conversation summary: NEW SUMMARY\n\n"
             "Additional context: PubMed context: relevant study details"
         )
+
+
+class TestSummaryStripHandlesRealCallerShapes:
+    """The de-nesting guard used to test `startswith(EARLIER_SUMMARY_LABEL)`,
+    but the production caller never passes that shape — it passes the model's
+    own per-turn summary, or chat_interface's
+    "Previous context summary: ... Most recent context summary: ..." wrapper,
+    optionally prefixed by the trim marker. So the strip never fired and
+    summaries nested on every band."""
+
+    def test_wrapped_and_trimmed_summaries_are_stripped(self):
+        existing = (
+            f"{TRIMMED_CONTEXT_PREFIX}Previous context summary:\n"
+            "Earlier conversation summary: OLD SUMMARY\n\n"
+            "Additional context: Microsite context:\nacme-health\n\n"
+            "Most recent context summary:\n"
+            "Earlier conversation summary: NEWER SUMMARY\n\n"
+            "Additional context: PubMed context: an abstract"
+        )
+        stripped = strip_previous_summary_blocks(existing)
+
+        assert "OLD SUMMARY" not in stripped
+        assert "NEWER SUMMARY" not in stripped
+        # Non-summary context survives.
+        assert "Microsite context" in stripped
+        assert "PubMed context" in stripped
+
+    def test_context_without_a_summary_block_is_untouched(self):
+        plain = "User asked about a knee MRI denial from Blue Shield."
+        assert strip_previous_summary_blocks(plain) == plain
+
+    def test_bare_summary_leaves_nothing(self):
+        assert (
+            strip_previous_summary_blocks("Earlier conversation summary: OLD") is None
+        )
+
+
+class TestBoundSummaryContextSmallLimits:
+    """`context[-0:]` is the WHOLE string, so any max_chars at or below the
+    trim marker's length returned MORE than the input — the bound silently
+    inverted, with a marker claiming trimming had happened."""
+
+    def test_limit_below_marker_length_still_bounds(self):
+        context = "old context " * 500
+        for limit in (1, 5, len(TRIMMED_CONTEXT_PREFIX)):
+            bounded = bound_summary_context(context, limit)
+            assert len(bounded) <= limit, f"limit={limit} produced {len(bounded)} chars"
+
+    def test_limit_above_marker_length_keeps_tail_with_marker(self):
+        context = "old " * 500 + "MOST RECENT"
+        bounded = bound_summary_context(context, 100)
+        assert len(bounded) <= 100
+        assert bounded.startswith(TRIMMED_CONTEXT_PREFIX)
+        assert bounded.endswith("MOST RECENT")

--- a/tests/sync/test_context_manager.py
+++ b/tests/sync/test_context_manager.py
@@ -21,6 +21,18 @@ from fighthealthinsurance.chat.context_manager import (
 )
 
 
+def _alternating_history(count):
+    """Alternating user/assistant history of `count` messages.
+
+    Module level so every test class here shares one definition (it was
+    duplicated across two classes).
+    """
+    return [
+        {"role": "user" if i % 2 == 0 else "assistant", "content": f"Message {i}"}
+        for i in range(count)
+    ]
+
+
 class TestPrepareHistoryForLLM:
     """Tests for prepare_history_for_llm function."""
 
@@ -137,13 +149,6 @@ class TestSummarizationTrigger:
     length parity (merged consecutive messages shift parity, and the old
     strict `% N == 0` check then never fired again)."""
 
-    def _history(self, count):
-        history = []
-        for i in range(count):
-            role = "user" if i % 2 == 0 else "assistant"
-            history.append({"role": role, "content": f"Message {i}"})
-        return history
-
     @pytest.mark.asyncio
     async def test_even_parity_summarizes_at_interval(self):
         count = DEFAULT_MESSAGES_TO_KEEP + SUMMARIZATION_INTERVAL
@@ -152,7 +157,7 @@ class TestSummarizationTrigger:
             new=AsyncMock(return_value="summary of old messages"),
         ) as mock_summarize:
             _, _, summary = await prepare_history_for_llm(
-                chat_history=self._history(count),
+                chat_history=_alternating_history(count),
                 existing_summary=None,
             )
         mock_summarize.assert_awaited_once()
@@ -168,7 +173,7 @@ class TestSummarizationTrigger:
             new=AsyncMock(return_value="summary of old messages"),
         ) as mock_summarize:
             _, _, summary = await prepare_history_for_llm(
-                chat_history=self._history(count),
+                chat_history=_alternating_history(count),
                 existing_summary=None,
             )
         mock_summarize.assert_awaited_once()
@@ -182,7 +187,7 @@ class TestSummarizationTrigger:
             new=AsyncMock(return_value="should not be called"),
         ) as mock_summarize:
             _, _, summary = await prepare_history_for_llm(
-                chat_history=self._history(count),
+                chat_history=_alternating_history(count),
                 existing_summary="keep me",
             )
         mock_summarize.assert_not_awaited()
@@ -488,13 +493,6 @@ class TestSummaryReplacesInsteadOfNesting:
     full-prefix summary block is replaced -- adjacent band triggers must not
     nest near-identical summaries inside each other."""
 
-    def _history(self, count):
-        history = []
-        for i in range(count):
-            role = "user" if i % 2 == 0 else "assistant"
-            history.append({"role": role, "content": f"Message {i}"})
-        return history
-
     @pytest.mark.asyncio
     async def test_previous_summary_block_is_replaced(self):
         existing = (
@@ -507,7 +505,7 @@ class TestSummaryReplacesInsteadOfNesting:
             new=AsyncMock(return_value="NEW SUMMARY"),
         ):
             _, _, summary = await prepare_history_for_llm(
-                chat_history=self._history(count),
+                chat_history=_alternating_history(count),
                 existing_summary=existing,
             )
         assert summary == (
@@ -525,7 +523,7 @@ class TestSummaryReplacesInsteadOfNesting:
             new=AsyncMock(return_value="NEW SUMMARY"),
         ):
             _, _, summary = await prepare_history_for_llm(
-                chat_history=self._history(count),
+                chat_history=_alternating_history(count),
                 existing_summary=existing,
             )
         assert summary == "Earlier conversation summary: NEW SUMMARY"
@@ -539,7 +537,7 @@ class TestSummaryReplacesInsteadOfNesting:
             new=AsyncMock(return_value="NEW SUMMARY"),
         ):
             _, _, summary = await prepare_history_for_llm(
-                chat_history=self._history(count),
+                chat_history=_alternating_history(count),
                 existing_summary=existing,
             )
         assert summary == (

--- a/tests/sync/test_context_manager.py
+++ b/tests/sync/test_context_manager.py
@@ -480,3 +480,68 @@ class TestBackgroundGenerateSummary:
 
         await chat.arefresh_from_db()
         assert chat.summary_for_next_call[-1] == placeholder
+
+
+class TestSummaryReplacesInsteadOfNesting:
+    """Re-summarization covers the whole dropped prefix, so a previous
+    full-prefix summary block is replaced -- adjacent band triggers must not
+    nest near-identical summaries inside each other."""
+
+    def _history(self, count):
+        history = []
+        for i in range(count):
+            role = "user" if i % 2 == 0 else "assistant"
+            history.append({"role": role, "content": f"Message {i}"})
+        return history
+
+    @pytest.mark.asyncio
+    async def test_previous_summary_block_is_replaced(self):
+        existing = (
+            "Earlier conversation summary: OLD SUMMARY\n\n"
+            "Additional context: microsite details here"
+        )
+        count = DEFAULT_MESSAGES_TO_KEEP + SUMMARIZATION_INTERVAL
+        with patch(
+            "fighthealthinsurance.chat.context_manager.ml_router.summarize_chat_history",
+            new=AsyncMock(return_value="NEW SUMMARY"),
+        ):
+            _, _, summary = await prepare_history_for_llm(
+                chat_history=self._history(count),
+                existing_summary=existing,
+            )
+        assert summary == (
+            "Earlier conversation summary: NEW SUMMARY\n\n"
+            "Additional context: microsite details here"
+        )
+        assert "OLD SUMMARY" not in summary
+
+    @pytest.mark.asyncio
+    async def test_summary_only_block_is_fully_replaced(self):
+        existing = "Earlier conversation summary: OLD SUMMARY"
+        count = DEFAULT_MESSAGES_TO_KEEP + SUMMARIZATION_INTERVAL
+        with patch(
+            "fighthealthinsurance.chat.context_manager.ml_router.summarize_chat_history",
+            new=AsyncMock(return_value="NEW SUMMARY"),
+        ):
+            _, _, summary = await prepare_history_for_llm(
+                chat_history=self._history(count),
+                existing_summary=existing,
+            )
+        assert summary == "Earlier conversation summary: NEW SUMMARY"
+
+    @pytest.mark.asyncio
+    async def test_non_summary_context_still_appended(self):
+        existing = "PubMed context: relevant study details"
+        count = DEFAULT_MESSAGES_TO_KEEP + SUMMARIZATION_INTERVAL
+        with patch(
+            "fighthealthinsurance.chat.context_manager.ml_router.summarize_chat_history",
+            new=AsyncMock(return_value="NEW SUMMARY"),
+        ):
+            _, _, summary = await prepare_history_for_llm(
+                chat_history=self._history(count),
+                existing_summary=existing,
+            )
+        assert summary == (
+            "Earlier conversation summary: NEW SUMMARY\n\n"
+            "Additional context: PubMed context: relevant study details"
+        )

--- a/tests/sync/test_context_manager.py
+++ b/tests/sync/test_context_manager.py
@@ -7,7 +7,9 @@ from unittest.mock import AsyncMock, patch
 
 from fighthealthinsurance.chat.context_manager import (
     MISSING_CONTEXT_PREFIX,
+    TRIMMED_CONTEXT_PREFIX,
     background_generate_summary,
+    bound_summary_context,
     make_placeholder,
     prepare_history_for_llm,
     should_store_summary,
@@ -127,6 +129,84 @@ class TestPrepareHistoryForLLM:
         # After alternation, consecutive same-role messages should be merged
         # The exact behavior depends on ensure_message_alternation implementation
         assert len(history) >= 1
+
+
+class TestSummarizationTrigger:
+    """Summarization must fire once per interval band regardless of history
+    length parity (merged consecutive messages shift parity, and the old
+    strict `% N == 0` check then never fired again)."""
+
+    def _history(self, count):
+        history = []
+        for i in range(count):
+            role = "user" if i % 2 == 0 else "assistant"
+            history.append({"role": role, "content": f"Message {i}"})
+        return history
+
+    @pytest.mark.asyncio
+    async def test_even_parity_summarizes_at_interval(self):
+        count = DEFAULT_MESSAGES_TO_KEEP + SUMMARIZATION_INTERVAL
+        with patch(
+            "fighthealthinsurance.chat.context_manager.ml_router.summarize_chat_history",
+            new=AsyncMock(return_value="summary of old messages"),
+        ) as mock_summarize:
+            _, _, summary = await prepare_history_for_llm(
+                chat_history=self._history(count),
+                existing_summary=None,
+            )
+        mock_summarize.assert_awaited_once()
+        assert summary is not None and "summary of old messages" in summary
+
+    @pytest.mark.asyncio
+    async def test_odd_parity_still_summarizes(self):
+        # Odd over-threshold counts (from message merging) previously never
+        # hit `% N == 0` and the summary silently stopped updating.
+        count = DEFAULT_MESSAGES_TO_KEEP + SUMMARIZATION_INTERVAL + 1
+        with patch(
+            "fighthealthinsurance.chat.context_manager.ml_router.summarize_chat_history",
+            new=AsyncMock(return_value="summary of old messages"),
+        ) as mock_summarize:
+            _, _, summary = await prepare_history_for_llm(
+                chat_history=self._history(count),
+                existing_summary=None,
+            )
+        mock_summarize.assert_awaited_once()
+        assert summary is not None and "summary of old messages" in summary
+
+    @pytest.mark.asyncio
+    async def test_mid_band_does_not_summarize(self):
+        count = DEFAULT_MESSAGES_TO_KEEP + SUMMARIZATION_INTERVAL // 2
+        with patch(
+            "fighthealthinsurance.chat.context_manager.ml_router.summarize_chat_history",
+            new=AsyncMock(return_value="should not be called"),
+        ) as mock_summarize:
+            _, _, summary = await prepare_history_for_llm(
+                chat_history=self._history(count),
+                existing_summary="keep me",
+            )
+        mock_summarize.assert_not_awaited()
+        assert summary == "keep me"
+
+
+class TestBoundSummaryContext:
+    """Tests for the accreted-summary length bound."""
+
+    def test_short_context_unchanged(self):
+        assert bound_summary_context("short summary", 100) == "short summary"
+
+    def test_none_passthrough(self):
+        assert bound_summary_context(None, 100) is None
+
+    def test_long_context_trimmed_keeps_tail(self):
+        context = "old " * 1000 + "MOST RECENT DETAILS"
+        bounded = bound_summary_context(context, 200)
+        assert bounded is not None
+        assert len(bounded) <= 200
+        assert bounded.startswith(TRIMMED_CONTEXT_PREFIX)
+        assert bounded.endswith("MOST RECENT DETAILS")
+
+    def test_nonpositive_limit_passthrough(self):
+        assert bound_summary_context("anything", 0) == "anything"
 
 
 class TestShouldStoreSummary:

--- a/tests/sync/test_delete_confirmation.py
+++ b/tests/sync/test_delete_confirmation.py
@@ -346,7 +346,9 @@ class TestConfirmDeleteDataView(TestCase):
     def test_email_case_insensitive_integration(self):
         """Integration test: mixed-case stored records are deleted by case-insensitive lookup."""
         # Store a record with mixed-case email
-        MailingListSubscriber.objects.create(email="Test@Test-FHI.COM", name="Test User")
+        MailingListSubscriber.objects.create(
+            email="Test@Test-FHI.COM", name="Test User"
+        )
         assert MailingListSubscriber.objects.filter(email="Test@Test-FHI.COM").exists()
 
         # Create a token for the lowercase version of the email

--- a/tests/sync/test_llm_client.py
+++ b/tests/sync/test_llm_client.py
@@ -23,7 +23,7 @@ from fighthealthinsurance.chat.llm_client import (
     BAD_RESPONSE_PATTERNS,
     BAD_CONTEXT_PATTERNS,
 )
-from tests.chat_fixtures import FRESH_REPLY, LOOPED_REPLY
+from tests.chat_fixtures import CANNED_MEDICAID_REPLY, FRESH_REPLY, LOOPED_REPLY
 
 
 class TestEstimateHistoryTokens(TestCase):
@@ -601,28 +601,18 @@ class TestCannedReplyExemption(TestCase):
     may legitimately repeat across turns — they are exempt from HARD
     rejection while soft penalties still apply."""
 
-    # The mandated block from the system prompt. The exemption requires the
-    # WHOLE block, not just the FAQ link: the prompt tells the model to link
-    # that FAQ on any work-requirements answer, so a marker-only match
-    # exempted ordinary (including looping) Medicaid replies from the ladder.
-    CANNED = (
-        "New federal rules require many adults (ages 19-64) to complete at "
-        "least 80 hours per month of work, job training, school, or community "
-        "service to keep Medicaid coverage. These requirements go into effect "
-        "by December 31, 2026. For detailed information visit: "
-        "[Medicaid Work Requirements FAQ](/faq/medicaid/)"
-    )
-
     def test_canned_reply_repeat_not_hard_rejected(self):
         history = [
             {"role": "user", "content": "tell me about the work requirements"},
-            {"role": "assistant", "content": self.CANNED},
+            {"role": "assistant", "content": CANNED_MEDICAID_REPLY},
         ]
         self.assertIsNone(
-            find_repeated_reply(self.CANNED, history, "and the work requirements?")
+            find_repeated_reply(
+                CANNED_MEDICAID_REPLY, history, "and the work requirements?"
+            )
         )
         score = score_llm_response(
-            (self.CANNED, "ctx"),
+            (CANNED_MEDICAID_REPLY, "ctx"),
             call_score=100,
             chat_history=history,
             current_message="what about the work requirements again?",

--- a/tests/sync/test_llm_client.py
+++ b/tests/sync/test_llm_client.py
@@ -619,10 +619,15 @@ class TestCannedReplyExemption(TestCase):
     may legitimately repeat across turns — they are exempt from HARD
     rejection while soft penalties still apply."""
 
+    # The mandated block from the system prompt. The exemption requires the
+    # WHOLE block, not just the FAQ link: the prompt tells the model to link
+    # that FAQ on any work-requirements answer, so a marker-only match
+    # exempted ordinary (including looping) Medicaid replies from the ladder.
     CANNED = (
         "New federal rules require many adults (ages 19-64) to complete at "
         "least 80 hours per month of work, job training, school, or community "
-        "service to keep Medicaid coverage. For detailed information visit: "
+        "service to keep Medicaid coverage. These requirements go into effect "
+        "by December 31, 2026. For detailed information visit: "
         "[Medicaid Work Requirements FAQ](/faq/medicaid/)"
     )
 
@@ -759,3 +764,88 @@ class TestRepeatOffenderDemotion(TestCase):
         )
         score = score_fn((FRESH_REPLY, self.CONTEXT), task)
         self.assertEqual(score_log, {task: score})
+
+
+class TestAlternateScreensRealToolCalls(TestCase):
+    """The tool handlers detect with DOTALL|MULTILINE|IGNORECASE. A flag-less
+    sweep over the `^...$`-anchored patterns only matched a tool call at the
+    very start of a reply, so an alternate whose tool call followed a line of
+    prose was shown to the user as raw syntax plus its JSON payload."""
+
+    PRIMARY = "Here is a summary of your options for this denial."
+
+    def test_appeal_tool_call_after_prose_is_rejected(self):
+        alternate = (
+            "I can draft that appeal for you.\n\n"
+            'create_or_update_appeal {"patient_name": "Jane Doe", '
+            '"appeal_text": "To whom it may concern..."}'
+        )
+        self.assertFalse(alternate_is_presentable(alternate, self.PRIMARY))
+
+    def test_mixed_case_bold_tool_call_is_rejected(self):
+        alternate = (
+            "Sure, drafting now.\n\n"
+            '**Create_Or_Update_Appeal** {"patient_name": "Jane Doe"}'
+        )
+        self.assertFalse(alternate_is_presentable(alternate, self.PRIMARY))
+
+    def test_prior_auth_tool_call_after_prose_is_rejected(self):
+        alternate = (
+            "Let me start that prior auth.\n\n"
+            'create_or_update_prior_auth {"procedure": "MRI"}'
+        )
+        self.assertFalse(alternate_is_presentable(alternate, self.PRIMARY))
+
+    def test_plain_answer_still_presentable(self):
+        alternate = (
+            "Another angle: ask the plan for its clinical policy bulletin for "
+            "this code, then cite the specific criteria you meet."
+        )
+        self.assertTrue(alternate_is_presentable(alternate, self.PRIMARY))
+
+
+class TestRepeatOffenderStrikesArePerTurn(TestCase):
+    """A backend contributes several candidates to one fan-out (the primary
+    backend is listed twice, each gets a truncated- and full-history call,
+    times message variants). Counting a strike per candidate ranked backends
+    by how many slots they filled and saturated the cap inside one turn."""
+
+    def test_one_looping_turn_costs_one_strike(self):
+        history = [
+            {"role": "user", "content": "Help me with the new requirements."},
+            {"role": "assistant", "content": LOOPED_REPLY},
+        ]
+        offenders: dict = {}
+        tasks = [object() for _ in range(4)]
+        score_fn = create_response_scorer(
+            call_scores={t: 1000 for t in tasks},
+            chat_history=history,
+            current_message="CA",
+            rejection_stats={},
+            call_labels={t: "looping-backend" for t in tasks},
+            repeat_offenders=offenders,
+        )
+        for task in tasks:
+            self.assertEqual(score_fn((LOOPED_REPLY, "ctx"), task), float("-inf"))
+
+        self.assertEqual(offenders, {"looping-backend": 1})
+
+    def test_strikes_accumulate_across_turns(self):
+        history = [
+            {"role": "user", "content": "Help me with the new requirements."},
+            {"role": "assistant", "content": LOOPED_REPLY},
+        ]
+        offenders: dict = {}
+        for _ in range(3):  # three separate turns, each with a fresh scorer
+            task = object()
+            score_fn = create_response_scorer(
+                call_scores={task: 1000},
+                chat_history=history,
+                current_message="CA",
+                rejection_stats={},
+                call_labels={task: "looping-backend"},
+                repeat_offenders=offenders,
+            )
+            score_fn((LOOPED_REPLY, "ctx"), task)
+
+        self.assertEqual(offenders, {"looping-backend": 3})

--- a/tests/sync/test_llm_client.py
+++ b/tests/sync/test_llm_client.py
@@ -9,12 +9,35 @@ from fighthealthinsurance.chat.llm_client import (
     normalize_text,
     bag_of_words,
     compute_repetition_penalty,
+    alternate_is_presentable,
+    find_repeated_reply,
+    user_requested_repeat,
     EXACT_REPEAT_PENALTY,
     BAG_OF_WORDS_REPEAT_PENALTY,
+    NEAR_REPEAT_PENALTY,
     OLDER_ASSISTANT_REPEAT_PENALTY,
     OLDER_USER_REPEAT_PENALTY,
     BAD_RESPONSE_PATTERNS,
     BAD_CONTEXT_PATTERNS,
+)
+
+# A realistic long assistant reply (matches the production loop shape).
+LOOPED_REPLY = (
+    "The new Medicaid requirements can be tricky! To help you understand them "
+    "better, could you tell me a bit more about your situation? For example:\n\n"
+    "* What state are you in?\n"
+    "* What is your current income and household size?\n"
+    "* Do you currently have Medicaid coverage?\n"
+    "* What specific requirements are you trying to understand?\n\n"
+    "Once I have this information, I can help you find the relevant resources "
+    "and explain how to navigate the new requirements."
+)
+
+FRESH_REPLY = (
+    "Great — since you're in California, your Medicaid program is Medi-Cal. "
+    "The new federal rules add an 80-hour monthly work/school/volunteering "
+    "requirement for many adults by the end of 2026. Want me to look up the "
+    "Medi-Cal specifics for you?"
 )
 
 
@@ -233,9 +256,7 @@ class TestComputeRepetitionPenalty(TestCase):
     def test_exact_match_user_message(self):
         """Exact match (ignoring case/spacing) with last user message => -500."""
         history = [{"role": "user", "content": "I need help with my denial"}]
-        penalty = compute_repetition_penalty(
-            "  i need help with  my denial  ", history
-        )
+        penalty = compute_repetition_penalty("  i need help with  my denial  ", history)
         self.assertEqual(penalty, EXACT_REPEAT_PENALTY)
 
     def test_bag_of_words_match_user_message(self):
@@ -357,6 +378,196 @@ class TestComputeRepetitionPenalty(TestCase):
         self.assertEqual(penalty, EXACT_REPEAT_PENALTY)
 
 
+class TestUserRequestedRepeat(TestCase):
+    """The explicit-repeat guard for hard rejection."""
+
+    def test_detects_repeat_requests(self):
+        for msg in [
+            "can you repeat that?",
+            "please say that again",
+            "one more time please",
+            "resend it",
+            "show that again",
+        ]:
+            self.assertTrue(user_requested_repeat(msg), msg)
+
+    def test_normal_messages_not_flagged(self):
+        for msg in ["CA", "I'm in California", "what about my denial?", None, ""]:
+            self.assertFalse(user_requested_repeat(msg), repr(msg))
+
+
+class TestFindRepeatedReply(TestCase):
+    """Detection of candidate replies that repeat the recent conversation."""
+
+    def _history(self):
+        return [
+            {"role": "user", "content": "Help me with the new medicaid requirements."},
+            {"role": "assistant", "content": LOOPED_REPLY},
+        ]
+
+    def test_verbatim_repeat_of_last_assistant_reply(self):
+        self.assertEqual(
+            find_repeated_reply(LOOPED_REPLY, self._history(), "CA"),
+            "repeats_recent_assistant_reply",
+        )
+
+    def test_alternating_loop_detected(self):
+        # A-B-A loop: the repeat matches the assistant reply two turns back.
+        history = self._history() + [
+            {"role": "user", "content": "CA"},
+            {"role": "assistant", "content": FRESH_REPLY},
+            {"role": "user", "content": "yes please"},
+        ]
+        self.assertEqual(
+            find_repeated_reply(LOOPED_REPLY, history, "yes please"),
+            "repeats_recent_assistant_reply",
+        )
+
+    def test_echo_of_current_message(self):
+        msg = "Help me figure out how to navigate the new medicaid requirements."
+        self.assertEqual(
+            find_repeated_reply(msg, [], msg),
+            "echoes_user_message",
+        )
+
+    def test_fresh_reply_passes(self):
+        self.assertIsNone(find_repeated_reply(FRESH_REPLY, self._history(), "CA"))
+
+    def test_empty_inputs(self):
+        self.assertIsNone(find_repeated_reply("", self._history(), "CA"))
+        self.assertIsNone(find_repeated_reply(FRESH_REPLY, None, None))
+
+
+class TestHardRepeatRejection(TestCase):
+    """score_llm_response must hard-reject (-inf) near-verbatim repeats.
+
+    Soft penalties are not enough: model base scores reach ~8800 via
+    quality**2 scaling, so -500 still let the repeated reply win — the
+    observed production chat loop.
+    """
+
+    def _history(self):
+        return [
+            {"role": "user", "content": "Help me with the new medicaid requirements."},
+            {"role": "assistant", "content": LOOPED_REPLY},
+        ]
+
+    def test_repeat_of_last_assistant_reply_rejected(self):
+        score = score_llm_response(
+            (LOOPED_REPLY, "Context summary"),
+            call_score=8800,
+            chat_history=self._history(),
+            current_message="CA",
+        )
+        self.assertEqual(score, float("-inf"))
+
+    def test_lightly_reworded_repeat_rejected(self):
+        reworded = LOOPED_REPLY.replace("can be tricky", "are quite tricky")
+        score = score_llm_response(
+            (reworded, "Context summary"),
+            call_score=8800,
+            chat_history=self._history(),
+            current_message="I'm in California",
+        )
+        self.assertEqual(score, float("-inf"))
+
+    def test_fresh_reply_scores_normally(self):
+        score = score_llm_response(
+            (FRESH_REPLY, "Context summary"),
+            call_score=100,
+            chat_history=self._history(),
+            current_message="CA",
+        )
+        self.assertGreater(score, 0)
+
+    def test_user_requested_repeat_not_rejected(self):
+        score = score_llm_response(
+            (LOOPED_REPLY, "Context summary"),
+            call_score=100,
+            chat_history=self._history(),
+            current_message="sorry, can you repeat that?",
+        )
+        self.assertGreater(score, float("-inf"))
+
+    def test_rejection_stats_incremented(self):
+        stats: dict = {}
+        score_llm_response(
+            (LOOPED_REPLY, "Context summary"),
+            call_score=100,
+            chat_history=self._history(),
+            current_message="CA",
+            rejection_stats=stats,
+        )
+        self.assertEqual(stats.get("repeated_rejected"), 1)
+
+    def test_rejection_stats_untouched_for_fresh_reply(self):
+        stats: dict = {}
+        score_llm_response(
+            (FRESH_REPLY, "Context summary"),
+            call_score=100,
+            chat_history=self._history(),
+            current_message="CA",
+            rejection_stats=stats,
+        )
+        self.assertNotIn("repeated_rejected", stats)
+
+
+class TestAlternateIsPresentable(TestCase):
+    """Filtering of runner-up answers for side-by-side display."""
+
+    PRIMARY = FRESH_REPLY
+
+    def test_distinct_clean_answer_is_presentable(self):
+        alternate = (
+            "California's Medicaid program is called Medi-Cal. You can call "
+            "their member help line or I can walk you through the new work "
+            "requirement rules — which would you prefer?"
+        )
+        self.assertTrue(alternate_is_presentable(alternate, self.PRIMARY))
+
+    def test_near_duplicate_rejected(self):
+        near_dup = self.PRIMARY.replace("Great —", "Good news:")
+        self.assertFalse(alternate_is_presentable(near_dup, self.PRIMARY))
+
+    def test_tool_call_rejected(self):
+        alternate = (
+            'Let me look that up for you. **medicaid_info {"state": '
+            '"California", "topic": "", "limit": 5}**'
+        )
+        self.assertFalse(alternate_is_presentable(alternate, self.PRIMARY))
+
+    def test_action_token_rejected(self):
+        alternate = (
+            "Here you go. **create_or_update_appeal**"
+            '{"patient_name": "X", "appeal_text": "..."} and more text to '
+            "reach the minimum length for an alternate answer."
+        )
+        self.assertFalse(alternate_is_presentable(alternate, self.PRIMARY))
+
+    def test_panda_residue_rejected(self):
+        alternate = (
+            "Sure, here's another way to think about your appeal options "
+            "🐼 user is in California asking about Medicaid"
+        )
+        self.assertFalse(alternate_is_presentable(alternate, self.PRIMARY))
+
+    def test_too_short_rejected(self):
+        self.assertFalse(alternate_is_presentable("Sure!", self.PRIMARY))
+        self.assertFalse(alternate_is_presentable(None, self.PRIMARY))
+        self.assertFalse(alternate_is_presentable("", self.PRIMARY))
+
+    def test_repeat_of_history_rejected(self):
+        history = [
+            {"role": "user", "content": "help"},
+            {"role": "assistant", "content": LOOPED_REPLY},
+        ]
+        self.assertFalse(
+            alternate_is_presentable(
+                LOOPED_REPLY, self.PRIMARY, chat_history=history, current_message="CA"
+            )
+        )
+
+
 class TestScoreLlmResponseRepetitionPenalty(TestCase):
     """Integration: repetition penalty within score_llm_response."""
 
@@ -370,12 +581,8 @@ class TestScoreLlmResponseRepetitionPenalty(TestCase):
         echo_result = ("I need help with my denial", "Context")
         good_result = ("I can help you appeal that. Let me look into it.", "Context")
 
-        echo_score = score_llm_response(
-            echo_result, 100, current_message=current_msg
-        )
-        good_score = score_llm_response(
-            good_result, 100, current_message=current_msg
-        )
+        echo_score = score_llm_response(echo_result, 100, current_message=current_msg)
+        good_score = score_llm_response(good_result, 100, current_message=current_msg)
         self.assertGreater(good_score, echo_score)
         self.assertLess(echo_score, 0)
 
@@ -398,11 +605,7 @@ class TestScoreLlmResponseRepetitionPenalty(TestCase):
         bow_result = ("my denial please help with", "Context")
         exact_result = ("help with my denial please", "Context")
 
-        bow_score = score_llm_response(
-            bow_result, 100, current_message=current_msg
-        )
-        exact_score = score_llm_response(
-            exact_result, 100, current_message=current_msg
-        )
+        bow_score = score_llm_response(bow_result, 100, current_message=current_msg)
+        exact_score = score_llm_response(exact_result, 100, current_message=current_msg)
         # Both penalized, but exact match more heavily
         self.assertGreater(bow_score, exact_score)

--- a/tests/sync/test_llm_client.py
+++ b/tests/sync/test_llm_client.py
@@ -648,3 +648,25 @@ class TestCannedReplyExemption(TestCase):
             find_repeated_reply(LOOPED_REPLY, history, "CA"),
             "repeats_recent_assistant_reply",
         )
+
+
+class TestPenaltySeverityOrdering(TestCase):
+    """Near-verbatim detection outranks bag-of-words equality: a LONG reply
+    sharing the exact word set is a near-verbatim reorder and must get
+    NEAR_REPEAT_PENALTY, while short reorders still land in the mild
+    bag-of-words bucket."""
+
+    def test_long_reordered_repeat_gets_near_penalty(self):
+        paragraphs = LOOPED_REPLY.split("\n\n")
+        reordered = "\n\n".join(reversed(paragraphs))
+        history = [
+            {"role": "user", "content": "something distinct entirely"},
+            {"role": "assistant", "content": LOOPED_REPLY},
+        ]
+        penalty = compute_repetition_penalty(reordered, history)
+        self.assertEqual(penalty, NEAR_REPEAT_PENALTY)
+
+    def test_short_reorder_still_bag_of_words(self):
+        history = [{"role": "user", "content": "help with my denial"}]
+        penalty = compute_repetition_penalty("my denial with help", history)
+        self.assertEqual(penalty, BAG_OF_WORDS_REPEAT_PENALTY)

--- a/tests/sync/test_llm_client.py
+++ b/tests/sync/test_llm_client.py
@@ -23,25 +23,7 @@ from fighthealthinsurance.chat.llm_client import (
     BAD_RESPONSE_PATTERNS,
     BAD_CONTEXT_PATTERNS,
 )
-
-# A realistic long assistant reply (matches the production loop shape).
-LOOPED_REPLY = (
-    "The new Medicaid requirements can be tricky! To help you understand them "
-    "better, could you tell me a bit more about your situation? For example:\n\n"
-    "* What state are you in?\n"
-    "* What is your current income and household size?\n"
-    "* Do you currently have Medicaid coverage?\n"
-    "* What specific requirements are you trying to understand?\n\n"
-    "Once I have this information, I can help you find the relevant resources "
-    "and explain how to navigate the new requirements."
-)
-
-FRESH_REPLY = (
-    "Great — since you're in California, your Medicaid program is Medi-Cal. "
-    "The new federal rules add an 80-hour monthly work/school/volunteering "
-    "requirement for many adults by the end of 2026. Want me to look up the "
-    "Medi-Cal specifics for you?"
-)
+from tests.chat_fixtures import FRESH_REPLY, LOOPED_REPLY
 
 
 class TestEstimateHistoryTokens(TestCase):

--- a/tests/sync/test_llm_client.py
+++ b/tests/sync/test_llm_client.py
@@ -609,3 +609,42 @@ class TestScoreLlmResponseRepetitionPenalty(TestCase):
         exact_score = score_llm_response(exact_result, 100, current_message=current_msg)
         # Both penalized, but exact match more heavily
         self.assertGreater(bow_score, exact_score)
+
+
+class TestCannedReplyExemption(TestCase):
+    """Mandated verbatim replies (e.g. the Medicaid work-requirements block)
+    may legitimately repeat across turns — they are exempt from HARD
+    rejection while soft penalties still apply."""
+
+    CANNED = (
+        "New federal rules require many adults (ages 19-64) to complete at "
+        "least 80 hours per month of work, job training, school, or community "
+        "service to keep Medicaid coverage. For detailed information visit: "
+        "[Medicaid Work Requirements FAQ](/faq/medicaid/)"
+    )
+
+    def test_canned_reply_repeat_not_hard_rejected(self):
+        history = [
+            {"role": "user", "content": "tell me about the work requirements"},
+            {"role": "assistant", "content": self.CANNED},
+        ]
+        self.assertIsNone(
+            find_repeated_reply(self.CANNED, history, "and the work requirements?")
+        )
+        score = score_llm_response(
+            (self.CANNED, "ctx"),
+            call_score=100,
+            chat_history=history,
+            current_message="what about the work requirements again?",
+        )
+        self.assertGreater(score, float("-inf"))
+
+    def test_non_canned_repeat_still_rejected(self):
+        history = [
+            {"role": "user", "content": "help"},
+            {"role": "assistant", "content": LOOPED_REPLY},
+        ]
+        self.assertEqual(
+            find_repeated_reply(LOOPED_REPLY, history, "CA"),
+            "repeats_recent_assistant_reply",
+        )

--- a/tests/sync/test_llm_client.py
+++ b/tests/sync/test_llm_client.py
@@ -11,12 +11,15 @@ from fighthealthinsurance.chat.llm_client import (
     compute_repetition_penalty,
     alternate_is_presentable,
     find_repeated_reply,
+    scores_closely_tied,
     user_requested_repeat,
+    ALTERNATE_CLOSE_TIE_RATIO,
     EXACT_REPEAT_PENALTY,
     BAG_OF_WORDS_REPEAT_PENALTY,
     NEAR_REPEAT_PENALTY,
     OLDER_ASSISTANT_REPEAT_PENALTY,
     OLDER_USER_REPEAT_PENALTY,
+    REPEAT_OFFENDER_DECAY,
     BAD_RESPONSE_PATTERNS,
     BAD_CONTEXT_PATTERNS,
 )
@@ -670,3 +673,89 @@ class TestPenaltySeverityOrdering(TestCase):
         history = [{"role": "user", "content": "help with my denial"}]
         penalty = compute_repetition_penalty("my denial with help", history)
         self.assertEqual(penalty, BAG_OF_WORDS_REPEAT_PENALTY)
+
+
+class TestScoresCloselyTied(TestCase):
+    """Alternates only show when the fan-out's top two scores are close."""
+
+    def test_within_ratio_is_tied(self):
+        self.assertTrue(scores_closely_tied(100.0, 100.0 * ALTERNATE_CLOSE_TIE_RATIO))
+        self.assertTrue(scores_closely_tied(2630.0, 2210.0))
+
+    def test_below_ratio_not_tied(self):
+        self.assertFalse(
+            scores_closely_tied(100.0, 100.0 * ALTERNATE_CLOSE_TIE_RATIO - 0.1)
+        )
+        # Cross-tier gap (internal ~8000 base vs external ~2000): never tied.
+        self.assertFalse(scores_closely_tied(8200.0, 2100.0))
+
+    def test_non_positive_scores_never_tied(self):
+        self.assertFalse(scores_closely_tied(0.0, 0.0))
+        self.assertFalse(scores_closely_tied(-50.0, -40.0))
+        self.assertFalse(scores_closely_tied(100.0, 0.0))
+
+    def test_non_finite_scores_never_tied(self):
+        self.assertFalse(scores_closely_tied(float("inf"), 100.0))
+        self.assertFalse(scores_closely_tied(100.0, float("-inf")))
+
+
+class TestRepeatOffenderDemotion(TestCase):
+    """Backends that produced hard-rejected repeats earlier in the session
+    have their base score decayed, and each rejection records a strike."""
+
+    CONTEXT = "context for the reply"
+
+    def _score(self, offenders, base=1000):
+        task = object()
+        score_fn = create_response_scorer(
+            call_scores={task: base},
+            chat_history=None,
+            current_message=None,
+            call_labels={task: "backend-a"},
+            repeat_offenders=offenders,
+        )
+        return score_fn((FRESH_REPLY, self.CONTEXT), task)
+
+    def test_strikes_decay_base_score(self):
+        clean = self._score({})
+        struck = self._score({"backend-a": 2})
+        expected_decayed_base = int(1000 * (REPEAT_OFFENDER_DECAY**2))
+        self.assertEqual(clean - struck, 1000 - expected_decayed_base)
+
+    def test_strike_count_capped(self):
+        at_cap = self._score({"backend-a": 4})
+        past_cap = self._score({"backend-a": 40})
+        self.assertEqual(at_cap, past_cap)
+
+    def test_rejected_repeat_records_strike(self):
+        task = object()
+        offenders: dict = {}
+        rejection_stats: dict = {}
+        history = [
+            {"role": "user", "content": "Help me with the new requirements."},
+            {"role": "assistant", "content": LOOPED_REPLY},
+        ]
+        score_fn = create_response_scorer(
+            call_scores={task: 1000},
+            chat_history=history,
+            current_message="CA",
+            rejection_stats=rejection_stats,
+            call_labels={task: "backend-a"},
+            repeat_offenders=offenders,
+        )
+        score = score_fn((LOOPED_REPLY, self.CONTEXT), task)
+        self.assertEqual(score, float("-inf"))
+        self.assertEqual(offenders, {"backend-a": 1})
+
+    def test_score_log_records_final_scores(self):
+        task = object()
+        score_log: dict = {}
+        score_fn = create_response_scorer(
+            call_scores={task: 1000},
+            chat_history=None,
+            current_message=None,
+            call_labels={task: "backend-a"},
+            score_log=score_log,
+        )
+        score = score_fn((FRESH_REPLY, self.CONTEXT), task)
+        self.assertEqual(score_log, {task: score})

--- a/tests/sync/test_report_client_error.py
+++ b/tests/sync/test_report_client_error.py
@@ -182,9 +182,7 @@ class ReportClientErrorTest(APITestCase):
             )
         self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
         mock_summarize.assert_not_called()
-        self.assertIn(
-            "context_tokens: unauthorized", self._logged_error(mock_logger)
-        )
+        self.assertIn("context_tokens: unauthorized", self._logged_error(mock_logger))
 
     def test_wrong_semi_sekret_is_unauthorized(self):
         denial = self._make_denial(denial_text="x" * 400)
@@ -200,6 +198,4 @@ class ReportClientErrorTest(APITestCase):
             )
         self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
         mock_summarize.assert_not_called()
-        self.assertIn(
-            "context_tokens: unauthorized", self._logged_error(mock_logger)
-        )
+        self.assertIn("context_tokens: unauthorized", self._logged_error(mock_logger))

--- a/tests/sync/test_response_similarity.py
+++ b/tests/sync/test_response_similarity.py
@@ -14,19 +14,7 @@ from fighthealthinsurance.ml.response_similarity import (
     sequence_similarity,
     user_requested_repeat,
 )
-
-# The reply from the observed production loop (assistant re-sent it verbatim
-# after the user answered "CA").
-LOOPED_REPLY = (
-    "The new Medicaid requirements can be tricky! To help you understand them "
-    "better, could you tell me a bit more about your situation? For example:\n\n"
-    "* What state are you in?\n"
-    "* What is your current income and household size?\n"
-    "* Do you currently have Medicaid coverage?\n"
-    "* What specific requirements are you trying to understand?\n\n"
-    "Once I have this information, I can help you find the relevant resources "
-    "and explain how to navigate the new requirements."
-)
+from tests.chat_fixtures import LOOPED_REPLY
 
 
 class TestNormalizeAndBags(TestCase):

--- a/tests/sync/test_response_similarity.py
+++ b/tests/sync/test_response_similarity.py
@@ -6,11 +6,13 @@ from fighthealthinsurance.ml.response_similarity import (
     EXACT_REPEAT_MIN_CHARS,
     NEAR_REPEAT_MIN_CHARS,
     bag_of_words,
+    is_canned_reply,
     is_mostly_repeated,
     jaccard_similarity,
     normalize_text,
     response_similarity,
     sequence_similarity,
+    user_requested_repeat,
 )
 
 # The reply from the observed production loop (assistant re-sent it verbatim
@@ -140,3 +142,91 @@ class TestResponseSimilarity(TestCase):
             "the county office for you if you'd like."
         )
         self.assertLess(response_similarity(a, b), 0.7)
+
+
+class TestLongNearVerbatimRepeats(TestCase):
+    """Regression: difflib's default autojunk heuristic treats every common
+    character in a 200+ element sequence as junk, collapsing ratio() for
+    exactly the long replies this module targets (0.33 measured where the
+    true ratio was 0.96, against a 0.9 threshold)."""
+
+    def test_reworded_long_reply_is_a_repeat(self):
+        reworded = LOOPED_REPLY.replace("can be tricky!", "are confusing.").replace(
+            "Once I have this information,", "Once I have that,"
+        )
+        self.assertTrue(is_mostly_repeated(reworded, LOOPED_REPLY))
+
+    def test_long_similarity_scores_high(self):
+        reworded = LOOPED_REPLY.replace("can be tricky!", "are confusing.")
+        self.assertGreater(sequence_similarity(reworded, LOOPED_REPLY), 0.9)
+
+    def test_unrelated_long_replies_are_not_repeats(self):
+        unrelated = (
+            "Your plan denied this as investigational, so the strongest "
+            "argument is medical necessity backed by the trial registry. "
+            "Start by requesting the full denial letter and the plan's "
+            "clinical policy bulletin for this code. "
+        ) * 3
+        self.assertFalse(is_mostly_repeated(unrelated, LOOPED_REPLY * 3))
+
+
+class TestUserRequestedRepeatPrecision(TestCase):
+    """`repeat` is everyday clinical vocabulary here, and this flag disables
+    every rung of the loop-prevention ladder — so it must match an explicit
+    request to say something again, not the topic of the conversation."""
+
+    CLINICAL_MENTIONS = [
+        "They denied my repeat colonoscopy.",
+        "This is a repeat denial for the same MRI.",
+        "I need a repeat prescription for my insulin.",
+        "my doctor ordered a repeat echocardiogram",
+        "The insurer keeps denying repeat imaging",
+        "Can you resend the fax to my doctor?",
+        "I filed an appeal one more time last month",
+    ]
+
+    EXPLICIT_REQUESTS = [
+        "can you repeat that?",
+        "repeat that please",
+        "say that again",
+        "please repeat the last answer",
+        "send it again",
+        "repeat",
+        "one more time please",
+        "resend it",
+        "show that again",
+    ]
+
+    def test_clinical_mentions_do_not_disable_the_ladder(self):
+        for message in self.CLINICAL_MENTIONS:
+            with self.subTest(message=message):
+                self.assertFalse(user_requested_repeat(message))
+
+    def test_explicit_requests_are_honored(self):
+        for message in self.EXPLICIT_REQUESTS:
+            with self.subTest(message=message):
+                self.assertTrue(user_requested_repeat(message))
+
+
+class TestCannedReplyRequiresTheWholeBlock(TestCase):
+    """The system prompt tells the model to link the Medicaid FAQ on every
+    work-requirements answer, so matching the link alone exempted ordinary
+    (including looping) Medicaid replies from the whole ladder."""
+
+    CANNED_BLOCK = (
+        "New federal rules require many adults (ages 19-64) to complete at "
+        "least 80 hours per month of work, job training, school, or community "
+        "service to keep Medicaid coverage. These requirements go into effect "
+        "by December 31, 2026. For detailed information, visit: "
+        "[Medicaid Work Requirements FAQ](/faq/medicaid/)"
+    )
+
+    def test_full_canned_block_is_exempt(self):
+        self.assertTrue(is_canned_reply(self.CANNED_BLOCK))
+
+    def test_reply_merely_linking_the_faq_is_not_exempt(self):
+        linking = (
+            LOOPED_REPLY
+            + "\n\nSee the [Medicaid Work Requirements FAQ](/faq/medicaid/)."
+        )
+        self.assertFalse(is_canned_reply(linking))

--- a/tests/sync/test_response_similarity.py
+++ b/tests/sync/test_response_similarity.py
@@ -14,7 +14,7 @@ from fighthealthinsurance.ml.response_similarity import (
     sequence_similarity,
     user_requested_repeat,
 )
-from tests.chat_fixtures import LOOPED_REPLY
+from tests.chat_fixtures import CANNED_MEDICAID_REPLY, LOOPED_REPLY
 
 
 class TestNormalizeAndBags(TestCase):
@@ -163,7 +163,7 @@ class TestUserRequestedRepeatPrecision(TestCase):
     every rung of the loop-prevention ladder — so it must match an explicit
     request to say something again, not the topic of the conversation."""
 
-    CLINICAL_MENTIONS = [
+    CLINICAL_MENTIONS = (
         "They denied my repeat colonoscopy.",
         "This is a repeat denial for the same MRI.",
         "I need a repeat prescription for my insulin.",
@@ -171,9 +171,9 @@ class TestUserRequestedRepeatPrecision(TestCase):
         "The insurer keeps denying repeat imaging",
         "Can you resend the fax to my doctor?",
         "I filed an appeal one more time last month",
-    ]
+    )
 
-    EXPLICIT_REQUESTS = [
+    EXPLICIT_REQUESTS = (
         "can you repeat that?",
         "repeat that please",
         "say that again",
@@ -183,7 +183,7 @@ class TestUserRequestedRepeatPrecision(TestCase):
         "one more time please",
         "resend it",
         "show that again",
-    ]
+    )
 
     def test_clinical_mentions_do_not_disable_the_ladder(self):
         for message in self.CLINICAL_MENTIONS:
@@ -201,16 +201,8 @@ class TestCannedReplyRequiresTheWholeBlock(TestCase):
     work-requirements answer, so matching the link alone exempted ordinary
     (including looping) Medicaid replies from the whole ladder."""
 
-    CANNED_BLOCK = (
-        "New federal rules require many adults (ages 19-64) to complete at "
-        "least 80 hours per month of work, job training, school, or community "
-        "service to keep Medicaid coverage. These requirements go into effect "
-        "by December 31, 2026. For detailed information, visit: "
-        "[Medicaid Work Requirements FAQ](/faq/medicaid/)"
-    )
-
     def test_full_canned_block_is_exempt(self):
-        self.assertTrue(is_canned_reply(self.CANNED_BLOCK))
+        self.assertTrue(is_canned_reply(CANNED_MEDICAID_REPLY))
 
     def test_reply_merely_linking_the_faq_is_not_exempt(self):
         linking = (

--- a/tests/sync/test_response_similarity.py
+++ b/tests/sync/test_response_similarity.py
@@ -1,0 +1,142 @@
+"""Tests for the shared response-similarity helpers (chat loop prevention)."""
+
+from django.test import TestCase
+
+from fighthealthinsurance.ml.response_similarity import (
+    EXACT_REPEAT_MIN_CHARS,
+    NEAR_REPEAT_MIN_CHARS,
+    bag_of_words,
+    is_mostly_repeated,
+    jaccard_similarity,
+    normalize_text,
+    response_similarity,
+    sequence_similarity,
+)
+
+# The reply from the observed production loop (assistant re-sent it verbatim
+# after the user answered "CA").
+LOOPED_REPLY = (
+    "The new Medicaid requirements can be tricky! To help you understand them "
+    "better, could you tell me a bit more about your situation? For example:\n\n"
+    "* What state are you in?\n"
+    "* What is your current income and household size?\n"
+    "* Do you currently have Medicaid coverage?\n"
+    "* What specific requirements are you trying to understand?\n\n"
+    "Once I have this information, I can help you find the relevant resources "
+    "and explain how to navigate the new requirements."
+)
+
+
+class TestNormalizeAndBags(TestCase):
+    def test_normalize_text(self):
+        self.assertEqual(normalize_text("  Hello   WORLD\n"), "hello world")
+
+    def test_bag_of_words(self):
+        self.assertEqual(bag_of_words("Hello, hello world!"), {"hello", "world"})
+
+    def test_jaccard_identical(self):
+        self.assertEqual(jaccard_similarity("a b c", "c b a"), 1.0)
+
+    def test_jaccard_disjoint(self):
+        self.assertEqual(jaccard_similarity("a b c", "d e f"), 0.0)
+
+    def test_jaccard_empty(self):
+        self.assertEqual(jaccard_similarity("", "a"), 0.0)
+
+
+class TestSequenceSimilarity(TestCase):
+    def test_identical_is_one(self):
+        self.assertEqual(sequence_similarity(LOOPED_REPLY, LOOPED_REPLY), 1.0)
+
+    def test_case_and_whitespace_insensitive(self):
+        self.assertEqual(
+            sequence_similarity("Hello  World", "hello world"),
+            1.0,
+        )
+
+    def test_different_texts_low(self):
+        self.assertLess(
+            sequence_similarity(
+                "Great, you're in California! Medi-Cal is the state program.",
+                "Please upload your denial letter so I can review it.",
+            ),
+            0.6,
+        )
+
+    def test_empty_returns_zero(self):
+        self.assertEqual(sequence_similarity("", "anything"), 0.0)
+
+
+class TestIsMostlyRepeated(TestCase):
+    def test_verbatim_repeat_detected(self):
+        self.assertTrue(is_mostly_repeated(LOOPED_REPLY, LOOPED_REPLY))
+
+    def test_whitespace_variation_still_detected(self):
+        self.assertTrue(
+            is_mostly_repeated(LOOPED_REPLY.replace("\n", " "), LOOPED_REPLY)
+        )
+
+    def test_light_rewording_detected(self):
+        # A few words changed in an otherwise identical long reply.
+        reworded = LOOPED_REPLY.replace("can be tricky", "are quite tricky").replace(
+            "a bit more", "some more"
+        )
+        self.assertTrue(is_mostly_repeated(reworded, LOOPED_REPLY))
+
+    def test_genuinely_new_reply_not_detected(self):
+        fresh = (
+            "Great — since you're in California, the program is called "
+            "Medi-Cal. The new federal rules add an 80-hour monthly work or "
+            "volunteering requirement for many adults starting at the end of "
+            "2026. Would you like me to check what applies to your situation?"
+        )
+        self.assertFalse(is_mostly_repeated(fresh, LOOPED_REPLY))
+
+    def test_short_exact_confirmation_not_detected(self):
+        # Below EXACT_REPEAT_MIN_CHARS: legitimate short repeats stay allowed.
+        short = "Yes."
+        self.assertLess(len(short), EXACT_REPEAT_MIN_CHARS)
+        self.assertFalse(is_mostly_repeated(short, short))
+
+    def test_short_exact_question_detected(self):
+        # At/above EXACT_REPEAT_MIN_CHARS an exact repeat counts even when
+        # short — re-sending the same question verbatim is still a loop.
+        question = "Which state are you in?"
+        self.assertGreaterEqual(len(question), EXACT_REPEAT_MIN_CHARS)
+        self.assertTrue(is_mostly_repeated(question, question))
+
+    def test_short_similar_but_not_exact_not_detected(self):
+        # Below NEAR_REPEAT_MIN_CHARS the similarity path must not fire, so a
+        # reworded short question is not treated as a repeat.
+        a = "So which state are you living in"
+        b = "Which state do you live in?"
+        self.assertLess(len(a), NEAR_REPEAT_MIN_CHARS)
+        self.assertFalse(is_mostly_repeated(a, b))
+
+    def test_none_and_empty_inputs(self):
+        self.assertFalse(is_mostly_repeated(None, LOOPED_REPLY))
+        self.assertFalse(is_mostly_repeated(LOOPED_REPLY, None))
+        self.assertFalse(is_mostly_repeated("", ""))
+
+    def test_reordered_long_text_detected_via_jaccard(self):
+        # Same content with paragraphs shuffled: word set is ~identical.
+        paragraphs = LOOPED_REPLY.split("\n\n")
+        reordered = "\n\n".join(reversed(paragraphs))
+        self.assertTrue(is_mostly_repeated(reordered, LOOPED_REPLY))
+
+
+class TestResponseSimilarity(TestCase):
+    def test_identical(self):
+        self.assertEqual(response_similarity(LOOPED_REPLY, LOOPED_REPLY), 1.0)
+
+    def test_none_inputs(self):
+        self.assertEqual(response_similarity(None, "x"), 0.0)
+        self.assertEqual(response_similarity("x", None), 0.0)
+
+    def test_distinct_answers_below_alternate_threshold(self):
+        a = "You can appeal within 180 days; start by requesting your denial letter."
+        b = (
+            "Medi-Cal has an eligibility phone line; I can also look up "
+            "the county office for you if you'd like."
+        )
+        self.assertLess(response_similarity(a, b), 0.7)

--- a/tests/sync/test_retry_anti_repeat.py
+++ b/tests/sync/test_retry_anti_repeat.py
@@ -50,12 +50,14 @@ class RecordingModel:
         is_professional=True,
         is_logged_in=True,
         temperature=0.7,
+        allow_repeated_reply=False,
     ):
         self.calls.append(
             {
                 "message": current_message_for_llm,
                 "temperature": temperature,
                 "history_len": len(history) if history else 0,
+                "allow_repeated_reply": allow_repeated_reply,
             }
         )
         return (self._response, self._context)
@@ -131,3 +133,25 @@ class TestRetryAntiRepeatInstruction:
         for call in model.calls:
             assert ANTI_REPEAT_NOTE not in call["message"]
             assert call["temperature"] == 0.7
+
+    @pytest.mark.asyncio
+    async def test_allow_repeated_reply_forwards_to_backends(self):
+        """The explicit-repeat flag (derived from the RAW user message by the
+        caller) must reach the backend so its self-heal loop doesn't fight a
+        user-requested repeat."""
+        model = RecordingModel()
+        await retry_llm_with_fallback(
+            model_backends=[model],
+            current_message="please repeat that",
+            previous_context_summary=None,
+            history=list(CHAT_HISTORY),
+            is_professional=False,
+            is_logged_in=False,
+            chat_history=CHAT_HISTORY,
+            user_message_for_scoring="please repeat that",
+            allow_repeated_reply=True,
+            timeout=5.0,
+        )
+        assert model.calls
+        for call in model.calls:
+            assert call["allow_repeated_reply"] is True

--- a/tests/sync/test_retry_anti_repeat.py
+++ b/tests/sync/test_retry_anti_repeat.py
@@ -9,21 +9,7 @@ from fighthealthinsurance.chat.retry_handler import (
     create_simple_retry_scorer,
     retry_llm_with_fallback,
 )
-
-LOOPED_REPLY = (
-    "The new Medicaid requirements can be tricky! To help you understand them "
-    "better, could you tell me a bit more about your situation? For example:\n\n"
-    "* What state are you in?\n"
-    "* What is your current income and household size?\n"
-    "* Do you currently have Medicaid coverage?\n"
-    "* What specific requirements are you trying to understand?"
-)
-
-FRESH_REPLY = (
-    "Great — you're in California, so your program is Medi-Cal. The new rules "
-    "add an 80-hour monthly activity requirement for many adults; want me to "
-    "look up the Medi-Cal specifics?"
-)
+from tests.chat_fixtures import FRESH_REPLY, LOOPED_REPLY
 
 CHAT_HISTORY = [
     {"role": "user", "content": "Help me with the new medicaid requirements."},

--- a/tests/sync/test_retry_anti_repeat.py
+++ b/tests/sync/test_retry_anti_repeat.py
@@ -1,0 +1,133 @@
+"""Tests for the anti-repeat retry ladder in the chat retry handler."""
+
+import pytest
+
+from fighthealthinsurance.chat.retry_handler import (
+    ANTI_REPEAT_NOTE,
+    ANTI_REPEAT_TEMPERATURE,
+    REPEAT_LAST_RESORT_PENALTY,
+    create_simple_retry_scorer,
+    retry_llm_with_fallback,
+)
+
+LOOPED_REPLY = (
+    "The new Medicaid requirements can be tricky! To help you understand them "
+    "better, could you tell me a bit more about your situation? For example:\n\n"
+    "* What state are you in?\n"
+    "* What is your current income and household size?\n"
+    "* Do you currently have Medicaid coverage?\n"
+    "* What specific requirements are you trying to understand?"
+)
+
+FRESH_REPLY = (
+    "Great — you're in California, so your program is Medi-Cal. The new rules "
+    "add an 80-hour monthly activity requirement for many adults; want me to "
+    "look up the Medi-Cal specifics?"
+)
+
+CHAT_HISTORY = [
+    {"role": "user", "content": "Help me with the new medicaid requirements."},
+    {"role": "assistant", "content": LOOPED_REPLY},
+]
+
+
+class RecordingModel:
+    """Minimal chat backend that records generate_chat_response calls."""
+
+    def __init__(self, response=FRESH_REPLY, context="ctx"):
+        self.calls = []
+        self._response = response
+        self._context = context
+
+    def quality(self):
+        return 100
+
+    async def generate_chat_response(
+        self,
+        current_message_for_llm,
+        previous_context_summary=None,
+        history=None,
+        is_professional=True,
+        is_logged_in=True,
+        temperature=0.7,
+    ):
+        self.calls.append(
+            {
+                "message": current_message_for_llm,
+                "temperature": temperature,
+                "history_len": len(history) if history else 0,
+            }
+        )
+        return (self._response, self._context)
+
+
+class TestRetryScorerRepeatPenalty:
+    """A retry candidate that still repeats loses to any fresh candidate but
+    stays deliverable as the absolute last resort (finite score, not -inf)."""
+
+    def _scorer(self):
+        return create_simple_retry_scorer(
+            call_scores={},
+            chat_history=CHAT_HISTORY,
+            current_message="CA",
+        )
+
+    def test_repeat_scores_decisively_below_fresh(self):
+        scorer = self._scorer()
+        repeat_score = scorer((LOOPED_REPLY, "ctx"), None)
+        fresh_score = scorer((FRESH_REPLY, "ctx"), None)
+        assert repeat_score < fresh_score + REPEAT_LAST_RESORT_PENALTY / 2
+        assert repeat_score > float("-inf")
+
+    def test_repeat_allowed_when_user_asked_for_it(self):
+        scorer = create_simple_retry_scorer(
+            call_scores={},
+            chat_history=CHAT_HISTORY,
+            current_message="can you repeat that?",
+        )
+        repeat_score = scorer((LOOPED_REPLY, "ctx"), None)
+        assert repeat_score > REPEAT_LAST_RESORT_PENALTY / 2
+
+
+class TestRetryAntiRepeatInstruction:
+    """retry_llm_with_fallback(anti_repeat=True) changes what the model sees."""
+
+    @pytest.mark.asyncio
+    async def test_anti_repeat_adds_note_and_raises_temperature(self):
+        model = RecordingModel()
+        response, context = await retry_llm_with_fallback(
+            model_backends=[model],
+            current_message="CA",
+            previous_context_summary=None,
+            history=list(CHAT_HISTORY),
+            is_professional=False,
+            is_logged_in=False,
+            chat_history=CHAT_HISTORY,
+            user_message_for_scoring="CA",
+            anti_repeat=True,
+            timeout=5.0,
+        )
+        assert response == FRESH_REPLY
+        assert model.calls
+        for call in model.calls:
+            assert ANTI_REPEAT_NOTE in call["message"]
+            assert call["temperature"] == ANTI_REPEAT_TEMPERATURE
+
+    @pytest.mark.asyncio
+    async def test_default_retry_has_no_note(self):
+        model = RecordingModel()
+        response, _ = await retry_llm_with_fallback(
+            model_backends=[model],
+            current_message="CA",
+            previous_context_summary=None,
+            history=list(CHAT_HISTORY),
+            is_professional=False,
+            is_logged_in=False,
+            chat_history=CHAT_HISTORY,
+            user_message_for_scoring="CA",
+            timeout=5.0,
+        )
+        assert response == FRESH_REPLY
+        for call in model.calls:
+            assert ANTI_REPEAT_NOTE not in call["message"]
+            assert call["temperature"] == 0.7

--- a/tests/sync/test_speculative_appeals.py
+++ b/tests/sync/test_speculative_appeals.py
@@ -431,7 +431,10 @@ class ConfirmedContextRefreshTest(TestCase):
 
     def _drafts(self, *texts):
         return iter(
-            [GeneratedAppeal(text=t, model_name="m", context_level="full") for t in texts]
+            [
+                GeneratedAppeal(text=t, model_name="m", context_level="full")
+                for t in texts
+            ]
         )
 
     def test_refresh_replaces_held_back_reserve_with_confirmed_rows(self):

--- a/tests/sync/test_ucr_source_url_live.py
+++ b/tests/sync/test_ucr_source_url_live.py
@@ -17,7 +17,6 @@ from django.test import SimpleTestCase
 
 from fighthealthinsurance.ucr_constants import UCR_SOURCE_URLS
 
-
 _HEAD_TIMEOUT_SECONDS = 8
 
 

--- a/tests/sync/test_understand_policy.py
+++ b/tests/sync/test_understand_policy.py
@@ -159,9 +159,7 @@ class TextExtractionTest(TestCase):
 
     def test_extract_text_from_plaintext(self):
         content = b"This is a plain text policy document with coverage details."
-        full_text, page_dict = extract_text_from_plaintext_bytes(
-            content
-        )
+        full_text, page_dict = extract_text_from_plaintext_bytes(content)
         self.assertIn("plain text policy", full_text)
         self.assertEqual(len(page_dict), 1)
 
@@ -172,28 +170,20 @@ class TextExtractionTest(TestCase):
         pdf_bytes = doc.tobytes()
         doc.close()
 
-        full_text, _ = extract_text_from_bytes(
-            pdf_bytes, "policy.pdf"
-        )
+        full_text, _ = extract_text_from_bytes(pdf_bytes, "policy.pdf")
         self.assertIn("Dispatcher PDF test", full_text)
 
     def test_extract_text_dispatcher_txt(self):
-        full_text, _ = extract_text_from_bytes(
-            b"Hello world", "notes.txt"
-        )
+        full_text, _ = extract_text_from_bytes(b"Hello world", "notes.txt")
         self.assertIn("Hello world", full_text)
 
     def test_extract_text_dispatcher_unsupported(self):
-        full_text, page_dict = extract_text_from_bytes(
-            b"data", "file.xyz"
-        )
+        full_text, page_dict = extract_text_from_bytes(b"data", "file.xyz")
         self.assertEqual(full_text, "")
         self.assertEqual(page_dict, {})
 
     def test_corrupt_pdf_returns_empty(self):
-        full_text, page_dict = extract_text_from_pdf_bytes(
-            b"not a pdf at all"
-        )
+        full_text, page_dict = extract_text_from_pdf_bytes(b"not a pdf at all")
         self.assertEqual(full_text, "")
         self.assertEqual(page_dict, {})
 


### PR DESCRIPTION
## Summary

Implements a multi-layer defense against the observed production failure where chat models re-send their previous reply verbatim instead of using the user's new answer. The fix combines hard rejection of repeated candidates in scoring, an anti-repeat retry with explicit instruction and hotter sampling, and optional side-by-side alternate answers.

## Key Changes

### Core Loop Prevention
- **Response similarity detection** (`ml/response_similarity.py`): New stdlib-only module with text-similarity helpers (exact/near-repeat detection via sequence matching and Jaccard similarity) shared by both the per-backend retry loop and candidate scoring without import cycles.
- **Hard rejection in scoring** (`chat/llm_client.py`): 
  - `find_repeated_reply()` detects when a candidate repeats recent assistant replies (covers A-A loops and A-B-A alternation)
  - `user_requested_repeat()` exempts explicit repeat requests from rejection
  - `is_canned_reply()` exempts mandated verbatim responses (e.g., Medicaid FAQ blocks)
  - Repeated candidates scored `-inf` so they never win in `best_within_timelimit()`
- **Anti-repeat retry ladder** (`chat/retry_handler.py`):
  - `ANTI_REPEAT_NOTE` instruction added to retry message when a repeat is detected
  - Temperature increased to 0.9 for hotter sampling on retry
  - Retry candidates still repeating get `REPEAT_LAST_RESORT_PENALTY` (finite but decisive) so a non-repeat always wins, but a repeat can still be delivered as absolute last resort
- **Per-backend self-heal** (`ml/ml_models.py`): `RemoteOpenLike.generate_chat_response()` detects near-repeats in fresh generations and retries once with corrective feedback before the caller's scoring ladder sees it

### Chat Interface Enhancements
- **State hint from IP** (`fhi_users/audit.py`): `guess_us_state()` derives best-effort US state from connection IP using geoip2fast (transient, unconfirmed, never persisted). Flows into LLM context each turn to help Medicaid questions start with "looks like you might be in California — is that right?"
- **Side-by-side alternates** (`chat_interface.py`): Runner-up answer from top-level LLM fan-out offered to client as collapsible alternate when presentable
- **Debug LLM input frame** (`chat_interface.py`): When `debug_llm=True` (gated to DEBUG deployments and staff), each turn sends a `debug_llm_input` frame showing exactly what was sent to the backend model
- **Terse-reply bridge note** (`chat_interface.py`): Short user messages (≤60 chars) right after an assistant question get a note explaining the model needs more detail — addresses the shape where models historically looped by re-asking instead of using terse answers

### Observability
- **Metrics** (`ml/ml_metrics.py`):
  - `fhi_chat_repeated_responses_total` with actions `rejected_candidates` (hard rejection in primary pass) and `delivered_repeat` (last-resort delivery)
  - `fhi_chat_alternate_answers_total` and `fhi_chat_answer_feedback_total` for side-by-side answer tracking
- **WebSocket feedback frame** (`websockets.py`): Lightweight `{"answer_feedback": {"preferred": ...}}` frame records which answer users preferred without starting an LLM turn

### Utility & Infrastructure
- **`best_two_within_timelimit()`** (`utils.py`): New variant of `best_within_timelimit()` that returns both the best and runner-up results (used to populate the alternate answer)
- **`-inf` scoring semantics** (`utils.py`): Hard-rejected results (scored `-inf`) are now treated as invalid and never returned, even if they complete first — guards against a bad-but-fast result winning by default
- **Context bounding** (`chat/context_manager.py`): `bound_summary_context()` trims accreted summary context with a `TRIMMED

https://claude.ai/code/session_01SMRUqEUViHv75a7Xns2AU1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic U.S. state and ASN detection when GeoIP data is available.
  * Added expandable alternate chat answers, preference feedback, and optional debugging views.
  * External model participation is now enabled by default and can be disabled.
* **Improvements**
  * Chat detects and recovers from repetitive responses.
  * Conversation summaries and stored history are bounded and better organized.
  * Internal context notes are hidden from user-facing history.
  * User messages are preserved more reliably during failures and replay.
* **Documentation**
  * Added setup, verification, security, and behavior guidance for GeoIP functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->