### PR TITLE
Improve Medicaid eligibility flow: fix checker stalls, chat guidance, landing page

### DIFF
--- a/fighthealthinsurance/chat/tools/medicaid_tool.py
+++ b/fighthealthinsurance/chat/tools/medicaid_tool.py
@@ -326,9 +326,11 @@ class MedicaidEligibilityTool(BaseTool):
                 "questions (no more than two or three per message, in the "
                 "order listed, rephrased naturally) or deliver the news of "
                 "our determination along with the alternatives. Don't re-ask "
-                "anything the user already answered. Always be careful to "
-                "indicate that this is an approximation and they should "
-                "contact the state to know for sure (you can use the "
+                "anything the user already answered. Always make it very "
+                "clear that this eligibility check is an EXPERIMENTAL "
+                "feature and only an approximation -- it can be wrong or "
+                "out of date -- and they must contact the state to know for "
+                "sure (you can use the "
                 "medicaid_info tool call to get state-specific contact info "
                 "to provide to the user). If the 2026 work requirement is "
                 "the barrier, suggest ways to reach 80 qualifying hours a "
@@ -411,7 +413,9 @@ class MedicaidEligibilityTool(BaseTool):
         """
         parts: List[str] = [
             "We're helping figure out if someone is likely eligible for "
-            "Medicaid. Be clear this is an approximation and they'll need "
+            "Medicaid using our EXPERIMENTAL eligibility checker. Be very "
+            "clear with the user that this is an experimental feature that "
+            "can be wrong: it only gives an approximation, and they'll need "
             "to confirm with the state to be sure."
         ]
 

--- a/fighthealthinsurance/chat/tools/medicaid_tool.py
+++ b/fighthealthinsurance/chat/tools/medicaid_tool.py
@@ -486,6 +486,10 @@ class MedicaidEligibilityTool(BaseTool):
             medicare: Whether eligible for Medicare
             alternatives: List of alternative suggestions
             missing: List of missing-information questions still to ask
+            determination_made: False when the checker could not score this
+                person at all (a US territory, or a required answer they
+                declined). A False here must never be rendered as an
+                ineligibility verdict -- that is the whole point of the flag.
 
         Returns:
             Formatted information text

--- a/fighthealthinsurance/chat/tools/medicaid_tool.py
+++ b/fighthealthinsurance/chat/tools/medicaid_tool.py
@@ -178,10 +178,12 @@ class MedicaidInfoTool(BaseTool):
                 await self.send_status_message(
                     "Need the user's state before looking up Medicaid info."
                 )
+                # BaseTool.handle propagates this as the assistant's reply,
+                # so it has to read as something we'd say to the user, not as
+                # an instruction addressed to the model.
                 return (
-                    "Ask the user which state they're in (or confirm it if "
-                    "they already said) so we can look up their state's "
-                    "Medicaid contact info.",
+                    "Which state are you in? I need it to look up your "
+                    "state's Medicaid contact information.",
                     context,
                 )
 
@@ -330,10 +332,16 @@ class MedicaidEligibilityTool(BaseTool):
                 medicare,
                 alternatives,
                 missing,
+                determination_made,
             ) = is_eligible(**loaded)
 
             info_text = self._build_eligibility_info(
-                eligible_2025, eligible_2026, medicare, alternatives, missing
+                eligible_2025,
+                eligible_2026,
+                medicare,
+                alternatives,
+                missing,
+                determination_made,
             )
             if parsed_summary:
                 info_text += "\n\n" + parsed_summary
@@ -459,6 +467,7 @@ class MedicaidEligibilityTool(BaseTool):
         medicare: bool,
         alternatives: List[str],
         missing: List[str],
+        determination_made: bool = True,
     ) -> str:
         """
         Build the eligibility information text passed back to the LLM.
@@ -477,8 +486,9 @@ class MedicaidEligibilityTool(BaseTool):
         # One shared description of the 2026 rules so the eligible and
         # not-eligible wordings can't drift apart.
         work_req_note = (
-            " (which add the federal 80-hours-per-month "
-            "work/community-engagement requirement)"
+            " (once the federal 80-hours-per-month work/community-engagement "
+            "requirement applies to them — states must implement it by "
+            "January 1, 2027, a few earlier)"
         )
 
         parts: List[str] = [
@@ -513,6 +523,25 @@ class MedicaidEligibilityTool(BaseTool):
                 parts.append(
                     "Our data already suggests they may be eligible for medicare."
                 )
+        elif not determination_made:
+            # We could not score this person at all (a US territory, or a
+            # required answer they declined). Saying "may not be eligible"
+            # here would be a confident denial we never actually computed --
+            # and it would contradict the explanation in the alternatives.
+            parts.append(
+                "We could NOT produce a Medicaid estimate for this person — "
+                "do not tell them they may be ineligible. Explain that their "
+                "situation isn't something our checker can estimate and point "
+                "them at the next step below."
+            )
+            if medicare:
+                parts.append(
+                    "We were able to check Medicare, and our data suggests "
+                    "they may be eligible for it."
+                )
+            if len(alternatives) > 0:
+                alternative_lines = "\n".join(f"- {a}" for a in alternatives)
+                parts.append("Next steps to share:\n" + alternative_lines)
         else:
             for label, is_eligible_for_year, note in (
                 ("current (2025)", eligible_2025, ""),

--- a/fighthealthinsurance/chat/tools/medicaid_tool.py
+++ b/fighthealthinsurance/chat/tools/medicaid_tool.py
@@ -309,9 +309,20 @@ class MedicaidEligibilityTool(BaseTool):
 
         try:
             # Import here to avoid circular imports
-            from fighthealthinsurance.medicaid_api import is_eligible
+            from fighthealthinsurance.medicaid_api import (
+                is_eligible,
+                summarize_eligibility_inputs,
+            )
 
             await self.send_status_message("Processing Medicaid eligibility data")
+
+            # What we actually understood from the payload. The LLM parses
+            # the user's free text and carries the running answers in its
+            # own context, so it needs this echo to stay in sync with us --
+            # especially for values we normalized and keys we ignored.
+            parsed_summary = self._build_parsed_summary(
+                summarize_eligibility_inputs(loaded)
+            )
 
             (
                 eligible_2025,
@@ -324,6 +335,8 @@ class MedicaidEligibilityTool(BaseTool):
             info_text = self._build_eligibility_info(
                 eligible_2025, eligible_2026, medicare, alternatives, missing
             )
+            if parsed_summary:
+                info_text += "\n\n" + parsed_summary
 
             action_text = (
                 "\n\nUse this info to either ask the user the next follow-up "
@@ -392,6 +405,52 @@ class MedicaidEligibilityTool(BaseTool):
                 "Please contact your state for more info.",
                 context,
             )
+
+    def _build_parsed_summary(self, summary: dict) -> str:
+        """Tell the LLM what we recorded, ignored, and couldn't read.
+
+        Without this the model gets no feedback on its own parsing: an
+        unrecognized key (``income`` instead of ``monthly_income``) is
+        dropped silently, which is indistinguishable from being accepted, so
+        the model believes it answered and the same question comes back.
+        """
+        parts: List[str] = []
+
+        recorded = summary.get("recorded") or {}
+        if recorded:
+            lines = "\n".join(f"- {k}: {v}" for k, v in sorted(recorded.items()))
+            parts.append(
+                "This is what we have recorded so far — keep these in your "
+                "context and send them all back on the next call:\n" + lines
+            )
+
+        unrecognized = summary.get("unrecognized") or []
+        if unrecognized:
+            parts.append(
+                "We do NOT have a parameter named "
+                + ", ".join(sorted(unrecognized))
+                + " so those values were ignored. Re-send them under the "
+                "documented parameter names if they still apply."
+            )
+
+        unreadable = summary.get("unreadable") or []
+        if unreadable:
+            parts.append(
+                "We couldn't read the value given for "
+                + ", ".join(sorted(unreadable))
+                + ". Send a plain number, a JSON true/false, or a US state "
+                'name — or "unknown" if the user can\'t answer.'
+            )
+
+        declined = summary.get("declined") or []
+        if declined:
+            parts.append(
+                "The user couldn't answer "
+                + ", ".join(sorted(declined))
+                + " — don't ask about those again."
+            )
+
+        return "\n\n".join(parts)
 
     def _build_eligibility_info(
         self,

--- a/fighthealthinsurance/chat/tools/medicaid_tool.py
+++ b/fighthealthinsurance/chat/tools/medicaid_tool.py
@@ -172,12 +172,16 @@ class MedicaidInfoTool(BaseTool):
                 return cleaned_response, context
 
             else:
+                # get_medicaid_info returns None when it can't tell which
+                # state was meant -- ask, rather than guessing or reporting a
+                # successful lookup.
                 await self.send_status_message(
-                    "No Medicaid info found for the provided data."
+                    "Need the user's state before looking up Medicaid info."
                 )
                 return (
-                    "I couldn't find Medicaid information for the requested state. "
-                    "Please check the state name and try again.",
+                    "Ask the user which state they're in (or confirm it if "
+                    "they already said) so we can look up their state's "
+                    "Medicaid contact info.",
                     context,
                 )
 
@@ -411,6 +415,13 @@ class MedicaidEligibilityTool(BaseTool):
         Returns:
             Formatted information text
         """
+        # One shared description of the 2026 rules so the eligible and
+        # not-eligible wordings can't drift apart.
+        work_req_note = (
+            " (which add the federal 80-hours-per-month "
+            "work/community-engagement requirement)"
+        )
+
         parts: List[str] = [
             "We're helping figure out if someone is likely eligible for "
             "Medicaid using our EXPERIMENTAL eligibility checker. Be very "
@@ -427,41 +438,44 @@ class MedicaidEligibilityTool(BaseTool):
                 "time, in this order, rephrased naturally):\n"
                 f"{question_lines}"
             )
-        else:
+            # Report findings that are already settled. Withholding them
+            # until every question is answered meant a firm "yes, you look
+            # eligible" sat unsaid behind an unrelated follow-up. Only
+            # positives are reported here: a False at this stage means "not
+            # established yet", not "no".
             if eligible_2025:
                 parts.append(
-                    "Our data so far suggests they could be eligible for "
-                    "medicaid under the current (2025) rules."
+                    "Based on what we have so far they already look eligible "
+                    "for medicaid under the current (2025) rules -- you can "
+                    "share that, while noting the questions above are still "
+                    "needed to be sure."
                 )
-            else:
+            if medicare:
                 parts.append(
-                    "Our data so far suggests they may not be eligible for "
-                    "medicaid under the current (2025) rules."
+                    "Our data already suggests they may be eligible for medicare."
                 )
-
-            if eligible_2026:
+        else:
+            for label, is_eligible_for_year, note in (
+                ("current (2025)", eligible_2025, ""),
+                ("2026", eligible_2026, work_req_note),
+            ):
+                verdict = "could be" if is_eligible_for_year else "may not be"
                 parts.append(
-                    "Our data so far suggests they could be eligible for "
-                    "medicaid under the 2026 rules (which add the federal "
-                    "80-hours-per-month work/community-engagement "
-                    "requirement)."
-                )
-            else:
-                parts.append(
-                    "Our data so far suggests they may not be eligible for "
-                    "medicaid under the 2026 rules (which add the federal "
-                    "80-hours-per-month work/community-engagement "
-                    "requirement)."
+                    f"Our data so far suggests they {verdict} eligible for "
+                    f"medicaid under the {label} rules{note}."
                 )
 
             if medicare:
                 parts.append("Our data suggests they may be eligible for medicare.")
 
-        if len(alternatives) > 0:
-            alternative_lines = "\n".join(f"- {a}" for a in alternatives)
-            parts.append(
-                "Alternative programs and next steps worth mentioning:\n"
-                f"{alternative_lines}"
-            )
+            # Alternatives are next-steps for a finished determination (they
+            # include appeal-after-denial advice), so they'd be confusing
+            # mid-interview for someone who currently looks eligible.
+            if len(alternatives) > 0:
+                alternative_lines = "\n".join(f"- {a}" for a in alternatives)
+                parts.append(
+                    "Alternative programs and next steps worth mentioning:\n"
+                    f"{alternative_lines}"
+                )
 
         return "\n\n".join(parts)

--- a/fighthealthinsurance/chat/tools/medicaid_tool.py
+++ b/fighthealthinsurance/chat/tools/medicaid_tool.py
@@ -322,12 +322,20 @@ class MedicaidEligibilityTool(BaseTool):
             )
 
             action_text = (
-                "Use this info to ask the user any follow up questions or deliver "
-                "the news of our determiniation and alternatives. Always be careful "
-                "to indicate that this is an approximation and they should contact "
-                "the state to know for sure (you can use the state tool call to get "
-                "more info to provide to the user). Remember to use the panda emoji "
-                "and context."
+                "\n\nUse this info to either ask the user the next follow-up "
+                "questions (no more than two or three per message, in the "
+                "order listed, rephrased naturally) or deliver the news of "
+                "our determination along with the alternatives. Don't re-ask "
+                "anything the user already answered. Always be careful to "
+                "indicate that this is an approximation and they should "
+                "contact the state to know for sure (you can use the "
+                "medicaid_info tool call to get state-specific contact info "
+                "to provide to the user). If the 2026 work requirement is "
+                "the barrier, suggest ways to reach 80 qualifying hours a "
+                "month (work, school, volunteering, or caregiving) and "
+                "remind them to keep good records -- with empathy, since "
+                "this is stressful and unfair. Remember to use the panda "
+                "emoji and context."
             )
 
             await self.send_status_message("Formatting response...")
@@ -388,57 +396,68 @@ class MedicaidEligibilityTool(BaseTool):
         missing: List[str],
     ) -> str:
         """
-        Build the eligibility information text.
+        Build the eligibility information text passed back to the LLM.
 
         Args:
-            eligible_2025: Whether eligible under 2025 rules
-            eligible_2026: Whether eligible under 2026 rules
+            eligible_2025: Whether eligible under the 2025 rules
+            eligible_2026: Whether eligible under the 2026 rules (which add
+                the federal work/community-engagement requirement)
             medicare: Whether eligible for Medicare
             alternatives: List of alternative suggestions
-            missing: List of missing information needed
+            missing: List of missing-information questions still to ask
 
         Returns:
             Formatted information text
         """
-        info_text = (
-            "We're helping figure out if someone is likely eligible for Medicaid. "
-            "Be clear this is an approximation and they'll need to confirm with "
-            "the state to be sure."
-        )
+        parts: List[str] = [
+            "We're helping figure out if someone is likely eligible for "
+            "Medicaid. Be clear this is an approximation and they'll need "
+            "to confirm with the state to be sure."
+        ]
 
         if len(missing) > 0:
-            info_text += (
-                f"To figure out if they're eligible we have {missing} questions to ask."
+            question_lines = "\n".join(f"- {q}" for q in missing)
+            parts.append(
+                "We don't have enough information yet, so we have the "
+                "following questions to ask (ask only two or three at a "
+                "time, in this order, rephrased naturally):\n"
+                f"{question_lines}"
             )
         else:
             if eligible_2025:
-                info_text += (
-                    "Our data so far suggests they could be eligible for medicaid "
-                    "under the 2025 rules."
+                parts.append(
+                    "Our data so far suggests they could be eligible for "
+                    "medicaid under the current (2025) rules."
                 )
             else:
-                info_text += (
-                    "Our data so far suggests they may not be eligible for medicaid "
-                    "under the 2025 rules."
+                parts.append(
+                    "Our data so far suggests they may not be eligible for "
+                    "medicaid under the current (2025) rules."
                 )
 
             if eligible_2026:
-                info_text += (
-                    "Our data so far suggests they could be eligible for medicaid "
-                    "under the 2026 rules."
+                parts.append(
+                    "Our data so far suggests they could be eligible for "
+                    "medicaid under the 2026 rules (which add the federal "
+                    "80-hours-per-month work/community-engagement "
+                    "requirement)."
                 )
             else:
-                info_text += (
-                    "Our data so far suggests they may not be eligible for medicaid "
-                    "under the 2026 rules."
+                parts.append(
+                    "Our data so far suggests they may not be eligible for "
+                    "medicaid under the 2026 rules (which add the federal "
+                    "80-hours-per-month work/community-engagement "
+                    "requirement)."
                 )
 
             if medicare:
-                info_text += "Our data suggests they may be eligible for medicare."
+                parts.append("Our data suggests they may be eligible for medicare.")
 
         if len(alternatives) > 0:
-            info_text += (
-                f"Some possible alternative suggestions to help are {alternatives}."
+            alternative_lines = "\n".join(f"- {a}" for a in alternatives)
+            parts.append(
+                "Alternative programs and next steps worth mentioning:\n"
+                f"{alternative_lines}"
             )
 
-        return info_text
+        return "\n\n".join(parts)

--- a/fighthealthinsurance/chat/tools/medicaid_tool.py
+++ b/fighthealthinsurance/chat/tools/medicaid_tool.py
@@ -452,10 +452,17 @@ class MedicaidEligibilityTool(BaseTool):
 
         declined = summary.get("declined") or []
         if declined:
+            # The declined marker lives only in the payload, so it has to come
+            # back on every subsequent call. Omitting it from the re-send list
+            # made the decline last exactly one turn: the next call arrived
+            # without it, the field read as unanswered again, and the
+            # suppressed question came straight back -- the stall this channel
+            # exists to prevent.
+            names = ", ".join(sorted(declined))
             parts.append(
-                "The user couldn't answer "
-                + ", ".join(sorted(declined))
-                + " — don't ask about those again."
+                f"The user couldn't answer {names} — don't ask about those "
+                f'again, and keep sending {names} back as "unknown" on '
+                "every following call so they stay marked as declined."
             )
 
         return "\n\n".join(parts)
@@ -522,6 +529,17 @@ class MedicaidEligibilityTool(BaseTool):
             if medicare:
                 parts.append(
                     "Our data already suggests they may be eligible for medicare."
+                )
+            if not determination_made and len(alternatives) > 0:
+                # Indeterminate with questions still outstanding -- a
+                # territory resident whose Medicare answer is still coming.
+                # The reason we can't estimate Medicaid is actionable right
+                # now, so don't sit on it until the interview finishes.
+                alternative_lines = "\n".join(f"- {a}" for a in alternatives)
+                parts.append(
+                    "Separately, we canNOT produce a Medicaid estimate for "
+                    "this person — do not say they may be ineligible. Share "
+                    "these next steps now:\n" + alternative_lines
                 )
         elif not determination_made:
             # We could not score this person at all (a US territory, or a

--- a/fighthealthinsurance/medicaid_api.py
+++ b/fighthealthinsurance/medicaid_api.py
@@ -147,6 +147,36 @@ _ALIASES = {
     "s. carolina": "south carolina",
     "n. dakota": "north dakota",
     "s. dakota": "south dakota",
+    # State Medicaid program names. The prompt asks the model to infer the
+    # state from these; this is the backstop for when it passes the program
+    # name straight through as the "state".
+    "medi-cal": "california",
+    "medical": "california",
+    "denalicare": "alaska",
+    "health first colorado": "colorado",
+    "husky health": "connecticut",
+    "diamond state health plan": "delaware",
+    "med-quest": "hawaii",
+    "medquest": "hawaii",
+    "healthchoice illinois": "illinois",
+    "hoosier healthwise": "indiana",
+    "kansas medical assistance program": "kansas",
+    "mainecare": "maine",
+    "masshealth": "massachusetts",
+    "mo healthnet": "missouri",
+    "nj familycare": "new jersey",
+    "turquoise care": "new mexico",
+    "soonercare": "oklahoma",
+    "healthy connections": "south carolina",
+    "tenncare": "tennessee",
+    "star+plus": "texas",
+    "star plus": "texas",
+    "green mountain care": "vermont",
+    "cardinal care": "virginia",
+    "apple health": "washington",
+    "forward health": "wisconsin",
+    "forwardhealth": "wisconsin",
+    "equality care": "wyoming",
     # “state of …” forms
     "state of california": "california",
     "state of new york": "new york",
@@ -318,6 +348,108 @@ _FALSE_STRINGS = frozenset(
     }
 )
 
+# How the model tells us a question was asked and cannot be answered ("I
+# don't know my countable assets", "prefer not to say"). Without this channel
+# the model has nothing valid to send, so the same question comes back every
+# turn and the conversation never terminates. See _DECLINE_DEFAULTS.
+_UNKNOWN_STRINGS = frozenset(
+    {
+        "unknown",
+        "unsure",
+        "not sure",
+        "dont know",
+        "don't know",
+        "do not know",
+        "no idea",
+        "idk",
+        "n/a",
+        "na",
+        "declined",
+        "prefer not to say",
+        "no answer",
+        "unanswered",
+        "maybe",
+    }
+)
+
+# Fields we can safely assume when the user can't answer, so one unknown
+# doesn't sink the whole estimate. Each assumption is the conservative one
+# (single filer's lower asset limit, no exemptions) and is disclosed in the
+# alternatives so the user can correct it.
+_DECLINE_DEFAULTS: Dict[str, Any] = {
+    "married": False,
+    "pregnant": False,
+    "children_in_household": 0,
+    "receiving_ssdi": False,
+    "disabled": False,
+    "on_medicare": False,
+    "esrd": False,
+    "als": False,
+    "home_owner": False,
+    "veteran_or_spouse_of_veteran": False,
+    "work_req_exempt_2026": False,
+}
+
+# Without these there is no estimate to give, so a decline here stops the
+# flow with an explanation instead of a silent "not eligible".
+_REQUIRED_FOR_ESTIMATE = ("state", "age", "household_size", "monthly_income")
+
+# Every kwarg is_eligible reads. Anything else the model sends is silently
+# ignored today, which looks to the model like the answer was accepted -- so
+# summarize_eligibility_inputs reports the strays back to it.
+_KNOWN_ELIGIBILITY_FIELDS = frozenset(
+    {
+        "state",
+        "married",
+        "age",
+        "pregnant",
+        "receiving_ssdi",
+        "disabled",
+        "ssdi_length",
+        "on_medicare",
+        "veteran_or_spouse_of_veteran",
+        "living_situation",
+        "applying_reason",
+        "household_size",
+        "monthly_income",
+        "assets_total",
+        "home_owner",
+        "home_equity",
+        "children_in_household",
+        "als",
+        "esrd",
+        "years_worked",
+        "on_medicaid_past",
+        "work_req_exempt_2026",
+        "qualifying_hours_weekly_last_12",
+        "avg_monthly_qualifying_hours_last_3mo",
+        "avg_weekly_qualifying_hours_last_3mo",
+        "total_qualifying_hours_last_3mo",
+    }
+)
+
+
+def _parse_bool(value: Any) -> Optional[bool]:
+    """Tri-state bool out of an LLM-supplied value (None = unanswered)."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        text = value.strip().lower().rstrip(".!").strip()
+        if text in _TRUE_STRINGS:
+            return True
+        if text in _FALSE_STRINGS:
+            return False
+        return None
+    return bool(value)
+
+
+def _is_unknown_marker(value: Any) -> bool:
+    """Whether a value means "asked, but the user couldn't answer"."""
+    if not isinstance(value, str):
+        return False
+    return value.strip().lower().rstrip(".!?").strip() in _UNKNOWN_STRINGS
+
+
 # Word forms for the small counts people spell out ("three people").
 _WORD_NUMBERS = {
     "zero": 0,
@@ -360,13 +492,19 @@ def _parse_numeric(value: Any) -> Optional[float]:
     if text in _WORD_NUMBERS:
         return float(_WORD_NUMBERS[text])
     # Keep the first number-like run, dropping $ , and any trailing units.
-    match = re.search(r"-?\d[\d,]*(?:\.\d+)?", text)
+    match = re.search(r"-?\d[\d,]*(?:\.\d+)?\s*([km])?\b", text)
     if not match:
         return None
     try:
-        return float(match.group(0).replace(",", ""))
+        number = float(match.group(0).rstrip("km ").replace(",", ""))
     except ValueError:
         return None
+    suffix = match.group(1)
+    if suffix == "k":
+        number *= 1_000
+    elif suffix == "m":
+        number *= 1_000_000
+    return number
 
 
 def _clean_token(s: str) -> str:
@@ -518,20 +656,9 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
 
     # ---- helpers ----
     def get_bool(name: str) -> Optional[bool]:
-        v = kwargs.get(name, None)
-        if v is None:
-            return None
-        if isinstance(v, str):
-            # LLM payloads sometimes carry "false"/"no" string booleans;
-            # bool("false") is True, which flipped verdicts. See
-            # _TRUE_STRINGS/_FALSE_STRINGS.
-            s = v.strip().lower().rstrip(".!").strip()
-            if s in _TRUE_STRINGS:
-                return True
-            if s in _FALSE_STRINGS:
-                return False
-            return None
-        return bool(v)
+        # LLM payloads sometimes carry "false"/"no" string booleans, and
+        # bool("false") is True -- see _parse_bool / _TRUE_STRINGS.
+        return _parse_bool(kwargs.get(name, None))
 
     def get_int(name: str) -> Optional[int]:
         parsed = _parse_numeric(kwargs.get(name, None))
@@ -582,6 +709,27 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
     # but they could also do three. Yaaay.
     REQUIRED_MONTHS = 3  # lookback period in months
     MIN_MONTHS_MEETING = 3  # require meeting monthly hours in at least this many months
+
+    # ---- honour "the user couldn't answer" markers ----
+    # The model parses free text and hands us values; when the user simply
+    # doesn't know, it has nothing valid to send, so without this the same
+    # question returns every turn forever. Fold the safe assumptions in and
+    # remember the rest so their questions are suppressed below.
+    declined_fields = sorted(
+        name for name, raw in kwargs.items() if _is_unknown_marker(raw)
+    )
+    assumed_fields: List[str] = []
+    if declined_fields:
+        kwargs = dict(kwargs)
+        for name in declined_fields:
+            if name in _DECLINE_DEFAULTS:
+                kwargs[name] = _DECLINE_DEFAULTS[name]
+                assumed_fields.append(name)
+            else:
+                # No safe assumption: drop it so extraction sees "unanswered",
+                # and ask() below keeps us from re-asking it.
+                kwargs.pop(name, None)
+    declined_set = set(declined_fields)
 
     # ---- extract inputs ----
     # A state we can't recognize (typo, garbled LLM value) becomes a re-ask
@@ -648,6 +796,12 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
     eligible_2026 = False
     eligible_medicare = False
 
+    def ask(field: str, question: str) -> None:
+        """Queue a question unless the user already declined that field."""
+        if field in declined_set:
+            return
+        missing.append(question)
+
     def _result() -> Tuple[bool, bool, bool, List[str], List[str]]:
         """Single exit point: casts + dedupes so every return stays consistent."""
         return (
@@ -670,38 +824,44 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
         )
         return _result()
     if not state:
-        missing.append("What state do you live in?")
+        ask("state", "What state do you live in?")
     if age is None:
-        missing.append("How old are you?")
+        ask("age", "How old are you?")
     # No federal minimum marriage age law exists Oo. We could _probably_ go with 16 though but
     # for now lets do 10 since asking is not terrible and some states do allow it.
     if age is not None and age < 10 and married is None:
         married = False
     if age is not None and age >= 10 and married is None:
-        missing.append("Are you married or single?")
+        ask("married", "Are you married or single?")
     if household_size is None:
-        missing.append(
-            "How many people are in your household for taxes (household size)?"
+        ask(
+            "household_size",
+            "How many people are in your household for taxes (household size)?",
         )
     if monthly_income is None:
-        missing.append(
-            "About how much is your household's monthly income before taxes?"
+        ask(
+            "monthly_income",
+            "About how much is your household's monthly income before taxes?",
         )
 
     # https://en.wikipedia.org/wiki/Lina_Medina :/ -- and at the other end, a
     # 95-year-old's determination should not sit blocked on this either.
     if age is not None and pregnant is None:
         if 4 < age <= 60:
-            missing.append("Are you currently pregnant?")
+            ask("pregnant", "Are you currently pregnant?")
         else:
             # Don't stall the determination on a question we'd never ask.
             pregnant = False
     if kids is None:
-        missing.append("How many children (under 19) live in your household?")
+        ask(
+            "children_in_household",
+            "How many children (under 19) live in your household?",
+        )
 
     if receiving_ssdi is None:
-        missing.append(
-            "Are you receiving SSDI or otherwise considered disabled for benefits?"
+        ask(
+            "receiving_ssdi",
+            "Are you receiving SSDI or otherwise considered disabled for benefits?",
         )
     # Only ask about SSDI duration when SSDI itself was answered yes. Someone
     # who said "disabled, but not on SSDI" cannot answer it, and the prompt
@@ -710,7 +870,7 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
     if ssdi_answer and ssdi_length is None:
         # Needed at any age: 24+ months of SSDI is its own Medicare pathway,
         # so a 67-year-old on SSDI must be asked too, not just under-65s.
-        missing.append(_Q_SSDI_MONTHS)
+        ask("ssdi_length", _Q_SSDI_MONTHS)
     if age is not None and age < 65:
         # ESRD and ALS each open a Medicare pathway at any age, but they are
         # rare enough that asking every healthy young adult about kidney
@@ -720,9 +880,9 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
         settled_by_ssdi = ssdi_length is not None and ssdi_length >= 24
         if (bool(receiving_ssdi) or bool(on_medicare)) and not settled_by_ssdi:
             if esrd is None:
-                missing.append(_Q_ESRD)
+                ask("esrd", _Q_ESRD)
             if als is None:
-                missing.append(_Q_ALS)
+                ask("als", _Q_ALS)
         else:
             if esrd is None:
                 esrd = False
@@ -740,7 +900,7 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
     )
     if medicare_pathway:
         if on_medicare is None:
-            missing.append("Are you currently on Medicare?")
+            ask("on_medicare", "Are you currently on Medicare?")
         if on_medicare:
             # Already enrolled (any age -- an affirmative answer alone is a
             # pathway, so an under-65 enrollee isn't told they're ineligible).
@@ -753,8 +913,9 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
             eligible_medicare = True
         elif is_65_plus:
             if years_worked is None:
-                missing.append(
-                    "How many years did you (or spouse or ex-spouse) work and pay medicare taxes?"
+                ask(
+                    "years_worked",
+                    "How many years did you (or spouse or ex-spouse) work and pay medicare taxes?",
                 )
             elif years_worked >= 10:
                 # 10 years (40 quarters) of Medicare taxes = premium-free Part A.
@@ -783,11 +944,11 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
     # nothing reads cost every LTC applicant an extra round trip.
     if applying_reason in _LTC_REASONS:
         if assets_total is None:
-            missing.append(_Q_ASSETS)
+            ask("assets_total", _Q_ASSETS)
         if home_owner is None:
-            missing.append(_Q_HOME_OWNER)
+            ask("home_owner", _Q_HOME_OWNER)
         if home_owner and home_equity is None:
-            missing.append(_Q_HOME_EQUITY)
+            ask("home_equity", _Q_HOME_EQUITY)
     else:
         # Only the ABD branch reads assets. Children and pregnancy are scored
         # on income alone and are matched earlier in the category chain, so
@@ -796,7 +957,7 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
             (age is not None and age >= 65) or (receiving_ssdi is True)
         ) and not ((age is not None and age < 19) or pregnant is True)
         if abd_candidate and assets_total is None:
-            missing.append(_Q_ASSETS)
+            ask("assets_total", _Q_ASSETS)
 
     # mypy isn't smart enough to infer the types with a loop :/
     if (
@@ -810,6 +971,15 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
         or receiving_ssdi is None
         or on_medicare is None
     ):
+        blocking = [f for f in _REQUIRED_FOR_ESTIMATE if f in declined_set]
+        if blocking and not missing:
+            # Everything answerable has been answered and what's left was
+            # declined -- say so rather than returning a bare "not eligible".
+            alts.append(
+                "We can't estimate eligibility without "
+                f"{', '.join(f.replace('_', ' ') for f in blocking)}"
+                "—your state Medicaid agency can check without it."
+            )
         return _result()
 
     # ---- with core info present, evaluate categories ----
@@ -848,7 +1018,7 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
         # LTC branch below (LTC applicants are almost always 65+/disabled, so
         # without this carve-out they'd be evaluated under the wrong rules).
         if assets_total is None:
-            missing.append(_Q_ASSETS)
+            ask("assets_total", _Q_ASSETS)
         else:
             asset_limit = ABD_ASSET_LIMIT_MARRIED if married else ABD_ASSET_LIMIT_SINGLE
             assets_ok = assets_total <= asset_limit
@@ -1012,11 +1182,13 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
             # total_qualifying_hours_last_3mo) so the answer has a slot to
             # land in instead of being silently dropped.
             if monthly_data is None:
-                missing.append(
-                    "For 2026, about how many qualifying hours per month (work, school, volunteering, or caregiving) do you average?"
+                ask(
+                    "avg_monthly_qualifying_hours_last_3mo",
+                    "For 2026, about how many qualifying hours per month (work, school, volunteering, or caregiving) do you average?",
                 )
-                missing.append(
-                    "If easier, share your total qualifying hours over the last 3 months."
+                ask(
+                    "total_qualifying_hours_last_3mo",
+                    "If easier, share your total qualifying hours over the last 3 months.",
                 )
                 eligible_2026 = False  # unknown until we get this
             else:
@@ -1039,6 +1211,15 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
                     )
 
     # ---- general alternatives / supportive pointers ----
+    if assumed_fields:
+        # The user couldn't answer these, so the estimate leans on an
+        # assumption -- say which, so they can correct it if it's wrong.
+        readable = ", ".join(f.replace("_", " ") for f in assumed_fields)
+        alts.append(
+            f"We assumed the most conservative answer for: {readable}. "
+            "If any of those are wrong the estimate may change."
+        )
+
     if veteran:
         alts.append(
             "Since there’s veteran status in the household, compare with VA health benefits."
@@ -1081,6 +1262,94 @@ def _load_medicaid_resources() -> "Optional[pd.DataFrame]":
     except Exception:
         logger.opt(exception=True).warning("Could not read Medicaid resources CSV")
         return None
+
+
+_BOOL_FIELDS = frozenset(
+    {
+        "married",
+        "pregnant",
+        "receiving_ssdi",
+        "disabled",
+        "on_medicare",
+        "veteran_or_spouse_of_veteran",
+        "home_owner",
+        "als",
+        "esrd",
+        "on_medicaid_past",
+        "work_req_exempt_2026",
+    }
+)
+_INT_FIELDS = frozenset(
+    {"age", "ssdi_length", "household_size", "children_in_household", "years_worked"}
+)
+_FLOAT_FIELDS = frozenset(
+    {
+        "monthly_income",
+        "assets_total",
+        "home_equity",
+        "avg_monthly_qualifying_hours_last_3mo",
+        "avg_weekly_qualifying_hours_last_3mo",
+        "total_qualifying_hours_last_3mo",
+    }
+)
+
+
+def summarize_eligibility_inputs(kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    """Report what is_eligible actually understood from a tool payload.
+
+    The model does its own parsing of the user's free text and keeps the
+    running answers in its context, so it needs to see what landed on our
+    side: values we normalized (``$1,200`` -> 1200.0, ``Medi-Cal`` -> ca),
+    values we could not read, keys we do not know (silently dropped
+    otherwise, which looks to the model exactly like acceptance), and the
+    fields the user declined.
+
+    Returns ``{"recorded", "unreadable", "unrecognized", "declined"}``.
+    """
+    recorded: Dict[str, Any] = {}
+    unreadable: List[str] = []
+    unrecognized: List[str] = []
+    declined: List[str] = []
+
+    for name, raw in kwargs.items():
+        if name not in _KNOWN_ELIGIBILITY_FIELDS:
+            unrecognized.append(name)
+            continue
+        if _is_unknown_marker(raw):
+            declined.append(name)
+            continue
+        if raw is None:
+            continue
+        if name == "state":
+            try:
+                normalized: Any = _normalize_state(raw)
+            except ValueError:
+                normalized = None
+            if normalized is None:
+                unreadable.append(name)
+            else:
+                recorded[name] = normalized
+        elif name in _BOOL_FIELDS:
+            parsed_bool = _parse_bool(raw)
+            if parsed_bool is None:
+                unreadable.append(name)
+            else:
+                recorded[name] = parsed_bool
+        elif name in _INT_FIELDS or name in _FLOAT_FIELDS:
+            number = _parse_numeric(raw)
+            if number is None:
+                unreadable.append(name)
+            else:
+                recorded[name] = int(number) if name in _INT_FIELDS else number
+        else:
+            recorded[name] = raw
+
+    return {
+        "recorded": recorded,
+        "unreadable": sorted(unreadable),
+        "unrecognized": sorted(unrecognized),
+        "declined": sorted(declined),
+    }
 
 
 def get_medicaid_info(query: Dict[str, Any]) -> Optional[str]:

--- a/fighthealthinsurance/medicaid_api.py
+++ b/fighthealthinsurance/medicaid_api.py
@@ -916,6 +916,29 @@ def is_eligible(
             determination_made,
         )
 
+    def magi_expansion_covers(*, require_inputs: bool = False) -> bool:
+        """Whether ACA expansion covers this adult on income alone.
+
+        Expansion (and the 100%-FPL waiver states) apply NO asset test, so
+        wherever this is true the asset question cannot change the verdict.
+        Shared by the stepwise block, which uses it to skip asking, and by
+        the ABD branch, which uses it to score -- keeping the question we
+        suppress and the answer we give from disagreeing.
+
+        ``require_inputs`` guards the stepwise call, which runs before the
+        completeness gate and so may not have income or household size yet.
+        """
+        if age is None or not (19 <= age <= 64):
+            return False
+        if monthly_income is None or household_size is None:
+            if require_inputs:
+                return False
+            raise AssertionError("scoring call needs income and household size")
+        pct = pct_fpl(monthly_income, household_size, 2025)
+        if state in _EXPANSION_STATES and pct <= THRESH_ADULT_MAGI:
+            return True
+        return state in _WAIVER_100FPL_STATES and pct <= 100.0
+
     # ---- prioritize missing info for stepwise questioning ----
     if not state:
         ask("state", "What state do you live in?")
@@ -961,10 +984,11 @@ def is_eligible(
     # who said "disabled, but not on SSDI" cannot answer it, and the prompt
     # forbids the model from inventing a value -- so asking anyway stalls the
     # conversation on a question with no possible answer.
+    ssdi_length_pending = False
     if ssdi_answer and ssdi_length is None:
         # Needed at any age: 24+ months of SSDI is its own Medicare pathway,
         # so a 67-year-old on SSDI must be asked too, not just under-65s.
-        ask("ssdi_length", _Q_SSDI_MONTHS)
+        ssdi_length_pending = ask("ssdi_length", _Q_SSDI_MONTHS)
     if age is not None and age < 65:
         # ESRD and ALS each open a Medicare pathway at any age, but they are
         # rare enough that asking every healthy young adult about kidney
@@ -1025,15 +1049,19 @@ def is_eligible(
             elif years_worked >= 10:
                 # 10 years (40 quarters) of Medicare taxes = premium-free Part A.
                 eligible_medicare = True
-            elif ssdi_answer and ssdi_length is None:
+            elif ssdi_length_pending:
                 # Don't rule Medicare out yet: 24+ months of SSDI would
                 # qualify them and that question is still outstanding.
                 #
-                # Gate on ssdi_answer, not receiving_ssdi: the latter is
-                # ORed with `disabled`, so someone who answered "disabled,
-                # not on SSDI" waited here for an ssdi_length question that
-                # is never asked (it is gated on ssdi_answer too). They fell
-                # out with a silent Medicare False and no alternatives.
+                # Gate on whether the question was actually QUEUED, not on
+                # the answers. Two ways to get this wrong, both of which
+                # ended in a silent Medicare False with no question and no
+                # alternatives: `receiving_ssdi` is ORed with `disabled`, so
+                # "disabled, not on SSDI" waited on a question gated behind
+                # the SSDI answer and never asked; and `ssdi_answer and
+                # ssdi_length is None` still waited when the duration was
+                # DECLINED, which suppresses the ask. Deferring only while
+                # the ask is outstanding covers both.
                 pass
             else:
                 eligible_medicare = False
@@ -1093,21 +1121,10 @@ def is_eligible(
         abd_candidate = (
             (age is not None and age >= 65) or (receiving_ssdi is True)
         ) and not ((age is not None and age < 19) or pregnant is True)
-        # ACA expansion applies no asset test, so for an adult 19-64 already
-        # under the threshold the answer cannot change the verdict -- don't
-        # spend a turn collecting it. Guarded on having the inputs, since
-        # this runs before the completeness gate.
-        covered_without_assets = False
-        if (
-            age is not None
-            and 19 <= age <= 64
-            and monthly_income is not None
-            and household_size is not None
-        ):
-            pct = pct_fpl(monthly_income, household_size, 2025)
-            covered_without_assets = (
-                state in _EXPANSION_STATES and pct <= THRESH_ADULT_MAGI
-            ) or (state in _WAIVER_100FPL_STATES and pct <= 100.0)
+        # Expansion applies no asset test, so for an adult already under the
+        # threshold the answer cannot change the verdict -- don't spend a
+        # turn collecting it.
+        covered_without_assets = magi_expansion_covers(require_inputs=True)
         if abd_candidate and assets_total is None and not covered_without_assets:
             ask("assets_total", _Q_ASSETS)
 
@@ -1165,19 +1182,6 @@ def is_eligible(
         # Someone explicitly applying for long-term care falls through to the
         # LTC branch below (LTC applicants are almost always 65+/disabled, so
         # without this carve-out they'd be evaluated under the wrong rules).
-        def qualifies_on_magi_alone() -> bool:
-            """Whether ACA expansion covers them on income alone.
-
-            Disability does not bar the expansion pathway, and that pathway
-            applies NO asset test -- so for an adult 19-64 under the
-            threshold the asset question cannot change the answer.
-            """
-            if not is_adult_magi:
-                return False
-            if state in _EXPANSION_STATES and pfpl_2025 <= THRESH_ADULT_MAGI:
-                return True
-            return state in _WAIVER_100FPL_STATES and pfpl_2025 <= 100.0
-
         def abd_alternatives() -> None:
             """Pathways worth naming when the ABD test does not come out yes."""
             if on_medicare:
@@ -1195,7 +1199,7 @@ def is_eligible(
             # navigator, appeal) still apply.
 
         if assets_total is None:
-            if qualifies_on_magi_alone():
+            if magi_expansion_covers():
                 # Score it rather than asking: expansion applies no asset
                 # test, so the answer is already determined. Treating this
                 # as indeterminate on a declined asset figure was worse than
@@ -1220,7 +1224,7 @@ def is_eligible(
             # "probably eligible". It stays a suggestion below instead.
             eligible_2025 = assets_ok and income_ok_2025
             if not eligible_2025:
-                eligible_2025 = qualifies_on_magi_alone()
+                eligible_2025 = magi_expansion_covers()
             if not eligible_2025:
                 abd_alternatives()
     elif applying_reason in _LTC_REASONS:

--- a/fighthealthinsurance/medicaid_api.py
+++ b/fighthealthinsurance/medicaid_api.py
@@ -150,6 +150,119 @@ _CANDIDATE_KEYS = set(_STATE_MAP.keys()) | set(_ALIASES.keys())
 _ABBR_TO_NAME = {abbr: full.title() for full, abbr in _STATE_MAP.items()}
 _ABBR_TO_NAME["dc"] = "District of Columbia"
 
+# ACA expansion states (40 states + DC per KFF; the ten that have not adopted
+# expansion are AL, FL, GA, KS, MS, SC, TN, TX, WI, and WY). Policy data that
+# changes: audit against KFF when updating.
+_EXPANSION_STATES = frozenset(
+    {
+        "ak",
+        "az",
+        "ar",
+        "ca",
+        "co",
+        "ct",
+        "de",
+        "hi",
+        "id",
+        "il",
+        "in",
+        "ia",
+        "ky",
+        "la",
+        "me",
+        "md",
+        "ma",
+        "mi",
+        "mn",
+        "mo",
+        "mt",
+        "ne",
+        "nv",
+        "nh",
+        "nj",
+        "nm",
+        "ny",
+        "nc",
+        "nd",
+        "oh",
+        "ok",
+        "or",
+        "pa",
+        "ri",
+        "sd",
+        "ut",
+        "vt",
+        "va",
+        "wa",
+        "wv",
+        "dc",
+    }
+)
+
+# Non-expansion states whose waiver still covers childless adults up to 100%
+# FPL (no coverage gap): currently just Wisconsin.
+_WAIVER_100FPL_STATES = frozenset({"wi"})
+
+# States with a medically-needy (spend-down) pathway.
+_MEDICALLY_NEEDY_STATES = frozenset(
+    {
+        "ar",
+        "ca",
+        "ct",
+        "dc",
+        "fl",
+        "ga",
+        "hi",
+        "il",
+        "ia",
+        "ks",
+        "ky",
+        "la",
+        "me",
+        "md",
+        "ma",
+        "mi",
+        "mn",
+        "mo",
+        "mt",
+        "ne",
+        "nh",
+        "nj",
+        "ny",
+        "nc",
+        "nd",
+        "pa",
+        "ri",
+        "ut",
+        "vt",
+        "va",
+        "wa",
+        "wv",
+        "wi",
+    }
+)
+
+# applying_reason values that mean a long-term-care application.
+_LTC_REASONS = ("ltc_nursing_home", "ltc_home_care")
+
+# Stepwise questions raised from more than one branch. Shared constants keep
+# every site byte-identical so the result dedup can collapse repeats
+# (divergent phrasings previously got the same question asked twice).
+_Q_ASSETS = "About how much are your countable financial assets (not including your primary home)?"
+_Q_HOME_OWNER = "Do you own a home?"
+_Q_HOME_EQUITY = "If you own a home, about how much equity do you have in it?"
+_Q_LIVING_SITUATION = (
+    "Where are you living now (home, assisted living, rehab, nursing home)?"
+)
+_Q_SSDI_MONTHS = "How many months have you been receiving SSDI?"
+
+# String truthiness for LLM-supplied "booleans": tool payloads are raw LLM
+# JSON, which sometimes carries "false"/"no" instead of JSON booleans -- and
+# bool("false") is True. Unknown strings read as unanswered (re-ask) rather
+# than guessed.
+_TRUE_STRINGS = frozenset({"true", "yes", "y", "1", "on"})
+_FALSE_STRINGS = frozenset({"false", "no", "n", "0", "off", ""})
+
 
 def _clean_token(s: str) -> str:
     """Lower, trim, collapse spaces, remove most punctuation except spaces."""
@@ -278,6 +391,7 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
       # 2026 federal work requirement (ALWAYS ASSUMED TRUE):
       - work_req_exempt_2026: Optional[bool]  # if caller knows the person is exempt from work rules
       - qualifying_hours_weekly_last_12: Optional[Sequence[float]]  # 12 numbers, one per week
+      - avg_monthly_qualifying_hours_last_3mo: Optional[float]      # matches how the re-ask question is phrased
       - avg_weekly_qualifying_hours_last_3mo: Optional[float]       # fallback if weekly list not available
       - total_qualifying_hours_last_3mo: Optional[float]            # fallback if neither weekly nor avg provided
 
@@ -300,7 +414,19 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
     # ---- helpers ----
     def get_bool(name: str) -> Optional[bool]:
         v = kwargs.get(name, None)
-        return bool(v) if v is not None else None
+        if v is None:
+            return None
+        if isinstance(v, str):
+            # LLM payloads sometimes carry "false"/"no" string booleans;
+            # bool("false") is True, which flipped verdicts. See
+            # _TRUE_STRINGS/_FALSE_STRINGS.
+            s = v.strip().lower()
+            if s in _TRUE_STRINGS:
+                return True
+            if s in _FALSE_STRINGS:
+                return False
+            return None
+        return bool(v)
 
     def get_int(name: str) -> Optional[int]:
         v = kwargs.get(name, None)
@@ -369,12 +495,19 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
     married = get_bool("married")
     age = get_int("age")
     pregnant = get_bool("pregnant")
-    # NOTE: not `get_bool("receiving_ssdi") or get_bool("disabled")` -- that
-    # coerced an explicit False back to None (the `or` moves on), so answering
-    # "no" to the SSDI question got the user re-asked it forever.
-    receiving_ssdi = get_bool("receiving_ssdi")
-    if receiving_ssdi is None:
-        receiving_ssdi = get_bool("disabled")
+    # receiving_ssdi and disabled are alternative spellings of the same
+    # answer: True from either wins (a non-SSDI disabled person stays on the
+    # disability pathway even when they also answered "no" to the SSDI
+    # question); an explicit False is preserved so a "no" isn't re-asked
+    # forever (the old `or` chain coerced False back to None); None only when
+    # neither was provided.
+    ssdi_answer = get_bool("receiving_ssdi")
+    disabled_answer = get_bool("disabled")
+    receiving_ssdi: Optional[bool]
+    if ssdi_answer is None and disabled_answer is None:
+        receiving_ssdi = None
+    else:
+        receiving_ssdi = bool(ssdi_answer) or bool(disabled_answer)
     ssdi_length = get_int("ssdi_length")
     on_medicare = get_bool("on_medicare")
     veteran = get_bool("veteran_or_spouse_of_veteran")
@@ -386,41 +519,7 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
     home_owner = get_bool("home_owner")
     home_equity = get_float("home_equity")
     kids = get_int("children_in_household")
-    medically_needy = state in [
-        "ar",
-        "ca",
-        "ct",
-        "dc",
-        "fl",
-        "ga",
-        "hi",
-        "il",
-        "ia",
-        "ks",
-        "ky",
-        "la",
-        "me",
-        "md",
-        "ma",
-        "mi",
-        "mn",
-        "mo",
-        "mt",
-        "ne",
-        "nh",
-        "nj",
-        "ny",
-        "nc",
-        "nd",
-        "pa",
-        "ri",
-        "ut",
-        "vt",
-        "va",
-        "wa",
-        "wv",
-        "wi",
-    ]
+    medically_needy = state in _MEDICALLY_NEEDY_STATES
     als = get_bool("als")
     esrd = get_bool("esrd")
     years_worked = get_int("years_worked")
@@ -432,9 +531,17 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
     work_req_exempt_2026 = get_bool("work_req_exempt_2026")
     weekly_hours = get_seq_of_floats("qualifying_hours_weekly_last_12")
     avg_weekly_hours = get_float("avg_weekly_qualifying_hours_last_3mo")
+    avg_monthly_hours = get_float("avg_monthly_qualifying_hours_last_3mo")
     total_hours_3mo = get_float("total_qualifying_hours_last_3mo")
+    if total_hours_3mo is None and avg_monthly_hours is not None:
+        # The re-ask question is phrased per month, so accept the answer in
+        # the same units.
+        total_hours_3mo = avg_monthly_hours * 3.0
     if total_hours_3mo is None and avg_weekly_hours is not None:
-        total_hours_3mo = avg_weekly_hours * 4 * 3
+        # 13 weeks per quarter, not 12: a 4-weeks-per-month conversion
+        # undercounts real calendar months by ~8%, enough to flip verdicts
+        # right at the 80-hour line.
+        total_hours_3mo = avg_weekly_hours * 13.0
 
     # ---- track outputs ----
     missing: List[str] = []
@@ -442,6 +549,16 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
     eligible_2025 = False
     eligible_2026 = False
     eligible_medicare = False
+
+    def _result() -> Tuple[bool, bool, bool, List[str], List[str]]:
+        """Single exit point: casts + dedupes so every return stays consistent."""
+        return (
+            bool(eligible_2025),
+            bool(eligible_2026),
+            bool(eligible_medicare),
+            list(dict.fromkeys(alts)),
+            list(dict.fromkeys(missing)),
+        )
 
     # ---- prioritize missing info for stepwise questioning ----
     if not state:
@@ -477,34 +594,39 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
         missing.append(
             "Are you receiving SSDI or otherwise considered disabled for benefits?"
         )
+    if receiving_ssdi and ssdi_length is None:
+        # Needed at any age: 24+ months of SSDI is its own Medicare pathway,
+        # so a 67-year-old on SSDI must be asked too, not just under-65s.
+        missing.append(_Q_SSDI_MONTHS)
     if age is not None and age < 65:
-        if receiving_ssdi is not None and receiving_ssdi and ssdi_length is None:
-            missing.append("How many months have you been receiving SSDI?")
         if (ssdi_length is None or ssdi_length < 24) and esrd is None:
             missing.append("Are you in end stage renal failure?")
         if esrd is not None and als is None:
             missing.append("Do you have ALS?")
 
-    # ---- Medicare pathway: 65+, 24+ months of SSDI, ESRD, or ALS ----
+    # ---- Medicare pathway: enrolled, 65+, 24+ months of SSDI, ESRD, or ALS ----
+    is_65_plus = age is not None and age >= 65
+    has_esrd_or_als = bool(esrd) or bool(als)
+    ssdi_24_months = (
+        bool(receiving_ssdi) and ssdi_length is not None and ssdi_length >= 24
+    )
     medicare_pathway = (
-        (age is not None and age >= 65)
-        or bool(esrd)
-        or bool(als)
-        or (bool(receiving_ssdi) and ssdi_length is not None and ssdi_length >= 24)
+        bool(on_medicare) or is_65_plus or has_esrd_or_als or ssdi_24_months
     )
     if medicare_pathway:
         if on_medicare is None:
             missing.append("Are you currently on Medicare?")
         if on_medicare:
-            # Already enrolled.
+            # Already enrolled (any age -- an affirmative answer alone is a
+            # pathway, so an under-65 enrollee isn't told they're ineligible).
             eligible_medicare = True
-        elif bool(esrd) or bool(als):
+        elif has_esrd_or_als:
             # ESRD and ALS have their own Medicare pathways regardless of age.
             eligible_medicare = True
-        elif bool(receiving_ssdi) and ssdi_length is not None and ssdi_length >= 24:
+        elif ssdi_24_months:
             # Medicare enrollment is automatic after 24 months of SSDI.
             eligible_medicare = True
-        elif age is not None and age >= 65:
+        elif is_65_plus:
             if years_worked is None:
                 missing.append(
                     "How many years did you (or spouse or ex-spouse) work and pay medicare taxes?"
@@ -512,6 +634,10 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
             elif years_worked >= 10:
                 # 10 years (40 quarters) of Medicare taxes = premium-free Part A.
                 eligible_medicare = True
+            elif receiving_ssdi and ssdi_length is None:
+                # Don't rule Medicare out yet: 24+ months of SSDI would
+                # qualify them and that question is still outstanding.
+                pass
             else:
                 eligible_medicare = False
                 alts.append(
@@ -527,27 +653,19 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
         on_medicare = False
 
     # LTC pathways
-    if applying_reason in ("ltc_nursing_home", "ltc_home_care"):
+    if applying_reason in _LTC_REASONS:
         if living_situation is None:
-            missing.append(
-                "Where are you living now (home, assisted living, rehab, nursing home)?"
-            )
+            missing.append(_Q_LIVING_SITUATION)
         if assets_total is None:
-            missing.append(
-                "About how much are your countable financial assets (not including your primary home)?"
-            )
+            missing.append(_Q_ASSETS)
         if home_owner is None:
-            missing.append("Do you own a home?")
+            missing.append(_Q_HOME_OWNER)
         if home_owner and home_equity is None:
-            missing.append(
-                "If you own a home, about how much equity do you have in it?"
-            )
+            missing.append(_Q_HOME_EQUITY)
     else:
         if (age is not None and age >= 65) or (receiving_ssdi is True):
             if assets_total is None:
-                missing.append(
-                    "About how much are your countable financial assets (not including your primary home)?"
-                )
+                missing.append(_Q_ASSETS)
 
     # mypy isn't smart enough to infer the types with a loop :/
     if (
@@ -561,13 +679,7 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
         or receiving_ssdi is None
         or on_medicare is None
     ):
-        return (
-            eligible_2025,
-            eligible_2026,
-            eligible_medicare,
-            list(dict.fromkeys(alts)),
-            list(dict.fromkeys(missing)),
-        )
+        return _result()
 
     # ---- with core info present, evaluate categories ----
     pfpl_2025 = pct_fpl(monthly_income, household_size, 2025)
@@ -594,24 +706,28 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
         work_req_exempt_2026 = True
     elif is_preg:
         eligible_2025 = pfpl_2025 <= THRESH_PREG
-    elif (is_abd_age or is_abd_disability or on_medicare) and applying_reason not in (
-        "ltc_nursing_home",
-        "ltc_home_care",
-    ):
+    elif (
+        is_abd_age or is_abd_disability or on_medicare
+    ) and applying_reason not in _LTC_REASONS:
         # Someone explicitly applying for long-term care falls through to the
         # LTC branch below (LTC applicants are almost always 65+/disabled, so
         # without this carve-out they'd be evaluated under the wrong rules).
         if assets_total is None:
-            # Same phrasing as the stepwise ask above so the question
-            # dedupes instead of appearing twice with different wording.
-            missing.append(
-                "About how much are your countable financial assets (not including your primary home)?"
-            )
+            missing.append(_Q_ASSETS)
         else:
             asset_limit = ABD_ASSET_LIMIT_MARRIED if married else ABD_ASSET_LIMIT_SINGLE
             assets_ok = assets_total <= asset_limit
             income_ok_2025 = pfpl_2025 <= 100.0
             eligible_2025 = assets_ok and (income_ok_2025 or medically_needy)
+            if not eligible_2025 and is_adult_magi:
+                # Disability doesn't bar the ACA expansion pathway: adults
+                # 19-64 in expansion (or 100%-FPL-waiver) states qualify on
+                # income alone with no asset test, so check MAGI before
+                # concluding ineligibility.
+                if state in _EXPANSION_STATES and pfpl_2025 <= THRESH_ADULT_MAGI:
+                    eligible_2025 = True
+                elif state in _WAIVER_100FPL_STATES and pfpl_2025 <= 100.0:
+                    eligible_2025 = True
             if not eligible_2025:
                 if on_medicare:
                     alts.append(
@@ -625,48 +741,36 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
                     alts.append(
                         "Ask about medically-needy/spend-down Medicaid in your state."
                     )
-    elif applying_reason in ("ltc_nursing_home", "ltc_home_care"):
+    elif applying_reason in _LTC_REASONS:
         # For LTC we need some extra info
-        need_fields = []
         if assets_total is None:
-            need_fields.append("assets_total")
+            missing.append(_Q_ASSETS)
         if home_owner is None:
-            need_fields.append("home_owner")
+            missing.append(_Q_HOME_OWNER)
         if living_situation is None:
-            need_fields.append("living_situation")
+            missing.append(_Q_LIVING_SITUATION)
         if home_owner and home_equity is None:
-            need_fields.append("home_equity")
-        if need_fields:
-            if "assets_total" in need_fields:
-                # Same phrasing as the stepwise ask above so the question
-                # dedupes instead of appearing twice with different wording.
-                missing.append(
-                    "About how much are your countable financial assets (not including your primary home)?"
-                )
-            if "home_owner" in need_fields:
-                missing.append("Do you own a home?")
-            if "living_situation" in need_fields:
-                missing.append(
-                    "Where are you living now (home, assisted living, rehab, nursing home)?"
-                )
-            if "home_equity" in need_fields:
-                missing.append("If you own a home, about how much equity is in it?")
-            return (
-                False,
-                False,
-                False,
-                [
-                    "If not eligible, ask about HCBS waivers or medically-needy/spend-down."
-                ],
-                list(dict.fromkeys(missing)),
+            missing.append(_Q_HOME_EQUITY)
+        if (
+            assets_total is None
+            or home_owner is None
+            or living_situation is None
+            or (home_owner and home_equity is None)
+        ):
+            # Keep any Medicare verdict and alternatives accumulated above --
+            # the old early return here clobbered eligible_medicare back to
+            # False and threw away the Part-A/MSP suggestions.
+            alts.append(
+                "If not eligible, ask about HCBS waivers or medically-needy/spend-down."
             )
+            return _result()
 
         asset_limit = ABD_ASSET_LIMIT_MARRIED if married else ABD_ASSET_LIMIT_SINGLE
 
-        # assets_total is not None here (the need_fields early-return above
-        # already asked for it -- the None arm just narrows for mypy), and
-        # zero assets passes the test.
-        assets_ok = assets_total is not None and assets_total <= asset_limit
+        # assets_total is narrowed by the early return above; zero assets
+        # passes the test.
+        assert assets_total is not None
+        assets_ok = assets_total <= asset_limit
         home_ok = True
         if home_owner:
             home_ok = (home_equity or 0.0) <= HOME_EQUITY_CAP_DEFAULT
@@ -691,58 +795,21 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
                 "Medically-needy/spend-down Medicaid may help if bills are very high."
             )
     elif is_adult_magi:
-        # ACA expansion states (40 states + DC per KFF; the ten that have not
-        # adopted expansion are AL, FL, GA, KS, MS, SC, TN, TX, WI, and WY).
-        expanded_states = [
-            "ak",
-            "az",
-            "ar",
-            "ca",
-            "co",
-            "ct",
-            "de",
-            "hi",
-            "id",
-            "il",
-            "in",
-            "ia",
-            "ky",
-            "la",
-            "me",
-            "md",
-            "ma",
-            "mi",
-            "mn",
-            "mo",
-            "mt",
-            "ne",
-            "nv",
-            "nh",
-            "nj",
-            "nm",
-            "ny",
-            "nc",
-            "nd",
-            "oh",
-            "ok",
-            "or",
-            "pa",
-            "ri",
-            "sd",
-            "ut",
-            "vt",
-            "va",
-            "wa",
-            "wv",
-            "dc",
-        ]
-        expanded = state in expanded_states
-        if expanded:
+        if state in _EXPANSION_STATES:
             eligible_2025 = pfpl_2025 <= THRESH_ADULT_MAGI
-        elif state == "wi":
-            # Wisconsin hasn't adopted ACA expansion but covers adults up to
-            # 100% FPL under a waiver, so it has no coverage gap.
+        elif state in _WAIVER_100FPL_STATES:
+            # No ACA expansion, but adults are covered up to 100% FPL under a
+            # waiver (Wisconsin), so there is no coverage gap.
             eligible_2025 = pfpl_2025 <= 100.0
+            if not eligible_2025:
+                # Above 100% FPL means marketplace subsidies are available.
+                alts.append(
+                    "Above your state's 100% FPL waiver limit—consider ACA marketplace subsidies (available starting at 100% FPL)."
+                )
+                if kids and kids > 0:
+                    alts.append(
+                        "If you’re a caretaker relative, check caretaker-relative Medicaid rules in your state."
+                    )
         else:
             eligible_2025 = False
             if pfpl_2025 >= 100.0:
@@ -763,14 +830,26 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
             alts.append("Children may qualify for CHIP.")
 
     # ---- 2026 eligibility = 2025 base eligibility + federal work overlay ----
-    # Exemptions (if caller knows): pregnancy, SSDI/disabled, Medicare, children,
-    # and 65+ (the requirement targets adults 19-64) are treated as exempt by default.
+    # Exemptions (if caller knows): pregnancy, SSDI/disabled, Medicare, ESRD/ALS,
+    # children, and 65+ (the requirement targets able-bodied adults 19-64) are
+    # treated as exempt by default.
     presumed_exempt = (
-        is_preg or is_abd_disability or bool(on_medicare) or is_child or is_abd_age
+        is_preg
+        or is_abd_disability
+        or bool(on_medicare)
+        or is_child
+        or is_abd_age
+        or has_esrd_or_als
     )
     exempt = (work_req_exempt_2026 is True) or presumed_exempt
 
-    if not eligible_2025:
+    if applying_reason in _LTC_REASONS:
+        # The LTC branch computed eligible_2026 itself (the LTC income cap
+        # differs by year, so income can pass 2026 while failing 2025), and
+        # LTC applicants are medically frail -- never subject them to the
+        # work overlay or the not-eligible-2025 clamp.
+        pass
+    elif not eligible_2025:
         # If not eligible in 2025, they won't be in 2026 either (even before work overlay).
         eligible_2026 = False
     else:
@@ -793,16 +872,16 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
                 return None
 
             monthly_data = compute_monthly_sums()
-            # Ask for hours if we can't compute
+            # Ask for hours if we can't compute. Each phrasing maps directly
+            # onto a documented kwarg (avg_monthly_qualifying_hours_last_3mo /
+            # total_qualifying_hours_last_3mo) so the answer has a slot to
+            # land in instead of being silently dropped.
             if monthly_data is None:
                 missing.append(
-                    "For 2026, about how many qualifying hours per MONTH do you think you will average over the last 3 months?"
+                    "For 2026, about how many qualifying hours per month (work, school, volunteering, or caregiving) do you average?"
                 )
                 missing.append(
                     "If easier, share your total qualifying hours over the last 3 months."
-                )
-                missing.append(
-                    "If you can, provide your hours for each of the last 3 months."
                 )
                 eligible_2026 = False  # unknown until we get this
             else:
@@ -846,13 +925,7 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
             "We can’t find a pathway with the current info—consider speaking with a benefits navigator or attorney."
         )
 
-    return (
-        bool(eligible_2025),
-        bool(eligible_2026),
-        bool(eligible_medicare),
-        list(dict.fromkeys(alts)),
-        list(dict.fromkeys(missing)),
-    )
+    return _result()
 
 
 def get_medicaid_info(query: Dict[str, Any]) -> str:
@@ -860,19 +933,30 @@ def get_medicaid_info(query: Dict[str, Any]) -> str:
     query example: {"state":"StateName","topic":"","limit":5}
     Returns a clean, professional format with key contact info.
     """
-    state_short = _normalize_state(
-        (query.get("state") or query.get("State") or "").strip()
-    )
+    raw_state = str(query.get("state") or query.get("State") or "").strip()
+    try:
+        state_short = _normalize_state(raw_state)
+    except ValueError:
+        # A state we can't recognize (typo, garbled LLM value) should read as
+        # a re-ask, not an exception that kills the whole tool call -- same
+        # hardening is_eligible has.
+        return (
+            f"We couldn't tell which state {raw_state!r} is. "
+            "Please ask the user to confirm their state and try again."
+        )
+    if state_short is None:
+        # No state (or a placeholder like "unknown"): without one we'd dump
+        # every state's contact info, which is useless in chat.
+        return (
+            "We need to know which state they're in to look up Medicaid "
+            "contact info. Please ask the user for their state and try again."
+        )
     topic = (query.get("topic") or "").strip().lower()
     limit = int(query.get("limit") or 5)
 
-    # Normalize the 2-letter code to a display name (shared reverse map keeps
-    # this in sync with _STATE_MAP instead of a second hand-maintained list).
-    if state_short in _ABBR_TO_NAME:
-        state = _ABBR_TO_NAME[state_short]
-    else:
-        # Try to match as full state name (title case)
-        state = state_short or ""
+    # _normalize_state only returns 2-letter codes, every one of which is in
+    # the shared reverse map (kept in sync with _STATE_MAP).
+    state = _ABBR_TO_NAME[state_short]
 
     # Pick the CSV
     file_path = DATA_DIR / DEFAULT_FILE

--- a/fighthealthinsurance/medicaid_api.py
+++ b/fighthealthinsurance/medicaid_api.py
@@ -151,7 +151,6 @@ _ALIASES = {
     # state from these; this is the backstop for when it passes the program
     # name straight through as the "state".
     "medi-cal": "california",
-    "medical": "california",
     "denalicare": "alaska",
     "health first colorado": "colorado",
     "husky health": "connecticut",
@@ -194,7 +193,6 @@ for full, abbr in list(_STATE_MAP.items()):
 _PROGRAM_ALIASES = frozenset(
     {
         "medi-cal",
-        "medical",
         "denalicare",
         "health first colorado",
         "husky health",
@@ -670,7 +668,8 @@ def is_eligible(
 ) -> Tuple[bool, bool, bool, List[str], List[str], bool]:
     """
     Perform an approximate eligibility check for Medicaid / Medicare based on the provided parameters.
-    Returns a tuple of (2025 eligibility, 2026 eligibility, medicare, alternatives, missing_info).
+    Returns a tuple of (2025 eligibility, 2026 eligibility, medicare,
+    alternatives, missing_info, determination_made).
 
     IMPORTANT: This uses simplified heuristics. Medicaid rules vary by state and change often.
     Treat results as a best guess only and confirm with state resources.
@@ -1034,9 +1033,15 @@ def is_eligible(
             elif years_worked >= 10:
                 # 10 years (40 quarters) of Medicare taxes = premium-free Part A.
                 eligible_medicare = True
-            elif receiving_ssdi and ssdi_length is None:
+            elif ssdi_answer and ssdi_length is None:
                 # Don't rule Medicare out yet: 24+ months of SSDI would
                 # qualify them and that question is still outstanding.
+                #
+                # Gate on ssdi_answer, not receiving_ssdi: the latter is
+                # ORed with `disabled`, so someone who answered "disabled,
+                # not on SSDI" waited here for an ssdi_length question that
+                # is never asked (it is gated on ssdi_answer too). They fell
+                # out with a silent Medicare False and no alternatives.
                 pass
             else:
                 eligible_medicare = False
@@ -1433,6 +1438,11 @@ def _load_medicaid_resources() -> "Optional[pd.DataFrame]":
 
     The file is ~400 KB and only ever yields one state's row, so re-parsing
     it on every lookup was pure overhead on a chat turn.
+
+    The cache hands every caller the SAME DataFrame for the life of the
+    process, so callers must treat it as read-only: slice and filter (which
+    build new objects) rather than mutating in place. An ``inplace=True``
+    rename or a column assignment here would corrupt every later lookup.
     """
     file_path = DATA_DIR / DEFAULT_FILE
     if not file_path.exists():

--- a/fighthealthinsurance/medicaid_api.py
+++ b/fighthealthinsurance/medicaid_api.py
@@ -144,6 +144,12 @@ for full, abbr in list(_STATE_MAP.items()):
 # Precompute candidate keys (full names + aliases)
 _CANDIDATE_KEYS = set(_STATE_MAP.keys()) | set(_ALIASES.keys())
 
+# Reverse map: 2-letter code -> display name, derived from _STATE_MAP so the
+# two never drift apart. Later duplicate full-name keys ("washington dc",
+# "dc") overwrite earlier ones, so pin the DC display name explicitly.
+_ABBR_TO_NAME = {abbr: full.title() for full, abbr in _STATE_MAP.items()}
+_ABBR_TO_NAME["dc"] = "District of Columbia"
+
 
 def _clean_token(s: str) -> str:
     """Lower, trim, collapse spaces, remove most punctuation except spaces."""
@@ -266,7 +272,8 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
       - als: bool
       - esrd: bool
       - ssdi_length: int # how many months have they been receiving ssdi
-      - on_medicaid_past: bool
+      - years_worked: int # years you (or spouse/ex-spouse) worked paying medicare taxes
+      - on_medicaid_past: bool  # accepted for backwards compatibility; unused
 
       # 2026 federal work requirement (ALWAYS ASSUMED TRUE):
       - work_req_exempt_2026: Optional[bool]  # if caller knows the person is exempt from work rules
@@ -280,8 +287,11 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
       - Pregnant: <= 200% FPL (often higher).
       - ABD & LTC: asset limits approx $2k single / $3k married; LTC income cap ~ $3,000/mo;
         home equity must be below a default cap (use $750k if unknown). Medically-needy may help.
-      - 2026 work overlay: requires >=80 qualifying hours per month on average across the last 12 weeks.
-        If weekly detail is provided, we also require at least 8 of 12 weeks to meet or exceed 80.
+      - 2026 work overlay: requires >=80 qualifying hours per month, averaged across a
+        3-month lookback, with each of the 3 months individually meeting 80 hours.
+      - Questions we would never ask (e.g. "are you on Medicare?" for a healthy
+        30-year-old, or "are you pregnant?" for a toddler) are defaulted instead of
+        stalling the determination waiting on an answer that will never come.
 
     Returns:
       (eligible_2025: bool, eligible_2026: bool, eligible_medicare: bool, alternatives: List[str], missing_info: List[str])
@@ -315,13 +325,15 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
         except Exception:
             return None
 
-    # Rough FPL table for 2025 (annual). These are approximations; use official values when available.
+    # FPL table for 2025 (annual, 48 contiguous states + DC published guidelines:
+    # $15,650 for one person plus $5,500 per additional person). Alaska and
+    # Hawaii run higher; we keep the contiguous values as the approximation.
     # We'll work monthly: divide by 12. For 2026 we model +3% inflation on thresholds.
     def fpl_annual_2025(hh: int) -> float:
         if hh <= 0:
             hh = 1
-        base = 15000.0
-        add = 5300.0
+        base = 15650.0
+        add = 5500.0
         return base + add * (hh - 1)
 
     def pct_fpl(monthly_income: float, hh: int, year: int) -> float:
@@ -348,11 +360,21 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
     MIN_MONTHS_MEETING = 3  # require meeting monthly hours in at least this many months
 
     # ---- extract inputs ----
-    state = _normalize_state(kwargs.get("state"))
+    # A state we can't recognize (typo, garbled LLM value) becomes a re-ask
+    # instead of an exception that kills the whole eligibility check.
+    try:
+        state = _normalize_state(kwargs.get("state"))
+    except ValueError:
+        state = None
     married = get_bool("married")
     age = get_int("age")
     pregnant = get_bool("pregnant")
-    receiving_ssdi = get_bool("receiving_ssdi") or get_bool("disabled")
+    # NOTE: not `get_bool("receiving_ssdi") or get_bool("disabled")` -- that
+    # coerced an explicit False back to None (the `or` moves on), so answering
+    # "no" to the SSDI question got the user re-asked it forever.
+    receiving_ssdi = get_bool("receiving_ssdi")
+    if receiving_ssdi is None:
+        receiving_ssdi = get_bool("disabled")
     ssdi_length = get_int("ssdi_length")
     on_medicare = get_bool("on_medicare")
     veteran = get_bool("veteran_or_spouse_of_veteran")
@@ -402,7 +424,9 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
     als = get_bool("als")
     esrd = get_bool("esrd")
     years_worked = get_int("years_worked")
-    on_medicaid_past = get_bool("on_medicaid_past")
+    # on_medicaid_past is still accepted in kwargs for backwards compatibility
+    # but no longer changes the result: past Medicaid enrollment does not by
+    # itself confer Medicare eligibility.
 
     # 2026 work requirement inputs
     work_req_exempt_2026 = get_bool("work_req_exempt_2026")
@@ -428,7 +452,7 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
     # for now lets do 10 since asking is not terrible and some states do allow it.
     if age is not None and age < 10 and married is None:
         married = False
-    if age is not None and married is None and age > 10:
+    if age is not None and age >= 10 and married is None:
         missing.append("Are you married or single?")
     if household_size is None:
         missing.append(
@@ -440,8 +464,12 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
         )
 
     # https://en.wikipedia.org/wiki/Lina_Medina :/
-    if age and age > 4 and pregnant is None:
-        missing.append("Are you currently pregnant?")
+    if age is not None and pregnant is None:
+        if age > 4:
+            missing.append("Are you currently pregnant?")
+        else:
+            # Don't stall the determination on a question we'd never ask.
+            pregnant = False
     if kids is None:
         missing.append("How many children (under 19) live in your household?")
 
@@ -451,32 +479,52 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
         )
     if age is not None and age < 65:
         if receiving_ssdi is not None and receiving_ssdi and ssdi_length is None:
-            missing.append("How long have you been receiving SSDI?")
+            missing.append("How many months have you been receiving SSDI?")
         if (ssdi_length is None or ssdi_length < 24) and esrd is None:
             missing.append("Are you in end stage renal failure?")
         if esrd is not None and als is None:
             missing.append("Do you have ALS?")
-    if (
-        (age is not None and age > 65)
-        or (esrd is not None and esrd)
-        or (als is not None and als)
-    ) and on_medicare is None:
-        missing.append("Are you currently on Medicare?")
-        if years_worked is None:
-            missing.append(
-                "How many years did you (or spouse or ex-spouse) work and pay medicare taxes?"
-            )
-        elif years_worked > 10:
+
+    # ---- Medicare pathway: 65+, 24+ months of SSDI, ESRD, or ALS ----
+    medicare_pathway = (
+        (age is not None and age >= 65)
+        or bool(esrd)
+        or bool(als)
+        or (bool(receiving_ssdi) and ssdi_length is not None and ssdi_length >= 24)
+    )
+    if medicare_pathway:
+        if on_medicare is None:
+            missing.append("Are you currently on Medicare?")
+        if on_medicare:
+            # Already enrolled.
             eligible_medicare = True
-        elif on_medicaid_past is None:
-            missing.append("Were you on medicaid previously?")
-        elif on_medicaid_past or esrd or als or receiving_ssdi:
+        elif bool(esrd) or bool(als):
+            # ESRD and ALS have their own Medicare pathways regardless of age.
             eligible_medicare = True
-        else:
-            eligible_medicare = False
-            alts.append(
-                "You may be eligible to buy Part-A medicare even if you don't qualify for premium-free part A."
-            )
+        elif bool(receiving_ssdi) and ssdi_length is not None and ssdi_length >= 24:
+            # Medicare enrollment is automatic after 24 months of SSDI.
+            eligible_medicare = True
+        elif age is not None and age >= 65:
+            if years_worked is None:
+                missing.append(
+                    "How many years did you (or spouse or ex-spouse) work and pay medicare taxes?"
+                )
+            elif years_worked >= 10:
+                # 10 years (40 quarters) of Medicare taxes = premium-free Part A.
+                eligible_medicare = True
+            else:
+                eligible_medicare = False
+                alts.append(
+                    "You may be eligible to buy Part-A medicare even if you don't qualify for premium-free part A."
+                )
+                alts.append(
+                    "Medicare Savings Programs (QMB/SLMB/QI) can help pay Medicare premiums when income and assets are low."
+                )
+    elif age is not None and on_medicare is None:
+        # Under 65 with no disability pathway: almost never on Medicare, so
+        # assume not enrolled instead of stalling the flow on a question
+        # whose answer is essentially always "no".
+        on_medicare = False
 
     # LTC pathways
     if applying_reason in ("ltc_nursing_home", "ltc_home_care"):
@@ -513,7 +561,13 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
         or receiving_ssdi is None
         or on_medicare is None
     ):
-        return (eligible_2025, eligible_2026, eligible_medicare, alts, missing)
+        return (
+            eligible_2025,
+            eligible_2026,
+            eligible_medicare,
+            list(dict.fromkeys(alts)),
+            list(dict.fromkeys(missing)),
+        )
 
     # ---- with core info present, evaluate categories ----
     pfpl_2025 = pct_fpl(monthly_income, household_size, 2025)
@@ -540,10 +594,18 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
         work_req_exempt_2026 = True
     elif is_preg:
         eligible_2025 = pfpl_2025 <= THRESH_PREG
-    elif is_abd_age or is_abd_disability or on_medicare:
+    elif (is_abd_age or is_abd_disability or on_medicare) and applying_reason not in (
+        "ltc_nursing_home",
+        "ltc_home_care",
+    ):
+        # Someone explicitly applying for long-term care falls through to the
+        # LTC branch below (LTC applicants are almost always 65+/disabled, so
+        # without this carve-out they'd be evaluated under the wrong rules).
         if assets_total is None:
+            # Same phrasing as the stepwise ask above so the question
+            # dedupes instead of appearing twice with different wording.
             missing.append(
-                "We need your countable assets to check ABD rules (approx, excluding your primary home)."
+                "About how much are your countable financial assets (not including your primary home)?"
             )
         else:
             asset_limit = ABD_ASSET_LIMIT_MARRIED if married else ABD_ASSET_LIMIT_SINGLE
@@ -576,8 +638,10 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
             need_fields.append("home_equity")
         if need_fields:
             if "assets_total" in need_fields:
+                # Same phrasing as the stepwise ask above so the question
+                # dedupes instead of appearing twice with different wording.
                 missing.append(
-                    "About how much are your countable financial assets (exclude your primary home)?"
+                    "About how much are your countable financial assets (not including your primary home)?"
                 )
             if "home_owner" in need_fields:
                 missing.append("Do you own a home?")
@@ -594,18 +658,15 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
                 [
                     "If not eligible, ask about HCBS waivers or medically-needy/spend-down."
                 ],
-                missing,
+                list(dict.fromkeys(missing)),
             )
 
         asset_limit = ABD_ASSET_LIMIT_MARRIED if married else ABD_ASSET_LIMIT_SINGLE
 
-        assets_ok = False
-        if not assets_total:
-            missing.append("What are you total assets excluding home equity?")
-        elif assets_total <= asset_limit:
-            assets_ok = True
-        else:
-            assets_ok = False
+        # assets_total is not None here (the need_fields early-return above
+        # already asked for it -- the None arm just narrows for mypy), and
+        # zero assets passes the test.
+        assets_ok = assets_total is not None and assets_total <= asset_limit
         home_ok = True
         if home_owner:
             home_ok = (home_equity or 0.0) <= HOME_EQUITY_CAP_DEFAULT
@@ -630,8 +691,9 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
                 "Medically-needy/spend-down Medicaid may help if bills are very high."
             )
     elif is_adult_magi:
-        expanded_states = [  # Note: this is based of off KFF Aug 26 2025
-            "al",
+        # ACA expansion states (40 states + DC per KFF; the ten that have not
+        # adopted expansion are AL, FL, GA, KS, MS, SC, TN, TX, WI, and WY).
+        expanded_states = [
             "ak",
             "az",
             "ar",
@@ -644,11 +706,11 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
             "il",
             "in",
             "ia",
-            "ks",
             "ky",
             "la",
             "me",
             "md",
+            "ma",
             "mi",
             "mn",
             "mo",
@@ -660,6 +722,7 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
             "nm",
             "ny",
             "nc",
+            "nd",
             "oh",
             "ok",
             "or",
@@ -671,17 +734,25 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
             "va",
             "wa",
             "wv",
-            "wi",
             "dc",
         ]
         expanded = state in expanded_states
         if expanded:
             eligible_2025 = pfpl_2025 <= THRESH_ADULT_MAGI
+        elif state == "wi":
+            # Wisconsin hasn't adopted ACA expansion but covers adults up to
+            # 100% FPL under a waiver, so it has no coverage gap.
+            eligible_2025 = pfpl_2025 <= 100.0
         else:
             eligible_2025 = False
-            alts.append(
-                "In non-expansion states, childless adults often aren’t eligible—consider ACA marketplace subsidies."
-            )
+            if pfpl_2025 >= 100.0:
+                alts.append(
+                    "In non-expansion states, childless adults often aren’t eligible—consider ACA marketplace subsidies (available starting at 100% FPL)."
+                )
+            else:
+                alts.append(
+                    "Your state hasn't expanded Medicaid and marketplace subsidies generally start at 100% FPL (the 'coverage gap')—community health centers with sliding-scale fees can help in the meantime."
+                )
             if kids and kids > 0:
                 alts.append(
                     "If you’re a caretaker relative, check caretaker-relative Medicaid rules in your state."
@@ -692,8 +763,11 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
             alts.append("Children may qualify for CHIP.")
 
     # ---- 2026 eligibility = 2025 base eligibility + federal work overlay ----
-    # Exemptions (if caller knows): pregnancy, SSDI/disabled, Medicare are treated as exempt by default.
-    presumed_exempt = is_preg or is_abd_disability or bool(on_medicare) or is_child
+    # Exemptions (if caller knows): pregnancy, SSDI/disabled, Medicare, children,
+    # and 65+ (the requirement targets adults 19-64) are treated as exempt by default.
+    presumed_exempt = (
+        is_preg or is_abd_disability or bool(on_medicare) or is_child or is_abd_age
+    )
     exempt = (work_req_exempt_2026 is True) or presumed_exempt
 
     if not eligible_2025:
@@ -777,7 +851,7 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
         bool(eligible_2026),
         bool(eligible_medicare),
         list(dict.fromkeys(alts)),
-        missing,
+        list(dict.fromkeys(missing)),
     )
 
 
@@ -792,63 +866,10 @@ def get_medicaid_info(query: Dict[str, Any]) -> str:
     topic = (query.get("topic") or "").strip().lower()
     limit = int(query.get("limit") or 5)
 
-    # Normalize state name to title case and handle abbreviations
-    state_abbrev_map = {
-        "ca": "California",
-        "oh": "Ohio",
-        "ny": "New York",
-        "tx": "Texas",
-        "fl": "Florida",
-        "pa": "Pennsylvania",
-        "il": "Illinois",
-        "mi": "Michigan",
-        "ga": "Georgia",
-        "nc": "North Carolina",
-        "nj": "New Jersey",
-        "va": "Virginia",
-        "wa": "Washington",
-        "az": "Arizona",
-        "ma": "Massachusetts",
-        "tn": "Tennessee",
-        "in": "Indiana",
-        "mo": "Missouri",
-        "md": "Maryland",
-        "wi": "Wisconsin",
-        "co": "Colorado",
-        "mn": "Minnesota",
-        "sc": "South Carolina",
-        "al": "Alabama",
-        "la": "Louisiana",
-        "ky": "Kentucky",
-        "or": "Oregon",
-        "ok": "Oklahoma",
-        "ct": "Connecticut",
-        "ut": "Utah",
-        "ia": "Iowa",
-        "nv": "Nevada",
-        "ar": "Arkansas",
-        "ms": "Mississippi",
-        "ks": "Kansas",
-        "nm": "New Mexico",
-        "ne": "Nebraska",
-        "wv": "West Virginia",
-        "id": "Idaho",
-        "hi": "Hawaii",
-        "nh": "New Hampshire",
-        "me": "Maine",
-        "ri": "Rhode Island",
-        "mt": "Montana",
-        "de": "Delaware",
-        "sd": "South Dakota",
-        "nd": "North Dakota",
-        "ak": "Alaska",
-        "vt": "Vermont",
-        "wy": "Wyoming",
-        "dc": "District of Columbia",
-    }
-
-    if state_short in state_abbrev_map:
-        state = state_abbrev_map[state_short]
+    # Normalize the 2-letter code to a display name (shared reverse map keeps
+    # this in sync with _STATE_MAP instead of a second hand-maintained list).
+    if state_short in _ABBR_TO_NAME:
+        state = _ABBR_TO_NAME[state_short]
     else:
         # Try to match as full state name (title case)
         state = state_short or ""

--- a/fighthealthinsurance/medicaid_api.py
+++ b/fighthealthinsurance/medicaid_api.py
@@ -309,6 +309,67 @@ _MEDICALLY_NEEDY_STATES = frozenset(
 # applying_reason values that mean a long-term-care application.
 _LTC_REASONS = ("ltc_nursing_home", "ltc_home_care")
 
+# Substrings that mean "this is a long-term-care application", however the
+# model phrases it. Every other field here has tolerant parsing because the
+# model does not reliably emit canonical tokens -- applying_reason had none,
+# and an unrecognized value does not re-ask or go indeterminate. It silently
+# routes to the MAGI/ABD branch, skipping the home-equity test entirely, and
+# reports a nursing-home applicant as PROBABLY ELIGIBLE. A false positive is
+# the worst answer this engine can give, so the matching is deliberately
+# generous: over-matching costs an extra question, under-matching costs a
+# wrong "yes". The branch treats the two LTC reasons identically, so a
+# generic "long term care" can land on either.
+_LTC_REASON_MARKERS = (
+    "nursing home",
+    "nursing facility",
+    "nursing_home",
+    "skilled nursing",
+    "snf",
+    "long term care",
+    "long-term care",
+    "longterm care",
+    "ltc",
+    "custodial care",
+    "home care",
+    "home-care",
+    "home_care",
+    "in-home care",
+    "in home care",
+    "home health",
+    "personal care",
+    "hcbs",
+    "home and community based",
+    "assisted living",
+    "assisted_living",
+)
+
+
+def _normalize_applying_reason(raw: Any, living_situation: Any = None) -> str:
+    """Map free-text application reasons onto the canonical LTC tokens.
+
+    ``living_situation`` is consulted only as a fallback: if the model put
+    the nursing-home fact there instead of in applying_reason, the LTC tests
+    still need to run. Routing into the LTC branch is the conservative
+    direction -- it applies MORE tests and returns indeterminate rather than
+    eligible when information is missing.
+    """
+    for value in (raw, living_situation):
+        if not isinstance(value, str):
+            continue
+        text = value.strip().lower()
+        if not text:
+            continue
+        if text in _LTC_REASONS:
+            return text
+        if any(marker in text for marker in _LTC_REASON_MARKERS):
+            return (
+                "ltc_home_care"
+                if ("home care" in text or "home-care" in text or "hcbs" in text)
+                else "ltc_nursing_home"
+            )
+    return "standard"
+
+
 # Stepwise questions raised from more than one branch. Shared constants keep
 # every site byte-identical so the result dedup can collapse repeats
 # (divergent phrasings previously got the same question asked twice).
@@ -844,7 +905,9 @@ def is_eligible(
     on_medicare = get_bool("on_medicare")
     veteran = get_bool("veteran_or_spouse_of_veteran")
     living_situation = kwargs.get("living_situation")
-    applying_reason = kwargs.get("applying_reason") or "standard"
+    applying_reason = _normalize_applying_reason(
+        kwargs.get("applying_reason"), living_situation
+    )
     household_size = get_int("household_size")
     monthly_income = get_float("monthly_income")
     assets_total = get_float("assets_total")

--- a/fighthealthinsurance/medicaid_api.py
+++ b/fighthealthinsurance/medicaid_api.py
@@ -385,7 +385,10 @@ _DECLINE_DEFAULTS: Dict[str, Any] = {
     "on_medicare": False,
     "esrd": False,
     "als": False,
-    "home_owner": False,
+    # NOTE: home_owner is deliberately NOT here. Assuming "no home" skips the
+    # LTC home-equity test entirely, so someone with equity over the cap
+    # would get a false "probably eligible" -- the opposite of conservative.
+    # Left indeterminate instead, so it is asked or reported as undetermined.
     "veteran_or_spouse_of_veteran": False,
     "work_req_exempt_2026": False,
 }
@@ -595,7 +598,9 @@ def _normalize_state(
     raise ValueError(f"Unknown state: {raw}")
 
 
-def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
+def is_eligible(
+    **kwargs,
+) -> Tuple[bool, bool, bool, List[str], List[str], bool]:
     """
     Perform an approximate eligibility check for Medicaid / Medicare based on the provided parameters.
     Returns a tuple of (2025 eligibility, 2026 eligibility, medicare, alternatives, missing_info).
@@ -604,8 +609,14 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
     Treat results as a best guess only and confirm with state resources.
 
     Federal work/community engagement requirement:
-      - Effective 12/31/2025 (i.e., for 2026 eligibility and onward), assume a federal requirement
-        of 80 qualifying hours PER MONTH with a 3-month lookback (12 weeks).
+      - Per the CMS interim final rule (CMS-2454-IFC, June 2026), states must
+        implement the requirement no later than JANUARY 1, 2027; a few have
+        gone earlier, and states showing good-faith effort can get extensions.
+        The ``eligible_2026`` flag therefore models "eligibility once the work
+        requirement applies to them", not calendar-year 2026 specifically.
+      - The requirement is 80 qualifying hours PER MONTH, checked at
+        application and renewal against a lookback of one to three months
+        (states choose), which is why late-2026 activity can already matter.
       - Qualifying hours may include work, school, volunteering, or caregiving.
       - Some people may be exempt (pregnant, disabled/SSDI/medically frail, etc.). If unsure, we ask.
 
@@ -644,14 +655,22 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
       - Pregnant: <= 200% FPL (often higher).
       - ABD & LTC: asset limits approx $2k single / $3k married; LTC income cap ~ $3,000/mo;
         home equity must be below a default cap (use $750k if unknown). Medically-needy may help.
-      - 2026 work overlay: requires >=80 qualifying hours per month, averaged across a
-        3-month lookback, with each of the 3 months individually meeting 80 hours.
+      - 2026 work overlay: requires >=80 qualifying hours per month across a
+        3-month lookback. Detailed weekly records are partitioned per month so
+        each month is checked on its own; a single monthly average or a 3-month
+        total has no per-month detail to check, so it is spread evenly and only
+        the average can be tested.
       - Questions we would never ask (e.g. "are you on Medicare?" for a healthy
         30-year-old, or "are you pregnant?" for a toddler) are defaulted instead of
         stalling the determination waiting on an answer that will never come.
 
     Returns:
-      (eligible_2025: bool, eligible_2026: bool, eligible_medicare: bool, alternatives: List[str], missing_info: List[str])
+      (eligible_2025, eligible_2026, eligible_medicare, alternatives,
+       missing_info, determination_made)
+
+    ``determination_made`` is False when we could not score the person at all
+    (US territory, or a required answer the user declined) — distinct from a
+    scored "not eligible". Callers must not present the former as a verdict.
     """
 
     # ---- helpers ----
@@ -802,27 +821,27 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
             return
         missing.append(question)
 
-    def _result() -> Tuple[bool, bool, bool, List[str], List[str]]:
-        """Single exit point: casts + dedupes so every return stays consistent."""
+    def _result(
+        determination_made: bool = False,
+    ) -> Tuple[bool, bool, bool, List[str], List[str], bool]:
+        """Single exit point: casts + dedupes so every return stays consistent.
+
+        ``determination_made`` separates "we scored this person and the answer
+        is no" from "we couldn't score them at all" (a US territory, or a
+        required answer the user declined). Both used to come back as
+        False/False with no questions left, which the chat tool rendered as a
+        confident "may not be eligible".
+        """
         return (
             bool(eligible_2025),
             bool(eligible_2026),
             bool(eligible_medicare),
             list(dict.fromkeys(alts)),
             list(dict.fromkeys(missing)),
+            determination_made,
         )
 
     # ---- prioritize missing info for stepwise questioning ----
-    if state in _TERRITORY_CODES:
-        # Territories run Medicaid under capped block grants with their own
-        # income rules, so the 50-state heuristics below don't apply. Say so
-        # and route to the local agency rather than guessing (or re-asking
-        # for a state the resident has already correctly given).
-        alts.append(
-            "Medicaid in US territories follows different rules than the states"
-            "—contact your territory's Medicaid agency for eligibility limits."
-        )
-        return _result()
     if not state:
         ask("state", "What state do you live in?")
     if age is None:
@@ -927,7 +946,7 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
             else:
                 eligible_medicare = False
                 alts.append(
-                    "You may be eligible to buy Part-A medicare even if you don't qualify for premium-free part A."
+                    "You may be eligible to buy Medicare Part A even if you don't qualify for premium-free Part A."
                 )
                 alts.append(
                     "Medicare Savings Programs (QMB/SLMB/QI) can help pay Medicare premiums when income and assets are low."
@@ -937,6 +956,20 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
         # assume not enrolled instead of stalling the flow on a question
         # whose answer is essentially always "no".
         on_medicare = False
+
+    if state in _TERRITORY_CODES:
+        # Territories run Medicaid under capped block grants with their own
+        # income rules, so the 50-state heuristics below don't apply. This
+        # runs AFTER the Medicare pathway above on purpose: Medicare is
+        # federal and does operate in PR/GU/VI/AS/MP, so a 67-year-old
+        # resident still gets a real Medicare answer. The Medicaid side
+        # comes back as not modeled (determination_made stays False) rather
+        # than as a "not eligible" verdict.
+        alts.append(
+            "Medicaid in US territories follows different rules than the states"
+            "—contact your territory's Medicaid agency for eligibility limits."
+        )
+        return _result()
 
     # LTC pathways. Note: living_situation is accepted as context but is not
     # asked for and does not gate the determination -- applying_reason already
@@ -1166,10 +1199,27 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
                 # sent a weekly list or a weekly average.
                 if weekly_hours:
                     weeks = len(weekly_hours)
-                    if weeks >= 4:
-                        weeks_per_month = 13.0 / REQUIRED_MONTHS
-                        per_month = (sum(weekly_hours) / weeks) * weeks_per_month
-                        return [per_month] * REQUIRED_MONTHS
+                    if weeks >= REQUIRED_MONTHS:
+                        # Partition the weeks across the 3 months so real
+                        # month-to-month variation survives -- averaging the
+                        # whole window and repeating it made [60]*4 + [0]*8
+                        # (two genuinely empty months) pass the per-month
+                        # rule. Each bucket is then scaled to a calendar
+                        # month (13 weeks per quarter, not 12), which keeps
+                        # this in agreement with the weekly-average path
+                        # instead of undercounting by ~8%.
+                        per_bucket = weeks / REQUIRED_MONTHS
+                        weeks_in_month = 13.0 / REQUIRED_MONTHS
+                        buckets: List[float] = []
+                        for index in range(REQUIRED_MONTHS):
+                            start = int(round(index * per_bucket))
+                            end = int(round((index + 1) * per_bucket))
+                            chunk = weekly_hours[start:end]
+                            if not chunk:
+                                continue
+                            buckets.append((sum(chunk) / len(chunk)) * weeks_in_month)
+                        if len(buckets) == REQUIRED_MONTHS:
+                            return buckets
                 if total_hours_3mo is not None:
                     # Average monthly hours from total
                     avg_monthly = float(total_hours_3mo) / REQUIRED_MONTHS
@@ -1241,7 +1291,7 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
             "We can’t find a pathway with the current info—consider speaking with a benefits navigator or attorney."
         )
 
-    return _result()
+    return _result(determination_made=True)
 
 
 @lru_cache(maxsize=1)

--- a/fighthealthinsurance/medicaid_api.py
+++ b/fighthealthinsurance/medicaid_api.py
@@ -147,9 +147,26 @@ _ALIASES = {
     "s. carolina": "south carolina",
     "n. dakota": "north dakota",
     "s. dakota": "south dakota",
-    # State Medicaid program names. The prompt asks the model to infer the
-    # state from these; this is the backstop for when it passes the program
-    # name straight through as the "state".
+    # “state of …” forms
+    "state of california": "california",
+    "state of new york": "new york",
+    "state of washington": "washington",
+}
+
+# State Medicaid program names. The prompt asks the model to infer the state
+# from these; this is the backstop for when it passes the program name
+# straight through as the "state".
+#
+# Kept separate from _ALIASES (and merged in below) so the fuzzy-exclusion
+# set can be DERIVED from it rather than hand-copied. A second hand-kept
+# list would drift, silently readmitting a program name to the fuzzy pool.
+#
+# Deliberately absent: a bare "medical". Pennsylvania, Minnesota and
+# Maryland all call their programs "Medical Assistance", so users there say
+# "Medical" and it must not resolve to California. Likewise "healthy
+# connections", which names both South Carolina's and Idaho's programs --
+# and they sit on opposite sides of the expansion line.
+_PROGRAM_NAME_TO_STATE = {
     "medi-cal": "california",
     "denalicare": "alaska",
     "health first colorado": "colorado",
@@ -175,50 +192,18 @@ _ALIASES = {
     "forward health": "wisconsin",
     "forwardhealth": "wisconsin",
     "equality care": "wyoming",
-    # “state of …” forms
-    "state of california": "california",
-    "state of new york": "new york",
-    "state of washington": "washington",
 }
+_ALIASES.update(_PROGRAM_NAME_TO_STATE)
 
 # Add 2-letter codes themselves as valid keys (so "CA"→"ca")
 for full, abbr in list(_STATE_MAP.items()):
     _ALIASES[abbr] = full
 
-# State program names are matched EXACTLY, never fuzzily. "medical" (how
-# "Medi-Cal" survives punctuation stripping) sits 0.857 away from "medicad",
-# a routine misspelling of "medicaid" -- above the 0.84 cutoff -- so leaving
-# these in the fuzzy pool silently scored typo'd input under California's
-# rules. A program name is either recognized exactly or it is not a state.
-_PROGRAM_ALIASES = frozenset(
-    {
-        "medi-cal",
-        "denalicare",
-        "health first colorado",
-        "husky health",
-        "diamond state health plan",
-        "med-quest",
-        "medquest",
-        "healthchoice illinois",
-        "hoosier healthwise",
-        "kansas medical assistance program",
-        "mainecare",
-        "masshealth",
-        "mo healthnet",
-        "nj familycare",
-        "turquoise care",
-        "soonercare",
-        "tenncare",
-        "star+plus",
-        "star plus",
-        "green mountain care",
-        "cardinal care",
-        "apple health",
-        "forward health",
-        "forwardhealth",
-        "equality care",
-    }
-)
+# Program names are matched EXACTLY, never fuzzily: they are short and
+# collide with ordinary words and with each other's typos, so fuzzy matching
+# them silently scores one state's applicant under another's rules. A
+# program name is either recognized exactly or it is not a state.
+_PROGRAM_ALIASES = frozenset(_PROGRAM_NAME_TO_STATE)
 
 # Precompute candidate keys (full names + aliases) for fuzzy matching
 _CANDIDATE_KEYS = (set(_STATE_MAP.keys()) | set(_ALIASES.keys())) - _PROGRAM_ALIASES
@@ -431,6 +416,13 @@ _DECLINE_DEFAULTS: Dict[str, Any] = {
     "veteran_or_spouse_of_veteran": False,
     "work_req_exempt_2026": False,
 }
+
+# Percent-of-FPL ceilings by category. Module scope because the stepwise
+# question block consults them to skip questions that cannot change the
+# answer, and it runs before the category chain.
+THRESH_ADULT_MAGI = 138.0
+THRESH_CHILD = 200.0
+THRESH_PREG = 200.0
 
 # Without these there is no estimate to give, so a decline here stops the
 # flow with an explanation instead of a silent "not eligible".
@@ -1076,7 +1068,7 @@ def is_eligible(
         # so those can still resolve into a real answer.
         keep = [
             question
-            for field, question in zip(asked_fields, missing)
+            for field, question in zip(asked_fields, missing, strict=True)
             if field in _MEDICARE_QUESTION_FIELDS
         ]
         asked_fields[:] = [f for f in asked_fields if f in _MEDICARE_QUESTION_FIELDS]
@@ -1101,7 +1093,22 @@ def is_eligible(
         abd_candidate = (
             (age is not None and age >= 65) or (receiving_ssdi is True)
         ) and not ((age is not None and age < 19) or pregnant is True)
-        if abd_candidate and assets_total is None:
+        # ACA expansion applies no asset test, so for an adult 19-64 already
+        # under the threshold the answer cannot change the verdict -- don't
+        # spend a turn collecting it. Guarded on having the inputs, since
+        # this runs before the completeness gate.
+        covered_without_assets = False
+        if (
+            age is not None
+            and 19 <= age <= 64
+            and monthly_income is not None
+            and household_size is not None
+        ):
+            pct = pct_fpl(monthly_income, household_size, 2025)
+            covered_without_assets = (
+                state in _EXPANSION_STATES and pct <= THRESH_ADULT_MAGI
+            ) or (state in _WAIVER_100FPL_STATES and pct <= 100.0)
+        if abd_candidate and assets_total is None and not covered_without_assets:
             ask("assets_total", _Q_ASSETS)
 
     # mypy isn't smart enough to infer the types with a loop :/
@@ -1141,10 +1148,6 @@ def is_eligible(
     is_abd_disability = bool(receiving_ssdi)
     is_preg = bool(pregnant)
 
-    THRESH_ADULT_MAGI = 138.0
-    THRESH_CHILD = 200.0
-    THRESH_PREG = 200.0
-
     # Category decisions → 2025 base eligibility (pre-work overlay)
     if is_child:
         eligible_2025 = pfpl_2025 <= THRESH_CHILD
@@ -1162,21 +1165,52 @@ def is_eligible(
         # Someone explicitly applying for long-term care falls through to the
         # LTC branch below (LTC applicants are almost always 65+/disabled, so
         # without this carve-out they'd be evaluated under the wrong rules).
+        def qualifies_on_magi_alone() -> bool:
+            """Whether ACA expansion covers them on income alone.
+
+            Disability does not bar the expansion pathway, and that pathway
+            applies NO asset test -- so for an adult 19-64 under the
+            threshold the asset question cannot change the answer.
+            """
+            if not is_adult_magi:
+                return False
+            if state in _EXPANSION_STATES and pfpl_2025 <= THRESH_ADULT_MAGI:
+                return True
+            return state in _WAIVER_100FPL_STATES and pfpl_2025 <= 100.0
+
+        def abd_alternatives() -> None:
+            """Pathways worth naming when the ABD test does not come out yes."""
+            if on_medicare:
+                alts.append(
+                    "Medicare Savings Programs (QMB/SLMB/QI) can help pay Part A/B premiums and cost-sharing."
+                )
+            if medically_needy:
+                alts.append(
+                    "Medically-needy/spend-down Medicaid may help if medical bills are high."
+                )
+            # No else: the ~17 states without a medically-needy program for
+            # aged/disabled adults have nothing to ask about, and sending
+            # someone to their agency for a program that doesn't exist there
+            # wastes a call. The generic pointers below (state page,
+            # navigator, appeal) still apply.
+
         if assets_total is None:
-            if not ask("assets_total", _Q_ASSETS):
-                # Declined: an asset test we cannot run is not a failed asset
-                # test. Without this the else-arm never ran, so a 66-year-old
-                # at 69% FPL who simply didn't know their asset total got a
-                # flat "may not be eligible" and none of the pathways below.
+            if qualifies_on_magi_alone():
+                # Score it rather than asking: expansion applies no asset
+                # test, so the answer is already determined. Treating this
+                # as indeterminate on a declined asset figure was worse than
+                # a wrong answer -- the same person who reported assets far
+                # OVER the ABD limit came back eligible via this pathway,
+                # while declining the question came back "we can't estimate".
+                eligible_2025 = True
+            elif not ask("assets_total", _Q_ASSETS):
+                # Declined, and no asset-free pathway applies: an asset test
+                # we cannot run is not a failed asset test. Without this the
+                # else-arm never ran, so a 66-year-old at 69% FPL who simply
+                # didn't know their asset total got a flat "may not be
+                # eligible" and none of the pathways below.
                 indeterminate.append("assets_total")
-                if on_medicare:
-                    alts.append(
-                        "Medicare Savings Programs (QMB/SLMB/QI) can help pay Part A/B premiums and cost-sharing."
-                    )
-                if medically_needy:
-                    alts.append(
-                        "Medically-needy/spend-down Medicaid may help if medical bills are high."
-                    )
+                abd_alternatives()
         else:
             asset_limit = ABD_ASSET_LIMIT_MARRIED if married else ABD_ASSET_LIMIT_SINGLE
             assets_ok = assets_total <= asset_limit
@@ -1185,29 +1219,10 @@ def is_eligible(
             # waiver -- treating it as one reported six-figure earners as
             # "probably eligible". It stays a suggestion below instead.
             eligible_2025 = assets_ok and income_ok_2025
-            if not eligible_2025 and is_adult_magi:
-                # Disability doesn't bar the ACA expansion pathway: adults
-                # 19-64 in expansion (or 100%-FPL-waiver) states qualify on
-                # income alone with no asset test, so check MAGI before
-                # concluding ineligibility.
-                if state in _EXPANSION_STATES and pfpl_2025 <= THRESH_ADULT_MAGI:
-                    eligible_2025 = True
-                elif state in _WAIVER_100FPL_STATES and pfpl_2025 <= 100.0:
-                    eligible_2025 = True
             if not eligible_2025:
-                if on_medicare:
-                    alts.append(
-                        "Medicare Savings Programs (QMB/SLMB/QI) can help pay Part A/B premiums and cost-sharing."
-                    )
-                if medically_needy:
-                    alts.append(
-                        "Medically-needy/spend-down Medicaid may help if medical bills are high."
-                    )
-                # No else: the ~17 states without a medically-needy program
-                # for aged/disabled adults have nothing to ask about, and
-                # sending someone to their agency for a program that doesn't
-                # exist there wastes a call. The generic pointers below
-                # (state page, navigator, appeal) still apply.
+                eligible_2025 = qualifies_on_magi_alone()
+            if not eligible_2025:
+                abd_alternatives()
     elif applying_reason in _LTC_REASONS:
         ltc_evaluated = True
         # The stepwise block above already queued these questions; here we

--- a/fighthealthinsurance/medicaid_api.py
+++ b/fighthealthinsurance/medicaid_api.py
@@ -167,7 +167,6 @@ _ALIASES = {
     "nj familycare": "new jersey",
     "turquoise care": "new mexico",
     "soonercare": "oklahoma",
-    "healthy connections": "south carolina",
     "tenncare": "tennessee",
     "star+plus": "texas",
     "star plus": "texas",
@@ -187,8 +186,44 @@ _ALIASES = {
 for full, abbr in list(_STATE_MAP.items()):
     _ALIASES[abbr] = full
 
-# Precompute candidate keys (full names + aliases)
-_CANDIDATE_KEYS = set(_STATE_MAP.keys()) | set(_ALIASES.keys())
+# State program names are matched EXACTLY, never fuzzily. "medical" (how
+# "Medi-Cal" survives punctuation stripping) sits 0.857 away from "medicad",
+# a routine misspelling of "medicaid" -- above the 0.84 cutoff -- so leaving
+# these in the fuzzy pool silently scored typo'd input under California's
+# rules. A program name is either recognized exactly or it is not a state.
+_PROGRAM_ALIASES = frozenset(
+    {
+        "medi-cal",
+        "medical",
+        "denalicare",
+        "health first colorado",
+        "husky health",
+        "diamond state health plan",
+        "med-quest",
+        "medquest",
+        "healthchoice illinois",
+        "hoosier healthwise",
+        "kansas medical assistance program",
+        "mainecare",
+        "masshealth",
+        "mo healthnet",
+        "nj familycare",
+        "turquoise care",
+        "soonercare",
+        "tenncare",
+        "star+plus",
+        "star plus",
+        "green mountain care",
+        "cardinal care",
+        "apple health",
+        "forward health",
+        "forwardhealth",
+        "equality care",
+    }
+)
+
+# Precompute candidate keys (full names + aliases) for fuzzy matching
+_CANDIDATE_KEYS = (set(_STATE_MAP.keys()) | set(_ALIASES.keys())) - _PROGRAM_ALIASES
 
 # Reverse map: 2-letter code -> display name, derived from _STATE_MAP so the
 # two never drift apart. Later duplicate full-name keys ("washington dc",
@@ -345,6 +380,12 @@ _FALSE_STRINGS = frozenset(
         "never",
         "i am not",
         "i'm not",
+        # Marital-status answers to "Are you married or single?". Without
+        # these the question is re-asked every turn, since the answer parses
+        # to None (unanswered) rather than to "not currently married".
+        "widowed",
+        "divorced",
+        "separated",
     }
 )
 
@@ -396,6 +437,21 @@ _DECLINE_DEFAULTS: Dict[str, Any] = {
 # Without these there is no estimate to give, so a decline here stops the
 # flow with an explanation instead of a silent "not eligible".
 _REQUIRED_FOR_ESTIMATE = ("state", "age", "household_size", "monthly_income")
+
+# Questions that feed the Medicare determination. Medicare is federal and
+# operates in the territories, so these survive the territory short-circuit
+# while the Medicaid-only questions are dropped.
+_MEDICARE_QUESTION_FIELDS = frozenset(
+    {
+        "age",
+        "on_medicare",
+        "years_worked",
+        "receiving_ssdi",
+        "ssdi_length",
+        "esrd",
+        "als",
+    }
+)
 
 # Every kwarg is_eligible reads. Anything else the model sends is silently
 # ignored today, which looks to the model like the answer was accepted -- so
@@ -457,6 +513,17 @@ def _is_unknown_marker(value: Any) -> bool:
 _WORD_NUMBERS = {
     "zero": 0,
     "none": 0,
+    # Natural answers to "About how much is your household's monthly income?"
+    # from someone with no income. monthly_income is in _REQUIRED_FOR_ESTIMATE
+    # so it cannot be defaulted away -- leaving these unparsed re-asked the
+    # same question every turn. "unemployed" is deliberately absent: it is a
+    # job status, not an amount, and unemployment benefits are income.
+    "no income": 0,
+    "zero income": 0,
+    "nothing": 0,
+    "none at all": 0,
+    "no money": 0,
+    "nil": 0,
     "one": 1,
     "two": 2,
     "three": 3,
@@ -738,6 +805,15 @@ def is_eligible(
         name for name, raw in kwargs.items() if _is_unknown_marker(raw)
     )
     assumed_fields: List[str] = []
+    # Field name behind each queued question, parallel to ``missing`` (every
+    # append goes through ask()). Lets the territory branch keep the
+    # questions that can still produce an answer and drop the rest.
+    asked_fields: List[str] = []
+    # Categories we could not score because the answer they need was
+    # declined. Unlike _REQUIRED_FOR_ESTIMATE (which stops the flow), these
+    # let the rest of the estimate stand while keeping determination_made
+    # False, so the chat tool reports "not scored" instead of "not eligible".
+    indeterminate: List[str] = []
     if declined_fields:
         kwargs = dict(kwargs)
         for name in declined_fields:
@@ -815,11 +891,19 @@ def is_eligible(
     eligible_2026 = False
     eligible_medicare = False
 
-    def ask(field: str, question: str) -> None:
-        """Queue a question unless the user already declined that field."""
+    def ask(field: str, question: str) -> bool:
+        """Queue a question unless the user already declined that field.
+
+        Returns True when the question was actually queued. Callers that
+        would otherwise fall straight through to a verdict need that
+        distinction: a declined field means "we could not score this", not
+        "the answer is no".
+        """
         if field in declined_set:
-            return
+            return False
         missing.append(question)
+        asked_fields.append(field)
+        return True
 
     def _result(
         determination_made: bool = False,
@@ -932,10 +1016,21 @@ def is_eligible(
             eligible_medicare = True
         elif is_65_plus:
             if years_worked is None:
-                ask(
+                if not ask(
                     "years_worked",
                     "How many years did you (or spouse or ex-spouse) work and pay medicare taxes?",
-                )
+                ):
+                    # Declined: we can't confirm premium-free Part A, but a
+                    # 65+ applicant still has the buy-in and MSP pathways.
+                    # Falling through silently left them with no Medicare
+                    # answer AND no alternatives at all.
+                    indeterminate.append("years_worked")
+                    alts.append(
+                        "You may be eligible to buy Medicare Part A even if you don't qualify for premium-free Part A."
+                    )
+                    alts.append(
+                        "Medicare Savings Programs (QMB/SLMB/QI) can help pay Medicare premiums when income and assets are low."
+                    )
             elif years_worked >= 10:
                 # 10 years (40 quarters) of Medicare taxes = premium-free Part A.
                 eligible_medicare = True
@@ -969,6 +1064,18 @@ def is_eligible(
             "Medicaid in US territories follows different rules than the states"
             "—contact your territory's Medicaid agency for eligibility limits."
         )
+        # Drop the Medicaid-only questions the stepwise block queued above: no
+        # answer to them can produce a territory Medicaid estimate, so asking
+        # spent several turns to arrive at the same "not modeled". Keep the
+        # Medicare-relevant ones -- Medicare is federal and does operate here,
+        # so those can still resolve into a real answer.
+        keep = [
+            question
+            for field, question in zip(asked_fields, missing)
+            if field in _MEDICARE_QUESTION_FIELDS
+        ]
+        asked_fields[:] = [f for f in asked_fields if f in _MEDICARE_QUESTION_FIELDS]
+        missing[:] = keep
         return _result()
 
     # LTC pathways. Note: living_situation is accepted as context but is not
@@ -1051,7 +1158,20 @@ def is_eligible(
         # LTC branch below (LTC applicants are almost always 65+/disabled, so
         # without this carve-out they'd be evaluated under the wrong rules).
         if assets_total is None:
-            ask("assets_total", _Q_ASSETS)
+            if not ask("assets_total", _Q_ASSETS):
+                # Declined: an asset test we cannot run is not a failed asset
+                # test. Without this the else-arm never ran, so a 66-year-old
+                # at 69% FPL who simply didn't know their asset total got a
+                # flat "may not be eligible" and none of the pathways below.
+                indeterminate.append("assets_total")
+                if on_medicare:
+                    alts.append(
+                        "Medicare Savings Programs (QMB/SLMB/QI) can help pay Part A/B premiums and cost-sharing."
+                    )
+                if medically_needy:
+                    alts.append(
+                        "Medically-needy/spend-down Medicaid may help if medical bills are high."
+                    )
         else:
             asset_limit = ABD_ASSET_LIMIT_MARRIED if married else ABD_ASSET_LIMIT_SINGLE
             assets_ok = assets_total <= asset_limit
@@ -1078,10 +1198,11 @@ def is_eligible(
                     alts.append(
                         "Medically-needy/spend-down Medicaid may help if medical bills are high."
                     )
-                else:
-                    alts.append(
-                        "Ask about medically-needy/spend-down Medicaid in your state."
-                    )
+                # No else: the ~17 states without a medically-needy program
+                # for aged/disabled adults have nothing to ask about, and
+                # sending someone to their agency for a program that doesn't
+                # exist there wastes a call. The generic pointers below
+                # (state page, navigator, appeal) still apply.
     elif applying_reason in _LTC_REASONS:
         ltc_evaluated = True
         # The stepwise block above already queued these questions; here we
@@ -1232,15 +1353,21 @@ def is_eligible(
             # total_qualifying_hours_last_3mo) so the answer has a slot to
             # land in instead of being silently dropped.
             if monthly_data is None:
-                ask(
+                asked_avg = ask(
                     "avg_monthly_qualifying_hours_last_3mo",
                     "For 2026, about how many qualifying hours per month (work, school, volunteering, or caregiving) do you average?",
                 )
-                ask(
+                asked_total = ask(
                     "total_qualifying_hours_last_3mo",
                     "If easier, share your total qualifying hours over the last 3 months.",
                 )
                 eligible_2026 = False  # unknown until we get this
+                if not asked_avg and not asked_total:
+                    # Both hour questions declined, so there is no way to
+                    # apply the 80-hrs/month rule. Without this the "unknown"
+                    # above shipped as a confident "may not be eligible under
+                    # the 2026 rules" to someone who just couldn't estimate.
+                    indeterminate.append("qualifying work hours")
             else:
                 # Check monthly requirement
                 avg_monthly = sum(monthly_data) / REQUIRED_MONTHS
@@ -1291,7 +1418,13 @@ def is_eligible(
             "We can’t find a pathway with the current info—consider speaking with a benefits navigator or attorney."
         )
 
-    return _result(determination_made=True)
+    if indeterminate:
+        readable = ", ".join(f.replace("_", " ") for f in indeterminate)
+        alts.append(
+            f"We could not check {readable} because that answer wasn't "
+            "available—your state Medicaid agency can check it directly."
+        )
+    return _result(determination_made=not indeterminate)
 
 
 @lru_cache(maxsize=1)
@@ -1442,7 +1575,13 @@ def get_medicaid_info(query: Dict[str, Any]) -> Optional[str]:
         df = df[df["state"].astype(str).str.lower() == state.lower()]
 
     if df.empty:
-        return f"No Medicaid data found for {state}."
+        # No row for this state. The territories (PR/GU/VI/AS/MP) normalize to
+        # a display name but have no entry in medicaid_resources.csv, and the
+        # caller wraps whatever comes back as "Here's the official Medicaid
+        # information for X:" -- so returning prose here presented "no data
+        # found" to the model as retrieved data. None routes it to the same
+        # re-ask/decline path as an unrecognized state.
+        return None
 
     # Focus on the most important contact info
     important_cols = [

--- a/fighthealthinsurance/medicaid_api.py
+++ b/fighthealthinsurance/medicaid_api.py
@@ -1,10 +1,12 @@
 import difflib
 import json
 import re
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import pandas as pd
+from loguru import logger
 
 # Look for data/ next to the repo root
 DATA_DIR = Path(__file__).resolve().parent.parent / "data"
@@ -96,7 +98,21 @@ _STATE_MAP = {
     "west virginia": "wv",
     "wisconsin": "wi",
     "wyoming": "wy",
+    # US territories run Medicaid under capped block grants with their own
+    # rules. They are recognized here so a resident's answer parses instead of
+    # re-asking "what state do you live in?" forever; is_eligible then routes
+    # them to their local agency rather than guessing with state rules.
+    "puerto rico": "pr",
+    "guam": "gu",
+    "us virgin islands": "vi",
+    "u.s. virgin islands": "vi",
+    "virgin islands": "vi",
+    "american samoa": "as",
+    "northern mariana islands": "mp",
 }
+
+# Territory codes, kept out of the 50-state policy sets above.
+_TERRITORY_CODES = frozenset({"pr", "gu", "vi", "as", "mp"})
 
 # Helpful aliases/variants -> canonical full name
 _ALIASES = {
@@ -255,13 +271,102 @@ _Q_LIVING_SITUATION = (
     "Where are you living now (home, assisted living, rehab, nursing home)?"
 )
 _Q_SSDI_MONTHS = "How many months have you been receiving SSDI?"
+_Q_ESRD = "Are you in end stage renal failure?"
+_Q_ALS = "Do you have ALS?"
 
 # String truthiness for LLM-supplied "booleans": tool payloads are raw LLM
 # JSON, which sometimes carries "false"/"no" instead of JSON booleans -- and
-# bool("false") is True. Unknown strings read as unanswered (re-ask) rather
-# than guessed.
-_TRUE_STRINGS = frozenset({"true", "yes", "y", "1", "on"})
-_FALSE_STRINGS = frozenset({"false", "no", "n", "0", "off", ""})
+# bool("false") is True. The vocabulary covers how people actually answer in
+# chat ("nope", "single") because an unrecognized string reads as unanswered,
+# and an unanswered required field re-asks the same question forever. An
+# empty string is explicitly NOT false: it is the most likely "I don't have
+# this value" placeholder, so it must re-ask rather than record a "no".
+_TRUE_STRINGS = frozenset(
+    {
+        "true",
+        "yes",
+        "y",
+        "1",
+        "on",
+        "t",
+        "yeah",
+        "yep",
+        "yup",
+        "correct",
+        "married",
+        "i am",
+        "i do",
+    }
+)
+_FALSE_STRINGS = frozenset(
+    {
+        "false",
+        "no",
+        "n",
+        "0",
+        "off",
+        "f",
+        "nope",
+        "nah",
+        "single",
+        "unmarried",
+        "not married",
+        "none",
+        "never",
+        "i am not",
+        "i'm not",
+    }
+)
+
+# Word forms for the small counts people spell out ("three people").
+_WORD_NUMBERS = {
+    "zero": 0,
+    "none": 0,
+    "one": 1,
+    "two": 2,
+    "three": 3,
+    "four": 4,
+    "five": 5,
+    "six": 6,
+    "seven": 7,
+    "eight": 8,
+    "nine": 9,
+    "ten": 10,
+    "eleven": 11,
+    "twelve": 12,
+}
+
+
+def _parse_numeric(value: Any) -> Optional[float]:
+    """Best-effort number out of an LLM-supplied value.
+
+    Chat answers arrive as "$1,200", "1200/month", "about 1200", or "three",
+    and a bare float() on those raises -- which the callers turn into None,
+    i.e. "unanswered", so the same question is asked again every turn. Strip
+    the currency/units decoration instead. Returns None only when there is
+    genuinely no number to find.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if not isinstance(value, str):
+        return None
+    text = value.strip().lower()
+    if not text:
+        return None
+    if text in _WORD_NUMBERS:
+        return float(_WORD_NUMBERS[text])
+    # Keep the first number-like run, dropping $ , and any trailing units.
+    match = re.search(r"-?\d[\d,]*(?:\.\d+)?", text)
+    if not match:
+        return None
+    try:
+        return float(match.group(0).replace(",", ""))
+    except ValueError:
+        return None
 
 
 def _clean_token(s: str) -> str:
@@ -420,7 +525,7 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
             # LLM payloads sometimes carry "false"/"no" string booleans;
             # bool("false") is True, which flipped verdicts. See
             # _TRUE_STRINGS/_FALSE_STRINGS.
-            s = v.strip().lower()
+            s = v.strip().lower().rstrip(".!").strip()
             if s in _TRUE_STRINGS:
                 return True
             if s in _FALSE_STRINGS:
@@ -429,18 +534,11 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
         return bool(v)
 
     def get_int(name: str) -> Optional[int]:
-        v = kwargs.get(name, None)
-        try:
-            return int(v) if v is not None else None
-        except Exception:
-            return None
+        parsed = _parse_numeric(kwargs.get(name, None))
+        return int(parsed) if parsed is not None else None
 
     def get_float(name: str) -> Optional[float]:
-        v = kwargs.get(name, None)
-        try:
-            return float(v) if v is not None else None
-        except Exception:
-            return None
+        return _parse_numeric(kwargs.get(name, None))
 
     def get_seq_of_floats(name: str) -> Optional[List[float]]:
         v = kwargs.get(name, None)
@@ -561,6 +659,16 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
         )
 
     # ---- prioritize missing info for stepwise questioning ----
+    if state in _TERRITORY_CODES:
+        # Territories run Medicaid under capped block grants with their own
+        # income rules, so the 50-state heuristics below don't apply. Say so
+        # and route to the local agency rather than guessing (or re-asking
+        # for a state the resident has already correctly given).
+        alts.append(
+            "Medicaid in US territories follows different rules than the states"
+            "—contact your territory's Medicaid agency for eligibility limits."
+        )
+        return _result()
     if not state:
         missing.append("What state do you live in?")
     if age is None:
@@ -580,9 +688,10 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
             "About how much is your household's monthly income before taxes?"
         )
 
-    # https://en.wikipedia.org/wiki/Lina_Medina :/
+    # https://en.wikipedia.org/wiki/Lina_Medina :/ -- and at the other end, a
+    # 95-year-old's determination should not sit blocked on this either.
     if age is not None and pregnant is None:
-        if age > 4:
+        if 4 < age <= 60:
             missing.append("Are you currently pregnant?")
         else:
             # Don't stall the determination on a question we'd never ask.
@@ -594,22 +703,38 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
         missing.append(
             "Are you receiving SSDI or otherwise considered disabled for benefits?"
         )
-    if receiving_ssdi and ssdi_length is None:
+    # Only ask about SSDI duration when SSDI itself was answered yes. Someone
+    # who said "disabled, but not on SSDI" cannot answer it, and the prompt
+    # forbids the model from inventing a value -- so asking anyway stalls the
+    # conversation on a question with no possible answer.
+    if ssdi_answer and ssdi_length is None:
         # Needed at any age: 24+ months of SSDI is its own Medicare pathway,
         # so a 67-year-old on SSDI must be asked too, not just under-65s.
         missing.append(_Q_SSDI_MONTHS)
     if age is not None and age < 65:
-        if (ssdi_length is None or ssdi_length < 24) and esrd is None:
-            missing.append("Are you in end stage renal failure?")
-        if esrd is not None and als is None:
-            missing.append("Do you have ALS?")
+        # ESRD and ALS each open a Medicare pathway at any age, but they are
+        # rare enough that asking every healthy young adult about kidney
+        # failure burns two turns on answers that cannot change the result.
+        # Ask only when there's already a disability/Medicare signal, and
+        # ask both at once rather than serializing them across turns.
+        settled_by_ssdi = ssdi_length is not None and ssdi_length >= 24
+        if (bool(receiving_ssdi) or bool(on_medicare)) and not settled_by_ssdi:
+            if esrd is None:
+                missing.append(_Q_ESRD)
+            if als is None:
+                missing.append(_Q_ALS)
+        else:
+            if esrd is None:
+                esrd = False
+            if als is None:
+                als = False
 
     # ---- Medicare pathway: enrolled, 65+, 24+ months of SSDI, ESRD, or ALS ----
     is_65_plus = age is not None and age >= 65
     has_esrd_or_als = bool(esrd) or bool(als)
-    ssdi_24_months = (
-        bool(receiving_ssdi) and ssdi_length is not None and ssdi_length >= 24
-    )
+    # Gate on ssdi_answer: ssdi_length means *SSDI* months, so a duration
+    # supplied alongside a non-SSDI disability must not confer Medicare.
+    ssdi_24_months = bool(ssdi_answer) and ssdi_length is not None and ssdi_length >= 24
     medicare_pathway = (
         bool(on_medicare) or is_65_plus or has_esrd_or_als or ssdi_24_months
     )
@@ -652,10 +777,11 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
         # whose answer is essentially always "no".
         on_medicare = False
 
-    # LTC pathways
+    # LTC pathways. Note: living_situation is accepted as context but is not
+    # asked for and does not gate the determination -- applying_reason already
+    # carries the nursing-home vs home-care distinction, and gating on a value
+    # nothing reads cost every LTC applicant an extra round trip.
     if applying_reason in _LTC_REASONS:
-        if living_situation is None:
-            missing.append(_Q_LIVING_SITUATION)
         if assets_total is None:
             missing.append(_Q_ASSETS)
         if home_owner is None:
@@ -663,9 +789,14 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
         if home_owner and home_equity is None:
             missing.append(_Q_HOME_EQUITY)
     else:
-        if (age is not None and age >= 65) or (receiving_ssdi is True):
-            if assets_total is None:
-                missing.append(_Q_ASSETS)
+        # Only the ABD branch reads assets. Children and pregnancy are scored
+        # on income alone and are matched earlier in the category chain, so
+        # asking them for a number nothing consumes just costs a turn.
+        abd_candidate = (
+            (age is not None and age >= 65) or (receiving_ssdi is True)
+        ) and not ((age is not None and age < 19) or pregnant is True)
+        if abd_candidate and assets_total is None:
+            missing.append(_Q_ASSETS)
 
     # mypy isn't smart enough to infer the types with a loop :/
     if (
@@ -683,7 +814,11 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
 
     # ---- with core info present, evaluate categories ----
     pfpl_2025 = pct_fpl(monthly_income, household_size, 2025)
-    pfpl_2026 = pct_fpl(monthly_income, household_size, 2026)
+
+    # Set by the LTC branch below: that branch computes its own 2026 verdict
+    # (the LTC income cap differs by year), so the work overlay must not
+    # recompute it -- but only when the branch actually ran.
+    ltc_evaluated = False
 
     is_child = age < 19
     is_adult_magi = 19 <= age <= 64
@@ -718,7 +853,10 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
             asset_limit = ABD_ASSET_LIMIT_MARRIED if married else ABD_ASSET_LIMIT_SINGLE
             assets_ok = assets_total <= asset_limit
             income_ok_2025 = pfpl_2025 <= 100.0
-            eligible_2025 = assets_ok and (income_ok_2025 or medically_needy)
+            # NOTE: medically_needy is a spend-down PATHWAY, not an income
+            # waiver -- treating it as one reported six-figure earners as
+            # "probably eligible". It stays a suggestion below instead.
+            eligible_2025 = assets_ok and income_ok_2025
             if not eligible_2025 and is_adult_magi:
                 # Disability doesn't bar the ACA expansion pathway: adults
                 # 19-64 in expansion (or 100%-FPL-waiver) states qualify on
@@ -742,19 +880,12 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
                         "Ask about medically-needy/spend-down Medicaid in your state."
                     )
     elif applying_reason in _LTC_REASONS:
-        # For LTC we need some extra info
-        if assets_total is None:
-            missing.append(_Q_ASSETS)
-        if home_owner is None:
-            missing.append(_Q_HOME_OWNER)
-        if living_situation is None:
-            missing.append(_Q_LIVING_SITUATION)
-        if home_owner and home_equity is None:
-            missing.append(_Q_HOME_EQUITY)
+        ltc_evaluated = True
+        # The stepwise block above already queued these questions; here we
+        # only decide whether we can score yet.
         if (
             assets_total is None
             or home_owner is None
-            or living_situation is None
             or (home_owner and home_equity is None)
         ):
             # Keep any Medicare verdict and alternatives accumulated above --
@@ -767,9 +898,7 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
 
         asset_limit = ABD_ASSET_LIMIT_MARRIED if married else ABD_ASSET_LIMIT_SINGLE
 
-        # assets_total is narrowed by the early return above; zero assets
-        # passes the test.
-        assert assets_total is not None
+        # assets_total is narrowed by the guard above; zero assets passes.
         assets_ok = assets_total <= asset_limit
         home_ok = True
         if home_owner:
@@ -824,10 +953,6 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
                 alts.append(
                     "If you’re a caretaker relative, check caretaker-relative Medicaid rules in your state."
                 )
-    else:
-        alts.append("Consider ACA marketplace plans with subsidies.")
-        if kids and kids > 0:
-            alts.append("Children may qualify for CHIP.")
 
     # ---- 2026 eligibility = 2025 base eligibility + federal work overlay ----
     # Exemptions (if caller knows): pregnancy, SSDI/disabled, Medicare, ESRD/ALS,
@@ -840,14 +965,19 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
         or is_child
         or is_abd_age
         or has_esrd_or_als
+        or applying_reason in _LTC_REASONS
     )
     exempt = (work_req_exempt_2026 is True) or presumed_exempt
 
-    if applying_reason in _LTC_REASONS:
+    if ltc_evaluated:
         # The LTC branch computed eligible_2026 itself (the LTC income cap
         # differs by year, so income can pass 2026 while failing 2025), and
         # LTC applicants are medically frail -- never subject them to the
-        # work overlay or the not-eligible-2025 clamp.
+        # work overlay or the not-eligible-2025 clamp. Keyed on the branch
+        # actually running, NOT on applying_reason: a child or pregnant LTC
+        # applicant is scored by the child/pregnancy branch earlier in the
+        # chain, and keying on the reason skipped their exemption entirely,
+        # handing a 10-year-old a final "not eligible in 2026".
         pass
     elif not eligible_2025:
         # If not eligible in 2025, they won't be in 2026 either (even before work overlay).
@@ -858,13 +988,18 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
         else:
             # We need a 3-month lookback assessment for 80 hours per month
             def compute_monthly_sums() -> Optional[List[float]]:
-                # Derive monthly totals from weekly data if available
-                if weekly_hours and len(weekly_hours) >= 12:
-                    # Group into 3 months of 4 weeks each
-                    return [
-                        sum(weekly_hours[i * 4 : (i + 1) * 4])
-                        for i in range(REQUIRED_MONTHS)
-                    ]
+                # Derive monthly totals from weekly data if available.
+                # Scale by weeks-per-month rather than slicing into 4-week
+                # buckets: bucketing dropped any weeks past the 12th and
+                # undercounted real calendar months by ~8%, so the same
+                # person got opposite verdicts depending on whether the model
+                # sent a weekly list or a weekly average.
+                if weekly_hours:
+                    weeks = len(weekly_hours)
+                    if weeks >= 4:
+                        weeks_per_month = 13.0 / REQUIRED_MONTHS
+                        per_month = (sum(weekly_hours) / weeks) * weeks_per_month
+                        return [per_month] * REQUIRED_MONTHS
                 if total_hours_3mo is not None:
                     # Average monthly hours from total
                     avg_monthly = float(total_hours_3mo) / REQUIRED_MONTHS
@@ -928,49 +1063,60 @@ def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str]]:
     return _result()
 
 
-def get_medicaid_info(query: Dict[str, Any]) -> str:
+@lru_cache(maxsize=1)
+def _load_medicaid_resources() -> "Optional[pd.DataFrame]":
+    """Read the Medicaid resources CSV once per process.
+
+    The file is ~400 KB and only ever yields one state's row, so re-parsing
+    it on every lookup was pure overhead on a chat turn.
     """
-    query example: {"state":"StateName","topic":"","limit":5}
+    file_path = DATA_DIR / DEFAULT_FILE
+    if not file_path.exists():
+        matches = list(DATA_DIR.glob("*medicaid*.csv"))
+        if not matches:
+            return None
+        file_path = matches[0]
+    try:
+        return pd.read_csv(file_path)
+    except Exception:
+        logger.opt(exception=True).warning("Could not read Medicaid resources CSV")
+        return None
+
+
+def get_medicaid_info(query: Dict[str, Any]) -> Optional[str]:
+    """
+    query example: {"state":"StateName"}
     Returns a clean, professional format with key contact info.
+
+    Returns None when the state can't be determined, so the caller can ask
+    the user which state they're in. (Returning prose here would be
+    indistinguishable from data: the chat tool wraps any string it gets in
+    "Here's the official Medicaid information for X".)
     """
     raw_state = str(query.get("state") or query.get("State") or "").strip()
+    if not raw_state:
+        # Check before normalizing: _normalize_state("") raises, which would
+        # otherwise report a garbled state the user never actually gave.
+        return None
     try:
         state_short = _normalize_state(raw_state)
     except ValueError:
         # A state we can't recognize (typo, garbled LLM value) should read as
         # a re-ask, not an exception that kills the whole tool call -- same
         # hardening is_eligible has.
-        return (
-            f"We couldn't tell which state {raw_state!r} is. "
-            "Please ask the user to confirm their state and try again."
-        )
+        return None
     if state_short is None:
-        # No state (or a placeholder like "unknown"): without one we'd dump
-        # every state's contact info, which is useless in chat.
-        return (
-            "We need to know which state they're in to look up Medicaid "
-            "contact info. Please ask the user for their state and try again."
-        )
-    topic = (query.get("topic") or "").strip().lower()
-    limit = int(query.get("limit") or 5)
+        # A placeholder like "unknown"/"StateName": without a real state we'd
+        # dump every state's contact info, which is useless in chat.
+        return None
 
     # _normalize_state only returns 2-letter codes, every one of which is in
     # the shared reverse map (kept in sync with _STATE_MAP).
     state = _ABBR_TO_NAME[state_short]
 
-    # Pick the CSV
-    file_path = DATA_DIR / DEFAULT_FILE
-    if not file_path.exists():
-        matches = list(DATA_DIR.glob("*medicaid*.csv"))
-        if not matches:
-            return f"Could not find Medicaid data file."
-        file_path = matches[0]
-
-    # Read CSV
-    try:
-        df = pd.read_csv(file_path)
-    except Exception as e:
-        return f"Error reading data: {e}"
+    df = _load_medicaid_resources()
+    if df is None:
+        return None
 
     # Filter by state
     if state and "state" in df.columns:
@@ -988,7 +1134,6 @@ def get_medicaid_info(query: Dict[str, Any]) -> str:
         "agency_website",
     ]
     available_cols = [col for col in important_cols if col in df.columns]
-    misc_cols = [col for col in df.columns if col not in important_cols]
 
     if not available_cols:
         return f"Medicaid data found for {state}, but no contact information available."
@@ -1042,10 +1187,5 @@ def get_medicaid_info(query: Dict[str, Any]) -> str:
             ):
                 phone = str(row["helpline_contact"]).strip()
                 result.append(f"Phone: {phone}")
-        result.append("")
-        result.append("***MISC info (less important)***")
-        for col in misc_cols:
-            if col in row and row[col]:
-                result.append(row[col])
 
     return "\n".join(result)

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -1228,7 +1228,8 @@ Possible kwargs (all optional; function will ask for missing, step-by-step):
       # 2026 federal work / community engagement requirement (80 qualifying hours per month;
       # hours from work, school, volunteering, or caregiving all count):
       - work_req_exempt_2026: bool                    # true if you know they're exempt (pregnant, disabled/medically frail, on medicare, etc.)
-      - avg_weekly_qualifying_hours_last_3mo: float   # average qualifying hours per week over the last 3 months
+      - avg_monthly_qualifying_hours_last_3mo: float  # average qualifying hours per MONTH (the units the tool asks in)
+      - avg_weekly_qualifying_hours_last_3mo: float   # or average per WEEK -- watch the units, never put a monthly number here
       - total_qualifying_hours_last_3mo: float        # or the total over the last 3 months
       - qualifying_hours_weekly_last_12: list of floats  # or 12 weekly numbers if they have detailed records
 

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -111,6 +111,26 @@ from fighthealthinsurance.utils import all_concrete_subclasses
 # followed by whitespace and a capital letter (avoids splitting on "Dr.", "U.S.", etc.)
 _sentence_split_re = re.compile(r"(?<=[.!?])\s+(?=[A-Z])")
 
+# The work-requirements answer the system prompt mandates VERBATIM. Named
+# here, rather than buried in the prompt literal, because two other places
+# have to agree with it: response_similarity.CANNED_REPLY_SIGNATURES (which
+# exempts this block from repeat-rejection, so a user who asks twice gets
+# the required text twice) and the drift test that checks the two still
+# match. Editing the wording is fine; editing it in only one of those places
+# is what broke it before.
+MEDICAID_WORK_REQUIREMENTS_BLOCK = """New federal rules require many adults (ages 19-64) to complete at least 80 hours per month of work, job training, school, or community service to keep Medicaid coverage. States must implement these requirements by January 1, 2027 — a few have started earlier, and some may receive extensions.
+
+**Key Points:**
+- Applies to adults ages 19-64 in most states
+- 80 hours per month minimum requirement (make sure to keep records)
+- Qualifying activities: work, job training, school, community service
+- There are groups which are often exempt, see the FAQ for more information.
+- Implementation deadline: January 1, 2027 (some states earlier; extensions possible)
+- States check the one to three months before you apply or renew, so late-2026 activity can already count
+- State-specific details may vary
+
+For detailed information and state-specific details, visit: [Medicaid Work Requirements FAQ](/faq/medicaid/)"""
+
 
 # ---------------------------------------------------------------------------
 # Shared helpers
@@ -1106,7 +1126,8 @@ IMPORTANT: Do NOT ask the user for the patient's name. The patient's name is pro
             base_system_prompt += logged_in_instructions
 
         # Continue with the rest of the system prompt
-        medicaid_resources_tool = """**Medicaid Information Tool**: For Medicaid/Medicare questions, you MUST use this tool format: **medicaid_info {"state": "StateName", "topic": "", "limit": 5}**
+        medicaid_resources_tool = (
+            """**Medicaid Information Tool**: For Medicaid/Medicare questions, you MUST use this tool format: **medicaid_info {"state": "StateName", "topic": "", "limit": 5}**
 
 (note: fill in the statename with the actual name of the state).
 When possible even if the user has not explicitily provided the state if they're using a state specific name (like MediCal) infer the state for them. Otherwise ask.
@@ -1129,21 +1150,13 @@ WRONG Examples:
 "California has a great Medicaid program called Medi-Cal. **medicaid_info {...}**"
 **Medicaid Work Requirements Information**: If users ask about or reference Medicaid work requirements, you must only respond with this exact text:
 
-New federal rules require many adults (ages 19-64) to complete at least 80 hours per month of work, job training, school, or community service to keep Medicaid coverage. States must implement these requirements by January 1, 2027 — a few have started earlier, and some may receive extensions.
-
-**Key Points:**
-- Applies to adults ages 19-64 in most states
-- 80 hours per month minimum requirement (make sure to keep records)
-- Qualifying activities: work, job training, school, community service
-- There are groups which are often exempt, see the FAQ for more information.
-- Implementation deadline: January 1, 2027 (some states earlier; extensions possible)
-- States check the one to three months before you apply or renew, so late-2026 activity can already count
-- State-specific details may vary
-
-For detailed information and state-specific details, visit: [Medicaid Work Requirements FAQ](/faq/medicaid/)
+"""
+            + MEDICAID_WORK_REQUIREMENTS_BLOCK
+            + """
 
 RULE: Do NOT add any conversational text, questions, or additional explanations when providing work requirements information. Use ONLY the text above.
 """
+        )
         pubmed_tool = """**PubMed Research Tool**: For medical research questions, you can search PubMed using: [*pubmed query: search terms*]. This provides access to recent medical literature and research. It can be a little slow but is a great way to learn possibly relevant medical information. Pubmed is not good for insurance information."""
 
         clinical_trials_tool = """**ClinicalTrials.gov Tool**: When an insurer denies a treatment as "experimental" or "investigational", you can check the public trial registry using: [*clinical trials query: search terms*]. The system returns clinicaltrialscontext:[...] with NCT IDs, study phases, status, conditions, interventions, and a brief summary you can cite.

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -1183,7 +1183,9 @@ All three keys are optional - supply whatever you know. The tool returns:
 
 Use this tool when the user asks about cost, affordability, copay assistance, "how can I afford this", coupons, GoodRx, manufacturer help, or whether the drug is available cheaper without insurance. Always remind the user that copay-foundation funds open and close throughout the year, and that pharmacy-discount payments don't count toward their OOP max."""
 
-        medicaid_eligibility_tool = """**Medicaid Eligibility Check**: To help check if someone is eligible for Medicaid or Medicare, you MUST ONLY use this tool format: **medicaid_eligibility {"state": "StateName", "married": false, ...}**
+        medicaid_eligibility_tool = """**Medicaid Eligibility Check (EXPERIMENTAL)**: To help check if someone is eligible for Medicaid or Medicare, you MUST ONLY use this tool format: **medicaid_eligibility {"state": "StateName", "married": false, ...}**
+
+THIS ELIGIBILITY CHECK IS AN EXPERIMENTAL FEATURE. Every time you start an eligibility check or deliver an estimate, tell the user in plain language that this is an experimental feature that can be wrong or out of date, that it is only a rough estimate and NOT an official eligibility determination, and that only their state Medicaid agency can determine eligibility for real. Do not let a whole eligibility conversation go by without this being said clearly.
 
 ONLY USE THIS TOOL WHEN ASKED IF SOMEONE IS ELIGIBLE FOR MEDICARE/MEDICAID
 
@@ -1230,7 +1232,7 @@ Possible kwargs (all optional; function will ask for missing, step-by-step):
       - total_qualifying_hours_last_3mo: float        # or the total over the last 3 months
       - qualifying_hours_weekly_last_12: list of floats  # or 12 weekly numbers if they have detailed records
 
-Be clear that these are only a best guess as the rules are evolving and you're an AI system who may not have the latest information and can also make mistakes.
+Be clear that this is an experimental feature and these are only a best guess as the rules are evolving and you're an AI system who may not have the latest information and can also make mistakes.
 
 *Only ask a few (two or three) questions at a time, in the order the tool suggests them, and only ask those suggested by the tool (although you can rephrase them naturally and with empathy). Don't re-ask anything the user already told you — pass it in the parameters instead.*
 For example, if someone asks if they're eligible for medi-cal you will call the tool with california and then only ask a few of the questions it gives back (although you can rephrase them).

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -1233,6 +1233,16 @@ Possible kwargs (all optional; function will ask for missing, step-by-step):
       - total_qualifying_hours_last_3mo: float        # or the total over the last 3 months
       - qualifying_hours_weekly_last_12: list of floats  # or 12 weekly numbers if they have detailed records
 
+**How to send values (you do the parsing):** the user answers in plain English; convert their answer into the canonical form before calling the tool, and keep the running set of answers in your panda context so you can re-send them every call.
+- Booleans: JSON `true` / `false`, not the words the user said. ("I'm single" -> `"married": false`.)
+- Numbers: a plain number with no currency symbol, comma, or unit. ("about twelve hundred a month" -> `"monthly_income": 1200`.)
+- State: the state name or its 2-letter code. If they name their program (Medi-Cal, MassHealth, TennCare, Apple Health...) infer the state yourself.
+- Hours: mind the units — `avg_monthly_qualifying_hours_last_3mo` is per MONTH, `avg_weekly_qualifying_hours_last_3mo` is per WEEK.
+
+**When the user can't answer**, send the string `"unknown"` for that parameter (e.g. `"assets_total": "unknown"`). That tells us to stop asking it and either assume the conservative answer or explain what we can't determine. Never invent a value, and never silently drop the question — an unanswered question comes back every turn.
+
+**The tool answers back with what it recorded.** It lists the values it stored (already normalized), any parameter names it did not recognize, and anything it couldn't read. Treat that list as the source of truth: re-send everything it recorded on your next call, fix anything it says it ignored, and don't re-ask what the user declined.
+
 Be clear that this is an experimental feature and these are only a best guess as the rules are evolving and you're an AI system who may not have the latest information and can also make mistakes.
 
 *Only ask a few (two or three) questions at a time, in the order the tool suggests them, and only ask those suggested by the tool (although you can rephrase them naturally and with empathy). Don't re-ask anything the user already told you — pass it in the parameters instead.*

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -1129,14 +1129,15 @@ WRONG Examples:
 "California has a great Medicaid program called Medi-Cal. **medicaid_info {...}**"
 **Medicaid Work Requirements Information**: If users ask about or reference Medicaid work requirements, you must only respond with this exact text:
 
-New federal rules require many adults (ages 19-64) to complete at least 80 hours per month of work, job training, school, or community service to keep Medicaid coverage. These requirements go into effect by December 31, 2026.
+New federal rules require many adults (ages 19-64) to complete at least 80 hours per month of work, job training, school, or community service to keep Medicaid coverage. States must implement these requirements by January 1, 2027 — a few have started earlier, and some may receive extensions.
 
 **Key Points:**
 - Applies to adults ages 19-64 in most states
 - 80 hours per month minimum requirement (make sure to keep records)
 - Qualifying activities: work, job training, school, community service
 - There are groups which are often exempt, see the FAQ for more information.
-- Implementation deadline: December 31, 2026
+- Implementation deadline: January 1, 2027 (some states earlier; extensions possible)
+- States check the one to three months before you apply or renew, so late-2026 activity can already count
 - State-specific details may vary
 
 For detailed information and state-specific details, visit: [Medicaid Work Requirements FAQ](/faq/medicaid/)
@@ -1189,6 +1190,8 @@ THIS ELIGIBILITY CHECK IS AN EXPERIMENTAL FEATURE. Every time you start an eligi
 
 ONLY USE THIS TOOL WHEN ASKED IF SOMEONE IS ELIGIBLE FOR MEDICARE/MEDICAID
 
+When the user asks whether they qualify or are eligible for Medicaid or Medicare, use **medicaid_eligibility** — NOT medicaid_info, even when they also name their state. medicaid_info is only for looking up a state's contact info and resources, which is a good follow-up AFTER the eligibility check.
+
 DO NOT ASK ANY QUESTIONS UNTIL YOU HAVE CALLED THE TOOL TO FIGURE OUT WHAT QUESTIONS NEED TO BE ASKED.
 
 This tool also checks for medicare eligibility.
@@ -1203,7 +1206,7 @@ At each step add the user's new answers to the parameters you've already collect
 
 Rules for medicaid eligibility:
 
-Call the tool, and the tool will tell you what other information is required until it eventually says probably eligible under todays rules only, probably eligible under todays rules and with the 2026 work requirements, or can't find eligibility. In any case you can send them to https://www.fighthealthinsurance.com/faq/medicaid/ once done along with the state specific medicaid information (see the next tool). You can suggest things like "maybe school or volunteering" to help get someone up to the 80 hours. Remind people to keep good records (while expressing empathy that this is unfair).
+Call the tool, and the tool will tell you what other information is required until it eventually says probably eligible under today's rules only, probably eligible under today's rules and with the 2026 work requirements, or can't find eligibility. In any case you can send them to https://www.fighthealthinsurance.com/faq/medicaid/ once done along with the state specific medicaid information (see the next tool). You can suggest things like "maybe school or volunteering" to help get someone up to the 80 hours. Remind people to keep good records (while expressing empathy that this is unfair).
 
 Possible kwargs (all optional; function will ask for missing, step-by-step):
       - state: str

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -1183,7 +1183,7 @@ All three keys are optional - supply whatever you know. The tool returns:
 
 Use this tool when the user asks about cost, affordability, copay assistance, "how can I afford this", coupons, GoodRx, manufacturer help, or whether the drug is available cheaper without insurance. Always remind the user that copay-foundation funds open and close throughout the year, and that pharmacy-discount payments don't count toward their OOP max."""
 
-        medicaid_eligibility_tool = """**Medicaid Eligibility Check**: To help check if someone is eligible Medicaid or medicare, you MUST ONLY use this tool format: **medicaid_eligibility {"state": "StateName", "married": false, ...}**
+        medicaid_eligibility_tool = """**Medicaid Eligibility Check**: To help check if someone is eligible for Medicaid or Medicare, you MUST ONLY use this tool format: **medicaid_eligibility {"state": "StateName", "married": false, ...}**
 
 ONLY USE THIS TOOL WHEN ASKED IF SOMEONE IS ELIGIBLE FOR MEDICARE/MEDICAID
 
@@ -1191,17 +1191,17 @@ DO NOT ASK ANY QUESTIONS UNTIL YOU HAVE CALLED THE TOOL TO FIGURE OUT WHAT QUEST
 
 This tool also checks for medicare eligibility.
 
-The parameters you are providing are in JSON format. If you don't know a parameter do not provide it.
+The parameters you are providing are in JSON format. If you don't know a parameter do not provide it. Never guess or make up a value the user hasn't given you.
 
 Note that format above is for example, you'd fill this in with the actual values when known.
 
-So (for example) if someone asks if their eligible for medicaid in california and you don't yet know anything else you would call **medicaid_eligibility {"state": "ca"}** or if someone were to ask if their eligible for medicaid but you don't yet know which state you would call **medicaid_eligibility {}**.
+So (for example) if someone asks if they're eligible for medicaid in california and you don't yet know anything else you would call **medicaid_eligibility {"state": "ca"}** or if someone were to ask if they're eligible for medicaid but you don't yet know which state you would call **medicaid_eligibility {}**.
 
-At each step call the tool to see what is left.
+At each step add the user's new answers to the parameters you've already collected (keep them in your panda context summary) and call the tool again to see what is left.
 
 Rules for medicaid eligibility:
 
-Call the tool, and the tool will tell you what other information is required until it eventually says probably eligibile under todays rules only, probably eligible under todays rules and with work requirements, or can't find elgibility. In any case you can send them to https://www.fighthealthinsurance.com/faq/medicaid/ once done along with the state specific medicaid information (see the next tool). You can suggest things like "maybe school or volunteering" to help get someone up to the 80 hours. Remind people to keep good records (while expressing empathy that this is unfair).
+Call the tool, and the tool will tell you what other information is required until it eventually says probably eligible under todays rules only, probably eligible under todays rules and with the 2026 work requirements, or can't find eligibility. In any case you can send them to https://www.fighthealthinsurance.com/faq/medicaid/ once done along with the state specific medicaid information (see the next tool). You can suggest things like "maybe school or volunteering" to help get someone up to the 80 hours. Remind people to keep good records (while expressing empathy that this is unfair).
 
 Possible kwargs (all optional; function will ask for missing, step-by-step):
       - state: str
@@ -1219,21 +1219,25 @@ Possible kwargs (all optional; function will ask for missing, step-by-step):
       - home_owner: bool
       - home_equity: float
       - children_in_household: int
-      - state_expanded_medicaid: bool
-      - state_has_medically_needy: bool
       - als: bool
       - esrd: bool
-      - ssdi_length: int # how many months have they been receiving ssdi
+      - ssdi_length: int # how many MONTHS they have been receiving SSDI
       - years_worked: int # how many years you or your spouse worked and paid medicare taxes
+      # 2026 federal work / community engagement requirement (80 qualifying hours per month;
+      # hours from work, school, volunteering, or caregiving all count):
+      - work_req_exempt_2026: bool                    # true if you know they're exempt (pregnant, disabled/medically frail, on medicare, etc.)
+      - avg_weekly_qualifying_hours_last_3mo: float   # average qualifying hours per week over the last 3 months
+      - total_qualifying_hours_last_3mo: float        # or the total over the last 3 months
+      - qualifying_hours_weekly_last_12: list of floats  # or 12 weekly numbers if they have detailed records
 
-Be clear that these are only a best guess as the rules are evolving and your an AI system who may not have the latest information and can also make mistakes.
+Be clear that these are only a best guess as the rules are evolving and you're an AI system who may not have the latest information and can also make mistakes.
 
-*Only ask a few questions at a time and only ask those suggested by the tool.*
-For example, if someone asks if their eligible for medi-cal you will call the tool with california and then only ask a few of the questions it gives back (although you can rephrase them).
+*Only ask a few (two or three) questions at a time, in the order the tool suggests them, and only ask those suggested by the tool (although you can rephrase them naturally and with empathy). Don't re-ask anything the user already told you — pass it in the parameters instead.*
+For example, if someone asks if they're eligible for medi-cal you will call the tool with california and then only ask a few of the questions it gives back (although you can rephrase them).
 
 When people ask about a state specific medicaid plan (e.g. medi-cal is california and STAR is texas) you can use that to infer the state.
 
-You can and should consider using the medicaid information tool once we've done an initial assesment and point them to state specific resources.
+You can and should consider using the medicaid information tool once we've done an initial assessment and point them to state specific resources (like where to apply and who to call).
 """
 
         # Build tools section conditionally based on whether the chat is Medicaid-related

--- a/fighthealthinsurance/ml/response_similarity.py
+++ b/fighthealthinsurance/ml/response_similarity.py
@@ -57,11 +57,16 @@ _WORD_RE = re.compile(r"[a-z0-9]+")
 # link the Medicaid FAQ whenever work requirements come up, so matching on
 # the link alone exempted every ordinary Medicaid reply -- including the
 # looping ones this module exists to catch -- from the whole ladder.
+# NOTE: every marker must be a DURABLE phrase, never a date. An earlier
+# version keyed the third marker on "December 31, 2026"; when the prompt's
+# block was corrected to the statutory January 1, 2027 deadline the signature
+# silently stopped matching, so the mandated block was hard-rejected as a
+# repeat and retried away from the text the prompt requires.
 CANNED_REPLY_SIGNATURES = (
     (
         "Medicaid Work Requirements FAQ",
         "80 hours per month",
-        "December 31, 2026",
+        "work, job training, school, or community service",
     ),
 )
 

--- a/fighthealthinsurance/settings.py
+++ b/fighthealthinsurance/settings.py
@@ -107,12 +107,10 @@ class Base(Configuration):
         os.getenv("NEW_PROFESSIONAL_SIGNUP_ENABLED", "false").lower() == "true"
     )
     # Experimental Medicaid eligibility landing page. Off by default: while
-    # the page is still cooking its URL isn't routed (and isn't in the
-    # sitemap), so it stays invisible in production. Dev/Test enable it so
-    # the page and its tests stay exercised.
-    MEDICAID_ELIGIBILITY_PAGE_ENABLED = (
-        os.getenv("MEDICAID_ELIGIBILITY_PAGE_ENABLED", "false").lower() == "true"
-    )
+    # the page is still cooking it serves 404 (and stays out of the sitemap),
+    # so the URL is invisible in production. Dev/Test enable it so the page
+    # and its tests stay exercised.
+    MEDICAID_ELIGIBILITY_PAGE_ENABLED = _env_flag("MEDICAID_ELIGIBILITY_PAGE_ENABLED")
 
     # --- Temporal (durable workflow execution) ---
     # Off by default: fax sending stays on the Ray fax actor until

--- a/fighthealthinsurance/settings.py
+++ b/fighthealthinsurance/settings.py
@@ -106,6 +106,13 @@ class Base(Configuration):
     NEW_PROFESSIONAL_SIGNUP_ENABLED = (
         os.getenv("NEW_PROFESSIONAL_SIGNUP_ENABLED", "false").lower() == "true"
     )
+    # Experimental Medicaid eligibility landing page. Off by default: while
+    # the page is still cooking its URL isn't routed (and isn't in the
+    # sitemap), so it stays invisible in production. Dev/Test enable it so
+    # the page and its tests stay exercised.
+    MEDICAID_ELIGIBILITY_PAGE_ENABLED = (
+        os.getenv("MEDICAID_ELIGIBILITY_PAGE_ENABLED", "false").lower() == "true"
+    )
 
     # --- Temporal (durable workflow execution) ---
     # Off by default: fax sending stays on the Ray fax actor until
@@ -618,6 +625,9 @@ class Dev(Base):
     # Keep the (production-closed) professional signup flow testable locally
     # and in the Test* configurations that subclass Dev.
     NEW_PROFESSIONAL_SIGNUP_ENABLED = True
+    # Keep the (production-hidden) experimental Medicaid eligibility landing
+    # page routable locally and in the Test* configurations.
+    MEDICAID_ELIGIBILITY_PAGE_ENABLED = True
     CSRF_TRUSTED_ORIGINS = [
         "https://fightpaperwork.com",
         "https://localhost:3000",

--- a/fighthealthinsurance/sitemap.py
+++ b/fighthealthinsurance/sitemap.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from django.contrib.sitemaps import Sitemap
 from django.contrib.sites.requests import RequestSite
+from django.conf import settings
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.http import HttpRequest, HttpResponse
 from django.urls import reverse
@@ -32,14 +33,13 @@ class StaticViewSitemap(Sitemap):
 
     def items(self) -> list[str]:
         """Return list of URL names for static pages."""
-        return [
+        items = [
             "root",
             "about",
             "pbs-newshour",
             "media-references",
             "preparing-2026",
             "turning-26",
-            "medicaid-eligibility",
             "other-resources",
             "faq",
             "medicaid-faq",
@@ -51,6 +51,11 @@ class StaticViewSitemap(Sitemap):
             "blog",
             "microsite_directory",
         ]
+        # The experimental Medicaid eligibility page is only routed (and only
+        # discoverable) when its staging flag is on; see urls.py.
+        if getattr(settings, "MEDICAID_ELIGIBILITY_PAGE_ENABLED", False):
+            items.append("medicaid-eligibility")
+        return items
 
     def location(self, item: str) -> str:
         """Return the URL for a given item."""

--- a/fighthealthinsurance/sitemap.py
+++ b/fighthealthinsurance/sitemap.py
@@ -15,7 +15,6 @@ domain (www.fighthealthinsurance.com) in production.
 import json
 from typing import Any
 
-from django.conf import settings
 from django.contrib.sitemaps import Sitemap
 from django.contrib.sites.requests import RequestSite
 from django.contrib.staticfiles.storage import staticfiles_storage
@@ -23,6 +22,8 @@ from django.http import HttpRequest, HttpResponse
 from django.urls import reverse
 
 from loguru import logger
+
+from fighthealthinsurance.utils import medicaid_eligibility_page_enabled
 
 
 class StaticViewSitemap(Sitemap):
@@ -51,9 +52,9 @@ class StaticViewSitemap(Sitemap):
             "blog",
             "microsite_directory",
         ]
-        # The experimental Medicaid eligibility page is only routed (and only
-        # discoverable) when its staging flag is on; see urls.py.
-        if getattr(settings, "MEDICAID_ELIGIBILITY_PAGE_ENABLED", False):
+        # The experimental Medicaid eligibility page only serves (and is only
+        # discoverable) when its staging flag is on; see views.py.
+        if medicaid_eligibility_page_enabled():
             items.append("medicaid-eligibility")
         return items
 

--- a/fighthealthinsurance/sitemap.py
+++ b/fighthealthinsurance/sitemap.py
@@ -39,6 +39,7 @@ class StaticViewSitemap(Sitemap):
             "media-references",
             "preparing-2026",
             "turning-26",
+            "medicaid-eligibility",
             "other-resources",
             "faq",
             "medicaid-faq",

--- a/fighthealthinsurance/sitemap.py
+++ b/fighthealthinsurance/sitemap.py
@@ -15,9 +15,9 @@ domain (www.fighthealthinsurance.com) in production.
 import json
 from typing import Any
 
+from django.conf import settings
 from django.contrib.sitemaps import Sitemap
 from django.contrib.sites.requests import RequestSite
-from django.conf import settings
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.http import HttpRequest, HttpResponse
 from django.urls import reverse

--- a/fighthealthinsurance/static/blog/medicaid-work-requirements.md
+++ b/fighthealthinsurance/static/blog/medicaid-work-requirements.md
@@ -17,7 +17,7 @@ Tens of millions could be at risk of losing healthcare. Here’s what the new ru
 
 Medicaid is the largest public health insurance program in the U.S. and big changes are coming.
 
-Congress has passed new rules that will require many adults to prove they’re working in order to keep their coverage. These Medicaid work requirements will go into effect in most states by **December 31, 2026**, but some may move even faster.
+Congress has passed new rules that will require many adults to prove they’re working in order to keep their coverage. These Medicaid work requirements must be in place in most states by **January 1, 2027**, but some have moved faster and others may receive extensions.
 
 ## Who's Affected and What’s Required
 

--- a/fighthealthinsurance/static/faq/medicaid-work-requirements-faq.md
+++ b/fighthealthinsurance/static/faq/medicaid-work-requirements-faq.md
@@ -67,7 +67,7 @@ You have the right to appeal a denial or termination. This is often called a "fa
 
 #### Immediate Steps to Take:
 1.  **Update your contact information** with your state's Medicaid agency so you don't miss important notices.
-2.  **Review your eligibility status** and see if you qualify for an exemption.
+2.  **Review your eligibility status** and see if you qualify for an exemption. Our free [Medicaid eligibility check](/medicaid-eligibility) can help you understand where you likely stand.
 3.  **Document your work activities**, school enrollment, or volunteer hours thoroughly.
 4.  **Respond quickly** to any mail or requests from the Medicaid office.
 5.  **Know your appeal rights** in case your coverage is unfairly terminated.

--- a/fighthealthinsurance/static/faq/medicaid-work-requirements-faq.md
+++ b/fighthealthinsurance/static/faq/medicaid-work-requirements-faq.md
@@ -20,7 +20,7 @@ tags: ["medicaid", "work-requirements", "healthcare", "policy", "faq"]
 ---
 
 ### What Are Medicaid Work Requirements? {#what-are-medicaid-work-requirements}
-Congress has passed new rules that will require many adult Medicaid beneficiaries to prove they are working or participating in other qualifying activities to keep their coverage. States must implement these requirements by December 31, 2026, though some may start sooner.
+Congress has passed new rules that will require many adult Medicaid beneficiaries to prove they are working or participating in other qualifying activities to keep their coverage. States must implement these requirements by January 1, 2027, though some have started sooner and others may receive extensions. Because states check the one to three months before you apply or renew, activity in late 2026 can already count.
 
 **Key Features:**
 - **Minimum hours:** You must prove at least **80 hours per month** of work, job training, education, community service, or a combination of these activities.

--- a/fighthealthinsurance/static/faq/medicaid-work-requirements-faq.md
+++ b/fighthealthinsurance/static/faq/medicaid-work-requirements-faq.md
@@ -67,7 +67,7 @@ You have the right to appeal a denial or termination. This is often called a "fa
 
 #### Immediate Steps to Take:
 1.  **Update your contact information** with your state's Medicaid agency so you don't miss important notices.
-2.  **Review your eligibility status** and see if you qualify for an exemption. Our free, **experimental** [Medicaid eligibility check](/medicaid-eligibility) can help you understand where you likely stand (it's an estimate only — always confirm with your state).
+2.  **Review your eligibility status** and see if you qualify for an exemption.
 3.  **Document your work activities**, school enrollment, or volunteer hours thoroughly.
 4.  **Respond quickly** to any mail or requests from the Medicaid office.
 5.  **Know your appeal rights** in case your coverage is unfairly terminated.

--- a/fighthealthinsurance/static/faq/medicaid-work-requirements-faq.md
+++ b/fighthealthinsurance/static/faq/medicaid-work-requirements-faq.md
@@ -67,7 +67,7 @@ You have the right to appeal a denial or termination. This is often called a "fa
 
 #### Immediate Steps to Take:
 1.  **Update your contact information** with your state's Medicaid agency so you don't miss important notices.
-2.  **Review your eligibility status** and see if you qualify for an exemption. Our free [Medicaid eligibility check](/medicaid-eligibility) can help you understand where you likely stand.
+2.  **Review your eligibility status** and see if you qualify for an exemption. Our free, **experimental** [Medicaid eligibility check](/medicaid-eligibility) can help you understand where you likely stand (it's an estimate only — always confirm with your state).
 3.  **Document your work activities**, school enrollment, or volunteer hours thoroughly.
 4.  **Respond quickly** to any mail or requests from the Medicaid office.
 5.  **Know your appeal rights** in case your coverage is unfairly terminated.

--- a/fighthealthinsurance/static/js/chat_interface.tsx
+++ b/fighthealthinsurance/static/js/chat_interface.tsx
@@ -650,7 +650,10 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
                 }),
               );
             }, 500);
-          } else if (defaultProcedure && !hasSentInitialMessage.current) {
+          } else if (
+            (defaultProcedure || micrositeSlug === "medicaid-eligibility") &&
+            !hasSentInitialMessage.current
+          ) {
             hasSentInitialMessage.current = true;
             console.log("Sending initial message for procedure:", defaultProcedure);
             if (defaultCondition) {
@@ -671,6 +674,11 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
               // Special message for medicare-work-requirements microsite
               if (micrositeSlug === "medicare-work-requirements") {
                 initialMessage = `I need help understanding the new Medicare work requirements. Can you explain what I need to know?`;
+              } else if (micrositeSlug === "medicaid-eligibility") {
+                // The /medicaid-eligibility landing page CTA. Without this the
+                // button dropped the user into an empty chat and they had to
+                // work out for themselves how to start an eligibility check.
+                initialMessage = `I'd like to check whether I might be eligible for Medicaid. Can you walk me through it?`;
               } else {
                 // Default message for appeals
                 initialMessage = `I'm working on an appeal for ${defaultProcedure}`;

--- a/fighthealthinsurance/templates/medicaid_eligibility.html
+++ b/fighthealthinsurance/templates/medicaid_eligibility.html
@@ -19,7 +19,7 @@
                     <h1 class="hero-headline">Do I Qualify for Medicaid?</h1>
                     <p class="hero-subcopy">Answer a few questions with our free, <strong>experimental</strong> AI assistant and get a rough estimate of whether you may qualify for Medicaid or Medicare in your state&mdash;plus what to do next either way. No account required. It's an estimate only, <strong>not</strong> an official determination&mdash;always confirm with your state.</p>
                     <div class="hero-cta-group">
-                        <a href="{% url 'chat' %}" class="section-btn btn btn-default primary-cta">Try the Experimental Eligibility Check</a>
+                        <a href="{% url 'chat' %}?microsite_slug=medicaid-eligibility" class="section-btn btn btn-default primary-cta">Try the Experimental Eligibility Check</a>
                     </div>
                     <div class="hero-cta-group hero-cta-secondary">
                         <a href="#how-it-works" class="btn btn-outline-green smoothScroll secondary-cta">How It Works</a>
@@ -131,7 +131,7 @@
                 </div>
 
                 <div class="text-center mt-4">
-                    <a href="{% url 'chat' %}" class="btn btn-green btn-lg">Start the Free Eligibility Check (Experimental)</a>
+                    <a href="{% url 'chat' %}?microsite_slug=medicaid-eligibility" class="btn btn-green btn-lg">Start the Free Eligibility Check (Experimental)</a>
                     <p class="text-muted small mt-2 mb-0">Experimental: results are estimates only&mdash;confirm with your state.</p>
                 </div>
             </div>
@@ -362,7 +362,7 @@
                 <h2 class="mb-3">Find Out Where You Stand&mdash;In Minutes</h2>
                 <p class="lead mb-4">Free, no account needed. Get an experimental Medicaid and Medicare eligibility estimate, plus a plan for what to do next&mdash;then confirm everything with your state.</p>
                 <div class="d-flex justify-content-center align-items-center gap-3 flex-wrap">
-                    <a href="{% url 'chat' %}" class="btn btn-green btn-lg">Check My Eligibility (Experimental)</a>
+                    <a href="{% url 'chat' %}?microsite_slug=medicaid-eligibility" class="btn btn-green btn-lg">Check My Eligibility (Experimental)</a>
                     <a href="{% url 'medicaid-faq' %}" class="btn btn-outline-green btn-lg">Work Requirements FAQ</a>
                     <a href="{% url 'state_help_index' %}" class="btn btn-outline-secondary btn-lg">State Resources</a>
                 </div>

--- a/fighthealthinsurance/templates/medicaid_eligibility.html
+++ b/fighthealthinsurance/templates/medicaid_eligibility.html
@@ -13,7 +13,7 @@
             <div class="caption d-flex flex-column align-items-center justify-content-center">
                 <div class="hero-inner" style="max-width: 900px;">
                     <div class="mb-3">
-                        <span class="badge experimental-badge"><svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" focusable="false"><path d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5zm.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2z"/></svg>EXPERIMENTAL FEATURE</span>
+                        {% include "partials/experimental_badge.html" %}
                     </div>
                     <p class="hero-tagline">Medicaid rules are confusing&mdash;checking shouldn't be</p>
                     <h1 class="hero-headline">Do I Qualify for Medicaid?</h1>
@@ -357,7 +357,7 @@
         <div class="row">
             <div class="col-lg-8 mx-auto text-center">
                 <div class="mb-3">
-                    <span class="badge experimental-badge"><svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" focusable="false"><path d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5zm.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2z"/></svg>EXPERIMENTAL FEATURE</span>
+                    {% include "partials/experimental_badge.html" %}
                 </div>
                 <h2 class="mb-3">Find Out Where You Stand&mdash;In Minutes</h2>
                 <p class="lead mb-4">Free, no account needed. Get an experimental Medicaid and Medicare eligibility estimate, plus a plan for what to do next&mdash;then confirm everything with your state.</p>
@@ -611,19 +611,12 @@
     }
 
     /* ---------- Buttons ---------- */
-    .btn-green {
-        background: linear-gradient(to right, #ADD100 0%, #7B920A 51%, #ADD100 100%);
-        background-size: 200% auto;
-        border: none;
-        color: white;
-        transition: 0.5s;
-    }
+    /* .btn-green's gradient comes from the site-wide custom.css -- don't
+       re-declare it here or the page drifts when the brand style changes.
+       Only the page-specific sizing/recolor overrides below are local. */
 
-    .btn-green:hover {
-        background-position: right center;
-        color: white;
-    }
-
+    /* Page-scoped recolor: the site default (#a5c422 + black hover) reads
+       poorly on this page's white sections. */
     .btn-outline-green {
         color: #7B920A;
         border-color: #7B920A;

--- a/fighthealthinsurance/templates/medicaid_eligibility.html
+++ b/fighthealthinsurance/templates/medicaid_eligibility.html
@@ -3,7 +3,7 @@
 
 {% block title %}Do I Qualify for Medicaid? Free Experimental Eligibility Check{% endblock title %}
 {% block metatitle %}Do I Qualify for Medicaid? Free Experimental Eligibility Check - Fight Health Insurance{% endblock metatitle %}
-{% block metadescription %}Check if you may qualify for Medicaid or Medicare with our free, experimental AI-powered eligibility assistant. It's an estimate only — not an official determination. Understand income limits, the 2026 work requirements, and your alternatives if you don't qualify.{% endblock metadescription %}
+{% block metadescription %}Check if you may qualify for Medicaid or Medicare with our free, experimental AI-powered eligibility assistant. It's an estimate only — not an official determination. Understand income limits, the new federal work requirements taking effect January 1, 2027, and your alternatives if you don't qualify.{% endblock metadescription %}
 
 {% block content %}
 <!-- Hero Section -->
@@ -82,7 +82,7 @@
                             <div class="card-body">
                                 <div class="step-num" aria-hidden="true">3</div>
                                 <h5 class="card-title">Get an estimate + next steps</h5>
-                                <p class="card-text">You'll get an experimental, best-guess estimate for today's rules and the 2026 work-requirement rules, alternatives if you don't qualify, and your state's contact info to confirm and apply.</p>
+                                <p class="card-text">You'll get an experimental, best-guess estimate for today's rules and for the new work requirements, alternatives if you don't qualify, and your state's contact info to confirm and apply.</p>
                             </div>
                         </div>
                     </div>
@@ -125,8 +125,8 @@
                         <p class="mb-1">For aged/blind/disabled and nursing-home pathways, states also look at countable assets (usually excluding your primary home) and, for long-term care, home equity.</p>
                     </div>
                     <div class="list-group-item">
-                        <h5 class="mb-1">Work, school, or volunteer hours (for 2026)</h5>
-                        <p class="mb-1">Under the new federal work requirements, many adults will need about 80 qualifying hours per month&mdash;so knowing your typical weekly hours helps estimate 2026 eligibility.</p>
+                        <h5 class="mb-1">Work, school, or volunteer hours</h5>
+                        <p class="mb-1">Under the new federal work requirements, many adults will need about 80 qualifying hours per month&mdash;so knowing your typical weekly hours helps estimate whether you'd keep coverage once they apply.</p>
                     </div>
                 </div>
 
@@ -202,17 +202,17 @@
     </div>
 </section>
 
-<!-- 2026 Work Requirements Section -->
+<!-- Work Requirements Section -->
 <section id="work-requirements" class="py-5 bg-light">
     <div class="container">
         <div class="row">
             <div class="col-lg-8 mx-auto">
-                <h2 class="text-center mb-4">The 2026 Work Requirements</h2>
+                <h2 class="text-center mb-4">The New Work Requirements</h2>
 
                 <div class="card mb-4 border-warning callout-card">
                     <div class="card-body">
                         <h5 class="card-title"><span class="text-warning me-2" aria-hidden="true">&#9888;</span>New Federal Rules</h5>
-                        <p class="card-text mb-0">New federal rules require many adults (ages 19&ndash;64) to complete at least <strong>80 hours per month</strong> of qualifying activities to keep Medicaid coverage, phasing in by December 31, 2026 (some states may start earlier or get extensions).</p>
+                        <p class="card-text mb-0">New federal rules require many adults (ages 19&ndash;64) to complete at least <strong>80 hours per month</strong> of qualifying activities to keep Medicaid coverage. States must implement them by <strong>January 1, 2027</strong>&mdash;a few have started earlier, and some may get extensions. Because states check the one to three months before you apply or renew, your activity in late 2026 can already count.</p>
                     </div>
                 </div>
 

--- a/fighthealthinsurance/templates/medicaid_eligibility.html
+++ b/fighthealthinsurance/templates/medicaid_eligibility.html
@@ -1,0 +1,426 @@
+{% extends 'base.html' %}
+{% load static %}
+
+{% block title %}Do I Qualify for Medicaid? Free Eligibility Check{% endblock title %}
+{% block metatitle %}Do I Qualify for Medicaid? Free Eligibility Check - Fight Health Insurance{% endblock metatitle %}
+{% block metadescription %}Check if you may qualify for Medicaid or Medicare with our free AI-powered eligibility assistant. Understand income limits, the 2026 work requirements, and your alternatives if you don't qualify.{% endblock metadescription %}
+
+{% block content %}
+<!-- Hero Section -->
+<section id="medicaid-eligibility-hero" class="slider" data-stellar-background-ratio="0.5">
+    <div class="row">
+        <div class="item item-first">
+            <div class="caption d-flex flex-column align-items-center justify-content-center">
+                <div class="hero-inner" style="max-width: 900px;">
+                    <h3 class="hero-tagline">Medicaid rules are confusing&mdash;checking shouldn't be</h3>
+                    <h1 class="hero-headline">Do I Qualify for Medicaid?</h1>
+                    <p class="hero-subcopy">Answer a few questions with our free AI assistant and get an estimate of whether you may qualify for Medicaid or Medicare in your state&mdash;plus what to do next either way. No account required.</p>
+                    <div class="hero-cta-group">
+                        <a href="{% url 'chat' %}" class="section-btn btn btn-default primary-cta">Check My Eligibility (Free AI Chat)</a>
+                    </div>
+                    <div class="hero-cta-group hero-cta-secondary">
+                        <a href="#how-it-works" class="btn btn-outline-green smoothScroll secondary-cta">How It Works</a>
+                        <a href="{% url 'medicaid-faq' %}" class="btn btn-outline-green tertiary-cta">Work Requirements FAQ</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<!-- How It Works Section -->
+<section id="how-it-works" class="py-5">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-8 mx-auto">
+                <h2 class="text-center mb-4">How Our Eligibility Check Works</h2>
+                <p class="lead text-center mb-4">Medicaid eligibility depends on your state, income, household, age, and situation. Our AI assistant walks through it with you a few questions at a time.</p>
+
+                <div class="row g-4">
+                    <div class="col-md-4">
+                        <div class="card h-100 border-info">
+                            <div class="card-body">
+                                <h5 class="card-title"><span class="badge bg-success me-2">1</span>Tell us your state</h5>
+                                <p class="card-text">Medicaid is run by states and goes by many names&mdash;Medi-Cal (California), Apple Health (Washington), MassHealth (Massachusetts), TennCare (Tennessee), and more. Rules differ a lot between states.</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-4">
+                        <div class="card h-100 border-info">
+                            <div class="card-body">
+                                <h5 class="card-title"><span class="badge bg-success me-2">2</span>Answer a few questions</h5>
+                                <p class="card-text">The assistant only asks what it actually needs: things like your age, household size, monthly income, and whether you're pregnant, disabled, or applying for long-term care.</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-4">
+                        <div class="card h-100 border-info">
+                            <div class="card-body">
+                                <h5 class="card-title"><span class="badge bg-success me-2">3</span>Get an estimate + next steps</h5>
+                                <p class="card-text">You'll get a best-guess estimate for today's rules and the 2026 work-requirement rules, alternatives if you don't qualify, and your state's contact info to confirm and apply.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="card mt-4 border-warning">
+                    <div class="card-body">
+                        <h5 class="card-title"><span class="text-warning me-2">&#9888;</span> An Estimate, Not a Determination</h5>
+                        <p class="card-text mb-0">Only your state Medicaid agency can officially determine eligibility, and rules change often. Our check is a free, fast way to understand where you likely stand and what to gather before you apply&mdash;always confirm with your state.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<!-- What You'll Need Section -->
+<section id="what-you-need" class="py-5 bg-light">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-8 mx-auto">
+                <h2 class="text-center mb-4">What You'll Want Handy</h2>
+                <p class="text-center text-muted mb-4">You don't need documents to get an estimate&mdash;rough numbers are fine. For the actual application, this is what states typically ask about.</p>
+
+                <div class="list-group">
+                    <div class="list-group-item">
+                        <h5 class="mb-1">Household basics</h5>
+                        <p class="mb-1">Your state, age, marital status, how many people are in your tax household, and how many children (under 19) live with you.</p>
+                    </div>
+                    <div class="list-group-item">
+                        <h5 class="mb-1">Monthly income before taxes</h5>
+                        <p class="mb-1">A rough total for your household&mdash;wages, self-employment, Social Security, unemployment. Most Medicaid categories compare this against a percentage of the Federal Poverty Level.</p>
+                    </div>
+                    <div class="list-group-item">
+                        <h5 class="mb-1">Health and disability status</h5>
+                        <p class="mb-1">Whether you're pregnant, receiving SSDI or otherwise disabled, on Medicare, or have conditions like ESRD (kidney failure) or ALS&mdash;these open different eligibility pathways.</p>
+                    </div>
+                    <div class="list-group-item">
+                        <h5 class="mb-1">Assets (65+, disabled, or long-term care)</h5>
+                        <p class="mb-1">For aged/blind/disabled and nursing-home pathways, states also look at countable assets (usually excluding your primary home) and, for long-term care, home equity.</p>
+                    </div>
+                    <div class="list-group-item">
+                        <h5 class="mb-1">Work, school, or volunteer hours (for 2026)</h5>
+                        <p class="mb-1">Under the new federal work requirements, many adults will need about 80 qualifying hours per month&mdash;so knowing your typical weekly hours helps estimate 2026 eligibility.</p>
+                    </div>
+                </div>
+
+                <div class="text-center mt-4">
+                    <a href="{% url 'chat' %}" class="btn btn-green btn-lg">Start the Free Eligibility Check</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<!-- Pathways Section -->
+<section id="pathways" class="py-5">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-8 mx-auto">
+                <h2 class="text-center mb-4">Common Ways People Qualify</h2>
+                <p class="text-center text-muted mb-4">Exact income limits vary by state and change yearly&mdash;these are the broad categories our assistant checks.</p>
+
+                <div class="row g-4">
+                    <div class="col-md-6">
+                        <div class="card h-100">
+                            <div class="card-body">
+                                <h5 class="card-title">Children &amp; CHIP</h5>
+                                <p class="card-text">Children under 19 generally qualify at higher household incomes than adults (often 200% of the poverty level or more). Even when parents don't qualify, kids frequently do&mdash;through Medicaid or the Children's Health Insurance Program (CHIP).</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-6">
+                        <div class="card h-100">
+                            <div class="card-body">
+                                <h5 class="card-title">Pregnancy</h5>
+                                <p class="card-text">Pregnant people qualify at higher income limits in most states (often around 200% of the poverty level, sometimes higher), with coverage that continues postpartum. Pregnancy is also generally exempt from work requirements.</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-6">
+                        <div class="card h-100">
+                            <div class="card-body">
+                                <h5 class="card-title">Adults 19&ndash;64 (Expansion States)</h5>
+                                <p class="card-text">In the 40 states (plus DC) that expanded Medicaid, adults generally qualify with household income up to 138% of the poverty level. Ten states haven't expanded&mdash;there, childless adults often can't qualify regardless of income.</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-6">
+                        <div class="card h-100">
+                            <div class="card-body">
+                                <h5 class="card-title">65+ or Disabled (ABD)</h5>
+                                <p class="card-text">Aged/blind/disabled pathways look at both income and countable assets (roughly $2,000 single / $3,000 married in many states, excluding your home). Medicare Savings Programs and medically-needy "spend-down" options can help near the limits.</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-6">
+                        <div class="card h-100">
+                            <div class="card-body">
+                                <h5 class="card-title">Long-Term Care</h5>
+                                <p class="card-text">Nursing home and home-care (HCBS) Medicaid has its own income cap (around $3,000/month in many states), asset limits, and home-equity rules. Miller trusts and spend-down planning can help if you're just over the limits.</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-6">
+                        <div class="card h-100">
+                            <div class="card-body">
+                                <h5 class="card-title">Medicare (65+, SSDI, ESRD, ALS)</h5>
+                                <p class="card-text">Our assistant also checks Medicare: most people qualify at 65 with 10 years of work history, after 24 months on SSDI, or at any age with ESRD or ALS. Some people qualify for both Medicare and Medicaid ("dual eligible").</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<!-- 2026 Work Requirements Section -->
+<section id="work-requirements" class="py-5 bg-light">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-8 mx-auto">
+                <h2 class="text-center mb-4">The 2026 Work Requirements</h2>
+
+                <div class="card mb-4 border-warning">
+                    <div class="card-body">
+                        <h5 class="card-title"><span class="text-warning me-2">&#9888;</span> New Federal Rules</h5>
+                        <p class="card-text">New federal rules require many adults (ages 19&ndash;64) to complete at least <strong>80 hours per month</strong> of qualifying activities to keep Medicaid coverage, phasing in by December 31, 2026 (some states may start earlier or get extensions).</p>
+                    </div>
+                </div>
+
+                <div class="row g-4">
+                    <div class="col-md-6">
+                        <div class="card h-100">
+                            <div class="card-body">
+                                <h6 class="card-subtitle mb-2 text-info">What Counts Toward 80 Hours</h6>
+                                <ul class="mb-0">
+                                    <li>Work (including self-employment)</li>
+                                    <li>School or job training</li>
+                                    <li>Volunteering / community service</li>
+                                    <li>Caregiving (varies by state)</li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-6">
+                        <div class="card h-100">
+                            <div class="card-body">
+                                <h6 class="card-subtitle mb-2 text-info">Groups Often Exempt</h6>
+                                <ul class="mb-0">
+                                    <li>Pregnant people</li>
+                                    <li>People with disabilities or who are medically frail</li>
+                                    <li>People on Medicare</li>
+                                    <li>Children and many caretakers&mdash;see the FAQ for details</li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="card mt-4 border-info">
+                    <div class="card-body">
+                        <h5 class="card-title"><span class="text-info me-2">&#128161;</span> Keep Records Now</h5>
+                        <p class="card-text mb-0">States may look back up to 3 months when checking hours. Keep pay stubs, class schedules, and volunteer logs&mdash;it's unfair paperwork, but good records are the best defense against wrongly losing coverage. If you're short of 80 hours, adding a class or regular volunteering can close the gap.</p>
+                    </div>
+                </div>
+
+                <div class="text-center mt-4">
+                    <a href="{% url 'medicaid-faq' %}" class="btn btn-outline-green btn-lg">Read the Work Requirements FAQ</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<!-- If You Don't Qualify Section -->
+<section id="alternatives" class="py-5">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-8 mx-auto">
+                <h2 class="text-center mb-4">If You Don't Qualify (or Lose Coverage)</h2>
+                <p class="text-center text-muted mb-4">A "no" on Medicaid isn't the end of the road. The assistant will point you to alternatives like these based on your situation.</p>
+
+                <div class="row g-4">
+                    <div class="col-md-6">
+                        <div class="card h-100">
+                            <div class="card-body">
+                                <h5 class="card-title">ACA Marketplace Subsidies</h5>
+                                <p class="card-text">If your income is at or above 100% of the poverty level, premium tax credits on Healthcare.gov (or your state's marketplace) can make plans much cheaper. Losing Medicaid also triggers a Special Enrollment Period.</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-6">
+                        <div class="card h-100">
+                            <div class="card-body">
+                                <h5 class="card-title">CHIP for Your Kids</h5>
+                                <p class="card-text">Children often qualify for CHIP even when adults in the household earn too much for Medicaid. It's worth applying for kids regardless of your own result.</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-6">
+                        <div class="card h-100">
+                            <div class="card-body">
+                                <h5 class="card-title">Medically Needy / Spend-Down</h5>
+                                <p class="card-text">Over 30 states let you qualify by "spending down"&mdash;subtracting high medical bills from your income. This can work for older adults and people with disabilities who are just over the limits.</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-6">
+                        <div class="card h-100">
+                            <div class="card-body">
+                                <h5 class="card-title">Medicare Savings Programs &amp; Clinics</h5>
+                                <p class="card-text">If you're on Medicare with limited income, QMB/SLMB/QI programs can pay premiums and cost-sharing. Community health centers offer sliding-scale care while you sort out coverage.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="card mt-4 border-warning">
+                    <div class="card-body">
+                        <h5 class="card-title">Denied or Terminated? You Can Appeal.</h5>
+                        <p class="card-text">If your state denies your Medicaid application or ends your coverage&mdash;including over work-requirement paperwork&mdash;you have the right to a fair hearing, and deadlines matter. Our free tools can help you fight back, and your state's legal aid resources can help too.</p>
+                        <a href="{% url 'scan' %}" class="btn btn-green">Generate an Appeal</a>
+                        <a href="{% url 'chat' %}" class="btn btn-outline-green">Ask the AI Assistant</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<!-- State Resources Section -->
+<section id="state-resources" class="py-5 bg-light">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-8 mx-auto">
+                <h2 class="text-center mb-4">Confirm With Your State</h2>
+                <p class="text-center mb-4">Ready to apply, or want the official word? Go straight to the source.</p>
+
+                <div class="row g-4">
+                    <div class="col-md-6">
+                        <div class="card h-100">
+                            <div class="card-body">
+                                <h5 class="card-title">Your State's Resources</h5>
+                                <p class="card-text">Find your state Medicaid agency, consumer assistance programs, and legal aid contacts&mdash;the assistant can also look these up for you in chat.</p>
+                                <a href="{% url 'state_help_index' %}" class="btn btn-outline-green">Find Your State's Resources</a>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-6">
+                        <div class="card h-100">
+                            <div class="card-body">
+                                <h5 class="card-title">Apply Through Healthcare.gov</h5>
+                                <p class="card-text">The Marketplace application automatically checks your Medicaid and CHIP eligibility and forwards your info to your state&mdash;one application covers both.</p>
+                                <a href="https://www.healthcare.gov/medicaid-chip/" target="_blank" rel="noopener noreferrer" class="btn btn-outline-green">Learn More at Healthcare.gov</a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<!-- Final CTA Section -->
+<section id="final-cta" class="py-5">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-8 mx-auto text-center">
+                <h2 class="mb-3">Find Out Where You Stand&mdash;In Minutes</h2>
+                <p class="lead mb-4">Free, no account needed. Get a Medicaid and Medicare eligibility estimate, plus a plan for what to do next.</p>
+                <div class="d-flex justify-content-center gap-3 flex-wrap">
+                    <a href="{% url 'chat' %}" class="btn btn-green btn-lg">Check My Eligibility</a>
+                    <a href="{% url 'medicaid-faq' %}" class="btn btn-outline-green btn-lg">Work Requirements FAQ</a>
+                    <a href="{% url 'state_help_index' %}" class="btn btn-outline-secondary btn-lg">State Resources</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<!-- Disclaimer Section -->
+<section id="disclaimer" class="py-4">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-8 mx-auto">
+                <div class="disclaimer-box p-3 bg-light border rounded">
+                    <p class="text-muted small mb-0">
+                        <strong>Disclaimer:</strong> This page and our AI assistant provide informational estimates only&mdash;not legal, medical, or financial advice, and not an official eligibility determination. Medicaid and Medicare rules vary by state and change frequently, including the phase-in of federal work requirements. Always confirm with your state Medicaid agency or a benefits navigator. Last updated: August 2026.
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+{% endblock content %}
+
+{% block extra_style %}
+<style>
+    #medicaid-eligibility-hero .hero-inner {
+        backdrop-filter: blur(3px);
+        padding: 2rem;
+        border-radius: 14px;
+    }
+
+    .list-group-item {
+        border-left: 4px solid #a5c422;
+    }
+
+    .list-group-item:hover {
+        background-color: rgba(165, 196, 34, 0.05);
+    }
+
+    .card.border-warning {
+        border-left: 4px solid #ffc107 !important;
+    }
+
+    .card.border-info {
+        border-left: 4px solid #17a2b8 !important;
+    }
+
+    #final-cta {
+        background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);
+    }
+
+    .btn-green {
+        background: linear-gradient(to right, #ADD100 0%, #7B920A 51%, #ADD100 100%);
+        background-size: 200% auto;
+        border: none;
+        color: white;
+        transition: 0.5s;
+    }
+
+    .btn-green:hover {
+        background-position: right center;
+        color: white;
+    }
+
+    .btn-outline-green {
+        color: #7B920A;
+        border-color: #7B920A;
+    }
+
+    .btn-outline-green:hover {
+        background-color: #7B920A;
+        border-color: #7B920A;
+        color: white;
+    }
+
+    section {
+        scroll-margin-top: 80px;
+    }
+
+    @media (max-width: 768px) {
+        #medicaid-eligibility-hero .hero-inner {
+            padding: 1.5rem;
+        }
+
+        .btn-lg {
+            padding: 0.5rem 1rem;
+            font-size: 1rem;
+        }
+    }
+</style>
+{% endblock extra_style %}

--- a/fighthealthinsurance/templates/medicaid_eligibility.html
+++ b/fighthealthinsurance/templates/medicaid_eligibility.html
@@ -1,9 +1,9 @@
 {% extends 'base.html' %}
 {% load static %}
 
-{% block title %}Do I Qualify for Medicaid? Free Eligibility Check{% endblock title %}
-{% block metatitle %}Do I Qualify for Medicaid? Free Eligibility Check - Fight Health Insurance{% endblock metatitle %}
-{% block metadescription %}Check if you may qualify for Medicaid or Medicare with our free AI-powered eligibility assistant. Understand income limits, the 2026 work requirements, and your alternatives if you don't qualify.{% endblock metadescription %}
+{% block title %}Do I Qualify for Medicaid? Free Experimental Eligibility Check{% endblock title %}
+{% block metatitle %}Do I Qualify for Medicaid? Free Experimental Eligibility Check - Fight Health Insurance{% endblock metatitle %}
+{% block metadescription %}Check if you may qualify for Medicaid or Medicare with our free, experimental AI-powered eligibility assistant. It's an estimate only — not an official determination. Understand income limits, the 2026 work requirements, and your alternatives if you don't qualify.{% endblock metadescription %}
 
 {% block content %}
 <!-- Hero Section -->
@@ -12,16 +12,33 @@
         <div class="item item-first">
             <div class="caption d-flex flex-column align-items-center justify-content-center">
                 <div class="hero-inner" style="max-width: 900px;">
+                    <div class="mb-3">
+                        <span class="badge experimental-badge">&#9888;&#65039; EXPERIMENTAL FEATURE</span>
+                    </div>
                     <h3 class="hero-tagline">Medicaid rules are confusing&mdash;checking shouldn't be</h3>
                     <h1 class="hero-headline">Do I Qualify for Medicaid?</h1>
-                    <p class="hero-subcopy">Answer a few questions with our free AI assistant and get an estimate of whether you may qualify for Medicaid or Medicare in your state&mdash;plus what to do next either way. No account required.</p>
+                    <p class="hero-subcopy">Answer a few questions with our free, <strong>experimental</strong> AI assistant and get a rough estimate of whether you may qualify for Medicaid or Medicare in your state&mdash;plus what to do next either way. No account required. It's an estimate only, <strong>not</strong> an official determination&mdash;always confirm with your state.</p>
                     <div class="hero-cta-group">
-                        <a href="{% url 'chat' %}" class="section-btn btn btn-default primary-cta">Check My Eligibility (Free AI Chat)</a>
+                        <a href="{% url 'chat' %}" class="section-btn btn btn-default primary-cta">Try the Experimental Eligibility Check</a>
                     </div>
                     <div class="hero-cta-group hero-cta-secondary">
                         <a href="#how-it-works" class="btn btn-outline-green smoothScroll secondary-cta">How It Works</a>
                         <a href="{% url 'medicaid-faq' %}" class="btn btn-outline-green tertiary-cta">Work Requirements FAQ</a>
                     </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<!-- Experimental Notice Banner -->
+<section id="experimental-notice" class="pt-4 pb-2">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-10 mx-auto">
+                <div class="alert alert-warning experimental-banner mb-0" role="alert">
+                    <h4 class="alert-heading mb-2">&#9888;&#65039; This eligibility check is an experimental feature</h4>
+                    <p class="mb-0">It is <strong>new, under active development, and can be wrong, incomplete, or out of date</strong>. It gives a rough estimate&mdash;<strong>not</strong> an official eligibility determination, and not legal, medical, or financial advice. Only your state Medicaid agency can determine your eligibility for real. Please double-check everything it tells you with <a href="{% url 'state_help_index' %}" class="alert-link">your state</a> before making any decisions about your coverage.</p>
                 </div>
             </div>
         </div>
@@ -57,7 +74,7 @@
                         <div class="card h-100 border-info">
                             <div class="card-body">
                                 <h5 class="card-title"><span class="badge bg-success me-2">3</span>Get an estimate + next steps</h5>
-                                <p class="card-text">You'll get a best-guess estimate for today's rules and the 2026 work-requirement rules, alternatives if you don't qualify, and your state's contact info to confirm and apply.</p>
+                                <p class="card-text">You'll get an experimental, best-guess estimate for today's rules and the 2026 work-requirement rules, alternatives if you don't qualify, and your state's contact info to confirm and apply.</p>
                             </div>
                         </div>
                     </div>
@@ -65,8 +82,8 @@
 
                 <div class="card mt-4 border-warning">
                     <div class="card-body">
-                        <h5 class="card-title"><span class="text-warning me-2">&#9888;</span> An Estimate, Not a Determination</h5>
-                        <p class="card-text mb-0">Only your state Medicaid agency can officially determine eligibility, and rules change often. Our check is a free, fast way to understand where you likely stand and what to gather before you apply&mdash;always confirm with your state.</p>
+                        <h5 class="card-title"><span class="text-warning me-2">&#9888;</span> Experimental: An Estimate, Not a Determination</h5>
+                        <p class="card-text mb-0">This checker is an <strong>experimental feature</strong>&mdash;the AI can make mistakes, and Medicaid rules change often. Only your state Medicaid agency can officially determine eligibility. Our check is a free, fast way to understand where you likely stand and what to gather before you apply&mdash;always confirm with your state.</p>
                     </div>
                 </div>
             </div>
@@ -106,7 +123,8 @@
                 </div>
 
                 <div class="text-center mt-4">
-                    <a href="{% url 'chat' %}" class="btn btn-green btn-lg">Start the Free Eligibility Check</a>
+                    <a href="{% url 'chat' %}" class="btn btn-green btn-lg">Start the Free Eligibility Check (Experimental)</a>
+                    <p class="text-muted small mt-2 mb-0">Experimental: results are estimates only&mdash;confirm with your state.</p>
                 </div>
             </div>
         </div>
@@ -328,10 +346,13 @@
     <div class="container">
         <div class="row">
             <div class="col-lg-8 mx-auto text-center">
+                <div class="mb-2">
+                    <span class="badge experimental-badge">&#9888;&#65039; EXPERIMENTAL FEATURE</span>
+                </div>
                 <h2 class="mb-3">Find Out Where You Stand&mdash;In Minutes</h2>
-                <p class="lead mb-4">Free, no account needed. Get a Medicaid and Medicare eligibility estimate, plus a plan for what to do next.</p>
+                <p class="lead mb-4">Free, no account needed. Get an experimental Medicaid and Medicare eligibility estimate, plus a plan for what to do next&mdash;then confirm everything with your state.</p>
                 <div class="d-flex justify-content-center gap-3 flex-wrap">
-                    <a href="{% url 'chat' %}" class="btn btn-green btn-lg">Check My Eligibility</a>
+                    <a href="{% url 'chat' %}" class="btn btn-green btn-lg">Check My Eligibility (Experimental)</a>
                     <a href="{% url 'medicaid-faq' %}" class="btn btn-outline-green btn-lg">Work Requirements FAQ</a>
                     <a href="{% url 'state_help_index' %}" class="btn btn-outline-secondary btn-lg">State Resources</a>
                 </div>
@@ -347,7 +368,7 @@
             <div class="col-lg-8 mx-auto">
                 <div class="disclaimer-box p-3 bg-light border rounded">
                     <p class="text-muted small mb-0">
-                        <strong>Disclaimer:</strong> This page and our AI assistant provide informational estimates only&mdash;not legal, medical, or financial advice, and not an official eligibility determination. Medicaid and Medicare rules vary by state and change frequently, including the phase-in of federal work requirements. Always confirm with your state Medicaid agency or a benefits navigator. Last updated: August 2026.
+                        <strong>Disclaimer:</strong> The Medicaid eligibility check is an <strong>EXPERIMENTAL feature</strong> that is under active development and can produce incorrect, incomplete, or outdated results. This page and our AI assistant provide informational estimates only&mdash;not legal, medical, or financial advice, and not an official eligibility determination. Medicaid and Medicare rules vary by state and change frequently, including the phase-in of federal work requirements. Always confirm with your state Medicaid agency or a benefits navigator before making decisions about your coverage. Last updated: August 2026.
                     </p>
                 </div>
             </div>
@@ -362,6 +383,29 @@
         backdrop-filter: blur(3px);
         padding: 2rem;
         border-radius: 14px;
+    }
+
+    .experimental-badge {
+        background-color: #ffc107;
+        color: #212529;
+        font-size: 0.95rem;
+        font-weight: 700;
+        letter-spacing: 0.06em;
+        padding: 0.5em 0.9em;
+        border: 2px solid #212529;
+        border-radius: 6px;
+        text-transform: uppercase;
+    }
+
+    .experimental-banner {
+        border: 2px solid #ffc107;
+        border-left-width: 8px;
+        background-color: #fff8e1;
+        color: #212529;
+    }
+
+    .experimental-banner .alert-heading {
+        font-weight: 700;
     }
 
     .list-group-item {

--- a/fighthealthinsurance/templates/medicaid_eligibility.html
+++ b/fighthealthinsurance/templates/medicaid_eligibility.html
@@ -13,9 +13,9 @@
             <div class="caption d-flex flex-column align-items-center justify-content-center">
                 <div class="hero-inner" style="max-width: 900px;">
                     <div class="mb-3">
-                        <span class="badge experimental-badge">&#9888;&#65039; EXPERIMENTAL FEATURE</span>
+                        <span class="badge experimental-badge"><svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" focusable="false"><path d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5zm.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2z"/></svg>EXPERIMENTAL FEATURE</span>
                     </div>
-                    <h3 class="hero-tagline">Medicaid rules are confusing&mdash;checking shouldn't be</h3>
+                    <p class="hero-tagline">Medicaid rules are confusing&mdash;checking shouldn't be</p>
                     <h1 class="hero-headline">Do I Qualify for Medicaid?</h1>
                     <p class="hero-subcopy">Answer a few questions with our free, <strong>experimental</strong> AI assistant and get a rough estimate of whether you may qualify for Medicaid or Medicare in your state&mdash;plus what to do next either way. No account required. It's an estimate only, <strong>not</strong> an official determination&mdash;always confirm with your state.</p>
                     <div class="hero-cta-group">
@@ -35,10 +35,15 @@
 <section id="experimental-notice" class="pt-4 pb-2">
     <div class="container">
         <div class="row">
-            <div class="col-lg-10 mx-auto">
+            <div class="col-lg-8 mx-auto">
                 <div class="alert alert-warning experimental-banner mb-0" role="alert">
-                    <h4 class="alert-heading mb-2">&#9888;&#65039; This eligibility check is an experimental feature</h4>
-                    <p class="mb-0">It is <strong>new, under active development, and can be wrong, incomplete, or out of date</strong>. It gives a rough estimate&mdash;<strong>not</strong> an official eligibility determination, and not legal, medical, or financial advice. Only your state Medicaid agency can determine your eligibility for real. Please double-check everything it tells you with <a href="{% url 'state_help_index' %}" class="alert-link">your state</a> before making any decisions about your coverage.</p>
+                    <div class="banner-icon" aria-hidden="true">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 16 16" fill="currentColor" focusable="false"><path d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5zm.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2z"/></svg>
+                    </div>
+                    <div class="banner-body">
+                        <h2 class="alert-heading">This eligibility check is an experimental feature</h2>
+                        <p>It is <strong>new, under active development, and can be wrong, incomplete, or out of date</strong>. It gives a rough estimate&mdash;<strong>not</strong> an official eligibility determination, and not legal, medical, or financial advice. Only your state Medicaid agency can determine your eligibility for real. Please double-check everything it tells you with <a href="{% url 'state_help_index' %}" class="alert-link">your state</a> before making any decisions about your coverage.</p>
+                    </div>
                 </div>
             </div>
         </div>
@@ -55,34 +60,37 @@
 
                 <div class="row g-4">
                     <div class="col-md-4">
-                        <div class="card h-100 border-info">
+                        <div class="card h-100 step-card">
                             <div class="card-body">
-                                <h5 class="card-title"><span class="badge bg-success me-2">1</span>Tell us your state</h5>
+                                <div class="step-num" aria-hidden="true">1</div>
+                                <h5 class="card-title">Tell us your state</h5>
                                 <p class="card-text">Medicaid is run by states and goes by many names&mdash;Medi-Cal (California), Apple Health (Washington), MassHealth (Massachusetts), TennCare (Tennessee), and more. Rules differ a lot between states.</p>
                             </div>
                         </div>
                     </div>
                     <div class="col-md-4">
-                        <div class="card h-100 border-info">
+                        <div class="card h-100 step-card">
                             <div class="card-body">
-                                <h5 class="card-title"><span class="badge bg-success me-2">2</span>Answer a few questions</h5>
+                                <div class="step-num" aria-hidden="true">2</div>
+                                <h5 class="card-title">Answer a few questions</h5>
                                 <p class="card-text">The assistant only asks what it actually needs: things like your age, household size, monthly income, and whether you're pregnant, disabled, or applying for long-term care.</p>
                             </div>
                         </div>
                     </div>
                     <div class="col-md-4">
-                        <div class="card h-100 border-info">
+                        <div class="card h-100 step-card">
                             <div class="card-body">
-                                <h5 class="card-title"><span class="badge bg-success me-2">3</span>Get an estimate + next steps</h5>
+                                <div class="step-num" aria-hidden="true">3</div>
+                                <h5 class="card-title">Get an estimate + next steps</h5>
                                 <p class="card-text">You'll get an experimental, best-guess estimate for today's rules and the 2026 work-requirement rules, alternatives if you don't qualify, and your state's contact info to confirm and apply.</p>
                             </div>
                         </div>
                     </div>
                 </div>
 
-                <div class="card mt-4 border-warning">
+                <div class="card mt-4 border-warning callout-card">
                     <div class="card-body">
-                        <h5 class="card-title"><span class="text-warning me-2">&#9888;</span> Experimental: An Estimate, Not a Determination</h5>
+                        <h5 class="card-title"><span class="text-warning me-2" aria-hidden="true">&#9888;</span>Experimental: An Estimate, Not a Determination</h5>
                         <p class="card-text mb-0">This checker is an <strong>experimental feature</strong>&mdash;the AI can make mistakes, and Medicaid rules change often. Only your state Medicaid agency can officially determine eligibility. Our check is a free, fast way to understand where you likely stand and what to gather before you apply&mdash;always confirm with your state.</p>
                     </div>
                 </div>
@@ -201,10 +209,10 @@
             <div class="col-lg-8 mx-auto">
                 <h2 class="text-center mb-4">The 2026 Work Requirements</h2>
 
-                <div class="card mb-4 border-warning">
+                <div class="card mb-4 border-warning callout-card">
                     <div class="card-body">
-                        <h5 class="card-title"><span class="text-warning me-2">&#9888;</span> New Federal Rules</h5>
-                        <p class="card-text">New federal rules require many adults (ages 19&ndash;64) to complete at least <strong>80 hours per month</strong> of qualifying activities to keep Medicaid coverage, phasing in by December 31, 2026 (some states may start earlier or get extensions).</p>
+                        <h5 class="card-title"><span class="text-warning me-2" aria-hidden="true">&#9888;</span>New Federal Rules</h5>
+                        <p class="card-text mb-0">New federal rules require many adults (ages 19&ndash;64) to complete at least <strong>80 hours per month</strong> of qualifying activities to keep Medicaid coverage, phasing in by December 31, 2026 (some states may start earlier or get extensions).</p>
                     </div>
                 </div>
 
@@ -212,8 +220,8 @@
                     <div class="col-md-6">
                         <div class="card h-100">
                             <div class="card-body">
-                                <h6 class="card-subtitle mb-2 text-info">What Counts Toward 80 Hours</h6>
-                                <ul class="mb-0">
+                                <h6 class="card-subtitle mb-3 wr-label">What Counts Toward 80 Hours</h6>
+                                <ul class="check-list mb-0">
                                     <li>Work (including self-employment)</li>
                                     <li>School or job training</li>
                                     <li>Volunteering / community service</li>
@@ -225,8 +233,8 @@
                     <div class="col-md-6">
                         <div class="card h-100">
                             <div class="card-body">
-                                <h6 class="card-subtitle mb-2 text-info">Groups Often Exempt</h6>
-                                <ul class="mb-0">
+                                <h6 class="card-subtitle mb-3 wr-label">Groups Often Exempt</h6>
+                                <ul class="check-list mb-0">
                                     <li>Pregnant people</li>
                                     <li>People with disabilities or who are medically frail</li>
                                     <li>People on Medicare</li>
@@ -237,9 +245,9 @@
                     </div>
                 </div>
 
-                <div class="card mt-4 border-info">
+                <div class="card mt-4 callout-card callout-tip">
                     <div class="card-body">
-                        <h5 class="card-title"><span class="text-info me-2">&#128161;</span> Keep Records Now</h5>
+                        <h5 class="card-title"><span class="me-2" aria-hidden="true">&#128161;</span>Keep Records Now</h5>
                         <p class="card-text mb-0">States may look back up to 3 months when checking hours. Keep pay stubs, class schedules, and volunteer logs&mdash;it's unfair paperwork, but good records are the best defense against wrongly losing coverage. If you're short of 80 hours, adding a class or regular volunteering can close the gap.</p>
                     </div>
                 </div>
@@ -295,12 +303,14 @@
                     </div>
                 </div>
 
-                <div class="card mt-4 border-warning">
+                <div class="card mt-4 border-warning callout-card">
                     <div class="card-body">
                         <h5 class="card-title">Denied or Terminated? You Can Appeal.</h5>
                         <p class="card-text">If your state denies your Medicaid application or ends your coverage&mdash;including over work-requirement paperwork&mdash;you have the right to a fair hearing, and deadlines matter. Our free tools can help you fight back, and your state's legal aid resources can help too.</p>
-                        <a href="{% url 'scan' %}" class="btn btn-green">Generate an Appeal</a>
-                        <a href="{% url 'chat' %}" class="btn btn-outline-green">Ask the AI Assistant</a>
+                        <div class="d-flex flex-wrap gap-2 mt-1">
+                            <a href="{% url 'scan' %}" class="btn btn-green">Generate an Appeal</a>
+                            <a href="{% url 'chat' %}" class="btn btn-outline-green">Ask the AI Assistant</a>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -319,19 +329,19 @@
                 <div class="row g-4">
                     <div class="col-md-6">
                         <div class="card h-100">
-                            <div class="card-body">
+                            <div class="card-body d-flex flex-column">
                                 <h5 class="card-title">Your State's Resources</h5>
                                 <p class="card-text">Find your state Medicaid agency, consumer assistance programs, and legal aid contacts&mdash;the assistant can also look these up for you in chat.</p>
-                                <a href="{% url 'state_help_index' %}" class="btn btn-outline-green">Find Your State's Resources</a>
+                                <a href="{% url 'state_help_index' %}" class="btn btn-outline-green mt-auto align-self-start">Find Your State's Resources</a>
                             </div>
                         </div>
                     </div>
                     <div class="col-md-6">
                         <div class="card h-100">
-                            <div class="card-body">
+                            <div class="card-body d-flex flex-column">
                                 <h5 class="card-title">Apply Through Healthcare.gov</h5>
                                 <p class="card-text">The Marketplace application automatically checks your Medicaid and CHIP eligibility and forwards your info to your state&mdash;one application covers both.</p>
-                                <a href="https://www.healthcare.gov/medicaid-chip/" target="_blank" rel="noopener noreferrer" class="btn btn-outline-green">Learn More at Healthcare.gov</a>
+                                <a href="https://www.healthcare.gov/medicaid-chip/" target="_blank" rel="noopener noreferrer" class="btn btn-outline-green mt-auto align-self-start">Learn More at Healthcare.gov</a>
                             </div>
                         </div>
                     </div>
@@ -346,12 +356,12 @@
     <div class="container">
         <div class="row">
             <div class="col-lg-8 mx-auto text-center">
-                <div class="mb-2">
-                    <span class="badge experimental-badge">&#9888;&#65039; EXPERIMENTAL FEATURE</span>
+                <div class="mb-3">
+                    <span class="badge experimental-badge"><svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" focusable="false"><path d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5zm.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2z"/></svg>EXPERIMENTAL FEATURE</span>
                 </div>
                 <h2 class="mb-3">Find Out Where You Stand&mdash;In Minutes</h2>
                 <p class="lead mb-4">Free, no account needed. Get an experimental Medicaid and Medicare eligibility estimate, plus a plan for what to do next&mdash;then confirm everything with your state.</p>
-                <div class="d-flex justify-content-center gap-3 flex-wrap">
+                <div class="d-flex justify-content-center align-items-center gap-3 flex-wrap">
                     <a href="{% url 'chat' %}" class="btn btn-green btn-lg">Check My Eligibility (Experimental)</a>
                     <a href="{% url 'medicaid-faq' %}" class="btn btn-outline-green btn-lg">Work Requirements FAQ</a>
                     <a href="{% url 'state_help_index' %}" class="btn btn-outline-secondary btn-lg">State Resources</a>
@@ -379,55 +389,228 @@
 
 {% block extra_style %}
 <style>
+    /* ============================================================
+       Page palette (matches the site theme):
+       brand green #a5c422 / #7B920A, experimental amber #ffc107,
+       ink #212529, body gray #575757
+       ============================================================ */
+
+    /* ---------- Hero ---------- */
     #medicaid-eligibility-hero .hero-inner {
-        backdrop-filter: blur(3px);
-        padding: 2rem;
-        border-radius: 14px;
+        background: rgba(24, 18, 48, 0.30);
+        backdrop-filter: blur(4px);
+        -webkit-backdrop-filter: blur(4px);
+        padding: 2.25rem 2.5rem;
+        border-radius: 16px;
+        border: 1px solid rgba(255, 255, 255, 0.14);
     }
 
+    #medicaid-eligibility-hero .hero-headline {
+        line-height: 1.12;
+    }
+
+    #medicaid-eligibility-hero .hero-subcopy {
+        max-width: 46rem;
+    }
+
+    /* Let "Work Requirements FAQ" fit on one line next to "How It Works" */
+    #medicaid-eligibility-hero .hero-cta-secondary a {
+        max-width: 300px;
+    }
+
+    /* ---------- Experimental badge (hero + final CTA) ---------- */
     .experimental-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5em;
         background-color: #ffc107;
-        color: #212529;
-        font-size: 0.95rem;
+        color: #332701;
+        font-size: 0.8rem;
         font-weight: 700;
-        letter-spacing: 0.06em;
-        padding: 0.5em 0.9em;
-        border: 2px solid #212529;
-        border-radius: 6px;
+        letter-spacing: 0.09em;
+        line-height: 1;
+        padding: 0.55em 1.1em;
+        border: 1px solid rgba(90, 64, 0, 0.35);
+        border-radius: 999px;
+        box-shadow: 0 2px 10px rgba(0, 0, 0, 0.18);
         text-transform: uppercase;
     }
 
+    .experimental-badge svg {
+        flex: 0 0 auto;
+        margin-top: -1px;
+    }
+
+    /* ---------- Experimental notice banner ---------- */
     .experimental-banner {
-        border: 2px solid #ffc107;
-        border-left-width: 8px;
-        background-color: #fff8e1;
-        color: #212529;
+        display: flex;
+        align-items: flex-start;
+        gap: 1rem;
+        background: linear-gradient(180deg, #fffdf5 0%, #fff8e6 100%);
+        border: 1px solid #f0dda2;
+        border-left: 4px solid #ffc107;
+        border-radius: 10px;
+        padding: 1.35rem 1.5rem;
+        box-shadow: 0 2px 10px rgba(120, 90, 0, 0.06);
     }
 
+    .experimental-banner .banner-icon {
+        flex: 0 0 auto;
+        width: 2.4rem;
+        height: 2.4rem;
+        border-radius: 50%;
+        background: #ffc107;
+        color: #332701;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin-top: 0.1rem;
+    }
+
+    /* Beat custom.css `.alert-warning h4` mustard and main.css h2 sizing */
     .experimental-banner .alert-heading {
+        color: #212529;
+        font-size: 1.2rem;
         font-weight: 700;
+        letter-spacing: 0;
+        line-height: 1.35;
+        padding-bottom: 0;
+        margin-bottom: 0.4rem;
     }
 
+    /* Beat main.css `p { color: #757575 }` for contrast on the cream panel */
+    .experimental-banner p {
+        color: #45412f;
+        font-size: 0.95rem;
+        line-height: 1.6;
+        margin-bottom: 0;
+    }
+
+    .experimental-banner .alert-link {
+        color: #6a7f0a;
+        font-weight: 600;
+        text-decoration: underline;
+    }
+
+    /* ---------- Typography rhythm ---------- */
+    #main-content h2 {
+        line-height: 1.25;
+    }
+
+    /* ---------- Cards ---------- */
+    #main-content .card {
+        border: 1px solid #e8e8e8;
+        border-radius: 10px;
+        box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
+    }
+
+    #main-content .card-title {
+        color: #272727;
+        font-weight: 600;
+    }
+
+    /* Numbered step cards */
+    .step-num {
+        width: 2.3rem;
+        height: 2.3rem;
+        border-radius: 50%;
+        background: #7B920A;
+        color: #ffffff;
+        font-weight: 700;
+        font-size: 1.05rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin-bottom: 0.85rem;
+        box-shadow: 0 2px 6px rgba(123, 146, 10, 0.35);
+    }
+
+    .step-card .card-body {
+        padding: 1.5rem 1.4rem;
+    }
+
+    .step-card .card-title {
+        font-size: 1.1rem;
+        margin-bottom: 0.5rem;
+    }
+
+    @media (min-width: 768px) {
+        /* keep step bodies aligned when titles wrap to two lines */
+        .step-card .card-title {
+            min-height: 3.05em;
+        }
+    }
+
+    /* Callout cards: amber = experimental/warning, green = tip */
+    .callout-card .card-body {
+        padding: 1.35rem 1.5rem;
+    }
+
+    .card.border-warning {
+        border-color: #f0dda2 !important;
+        border-left: 4px solid #ffc107 !important;
+        background: #fffdf7;
+    }
+
+    .card.callout-tip {
+        border-color: #dfe8bc !important;
+        border-left: 4px solid #a5c422 !important;
+        background: #fbfdf2;
+    }
+
+    /* ---------- "What you'll want handy" list ---------- */
     .list-group-item {
         border-left: 4px solid #a5c422;
+        padding: 1rem 1.25rem;
     }
 
     .list-group-item:hover {
         background-color: rgba(165, 196, 34, 0.05);
     }
 
-    .card.border-warning {
-        border-left: 4px solid #ffc107 !important;
+    .list-group-item h5 {
+        font-size: 1.05rem;
+        font-weight: 600;
+        color: #272727;
     }
 
-    .card.border-info {
-        border-left: 4px solid #17a2b8 !important;
+    /* ---------- Work requirements ---------- */
+    .wr-label {
+        color: #6a7f0a;
+        font-size: 0.8rem;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
     }
 
-    #final-cta {
-        background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);
+    .check-list {
+        list-style: none;
+        padding-left: 0;
+        margin-bottom: 0;
     }
 
+    .check-list li {
+        position: relative;
+        padding-left: 1.5rem;
+        margin-bottom: 0.5rem;
+        color: #575757;
+        line-height: 1.5;
+    }
+
+    .check-list li:last-child {
+        margin-bottom: 0;
+    }
+
+    .check-list li::before {
+        content: "\2713";
+        position: absolute;
+        left: 0;
+        top: 0;
+        color: #7B920A;
+        font-weight: 700;
+    }
+
+    /* ---------- Buttons ---------- */
     .btn-green {
         background: linear-gradient(to right, #ADD100 0%, #7B920A 51%, #ADD100 100%);
         background-size: 200% auto;
@@ -452,18 +635,82 @@
         color: white;
     }
 
+    /* Restore a real size hierarchy: custom.css pins .btn-green to 1rem,
+       which made the primary CTA smaller than its outline neighbors. */
+    .btn-green.btn-lg {
+        font-size: 1.15rem;
+        font-weight: 700;
+        padding: 0.8rem 1.5rem;
+    }
+
+    .btn-outline-green.btn-lg,
+    .btn-outline-secondary.btn-lg {
+        font-size: 1.05rem;
+        padding: 0.75rem 1.2rem;
+    }
+
+    .btn:focus-visible {
+        outline: 3px solid rgba(123, 146, 10, 0.5);
+        outline-offset: 2px;
+    }
+
+    /* ---------- Final CTA ---------- */
+    #final-cta {
+        background: linear-gradient(135deg, #f8f9fa 0%, #eef1e0 100%);
+    }
+
+    #final-cta .lead {
+        max-width: 44rem;
+        margin-left: auto;
+        margin-right: auto;
+    }
+
     section {
         scroll-margin-top: 80px;
     }
 
+    /* ---------- Mobile ---------- */
     @media (max-width: 768px) {
         #medicaid-eligibility-hero .hero-inner {
-            padding: 1.5rem;
+            padding: 1.5rem 1.15rem;
         }
 
-        .btn-lg {
-            padding: 0.5rem 1rem;
+        .experimental-badge {
+            font-size: 0.72rem;
+        }
+
+        /* stacked hero buttons get one consistent width */
+        #medicaid-eligibility-hero .hero-cta-secondary a {
+            flex: 1 1 100%;
+            max-width: 320px;
+        }
+
+        .experimental-banner {
+            gap: 0.75rem;
+            padding: 1.1rem 1.15rem;
+        }
+
+        .experimental-banner .banner-icon {
+            width: 2rem;
+            height: 2rem;
+        }
+
+        .experimental-banner .alert-heading {
+            font-size: 1.1rem;
+        }
+
+        .btn-green.btn-lg,
+        .btn-outline-green.btn-lg,
+        .btn-outline-secondary.btn-lg {
             font-size: 1rem;
+            padding: 0.6rem 1.1rem;
+        }
+    }
+
+    @media (max-width: 576px) {
+        #final-cta .d-flex .btn {
+            flex: 1 1 100%;
+            max-width: 340px;
         }
     }
 </style>

--- a/fighthealthinsurance/templates/partials/experimental_badge.html
+++ b/fighthealthinsurance/templates/partials/experimental_badge.html
@@ -1,0 +1,7 @@
+{% comment %}
+Amber "EXPERIMENTAL FEATURE" pill used wherever the Medicaid eligibility
+check needs its experimental status flagged (hero, final CTA). One shared
+copy so wording/icon/accessibility changes happen in exactly one place.
+Styled by .experimental-badge in the including page's extra_style block.
+{% endcomment %}
+<span class="badge experimental-badge"><svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" focusable="false"><path d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5zm.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2z"/></svg>EXPERIMENTAL FEATURE</span>

--- a/fighthealthinsurance/templates/turning_26.html
+++ b/fighthealthinsurance/templates/turning_26.html
@@ -147,7 +147,7 @@
                                     <li>Medicaid has no enrollment periods&mdash;you can apply anytime</li>
                                     <li>Coverage is often free or very low cost</li>
                                     <li>Check your state's Medicaid website or apply through Healthcare.gov</li>
-                                    <li>Not sure where you stand? <a href="{% url 'medicaid-eligibility' %}" class="link">Try our free Medicaid eligibility check</a></li>
+                                    <li>Not sure where you stand? <a href="{% url 'medicaid-eligibility' %}" class="link">Try our free experimental Medicaid eligibility check</a> (an estimate only&mdash;confirm with your state)</li>
                                 </ul>
                                 <p class="mb-0"><strong>Tip:</strong> Even if you're not sure you qualify, apply anyway. The Marketplace application will automatically check your Medicaid eligibility.</p>
                             </div>

--- a/fighthealthinsurance/templates/turning_26.html
+++ b/fighthealthinsurance/templates/turning_26.html
@@ -147,7 +147,6 @@
                                     <li>Medicaid has no enrollment periods&mdash;you can apply anytime</li>
                                     <li>Coverage is often free or very low cost</li>
                                     <li>Check your state's Medicaid website or apply through Healthcare.gov</li>
-                                    <li>Not sure where you stand? <a href="{% url 'medicaid-eligibility' %}" class="link">Try our free experimental Medicaid eligibility check</a> (an estimate only&mdash;confirm with your state)</li>
                                 </ul>
                                 <p class="mb-0"><strong>Tip:</strong> Even if you're not sure you qualify, apply anyway. The Marketplace application will automatically check your Medicaid eligibility.</p>
                             </div>

--- a/fighthealthinsurance/templates/turning_26.html
+++ b/fighthealthinsurance/templates/turning_26.html
@@ -147,6 +147,7 @@
                                     <li>Medicaid has no enrollment periods&mdash;you can apply anytime</li>
                                     <li>Coverage is often free or very low cost</li>
                                     <li>Check your state's Medicaid website or apply through Healthcare.gov</li>
+                                    <li>Not sure where you stand? <a href="{% url 'medicaid-eligibility' %}" class="link">Try our free Medicaid eligibility check</a></li>
                                 </ul>
                                 <p class="mb-0"><strong>Tip:</strong> Even if you're not sure you qualify, apply anyway. The Marketplace application will automatically check your Medicaid eligibility.</p>
                             </div>

--- a/fighthealthinsurance/urls.py
+++ b/fighthealthinsurance/urls.py
@@ -255,6 +255,14 @@ urlpatterns: List[Union[URLPattern, URLResolver]] = [
         views.Turning26View.as_view(),
         name="turning-26",
     ),
+    # Experimental page: always routed so reverse() works everywhere, but the
+    # view serves 404 unless MEDICAID_ELIGIBILITY_PAGE_ENABLED is on (checked
+    # per-request, like NEW_PROFESSIONAL_SIGNUP_ENABLED).
+    path(
+        "medicaid-eligibility",
+        views.MedicaidEligibilityView.as_view(),
+        name="medicaid-eligibility",
+    ),
     path(
         "as-seen-on-pbs",
         views.PBSNewsHourView.as_view(),
@@ -497,18 +505,6 @@ urlpatterns += [
 urlpatterns += staticfiles_urlpatterns()
 
 # Serve static files in development
-if getattr(settings, "MEDICAID_ELIGIBILITY_PAGE_ENABLED", False):
-    # Experimental Medicaid eligibility landing page -- staged behind a
-    # settings flag (see MEDICAID_ELIGIBILITY_PAGE_ENABLED) so the URL stays
-    # unrouted in production while the page is iterated on.
-    urlpatterns.append(
-        path(
-            "medicaid-eligibility",
-            views.MedicaidEligibilityView.as_view(),
-            name="medicaid-eligibility",
-        )
-    )
-
 if settings.DEBUG:
     # Serve files from the app static dir in development
     if settings.STATIC_URL:

--- a/fighthealthinsurance/urls.py
+++ b/fighthealthinsurance/urls.py
@@ -256,6 +256,11 @@ urlpatterns: List[Union[URLPattern, URLResolver]] = [
         name="turning-26",
     ),
     path(
+        "medicaid-eligibility",
+        views.MedicaidEligibilityView.as_view(),
+        name="medicaid-eligibility",
+    ),
+    path(
         "as-seen-on-pbs",
         views.PBSNewsHourView.as_view(),
         name="pbs-newshour",

--- a/fighthealthinsurance/urls.py
+++ b/fighthealthinsurance/urls.py
@@ -256,11 +256,6 @@ urlpatterns: List[Union[URLPattern, URLResolver]] = [
         name="turning-26",
     ),
     path(
-        "medicaid-eligibility",
-        views.MedicaidEligibilityView.as_view(),
-        name="medicaid-eligibility",
-    ),
-    path(
         "as-seen-on-pbs",
         views.PBSNewsHourView.as_view(),
         name="pbs-newshour",
@@ -502,6 +497,18 @@ urlpatterns += [
 urlpatterns += staticfiles_urlpatterns()
 
 # Serve static files in development
+if getattr(settings, "MEDICAID_ELIGIBILITY_PAGE_ENABLED", False):
+    # Experimental Medicaid eligibility landing page -- staged behind a
+    # settings flag (see MEDICAID_ELIGIBILITY_PAGE_ENABLED) so the URL stays
+    # unrouted in production while the page is iterated on.
+    urlpatterns.append(
+        path(
+            "medicaid-eligibility",
+            views.MedicaidEligibilityView.as_view(),
+            name="medicaid-eligibility",
+        )
+    )
+
 if settings.DEBUG:
     # Serve files from the app static dir in development
     if settings.STATIC_URL:

--- a/fighthealthinsurance/utils.py
+++ b/fighthealthinsurance/utils.py
@@ -1714,6 +1714,4 @@ def medicaid_eligibility_page_enabled() -> bool:
     hand-copied ``getattr(settings, ...)`` checks could drift, which would
     either hide a live page from crawlers or advertise a 404 to them.
     """
-    from django.conf import settings
-
     return bool(getattr(settings, "MEDICAID_ELIGIBILITY_PAGE_ENABLED", False))

--- a/fighthealthinsurance/utils.py
+++ b/fighthealthinsurance/utils.py
@@ -1704,3 +1704,16 @@ def extract_file_text(path: str) -> str:
         except Exception as e:
             logger.warning(f"Could not read {path} as text: {e}")
             return ""
+
+
+def medicaid_eligibility_page_enabled() -> bool:
+    """Whether the experimental Medicaid eligibility landing page is staged on.
+
+    Single source of truth for the flag: the view uses it to 404 the route
+    and the sitemap uses it to decide whether to advertise the URL. Two
+    hand-copied ``getattr(settings, ...)`` checks could drift, which would
+    either hide a live page from crawlers or advertise a 404 to them.
+    """
+    from django.conf import settings
+
+    return bool(getattr(settings, "MEDICAID_ELIGIBILITY_PAGE_ENABLED", False))

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -3,6 +3,7 @@ import json
 import os
 import random
 import re
+import functools
 import typing
 from typing import TypedDict
 from urllib.parse import quote, urlencode
@@ -549,6 +550,7 @@ class MedicaidEligibilityView(StaticIshView):
     ) -> typing.Callable[..., HttpResponseBase]:
         cached_view = super().as_view(**initkwargs)
 
+        @functools.wraps(cached_view)
         def view(
             request: HttpRequest, *args: typing.Any, **kwargs: typing.Any
         ) -> HttpResponseBase:
@@ -558,6 +560,9 @@ class MedicaidEligibilityView(StaticIshView):
                 raise Http404("This page is not available yet.")
             return cached_view(request, *args, **kwargs)
 
+        # functools.wraps keeps view_class / view_initkwargs / __name__ that
+        # Django attaches to the as_view callable and that middleware and
+        # URL introspection read.
         return view
 
 

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -525,6 +525,12 @@ class Turning26View(StaticIshView):
     template_name = "turning_26.html"
 
 
+class MedicaidEligibilityView(StaticIshView):
+    """Landing page for the AI-assisted Medicaid/Medicare eligibility check."""
+
+    template_name = "medicaid_eligibility.html"
+
+
 class PBSNewsHourView(StaticIshView):
     """Page about the PBS NewsHour feature."""
 

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -58,6 +58,7 @@ from fighthealthinsurance.models import (
 from fighthealthinsurance.type_utils import User
 from fighthealthinsurance.utils import (
     is_valid_denial_id,
+    medicaid_eligibility_page_enabled,
     notify_interested_professional,
     send_fallback_email,
     should_notify_returning_lead,
@@ -528,22 +529,36 @@ class Turning26View(StaticIshView):
 class MedicaidEligibilityView(StaticIshView):
     """Landing page for the AI-assisted Medicaid/Medicare eligibility check.
 
-    Staged behind MEDICAID_ELIGIBILITY_PAGE_ENABLED, checked per request
-    (the NEW_PROFESSIONAL_SIGNUP_ENABLED pattern): the route always exists so
-    reverse() and templates never break, but the page 404s in production
-    until the flag is flipped -- and both states are testable with
-    override_settings. cache_page only stores 200s, so a 404 here is never
-    served from the page cache after the flag turns on.
+    Staged behind MEDICAID_ELIGIBILITY_PAGE_ENABLED: the route always exists
+    so reverse() and templates never break, but the page 404s until the flag
+    is flipped -- and both states are testable with override_settings.
+
+    The check wraps ``as_view`` OUTSIDE StaticIshView's cache_page, rather
+    than living in ``get``, for two reasons: Django serves a cached response
+    before the view ever runs, so an in-view check could not switch the page
+    back OFF once a 200 had been cached (the direction that matters for a
+    staged experimental page); and ``View.options`` answers 200 without
+    dispatching to ``get``, which left the route enumerable when disabled.
     """
 
     template_name = "medicaid_eligibility.html"
 
-    def get(self, request, *args, **kwargs):
-        if not getattr(settings, "MEDICAID_ELIGIBILITY_PAGE_ENABLED", False):
-            from django.http import Http404
+    @classonlymethod
+    def as_view(  # type: ignore[override]
+        cls, **initkwargs: typing.Any
+    ) -> typing.Callable[..., HttpResponseBase]:
+        cached_view = super().as_view(**initkwargs)
 
-            raise Http404("This page is not available yet.")
-        return super().get(request, *args, **kwargs)
+        def view(
+            request: HttpRequest, *args: typing.Any, **kwargs: typing.Any
+        ) -> HttpResponseBase:
+            if not medicaid_eligibility_page_enabled():
+                from django.http import Http404
+
+                raise Http404("This page is not available yet.")
+            return cached_view(request, *args, **kwargs)
+
+        return view
 
 
 class PBSNewsHourView(StaticIshView):

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -526,9 +526,24 @@ class Turning26View(StaticIshView):
 
 
 class MedicaidEligibilityView(StaticIshView):
-    """Landing page for the AI-assisted Medicaid/Medicare eligibility check."""
+    """Landing page for the AI-assisted Medicaid/Medicare eligibility check.
+
+    Staged behind MEDICAID_ELIGIBILITY_PAGE_ENABLED, checked per request
+    (the NEW_PROFESSIONAL_SIGNUP_ENABLED pattern): the route always exists so
+    reverse() and templates never break, but the page 404s in production
+    until the flag is flipped -- and both states are testable with
+    override_settings. cache_page only stores 200s, so a 404 here is never
+    served from the page cache after the flag turns on.
+    """
 
     template_name = "medicaid_eligibility.html"
+
+    def get(self, request, *args, **kwargs):
+        if not getattr(settings, "MEDICAID_ELIGIBILITY_PAGE_ENABLED", False):
+            from django.http import Http404
+
+            raise Http404("This page is not available yet.")
+        return super().get(request, *args, **kwargs)
 
 
 class PBSNewsHourView(StaticIshView):

--- a/tests/chat_fixtures.py
+++ b/tests/chat_fixtures.py
@@ -45,7 +45,7 @@ CANNED_MEDICAID_REPLY = (
     "New federal rules require many adults (ages 19-64) to complete at least "
     "80 hours per month of work, job training, school, or community service "
     "to keep Medicaid coverage. These requirements go into effect by "
-    "December 31, 2026. For detailed information, visit: "
+    "January 1, 2027. For detailed information, visit: "
     "[Medicaid Work Requirements FAQ](/faq/medicaid/)"
 )
 

--- a/tests/sync/test_chat_tools.py
+++ b/tests/sync/test_chat_tools.py
@@ -458,6 +458,53 @@ class TestMedicaidEligibilityTool(TestCase):
 
         self.assertIn("questions to ask", info)
 
+    def test_build_eligibility_info_lists_questions_not_python_repr(self):
+        """Missing questions render as a readable list, not a list repr."""
+        mock_status = AsyncMock()
+        tool = MedicaidEligibilityTool(mock_status)
+
+        info = tool._build_eligibility_info(
+            eligible_2025=False,
+            eligible_2026=False,
+            medicare=False,
+            alternatives=[],
+            missing=["What state do you live in?", "How old are you?"],
+        )
+
+        self.assertIn("- What state do you live in?", info)
+        self.assertNotIn("['What state", info)
+
+    def test_build_eligibility_info_paces_questions(self):
+        """The LLM is told to ask only a few questions at a time."""
+        mock_status = AsyncMock()
+        tool = MedicaidEligibilityTool(mock_status)
+
+        info = tool._build_eligibility_info(
+            eligible_2025=False,
+            eligible_2026=False,
+            medicare=False,
+            alternatives=[],
+            missing=["q1", "q2", "q3", "q4"],
+        )
+
+        self.assertIn("two or three at a time", info)
+
+    def test_build_eligibility_info_lists_alternatives_not_python_repr(self):
+        """Alternatives render as a readable list, not a list repr."""
+        mock_status = AsyncMock()
+        tool = MedicaidEligibilityTool(mock_status)
+
+        info = tool._build_eligibility_info(
+            eligible_2025=False,
+            eligible_2026=False,
+            medicare=False,
+            alternatives=["Consider CHIP for the kids."],
+            missing=[],
+        )
+
+        self.assertIn("- Consider CHIP for the kids.", info)
+        self.assertNotIn("['Consider", info)
+
 
 class TestDocFetcherPatterns(TestCase):
     """Test FETCH_DOC_REGEX pattern matching."""

--- a/tests/sync/test_chat_tools.py
+++ b/tests/sync/test_chat_tools.py
@@ -24,6 +24,10 @@ from fighthealthinsurance.chat.tools import (
     RxNormLookupTool,
     USPSTFLookupTool,
 )
+from fighthealthinsurance.medicaid_api import (
+    is_eligible,
+    summarize_eligibility_inputs,
+)
 from fighthealthinsurance.chat.tools.doc_fetcher_tool import (
     MAX_FETCHES_PER_SESSION,
     _sanitize_url_for_display,
@@ -1009,3 +1013,81 @@ class TestUSPSTFLookupTool(TestCase):
         # lookup so the LLM follow-up call gets the correct provenance label.
         call_args = callback.call_args
         self.assertEqual(call_args.args[2], "USPSTF preventive-services lookup")
+
+
+class TestMedicaidDeclinedAnswerRoundTrip(TestCase):
+    """A declined answer has to survive into the next tool call.
+
+    ``declined_set`` is rebuilt from the current payload each call, so the
+    "unknown" marker only suppresses its question for as long as the model
+    keeps re-sending it. The parsed-input echo is the only place the model is
+    told what to re-send, so it has to name the declined fields explicitly.
+    """
+
+    def setUp(self):
+        self.tool = MedicaidEligibilityTool(AsyncMock())
+
+    def test_summary_tells_the_model_to_resend_declined_fields(self):
+        summary = summarize_eligibility_inputs(
+            {"state": "ca", "age": 66, "assets_total": "unknown"}
+        )
+        text = self.tool._build_parsed_summary(summary)
+        self.assertIn("assets_total", text)
+        self.assertIn('"unknown"', text)
+
+    def test_resending_the_unknown_marker_keeps_the_question_suppressed(self):
+        first = dict(
+            state="ca", age=66, married=False, household_size=1,
+            monthly_income=900, children_in_household=0, pregnant=False,
+            receiving_ssdi=False, on_medicare=False, years_worked=40,
+            assets_total="unknown",
+        )
+        # What the echo tells the model to send back, plus the declined marker
+        # the echo now names separately.
+        summary = summarize_eligibility_inputs(first)
+        second = dict(summary["recorded"])
+        for field in summary["declined"]:
+            second[field] = "unknown"
+
+        *_, missing, _ = is_eligible(**second)
+        self.assertEqual(missing, [])
+
+
+class TestMedicaidIndeterminateWithQuestions(TestCase):
+    """An unscorable result's next steps are actionable before the interview ends."""
+
+    def setUp(self):
+        self.tool = MedicaidEligibilityTool(AsyncMock())
+
+    def test_next_steps_are_shared_while_questions_remain(self):
+        info = self.tool._build_eligibility_info(
+            eligible_2025=False,
+            eligible_2026=False,
+            medicare=False,
+            alternatives=["Contact your territory's Medicaid agency."],
+            missing=["How old are you?"],
+            determination_made=False,
+        )
+        self.assertIn("Contact your territory's Medicaid agency.", info)
+
+    def test_no_ineligibility_claim_while_questions_remain(self):
+        info = self.tool._build_eligibility_info(
+            eligible_2025=False,
+            eligible_2026=False,
+            medicare=False,
+            alternatives=["Contact your territory's Medicaid agency."],
+            missing=["How old are you?"],
+            determination_made=False,
+        )
+        self.assertNotIn("may not be eligible", info)
+
+    def test_a_scored_result_does_not_get_the_cannot_estimate_banner(self):
+        info = self.tool._build_eligibility_info(
+            eligible_2025=True,
+            eligible_2026=True,
+            medicare=False,
+            alternatives=["Visit your state Medicaid page."],
+            missing=["How old are you?"],
+            determination_made=True,
+        )
+        self.assertNotIn("canNOT produce a Medicaid estimate", info)

--- a/tests/sync/test_chat_tools.py
+++ b/tests/sync/test_chat_tools.py
@@ -526,6 +526,30 @@ class TestMedicaidEligibilityTool(TestCase):
 
         self.assertNotIn("If denied", info)
 
+    def test_parsed_summary_echoes_recorded_values(self):
+        """The LLM keeps its own context, so it must see what we recorded."""
+        text = self.tool._build_parsed_summary(
+            {"recorded": {"state": "ca"}, "unreadable": [], "unrecognized": [], "declined": []}
+        )
+
+        self.assertIn("state: ca", text)
+
+    def test_parsed_summary_flags_unrecognized_parameters(self):
+        """A silently dropped key looks to the model just like acceptance."""
+        text = self.tool._build_parsed_summary(
+            {"recorded": {}, "unreadable": [], "unrecognized": ["income"], "declined": []}
+        )
+
+        self.assertIn("income", text)
+        self.assertIn("ignored", text)
+
+    def test_parsed_summary_tells_llm_not_to_reask_declined_fields(self):
+        text = self.tool._build_parsed_summary(
+            {"recorded": {}, "unreadable": [], "unrecognized": [], "declined": ["assets_total"]}
+        )
+
+        self.assertIn("don't ask about those again", text)
+
     def test_build_eligibility_info_lists_alternatives_not_python_repr(self):
         """Alternatives render as a readable list, not a list repr."""
         info = self.tool._build_eligibility_info(

--- a/tests/sync/test_chat_tools.py
+++ b/tests/sync/test_chat_tools.py
@@ -526,6 +526,45 @@ class TestMedicaidEligibilityTool(TestCase):
 
         self.assertNotIn("If denied", info)
 
+    def test_indeterminate_result_is_not_rendered_as_a_denial(self):
+        """"Couldn't score them" must not become "may not be eligible"."""
+        info = self.tool._build_eligibility_info(
+            eligible_2025=False,
+            eligible_2026=False,
+            medicare=False,
+            alternatives=["Contact your territory's Medicaid agency."],
+            missing=[],
+            determination_made=False,
+        )
+
+        self.assertIn("could NOT produce a Medicaid estimate", info)
+        self.assertNotIn("may not be eligible", info)
+
+    def test_indeterminate_result_still_reports_medicare(self):
+        """Medicare is federal, so a territory resident still gets that answer."""
+        info = self.tool._build_eligibility_info(
+            eligible_2025=False,
+            eligible_2026=False,
+            medicare=True,
+            alternatives=[],
+            missing=[],
+            determination_made=False,
+        )
+
+        self.assertIn("may be eligible for it", info)
+
+    def test_scored_ineligible_still_reads_as_a_verdict(self):
+        info = self.tool._build_eligibility_info(
+            eligible_2025=False,
+            eligible_2026=False,
+            medicare=False,
+            alternatives=[],
+            missing=[],
+            determination_made=True,
+        )
+
+        self.assertIn("may not be eligible", info)
+
     def test_parsed_summary_echoes_recorded_values(self):
         """The LLM keeps its own context, so it must see what we recorded."""
         text = self.tool._build_parsed_summary(

--- a/tests/sync/test_chat_tools.py
+++ b/tests/sync/test_chat_tools.py
@@ -474,6 +474,36 @@ class TestMedicaidEligibilityTool(TestCase):
         self.assertIn("- What state do you live in?", info)
         self.assertNotIn("['What state", info)
 
+    def test_build_eligibility_info_flags_experimental_when_asking(self):
+        """The LLM is told to disclose the experimental status while asking."""
+        mock_status = AsyncMock()
+        tool = MedicaidEligibilityTool(mock_status)
+
+        info = tool._build_eligibility_info(
+            eligible_2025=False,
+            eligible_2026=False,
+            medicare=False,
+            alternatives=[],
+            missing=["What state do you live in?"],
+        )
+
+        self.assertIn("EXPERIMENTAL", info)
+
+    def test_build_eligibility_info_flags_experimental_on_verdict(self):
+        """The LLM is told to disclose the experimental status with verdicts."""
+        mock_status = AsyncMock()
+        tool = MedicaidEligibilityTool(mock_status)
+
+        info = tool._build_eligibility_info(
+            eligible_2025=True,
+            eligible_2026=True,
+            medicare=False,
+            alternatives=[],
+            missing=[],
+        )
+
+        self.assertIn("EXPERIMENTAL", info)
+
     def test_build_eligibility_info_paces_questions(self):
         """The LLM is told to ask only a few questions at a time."""
         mock_status = AsyncMock()

--- a/tests/sync/test_chat_tools.py
+++ b/tests/sync/test_chat_tools.py
@@ -415,23 +415,20 @@ class TestMedicaidInfoTool(TestCase):
 class TestMedicaidEligibilityTool(TestCase):
     """Test MedicaidEligibilityTool functionality."""
 
+    def setUp(self):
+        self.tool = MedicaidEligibilityTool(AsyncMock())
+
     def test_detect_medicaid_eligibility(self):
         """Test Medicaid eligibility tool detects pattern."""
-        mock_status = AsyncMock()
-        tool = MedicaidEligibilityTool(mock_status)
-
         text = 'medicaid_eligibility {"income": 25000}'
-        match = tool.detect(text)
+        match = self.tool.detect(text)
 
         self.assertIsNotNone(match)
         self.assertIn("income", match.group(1))
 
     def test_build_eligibility_info_eligible(self):
         """Test eligibility info text generation for eligible user."""
-        mock_status = AsyncMock()
-        tool = MedicaidEligibilityTool(mock_status)
-
-        info = tool._build_eligibility_info(
+        info = self.tool._build_eligibility_info(
             eligible_2025=True,
             eligible_2026=True,
             medicare=False,
@@ -445,10 +442,7 @@ class TestMedicaidEligibilityTool(TestCase):
 
     def test_build_eligibility_info_with_missing(self):
         """Test eligibility info text when questions are missing."""
-        mock_status = AsyncMock()
-        tool = MedicaidEligibilityTool(mock_status)
-
-        info = tool._build_eligibility_info(
+        info = self.tool._build_eligibility_info(
             eligible_2025=False,
             eligible_2026=False,
             medicare=False,
@@ -460,10 +454,7 @@ class TestMedicaidEligibilityTool(TestCase):
 
     def test_build_eligibility_info_lists_questions_not_python_repr(self):
         """Missing questions render as a readable list, not a list repr."""
-        mock_status = AsyncMock()
-        tool = MedicaidEligibilityTool(mock_status)
-
-        info = tool._build_eligibility_info(
+        info = self.tool._build_eligibility_info(
             eligible_2025=False,
             eligible_2026=False,
             medicare=False,
@@ -476,10 +467,7 @@ class TestMedicaidEligibilityTool(TestCase):
 
     def test_build_eligibility_info_flags_experimental_when_asking(self):
         """The LLM is told to disclose the experimental status while asking."""
-        mock_status = AsyncMock()
-        tool = MedicaidEligibilityTool(mock_status)
-
-        info = tool._build_eligibility_info(
+        info = self.tool._build_eligibility_info(
             eligible_2025=False,
             eligible_2026=False,
             medicare=False,
@@ -491,10 +479,7 @@ class TestMedicaidEligibilityTool(TestCase):
 
     def test_build_eligibility_info_flags_experimental_on_verdict(self):
         """The LLM is told to disclose the experimental status with verdicts."""
-        mock_status = AsyncMock()
-        tool = MedicaidEligibilityTool(mock_status)
-
-        info = tool._build_eligibility_info(
+        info = self.tool._build_eligibility_info(
             eligible_2025=True,
             eligible_2026=True,
             medicare=False,
@@ -506,10 +491,7 @@ class TestMedicaidEligibilityTool(TestCase):
 
     def test_build_eligibility_info_paces_questions(self):
         """The LLM is told to ask only a few questions at a time."""
-        mock_status = AsyncMock()
-        tool = MedicaidEligibilityTool(mock_status)
-
-        info = tool._build_eligibility_info(
+        info = self.tool._build_eligibility_info(
             eligible_2025=False,
             eligible_2026=False,
             medicare=False,
@@ -521,10 +503,7 @@ class TestMedicaidEligibilityTool(TestCase):
 
     def test_build_eligibility_info_lists_alternatives_not_python_repr(self):
         """Alternatives render as a readable list, not a list repr."""
-        mock_status = AsyncMock()
-        tool = MedicaidEligibilityTool(mock_status)
-
-        info = tool._build_eligibility_info(
+        info = self.tool._build_eligibility_info(
             eligible_2025=False,
             eligible_2026=False,
             medicare=False,

--- a/tests/sync/test_chat_tools.py
+++ b/tests/sync/test_chat_tools.py
@@ -1058,28 +1058,24 @@ class TestMedicaidIndeterminateWithQuestions(TestCase):
 
     def setUp(self):
         self.tool = MedicaidEligibilityTool(AsyncMock())
+        # An unscorable result that still has an outstanding question -- the
+        # territory case, where Medicare may yet resolve.
+        self.indeterminate_info = self.tool._build_eligibility_info(
+            eligible_2025=False,
+            eligible_2026=False,
+            medicare=False,
+            alternatives=["Contact your territory's Medicaid agency."],
+            missing=["How old are you?"],
+            determination_made=False,
+        )
 
     def test_next_steps_are_shared_while_questions_remain(self):
-        info = self.tool._build_eligibility_info(
-            eligible_2025=False,
-            eligible_2026=False,
-            medicare=False,
-            alternatives=["Contact your territory's Medicaid agency."],
-            missing=["How old are you?"],
-            determination_made=False,
+        self.assertIn(
+            "Contact your territory's Medicaid agency.", self.indeterminate_info
         )
-        self.assertIn("Contact your territory's Medicaid agency.", info)
 
     def test_no_ineligibility_claim_while_questions_remain(self):
-        info = self.tool._build_eligibility_info(
-            eligible_2025=False,
-            eligible_2026=False,
-            medicare=False,
-            alternatives=["Contact your territory's Medicaid agency."],
-            missing=["How old are you?"],
-            determination_made=False,
-        )
-        self.assertNotIn("may not be eligible", info)
+        self.assertNotIn("may not be eligible", self.indeterminate_info)
 
     def test_a_scored_result_does_not_get_the_cannot_estimate_banner(self):
         info = self.tool._build_eligibility_info(

--- a/tests/sync/test_chat_tools.py
+++ b/tests/sync/test_chat_tools.py
@@ -501,6 +501,31 @@ class TestMedicaidEligibilityTool(TestCase):
 
         self.assertIn("two or three at a time", info)
 
+    def test_build_eligibility_info_reports_settled_verdict_while_asking(self):
+        """A determination already reached isn't withheld behind a question."""
+        info = self.tool._build_eligibility_info(
+            eligible_2025=True,
+            eligible_2026=False,
+            medicare=True,
+            alternatives=[],
+            missing=["Do you have ALS?"],
+        )
+
+        self.assertIn("already look eligible", info)
+        self.assertIn("medicare", info.lower())
+
+    def test_build_eligibility_info_holds_alternatives_until_verdict(self):
+        """Denial-flavored next steps don't surface mid-interview."""
+        info = self.tool._build_eligibility_info(
+            eligible_2025=True,
+            eligible_2026=False,
+            medicare=False,
+            alternatives=["If denied, you can appeal; gather documentation."],
+            missing=["Do you have ALS?"],
+        )
+
+        self.assertNotIn("If denied", info)
+
     def test_build_eligibility_info_lists_alternatives_not_python_repr(self):
         """Alternatives render as a readable list, not a list repr."""
         info = self.tool._build_eligibility_info(

--- a/tests/sync/test_medicaid_eligibility_api.py
+++ b/tests/sync/test_medicaid_eligibility_api.py
@@ -751,3 +751,178 @@ class TestGetMedicaidInfo(SimpleTestCase):
         # The MISC section looped over columns already projected away, so it
         # emitted a header promising data it structurally could not deliver.
         self.assertNotIn("MISC", get_medicaid_info({"state": "ca"}))
+
+    def test_territory_with_no_csv_row_returns_none(self):
+        # PR/GU/VI/AS/MP normalize to a display name but have no row in
+        # medicaid_resources.csv. Returning "No Medicaid data found for X."
+        # here handed the caller prose it wraps as "Here's the official
+        # Medicaid information for Puerto Rico:" -- presenting a miss as data.
+        self.assertIsNone(get_medicaid_info({"state": "Puerto Rico"}))
+
+
+class TestDeclinedAnswersDoNotBecomeVerdicts(SimpleTestCase):
+    """A question the user declined leaves the category unscored.
+
+    ``ask()`` silently skips declined fields, so every caller that would
+    otherwise fall through to a verdict has to notice the difference between
+    "the answer is no" and "we never got to run this test".
+    """
+
+    def test_declined_assets_leaves_abd_pathway_unscored(self):
+        _, _, _, _, missing, determination_made = is_eligible(
+            **_answers(
+                age=66, monthly_income=900, on_medicare=False,
+                years_worked=40, assets_total="unknown",
+            )
+        )
+        self.assertFalse(determination_made)
+        self.assertEqual(missing, [])
+
+    def test_declined_assets_still_offers_spend_down_in_a_medically_needy_state(self):
+        *_, alts, _, _ = is_eligible(
+            **_answers(
+                age=66, monthly_income=900, on_medicare=False,
+                years_worked=40, assets_total="unknown",
+            )
+        )
+        self.assertIn(
+            "Medically-needy/spend-down Medicaid may help if medical bills are high.",
+            alts,
+        )
+
+    def test_declined_work_hours_leaves_2026_unscored(self):
+        _, _, _, _, missing, determination_made = is_eligible(
+            **_answers(
+                avg_monthly_qualifying_hours_last_3mo="unknown",
+                total_qualifying_hours_last_3mo="unknown",
+            )
+        )
+        self.assertFalse(determination_made)
+        self.assertEqual(missing, [])
+
+    def test_declined_work_hours_keeps_the_settled_2025_verdict(self):
+        eligible_2025, *_ = is_eligible(
+            **_answers(
+                avg_monthly_qualifying_hours_last_3mo="unknown",
+                total_qualifying_hours_last_3mo="unknown",
+            )
+        )
+        self.assertTrue(eligible_2025)
+
+    def test_declined_years_worked_still_offers_the_part_a_buy_in(self):
+        *_, alts, _, _ = is_eligible(
+            **_answers(age=67, on_medicare=False, years_worked="unknown", assets_total=500)
+        )
+        self.assertIn(
+            "You may be eligible to buy Medicare Part A even if you don't "
+            "qualify for premium-free Part A.",
+            alts,
+        )
+
+    def test_declined_years_worked_leaves_medicare_unscored(self):
+        _, _, _, _, _, determination_made = is_eligible(
+            **_answers(age=67, on_medicare=False, years_worked="unknown", assets_total=500)
+        )
+        self.assertFalse(determination_made)
+
+    def test_indeterminate_result_names_the_field_it_could_not_check(self):
+        *_, alts, _, _ = is_eligible(
+            **_answers(
+                age=66, monthly_income=900, on_medicare=False,
+                years_worked=40, assets_total="unknown",
+            )
+        )
+        self.assertTrue(
+            any("could not check assets total" in a for a in alts),
+            f"no disclosure of the unchecked field in {alts}",
+        )
+
+
+class TestTerritoryShortCircuit(SimpleTestCase):
+    """Territories are not modeled, so don't interrogate them about Medicaid."""
+
+    def test_medicaid_only_questions_are_dropped(self):
+        *_, missing, _ = is_eligible(state="pr")
+        for question in missing:
+            self.assertNotIn("household", question.lower())
+            self.assertNotIn("income", question.lower())
+
+    def test_medicare_relevant_questions_survive(self):
+        *_, missing, _ = is_eligible(state="pr")
+        self.assertIn("How old are you?", missing)
+
+    def test_territory_medicare_verdict_is_still_produced(self):
+        _, _, medicare, _, missing, determination_made = is_eligible(
+            **_answers(state="pr", age=67, on_medicare=False, years_worked=40)
+        )
+        self.assertTrue(medicare)
+        self.assertEqual(missing, [])
+        self.assertFalse(determination_made)
+
+
+class TestAmbiguousStateInput(SimpleTestCase):
+    """Program names resolve exactly or not at all -- never fuzzily."""
+
+    def test_misspelled_medicaid_does_not_resolve_to_california(self):
+        *_, missing, _ = is_eligible(state="medicad")
+        self.assertIn("What state do you live in?", missing)
+
+    def test_exact_program_name_still_resolves(self):
+        eligible_2025, *_ = is_eligible(**_answers(state="medi-cal"))
+        self.assertTrue(eligible_2025)
+
+    def test_a_program_name_shared_by_two_states_re_asks(self):
+        *_, missing, _ = is_eligible(state="healthy connections")
+        self.assertIn("What state do you live in?", missing)
+
+    def test_a_genuine_state_typo_still_fuzzy_matches(self):
+        eligible_2025, *_ = is_eligible(**_answers(state="californa"))
+        self.assertTrue(eligible_2025)
+
+
+class TestAnswerVocabulary(SimpleTestCase):
+    """Natural phrasings of common answers must not read as unanswered."""
+
+    def test_no_income_is_recorded_as_zero(self):
+        summary = summarize_eligibility_inputs({"monthly_income": "no income"})
+        self.assertEqual(summary["recorded"]["monthly_income"], 0.0)
+
+    def test_no_income_does_not_re_ask_for_income(self):
+        *_, missing, _ = is_eligible(**_answers(monthly_income="no income"))
+        for question in missing:
+            self.assertNotIn("monthly income", question.lower())
+
+    def test_unemployed_is_not_treated_as_zero_income(self):
+        # A job status is not an amount, and unemployment benefits are income.
+        summary = summarize_eligibility_inputs({"monthly_income": "unemployed"})
+        self.assertIn("monthly_income", summary["unreadable"])
+
+    def test_widowed_answers_the_married_question(self):
+        summary = summarize_eligibility_inputs({"married": "widowed"})
+        self.assertIs(summary["recorded"]["married"], False)
+
+
+class TestSpendDownSuggestion(SimpleTestCase):
+    """Only suggest medically-needy Medicaid where the program exists."""
+
+    def test_not_suggested_in_a_state_without_the_program(self):
+        *_, alts, _, _ = is_eligible(
+            **_answers(
+                state="tx", age=70, monthly_income=3000, on_medicare=True,
+                assets_total=50000, years_worked=40,
+            )
+        )
+        for alt in alts:
+            self.assertNotIn("medically-needy", alt.lower())
+
+    def test_suggested_in_a_state_with_the_program(self):
+        *_, alts, _, _ = is_eligible(
+            **_answers(
+                state="ca", age=70, monthly_income=3000, on_medicare=True,
+                assets_total=50000, years_worked=40,
+            )
+        )
+        self.assertTrue(
+            any("medically-needy" in a.lower() for a in alts),
+            f"expected a spend-down pointer in {alts}",
+        )

--- a/tests/sync/test_medicaid_eligibility_api.py
+++ b/tests/sync/test_medicaid_eligibility_api.py
@@ -6,7 +6,9 @@ with "not eligible" plus an empty question list just because a question was
 never going to be asked (the pre-2026-08 stall bugs).
 """
 
-from django.test import TestCase
+# SimpleTestCase: is_eligible is pure computation and get_medicaid_info reads
+# a CSV -- no ORM, so skip TestCase's per-test transaction machinery.
+from django.test import SimpleTestCase
 
 from fighthealthinsurance.medicaid_api import get_medicaid_info, is_eligible
 
@@ -29,7 +31,7 @@ def _answers(**overrides):
     return base
 
 
-class TestExpansionAdultFlow(TestCase):
+class TestExpansionAdultFlow(SimpleTestCase):
     """MAGI adults in expansion states."""
 
     def test_low_income_expansion_adult_is_eligible_2025(self):
@@ -88,8 +90,65 @@ class TestExpansionAdultFlow(TestCase):
         _, _, _, alts, _ = is_eligible(**_answers(state="tx"))
         self.assertTrue(any("coverage gap" in a for a in alts))
 
+    def test_wisconsin_over_waiver_limit_gets_marketplace_alternative(self):
+        # Review regression: the WI waiver branch had no not-eligible arm, so
+        # WI adults over 100% FPL got no subsidy pointer at all.
+        eligible_2025, _, _, alts, _ = is_eligible(
+            **_answers(state="wi", monthly_income=1600.0)
+        )
+        self.assertFalse(eligible_2025)
+        self.assertTrue(any("marketplace subsidies" in a for a in alts))
 
-class TestQuestionFlow(TestCase):
+    def test_ssdi_adult_in_expansion_state_keeps_magi_pathway(self):
+        # Review regression: answering yes to SSDI routed 19-64 adults into
+        # the asset-tested ABD branch only; SSDI receipt does not bar the
+        # MAGI expansion pathway (income-only, up to 138% FPL).
+        eligible_2025, eligible_2026, _, _, _ = is_eligible(
+            **_answers(
+                state="co",
+                monthly_income=1500.0,
+                receiving_ssdi=True,
+                ssdi_length=12,
+                on_medicare=False,
+                assets_total=5000.0,
+            )
+        )
+        self.assertTrue(eligible_2025)
+        self.assertTrue(eligible_2026)
+
+    def test_monthly_hours_average_matches_question_units(self):
+        # Review regression: the tool asks for hours per MONTH but only a
+        # per-week kwarg existed, inviting a 4x unit error. 60/month fails
+        # the 80-hours rule; 90/month meets it.
+        _, eligible_2026, _, _, _ = is_eligible(
+            **_answers(avg_monthly_qualifying_hours_last_3mo=60.0)
+        )
+        self.assertFalse(eligible_2026)
+        _, eligible_2026, _, _, _ = is_eligible(
+            **_answers(avg_monthly_qualifying_hours_last_3mo=90.0)
+        )
+        self.assertTrue(eligible_2026)
+
+    def test_weekly_hours_use_thirteen_week_quarter(self):
+        # Review regression: 4-weeks-per-month undercounted real months by
+        # ~8%. 19 hrs/week is ~82.3 hrs per calendar month, which meets 80.
+        _, eligible_2026, _, _, _ = is_eligible(
+            **_answers(avg_weekly_qualifying_hours_last_3mo=19.0)
+        )
+        self.assertTrue(eligible_2026)
+
+    def test_esrd_patient_exempt_from_work_requirement(self):
+        # Review regression: ESRD/ALS (medically frail) were subjected to the
+        # 2026 work-hours demand.
+        _, eligible_2026, medicare, _, missing = is_eligible(
+            **_answers(esrd=True, on_medicare=False, assets_total=500.0)
+        )
+        self.assertTrue(eligible_2026)
+        self.assertTrue(medicare)
+        self.assertFalse(any("hours" in q for q in missing))
+
+
+class TestQuestionFlow(SimpleTestCase):
     """Stepwise questioning behavior."""
 
     def test_answering_no_to_ssdi_is_not_reasked(self):
@@ -140,8 +199,39 @@ class TestQuestionFlow(TestCase):
             len([q for q in missing if "countable financial assets" in q]), 1
         )
 
+    def test_string_no_is_treated_as_no(self):
+        # Review regression: bool("no") is True, so LLM string booleans
+        # flipped answers. A string "no" must behave like False.
+        eligible_2025, _, _, _, _ = is_eligible(**_answers(state="tx", pregnant="no"))
+        self.assertFalse(eligible_2025)
 
-class TestMedicarePathways(TestCase):
+    def test_string_false_work_exemption_is_not_treated_as_exempt(self):
+        # Review regression: work_req_exempt_2026="false" was truthy and
+        # skipped the work-hours questions entirely.
+        _, eligible_2026, _, _, missing = is_eligible(
+            **_answers(work_req_exempt_2026="false")
+        )
+        self.assertFalse(eligible_2026)
+        self.assertTrue(any("hours" in q for q in missing))
+
+    def test_home_equity_question_asked_only_once(self):
+        # Review regression: two divergent phrasings of the home-equity
+        # question survived dedup and got asked twice in one message.
+        _, _, _, _, missing = is_eligible(
+            **_answers(
+                age=80,
+                on_medicare=True,
+                applying_reason="ltc_nursing_home",
+                living_situation="nursing_home_perm",
+                assets_total=0.0,
+                home_owner=True,
+                monthly_income=1500.0,
+            )
+        )
+        self.assertEqual(len([q for q in missing if "equity" in q]), 1)
+
+
+class TestMedicarePathways(SimpleTestCase):
     """Medicare eligibility determinations."""
 
     def test_ssdi_24_months_confers_medicare(self):
@@ -187,8 +277,66 @@ class TestMedicarePathways(TestCase):
         self.assertFalse(medicare)
         self.assertTrue(any("Part-A" in a or "Medicare Savings" in a for a in alts))
 
+    def test_under_65_already_on_medicare_is_acknowledged(self):
+        # Review regression: an under-65 user who said they are ON Medicare
+        # was reported not Medicare-eligible (the enrolled branch was only
+        # reachable through the other pathways).
+        _, _, medicare, _, _ = is_eligible(
+            **_answers(age=40, monthly_income=800.0, on_medicare=True, assets_total=500.0)
+        )
+        self.assertTrue(medicare)
 
-class TestLongTermCareFlow(TestCase):
+    def test_ssdi_recipient_at_67_is_asked_ssdi_months(self):
+        # Review regression: the ssdi_length question was only asked under
+        # 65, so the 24-month pathway was unreachable for 65+ SSDI
+        # recipients and they got a definitive wrong "not eligible".
+        _, _, medicare, _, missing = is_eligible(
+            **_answers(
+                age=67,
+                receiving_ssdi=True,
+                on_medicare=False,
+                years_worked=5,
+                assets_total=500.0,
+            )
+        )
+        self.assertTrue(any("months have you been receiving SSDI" in q for q in missing))
+        # No definitive verdict while that question is outstanding.
+        self.assertFalse(medicare)
+
+    def test_ssdi_recipient_at_67_with_24_months_gets_medicare(self):
+        _, _, medicare, _, missing = is_eligible(
+            **_answers(
+                age=67,
+                receiving_ssdi=True,
+                ssdi_length=36,
+                on_medicare=False,
+                years_worked=5,
+                assets_total=500.0,
+            )
+        )
+        self.assertTrue(medicare)
+        self.assertEqual(missing, [])
+
+    def test_explicit_ssdi_no_does_not_mask_disabled_yes(self):
+        # Review regression: receiving_ssdi=False silently discarded
+        # disabled=True, dropping the disability pathway and its work
+        # exemption.
+        eligible_2025, eligible_2026, _, _, _ = is_eligible(
+            **_answers(
+                state="tx",
+                monthly_income=800.0,
+                receiving_ssdi=False,
+                disabled=True,
+                ssdi_length=0,
+                on_medicare=False,
+                assets_total=500.0,
+            )
+        )
+        self.assertTrue(eligible_2025)
+        self.assertTrue(eligible_2026)
+
+
+class TestLongTermCareFlow(SimpleTestCase):
     """LTC pathway checks."""
 
     def _ltc_answers(self, **overrides):
@@ -207,12 +355,44 @@ class TestLongTermCareFlow(TestCase):
     def test_zero_assets_pass_the_ltc_asset_test(self):
         # Regression: `if not assets_total` treated $0 (the most-eligible
         # case) as missing info and failed the asset test.
-        eligible_2025, eligible_2026, _, _, missing = is_eligible(
-            **self._ltc_answers()
-        )
+        eligible_2025, _, _, _, missing = is_eligible(**self._ltc_answers())
         self.assertTrue(eligible_2025)
-        self.assertTrue(eligible_2026)
         self.assertEqual(missing, [])
+
+    def test_eligible_ltc_applicant_is_exempt_from_2026_work_overlay(self):
+        # Split from the asset test: 2026 exemption is a distinct rule
+        # (LTC applicants are medically frail, never asked for work hours).
+        _, eligible_2026, _, _, missing = is_eligible(**self._ltc_answers())
+        self.assertTrue(eligible_2026)
+        self.assertFalse(any("hours" in q for q in missing))
+
+    def test_under_65_ltc_applicant_not_asked_for_work_hours(self):
+        # Review regression: a 55-year-old permanent nursing-home resident
+        # was subjected to the 80-hours-per-month work requirement.
+        _, eligible_2026, _, _, missing = is_eligible(
+            **self._ltc_answers(age=55, on_medicare=False)
+        )
+        self.assertTrue(eligible_2026)
+        self.assertFalse(any("hours" in q for q in missing))
+
+    def test_ltc_income_between_year_caps_keeps_2026_eligibility(self):
+        # Review regression: the work overlay's not-eligible-2025 clamp
+        # discarded the LTC branch's own 2026 result. $3,050/month is over
+        # the $3,000 2025 cap but under the inflated 2026 cap.
+        eligible_2025, eligible_2026, _, _, _ = is_eligible(
+            **self._ltc_answers(monthly_income=3050.0)
+        )
+        self.assertFalse(eligible_2025)
+        self.assertTrue(eligible_2026)
+
+    def test_ltc_missing_info_return_preserves_medicare_verdict(self):
+        # Review regression: the LTC ask-for-more-info early return clobbered
+        # an already-computed Medicare verdict back to False.
+        _, _, medicare, _, missing = is_eligible(
+            **self._ltc_answers(assets_total=None, home_owner=None, living_situation=None)
+        )
+        self.assertTrue(medicare)
+        self.assertTrue(len(missing) > 0)
 
     def test_elderly_ltc_applicant_uses_ltc_income_cap_not_abd(self):
         # Regression: 65+ applicants matched the ABD branch first and never
@@ -230,7 +410,7 @@ class TestLongTermCareFlow(TestCase):
         self.assertTrue(any("Miller trust" in a for a in alts))
 
 
-class TestGetMedicaidInfo(TestCase):
+class TestGetMedicaidInfo(SimpleTestCase):
     """State info lookups keep working with the shared state map."""
 
     def test_lookup_by_abbreviation(self):
@@ -242,3 +422,17 @@ class TestGetMedicaidInfo(TestCase):
         # which is what the CSV rows are keyed on.
         result = get_medicaid_info({"state": "washington, dc", "topic": "", "limit": 5})
         self.assertIn("Health Care Finance", result)
+
+    def test_garbled_state_returns_reask_instead_of_raising(self):
+        # Review regression: is_eligible got the garbled-state hardening but
+        # this sibling entry point still raised ValueError, killing the whole
+        # chat tool call.
+        result = get_medicaid_info({"state": "medi-cal er california"})
+        self.assertIn("confirm their state", result)
+
+    def test_missing_state_asks_instead_of_dumping_every_state(self):
+        # Review regression: no state (or the "unknown" placeholder) skipped
+        # the CSV filter and returned an 11k-character all-states dump.
+        result = get_medicaid_info({"state": "unknown"})
+        self.assertIn("ask the user for their state", result)
+        self.assertLess(len(result), 500)

--- a/tests/sync/test_medicaid_eligibility_api.py
+++ b/tests/sync/test_medicaid_eligibility_api.py
@@ -1,0 +1,244 @@
+"""Tests for the approximate Medicaid/Medicare eligibility checker.
+
+These cover the stepwise-questioning flow the chat tool drives: the checker
+must either produce a verdict or ask for more information -- never dead-end
+with "not eligible" plus an empty question list just because a question was
+never going to be asked (the pre-2026-08 stall bugs).
+"""
+
+from django.test import TestCase
+
+from fighthealthinsurance.medicaid_api import get_medicaid_info, is_eligible
+
+
+def _answers(**overrides):
+    """Fully-answered baseline for a 30-year-old single adult in California."""
+    base = dict(
+        state="ca",
+        age=30,
+        married=False,
+        household_size=1,
+        monthly_income=1200.0,
+        pregnant=False,
+        children_in_household=0,
+        receiving_ssdi=False,
+        esrd=False,
+        als=False,
+    )
+    base.update(overrides)
+    return base
+
+
+class TestExpansionAdultFlow(TestCase):
+    """MAGI adults in expansion states."""
+
+    def test_low_income_expansion_adult_is_eligible_2025(self):
+        eligible_2025, _, _, _, missing = is_eligible(**_answers())
+        self.assertTrue(eligible_2025)
+
+    def test_flow_never_dead_ends_without_questions(self):
+        # Regression: on_medicare/pregnant were required internally but never
+        # asked for under-65 adults, so a fully-cooperative user got
+        # "not eligible" with zero remaining questions.
+        eligible_2025, eligible_2026, _, _, missing = is_eligible(**_answers())
+        self.assertTrue(eligible_2025 or len(missing) > 0)
+
+    def test_2026_requires_work_hours_question(self):
+        _, eligible_2026, _, _, missing = is_eligible(**_answers())
+        self.assertFalse(eligible_2026)
+        self.assertTrue(any("qualifying hours" in q for q in missing))
+
+    def test_2026_eligible_with_sufficient_hours(self):
+        _, eligible_2026, _, _, missing = is_eligible(
+            **_answers(avg_weekly_qualifying_hours_last_3mo=25.0)
+        )
+        self.assertTrue(eligible_2026)
+        self.assertEqual(missing, [])
+
+    def test_2026_not_eligible_with_insufficient_hours(self):
+        _, eligible_2026, _, alts, _ = is_eligible(
+            **_answers(avg_weekly_qualifying_hours_last_3mo=10.0)
+        )
+        self.assertFalse(eligible_2026)
+        self.assertTrue(any("80" in a for a in alts))
+
+    def test_massachusetts_is_an_expansion_state(self):
+        # Regression: MA was missing from the expansion list.
+        eligible_2025, _, _, _, _ = is_eligible(**_answers(state="ma"))
+        self.assertTrue(eligible_2025)
+
+    def test_north_dakota_is_an_expansion_state(self):
+        # Regression: ND was missing from the expansion list.
+        eligible_2025, _, _, _, _ = is_eligible(**_answers(state="nd"))
+        self.assertTrue(eligible_2025)
+
+    def test_alabama_is_not_an_expansion_state(self):
+        # Regression: AL was wrongly listed as expanded.
+        eligible_2025, _, _, _, _ = is_eligible(**_answers(state="al"))
+        self.assertFalse(eligible_2025)
+
+    def test_wisconsin_waiver_covers_adults_under_poverty_line(self):
+        # WI has no ACA expansion but covers adults to 100% FPL via waiver.
+        eligible_2025, _, _, _, _ = is_eligible(**_answers(state="wi"))
+        self.assertTrue(eligible_2025)
+
+    def test_coverage_gap_alternative_mentions_health_centers(self):
+        # Below 100% FPL in a non-expansion state there are no marketplace
+        # subsidies; the guidance must not pretend there are.
+        _, _, _, alts, _ = is_eligible(**_answers(state="tx"))
+        self.assertTrue(any("coverage gap" in a for a in alts))
+
+
+class TestQuestionFlow(TestCase):
+    """Stepwise questioning behavior."""
+
+    def test_answering_no_to_ssdi_is_not_reasked(self):
+        # Regression: `get_bool("receiving_ssdi") or get_bool("disabled")`
+        # coerced an explicit False back to None, re-asking forever.
+        _, _, _, _, missing = is_eligible(state="ca", age=30, receiving_ssdi=False)
+        self.assertFalse(any("SSDI" in q for q in missing))
+
+    def test_young_child_not_asked_about_pregnancy(self):
+        _, _, _, _, missing = is_eligible(state="wa", age=2)
+        self.assertFalse(any("pregnant" in q.lower() for q in missing))
+
+    def test_unrecognized_state_becomes_a_reask_not_an_exception(self):
+        # A garbled state from the LLM used to raise ValueError and kill the
+        # whole check; now it just re-asks for the state.
+        _, _, _, _, missing = is_eligible(state="medi-cal er california", age=30)
+        self.assertTrue(any("state" in q.lower() for q in missing))
+
+    def test_young_child_verdict_does_not_stall_on_pregnancy(self):
+        eligible_2025, _, _, _, missing = is_eligible(
+            state="wa",
+            age=2,
+            household_size=3,
+            monthly_income=2500.0,
+            children_in_household=1,
+            receiving_ssdi=False,
+            esrd=False,
+            als=False,
+        )
+        self.assertTrue(eligible_2025)
+
+    def test_sixty_five_year_old_is_asked_about_medicare(self):
+        # Regression: the medicare question used `age > 65`, skipping
+        # people who are exactly 65.
+        _, _, _, _, missing = is_eligible(
+            **_answers(age=65, esrd=None, als=None, receiving_ssdi=False)
+        )
+        self.assertTrue(any("Medicare" in q for q in missing))
+
+    def test_missing_questions_are_deduplicated(self):
+        # The assets question is raised by both the stepwise 65+ ask and the
+        # ABD evaluation; the caller should only ever see it once.
+        _, _, _, _, missing = is_eligible(
+            **_answers(age=70, on_medicare=True, years_worked=15)
+        )
+        self.assertEqual(len(missing), len(set(missing)))
+        self.assertEqual(
+            len([q for q in missing if "countable financial assets" in q]), 1
+        )
+
+
+class TestMedicarePathways(TestCase):
+    """Medicare eligibility determinations."""
+
+    def test_ssdi_24_months_confers_medicare(self):
+        _, _, medicare, _, _ = is_eligible(
+            **_answers(
+                age=50,
+                receiving_ssdi=True,
+                ssdi_length=30,
+                on_medicare=False,
+                assets_total=1000.0,
+            )
+        )
+        self.assertTrue(medicare)
+
+    def test_ten_years_worked_at_65_confers_medicare(self):
+        # Regression: the check was `years_worked > 10`, and was only
+        # evaluated while the on_medicare question was still unanswered.
+        _, _, medicare, _, _ = is_eligible(
+            **_answers(
+                age=67,
+                on_medicare=False,
+                years_worked=10,
+                assets_total=1000.0,
+            )
+        )
+        self.assertTrue(medicare)
+
+    def test_als_confers_medicare(self):
+        _, _, medicare, _, _ = is_eligible(
+            **_answers(als=True, on_medicare=False, assets_total=500.0)
+        )
+        self.assertTrue(medicare)
+
+    def test_under_ten_years_worked_suggests_medicare_savings_programs(self):
+        _, _, medicare, alts, _ = is_eligible(
+            **_answers(
+                age=70,
+                on_medicare=False,
+                years_worked=5,
+                assets_total=1000.0,
+            )
+        )
+        self.assertFalse(medicare)
+        self.assertTrue(any("Part-A" in a or "Medicare Savings" in a for a in alts))
+
+
+class TestLongTermCareFlow(TestCase):
+    """LTC pathway checks."""
+
+    def _ltc_answers(self, **overrides):
+        base = _answers(
+            age=80,
+            on_medicare=True,
+            applying_reason="ltc_nursing_home",
+            living_situation="nursing_home_perm",
+            assets_total=0.0,
+            home_owner=False,
+            monthly_income=1500.0,
+        )
+        base.update(overrides)
+        return base
+
+    def test_zero_assets_pass_the_ltc_asset_test(self):
+        # Regression: `if not assets_total` treated $0 (the most-eligible
+        # case) as missing info and failed the asset test.
+        eligible_2025, eligible_2026, _, _, missing = is_eligible(
+            **self._ltc_answers()
+        )
+        self.assertTrue(eligible_2025)
+        self.assertTrue(eligible_2026)
+        self.assertEqual(missing, [])
+
+    def test_elderly_ltc_applicant_uses_ltc_income_cap_not_abd(self):
+        # Regression: 65+ applicants matched the ABD branch first and never
+        # reached the LTC rules. $2,500/month fails the ABD 100%-FPL test but
+        # passes the ~$3,000 LTC cap.
+        eligible_2025, _, _, _, _ = is_eligible(
+            **self._ltc_answers(state="wy", monthly_income=2500.0)
+        )
+        self.assertTrue(eligible_2025)
+
+    def test_income_over_ltc_cap_suggests_miller_trust(self):
+        _, _, _, alts, _ = is_eligible(
+            **self._ltc_answers(monthly_income=3500.0)
+        )
+        self.assertTrue(any("Miller trust" in a for a in alts))
+
+
+class TestGetMedicaidInfo(TestCase):
+    """State info lookups keep working with the shared state map."""
+
+    def test_lookup_by_abbreviation(self):
+        result = get_medicaid_info({"state": "CA", "topic": "", "limit": 5})
+        self.assertIn("California", result)
+
+    def test_lookup_dc_alias_resolves_to_district_of_columbia_data(self):
+        # "washington, dc" -> "dc" -> "District of Columbia" display name,
+        # which is what the CSV rows are keyed on.
+        result = get_medicaid_info({"state": "washington, dc", "topic": "", "limit": 5})
+        self.assertIn("Health Care Finance", result)

--- a/tests/sync/test_medicaid_eligibility_api.py
+++ b/tests/sync/test_medicaid_eligibility_api.py
@@ -39,30 +39,30 @@ class TestExpansionAdultFlow(SimpleTestCase):
     """MAGI adults in expansion states."""
 
     def test_low_income_expansion_adult_is_eligible_2025(self):
-        eligible_2025, _, _, _, missing = is_eligible(**_answers())
+        eligible_2025, _, _, _, _, _ = is_eligible(**_answers())
         self.assertTrue(eligible_2025)
 
     def test_flow_never_dead_ends_without_questions(self):
         # Regression: on_medicare/pregnant were required internally but never
         # asked for under-65 adults, so a fully-cooperative user got
         # "not eligible" with zero remaining questions.
-        eligible_2025, eligible_2026, _, _, missing = is_eligible(**_answers())
+        eligible_2025, _, _, _, missing, _ = is_eligible(**_answers())
         self.assertTrue(eligible_2025 or len(missing) > 0)
 
     def test_2026_requires_work_hours_question(self):
-        _, eligible_2026, _, _, missing = is_eligible(**_answers())
+        _, eligible_2026, _, _, missing, _ = is_eligible(**_answers())
         self.assertFalse(eligible_2026)
         self.assertTrue(any("qualifying hours" in q for q in missing))
 
     def test_2026_eligible_with_sufficient_hours(self):
-        _, eligible_2026, _, _, missing = is_eligible(
+        _, eligible_2026, _, _, missing, _ = is_eligible(
             **_answers(avg_weekly_qualifying_hours_last_3mo=25.0)
         )
         self.assertTrue(eligible_2026)
         self.assertEqual(missing, [])
 
     def test_2026_not_eligible_with_insufficient_hours(self):
-        _, eligible_2026, _, alts, _ = is_eligible(
+        _, eligible_2026, _, alts, _, _ = is_eligible(
             **_answers(avg_weekly_qualifying_hours_last_3mo=10.0)
         )
         self.assertFalse(eligible_2026)
@@ -70,34 +70,34 @@ class TestExpansionAdultFlow(SimpleTestCase):
 
     def test_massachusetts_is_an_expansion_state(self):
         # Regression: MA was missing from the expansion list.
-        eligible_2025, _, _, _, _ = is_eligible(**_answers(state="ma"))
+        eligible_2025, _, _, _, _, _ = is_eligible(**_answers(state="ma"))
         self.assertTrue(eligible_2025)
 
     def test_north_dakota_is_an_expansion_state(self):
         # Regression: ND was missing from the expansion list.
-        eligible_2025, _, _, _, _ = is_eligible(**_answers(state="nd"))
+        eligible_2025, _, _, _, _, _ = is_eligible(**_answers(state="nd"))
         self.assertTrue(eligible_2025)
 
     def test_alabama_is_not_an_expansion_state(self):
         # Regression: AL was wrongly listed as expanded.
-        eligible_2025, _, _, _, _ = is_eligible(**_answers(state="al"))
+        eligible_2025, _, _, _, _, _ = is_eligible(**_answers(state="al"))
         self.assertFalse(eligible_2025)
 
     def test_wisconsin_waiver_covers_adults_under_poverty_line(self):
         # WI has no ACA expansion but covers adults to 100% FPL via waiver.
-        eligible_2025, _, _, _, _ = is_eligible(**_answers(state="wi"))
+        eligible_2025, _, _, _, _, _ = is_eligible(**_answers(state="wi"))
         self.assertTrue(eligible_2025)
 
     def test_coverage_gap_alternative_mentions_health_centers(self):
         # Below 100% FPL in a non-expansion state there are no marketplace
         # subsidies; the guidance must not pretend there are.
-        _, _, _, alts, _ = is_eligible(**_answers(state="tx"))
+        _, _, _, alts, _, _ = is_eligible(**_answers(state="tx"))
         self.assertTrue(any("coverage gap" in a for a in alts))
 
     def test_wisconsin_over_waiver_limit_gets_marketplace_alternative(self):
         # Review regression: the WI waiver branch had no not-eligible arm, so
         # WI adults over 100% FPL got no subsidy pointer at all.
-        eligible_2025, _, _, alts, _ = is_eligible(
+        eligible_2025, _, _, alts, _, _ = is_eligible(
             **_answers(state="wi", monthly_income=1600.0)
         )
         self.assertFalse(eligible_2025)
@@ -107,7 +107,7 @@ class TestExpansionAdultFlow(SimpleTestCase):
         # Review regression: answering yes to SSDI routed 19-64 adults into
         # the asset-tested ABD branch only; SSDI receipt does not bar the
         # MAGI expansion pathway (income-only, up to 138% FPL).
-        eligible_2025, eligible_2026, _, _, _ = is_eligible(
+        eligible_2025, eligible_2026, _, _, _, _ = is_eligible(
             **_answers(
                 state="co",
                 monthly_income=1500.0,
@@ -123,13 +123,13 @@ class TestExpansionAdultFlow(SimpleTestCase):
     def test_monthly_hours_below_threshold_is_not_eligible_2026(self):
         # Review regression: the tool asks for hours per MONTH but only a
         # per-week kwarg existed, inviting a 4x unit error.
-        _, eligible_2026, _, _, _ = is_eligible(
+        _, eligible_2026, _, _, _, _ = is_eligible(
             **_answers(avg_monthly_qualifying_hours_last_3mo=60.0)
         )
         self.assertFalse(eligible_2026)
 
     def test_monthly_hours_above_threshold_is_eligible_2026(self):
-        _, eligible_2026, _, _, _ = is_eligible(
+        _, eligible_2026, _, _, _, _ = is_eligible(
             **_answers(avg_monthly_qualifying_hours_last_3mo=90.0)
         )
         self.assertTrue(eligible_2026)
@@ -139,17 +139,26 @@ class TestExpansionAdultFlow(SimpleTestCase):
         # weekly-list path bucketed 4-week months, so the same 19.5 hrs/week
         # got opposite verdicts depending on which kwarg the model filled --
         # and the user with detailed records got the harsher answer.
-        _, from_average, _, _, _ = is_eligible(
+        _, from_average, _, _, _, _ = is_eligible(
             **_answers(avg_weekly_qualifying_hours_last_3mo=19.5)
         )
-        _, from_list, _, _, _ = is_eligible(
+        _, from_list, _, _, _, _ = is_eligible(
             **_answers(qualifying_hours_weekly_last_12=[19.5] * 12)
         )
         self.assertEqual(from_average, from_list)
 
+    def test_weekly_hours_keep_month_to_month_variation(self):
+        # Review finding: averaging the whole window and repeating it let
+        # [60]*4 + [0]*8 -- two genuinely empty months -- pass a rule that
+        # requires each month to reach 80 hours.
+        _, eligible_2026, _, _, _, _ = is_eligible(
+            **_answers(qualifying_hours_weekly_last_12=[60.0] * 4 + [0.0] * 8)
+        )
+        self.assertFalse(eligible_2026)
+
     def test_weekly_hours_list_does_not_drop_extra_weeks(self):
         # Bucketing by index silently discarded anything past the 12th entry.
-        _, eligible_2026, _, _, _ = is_eligible(
+        _, eligible_2026, _, _, _, _ = is_eligible(
             **_answers(qualifying_hours_weekly_last_12=[0.0] * 4 + [10.0] * 12)
         )
         self.assertFalse(eligible_2026)
@@ -157,7 +166,7 @@ class TestExpansionAdultFlow(SimpleTestCase):
     def test_weekly_hours_use_thirteen_week_quarter(self):
         # Review regression: 4-weeks-per-month undercounted real months by
         # ~8%. 19 hrs/week is ~82.3 hrs per calendar month, which meets 80.
-        _, eligible_2026, _, _, _ = is_eligible(
+        _, eligible_2026, _, _, _, _ = is_eligible(
             **_answers(avg_weekly_qualifying_hours_last_3mo=19.0)
         )
         self.assertTrue(eligible_2026)
@@ -165,7 +174,7 @@ class TestExpansionAdultFlow(SimpleTestCase):
     def test_esrd_patient_exempt_from_work_requirement(self):
         # Review regression: ESRD/ALS (medically frail) were subjected to the
         # 2026 work-hours demand.
-        _, eligible_2026, _, _, missing = is_eligible(
+        _, eligible_2026, _, _, missing, _ = is_eligible(
             **_answers(esrd=True, on_medicare=False, assets_total=500.0)
         )
         self.assertTrue(eligible_2026)
@@ -178,21 +187,21 @@ class TestQuestionFlow(SimpleTestCase):
     def test_answering_no_to_ssdi_is_not_reasked(self):
         # Regression: `get_bool("receiving_ssdi") or get_bool("disabled")`
         # coerced an explicit False back to None, re-asking forever.
-        _, _, _, _, missing = is_eligible(state="ca", age=30, receiving_ssdi=False)
+        _, _, _, _, missing, _ = is_eligible(state="ca", age=30, receiving_ssdi=False)
         self.assertFalse(any("SSDI" in q for q in missing))
 
     def test_young_child_not_asked_about_pregnancy(self):
-        _, _, _, _, missing = is_eligible(state="wa", age=2)
+        _, _, _, _, missing, _ = is_eligible(state="wa", age=2)
         self.assertFalse(any("pregnant" in q.lower() for q in missing))
 
     def test_unrecognized_state_becomes_a_reask_not_an_exception(self):
         # A garbled state from the LLM used to raise ValueError and kill the
         # whole check; now it just re-asks for the state.
-        _, _, _, _, missing = is_eligible(state="medi-cal er california", age=30)
+        _, _, _, _, missing, _ = is_eligible(state="medi-cal er california", age=30)
         self.assertTrue(any("state" in q.lower() for q in missing))
 
     def test_young_child_verdict_does_not_stall_on_pregnancy(self):
-        eligible_2025, _, _, _, missing = is_eligible(
+        eligible_2025, _, _, _, missing, _ = is_eligible(
             state="wa",
             age=2,
             household_size=3,
@@ -207,7 +216,7 @@ class TestQuestionFlow(SimpleTestCase):
     def test_sixty_five_year_old_is_asked_about_medicare(self):
         # Regression: the medicare question used `age > 65`, skipping
         # people who are exactly 65.
-        _, _, _, _, missing = is_eligible(
+        _, _, _, _, missing, _ = is_eligible(
             **_answers(age=65, esrd=None, als=None, receiving_ssdi=False)
         )
         self.assertTrue(any("Medicare" in q for q in missing))
@@ -215,7 +224,7 @@ class TestQuestionFlow(SimpleTestCase):
     def test_missing_questions_are_deduplicated(self):
         # The assets question is raised by both the stepwise 65+ ask and the
         # ABD evaluation; the caller should only ever see it once.
-        _, _, _, _, missing = is_eligible(
+        _, _, _, _, missing, _ = is_eligible(
             **_answers(age=70, on_medicare=True, years_worked=15)
         )
         self.assertEqual(len(missing), len(set(missing)))
@@ -226,13 +235,13 @@ class TestQuestionFlow(SimpleTestCase):
     def test_string_no_is_treated_as_no(self):
         # Review regression: bool("no") is True, so LLM string booleans
         # flipped answers. A string "no" must behave like False.
-        eligible_2025, _, _, _, _ = is_eligible(**_answers(state="tx", pregnant="no"))
+        eligible_2025, _, _, _, _, _ = is_eligible(**_answers(state="tx", pregnant="no"))
         self.assertFalse(eligible_2025)
 
     def test_string_false_work_exemption_is_not_treated_as_exempt(self):
         # Review regression: work_req_exempt_2026="false" was truthy and
         # skipped the work-hours questions entirely.
-        _, eligible_2026, _, _, missing = is_eligible(
+        _, eligible_2026, _, _, missing, _ = is_eligible(
             **_answers(work_req_exempt_2026="false")
         )
         self.assertFalse(eligible_2026)
@@ -241,7 +250,7 @@ class TestQuestionFlow(SimpleTestCase):
     def test_home_equity_question_asked_only_once(self):
         # Review regression: two divergent phrasings of the home-equity
         # question survived dedup and got asked twice in one message.
-        _, _, _, _, missing = is_eligible(
+        _, _, _, _, missing, _ = is_eligible(
             **_answers(
                 age=80,
                 on_medicare=True,
@@ -262,19 +271,19 @@ class TestLlmPayloadParsing(SimpleTestCase):
         # The question is literally "Are you married or single?", so "single"
         # is the expected answer -- and an unrecognized string reads as
         # unanswered, which re-asked the same question every turn forever.
-        _, _, _, _, missing = is_eligible(**_answers(married="single"))
+        _, _, _, _, missing, _ = is_eligible(**_answers(married="single"))
         self.assertFalse(any("married" in q for q in missing))
 
     def test_empty_string_is_unanswered_not_no(self):
         # "" is the likeliest "I don't have this value" placeholder; recording
         # it as a definitive no silently routed a pregnant applicant down the
         # able-bodied pathway with no question left to correct it.
-        _, _, _, _, missing = is_eligible(**_answers(pregnant=""))
+        _, _, _, _, missing, _ = is_eligible(**_answers(pregnant=""))
         self.assertTrue(any("pregnant" in q.lower() for q in missing))
 
     def test_currency_formatted_income_is_parsed(self):
         # "$1,200" raised in float(), became None, and re-asked forever.
-        _, _, _, _, missing = is_eligible(**_answers(monthly_income="$1,200"))
+        _, _, _, _, missing, _ = is_eligible(**_answers(monthly_income="$1,200"))
         self.assertFalse(any("monthly income" in q for q in missing))
 
     def test_abbreviated_thousands_income_is_parsed(self):
@@ -282,15 +291,32 @@ class TestLlmPayloadParsing(SimpleTestCase):
         self.assertEqual(summary["recorded"]["monthly_income"], 1200.0)
 
     def test_spelled_out_household_size_is_parsed(self):
-        _, _, _, _, missing = is_eligible(**_answers(household_size="three"))
+        _, _, _, _, missing, _ = is_eligible(**_answers(household_size="three"))
         self.assertFalse(any("household size" in q for q in missing))
 
     def test_territory_resident_is_not_asked_for_a_state_forever(self):
         # Puerto Rico has Medicaid but never parsed as a state, so the flow
         # re-asked a question the resident had already answered correctly.
-        _, _, _, alts, missing = is_eligible(state="Puerto Rico", age=30)
+        _, _, _, alts, missing, _ = is_eligible(state="Puerto Rico", age=30)
         self.assertFalse(any("state do you live" in q for q in missing))
         self.assertTrue(any("territor" in a.lower() for a in alts))
+
+    def test_territory_result_is_not_a_determination(self):
+        # Review finding: the territory exit returned False/False with no
+        # questions left, which the chat tool rendered as a confident "may
+        # not be eligible" -- contradicting the alternative it returned.
+        _, _, _, _, _, determination_made = is_eligible(
+            state="Puerto Rico", age=30
+        )
+        self.assertFalse(determination_made)
+
+    def test_territory_resident_still_gets_a_medicare_answer(self):
+        # Medicare is federal and does operate in PR/GU/VI/AS/MP, so the
+        # territory exit must not skip the Medicare pathway.
+        _, _, medicare, _, _, _ = is_eligible(
+            **_answers(state="Puerto Rico", age=67, on_medicare=True)
+        )
+        self.assertTrue(medicare)
 
 
 class TestUnknownAnswerChannel(SimpleTestCase):
@@ -299,32 +325,32 @@ class TestUnknownAnswerChannel(SimpleTestCase):
     def test_declined_optional_field_is_not_reasked(self):
         # Without this channel the model has nothing valid to send for "I
         # don't know", so the question returns every turn forever.
-        _, _, _, _, missing = is_eligible(**_answers(married="unknown"))
+        _, _, _, _, missing, _ = is_eligible(**_answers(married="unknown"))
         self.assertFalse(any("married" in q for q in missing))
 
     def test_declined_optional_field_still_yields_a_verdict(self):
-        eligible_2025, _, _, _, _ = is_eligible(**_answers(married="unknown"))
+        eligible_2025, _, _, _, _, _ = is_eligible(**_answers(married="unknown"))
         self.assertTrue(eligible_2025)
 
     def test_declined_optional_field_discloses_the_assumption(self):
-        _, _, _, alts, _ = is_eligible(**_answers(married="prefer not to say"))
+        _, _, _, alts, _, _ = is_eligible(**_answers(married="prefer not to say"))
         self.assertTrue(any("assumed the most conservative" in a for a in alts))
 
     def test_declined_required_field_is_not_reasked(self):
-        _, _, _, _, missing = is_eligible(
+        _, _, _, _, missing, _ = is_eligible(
             **_answers(household_size="don't know", monthly_income="idk")
         )
         self.assertFalse(any("household" in q for q in missing))
 
     def test_declined_required_field_explains_the_blocked_estimate(self):
         # Not a silent "not eligible" dead end -- say what's missing.
-        _, _, _, alts, _ = is_eligible(
+        _, _, _, alts, _, _ = is_eligible(
             **_answers(household_size="don't know", monthly_income="idk")
         )
         self.assertTrue(any("can't estimate eligibility without" in a for a in alts))
 
     def test_declined_assets_question_is_not_reasked(self):
-        _, _, _, _, missing = is_eligible(
+        _, _, _, _, missing, _ = is_eligible(
             **_answers(
                 age=70,
                 on_medicare=True,
@@ -333,6 +359,38 @@ class TestUnknownAnswerChannel(SimpleTestCase):
             )
         )
         self.assertFalse(any("assets" in q for q in missing))
+
+
+class TestIndeterminateResults(SimpleTestCase):
+    """"Couldn't score them" must never be rendered as "not eligible"."""
+
+    def test_scored_ineligible_is_a_determination(self):
+        _, _, _, _, _, determination_made = is_eligible(
+            **_answers(state="tx", monthly_income=1100.0)
+        )
+        self.assertTrue(determination_made)
+
+    def test_declined_required_field_is_not_a_determination(self):
+        _, _, _, _, _, determination_made = is_eligible(
+            **_answers(household_size="don't know", monthly_income="idk")
+        )
+        self.assertFalse(determination_made)
+
+    def test_declined_home_ownership_does_not_assume_no_home(self):
+        # Review finding: defaulting home_owner to False skipped the LTC
+        # home-equity test, so someone with equity over the cap could get a
+        # false "probably eligible". It must stay indeterminate instead.
+        _, _, _, _, _, determination_made = is_eligible(
+            **_answers(
+                age=80,
+                on_medicare=True,
+                applying_reason="ltc_nursing_home",
+                assets_total=0.0,
+                home_owner="unknown",
+                monthly_income=1500.0,
+            )
+        )
+        self.assertFalse(determination_made)
 
 
 class TestParsedInputFeedback(SimpleTestCase):
@@ -365,11 +423,11 @@ class TestStateProgramNames(SimpleTestCase):
     """Program names are what users actually say; resolve them as a backstop."""
 
     def test_medi_cal_resolves_to_california(self):
-        eligible_2025, _, _, _, _ = is_eligible(**_answers(state="Medi-Cal"))
+        eligible_2025, _, _, _, _, _ = is_eligible(**_answers(state="Medi-Cal"))
         self.assertTrue(eligible_2025)
 
     def test_masshealth_resolves_to_massachusetts(self):
-        eligible_2025, _, _, _, _ = is_eligible(**_answers(state="MassHealth"))
+        eligible_2025, _, _, _, _, _ = is_eligible(**_answers(state="MassHealth"))
         self.assertTrue(eligible_2025)
 
 
@@ -380,7 +438,7 @@ class TestQuestionsThatCannotChangeTheAnswer(SimpleTestCase):
         # Answering "disabled, but not on SSDI" made receiving_ssdi True,
         # which asked for SSDI months -- unanswerable, and the prompt forbids
         # the model inventing one, so the conversation never terminated.
-        _, _, _, _, missing = is_eligible(
+        _, _, _, _, missing, _ = is_eligible(
             **_answers(receiving_ssdi=False, disabled=True, assets_total=0.0)
         )
         self.assertFalse(any("SSDI" in q for q in missing))
@@ -388,7 +446,7 @@ class TestQuestionsThatCannotChangeTheAnswer(SimpleTestCase):
     def test_disability_duration_without_ssdi_does_not_confer_medicare(self):
         # ssdi_length means SSDI months; a non-SSDI disability duration must
         # not satisfy the 24-month Medicare pathway.
-        _, _, medicare, _, _ = is_eligible(
+        _, _, medicare, _, _, _ = is_eligible(
             **_answers(
                 receiving_ssdi=False, disabled=True, ssdi_length=24, assets_total=0.0
             )
@@ -396,18 +454,18 @@ class TestQuestionsThatCannotChangeTheAnswer(SimpleTestCase):
         self.assertFalse(medicare)
 
     def test_healthy_young_adult_is_not_asked_about_kidney_failure(self):
-        _, _, _, _, missing = is_eligible(**_answers(esrd=None, als=None))
+        _, _, _, _, missing, _ = is_eligible(**_answers(esrd=None, als=None))
         self.assertFalse(any("renal" in q for q in missing))
 
     def test_ninety_five_year_old_is_not_asked_about_pregnancy(self):
-        _, _, _, _, missing = is_eligible(
+        _, _, _, _, missing, _ = is_eligible(
             **_answers(age=95, pregnant=None, on_medicare=True, assets_total=0.0)
         )
         self.assertFalse(any("pregnant" in q.lower() for q in missing))
 
     def test_child_is_not_asked_for_countable_assets(self):
         # Only the ABD branch reads assets; children are scored on income.
-        _, _, _, _, missing = is_eligible(
+        _, _, _, _, missing, _ = is_eligible(
             **_answers(age=10, receiving_ssdi=True, ssdi_length=6)
         )
         self.assertFalse(any("countable financial assets" in q for q in missing))
@@ -417,7 +475,7 @@ class TestMedicarePathways(SimpleTestCase):
     """Medicare eligibility determinations."""
 
     def test_ssdi_24_months_confers_medicare(self):
-        _, _, medicare, _, _ = is_eligible(
+        _, _, medicare, _, _, _ = is_eligible(
             **_answers(
                 age=50,
                 receiving_ssdi=True,
@@ -431,7 +489,7 @@ class TestMedicarePathways(SimpleTestCase):
     def test_ten_years_worked_at_65_confers_medicare(self):
         # Regression: the check was `years_worked > 10`, and was only
         # evaluated while the on_medicare question was still unanswered.
-        _, _, medicare, _, _ = is_eligible(
+        _, _, medicare, _, _, _ = is_eligible(
             **_answers(
                 age=67,
                 on_medicare=False,
@@ -442,13 +500,13 @@ class TestMedicarePathways(SimpleTestCase):
         self.assertTrue(medicare)
 
     def test_als_confers_medicare(self):
-        _, _, medicare, _, _ = is_eligible(
+        _, _, medicare, _, _, _ = is_eligible(
             **_answers(als=True, on_medicare=False, assets_total=500.0)
         )
         self.assertTrue(medicare)
 
     def test_under_ten_years_worked_suggests_medicare_savings_programs(self):
-        _, _, medicare, alts, _ = is_eligible(
+        _, _, medicare, alts, _, _ = is_eligible(
             **_answers(
                 age=70,
                 on_medicare=False,
@@ -463,7 +521,7 @@ class TestMedicarePathways(SimpleTestCase):
         # Review regression: an under-65 user who said they are ON Medicare
         # was reported not Medicare-eligible (the enrolled branch was only
         # reachable through the other pathways).
-        _, _, medicare, _, _ = is_eligible(
+        _, _, medicare, _, _, _ = is_eligible(
             **_answers(age=40, monthly_income=800.0, on_medicare=True, assets_total=500.0)
         )
         self.assertTrue(medicare)
@@ -472,7 +530,7 @@ class TestMedicarePathways(SimpleTestCase):
         # Review regression: the ssdi_length question was only asked under
         # 65, so the 24-month pathway was unreachable for 65+ SSDI
         # recipients and they got a definitive wrong "not eligible".
-        _, _, medicare, _, missing = is_eligible(
+        _, _, medicare, _, missing, _ = is_eligible(
             **_answers(
                 age=67,
                 receiving_ssdi=True,
@@ -486,7 +544,7 @@ class TestMedicarePathways(SimpleTestCase):
         self.assertFalse(medicare)
 
     def test_ssdi_recipient_at_67_with_24_months_gets_medicare(self):
-        _, _, medicare, _, missing = is_eligible(
+        _, _, medicare, _, missing, _ = is_eligible(
             **_answers(
                 age=67,
                 receiving_ssdi=True,
@@ -503,7 +561,7 @@ class TestMedicarePathways(SimpleTestCase):
         # Review regression: receiving_ssdi=False silently discarded
         # disabled=True, dropping the disability pathway and its work
         # exemption.
-        eligible_2025, eligible_2026, _, _, _ = is_eligible(
+        eligible_2025, eligible_2026, _, _, _, _ = is_eligible(
             **_answers(
                 state="tx",
                 monthly_income=800.0,
@@ -537,21 +595,21 @@ class TestLongTermCareFlow(SimpleTestCase):
     def test_zero_assets_pass_the_ltc_asset_test(self):
         # Regression: `if not assets_total` treated $0 (the most-eligible
         # case) as missing info and failed the asset test.
-        eligible_2025, _, _, _, missing = is_eligible(**self._ltc_answers())
+        eligible_2025, _, _, _, missing, _ = is_eligible(**self._ltc_answers())
         self.assertTrue(eligible_2025)
         self.assertEqual(missing, [])
 
     def test_eligible_ltc_applicant_is_exempt_from_2026_work_overlay(self):
         # Split from the asset test: 2026 exemption is a distinct rule
         # (LTC applicants are medically frail, never asked for work hours).
-        _, eligible_2026, _, _, missing = is_eligible(**self._ltc_answers())
+        _, eligible_2026, _, _, missing, _ = is_eligible(**self._ltc_answers())
         self.assertTrue(eligible_2026)
         self.assertFalse(any("hours" in q for q in missing))
 
     def test_under_65_ltc_applicant_not_asked_for_work_hours(self):
         # Review regression: a 55-year-old permanent nursing-home resident
         # was subjected to the 80-hours-per-month work requirement.
-        _, eligible_2026, _, _, missing = is_eligible(
+        _, eligible_2026, _, _, missing, _ = is_eligible(
             **self._ltc_answers(age=55, on_medicare=False)
         )
         self.assertTrue(eligible_2026)
@@ -561,7 +619,7 @@ class TestLongTermCareFlow(SimpleTestCase):
         # Review regression: the work overlay's not-eligible-2025 clamp
         # discarded the LTC branch's own 2026 result. $3,050/month is over
         # the $3,000 2025 cap but under the inflated 2026 cap.
-        eligible_2025, eligible_2026, _, _, _ = is_eligible(
+        eligible_2025, eligible_2026, _, _, _, _ = is_eligible(
             **self._ltc_answers(monthly_income=3050.0)
         )
         self.assertFalse(eligible_2025)
@@ -570,7 +628,7 @@ class TestLongTermCareFlow(SimpleTestCase):
     def test_ltc_missing_info_return_preserves_medicare_verdict(self):
         # Review regression: the LTC ask-for-more-info early return clobbered
         # an already-computed Medicare verdict back to False.
-        _, _, medicare, _, missing = is_eligible(
+        _, _, medicare, _, missing, _ = is_eligible(
             **self._ltc_answers(assets_total=None, home_owner=None, living_situation=None)
         )
         self.assertTrue(medicare)
@@ -582,14 +640,14 @@ class TestLongTermCareFlow(SimpleTestCase):
         # branch never ran and eligible_2026 kept its False initializer --
         # telling a 10-year-old in a nursing home they may lose coverage in
         # 2026 for not working 80 hours a month, with no question left.
-        _, eligible_2026, _, _, missing = is_eligible(
+        _, eligible_2026, _, _, missing, _ = is_eligible(
             **self._ltc_answers(age=10, on_medicare=False, children_in_household=1)
         )
         self.assertTrue(eligible_2026)
         self.assertEqual(missing, [])
 
     def test_pregnant_ltc_applicant_keeps_2026_exemption(self):
-        _, eligible_2026, _, _, _ = is_eligible(
+        _, eligible_2026, _, _, _, _ = is_eligible(
             **self._ltc_answers(age=30, pregnant=True, on_medicare=False)
         )
         self.assertTrue(eligible_2026)
@@ -599,7 +657,7 @@ class TestLongTermCareFlow(SimpleTestCase):
         # every LTC applicant a round trip for an inert answer.
         answers = self._ltc_answers()
         answers.pop("living_situation", None)
-        eligible_2025, _, _, _, missing = is_eligible(**answers)
+        eligible_2025, _, _, _, missing, _ = is_eligible(**answers)
         self.assertTrue(eligible_2025)
         self.assertFalse(any("living" in q.lower() for q in missing))
 
@@ -607,13 +665,13 @@ class TestLongTermCareFlow(SimpleTestCase):
         # Regression: 65+ applicants matched the ABD branch first and never
         # reached the LTC rules. $2,500/month fails the ABD 100%-FPL test but
         # passes the ~$3,000 LTC cap.
-        eligible_2025, _, _, _, _ = is_eligible(
+        eligible_2025, _, _, _, _, _ = is_eligible(
             **self._ltc_answers(state="wy", monthly_income=2500.0)
         )
         self.assertTrue(eligible_2025)
 
     def test_income_over_ltc_cap_suggests_miller_trust(self):
-        _, _, _, alts, _ = is_eligible(
+        _, _, _, alts, _, _ = is_eligible(
             **self._ltc_answers(monthly_income=3500.0)
         )
         self.assertTrue(any("Miller trust" in a for a in alts))
@@ -626,7 +684,7 @@ class TestAbdPathway(SimpleTestCase):
         # Review finding: medically-needy is a spend-down PATHWAY, not an
         # income waiver -- treating it as one reported a $120k/yr earner in
         # New York as "probably eligible" in both years.
-        eligible_2025, eligible_2026, _, alts, _ = is_eligible(
+        eligible_2025, eligible_2026, _, _, _, _ = is_eligible(
             **_answers(
                 state="ny",
                 age=70,
@@ -639,7 +697,7 @@ class TestAbdPathway(SimpleTestCase):
         self.assertFalse(eligible_2026)
 
     def test_medically_needy_state_still_suggests_spend_down(self):
-        _, _, _, alts, _ = is_eligible(
+        _, _, _, alts, _, _ = is_eligible(
             **_answers(
                 state="ny",
                 age=70,

--- a/tests/sync/test_medicaid_eligibility_api.py
+++ b/tests/sync/test_medicaid_eligibility_api.py
@@ -11,6 +11,7 @@ never going to be asked (the pre-2026-08 stall bugs).
 from django.test import SimpleTestCase
 
 from fighthealthinsurance.medicaid_api import (
+    _normalize_applying_reason,
     get_medicaid_info,
     is_eligible,
     summarize_eligibility_inputs,
@@ -1060,3 +1061,56 @@ class TestAssetTestIsSkippedWhenIrrelevant(SimpleTestCase):
             )
         )
         self.assertTrue(any("assets" in q.lower() for q in missing))
+
+
+class TestLongTermCareReasonIsRecognized(SimpleTestCase):
+    """Free-text LTC reasons must reach the LTC branch, not the ABD one.
+
+    Found by sweeping the answer space rather than from a report:
+    applying_reason was the one decision-critical field with no tolerant
+    parsing. An unrecognized value doesn't re-ask -- it silently routes to
+    the MAGI/ABD branch, skipping the home-equity test, and reports a
+    nursing-home applicant as probably eligible. A false positive is the
+    worst answer this engine can give.
+    """
+
+    def _nursing_home_applicant(self, **overrides):
+        return is_eligible(
+            **_answers(
+                state="tx",
+                age=80,
+                monthly_income=900,
+                years_worked=40,
+                assets_total=1000,
+                home_owner="unknown",
+                **overrides,
+            )
+        )
+
+    def test_free_text_nursing_home_does_not_produce_a_false_positive(self):
+        eligible_2025, _, _, _, _, determination_made = self._nursing_home_applicant(
+            applying_reason="nursing home"
+        )
+        self.assertFalse(eligible_2025)
+        self.assertFalse(determination_made)
+
+    def test_canonical_token_behaves_the_same(self):
+        free_text = self._nursing_home_applicant(applying_reason="nursing home")
+        canonical = self._nursing_home_applicant(applying_reason="ltc_nursing_home")
+        self.assertEqual(free_text, canonical)
+
+    def test_living_situation_alone_still_reaches_the_ltc_branch(self):
+        # The model may put the nursing-home fact here instead.
+        _, _, _, _, _, determination_made = self._nursing_home_applicant(
+            living_situation="nursing_home_perm"
+        )
+        self.assertFalse(determination_made)
+
+    def test_home_care_phrasings_map_to_the_home_care_reason(self):
+        self.assertEqual(_normalize_applying_reason("HCBS"), "ltc_home_care")
+        self.assertEqual(_normalize_applying_reason("in-home care"), "ltc_home_care")
+
+    def test_an_ordinary_application_is_not_treated_as_long_term_care(self):
+        self.assertEqual(_normalize_applying_reason("standard"), "standard")
+        self.assertEqual(_normalize_applying_reason("applying for medicaid"), "standard")
+        self.assertEqual(_normalize_applying_reason(None), "standard")

--- a/tests/sync/test_medicaid_eligibility_api.py
+++ b/tests/sync/test_medicaid_eligibility_api.py
@@ -967,6 +967,26 @@ class TestDisabledButNotOnSsdi(SimpleTestCase):
             f"expected the Part-A buy-in pointer in {alts}",
         )
 
+    def test_declining_the_ssdi_duration_does_not_deny_medicare_silently(self):
+        # Same silent-denial shape one step further along: they ARE on SSDI,
+        # so the duration question is relevant -- but declining it suppresses
+        # the ask, and deferring on "no answer yet" then waited forever.
+        *_, alts, missing, _ = is_eligible(
+            **_answers(
+                age=66,
+                receiving_ssdi=True,
+                ssdi_length="unknown",
+                on_medicare=False,
+                years_worked=5,
+                assets_total=500,
+            )
+        )
+        self.assertEqual(missing, [])
+        self.assertTrue(
+            any("buy Medicare Part A" in a for a in alts),
+            f"declined SSDI duration left no Medicare next step: {alts}",
+        )
+
     def test_actual_ssdi_recipient_still_defers(self):
         # The deferral is still correct when they really are on SSDI: the
         # ssdi_length question is asked, so don't conclude anything yet.

--- a/tests/sync/test_medicaid_eligibility_api.py
+++ b/tests/sync/test_medicaid_eligibility_api.py
@@ -116,18 +116,39 @@ class TestExpansionAdultFlow(SimpleTestCase):
         self.assertTrue(eligible_2025)
         self.assertTrue(eligible_2026)
 
-    def test_monthly_hours_average_matches_question_units(self):
+    def test_monthly_hours_below_threshold_is_not_eligible_2026(self):
         # Review regression: the tool asks for hours per MONTH but only a
-        # per-week kwarg existed, inviting a 4x unit error. 60/month fails
-        # the 80-hours rule; 90/month meets it.
+        # per-week kwarg existed, inviting a 4x unit error.
         _, eligible_2026, _, _, _ = is_eligible(
             **_answers(avg_monthly_qualifying_hours_last_3mo=60.0)
         )
         self.assertFalse(eligible_2026)
+
+    def test_monthly_hours_above_threshold_is_eligible_2026(self):
         _, eligible_2026, _, _, _ = is_eligible(
             **_answers(avg_monthly_qualifying_hours_last_3mo=90.0)
         )
         self.assertTrue(eligible_2026)
+
+    def test_weekly_hours_list_agrees_with_weekly_average(self):
+        # Review regression: the scalar path used a 13-week quarter while the
+        # weekly-list path bucketed 4-week months, so the same 19.5 hrs/week
+        # got opposite verdicts depending on which kwarg the model filled --
+        # and the user with detailed records got the harsher answer.
+        _, from_average, _, _, _ = is_eligible(
+            **_answers(avg_weekly_qualifying_hours_last_3mo=19.5)
+        )
+        _, from_list, _, _, _ = is_eligible(
+            **_answers(qualifying_hours_weekly_last_12=[19.5] * 12)
+        )
+        self.assertEqual(from_average, from_list)
+
+    def test_weekly_hours_list_does_not_drop_extra_weeks(self):
+        # Bucketing by index silently discarded anything past the 12th entry.
+        _, eligible_2026, _, _, _ = is_eligible(
+            **_answers(qualifying_hours_weekly_last_12=[0.0] * 4 + [10.0] * 12)
+        )
+        self.assertFalse(eligible_2026)
 
     def test_weekly_hours_use_thirteen_week_quarter(self):
         # Review regression: 4-weeks-per-month undercounted real months by
@@ -140,11 +161,10 @@ class TestExpansionAdultFlow(SimpleTestCase):
     def test_esrd_patient_exempt_from_work_requirement(self):
         # Review regression: ESRD/ALS (medically frail) were subjected to the
         # 2026 work-hours demand.
-        _, eligible_2026, medicare, _, missing = is_eligible(
+        _, eligible_2026, _, _, missing = is_eligible(
             **_answers(esrd=True, on_medicare=False, assets_total=500.0)
         )
         self.assertTrue(eligible_2026)
-        self.assertTrue(medicare)
         self.assertFalse(any("hours" in q for q in missing))
 
 
@@ -229,6 +249,80 @@ class TestQuestionFlow(SimpleTestCase):
             )
         )
         self.assertEqual(len([q for q in missing if "equity" in q]), 1)
+
+
+class TestLlmPayloadParsing(SimpleTestCase):
+    """Answers arrive as raw LLM JSON, so loose values must not stall the flow."""
+
+    def test_word_answer_to_married_question_is_understood(self):
+        # The question is literally "Are you married or single?", so "single"
+        # is the expected answer -- and an unrecognized string reads as
+        # unanswered, which re-asked the same question every turn forever.
+        _, _, _, _, missing = is_eligible(**_answers(married="single"))
+        self.assertFalse(any("married" in q for q in missing))
+
+    def test_empty_string_is_unanswered_not_no(self):
+        # "" is the likeliest "I don't have this value" placeholder; recording
+        # it as a definitive no silently routed a pregnant applicant down the
+        # able-bodied pathway with no question left to correct it.
+        _, _, _, _, missing = is_eligible(**_answers(pregnant=""))
+        self.assertTrue(any("pregnant" in q.lower() for q in missing))
+
+    def test_currency_formatted_income_is_parsed(self):
+        # "$1,200" raised in float(), became None, and re-asked forever.
+        _, _, _, _, missing = is_eligible(**_answers(monthly_income="$1,200"))
+        self.assertFalse(any("monthly income" in q for q in missing))
+
+    def test_spelled_out_household_size_is_parsed(self):
+        _, _, _, _, missing = is_eligible(**_answers(household_size="three"))
+        self.assertFalse(any("household size" in q for q in missing))
+
+    def test_territory_resident_is_not_asked_for_a_state_forever(self):
+        # Puerto Rico has Medicaid but never parsed as a state, so the flow
+        # re-asked a question the resident had already answered correctly.
+        _, _, _, alts, missing = is_eligible(state="Puerto Rico", age=30)
+        self.assertFalse(any("state do you live" in q for q in missing))
+        self.assertTrue(any("territor" in a.lower() for a in alts))
+
+
+class TestQuestionsThatCannotChangeTheAnswer(SimpleTestCase):
+    """Questions are turns of a real conversation; don't spend them for nothing."""
+
+    def test_disabled_non_ssdi_user_is_not_asked_for_ssdi_months(self):
+        # Answering "disabled, but not on SSDI" made receiving_ssdi True,
+        # which asked for SSDI months -- unanswerable, and the prompt forbids
+        # the model inventing one, so the conversation never terminated.
+        _, _, _, _, missing = is_eligible(
+            **_answers(receiving_ssdi=False, disabled=True, assets_total=0.0)
+        )
+        self.assertFalse(any("SSDI" in q for q in missing))
+
+    def test_disability_duration_without_ssdi_does_not_confer_medicare(self):
+        # ssdi_length means SSDI months; a non-SSDI disability duration must
+        # not satisfy the 24-month Medicare pathway.
+        _, _, medicare, _, _ = is_eligible(
+            **_answers(
+                receiving_ssdi=False, disabled=True, ssdi_length=24, assets_total=0.0
+            )
+        )
+        self.assertFalse(medicare)
+
+    def test_healthy_young_adult_is_not_asked_about_kidney_failure(self):
+        _, _, _, _, missing = is_eligible(**_answers(esrd=None, als=None))
+        self.assertFalse(any("renal" in q for q in missing))
+
+    def test_ninety_five_year_old_is_not_asked_about_pregnancy(self):
+        _, _, _, _, missing = is_eligible(
+            **_answers(age=95, pregnant=None, on_medicare=True, assets_total=0.0)
+        )
+        self.assertFalse(any("pregnant" in q.lower() for q in missing))
+
+    def test_child_is_not_asked_for_countable_assets(self):
+        # Only the ABD branch reads assets; children are scored on income.
+        _, _, _, _, missing = is_eligible(
+            **_answers(age=10, receiving_ssdi=True, ssdi_length=6)
+        )
+        self.assertFalse(any("countable financial assets" in q for q in missing))
 
 
 class TestMedicarePathways(SimpleTestCase):
@@ -394,6 +488,33 @@ class TestLongTermCareFlow(SimpleTestCase):
         self.assertTrue(medicare)
         self.assertTrue(len(missing) > 0)
 
+    def test_child_ltc_applicant_keeps_2026_exemption(self):
+        # Review regression: the overlay's LTC bypass keyed on applying_reason,
+        # but children are matched earlier in the category chain, so the LTC
+        # branch never ran and eligible_2026 kept its False initializer --
+        # telling a 10-year-old in a nursing home they may lose coverage in
+        # 2026 for not working 80 hours a month, with no question left.
+        _, eligible_2026, _, _, missing = is_eligible(
+            **self._ltc_answers(age=10, on_medicare=False, children_in_household=1)
+        )
+        self.assertTrue(eligible_2026)
+        self.assertEqual(missing, [])
+
+    def test_pregnant_ltc_applicant_keeps_2026_exemption(self):
+        _, eligible_2026, _, _, _ = is_eligible(
+            **self._ltc_answers(age=30, pregnant=True, on_medicare=False)
+        )
+        self.assertTrue(eligible_2026)
+
+    def test_living_situation_does_not_block_the_determination(self):
+        # It gated the whole LTC verdict but nothing ever read it, costing
+        # every LTC applicant a round trip for an inert answer.
+        answers = self._ltc_answers()
+        answers.pop("living_situation", None)
+        eligible_2025, _, _, _, missing = is_eligible(**answers)
+        self.assertTrue(eligible_2025)
+        self.assertFalse(any("living" in q.lower() for q in missing))
+
     def test_elderly_ltc_applicant_uses_ltc_income_cap_not_abd(self):
         # Regression: 65+ applicants matched the ABD branch first and never
         # reached the LTC rules. $2,500/month fails the ABD 100%-FPL test but
@@ -410,6 +531,38 @@ class TestLongTermCareFlow(SimpleTestCase):
         self.assertTrue(any("Miller trust" in a for a in alts))
 
 
+class TestAbdPathway(SimpleTestCase):
+    """Aged/blind/disabled income and asset rules."""
+
+    def test_medically_needy_state_does_not_waive_the_income_test(self):
+        # Review finding: medically-needy is a spend-down PATHWAY, not an
+        # income waiver -- treating it as one reported a $120k/yr earner in
+        # New York as "probably eligible" in both years.
+        eligible_2025, eligible_2026, _, alts, _ = is_eligible(
+            **_answers(
+                state="ny",
+                age=70,
+                monthly_income=10000.0,
+                on_medicare=True,
+                assets_total=1500.0,
+            )
+        )
+        self.assertFalse(eligible_2025)
+        self.assertFalse(eligible_2026)
+
+    def test_medically_needy_state_still_suggests_spend_down(self):
+        _, _, _, alts, _ = is_eligible(
+            **_answers(
+                state="ny",
+                age=70,
+                monthly_income=10000.0,
+                on_medicare=True,
+                assets_total=1500.0,
+            )
+        )
+        self.assertTrue(any("spend-down" in a for a in alts))
+
+
 class TestGetMedicaidInfo(SimpleTestCase):
     """State info lookups keep working with the shared state map."""
 
@@ -423,16 +576,32 @@ class TestGetMedicaidInfo(SimpleTestCase):
         result = get_medicaid_info({"state": "washington, dc", "topic": "", "limit": 5})
         self.assertIn("Health Care Finance", result)
 
-    def test_garbled_state_returns_reask_instead_of_raising(self):
+    def test_garbled_state_returns_none_instead_of_raising(self):
         # Review regression: is_eligible got the garbled-state hardening but
         # this sibling entry point still raised ValueError, killing the whole
-        # chat tool call.
-        result = get_medicaid_info({"state": "medi-cal er california"})
-        self.assertIn("confirm their state", result)
+        # chat tool call. None (not prose) so the caller can tell this apart
+        # from real data -- it wraps any string in "Here's the official
+        # Medicaid information for X".
+        self.assertIsNone(get_medicaid_info({"state": "medi-cal er california"}))
 
-    def test_missing_state_asks_instead_of_dumping_every_state(self):
-        # Review regression: no state (or the "unknown" placeholder) skipped
-        # the CSV filter and returned an 11k-character all-states dump.
-        result = get_medicaid_info({"state": "unknown"})
-        self.assertIn("ask the user for their state", result)
-        self.assertLess(len(result), 500)
+    def test_placeholder_state_returns_none(self):
+        # Review regression: the "unknown"/"StateName" placeholders the model
+        # copies out of the prompt skipped the CSV filter and returned an
+        # 11k-character all-states dump.
+        self.assertIsNone(get_medicaid_info({"state": "unknown"}))
+
+    def test_absent_state_returns_none(self):
+        # Review regression: an absent key became "", and _normalize_state("")
+        # raises, so this landed in the garbled-state arm and told the model
+        # to "confirm" a state the user never gave.
+        self.assertIsNone(get_medicaid_info({}))
+
+    def test_non_numeric_limit_does_not_raise(self):
+        # Review regression: int(query["limit"]) blew up the whole tool call
+        # on an LLM payload like {"limit": "five"}.
+        self.assertIn("California", get_medicaid_info({"state": "ca", "limit": "five"}))
+
+    def test_no_dangling_misc_header(self):
+        # The MISC section looped over columns already projected away, so it
+        # emitted a header promising data it structurally could not deliver.
+        self.assertNotIn("MISC", get_medicaid_info({"state": "ca"}))

--- a/tests/sync/test_medicaid_eligibility_api.py
+++ b/tests/sync/test_medicaid_eligibility_api.py
@@ -772,51 +772,57 @@ class TestDeclinedAnswersDoNotBecomeVerdicts(SimpleTestCase):
     "the answer is no" and "we never got to run this test".
     """
 
-    def test_declined_assets_leaves_abd_pathway_unscored(self):
-        _, _, _, _, missing, determination_made = is_eligible(
+    def setUp(self):
+        # Three scenarios, each shared by the tests that split its
+        # assertions. Age 66 keeps the assets case on the ABD pathway rather
+        # than the MAGI expansion one, which applies no asset test.
+        self.declined_assets = is_eligible(
             **_answers(
-                age=66, monthly_income=900, on_medicare=False,
-                years_worked=40, assets_total="unknown",
+                age=66,
+                monthly_income=900,
+                on_medicare=False,
+                years_worked=40,
+                assets_total="unknown",
             )
         )
+        self.declined_work_hours = is_eligible(
+            **_answers(
+                avg_monthly_qualifying_hours_last_3mo="unknown",
+                total_qualifying_hours_last_3mo="unknown",
+            )
+        )
+        self.declined_years_worked = is_eligible(
+            **_answers(
+                age=67,
+                on_medicare=False,
+                years_worked="unknown",
+                assets_total=500,
+            )
+        )
+
+    def test_declined_assets_leaves_abd_pathway_unscored(self):
+        *_, missing, determination_made = self.declined_assets
         self.assertFalse(determination_made)
         self.assertEqual(missing, [])
 
     def test_declined_assets_still_offers_spend_down_in_a_medically_needy_state(self):
-        *_, alts, _, _ = is_eligible(
-            **_answers(
-                age=66, monthly_income=900, on_medicare=False,
-                years_worked=40, assets_total="unknown",
-            )
-        )
+        *_, alts, _, _ = self.declined_assets
         self.assertIn(
             "Medically-needy/spend-down Medicaid may help if medical bills are high.",
             alts,
         )
 
     def test_declined_work_hours_leaves_2026_unscored(self):
-        _, _, _, _, missing, determination_made = is_eligible(
-            **_answers(
-                avg_monthly_qualifying_hours_last_3mo="unknown",
-                total_qualifying_hours_last_3mo="unknown",
-            )
-        )
+        *_, missing, determination_made = self.declined_work_hours
         self.assertFalse(determination_made)
         self.assertEqual(missing, [])
 
     def test_declined_work_hours_keeps_the_settled_2025_verdict(self):
-        eligible_2025, *_ = is_eligible(
-            **_answers(
-                avg_monthly_qualifying_hours_last_3mo="unknown",
-                total_qualifying_hours_last_3mo="unknown",
-            )
-        )
+        eligible_2025, *_ = self.declined_work_hours
         self.assertTrue(eligible_2025)
 
     def test_declined_years_worked_still_offers_the_part_a_buy_in(self):
-        *_, alts, _, _ = is_eligible(
-            **_answers(age=67, on_medicare=False, years_worked="unknown", assets_total=500)
-        )
+        *_, alts, _, _ = self.declined_years_worked
         self.assertIn(
             "You may be eligible to buy Medicare Part A even if you don't "
             "qualify for premium-free Part A.",
@@ -824,18 +830,11 @@ class TestDeclinedAnswersDoNotBecomeVerdicts(SimpleTestCase):
         )
 
     def test_declined_years_worked_leaves_medicare_unscored(self):
-        _, _, _, _, _, determination_made = is_eligible(
-            **_answers(age=67, on_medicare=False, years_worked="unknown", assets_total=500)
-        )
+        *_, determination_made = self.declined_years_worked
         self.assertFalse(determination_made)
 
     def test_indeterminate_result_names_the_field_it_could_not_check(self):
-        *_, alts, _, _ = is_eligible(
-            **_answers(
-                age=66, monthly_income=900, on_medicare=False,
-                years_worked=40, assets_total="unknown",
-            )
-        )
+        *_, alts, _, _ = self.declined_assets
         self.assertTrue(
             any("could not check assets total" in a for a in alts),
             f"no disclosure of the unchecked field in {alts}",
@@ -942,23 +941,27 @@ class TestDisabledButNotOnSsdi(SimpleTestCase):
     question that never got asked.
     """
 
-    def _disabled_senior(self):
-        return is_eligible(
+    def setUp(self):
+        self.result = is_eligible(
             **_answers(
-                age=66, receiving_ssdi=False, disabled=True,
-                on_medicare=False, years_worked=5, assets_total=500,
+                age=66,
+                receiving_ssdi=False,
+                disabled=True,
+                on_medicare=False,
+                years_worked=5,
+                assets_total=500,
             )
         )
 
     def test_no_silent_medicare_denial(self):
-        *_, alts, missing, _ = self._disabled_senior()
+        *_, alts, missing, _ = self.result
         self.assertTrue(
             missing or alts,
             "a 66-year-old got no Medicare verdict, no question, and no next step",
         )
 
     def test_part_a_buy_in_is_offered(self):
-        *_, alts, _, _ = self._disabled_senior()
+        *_, alts, _, _ = self.result
         self.assertTrue(
             any("buy Medicare Part A" in a for a in alts),
             f"expected the Part-A buy-in pointer in {alts}",
@@ -986,3 +989,54 @@ class TestBareMedicalIsAmbiguous(SimpleTestCase):
     def test_hyphenated_medi_cal_still_resolves(self):
         eligible_2025, *_ = is_eligible(**_answers(state="medi-cal"))
         self.assertTrue(eligible_2025)
+
+
+class TestAssetTestIsSkippedWhenIrrelevant(SimpleTestCase):
+    """ACA expansion applies no asset test, so a missing asset figure can't matter.
+
+    Regression: marking a declined ``assets_total`` indeterminate was applied
+    before checking the expansion pathway, so a disabled 19-64 adult in an
+    expansion state under 138% FPL got "we could not produce an estimate" --
+    while the same person reporting assets far OVER the ABD limit came back
+    eligible through that very pathway. Declining was worse than answering
+    badly.
+    """
+
+    def _disabled_expansion_adult(self, **overrides):
+        return is_eligible(
+            **_answers(
+                age=40,
+                receiving_ssdi=True,
+                ssdi_length=6,
+                on_medicare=False,
+                avg_monthly_qualifying_hours_last_3mo=100,
+                **overrides,
+            )
+        )
+
+    def test_declined_assets_still_scores_via_expansion(self):
+        eligible_2025, _, _, _, _, determination_made = self._disabled_expansion_adult(
+            assets_total="unknown"
+        )
+        self.assertTrue(eligible_2025)
+        self.assertTrue(determination_made)
+
+    def test_declining_matches_answering_when_assets_are_irrelevant(self):
+        declined, *_ = self._disabled_expansion_adult(assets_total="unknown")
+        over_limit, *_ = self._disabled_expansion_adult(assets_total=99999)
+        self.assertEqual(declined, over_limit)
+
+    def test_the_asset_question_is_not_even_asked(self):
+        *_, missing, _ = self._disabled_expansion_adult()
+        for question in missing:
+            self.assertNotIn("assets", question.lower())
+
+    def test_non_expansion_state_still_needs_the_asset_answer(self):
+        # Texas has no expansion pathway, so the asset test genuinely applies.
+        *_, missing, _ = is_eligible(
+            **_answers(
+                state="tx", age=40, receiving_ssdi=True, ssdi_length=6,
+                on_medicare=False, avg_monthly_qualifying_hours_last_3mo=100,
+            )
+        )
+        self.assertTrue(any("assets" in q.lower() for q in missing))

--- a/tests/sync/test_medicaid_eligibility_api.py
+++ b/tests/sync/test_medicaid_eligibility_api.py
@@ -10,7 +10,11 @@ never going to be asked (the pre-2026-08 stall bugs).
 # a CSV -- no ORM, so skip TestCase's per-test transaction machinery.
 from django.test import SimpleTestCase
 
-from fighthealthinsurance.medicaid_api import get_medicaid_info, is_eligible
+from fighthealthinsurance.medicaid_api import (
+    get_medicaid_info,
+    is_eligible,
+    summarize_eligibility_inputs,
+)
 
 
 def _answers(**overrides):
@@ -273,6 +277,10 @@ class TestLlmPayloadParsing(SimpleTestCase):
         _, _, _, _, missing = is_eligible(**_answers(monthly_income="$1,200"))
         self.assertFalse(any("monthly income" in q for q in missing))
 
+    def test_abbreviated_thousands_income_is_parsed(self):
+        summary = summarize_eligibility_inputs({"monthly_income": "1.2k"})
+        self.assertEqual(summary["recorded"]["monthly_income"], 1200.0)
+
     def test_spelled_out_household_size_is_parsed(self):
         _, _, _, _, missing = is_eligible(**_answers(household_size="three"))
         self.assertFalse(any("household size" in q for q in missing))
@@ -283,6 +291,86 @@ class TestLlmPayloadParsing(SimpleTestCase):
         _, _, _, alts, missing = is_eligible(state="Puerto Rico", age=30)
         self.assertFalse(any("state do you live" in q for q in missing))
         self.assertTrue(any("territor" in a.lower() for a in alts))
+
+
+class TestUnknownAnswerChannel(SimpleTestCase):
+    """The model needs a way to say "asked, and the user can't answer"."""
+
+    def test_declined_optional_field_is_not_reasked(self):
+        # Without this channel the model has nothing valid to send for "I
+        # don't know", so the question returns every turn forever.
+        _, _, _, _, missing = is_eligible(**_answers(married="unknown"))
+        self.assertFalse(any("married" in q for q in missing))
+
+    def test_declined_optional_field_still_yields_a_verdict(self):
+        eligible_2025, _, _, _, _ = is_eligible(**_answers(married="unknown"))
+        self.assertTrue(eligible_2025)
+
+    def test_declined_optional_field_discloses_the_assumption(self):
+        _, _, _, alts, _ = is_eligible(**_answers(married="prefer not to say"))
+        self.assertTrue(any("assumed the most conservative" in a for a in alts))
+
+    def test_declined_required_field_is_not_reasked(self):
+        _, _, _, _, missing = is_eligible(
+            **_answers(household_size="don't know", monthly_income="idk")
+        )
+        self.assertFalse(any("household" in q for q in missing))
+
+    def test_declined_required_field_explains_the_blocked_estimate(self):
+        # Not a silent "not eligible" dead end -- say what's missing.
+        _, _, _, alts, _ = is_eligible(
+            **_answers(household_size="don't know", monthly_income="idk")
+        )
+        self.assertTrue(any("can't estimate eligibility without" in a for a in alts))
+
+    def test_declined_assets_question_is_not_reasked(self):
+        _, _, _, _, missing = is_eligible(
+            **_answers(
+                age=70,
+                on_medicare=True,
+                years_worked=20,
+                assets_total="prefer not to say",
+            )
+        )
+        self.assertFalse(any("assets" in q for q in missing))
+
+
+class TestParsedInputFeedback(SimpleTestCase):
+    """The model parses user text, so it needs to see what actually landed."""
+
+    def test_normalized_values_are_reported_back(self):
+        summary = summarize_eligibility_inputs(
+            {"state": "Medi-Cal", "monthly_income": "$1,200", "married": "single"}
+        )
+        self.assertEqual(summary["recorded"]["state"], "ca")
+        self.assertEqual(summary["recorded"]["monthly_income"], 1200.0)
+        self.assertFalse(summary["recorded"]["married"])
+
+    def test_unrecognized_parameter_names_are_reported(self):
+        # Silently dropping these looks to the model exactly like acceptance,
+        # so it believes it answered and the question comes back.
+        summary = summarize_eligibility_inputs({"income": 999, "state": "ca"})
+        self.assertEqual(summary["unrecognized"], ["income"])
+
+    def test_unreadable_values_are_reported(self):
+        summary = summarize_eligibility_inputs({"age": "thirtyish"})
+        self.assertEqual(summary["unreadable"], ["age"])
+
+    def test_declined_fields_are_reported(self):
+        summary = summarize_eligibility_inputs({"assets_total": "unknown"})
+        self.assertEqual(summary["declined"], ["assets_total"])
+
+
+class TestStateProgramNames(SimpleTestCase):
+    """Program names are what users actually say; resolve them as a backstop."""
+
+    def test_medi_cal_resolves_to_california(self):
+        eligible_2025, _, _, _, _ = is_eligible(**_answers(state="Medi-Cal"))
+        self.assertTrue(eligible_2025)
+
+    def test_masshealth_resolves_to_massachusetts(self):
+        eligible_2025, _, _, _, _ = is_eligible(**_answers(state="MassHealth"))
+        self.assertTrue(eligible_2025)
 
 
 class TestQuestionsThatCannotChangeTheAnswer(SimpleTestCase):

--- a/tests/sync/test_medicaid_eligibility_api.py
+++ b/tests/sync/test_medicaid_eligibility_api.py
@@ -212,6 +212,10 @@ class TestQuestionFlow(SimpleTestCase):
             als=False,
         )
         self.assertTrue(eligible_2025)
+        # The stall this name refers to: pregnancy was required by the
+        # completeness gate but never asked for a 2-year-old, so the flow
+        # dead-ended. Assert it is neither asked nor outstanding.
+        self.assertEqual(missing, [])
 
     def test_sixty_five_year_old_is_asked_about_medicare(self):
         # Regression: the medicare question used `age > 65`, skipping
@@ -926,3 +930,59 @@ class TestSpendDownSuggestion(SimpleTestCase):
             any("medically-needy" in a.lower() for a in alts),
             f"expected a spend-down pointer in {alts}",
         )
+
+
+class TestDisabledButNotOnSsdi(SimpleTestCase):
+    """`receiving_ssdi` is ORed with `disabled`; the SSDI question is not.
+
+    Regression: the "don't rule Medicare out yet" branch waited on
+    ``receiving_ssdi``, which is true when only ``disabled`` was supplied,
+    but the ssdi_length question it waits for is gated on the SSDI answer
+    alone. Someone who said "disabled, not on SSDI" therefore waited on a
+    question that never got asked.
+    """
+
+    def _disabled_senior(self):
+        return is_eligible(
+            **_answers(
+                age=66, receiving_ssdi=False, disabled=True,
+                on_medicare=False, years_worked=5, assets_total=500,
+            )
+        )
+
+    def test_no_silent_medicare_denial(self):
+        *_, alts, missing, _ = self._disabled_senior()
+        self.assertTrue(
+            missing or alts,
+            "a 66-year-old got no Medicare verdict, no question, and no next step",
+        )
+
+    def test_part_a_buy_in_is_offered(self):
+        *_, alts, _, _ = self._disabled_senior()
+        self.assertTrue(
+            any("buy Medicare Part A" in a for a in alts),
+            f"expected the Part-A buy-in pointer in {alts}",
+        )
+
+    def test_actual_ssdi_recipient_still_defers(self):
+        # The deferral is still correct when they really are on SSDI: the
+        # ssdi_length question is asked, so don't conclude anything yet.
+        *_, missing, _ = is_eligible(
+            **_answers(
+                age=66, receiving_ssdi=True, on_medicare=False,
+                years_worked=5, assets_total=500,
+            )
+        )
+        self.assertIn("How many months have you been receiving SSDI?", missing)
+
+
+class TestBareMedicalIsAmbiguous(SimpleTestCase):
+    """Pennsylvania, Minnesota and Maryland all call their program "Medical Assistance"."""
+
+    def test_bare_medical_re_asks_instead_of_guessing_california(self):
+        *_, missing, _ = is_eligible(state="medical", age=30)
+        self.assertTrue(any("state" in q.lower() for q in missing))
+
+    def test_hyphenated_medi_cal_still_resolves(self):
+        eligible_2025, *_ = is_eligible(**_answers(state="medi-cal"))
+        self.assertTrue(eligible_2025)

--- a/tests/sync/test_medicaid_eligibility_landing_page.py
+++ b/tests/sync/test_medicaid_eligibility_landing_page.py
@@ -27,6 +27,21 @@ class TestMedicaidEligibilityLandingPage(TestCase):
         # The page must not present the AI check as an official determination.
         self.assertContains(self.response, "Estimate, Not a Determination")
 
+    def test_page_shows_experimental_badge_in_hero(self):
+        self.assertContains(self.response, "EXPERIMENTAL FEATURE")
+
+    def test_page_has_prominent_experimental_banner(self):
+        self.assertContains(
+            self.response, "This eligibility check is an experimental feature"
+        )
+
+    def test_page_ctas_are_labeled_experimental(self):
+        self.assertContains(self.response, "Try the Experimental Eligibility Check")
+        self.assertContains(self.response, "Check My Eligibility (Experimental)")
+
+    def test_page_disclaimer_flags_experimental(self):
+        self.assertContains(self.response, "EXPERIMENTAL feature")
+
     def test_page_covers_2026_work_requirements(self):
         self.assertContains(self.response, "80 hours per month")
 

--- a/tests/sync/test_medicaid_eligibility_landing_page.py
+++ b/tests/sync/test_medicaid_eligibility_landing_page.py
@@ -47,8 +47,10 @@ class TestMedicaidEligibilityLandingPage(TestCase):
             "This eligibility check is an experimental feature", self.content
         )
 
-    def test_page_ctas_are_labeled_experimental(self):
+    def test_hero_cta_is_labeled_experimental(self):
         self.assertIn("Try the Experimental Eligibility Check", self.content)
+
+    def test_final_cta_is_labeled_experimental(self):
         self.assertIn("Check My Eligibility (Experimental)", self.content)
 
     def test_page_disclaimer_flags_experimental(self):
@@ -67,10 +69,22 @@ class TestMedicaidEligibilityPageStaging(TestCase):
         response = Client().get(reverse("medicaid-eligibility"))
         self.assertEqual(response.status_code, 404)
 
+    @override_settings(MEDICAID_ELIGIBILITY_PAGE_ENABLED=True)
     def test_page_is_in_the_static_sitemap_when_enabled(self):
+        # Pin the precondition the name states rather than leaning on the
+        # ambient Dev/Test default, which will change when the flag is
+        # promoted or retired.
         from fighthealthinsurance.sitemap import StaticViewSitemap
 
         self.assertIn("medicaid-eligibility", StaticViewSitemap().items())
+
+    @override_settings(MEDICAID_ELIGIBILITY_PAGE_ENABLED=False)
+    def test_options_does_not_reveal_the_route_when_disabled(self):
+        # Review regression: the flag lived in get(), but View.options()
+        # answers 200 without dispatching there, leaving the staged route
+        # enumerable while it was supposed to be invisible.
+        response = Client().options(reverse("medicaid-eligibility"))
+        self.assertEqual(response.status_code, 404)
 
     @override_settings(MEDICAID_ELIGIBILITY_PAGE_ENABLED=False)
     def test_page_is_hidden_from_the_sitemap_when_disabled(self):

--- a/tests/sync/test_medicaid_eligibility_landing_page.py
+++ b/tests/sync/test_medicaid_eligibility_landing_page.py
@@ -1,0 +1,39 @@
+"""Tests for the Medicaid eligibility landing page."""
+
+from django.test import Client, TestCase
+from django.urls import reverse
+
+
+class TestMedicaidEligibilityLandingPage(TestCase):
+    """The /medicaid-eligibility landing page renders and routes users."""
+
+    def setUp(self):
+        self.client = Client()
+        self.response = self.client.get(reverse("medicaid-eligibility"))
+
+    def test_page_renders(self):
+        self.assertEqual(self.response.status_code, 200)
+
+    def test_page_links_to_the_chat_eligibility_flow(self):
+        self.assertContains(self.response, reverse("chat"))
+
+    def test_page_links_to_work_requirements_faq(self):
+        self.assertContains(self.response, reverse("medicaid-faq"))
+
+    def test_page_links_to_state_resources(self):
+        self.assertContains(self.response, reverse("state_help_index"))
+
+    def test_page_explains_estimate_not_determination(self):
+        # The page must not present the AI check as an official determination.
+        self.assertContains(self.response, "Estimate, Not a Determination")
+
+    def test_page_covers_2026_work_requirements(self):
+        self.assertContains(self.response, "80 hours per month")
+
+    def test_page_is_cached_like_other_static_ish_pages(self):
+        self.assertIn("public", self.response["Cache-Control"])
+
+    def test_page_is_in_the_static_sitemap(self):
+        from fighthealthinsurance.sitemap import StaticViewSitemap
+
+        self.assertIn("medicaid-eligibility", StaticViewSitemap().items())

--- a/tests/sync/test_medicaid_eligibility_landing_page.py
+++ b/tests/sync/test_medicaid_eligibility_landing_page.py
@@ -1,6 +1,10 @@
-"""Tests for the Medicaid eligibility landing page."""
+"""Tests for the Medicaid eligibility landing page.
 
-from django.test import Client, TestCase
+The page is staged behind MEDICAID_ELIGIBILITY_PAGE_ENABLED (on in Dev/Test,
+off in production) so the URL stays invisible while the page is iterated on.
+"""
+
+from django.test import Client, TestCase, override_settings
 from django.urls import reverse
 
 
@@ -48,7 +52,15 @@ class TestMedicaidEligibilityLandingPage(TestCase):
     def test_page_is_cached_like_other_static_ish_pages(self):
         self.assertIn("public", self.response["Cache-Control"])
 
-    def test_page_is_in_the_static_sitemap(self):
+    def test_page_is_in_the_static_sitemap_when_enabled(self):
         from fighthealthinsurance.sitemap import StaticViewSitemap
 
         self.assertIn("medicaid-eligibility", StaticViewSitemap().items())
+
+    @override_settings(MEDICAID_ELIGIBILITY_PAGE_ENABLED=False)
+    def test_page_is_hidden_from_the_sitemap_when_disabled(self):
+        # In production the staging flag is off: the page must not be
+        # discoverable via the sitemap (the URL isn't routed there either).
+        from fighthealthinsurance.sitemap import StaticViewSitemap
+
+        self.assertNotIn("medicaid-eligibility", StaticViewSitemap().items())

--- a/tests/sync/test_medicaid_eligibility_landing_page.py
+++ b/tests/sync/test_medicaid_eligibility_landing_page.py
@@ -1,7 +1,8 @@
 """Tests for the Medicaid eligibility landing page.
 
 The page is staged behind MEDICAID_ELIGIBILITY_PAGE_ENABLED (on in Dev/Test,
-off in production) so the URL stays invisible while the page is iterated on.
+off in production): the route always exists, but the view serves 404 and the
+sitemap omits the page until the flag is flipped.
 """
 
 from django.test import Client, TestCase, override_settings
@@ -11,46 +12,60 @@ from django.urls import reverse
 class TestMedicaidEligibilityLandingPage(TestCase):
     """The /medicaid-eligibility landing page renders and routes users."""
 
-    def setUp(self):
-        self.client = Client()
-        self.response = self.client.get(reverse("medicaid-eligibility"))
+    @classmethod
+    def setUpClass(cls):
+        # One shared render: the page is read-only and identical for every
+        # assertion below, so don't re-render it per test. Keep primitives
+        # (not the HttpResponse -- Django's setUpTestData/deepcopy machinery
+        # can't copy one).
+        super().setUpClass()
+        response = Client().get(reverse("medicaid-eligibility"))
+        cls.status_code = response.status_code
+        cls.content = response.content.decode()
 
     def test_page_renders(self):
-        self.assertEqual(self.response.status_code, 200)
+        self.assertEqual(self.status_code, 200)
 
     def test_page_links_to_the_chat_eligibility_flow(self):
-        self.assertContains(self.response, reverse("chat"))
+        self.assertIn(reverse("chat"), self.content)
 
     def test_page_links_to_work_requirements_faq(self):
-        self.assertContains(self.response, reverse("medicaid-faq"))
+        self.assertIn(reverse("medicaid-faq"), self.content)
 
     def test_page_links_to_state_resources(self):
-        self.assertContains(self.response, reverse("state_help_index"))
+        self.assertIn(reverse("state_help_index"), self.content)
 
     def test_page_explains_estimate_not_determination(self):
         # The page must not present the AI check as an official determination.
-        self.assertContains(self.response, "Estimate, Not a Determination")
+        self.assertIn("Estimate, Not a Determination", self.content)
 
     def test_page_shows_experimental_badge_in_hero(self):
-        self.assertContains(self.response, "EXPERIMENTAL FEATURE")
+        self.assertIn("EXPERIMENTAL FEATURE", self.content)
 
     def test_page_has_prominent_experimental_banner(self):
-        self.assertContains(
-            self.response, "This eligibility check is an experimental feature"
+        self.assertIn(
+            "This eligibility check is an experimental feature", self.content
         )
 
     def test_page_ctas_are_labeled_experimental(self):
-        self.assertContains(self.response, "Try the Experimental Eligibility Check")
-        self.assertContains(self.response, "Check My Eligibility (Experimental)")
+        self.assertIn("Try the Experimental Eligibility Check", self.content)
+        self.assertIn("Check My Eligibility (Experimental)", self.content)
 
     def test_page_disclaimer_flags_experimental(self):
-        self.assertContains(self.response, "EXPERIMENTAL feature")
+        self.assertIn("EXPERIMENTAL feature", self.content)
 
     def test_page_covers_2026_work_requirements(self):
-        self.assertContains(self.response, "80 hours per month")
+        self.assertIn("80 hours per month", self.content)
 
-    def test_page_is_cached_like_other_static_ish_pages(self):
-        self.assertIn("public", self.response["Cache-Control"])
+
+class TestMedicaidEligibilityPageStaging(TestCase):
+    """The staging flag controls both routing and discoverability."""
+
+    @override_settings(MEDICAID_ELIGIBILITY_PAGE_ENABLED=False)
+    def test_page_serves_404_when_disabled(self):
+        # Production runs with the flag off: the URL must be invisible.
+        response = Client().get(reverse("medicaid-eligibility"))
+        self.assertEqual(response.status_code, 404)
 
     def test_page_is_in_the_static_sitemap_when_enabled(self):
         from fighthealthinsurance.sitemap import StaticViewSitemap
@@ -59,8 +74,6 @@ class TestMedicaidEligibilityLandingPage(TestCase):
 
     @override_settings(MEDICAID_ELIGIBILITY_PAGE_ENABLED=False)
     def test_page_is_hidden_from_the_sitemap_when_disabled(self):
-        # In production the staging flag is off: the page must not be
-        # discoverable via the sitemap (the URL isn't routed there either).
         from fighthealthinsurance.sitemap import StaticViewSitemap
 
         self.assertNotIn("medicaid-eligibility", StaticViewSitemap().items())

--- a/tests/sync/test_response_similarity.py
+++ b/tests/sync/test_response_similarity.py
@@ -1,8 +1,11 @@
 """Tests for the shared response-similarity helpers (chat loop prevention)."""
 
+import inspect
+
 from django.test import TestCase
 
 from fighthealthinsurance.ml.response_similarity import (
+    CANNED_REPLY_SIGNATURES,
     EXACT_REPEAT_MIN_CHARS,
     NEAR_REPEAT_MIN_CHARS,
     bag_of_words,
@@ -210,3 +213,36 @@ class TestCannedReplyRequiresTheWholeBlock(TestCase):
             + "\n\nSee the [Medicaid Work Requirements FAQ](/faq/medicaid/)."
         )
         self.assertFalse(is_canned_reply(linking))
+
+
+class TestCannedSignatureTracksTheActualPrompt(TestCase):
+    """The signature must recognize the block the system prompt mandates.
+
+    Regression: the third marker used to be the literal date "December 31,
+    2026". When the prompt's block was corrected to the statutory January 1,
+    2027 deadline the signature silently stopped matching, so a second
+    work-requirements reply was hard-rejected as a repeat and the self-heal
+    retry steered the model away from text the prompt requires verbatim.
+    Asserting against the live prompt keeps the two from drifting again.
+    """
+
+    def _mandated_block(self):
+        from fighthealthinsurance.ml import ml_models
+
+        source = inspect.getsource(ml_models)
+        start = source.index("New federal rules require many adults")
+        end = source.index("(/faq/medicaid/)", start) + len("(/faq/medicaid/)")
+        return source[start:end]
+
+    def test_prompt_block_is_recognized_as_canned(self):
+        self.assertTrue(is_canned_reply(self._mandated_block()))
+
+    def test_signature_carries_no_date_marker(self):
+        # Dates rot; the phrases describing the requirement do not.
+        for signature in CANNED_REPLY_SIGNATURES:
+            for marker in signature:
+                self.assertNotRegex(
+                    marker,
+                    r"\b(19|20)\d{2}\b",
+                    f"{marker!r} pins the signature to a date that will change",
+                )

--- a/tests/sync/test_response_similarity.py
+++ b/tests/sync/test_response_similarity.py
@@ -234,11 +234,16 @@ class TestCannedSignatureTracksTheActualPrompt(TestCase):
         # The constant is only a useful anchor while the prompt is actually
         # built from it; re-inlining the text would leave the test above
         # passing against a string nothing sends.
+        #
+        # Match the identifier, not the concatenation syntax: a Black reflow
+        # or a switch to an f-string placeholder keeps the prompt correct,
+        # and this test should not fail for either. Scoped to the
+        # prompt-building method so an unrelated reference elsewhere in the
+        # module can't satisfy it.
         from fighthealthinsurance.ml import ml_models
 
-        self.assertIn(
-            "+ MEDICAID_WORK_REQUIREMENTS_BLOCK", inspect.getsource(ml_models)
-        )
+        source = inspect.getsource(ml_models.RemoteModelLike.generate_chat_response)
+        self.assertIn("MEDICAID_WORK_REQUIREMENTS_BLOCK", source)
 
     def test_signature_carries_no_date_marker(self):
         # Dates rot; the phrases describing the requirement do not.

--- a/tests/sync/test_response_similarity.py
+++ b/tests/sync/test_response_similarity.py
@@ -17,6 +17,7 @@ from fighthealthinsurance.ml.response_similarity import (
     sequence_similarity,
     user_requested_repeat,
 )
+from fighthealthinsurance.ml.ml_models import MEDICAID_WORK_REQUIREMENTS_BLOCK
 from tests.chat_fixtures import CANNED_MEDICAID_REPLY, LOOPED_REPLY
 
 
@@ -226,16 +227,18 @@ class TestCannedSignatureTracksTheActualPrompt(TestCase):
     Asserting against the live prompt keeps the two from drifting again.
     """
 
-    def _mandated_block(self):
+    def test_prompt_block_is_recognized_as_canned(self):
+        self.assertTrue(is_canned_reply(MEDICAID_WORK_REQUIREMENTS_BLOCK))
+
+    def test_prompt_is_built_from_the_named_block(self):
+        # The constant is only a useful anchor while the prompt is actually
+        # built from it; re-inlining the text would leave the test above
+        # passing against a string nothing sends.
         from fighthealthinsurance.ml import ml_models
 
-        source = inspect.getsource(ml_models)
-        start = source.index("New federal rules require many adults")
-        end = source.index("(/faq/medicaid/)", start) + len("(/faq/medicaid/)")
-        return source[start:end]
-
-    def test_prompt_block_is_recognized_as_canned(self):
-        self.assertTrue(is_canned_reply(self._mandated_block()))
+        self.assertIn(
+            "+ MEDICAID_WORK_REQUIREMENTS_BLOCK", inspect.getsource(ml_models)
+        )
 
     def test_signature_carries_no_date_marker(self):
         # Dates rot; the phrases describing the requirement do not.


### PR DESCRIPTION
Eligibility engine (medicaid_api.py):
- Fix flows that dead-ended with "not eligible" and no questions left:
  on_medicare/pregnant were required by the completeness gate but never
  asked for under-65 adults / young children; they now default when the
  question would never be asked. Also, answering "no" to the SSDI
  question was coerced back to unanswered by an `or` chain and re-asked
  forever.
- Ask the Medicare question at exactly 65 (was `> 65`) and conclude
  Medicare eligibility from 24+ months of SSDI, ESRD, ALS, or 10+ years
  of work (was only evaluated while the question was still pending, and
  10 years exactly didn't count).
- Correct the ACA expansion-state list (AL/KS/WI were wrongly included,
  MA/ND missing), model Wisconsin's 100%-FPL waiver, and stop suggesting
  marketplace subsidies below 100% FPL (the coverage gap).
- LTC: $0 countable assets now passes the asset test (was treated as
  missing info and failed), and 65+/disabled LTC applicants are
  evaluated under the LTC income cap instead of being shadowed by the
  ABD branch.
- An unrecognized state re-asks instead of raising; missing questions
  are deduplicated; FPL table updated to the published 2025 values;
  state display names derive from the shared state map (DRY).

Chat tool (chat/tools/medicaid_tool.py):
- Eligibility context handed to the LLM is now readable structured text
  (bulleted questions and alternatives) instead of run-on sentences
  embedding raw Python list reprs, with pacing guidance: ask two or
  three questions per turn, in order, without re-asking answered ones.

Model prompt (ml/ml_models.py):
- Document the 2026 work-requirement hour parameters so the model can
  actually complete a 2026 determination, drop two parameters the API
  never read (state_expanded_medicaid, state_has_medically_needy), add
  question-pacing rules, and fix typos.

Landing page:
- New /medicaid-eligibility landing page (template, view, URL, sitemap)
  that routes into the chat eligibility flow, explains the common
  qualification pathways and the 2026 work requirements, and links
  state resources; cross-linked from turning-26 and the
  work-requirements FAQ.

Tests: new coverage for the stall regressions, Medicare pathways, LTC
zero-asset and income-cap behavior, question dedupe, tool text
formatting, and the landing page.

---

## Added since the description above

The branch grew through several review rounds and a rebase onto `main`
(picking up the chat loop-prevention work in #934). Summary of what a
reviewer will see beyond the original scope:

**Staging and framing**
- The page is staged behind `MEDICAID_ELIGIBILITY_PAGE_ENABLED` (off by
  default, on in Dev). The flag gates the route and the sitemap entry
  from one shared helper, and is checked outside `cache_page` so it acts
  as a real kill switch.
- The experimental nature is made unmistakable: a shared badge partial,
  a warning banner, explicit CTA labels, and a prompt rule requiring the
  model to disclose it on every eligibility check.
- The landing page was redesigned to match the site's design system.

**Correctness of the work-requirement dates**
- The federal community-engagement requirement takes effect **January 1,
  2027**, not December 2026; December 2026 is a possible look-back month.
  Verified against CMS (CMS-2454-IFC) and KFF. Corrected in the engine,
  the prompt, the landing page, and the linked FAQ and blog post, which
  carried the same wrong date.

**"We couldn't score this" vs "the answer is no"**
- `is_eligible` now returns a sixth value, `determination_made`. A US
  territory, or a required answer the user declined, used to come back
  as `False/False` with no questions left, which the chat tool rendered
  as a confident denial. Those now report as not-scored, with the reason
  named in the alternatives.
- Declining an answer no longer silently becomes a verdict on any
  pathway (assets, work hours, years worked, SSDI duration), and no
  longer suppresses the alternatives that pathway would have offered.
- Territory residents keep a real Medicare answer (Medicare is federal
  and operates in PR/GU/VI/AS/MP) and are no longer asked several
  Medicaid-only questions before being told the checker can't estimate.

**Input handling**
- Program names resolve exactly, never fuzzily: `medicad` (a routine
  misspelling of "medicaid") was matching the `medical` alias and
  scoring under California's rules. The bare `medical` alias is gone
  entirely — PA/MN/MD all call their programs "Medical Assistance".
- `applying_reason` is normalized like every other field. Free text such
  as "nursing home" previously missed `_LTC_REASONS`, skipped the LTC
  home-equity test, and reported a nursing-home applicant as probably
  eligible.
- "no income"/"nothing" parse as zero; "widowed"/"divorced"/"separated"
  answer the married question. Both previously re-asked forever.

**Chat/model plumbing**
- The tool echoes back what it parsed — recorded, unreadable,
  unrecognized, and declined — so the model can see its own parsing and
  re-send declined fields as `"unknown"`.
- The landing page CTAs now start the eligibility flow via
  `?microsite_slug=medicaid-eligibility` instead of opening a blank chat.
- Correcting the work-requirement date desynced the mandated block from
  `CANNED_REPLY_SIGNATURES`, which keyed on the old literal date, so a
  second work-requirements reply was hard-rejected as a repeat. The
  signature now keys on a durable phrase, with a drift test.

**Verification beyond the reported findings**

Four review rounds each surfaced another variant of a single defect — a
path concluding with no question and no alternative. Rather than keep
patching per report, the answer space was swept for that shape: ~208k
input combinations across the Medicare, ABD, LTC, child, pregnancy and
territory branches. Zero dead ends remain. The sweep also found the
`applying_reason` false positive above, which no review had reported.

**Known follow-up (not in this PR)**

Declined fields are held only in the tool payload, so the suppression
lasts only as long as the model keeps echoing them back. Persisting them
in chat session state would make it durable, but that reaches into chat
session handling well beyond this change.
