### PR TITLE
Add one-press Cofactor AI introduction flow from signup notification

### DIFF
--- a/fighthealthinsurance/proconnector.py
+++ b/fighthealthinsurance/proconnector.py
@@ -664,6 +664,46 @@ def processable_queryset() -> "QuerySet[InterestedProfessional]":
     )
 
 
+def quick_intro_block_reason(pro: InterestedProfessional) -> Optional[str]:
+    """Human-readable reason ``pro`` can't be introduced right now, or ``None``.
+
+    Gate for the one-press intro flow launched from the signup notification
+    email (see ``ProConnectorQuickIntroView``). ``None`` means the record is
+    claimable exactly as the main processing queue would see it; otherwise the
+    reason distinguishes the already-processed states from records the queue
+    filters out entirely, so the email button can never become a side door
+    around the queue's rules (an internal test account, an unsubscribed
+    professional, a double send).
+    """
+    if pro.proconnector_attempted:
+        if pro.proconnector_sent_at:
+            return (
+                "The Cofactor AI introduction was already sent on "
+                f"{pro.proconnector_sent_at:%Y-%m-%d}."
+            )
+        return (
+            "The Cofactor AI introduction was already queued to send during "
+            "business hours (or a send is in flight)."
+        )
+    if pro.proconnector_skipped:
+        reason = (pro.proconnector_skip_reason or "").strip()
+        suffix = f" (reason: {reason})" if reason else ""
+        return f"This record was skipped in the Pro Connector workflow{suffix}."
+    if pro.unsubscribed:
+        return (
+            "This professional has unsubscribed from Fight Health Insurance "
+            "emails, so the introduction cannot be sent."
+        )
+    # Attempted/skipped/unsubscribed are ruled out above, so the only way to
+    # miss the processable queryset now is the test/spam filtering.
+    if not processable_queryset().filter(pk=pro.pk).exists():
+        return (
+            "This signup is filtered out of pro-connector processing as a "
+            "test or spam address."
+        )
+    return None
+
+
 def get_next_interested_professional() -> Optional[InterestedProfessional]:
     """Next interested professional to process, or ``None``.
 

--- a/fighthealthinsurance/proconnector.py
+++ b/fighthealthinsurance/proconnector.py
@@ -679,7 +679,7 @@ def quick_intro_block_reason(pro: InterestedProfessional) -> Optional[str]:
         if pro.proconnector_sent_at:
             return (
                 "The Cofactor AI introduction was already sent on "
-                f"{pro.proconnector_sent_at:%Y-%m-%d}."
+                f"{timezone.localtime(pro.proconnector_sent_at):%Y-%m-%d}."
             )
         return (
             "The Cofactor AI introduction was already queued to send during "
@@ -694,9 +694,12 @@ def quick_intro_block_reason(pro: InterestedProfessional) -> Optional[str]:
             "This professional has unsubscribed from Fight Health Insurance "
             "emails, so the introduction cannot be sent."
         )
-    # Attempted/skipped/unsubscribed are ruled out above, so the only way to
-    # miss the processable queryset now is the test/spam filtering.
-    if not processable_queryset().filter(pk=pro.pk).exists():
+    # Probe exactly the test/spam filter (not the whole processable queryset,
+    # whose attempted/skipped/unsubscribed conditions re-test the instance
+    # flags above from the DB): a record claimed by a concurrent request
+    # between the instance load and this query must never be mislabeled as
+    # spam. The atomic claim in the send path remains the authority on races.
+    if not _exclude_filtered(InterestedProfessional.objects.filter(pk=pro.pk)).exists():
         return (
             "This signup is filtered out of pro-connector processing as a "
             "test or spam address."

--- a/fighthealthinsurance/staff_views.py
+++ b/fighthealthinsurance/staff_views.py
@@ -66,6 +66,7 @@ from fighthealthinsurance.proconnector import (
     release_email_claim,
     non_spam_interested_professionals,
     queue_proconnector_intro_email,
+    quick_intro_block_reason,
     subject_wording_problem,
     remaining_interested_professionals_count,
     send_proconnector_intro_email,
@@ -1421,6 +1422,155 @@ class ProConnectorLetterView(View):
             "today": timezone.now().date(),
         }
         return render(request, self.template_name, context)
+
+
+class ProConnectorQuickIntroView(View):
+    """One-press Cofactor AI introduction for a specific interested professional.
+
+    Linked (as a button) from the team notification email each new
+    interested-professional signup sends: staff press it, land here behind the
+    staff login, and confirm with a single press -- the intro email is drafted
+    automatically (AI-personalized, falling back to the approved base email)
+    and sent and recorded exactly like a send from the full processing
+    workflow (:class:`ProConnectorProcessView`). The GET only previews the
+    draft; the send itself is a POST, so mail scanners prefetching the email's
+    links can never trigger an introduction.
+
+    The same eligibility rules as the processing queue apply (see
+    :func:`quick_intro_block_reason`): an already-sent/queued/skipped record,
+    an unsubscribed professional, or a filtered test/spam signup gets a status
+    page instead of a send button, so the email link can't bypass the queue.
+    """
+
+    template_name = "proconnector_quick_intro.html"
+
+    def _render(
+        self,
+        request,
+        pro: InterestedProfessional,
+        *,
+        draft: Optional[str] = None,
+        error: Optional[str] = None,
+        notice: Optional[str] = None,
+        status: int = 200,
+    ) -> HttpResponse:
+        """Render the quick-intro page for ``pro``.
+
+        The AI draft is only generated when the record is actually sendable
+        (no block reason) and no ``draft`` was supplied -- re-renders after an
+        error preserve the posted body, and blocked records (including
+        just-sent ones) show their stored state instead of paying for a fresh
+        draft.
+        """
+        block_reason = quick_intro_block_reason(pro)
+        if draft is None and block_reason is None:
+            draft = generate_intro_email(pro)
+        context = {
+            "title": "Quick Cofactor AI Introduction",
+            "pro": pro,
+            "block_reason": block_reason,
+            "email_body": draft,
+            "subject": PROCONNECTOR_INTRO_SUBJECT,
+            "cc_emails": default_intro_cc_recipients(),
+            "cofactor_cc_email": get_cofactor_cc_email(),
+            "cofactor_cc_problem": cofactor_cc_problem(),
+            "contact_email": get_professional_cc_email(),
+            "error": error,
+            "notice": notice,
+            "send_window_hint": describe_send_window(pro.phone_number),
+        }
+        return render(request, self.template_name, context, status=status)
+
+    def get(self, request, pro_id: int) -> HttpResponse:
+        pro = InterestedProfessional.objects.filter(pk=pro_id).first()
+        if pro is None:
+            # Bad / stale id (deleted record, hand-edited URL). Send staff to
+            # the processing queue rather than 404 on a link from an email.
+            return redirect("proconnector_process")
+        return self._render(request, pro)
+
+    def post(self, request, pro_id: int) -> HttpResponse:
+        pro = InterestedProfessional.objects.filter(pk=pro_id).first()
+        if pro is None:
+            return redirect("proconnector_process")
+        action = request.POST.get("action") or "send"
+        if action not in ("send", "queue"):
+            return self._render(
+                request,
+                pro,
+                draft=(request.POST.get("email_body") or "").strip() or None,
+                error="Unknown action.",
+                status=400,
+            )
+        if quick_intro_block_reason(pro) is not None:
+            # Already handled (double press, another session, an unsubscribe)
+            # or filtered; the render shows the reason instead of a button.
+            # claim_email_for_send below re-checks atomically -- this is UX.
+            return self._render(request, pro)
+        # The previewed draft round-trips through the (editable) form so what
+        # was shown is exactly what is sent; a missing body (a direct POST) is
+        # drafted automatically, which is always safe -- generate_intro_email
+        # output is validated with fallback to the approved base email.
+        body = (request.POST.get("email_body") or "").strip()
+        if not body:
+            body = generate_intro_email(pro)
+        subject = PROCONNECTOR_INTRO_SUBJECT
+        error = ProConnectorProcessView._intro_form_problem(body, subject)
+        if error is None and not is_sendable_email(pro.email):
+            error = f"{pro.email} is not a sendable address; cannot send."
+        if error is None:
+            error = cofactor_cc_problem()
+        if error:
+            return self._render(request, pro, draft=body, error=error, status=400)
+
+        dispatch: Dict[
+            str, Tuple[Callable[..., Any], Callable[[str, str], int], str]
+        ] = {
+            "send": (send_proconnector_intro_email, mark_email_sent, "sent"),
+            "queue": (queue_proconnector_intro_email, mark_email_queued, "queued"),
+        }
+        deliver, mark, verb = dispatch[action]
+        # Atomically claim the address (shared with the processing workflow) so
+        # a double press here, or a concurrent send from the queue view, can
+        # never double-introduce; losing the claim means someone else just
+        # handled it, and the re-render's block reason says so.
+        if claim_email_for_send(pro.email) == 0:
+            pro.refresh_from_db()
+            return self._render(request, pro)
+        try:
+            deliver(pro, subject=subject, body=body)
+        except Exception as e:
+            logger.opt(exception=True).error(
+                f"Failed to {action} quick pro-connector intro to "
+                f"{mask_email_for_logging(pro.email)}: {e}"
+            )
+            release_email_claim(pro.email)
+            return self._render(
+                request,
+                pro,
+                draft=body,
+                error=(
+                    f"Failed to {action} the email. The error has been "
+                    "logged; please try again."
+                ),
+                status=500,
+            )
+        mark(pro.email, body)
+        logger.info(
+            f"Staff user {request.user.username} {verb} pro-connector intro to "
+            f"InterestedProfessional {pro.id} ({mask_email_for_logging(pro.email)}) "
+            "via the quick-intro flow"
+        )
+        pro.refresh_from_db()
+        notice = (
+            f"Introduction sent to {pro.email}."
+            if verb == "sent"
+            else (
+                f"Introduction queued to send to {pro.email} during their "
+                "likely business hours."
+            )
+        )
+        return self._render(request, pro, draft=body, notice=notice)
 
 
 class _CSVEcho:

--- a/fighthealthinsurance/staff_views.py
+++ b/fighthealthinsurance/staff_views.py
@@ -1092,6 +1092,23 @@ class ModelBackendStatusView(generic.TemplateView):
         return last
 
 
+def _intro_action_dispatch() -> (
+    Dict[str, Tuple[Callable[..., Any], Callable[[str, str], int], str]]
+):
+    """Send/queue dispatch shared by the pro-connector intro flows.
+
+    Maps each accepted action to (deliver-now-or-enqueue helper, matching
+    per-email mark helper, past-tense verb for logs/notices). One table so the
+    full processing workflow and the quick-intro view can never disagree about
+    what an action does. Built at call time, not import time, so tests (and
+    anything else) patching this module's helper names still take effect.
+    """
+    return {
+        "send": (send_proconnector_intro_email, mark_email_sent, "sent"),
+        "queue": (queue_proconnector_intro_email, mark_email_queued, "queued"),
+    }
+
+
 class ProConnectorProcessView(View):
     """Staff workflow to introduce interested professionals to Cofactor AI.
 
@@ -1215,17 +1232,12 @@ class ProConnectorProcessView(View):
 
         # "send" delivers now; "queue" defers to the recipient's likely business
         # hours. They share validation and edit-preserving error handling.
-        if action in ("send", "queue"):
+        dispatch = _intro_action_dispatch()
+        if action in dispatch:
             validated = self._validated_intro(request, pro)
             if isinstance(validated, HttpResponse):
                 return validated
             body, subject, skip_reason = validated
-            dispatch: Dict[
-                str, Tuple[Callable[..., Any], Callable[[str, str], int], str]
-            ] = {
-                "send": (send_proconnector_intro_email, mark_email_sent, "sent"),
-                "queue": (queue_proconnector_intro_email, mark_email_queued, "queued"),
-            }
             deliver, mark, verb = dispatch[action]
             failed_msg = f"Failed to {action} the email."
             # Atomically claim the address before sending. Two staff sessions are
@@ -1300,15 +1312,7 @@ class ProConnectorProcessView(View):
             request.POST.get("subject") or ""
         ).strip() or PROCONNECTOR_INTRO_SUBJECT
         skip_reason = (request.POST.get("skip_reason") or "").strip()
-        error = self._intro_form_problem(body, subject)
-        if error is None and not is_sendable_email(pro.email):
-            error = f"{pro.email} is not a sendable address; cannot send."
-        # A misconfigured Cofactor CC makes the send helpers raise. Catch it here
-        # -- before the record is claimed -- so staff get the actual reason instead
-        # of a generic failure, and the record stays in the queue for a retry once
-        # the setting is fixed.
-        if error is None:
-            error = cofactor_cc_problem()
+        error = _intro_send_problem(pro, body, subject)
         if error:
             return self._render_record(
                 request,
@@ -1393,6 +1397,29 @@ class ProConnectorProcessView(View):
         )
 
 
+def _intro_send_problem(
+    pro: InterestedProfessional, body: str, subject: str
+) -> Optional[str]:
+    """First problem blocking a *real* send/queue of the intro to ``pro``, or
+    ``None``.
+
+    The full pre-claim validation chain shared by every real-send path (the
+    processing workflow's ``_validated_intro`` and the quick-intro view), so a
+    rule added for one can never silently miss the other: the editable-field
+    rules (:meth:`ProConnectorProcessView._intro_form_problem`), then the
+    recipient being sendable, then the Cofactor CC configuration -- the latter
+    because a misconfigured CC makes the send helpers raise, and checking
+    before the record is claimed means staff see the actual reason and the
+    record stays in the queue for a retry once the setting is fixed.
+    """
+    problem = ProConnectorProcessView._intro_form_problem(body, subject)
+    if problem is not None:
+        return problem
+    if not is_sendable_email(pro.email):
+        return f"{pro.email} is not a sendable address; cannot send."
+    return cofactor_cc_problem()
+
+
 class ProConnectorLetterView(View):
     """Print-friendly physical intro letter for an interested professional.
 
@@ -1472,9 +1499,7 @@ class ProConnectorQuickIntroView(View):
             "email_body": draft,
             "subject": PROCONNECTOR_INTRO_SUBJECT,
             "cc_emails": default_intro_cc_recipients(),
-            "cofactor_cc_email": get_cofactor_cc_email(),
             "cofactor_cc_problem": cofactor_cc_problem(),
-            "contact_email": get_professional_cc_email(),
             "error": error,
             "notice": notice,
             "send_window_hint": describe_send_window(pro.phone_number),
@@ -1493,50 +1518,52 @@ class ProConnectorQuickIntroView(View):
         pro = InterestedProfessional.objects.filter(pk=pro_id).first()
         if pro is None:
             return redirect("proconnector_process")
-        action = request.POST.get("action") or "send"
-        if action not in ("send", "queue"):
+        action = request.POST.get("action")
+        body = (request.POST.get("email_body") or "").strip()
+        dispatch = _intro_action_dispatch()
+        if action not in dispatch:
+            # No default action: a POST that lost the submit button's value (a
+            # scripted form.submit(), a mangled resubmission) must fail safe,
+            # never fall through to an irreversible send.
             return self._render(
-                request,
-                pro,
-                draft=(request.POST.get("email_body") or "").strip() or None,
-                error="Unknown action.",
-                status=400,
+                request, pro, draft=body, error="Unknown action.", status=400
             )
         if quick_intro_block_reason(pro) is not None:
             # Already handled (double press, another session, an unsubscribe)
             # or filtered; the render shows the reason instead of a button.
             # claim_email_for_send below re-checks atomically -- this is UX.
             return self._render(request, pro)
-        # The previewed draft round-trips through the (editable) form so what
-        # was shown is exactly what is sent; a missing body (a direct POST) is
-        # drafted automatically, which is always safe -- generate_intro_email
-        # output is validated with fallback to the approved base email.
-        body = (request.POST.get("email_body") or "").strip()
-        if not body:
-            body = generate_intro_email(pro)
+        # The previewed draft round-trips through the (editable) form, so what
+        # was shown (or hand-edited) is exactly what is sent. An empty body is
+        # rejected like the full workflow's -- never auto-drafted -- so content
+        # nobody reviewed can never go out.
         subject = PROCONNECTOR_INTRO_SUBJECT
-        error = ProConnectorProcessView._intro_form_problem(body, subject)
-        if error is None and not is_sendable_email(pro.email):
-            error = f"{pro.email} is not a sendable address; cannot send."
-        if error is None:
-            error = cofactor_cc_problem()
+        error = _intro_send_problem(pro, body, subject)
         if error:
             return self._render(request, pro, draft=body, error=error, status=400)
 
-        dispatch: Dict[
-            str, Tuple[Callable[..., Any], Callable[[str, str], int], str]
-        ] = {
-            "send": (send_proconnector_intro_email, mark_email_sent, "sent"),
-            "queue": (queue_proconnector_intro_email, mark_email_queued, "queued"),
-        }
         deliver, mark, verb = dispatch[action]
         # Atomically claim the address (shared with the processing workflow) so
         # a double press here, or a concurrent send from the queue view, can
         # never double-introduce; losing the claim means someone else just
-        # handled it, and the re-render's block reason says so.
+        # handled it.
         if claim_email_for_send(pro.email) == 0:
-            pro.refresh_from_db()
-            return self._render(request, pro)
+            # Re-fetch for the freshest state; the notice tells staff this
+            # press did nothing even in the narrow race where the competing
+            # send failed and released the claim (block reason gone again).
+            pro = InterestedProfessional.objects.filter(pk=pro_id).first()
+            if pro is None:
+                return redirect("proconnector_process")
+            return self._render(
+                request,
+                pro,
+                draft=body,
+                notice=(
+                    "This press made no changes -- the record was just "
+                    "handled in another session. Its current state is shown "
+                    "below."
+                ),
+            )
         try:
             deliver(pro, subject=subject, body=body)
         except Exception as e:
@@ -1561,16 +1588,20 @@ class ProConnectorQuickIntroView(View):
             f"InterestedProfessional {pro.id} ({mask_email_for_logging(pro.email)}) "
             "via the quick-intro flow"
         )
-        pro.refresh_from_db()
+        # Re-fetch rather than refresh_from_db(): a concurrent delete of the
+        # record must not 500 after an email that already went out.
+        pro = InterestedProfessional.objects.filter(pk=pro_id).first()
+        if pro is None:
+            return redirect("proconnector_process")
         notice = (
             f"Introduction sent to {pro.email}."
-            if verb == "sent"
+            if action == "send"
             else (
                 f"Introduction queued to send to {pro.email} during their "
                 "likely business hours."
             )
         )
-        return self._render(request, pro, draft=body, notice=notice)
+        return self._render(request, pro, notice=notice)
 
 
 class _CSVEcho:

--- a/fighthealthinsurance/templates/proconnector_quick_intro.html
+++ b/fighthealthinsurance/templates/proconnector_quick_intro.html
@@ -1,0 +1,222 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>{{ title|default:"Quick Cofactor AI Introduction" }}</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 20px;
+      background-color: #f5f5f5;
+    }
+    h1 {
+      color: #333;
+      border-bottom: 2px solid #007bff;
+      padding-bottom: 10px;
+    }
+    .card {
+      background: white;
+      padding: 20px;
+      border-radius: 8px;
+      margin-bottom: 20px;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    }
+    table.info {
+      width: 100%;
+      border-collapse: collapse;
+    }
+    table.info th, table.info td {
+      text-align: left;
+      padding: 6px 10px;
+      border-bottom: 1px solid #eee;
+      vertical-align: top;
+    }
+    table.info th {
+      width: 230px;
+      color: #555;
+      white-space: nowrap;
+    }
+    .muted { color: #999; font-style: italic; }
+    label { display: block; font-weight: bold; margin-top: 14px; color: #444; }
+    input[type=text], textarea {
+      width: 100%;
+      box-sizing: border-box;
+      padding: 8px;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      font-family: inherit;
+      font-size: 14px;
+    }
+    textarea { min-height: 360px; white-space: pre-wrap; }
+    .disclosure {
+      background: #fff8e1;
+      border: 1px solid #ffe0a3;
+      border-radius: 4px;
+      padding: 10px 14px;
+      margin: 14px 0;
+      font-size: 0.92em;
+      color: #6b4e00;
+    }
+    .blocked {
+      background: #e2e3e5;
+      border: 1px solid #c4c8cb;
+      border-radius: 4px;
+      padding: 12px 16px;
+      color: #41464b;
+    }
+    .actions { margin-top: 18px; display: flex; gap: 12px; }
+    button {
+      padding: 10px 18px;
+      border: none;
+      border-radius: 4px;
+      font-size: 15px;
+      cursor: pointer;
+    }
+    button.send { background-color: #28a745; color: white; }
+    button.send:hover { background-color: #218838; }
+    button.queue { background-color: #007bff; color: white; }
+    button.queue:hover { background-color: #0069d9; }
+    .send-window {
+      background: #e7f3ff;
+      border: 1px solid #b6d8ff;
+      border-radius: 4px;
+      padding: 8px 12px;
+      margin: 14px 0 0;
+      font-size: 0.9em;
+      color: #0b4f8a;
+    }
+    .error {
+      background: #f8d7da;
+      border: 1px solid #f5c2c7;
+      color: #842029;
+      padding: 12px 16px;
+      border-radius: 4px;
+      margin-bottom: 16px;
+    }
+    .notice {
+      background: #d1e7dd;
+      border: 1px solid #a3cfbb;
+      color: #0a3622;
+      padding: 12px 16px;
+      border-radius: 4px;
+      margin-bottom: 16px;
+    }
+    .hint {
+      font-size: 0.88em;
+      color: #555;
+      margin: 6px 0 0;
+    }
+    .sent-body {
+      background: #f8f9fa;
+      border: 1px solid #e0e0e0;
+      border-radius: 4px;
+      padding: 12px 14px;
+      white-space: pre-wrap;
+      font-size: 14px;
+    }
+    .readonly { color: #333; }
+    .back { display: inline-block; margin-top: 10px; margin-right: 16px; color: #007bff; }
+  </style>
+</head>
+<body>
+  <h1>{{ title|default:"Quick Cofactor AI Introduction" }}</h1>
+
+  {% if error %}
+    <div class="error">{{ error }}</div>
+  {% endif %}
+  {% if notice %}
+    <div class="notice">✅ {{ notice }}</div>
+  {% endif %}
+
+  <div class="card">
+    <h2>Signup #{{ pro.id }}</h2>
+    <table class="info">
+      <tr><th>Name</th><td>{% if pro.name %}{{ pro.name }}{% else %}<span class="muted">(none)</span>{% endif %}</td></tr>
+      <tr><th>Email</th><td>{{ pro.email }}</td></tr>
+      <tr><th>Organization</th><td>{% if pro.business_name %}{{ pro.business_name }}{% else %}<span class="muted">(none)</span>{% endif %}</td></tr>
+      <tr><th>Role / provider type</th><td>{% if pro.job_title_or_provider_type %}{{ pro.job_title_or_provider_type }}{% else %}<span class="muted">(none)</span>{% endif %}</td></tr>
+      <tr><th>Most common denial / stated needs</th><td>{% if pro.most_common_denial %}{{ pro.most_common_denial }}{% else %}<span class="muted">(none)</span>{% endif %}</td></tr>
+      <tr><th>Notes / comments</th><td>{% if pro.comments %}{{ pro.comments }}{% else %}<span class="muted">(none)</span>{% endif %}</td></tr>
+      <tr><th>Phone number</th><td>{% if pro.phone_number %}{{ pro.phone_number }}{% else %}<span class="muted">(none)</span>{% endif %}</td></tr>
+      <tr><th>Signup / created date</th><td>{{ pro.signup_date }}</td></tr>
+    </table>
+  </div>
+
+  {% if block_reason %}
+    <div class="card">
+      <div class="blocked">ℹ️ {{ block_reason }}</div>
+      {% if pro.proconnector_email_body %}
+        <label>Introduction email on record</label>
+        <div class="sent-body">{{ pro.proconnector_email_body }}</div>
+      {% endif %}
+    </div>
+  {% else %}
+    <div class="card">
+      <h2>Introduction email</h2>
+      <div class="disclosure">
+        This draft was generated automatically &mdash; press the button below
+        to send it as-is, or tweak it first. The email includes a
+        plain-language disclosure that FHI may receive compensation under our
+        sourcing agreement if the recipient chooses to work with Cofactor AI
+        &mdash; please keep that disclosure in the email. Cofactor AI is
+        described as a sourcing agreement, not a partnership.
+      </div>
+
+      <form method="post">
+        {% csrf_token %}
+
+        <label>To</label>
+        <input type="text" class="readonly" value="{{ pro.email }}" readonly>
+
+        <label>CC</label>
+        <input type="text" class="readonly" value="{{ cc_emails|join:', ' }}" readonly>
+        {% if cofactor_cc_problem %}
+          <p class="error">⚠️ {{ cofactor_cc_problem }}</p>
+        {% endif %}
+
+        <label>Subject</label>
+        <input type="text" class="readonly" value="{{ subject }}" readonly>
+
+        <label for="email_body">Email body (editable)</label>
+        <textarea id="email_body" name="email_body">{{ email_body }}</textarea>
+
+        {% if send_window_hint %}
+          <p class="send-window">⏰ {{ send_window_hint }}</p>
+        {% endif %}
+
+        <div class="actions">
+          <button type="submit" class="send" name="action" value="send">Send intro email now</button>
+          <button type="submit" class="queue" name="action" value="queue">Send during business hours</button>
+        </div>
+        <p class="hint">
+          To research the professional first, edit further, send a test copy,
+          or skip the record, use the full
+          <a href="{% url 'proconnector_process' %}">Pro Connector workflow</a>.
+        </p>
+      </form>
+    </div>
+  {% endif %}
+
+  <a class="back" href="{% url 'proconnector_process' %}">&larr; Pro Connector queue</a>
+  <a class="back" href="{% url 'staff_dashboard' %}">&larr; Staff dashboard</a>
+
+  <script>
+    // Guard against a double-click / double-submit sending the intro twice.
+    // We only block a second submit of the same form; the first submit (with
+    // the clicked button's action) goes through normally.
+    (function () {
+      var form = document.querySelector("form");
+      if (!form) return;
+      var submitted = false;
+      form.addEventListener("submit", function (e) {
+        if (submitted) {
+          e.preventDefault();
+          return;
+        }
+        submitted = true;
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/fighthealthinsurance/urls.py
+++ b/fighthealthinsurance/urls.py
@@ -144,6 +144,11 @@ urlpatterns: List[Union[URLPattern, URLResolver]] = [
         name="proconnector_letter",
     ),
     path(
+        "timbit/help/proconnector/<int:pro_id>/intro",
+        staff_member_required(staff_views.ProConnectorQuickIntroView.as_view()),
+        name="proconnector_quick_intro",
+    ),
+    path(
         "timbit/help/proconnector_extract.csv",
         staff_member_required(staff_views.ProConnectorExtractCSVView.as_view()),
         name="proconnector_extract_csv",

--- a/fighthealthinsurance/utils.py
+++ b/fighthealthinsurance/utils.py
@@ -41,6 +41,7 @@ from django.core.mail import EmailMultiAlternatives, send_mail
 from django.db.models import ForeignKey, Model
 from django.template.loader import render_to_string
 from django.urls import reverse
+from django.utils.html import format_html, format_html_join
 
 if TYPE_CHECKING:
     from fighthealthinsurance.models import InterestedProfessional
@@ -555,15 +556,18 @@ def send_fallback_email(
         pass
 
 
-def notify_professional_signup(subject: str, body: str) -> None:
+def notify_professional_signup(
+    subject: str, body: str, html_body: Optional[str] = None
+) -> None:
     """Send a best-effort team notification about a new professional signup.
 
     Shared by the web /pro_version interest form and the Fight Paperwork REST
     professional sign-up endpoint. Recipients default to
     support42@fighthealthinsurance.com and professional@fighthealthinsurance.com
-    and can be extended via settings.PROFESSIONAL_SIGNUP_NOTIFICATION_EMAILS. A
-    mail failure is logged and swallowed so it never breaks the signup it is
-    reporting on.
+    and can be extended via settings.PROFESSIONAL_SIGNUP_NOTIFICATION_EMAILS.
+    ``html_body``, when given, is attached as an HTML alternative (used for the
+    one-press Cofactor-intro button). A mail failure is logged and swallowed so
+    it never breaks the signup it is reporting on.
     """
     recipients = list(
         getattr(
@@ -578,7 +582,13 @@ def notify_professional_signup(subject: str, body: str) -> None:
     if not recipients:
         return
     try:
-        send_mail(subject, body, settings.DEFAULT_FROM_EMAIL, recipients)
+        send_mail(
+            subject,
+            body,
+            settings.DEFAULT_FROM_EMAIL,
+            recipients,
+            html_message=html_body,
+        )
     except Exception:
         # Don't interpolate `subject`/`body`: for REST signups the subject
         # embeds the professional's email and the body is full of PII. The
@@ -621,6 +631,51 @@ def should_notify_returning_lead(email: str) -> bool:
         return True
 
 
+def _interested_professional_notification_html(
+    *,
+    source: str,
+    rows: Sequence[Tuple[str, str]],
+    intro_url: str,
+    admin_url: str,
+) -> str:
+    """HTML alternative for the professional-interest team notification.
+
+    Same information as the plain-text body plus a one-press button opening
+    the staff quick-intro page for this signup, where a single press sends the
+    Cofactor AI introduction (the page sits behind the staff login and the
+    send itself is a POST there, so a mail scanner prefetching the link can
+    never trigger it). Every row value comes from the public, unauthenticated
+    signup form, so everything is interpolated via format_html and escaped.
+    """
+    rows_html = format_html_join(
+        "",
+        '<tr><th align="left" style="padding: 4px 12px 4px 0; color: #555555; '
+        'vertical-align: top; white-space: nowrap;">{}</th>'
+        '<td style="padding: 4px 0;">{}</td></tr>',
+        rows,
+    )
+    return format_html(
+        '<div style="font-family: Arial, sans-serif; font-size: 14px; color: #222222;">'
+        "<p>A new professional signed up via {source}.</p>"
+        '<table style="border-collapse: collapse;">{rows}</table>'
+        '<p style="margin: 18px 0;">'
+        '<a href="{intro_url}" style="background-color: #28a745; color: #ffffff; '
+        "padding: 10px 18px; border-radius: 4px; text-decoration: none; "
+        'font-weight: bold; display: inline-block;">'
+        "Send the Cofactor AI introduction</a></p>"
+        '<p style="color: #555555; font-size: 12px;">'
+        "The button opens the staff quick-intro page (staff login required) "
+        "with a ready-to-send draft; the introduction only goes out after you "
+        "confirm there.</p>"
+        '<p><a href="{admin_url}">Open in Django admin</a></p>'
+        "</div>",
+        source=source,
+        rows=rows_html,
+        intro_url=intro_url,
+        admin_url=admin_url,
+    )
+
+
 def notify_interested_professional(
     interested_pro: "InterestedProfessional", *, source: str, subject: str
 ) -> None:
@@ -628,7 +683,8 @@ def notify_interested_professional(
 
     Shared by the web /pro_version interest form and the Fight Paperwork REST
     interested-professional endpoint so both produce an identical inbox format
-    (the same field layout and admin deep-link). `source` names where the lead
+    (the same field layout, admin deep-link, and one-press Cofactor-intro
+    button — see ProConnectorQuickIntroView). `source` names where the lead
     came from (e.g. "/pro_version"); `subject` is the email subject. Best-effort:
     failures building (e.g. a missing admin URL) or sending the notification are
     logged, not raised, so they never fail the already-persisted lead.
@@ -639,17 +695,29 @@ def notify_interested_professional(
             args=[interested_pro.id],
         )
         admin_url = f"https://{settings.FIGHT_HEALTH_INSURANCE_DOMAIN}{admin_path}"
+        intro_path = reverse("proconnector_quick_intro", args=[interested_pro.id])
+        intro_url = f"https://{settings.FIGHT_HEALTH_INSURANCE_DOMAIN}{intro_path}"
+        rows = [
+            ("Name", interested_pro.name or "N/A"),
+            ("Email", interested_pro.email),
+            (
+                "Job title / provider type",
+                interested_pro.job_title_or_provider_type or "N/A",
+            ),
+            ("Business", interested_pro.business_name or "N/A"),
+            ("Phone", interested_pro.phone_number or "N/A"),
+            ("Address", interested_pro.address or "N/A"),
+            ("Most common denial", interested_pro.most_common_denial or "N/A"),
+            ("Comments", interested_pro.comments or "N/A"),
+        ]
         body = (
             f"A new professional signed up via {source}.\n\n"
-            f"Name: {interested_pro.name or 'N/A'}\n"
-            f"Email: {interested_pro.email}\n"
-            f"Job title / provider type: {interested_pro.job_title_or_provider_type or 'N/A'}\n"
-            f"Business: {interested_pro.business_name or 'N/A'}\n"
-            f"Phone: {interested_pro.phone_number or 'N/A'}\n"
-            f"Address: {interested_pro.address or 'N/A'}\n"
-            f"Most common denial: {interested_pro.most_common_denial or 'N/A'}\n"
-            f"Comments: {interested_pro.comments or 'N/A'}\n"
-            f"Admin: {admin_url}\n"
+            + "".join(f"{label}: {value}\n" for label, value in rows)
+            + f"Admin: {admin_url}\n"
+            + f"Send the Cofactor AI introduction (staff login): {intro_url}\n"
+        )
+        html_body = _interested_professional_notification_html(
+            source=source, rows=rows, intro_url=intro_url, admin_url=admin_url
         )
     except Exception:
         logger.opt(exception=True).error(
@@ -657,7 +725,7 @@ def notify_interested_professional(
             f"(interested_pro_id={interested_pro.id})"
         )
         return
-    notify_professional_signup(subject, body)
+    notify_professional_signup(subject, body, html_body=html_body)
 
 
 def get_unsubscribe_url(email: str) -> Optional[str]:

--- a/tests/sync/test_pro_version_signup.py
+++ b/tests/sync/test_pro_version_signup.py
@@ -31,9 +31,18 @@ class ProVersionSignupSuccessTest(TestCase):
         self.response = self.client.post(reverse("pro_version"), self.PAYLOAD)
         self.pro = InterestedProfessional.objects.get(email=self.PAYLOAD["email"])
 
-    def _team_email(self):
-        subject = f"New pro version signup #{self.pro.id}"
+    def _team_email(self, pro=None):
+        subject = f"New pro version signup #{(pro or self.pro).id}"
         return next(m for m in mail.outbox if m.subject == subject)
+
+    @staticmethod
+    def _team_email_html(email):
+        """The HTML alternative of a team notification email."""
+        return next(
+            content
+            for content, mimetype in email.alternatives
+            if mimetype == "text/html"
+        )
 
     def test_redirects_to_thankyou_page(self):
         self.assertRedirects(self.response, reverse("pro_version_thankyou"))
@@ -88,10 +97,7 @@ class ProVersionSignupSuccessTest(TestCase):
 
     def test_team_notification_html_renders_intro_button(self):
         # The HTML alternative renders the same link as a press-able button.
-        email = self._team_email()
-        html = next(
-            content for content, mimetype in email.alternatives if mimetype == "text/html"
-        )
+        html = self._team_email_html(self._team_email())
         self.assertIn(reverse("proconnector_quick_intro", args=[self.pro.id]), html)
         self.assertIn("Send the Cofactor AI introduction", html)
 
@@ -101,12 +107,7 @@ class ProVersionSignupSuccessTest(TestCase):
         payload["name"] = 'Jane <img src=x onerror="alert(1)">'
         self.client.post(reverse("pro_version"), payload)
         pro = InterestedProfessional.objects.get(email="mallory@clinic.example")
-        notification = next(
-            m for m in mail.outbox if m.subject == f"New pro version signup #{pro.id}"
-        )
-        html = next(
-            content for content, mimetype in notification.alternatives if mimetype == "text/html"
-        )
+        html = self._team_email_html(self._team_email(pro=pro))
         self.assertNotIn("<img src=x", html)
         self.assertIn("Jane &lt;img src=x", html)
 

--- a/tests/sync/test_pro_version_signup.py
+++ b/tests/sync/test_pro_version_signup.py
@@ -80,6 +80,36 @@ class ProVersionSignupSuccessTest(TestCase):
             )
         )
 
+    def test_team_notification_includes_quick_intro_link(self):
+        # The body carries the one-press Cofactor-intro link so the team can
+        # do the introduction straight from the notification.
+        intro_path = reverse("proconnector_quick_intro", args=[self.pro.id])
+        self.assertIn(intro_path, self._team_email().body)
+
+    def test_team_notification_html_renders_intro_button(self):
+        # The HTML alternative renders the same link as a press-able button.
+        email = self._team_email()
+        html = next(
+            content for content, mimetype in email.alternatives if mimetype == "text/html"
+        )
+        self.assertIn(reverse("proconnector_quick_intro", args=[self.pro.id]), html)
+        self.assertIn("Send the Cofactor AI introduction", html)
+
+    def test_team_notification_html_escapes_submitted_fields(self):
+        # Every field comes from the public form; markup must arrive escaped.
+        payload = dict(self.PAYLOAD, email="mallory@clinic.example")
+        payload["name"] = 'Jane <img src=x onerror="alert(1)">'
+        self.client.post(reverse("pro_version"), payload)
+        pro = InterestedProfessional.objects.get(email="mallory@clinic.example")
+        notification = next(
+            m for m in mail.outbox if m.subject == f"New pro version signup #{pro.id}"
+        )
+        html = next(
+            content for content, mimetype in notification.alternatives if mimetype == "text/html"
+        )
+        self.assertNotIn("<img src=x", html)
+        self.assertIn("Jane &lt;img src=x", html)
+
 
 class ProVersionSignupInvalidSubmissionTest(TestCase):
     """A submission missing the required email is rejected, not saved.

--- a/tests/sync/test_proconnector.py
+++ b/tests/sync/test_proconnector.py
@@ -1855,24 +1855,94 @@ class QuickIntroSendTest(_QuickIntroTestCase):
         self.assertIsNotNone(pro.proconnector_sent_at)
         self.assertEqual(pro.proconnector_email_body, body)
 
-    @patch(
-        "fighthealthinsurance.staff_views.generate_intro_email",
-        return_value="Generated body with the compensation disclosure.",
-    )
+    @patch("fighthealthinsurance.staff_views.generate_intro_email")
     @patch("fighthealthinsurance.staff_views.send_proconnector_intro_email")
-    def test_missing_body_is_drafted_automatically(self, mock_send, mock_gen):
-        # A bare one-press POST (no previewed body round-tripped) drafts the
-        # email itself, so the flow stays fully automatic.
+    def test_empty_body_rejected_never_auto_drafted(self, mock_send, mock_gen):
+        # An emptied/missing body must be rejected like the full workflow --
+        # never silently replaced by a fresh AI draft nobody reviewed.
         pro = _make_pro(email="jane@janeclinic.com")
         response = self._post(pro.id, "send")
-        self.assertEqual(response.status_code, 200)
-        mock_gen.assert_called_once()
-        self.assertEqual(
-            mock_send.call_args.kwargs["body"],
-            "Generated body with the compensation disclosure.",
+        self.assertEqual(response.status_code, 400)
+        self.assertContains(response, "cannot be empty", status_code=400)
+        mock_gen.assert_not_called()
+        mock_send.assert_not_called()
+        pro.refresh_from_db()
+        self.assertFalse(pro.proconnector_attempted)
+
+    @patch("fighthealthinsurance.staff_views.generate_intro_email")
+    @patch("fighthealthinsurance.staff_views.send_proconnector_intro_email")
+    def test_missing_action_rejected(self, mock_send, mock_gen):
+        # A POST that lost the submit button's value (scripted form.submit(),
+        # mangled resubmission) must fail safe, not default to a real send.
+        pro = _make_pro(email="jane@janeclinic.com")
+        response = self.client.post(
+            self._url(pro.id),
+            {"email_body": "Body with compensation disclosure."},
         )
+        self.assertEqual(response.status_code, 400)
+        self.assertContains(response, "Unknown action", status_code=400)
+        mock_gen.assert_not_called()
+        mock_send.assert_not_called()
+        pro.refresh_from_db()
+        self.assertFalse(pro.proconnector_attempted)
+
+    @patch("fighthealthinsurance.staff_views.claim_email_for_send", return_value=0)
+    @patch("fighthealthinsurance.staff_views.send_proconnector_intro_email")
+    def test_lost_claim_explains_and_preserves_edits(self, mock_send, _mock_claim):
+        # Losing the atomic claim (another session just handled the record)
+        # must say so and keep the staff member's edits on the page, even in
+        # the race where the competing send failed and released the claim.
+        pro = _make_pro(email="race@clinic.org")
+        body = "Edited body with the compensation disclosure."
+        response = self._post(pro.id, "send", email_body=body)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "handled in another session")
+        self.assertContains(response, body)
+        mock_send.assert_not_called()
+
+    @patch(
+        "fighthealthinsurance.staff_views.mark_email_sent",
+        side_effect=RuntimeError("db down"),
+    )
+    @patch("fighthealthinsurance.staff_views.send_proconnector_intro_email")
+    def test_mark_failure_after_send_never_resends(self, mock_send, _mock_mark):
+        # If recording the send fails after the email went out, the claim must
+        # hold (fail safe against double-introducing): the record never
+        # resurfaces and a retry press is blocked instead of re-emailing.
+        pro = _make_pro(email="jane@janeclinic.com")
+        body = "Body with the compensation disclosure."
+        with self.assertRaises(RuntimeError):
+            self._post(pro.id, "send", email_body=body)
+        mock_send.assert_called_once()
         pro.refresh_from_db()
         self.assertTrue(pro.proconnector_attempted)
+        response = self._post(pro.id, "send", email_body=body)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "already queued")
+        mock_send.assert_called_once()  # still exactly one delivery
+
+    @patch("fighthealthinsurance.staff_views.send_proconnector_intro_email")
+    def test_concurrent_delete_after_send_redirects(self, mock_send):
+        # A record deleted mid-request (e.g. via the admin) must not 500 after
+        # an email that already went out; the view falls back to the queue.
+        pro = _make_pro(email="jane@janeclinic.com")
+
+        def _delete_rows(email, body):
+            return InterestedProfessional.objects.filter(email__iexact=email).delete()[
+                0
+            ]
+
+        with patch(
+            "fighthealthinsurance.staff_views.mark_email_sent",
+            side_effect=_delete_rows,
+        ):
+            response = self._post(
+                pro.id, "send", email_body="Body with compensation disclosure."
+            )
+        self.assertRedirects(
+            response, reverse("proconnector_process"), fetch_redirect_response=False
+        )
+        mock_send.assert_called_once()
 
     @patch("fighthealthinsurance.staff_views.send_proconnector_intro_email")
     def test_send_rejects_edit_missing_compensation(self, mock_send):
@@ -1958,12 +2028,11 @@ class QuickIntroSendTest(_QuickIntroTestCase):
         self.assertIsNone(pro.proconnector_sent_at)
         self.assertEqual(pro.proconnector_email_body, body)
 
-    @patch(
-        "fighthealthinsurance.staff_views.generate_intro_email",
-        return_value="A draft body with compensation disclosure.",
-    )
+    @patch("fighthealthinsurance.staff_views.generate_intro_email")
     @patch("fighthealthinsurance.staff_views.send_proconnector_intro_email")
-    def test_unknown_action_rejected(self, mock_send, _mock_gen):
+    def test_unknown_action_rejected(self, mock_send, mock_gen):
+        # The 400 re-render round-trips the posted body; it never pays for a
+        # fresh AI draft just to decorate an error page.
         pro = _make_pro(email="jane@janeclinic.com")
         response = self._post(
             pro.id, "explode", email_body="Body with compensation disclosure."
@@ -1971,6 +2040,7 @@ class QuickIntroSendTest(_QuickIntroTestCase):
         self.assertEqual(response.status_code, 400)
         self.assertContains(response, "Unknown action", status_code=400)
         mock_send.assert_not_called()
+        mock_gen.assert_not_called()
 
     @patch("fighthealthinsurance.staff_views.send_proconnector_intro_email")
     def test_missing_record_post_redirects_to_process(self, mock_send):

--- a/tests/sync/test_proconnector.py
+++ b/tests/sync/test_proconnector.py
@@ -34,6 +34,7 @@ from fighthealthinsurance.proconnector import (
     get_professional_cc_email,
     partner_framing_problem,
     queue_proconnector_intro_email,
+    quick_intro_block_reason,
     send_proconnector_test_email,
 )
 
@@ -1699,3 +1700,297 @@ class ProExtractCSVTest(TestCase):
             )
         self.assertEqual(_csv_safe("Dr. Jane"), "Dr. Jane")
         self.assertEqual(_csv_safe(None), "")
+
+
+# ---------------------------------------------------------------------------
+# Quick intro (one-press flow linked from the signup notification email)
+# ---------------------------------------------------------------------------
+class QuickIntroBlockReasonTest(TestCase):
+    def test_fresh_record_is_not_blocked(self):
+        self.assertIsNone(quick_intro_block_reason(_make_pro()))
+
+    def test_sent_record_reports_already_sent(self):
+        pro = _make_pro(proconnector_attempted=True)
+        InterestedProfessional.objects.filter(pk=pro.pk).update(
+            proconnector_sent_at=timezone.now()
+        )
+        pro.refresh_from_db()
+        self.assertIn("already sent", quick_intro_block_reason(pro))
+
+    def test_queued_record_reports_already_queued(self):
+        pro = _make_pro(proconnector_attempted=True)
+        self.assertIn("already queued", quick_intro_block_reason(pro))
+
+    def test_skipped_record_reports_reason(self):
+        pro = _make_pro(proconnector_skipped=True, proconnector_skip_reason="not a fit")
+        reason = quick_intro_block_reason(pro)
+        self.assertIn("skipped", reason)
+        self.assertIn("not a fit", reason)
+
+    def test_unsubscribed_record_is_blocked(self):
+        pro = _make_pro(unsubscribed=True)
+        self.assertIn("unsubscribed", quick_intro_block_reason(pro))
+
+    def test_filtered_test_signup_is_blocked(self):
+        pro = _make_pro(email="test@test.com")
+        self.assertIn("filtered", quick_intro_block_reason(pro))
+
+
+class QuickIntroAccessTest(TestCase):
+    def setUp(self):
+        self.pro = _make_pro(email="jane@janeclinic.com")
+        self.url = reverse("proconnector_quick_intro", args=[self.pro.id])
+
+    def test_anonymous_redirected_to_login(self):
+        response = self.client.get(self.url)
+        self.assertRedirects(
+            response,
+            f"{reverse('admin:login')}?next={self.url}",
+            fetch_redirect_response=False,
+        )
+
+    def test_non_staff_post_redirected_and_nothing_sent(self):
+        _login(self.client, is_staff=False)
+        response = self.client.post(self.url, {"action": "send"})
+        self.assertRedirects(
+            response,
+            f"{reverse('admin:login')}?next={self.url}",
+            fetch_redirect_response=False,
+        )
+        self.pro.refresh_from_db()
+        self.assertFalse(self.pro.proconnector_attempted)
+        self.assertEqual(len(mail.outbox), 0)
+
+
+class _QuickIntroTestCase(TestCase):
+    """Shared staff login and URL helpers for the quick-intro flow tests."""
+
+    def setUp(self):
+        _login(self.client, is_staff=True)
+
+    def _url(self, pro_id) -> str:
+        return reverse("proconnector_quick_intro", args=[pro_id])
+
+    def _post(self, pro_id, action="send", **fields):
+        return self.client.post(self._url(pro_id), {"action": action, **fields})
+
+
+class QuickIntroPageTest(_QuickIntroTestCase):
+    @patch(
+        "fighthealthinsurance.staff_views.generate_intro_email",
+        return_value="A draft body with compensation disclosure.",
+    )
+    def test_page_shows_draft_and_send_buttons(self, mock_gen):
+        pro = _make_pro(email="jane@janeclinic.com")
+        response = self.client.get(self._url(pro.id))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "proconnector_quick_intro.html")
+        self.assertContains(response, "jane@janeclinic.com")
+        self.assertContains(response, "A draft body with compensation disclosure.")
+        self.assertContains(response, "Send intro email now")
+        self.assertContains(response, "Send during business hours")
+        mock_gen.assert_called_once()
+
+    def test_missing_record_redirects_to_process(self):
+        response = self.client.get(self._url(999999))
+        self.assertRedirects(
+            response, reverse("proconnector_process"), fetch_redirect_response=False
+        )
+
+    def test_page_view_does_not_record_anything(self):
+        # Previewing (including by a link prefetcher with a staff session) must
+        # not claim / send / mark the record -- only the POST does.
+        pro = _make_pro(email="jane@janeclinic.com")
+        with patch(
+            "fighthealthinsurance.staff_views.generate_intro_email",
+            return_value="A draft body with compensation disclosure.",
+        ):
+            self.client.get(self._url(pro.id))
+        pro.refresh_from_db()
+        self.assertFalse(pro.proconnector_attempted)
+        self.assertEqual(len(mail.outbox), 0)
+
+    @patch("fighthealthinsurance.staff_views.generate_intro_email")
+    def test_already_sent_record_shows_status_without_drafting(self, mock_gen):
+        pro = _make_pro(email="done@janeclinic.com", proconnector_attempted=True)
+        InterestedProfessional.objects.filter(pk=pro.pk).update(
+            proconnector_sent_at=timezone.now(),
+            proconnector_email_body="The body that went out.",
+        )
+        response = self.client.get(self._url(pro.id))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "already sent")
+        # The stored audit body is shown instead of paying for a fresh draft.
+        self.assertContains(response, "The body that went out.")
+        self.assertNotContains(response, "Send intro email now")
+        mock_gen.assert_not_called()
+
+    @patch("fighthealthinsurance.staff_views.generate_intro_email")
+    def test_filtered_test_signup_shows_block_and_no_button(self, mock_gen):
+        pro = _make_pro(email="test@test.com")
+        response = self.client.get(self._url(pro.id))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "filtered")
+        self.assertNotContains(response, "Send intro email now")
+        mock_gen.assert_not_called()
+
+
+class QuickIntroSendTest(_QuickIntroTestCase):
+    @patch("fighthealthinsurance.staff_views.send_proconnector_intro_email")
+    def test_send_marks_record_and_confirms(self, mock_send):
+        pro = _make_pro(email="jane@janeclinic.com")
+        body = "Previewed body mentioning the compensation disclosure."
+        response = self._post(pro.id, "send", email_body=body)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Introduction sent to jane@janeclinic.com")
+
+        mock_send.assert_called_once()
+        args, kwargs = mock_send.call_args
+        self.assertEqual(args[0].pk, pro.pk)
+        self.assertEqual(kwargs["body"], body)
+        self.assertEqual(kwargs["subject"], proconnector.PROCONNECTOR_INTRO_SUBJECT)
+
+        pro.refresh_from_db()
+        self.assertTrue(pro.proconnector_attempted)
+        self.assertIsNotNone(pro.proconnector_sent_at)
+        self.assertEqual(pro.proconnector_email_body, body)
+
+    @patch(
+        "fighthealthinsurance.staff_views.generate_intro_email",
+        return_value="Generated body with the compensation disclosure.",
+    )
+    @patch("fighthealthinsurance.staff_views.send_proconnector_intro_email")
+    def test_missing_body_is_drafted_automatically(self, mock_send, mock_gen):
+        # A bare one-press POST (no previewed body round-tripped) drafts the
+        # email itself, so the flow stays fully automatic.
+        pro = _make_pro(email="jane@janeclinic.com")
+        response = self._post(pro.id, "send")
+        self.assertEqual(response.status_code, 200)
+        mock_gen.assert_called_once()
+        self.assertEqual(
+            mock_send.call_args.kwargs["body"],
+            "Generated body with the compensation disclosure.",
+        )
+        pro.refresh_from_db()
+        self.assertTrue(pro.proconnector_attempted)
+
+    @patch("fighthealthinsurance.staff_views.send_proconnector_intro_email")
+    def test_send_rejects_edit_missing_compensation(self, mock_send):
+        pro = _make_pro(email="jane@janeclinic.com")
+        response = self._post(
+            pro.id, "send", email_body="Hi, meet Cofactor AI. No disclosure here."
+        )
+        self.assertEqual(response.status_code, 400)
+        mock_send.assert_not_called()
+        pro.refresh_from_db()
+        self.assertFalse(pro.proconnector_attempted)
+
+    @patch("fighthealthinsurance.staff_views.send_proconnector_intro_email")
+    def test_send_to_unsendable_address_rejected(self, mock_send):
+        # example.com is a blocked domain -> not sendable.
+        pro = _make_pro(email="blocked@example.com")
+        response = self._post(
+            pro.id, "send", email_body="Body with compensation disclosure."
+        )
+        self.assertEqual(response.status_code, 400)
+        mock_send.assert_not_called()
+
+    @patch("fighthealthinsurance.staff_views.send_proconnector_intro_email")
+    def test_double_press_does_not_resend(self, mock_send):
+        pro = _make_pro(email="jane@janeclinic.com")
+        body = "Body with the compensation disclosure."
+        self._post(pro.id, "send", email_body=body)
+        response = self._post(pro.id, "send", email_body=body)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "already sent")
+        mock_send.assert_called_once()  # only the first press delivered
+
+    @patch("fighthealthinsurance.staff_views.send_proconnector_intro_email")
+    def test_unsubscribed_record_is_not_sent(self, mock_send):
+        pro = _make_pro(email="jane@janeclinic.com", unsubscribed=True)
+        response = self._post(
+            pro.id, "send", email_body="Body with compensation disclosure."
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "unsubscribed")
+        mock_send.assert_not_called()
+        pro.refresh_from_db()
+        self.assertFalse(pro.proconnector_attempted)
+
+    @patch("fighthealthinsurance.staff_views.send_proconnector_intro_email")
+    def test_filtered_test_signup_is_not_sent(self, mock_send):
+        # The email button must not become a side door around the queue's
+        # test/spam filtering (claim_email_for_send doesn't check it).
+        pro = _make_pro(email="test@test.com")
+        response = self._post(
+            pro.id, "send", email_body="Body with compensation disclosure."
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "filtered")
+        mock_send.assert_not_called()
+        pro.refresh_from_db()
+        self.assertFalse(pro.proconnector_attempted)
+
+    @patch(
+        "fighthealthinsurance.staff_views.send_proconnector_intro_email",
+        side_effect=RuntimeError("smtp down"),
+    )
+    def test_send_failure_releases_claim(self, _mock_send):
+        pro = _make_pro(email="jane@janeclinic.com")
+        response = self._post(
+            pro.id, "send", email_body="Body with compensation disclosure."
+        )
+        self.assertEqual(response.status_code, 500)
+        self.assertContains(response, "Failed to send", status_code=500)
+        pro.refresh_from_db()
+        self.assertFalse(pro.proconnector_attempted)  # back in the queue
+
+    @patch("fighthealthinsurance.staff_views.queue_proconnector_intro_email")
+    def test_queue_marks_attempted_without_sent_at(self, mock_queue):
+        pro = _make_pro(email="jane@janeclinic.com")
+        body = "Body with the compensation disclosure."
+        response = self._post(pro.id, "queue", email_body=body)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "business hours")
+        mock_queue.assert_called_once()
+        pro.refresh_from_db()
+        self.assertTrue(pro.proconnector_attempted)
+        self.assertIsNone(pro.proconnector_sent_at)
+        self.assertEqual(pro.proconnector_email_body, body)
+
+    @patch(
+        "fighthealthinsurance.staff_views.generate_intro_email",
+        return_value="A draft body with compensation disclosure.",
+    )
+    @patch("fighthealthinsurance.staff_views.send_proconnector_intro_email")
+    def test_unknown_action_rejected(self, mock_send, _mock_gen):
+        pro = _make_pro(email="jane@janeclinic.com")
+        response = self._post(
+            pro.id, "explode", email_body="Body with compensation disclosure."
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertContains(response, "Unknown action", status_code=400)
+        mock_send.assert_not_called()
+
+    @patch("fighthealthinsurance.staff_views.send_proconnector_intro_email")
+    def test_missing_record_post_redirects_to_process(self, mock_send):
+        response = self._post(999999, "send", email_body="x")
+        self.assertRedirects(
+            response, reverse("proconnector_process"), fetch_redirect_response=False
+        )
+        mock_send.assert_not_called()
+
+    @patch("fighthealthinsurance.staff_views.send_proconnector_intro_email")
+    def test_send_resolves_all_records_with_same_email(self, mock_send):
+        # Two signups share an email; one press marks both and emails once.
+        a = _make_pro(email="dup@clinic.org")
+        b = _make_pro(email="dup@clinic.org")
+        response = self._post(
+            a.id, "send", email_body="Body with the compensation disclosure."
+        )
+        self.assertEqual(response.status_code, 200)
+        mock_send.assert_called_once()
+        for rec in (a, b):
+            rec.refresh_from_db()
+            self.assertTrue(rec.proconnector_attempted)
+        self.assertIsNone(get_next_interested_professional())

--- a/tests/sync/test_proconnector.py
+++ b/tests/sync/test_proconnector.py
@@ -1921,6 +1921,27 @@ class QuickIntroSendTest(_QuickIntroTestCase):
         self.assertContains(response, "already queued")
         mock_send.assert_called_once()  # still exactly one delivery
 
+    @patch(
+        "fighthealthinsurance.staff_views.mark_email_queued",
+        side_effect=RuntimeError("db down"),
+    )
+    @patch("fighthealthinsurance.staff_views.queue_proconnector_intro_email")
+    def test_mark_failure_after_queue_never_requeues(self, mock_queue, _mock_mark):
+        # The queue-path twin of the send test above: if recording fails after
+        # the intro was handed to the business-hours queue, the claim must
+        # hold so a retry press cannot enqueue a second introduction.
+        pro = _make_pro(email="jane@janeclinic.com")
+        body = "Body with the compensation disclosure."
+        with self.assertRaises(RuntimeError):
+            self._post(pro.id, "queue", email_body=body)
+        mock_queue.assert_called_once()
+        pro.refresh_from_db()
+        self.assertTrue(pro.proconnector_attempted)
+        response = self._post(pro.id, "queue", email_body=body)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "already queued")
+        mock_queue.assert_called_once()  # still exactly one enqueue
+
     @patch("fighthealthinsurance.staff_views.send_proconnector_intro_email")
     def test_concurrent_delete_after_send_redirects(self, mock_send):
         # A record deleted mid-request (e.g. via the admin) must not 500 after


### PR DESCRIPTION
## Summary

Adds a new quick-intro workflow that allows staff to send a Cofactor AI introduction email to interested professionals with a single click from the signup notification email. The feature includes a dedicated view, template, and eligibility checks to ensure the email button cannot bypass the queue's filtering rules.

## Key Changes

- **New `ProConnectorQuickIntroView`** (`staff_views.py`): Implements the one-press intro flow behind staff login. GET previews the AI-drafted email; POST sends it immediately or queues it for business hours. Shares the same eligibility rules and atomic claiming mechanism as the main processing queue to prevent double-sends and filter bypasses.

- **New `quick_intro_block_reason()` function** (`proconnector.py`): Gate function that returns a human-readable reason why a record can't be introduced (already sent/queued/skipped, unsubscribed, or filtered as test/spam), or `None` if sendable. Ensures the email button respects all queue filtering.

- **New `proconnector_quick_intro.html` template**: Staff-facing page showing signup details, an editable email draft (auto-generated via AI), and two action buttons: "Send intro email now" (immediate) and "Send during business hours" (queued). Blocked records show their status instead of send buttons. Includes client-side double-submit protection.

- **Enhanced team notification** (`utils.py`): 
  - `notify_interested_professional()` now generates an HTML alternative with a prominent "Send the Cofactor AI introduction" button linking to the quick-intro page
  - New `_interested_professional_notification_html()` helper renders the HTML with proper escaping of all user-submitted fields
  - `notify_professional_signup()` accepts optional `html_body` parameter for HTML alternatives

- **New URL route** (`urls.py`): Added `proconnector_quick_intro` path for the quick-intro view.

- **Comprehensive test coverage** (`test_proconnector.py`, `test_pro_version_signup.py`):
  - `QuickIntroBlockReasonTest`: Validates eligibility checks for all blocking conditions
  - `QuickIntroAccessTest`: Verifies staff-only access and login requirements
  - `QuickIntroPageTest`: Tests GET rendering, draft generation, and blocked-record handling
  - `QuickIntroSendTest`: Tests POST actions (send/queue), validation, double-press protection, and error handling
  - Pro version signup tests verify the HTML notification includes the intro button and properly escapes user input

## Implementation Details

- The quick-intro flow uses the same `claim_email_for_send()` atomic claiming mechanism as the main queue, preventing concurrent double-sends even across views
- AI draft generation only happens when the record is sendable and no draft was posted (re-renders after errors preserve the user's edits)
- Already-sent records show their stored email body instead of paying for a fresh draft
- The send itself is a POST (not a GET), so mail scanner link prefetching cannot trigger an introduction
- All user-submitted fields in the HTML notification are escaped via `format_html` to prevent XSS
- Validation ensures the compensation disclosure is present in any edited email body before sending

https://claude.ai/code/session_01R9CbUGtA78mBb8GbHMGspK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a staff-only quick-introduction workflow for eligible professionals.
  - Preview, edit, send, or queue introduction emails with recipient, CC, subject, and disclosure details.
  - Added quick-introduction links and HTML buttons to signup notifications.

- **Bug Fixes**
  - Prevented empty submissions from triggering automatic email generation.
  - Improved duplicate-processing, concurrent-record, delivery, and failure handling.
  - Escaped notification fields to prevent markup injection and formatted dates in local time.

- **Tests**
  - Added coverage for access control, validation, notifications, sending, queuing, and race conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->