### PR TITLE
For chat enable external models by default

### DIFF
--- a/fighthealthinsurance/static/js/user_info_storage.ts
+++ b/fighthealthinsurance/static/js/user_info_storage.ts
@@ -7,9 +7,6 @@
 const USER_INFO_KEY = "fhi_user_info";
 // Storage key for external models preference
 const EXTERNAL_MODELS_KEY = "fhi_use_external_models";
-// External models are opt-out: anything other than an explicit stored "false"
-// (no key, an unreadable store, a value written by an older build) means on.
-const EXTERNAL_MODELS_DEFAULT = true;
 
 // Interface for user information
 export interface UserInfo {
@@ -71,37 +68,20 @@ export function saveExternalModelsPreference(useExternalModels: boolean): void {
 }
 
 /**
- * Read an explicitly stored external models preference, or null when the user
- * has never made a choice.
- *
- * Pure read: a missing key means "no stored choice", and a read must not
- * materialize a value. Writing "true" here recorded an explicit opt-in for
- * anyone who merely opened the chat, which made a real choice indistinguishable
- * from never having been asked.
- *
- * Only an exact "false" counts as opting out. Any other value (a stray or
- * legacy string, an unreadable store) is not a choice to turn external models
- * off, so it falls back to the default.
+ * Get external models preference from localStorage
  */
-export function getStoredExternalModelsPreference(): boolean | null {
+export function getExternalModelsPreference(): boolean {
   try {
     const stored = localStorage.getItem(EXTERNAL_MODELS_KEY);
-    if (stored === null) return null;
-    if (stored === "false") return false;
-    if (stored === "true") return true;
-    return null;
+    // Pure read: no key means "no stored choice, use the default", and a read
+    // must not materialize a value. Writing "true" here recorded an explicit
+    // opt-in for anyone who merely opened the chat, which made a real choice
+    // indistinguishable from never having been asked.
+    return stored === null ? true : stored === "true";
   } catch (e) {
     console.error("Error getting external models preference from localStorage:", e);
   }
-  return null;
-}
-
-/**
- * Get external models preference, defaulting to on when nothing was chosen.
- */
-export function getExternalModelsPreference(): boolean {
-  const stored = getStoredExternalModelsPreference();
-  return stored === null ? EXTERNAL_MODELS_DEFAULT : stored;
+  return true;
 }
 
 /**
@@ -331,13 +311,10 @@ export function setupFormPersistence(formId: string): void {
     populateFormFromUserInfo(storedInfo);
   }
 
-  // Restore external models preference. Only an explicit stored choice
-  // overrides the checkbox; with nothing stored we leave the server-rendered
-  // state alone so the default (on) lives in the form, not in two places.
+  // Restore external models preference
   const externalModelsCheckbox = document.getElementById("use_external_models") as HTMLInputElement | null;
-  const storedExternalModels = getStoredExternalModelsPreference();
-  if (externalModelsCheckbox && storedExternalModels !== null) {
-    externalModelsCheckbox.checked = storedExternalModels;
+  if (externalModelsCheckbox) {
+    externalModelsCheckbox.checked = getExternalModelsPreference();
   }
 
   // Save to localStorage on form submit
@@ -361,7 +338,6 @@ if (typeof window !== "undefined") {
     clearUserInfo,
     saveExternalModelsPreference,
     getExternalModelsPreference,
-    getStoredExternalModelsPreference,
     scrubPersonalInfo,
     restorePersonalInfo,
     collectUserInfoFromForm,

--- a/fighthealthinsurance/static/js/user_info_storage.ts
+++ b/fighthealthinsurance/static/js/user_info_storage.ts
@@ -7,6 +7,9 @@
 const USER_INFO_KEY = "fhi_user_info";
 // Storage key for external models preference
 const EXTERNAL_MODELS_KEY = "fhi_use_external_models";
+// External models are opt-out: anything other than an explicit stored "false"
+// (no key, an unreadable store, a value written by an older build) means on.
+const EXTERNAL_MODELS_DEFAULT = true;
 
 // Interface for user information
 export interface UserInfo {
@@ -68,20 +71,37 @@ export function saveExternalModelsPreference(useExternalModels: boolean): void {
 }
 
 /**
- * Get external models preference from localStorage
+ * Read an explicitly stored external models preference, or null when the user
+ * has never made a choice.
+ *
+ * Pure read: a missing key means "no stored choice", and a read must not
+ * materialize a value. Writing "true" here recorded an explicit opt-in for
+ * anyone who merely opened the chat, which made a real choice indistinguishable
+ * from never having been asked.
+ *
+ * Only an exact "false" counts as opting out. Any other value (a stray or
+ * legacy string, an unreadable store) is not a choice to turn external models
+ * off, so it falls back to the default.
  */
-export function getExternalModelsPreference(): boolean {
+export function getStoredExternalModelsPreference(): boolean | null {
   try {
     const stored = localStorage.getItem(EXTERNAL_MODELS_KEY);
-    // Pure read: no key means "no stored choice, use the default", and a read
-    // must not materialize a value. Writing "true" here recorded an explicit
-    // opt-in for anyone who merely opened the chat, which made a real choice
-    // indistinguishable from never having been asked.
-    return stored === null ? true : stored === "true";
+    if (stored === null) return null;
+    if (stored === "false") return false;
+    if (stored === "true") return true;
+    return null;
   } catch (e) {
     console.error("Error getting external models preference from localStorage:", e);
   }
-  return true;
+  return null;
+}
+
+/**
+ * Get external models preference, defaulting to on when nothing was chosen.
+ */
+export function getExternalModelsPreference(): boolean {
+  const stored = getStoredExternalModelsPreference();
+  return stored === null ? EXTERNAL_MODELS_DEFAULT : stored;
 }
 
 /**
@@ -311,10 +331,13 @@ export function setupFormPersistence(formId: string): void {
     populateFormFromUserInfo(storedInfo);
   }
 
-  // Restore external models preference
+  // Restore external models preference. Only an explicit stored choice
+  // overrides the checkbox; with nothing stored we leave the server-rendered
+  // state alone so the default (on) lives in the form, not in two places.
   const externalModelsCheckbox = document.getElementById("use_external_models") as HTMLInputElement | null;
-  if (externalModelsCheckbox) {
-    externalModelsCheckbox.checked = getExternalModelsPreference();
+  const storedExternalModels = getStoredExternalModelsPreference();
+  if (externalModelsCheckbox && storedExternalModels !== null) {
+    externalModelsCheckbox.checked = storedExternalModels;
   }
 
   // Save to localStorage on form submit
@@ -338,6 +361,7 @@ if (typeof window !== "undefined") {
     clearUserInfo,
     saveExternalModelsPreference,
     getExternalModelsPreference,
+    getStoredExternalModelsPreference,
     scrubPersonalInfo,
     restorePersonalInfo,
     collectUserInfoFromForm,

--- a/tests/selenium/test_selenium_chat_status.py
+++ b/tests/selenium/test_selenium_chat_status.py
@@ -455,6 +455,33 @@ class SeleniumChatStatusMessagesTest(FHISeleniumBase, StaticLiveServerTestCase):
         assert is_checked is True, "External models toggle should default to on"
         print("✓ External models toggle defaults to on in consent form")
 
+    def test_external_models_unrecognized_stored_value_is_not_opt_in(self):
+        """An unparseable stored preference must not read as consent to share.
+
+        Nothing in the app writes anything but "true"/"false" today, so this
+        pins the fail-closed direction for a third-party data-sharing control:
+        a value we cannot interpret is not an opt-in.
+        """
+        self.open(f"{self.live_server_url}/chat-consent")
+        self.execute_script(
+            "localStorage.setItem('fhi_use_external_models', 'not-a-boolean');"
+        )
+
+        # Reload so user_info_storage.ts re-runs against the stray value
+        self.open(f"{self.live_server_url}/chat-consent")
+
+        is_checked = self.execute_script("""
+            const toggle = document.getElementById('use_external_models');
+            return toggle ? toggle.checked : null;
+        """)
+
+        assert (
+            is_checked is False
+        ), f"Unrecognized stored value should not opt in, got checked={is_checked}"
+
+        # Clean up so we don't leak the stray value into sibling tests
+        self.execute_script("localStorage.removeItem('fhi_use_external_models');")
+
     def test_external_models_toggled_off_is_respected(self):
         """Test that explicitly disabling external models is saved and respected."""
         # Clear any prior preference so we start from the default-on state

--- a/tests/sync/test_chat_consent_external_models_default.py
+++ b/tests/sync/test_chat_consent_external_models_default.py
@@ -1,4 +1,10 @@
-"""External AI models must be opt-out: the consent form ships with the box checked."""
+"""External AI models must be opt-out: the consent form ships with the box checked.
+
+These cover the Django half only — the checkbox state the consent pages render
+before any stored preference is applied. The client-side half (localStorage
+resolution in ``user_info_storage.ts``, which is what actually reaches the chat)
+is covered by ``tests/selenium/test_selenium_chat_status.py``.
+"""
 
 import re
 
@@ -11,41 +17,31 @@ from fighthealthinsurance.chat_forms import UserConsentForm
 EXTERNAL_MODELS_INPUT = re.compile(r'<input[^>]*id="use_external_models"[^>]*>')
 
 
-def rendered_external_models_input(html: str) -> str:
-    match = EXTERNAL_MODELS_INPUT.search(html)
-    assert match is not None, "use_external_models checkbox missing from page"
-    return match.group(0)
-
-
 class ChatConsentExternalModelsDefaultTest(TestCase):
-    """The server-rendered default is the one users get without any JavaScript."""
+    """The rendered default is what a user sees before any prior choice applies."""
 
     def setUp(self):
         self.client = Client()
+
+    def assertRendersCheckboxChecked(self, response):
+        self.assertEqual(response.status_code, 200)
+        match = EXTERNAL_MODELS_INPUT.search(response.content.decode())
+        self.assertIsNotNone(match, "use_external_models checkbox missing from page")
+        self.assertIn("checked", match.group(0))
 
     def test_form_field_defaults_to_enabled(self):
         form = UserConsentForm()
         self.assertTrue(form.fields["use_external_models"].initial)
 
     def test_consent_page_renders_checkbox_checked(self):
-        response = self.client.get(reverse("chat_consent"))
-        self.assertEqual(response.status_code, 200)
-        self.assertIn(
-            "checked",
-            rendered_external_models_input(response.content.decode()),
-        )
+        self.assertRendersCheckboxChecked(self.client.get(reverse("chat_consent")))
 
     def test_explain_denial_page_renders_checkbox_checked(self):
         """The other page sharing the consent partial gets the same default."""
-        response = self.client.get(reverse("explain_denial"))
-        self.assertEqual(response.status_code, 200)
-        self.assertIn(
-            "checked",
-            rendered_external_models_input(response.content.decode()),
-        )
+        self.assertRendersCheckboxChecked(self.client.get(reverse("explain_denial")))
 
     def test_unchecked_submission_is_still_respected(self):
-        """Default-on must not become force-on."""
+        """Default-on must not be hardened into force-on (required, or clean()ed True)."""
         form = UserConsentForm(
             data={
                 "first_name": "Test",

--- a/tests/sync/test_chat_consent_external_models_default.py
+++ b/tests/sync/test_chat_consent_external_models_default.py
@@ -1,37 +1,36 @@
 """External AI models must be opt-out: the consent form ships with the box checked.
 
-These cover the Django half only — the checkbox state the consent pages render
-before any stored preference is applied. The client-side half (localStorage
-resolution in ``user_info_storage.ts``, which is what actually reaches the chat)
-is covered by ``tests/selenium/test_selenium_chat_status.py``.
+These cover the Django half — the checkbox state the consent pages render. The
+client-side half (localStorage resolution in ``user_info_storage.ts``) is covered
+by ``tests/selenium/test_selenium_chat_status.py``.
 """
 
-import re
-
-from django.test import Client, TestCase
+from django.test import TestCase
 from django.urls import reverse
 
 from fighthealthinsurance.chat_forms import UserConsentForm
 
-# The rendered checkbox tag, whatever order Django emits its attributes in.
-EXTERNAL_MODELS_INPUT = re.compile(r'<input[^>]*id="use_external_models"[^>]*>')
+CHECKED_CHECKBOX = (
+    '<input type="checkbox" name="use_external_models" '
+    'class="form-check-input" id="use_external_models" checked>'
+)
 
 
 class ChatConsentExternalModelsDefaultTest(TestCase):
     """The rendered default is what a user sees before any prior choice applies."""
 
-    def setUp(self):
-        self.client = Client()
-
     def assertRendersCheckboxChecked(self, response):
-        self.assertEqual(response.status_code, 200)
-        match = EXTERNAL_MODELS_INPUT.search(response.content.decode())
-        self.assertIsNotNone(match, "use_external_models checkbox missing from page")
-        self.assertIn("checked", match.group(0))
+        # Exact widget markup, not a substring search for "checked": a tag
+        # carrying value="checked" but no boolean checked attribute (the style
+        # used in scrub.html) must not satisfy this. html=True would be the
+        # house idiom, but it parses the whole response and both pages carry a
+        # pre-existing unbalanced </div> that trips the parser.
+        self.assertContains(response, CHECKED_CHECKBOX)
 
-    def test_form_field_defaults_to_enabled(self):
-        form = UserConsentForm()
-        self.assertTrue(form.fields["use_external_models"].initial)
+    def test_form_renders_field_enabled(self):
+        # value(), not fields[...].initial: a view's get_initial() overrides the
+        # field default, and value() is what actually reaches the template.
+        self.assertTrue(UserConsentForm()["use_external_models"].value())
 
     def test_consent_page_renders_checkbox_checked(self):
         self.assertRendersCheckboxChecked(self.client.get(reverse("chat_consent")))
@@ -40,8 +39,12 @@ class ChatConsentExternalModelsDefaultTest(TestCase):
         """The other page sharing the consent partial gets the same default."""
         self.assertRendersCheckboxChecked(self.client.get(reverse("explain_denial")))
 
-    def test_unchecked_submission_is_still_respected(self):
-        """Default-on must not be hardened into force-on (required, or clean()ed True)."""
+    def test_unchecked_submission_cleans_to_false(self):
+        """Default-on must not be hardened into force-on (required, or clean()ed True).
+
+        The consent POST does not carry the preference to the backend — that
+        travels via localStorage — so this guards the form, not the request.
+        """
         form = UserConsentForm(
             data={
                 "first_name": "Test",

--- a/tests/sync/test_chat_consent_external_models_default.py
+++ b/tests/sync/test_chat_consent_external_models_default.py
@@ -1,0 +1,59 @@
+"""External AI models must be opt-out: the consent form ships with the box checked."""
+
+import re
+
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from fighthealthinsurance.chat_forms import UserConsentForm
+
+# The rendered checkbox tag, whatever order Django emits its attributes in.
+EXTERNAL_MODELS_INPUT = re.compile(r'<input[^>]*id="use_external_models"[^>]*>')
+
+
+def rendered_external_models_input(html: str) -> str:
+    match = EXTERNAL_MODELS_INPUT.search(html)
+    assert match is not None, "use_external_models checkbox missing from page"
+    return match.group(0)
+
+
+class ChatConsentExternalModelsDefaultTest(TestCase):
+    """The server-rendered default is the one users get without any JavaScript."""
+
+    def setUp(self):
+        self.client = Client()
+
+    def test_form_field_defaults_to_enabled(self):
+        form = UserConsentForm()
+        self.assertTrue(form.fields["use_external_models"].initial)
+
+    def test_consent_page_renders_checkbox_checked(self):
+        response = self.client.get(reverse("chat_consent"))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            "checked",
+            rendered_external_models_input(response.content.decode()),
+        )
+
+    def test_explain_denial_page_renders_checkbox_checked(self):
+        """The other page sharing the consent partial gets the same default."""
+        response = self.client.get(reverse("explain_denial"))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            "checked",
+            rendered_external_models_input(response.content.decode()),
+        )
+
+    def test_unchecked_submission_is_still_respected(self):
+        """Default-on must not become force-on."""
+        form = UserConsentForm(
+            data={
+                "first_name": "Test",
+                "last_name": "User",
+                "email": "external-default@example.com",
+                "tos_agreement": "on",
+                "privacy_policy": "on",
+            }
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertFalse(form.cleaned_data["use_external_models"])


### PR DESCRIPTION
## Summary
Changes the external AI models feature from opt-in to opt-out by making it the default choice on chat consent forms. The default is now enforced at the server level (form field initial value) rather than only in client-side JavaScript, ensuring users who disable JavaScript still get the opt-out behavior.

## Key Changes

- **Form field default**: `UserConsentForm.use_external_models` now defaults to `True` (checked), making external models the default choice
- **Server-rendered checkbox**: The consent form now renders the checkbox as `checked` by default, so users without JavaScript see the opt-out state
- **Client-side logic refactored**: 
  - Split `getExternalModelsPreference()` into two functions:
    - `getStoredExternalModelsPreference()`: Returns the explicitly stored choice (`true`/`false`) or `null` if never set
    - `getExternalModelsPreference()`: Returns the stored choice or defaults to `true`
  - Form restoration now only overrides the server-rendered state when an explicit choice was previously stored, avoiding double-defaults
- **Comprehensive test coverage**: New test suite (`ChatConsentExternalModelsDefaultTest`) verifies:
  - Form field defaults to enabled
  - Both consent pages render the checkbox as checked
  - Unchecked submissions are still respected (default-on is not force-on)

## Implementation Details

The key insight is distinguishing between "no stored choice" (null) and "explicit choice to disable" (false). The localStorage read is now a pure read that doesn't materialize values—writing "true" for mere form opens would make real choices indistinguishable from never being asked. Only an exact "false" string counts as opting out; any other value (missing key, legacy string, unreadable store) falls back to the default.

This ensures the opt-out default lives in one place (the form field) rather than duplicated across server and client logic.

https://claude.ai/code/session_012EM7927BDThXWmHiTKAZxD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved coverage for external-model consent behavior.
  * Added clearer validation of checkbox rendering and submitted values.
  * Clarified handling when consent is unchecked.
  * Consolidated response assertions for more consistent test results.
* **Documentation**
  * Added guidance distinguishing server-rendered form behavior from client-side consent handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->