### PR TITLE
Add Claude Fable 5 as a frontier-tier Azure deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -130,7 +130,7 @@ ANTHROPIC_API_KEY=your-anthropic-api-key
 # AZURE_ANTHROPIC_ENDPOINT=https://your-resource.services.ai.azure.com/anthropic
 # AZURE_ANTHROPIC_API_KEY=your-azure-foundry-key
 # Optional: override the default latest-model deployments (comma-separated).
-# Defaults to: claude-haiku-4-5, claude-sonnet-4-6, claude-opus-4-8
+# Defaults to: claude-haiku-4-5, claude-sonnet-4-6, claude-opus-4-8, claude-fable-5
 # AZURE_ANTHROPIC_MODELS=claude-opus-4-8,claude-sonnet-4-6
 
 # Restrict which REMOTE models are loaded (optional). Comma-separated list of

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ recorded for usage tracking in both the regular appeal workflow and the chooser
    ```
 4. By default the latest models are exposed (Azure OpenAI: `gpt-4.1-mini`,
    `gpt-5-mini`, `gpt-5`; Azure Claude: `claude-haiku-4-5`, `claude-sonnet-4-6`,
-   `claude-opus-4-8`). If your Azure *deployment names* differ from these model
+   `claude-opus-4-8`, `claude-fable-5`). If your Azure *deployment names* differ from these model
    ids, list them explicitly with `AZURE_OPENAI_MODELS` /
    `AZURE_ANTHROPIC_MODELS` (comma-separated).
 

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -286,6 +286,21 @@ def _http_error_indicates_context_overflow(status: int, body: Optional[str]) -> 
     return "prompt is too long" in lowered or "input is too long" in lowered
 
 
+# Claude models that dropped the sampling parameters: on Claude 4.7 and newer
+# (including the Claude 5 family) ``temperature``/``top_p``/``top_k`` are not
+# just clamped but rejected outright with HTTP 400, so the field has to be
+# omitted from the request body. Claude 4.6 and older still accept it. Matched
+# as a prefix so dated snapshot ids (``claude-opus-4-8-20260115``) are covered.
+_CLAUDE_NO_SAMPLING_PREFIXES: tuple[str, ...] = (
+    "claude-fable-5",
+    "claude-mythos-5",
+    "claude-opus-5",
+    "claude-sonnet-5",
+    "claude-opus-4-7",
+    "claude-opus-4-8",
+)
+
+
 def _http_error_indicates_unsupported_temperature(status: int, body: str) -> bool:
     """True when a 400 means the model rejected the ``temperature`` parameter
     outright (OpenAI/Azure reasoning models accept only the default value).
@@ -2709,9 +2724,12 @@ class RemoteOpenLike(RemoteModel):
         OpenAI's reasoning models (the gpt-5 family and o-series) reject any
         temperature other than the default with HTTP 400 ("Only the default
         (1) value is supported"), on both openai.com and Azure OpenAI
-        deployments. For those models the request body must omit the field
-        entirely or every call fails. Matched on the bare deployment/model
-        name so provider-prefixed registrations (``azure-openai/gpt-5``) are
+        deployments; Claude 4.7 and newer removed the sampling parameters
+        altogether and 400 the same way (see
+        ``_CLAUDE_NO_SAMPLING_PREFIXES``). For those models the request body
+        must omit the field entirely or every call fails. Matched on the bare
+        deployment/model name so provider-prefixed registrations
+        (``azure-openai/gpt-5``, ``azure-anthropic/claude-fable-5``) are
         covered too. Deployments that can't be recognized by name are caught
         at runtime instead: a temperature-rejection 400 lands them in
         ``_temperature_unsupported_models`` (see ``__infer``).
@@ -2722,6 +2740,8 @@ class RemoteOpenLike(RemoteModel):
         if name == "gpt-5" or name.startswith("gpt-5-"):
             return False
         if re.match(r"^o[134](-|$)", name):
+            return False
+        if name.startswith(_CLAUDE_NO_SAMPLING_PREFIXES):
             return False
         return True
 
@@ -4867,6 +4887,11 @@ class RemoteAzureClaude(RemoteAzureOpenLike):
         # OpenAI surface's 2.0); clamp so a shared router temperature that's
         # valid for other providers can't trigger a 400 here.
         temperature = max(0.0, min(temperature, 1.0))
+        # Claude 4.7+ deployments (Fable 5 among them) reject the field
+        # outright rather than clamping it, so it has to be left out. A
+        # deployment name we can't recognize is handled at runtime by the
+        # rejection retry below.
+        send_temperature = self._supports_custom_temperature(self.model)
         context_extra = self._build_context_extra(
             patient_context,
             pubmed_context,
@@ -4893,14 +4918,42 @@ class RemoteAzureClaude(RemoteAzureOpenLike):
             cleaned_messages = [
                 {"role": m.get("role"), "content": m.get("content")} for m in messages
             ]
-            body = {
+            body: dict[str, Any] = {
                 "model": self.model,
                 "max_tokens": self.MAX_OUTPUT_TOKENS,
                 "system": system_prompt,
                 "messages": cleaned_messages,
-                "temperature": temperature,
             }
-            result = await self._messages_request(url, headers, body, timeout=timeout)
+            if send_temperature:
+                body["temperature"] = temperature
+            try:
+                result = await self._messages_request(
+                    url, headers, body, timeout=timeout
+                )
+            except aiohttp.ClientResponseError as e:
+                if not (
+                    send_temperature
+                    and _http_error_indicates_unsupported_temperature(
+                        e.status, e.message or ""
+                    )
+                ):
+                    raise
+                # A sampling-free Claude behind a deployment name the
+                # name-based check couldn't recognize. Remember it so later
+                # calls skip the field, and retry this one without it.
+                logger.warning(
+                    f"Model {self.model} at {self.api_base} rejected "
+                    f"'temperature'; retrying without it and omitting it for "
+                    f"this deployment from now on."
+                )
+                self._temperature_unsupported_models.add(self.model)
+                send_temperature = False
+                # Fresh dict rather than popping in place: the sent body may
+                # still be referenced elsewhere (e.g. captured by tests).
+                body = {k: v for k, v in body.items() if k != "temperature"}
+                result = await self._messages_request(
+                    url, headers, body, timeout=timeout
+                )
             if result and result[0]:
                 return result
         return None
@@ -4928,7 +4981,23 @@ class RemoteAzureClaude(RemoteAzureOpenLike):
             )
             async with aiohttp.ClientSession(timeout=client_timeout) as session:
                 async with session.post(url, headers=headers, json=body) as response:
-                    response.raise_for_status()
+                    # Read the error body BEFORE raise_for_status() (same
+                    # rationale as RemoteOpenLike.__infer: raising can release
+                    # the connection and make text() unreadable afterwards),
+                    # then carry it on the exception -- aiohttp's own message
+                    # is only the HTTP reason phrase, and _do_infer's
+                    # unsupported-temperature retry classifies on the body.
+                    response_body = ""
+                    if response.status >= 400:
+                        try:
+                            response_body = await response.text()
+                        except Exception:
+                            response_body = "<failed to read response body>"
+                    try:
+                        response.raise_for_status()
+                    except aiohttp.ClientResponseError as e:
+                        e.message = response_body or e.message
+                        raise
                     json_result = await response.json()
             return self._parse_messages_response(json_result)
 

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -286,11 +286,19 @@ def _http_error_indicates_context_overflow(status: int, body: Optional[str]) -> 
     return "prompt is too long" in lowered or "input is too long" in lowered
 
 
-# Claude models that dropped the sampling parameters: on Claude 4.7 and newer
-# (including the Claude 5 family) ``temperature``/``top_p``/``top_k`` are not
-# just clamped but rejected outright with HTTP 400, so the field has to be
-# omitted from the request body. Claude 4.6 and older still accept it. Matched
-# as a prefix so dated snapshot ids (``claude-opus-4-8-20260115``) are covered.
+# Claude models that dropped the sampling parameters: ``temperature`` /
+# ``top_p`` / ``top_k`` are not clamped but rejected outright with HTTP 400, so
+# the field has to be omitted from the request body. Claude 4.6 and older still
+# accept it. Matched as a prefix so dated snapshot ids
+# (``claude-opus-4-8-20260115``) are covered.
+#
+# This ENUMERATES the released model ids that behave this way rather than
+# deriving them from a version rule -- there is no Sonnet/Haiku 4.7 or Haiku 5
+# to list, and guessing a rule for ids that do not exist yet would be a
+# fiction. A model missing from this table is not stranded: the transports
+# classify a rejection at runtime (see
+# ``_http_error_indicates_unsupported_temperature``) and drop the field from
+# then on. Add new ids here so that costs one 400 instead of nothing.
 _CLAUDE_NO_SAMPLING_PREFIXES: tuple[str, ...] = (
     "claude-fable-5",
     "claude-mythos-5",
@@ -303,14 +311,20 @@ _CLAUDE_NO_SAMPLING_PREFIXES: tuple[str, ...] = (
 
 def _http_error_indicates_unsupported_temperature(status: int, body: str) -> bool:
     """True when a 400 means the model rejected the ``temperature`` parameter
-    outright (OpenAI/Azure reasoning models accept only the default value).
+    outright (reasoning/no-sampling models accept only the default value).
 
     Name-based detection in ``_supports_custom_temperature`` can't recognize a
-    reasoning model behind a custom deployment name (e.g. an Azure gpt-5
-    deployment called "appeals-prod"), so the transport uses this to fall back
-    at runtime: retry the request once without the field and remember the
-    deployment. Matched loosely on the error text, e.g. "Unsupported value:
-    'temperature' ... Only the default (1) value is supported."
+    model behind a custom deployment name (e.g. an Azure gpt-5 deployment
+    called "appeals-prod", or a Foundry Fable deployment called
+    "appeals-fable"), so the transports use this to fall back at runtime:
+    retry the request once without the field and remember the deployment.
+
+    Matched loosely, because the two surfaces word it differently: OpenAI and
+    Azure OpenAI say "Unsupported value: 'temperature' ... Only the default
+    (1) value is supported.", while the Anthropic Messages API rejects a
+    removed field as an ``invalid_request_error`` reading "temperature: Extra
+    inputs are not permitted". Matching only the OpenAI phrasing would leave
+    the fallback dead on the Messages transport.
     """
     if status != 400 or not body:
         return False
@@ -321,7 +335,53 @@ def _http_error_indicates_unsupported_temperature(status: int, body: str) -> boo
         "unsupported" in lowered
         or "only the default" in lowered
         or "not supported" in lowered
+        or "not permitted" in lowered
+        or "extra input" in lowered
+        or "unexpected" in lowered
     )
+
+
+# Cap on the provider error body we retain. Long enough for every classifier
+# and log preview here, short enough that a gateway's HTML error page can't
+# reach a log line or the persisted attempt record whole.
+_ERROR_BODY_LIMIT = 4000
+
+
+async def _read_error_body(response) -> str:
+    """Read an aiohttp error response body for classification, or "" if the
+    status is not an error.
+
+    Read BEFORE raise_for_status(): depending on the aiohttp version, raising
+    can release the connection and make text() unreadable afterwards, which
+    would reduce every error body to the fallback string — hiding the payload
+    from the logs and from the error classifiers the retry paths depend on.
+    Truncated to ``_ERROR_BODY_LIMIT``; callers may shorten further for logs.
+    """
+    if response.status < 400:
+        return ""
+    try:
+        body = str(await response.text())
+    except Exception:
+        return "<failed to read response body>"
+    return body[:_ERROR_BODY_LIMIT]
+
+
+def _attach_error_body(exc: aiohttp.ClientResponseError, body: str) -> None:
+    """Carry the provider's response body on the exception for callers that
+    classify on it.
+
+    A dedicated attribute rather than ``exc.message``: that field is the HTTP
+    reason phrase every log site, ``describe_model_error``, the persisted
+    attempt record, and ``model_health_check._categorize_http_error`` read, and
+    overwriting it with a body would both bloat those and flip the health
+    check's "400 mentioning model" heuristic to MODEL_NOT_FOUND.
+    """
+    setattr(exc, "fhi_response_body", body)
+
+
+def _error_body_of(exc: aiohttp.ClientResponseError) -> str:
+    """The body attached by ``_attach_error_body``, or "" when there is none."""
+    return getattr(exc, "fhi_response_body", "") or ""
 
 
 def _count_items(items: list[str]) -> dict[str, int]:
@@ -2120,6 +2180,12 @@ class RemoteOpenLike(RemoteModel):
         if infer_type == "full" and not self._expensive and not self.slow:
             # Special case for the full one where we really want to explore the problem space
             temperatures = [0.6, 0.1]
+            if not self._supports_custom_temperature(self.model):
+                # Models that reject the sampling parameters (Claude 4.7+) get
+                # the field omitted, so the two legs would post byte-identical
+                # bodies: a second paid call per system prompt buying no
+                # diversity. Keep one leg rather than pay twice for it.
+                temperatures = [0.6]
         system_prompts = self.get_system_prompts(infer_type, prof_pov)
         calls = itertools.chain.from_iterable(
             map(
@@ -2732,7 +2798,9 @@ class RemoteOpenLike(RemoteModel):
         (``azure-openai/gpt-5``, ``azure-anthropic/claude-fable-5``) are
         covered too. Deployments that can't be recognized by name are caught
         at runtime instead: a temperature-rejection 400 lands them in
-        ``_temperature_unsupported_models`` (see ``__infer``).
+        ``_temperature_unsupported_models`` (see ``__infer`` for the
+        OpenAI-compatible transport and ``RemoteAzureClaude._do_infer`` for
+        the Anthropic Messages one).
         """
         if model in self._temperature_unsupported_models:
             return False
@@ -3068,19 +3136,7 @@ class RemoteOpenLike(RemoteModel):
                         headers={"Authorization": f"Bearer {self.token}"},
                         json=request_body,
                     ) as response:
-                        # Read the error body BEFORE raise_for_status():
-                        # depending on the aiohttp version, raising can
-                        # release the connection and make text() unreadable
-                        # afterwards, which would reduce every error body to
-                        # the fallback string — hiding the payload from the
-                        # logs and from the unsupported-temperature detection
-                        # the retry below depends on.
-                        response_body = ""
-                        if response.status >= 400:
-                            try:
-                                response_body = await response.text()
-                            except Exception:
-                                response_body = "<failed to read response body>"
+                        response_body = await _read_error_body(response)
                         # Raise ClientResponseError for HTTP error status codes (4xx, 5xx)
                         # This allows subclasses to catch and handle specific errors like 429
                         try:
@@ -4926,34 +4982,47 @@ class RemoteAzureClaude(RemoteAzureOpenLike):
             }
             if send_temperature:
                 body["temperature"] = temperature
+            attempt_timeout = timeout if timeout is not None else self._timeout
+            started = time.monotonic()
             try:
                 result = await self._messages_request(
-                    url, headers, body, timeout=timeout
+                    url, headers, body, timeout=attempt_timeout
                 )
             except aiohttp.ClientResponseError as e:
-                if not (
-                    send_temperature
-                    and _http_error_indicates_unsupported_temperature(
-                        e.status, e.message or ""
-                    )
+                if send_temperature and _http_error_indicates_unsupported_temperature(
+                    e.status, _error_body_of(e)
                 ):
+                    # A sampling-free Claude behind a deployment name the
+                    # name-based check couldn't recognize. Remember it so later
+                    # calls skip the field, and retry this one without it.
+                    logger.warning(
+                        f"Model {self.model} at {self.api_base} rejected "
+                        f"'temperature'; retrying without it and omitting it "
+                        f"for this deployment from now on."
+                    )
+                    self._temperature_unsupported_models.add(self.model)
+                    send_temperature = False
+                    # Fresh dict rather than popping in place: the sent body may
+                    # still be referenced elsewhere (e.g. captured by tests).
+                    body = {k: v for k, v in body.items() if k != "temperature"}
+                    # The retry shares the first attempt's budget rather than
+                    # starting a fresh one, so a slow rejection can't let one
+                    # _do_infer call run for twice the caller's timeout.
+                    retry_timeout = None
+                    if attempt_timeout is not None:
+                        retry_timeout = attempt_timeout - (time.monotonic() - started)
+                        if retry_timeout <= 0:
+                            logger.warning(
+                                f"No budget left to retry {self.model} without "
+                                f"'temperature' after a {attempt_timeout:.0f}s "
+                                f"attempt."
+                            )
+                            return None
+                    result = await self._messages_request(
+                        url, headers, body, timeout=retry_timeout
+                    )
+                else:
                     raise
-                # A sampling-free Claude behind a deployment name the
-                # name-based check couldn't recognize. Remember it so later
-                # calls skip the field, and retry this one without it.
-                logger.warning(
-                    f"Model {self.model} at {self.api_base} rejected "
-                    f"'temperature'; retrying without it and omitting it for "
-                    f"this deployment from now on."
-                )
-                self._temperature_unsupported_models.add(self.model)
-                send_temperature = False
-                # Fresh dict rather than popping in place: the sent body may
-                # still be referenced elsewhere (e.g. captured by tests).
-                body = {k: v for k, v in body.items() if k != "temperature"}
-                result = await self._messages_request(
-                    url, headers, body, timeout=timeout
-                )
             if result and result[0]:
                 return result
         return None
@@ -4981,22 +5050,13 @@ class RemoteAzureClaude(RemoteAzureOpenLike):
             )
             async with aiohttp.ClientSession(timeout=client_timeout) as session:
                 async with session.post(url, headers=headers, json=body) as response:
-                    # Read the error body BEFORE raise_for_status() (same
-                    # rationale as RemoteOpenLike.__infer: raising can release
-                    # the connection and make text() unreadable afterwards),
-                    # then carry it on the exception -- aiohttp's own message
-                    # is only the HTTP reason phrase, and _do_infer's
-                    # unsupported-temperature retry classifies on the body.
-                    response_body = ""
-                    if response.status >= 400:
-                        try:
-                            response_body = await response.text()
-                        except Exception:
-                            response_body = "<failed to read response body>"
+                    response_body = await _read_error_body(response)
                     try:
                         response.raise_for_status()
                     except aiohttp.ClientResponseError as e:
-                        e.message = response_body or e.message
+                        # Carry the body alongside the reason phrase (never
+                        # over it) so _do_infer can classify a rejection.
+                        _attach_error_body(e, response_body)
                         raise
                     json_result = await response.json()
             return self._parse_messages_response(json_result)
@@ -5019,6 +5079,15 @@ class RemoteAzureClaude(RemoteAzureOpenLike):
         ``text`` content blocks, then apply the same validity check and
         reasoning-answer extraction as the OpenAI path."""
         blocks = json_result.get("content") or []
+        if json_result.get("stop_reason") == "max_tokens":
+            # The letter is cut off mid-sentence but still reads as valid text,
+            # so nothing downstream would notice. Most likely on a deployment
+            # whose thinking cannot be turned off (Claude 5 family): thinking
+            # tokens are drawn from the same MAX_OUTPUT_TOKENS budget.
+            logger.warning(
+                f"{self.model} hit its {self.MAX_OUTPUT_TOKENS}-token output "
+                f"budget; the response is truncated."
+            )
         text = "".join(
             block.get("text", "")
             for block in blocks

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -4943,11 +4943,6 @@ class RemoteAzureClaude(RemoteAzureOpenLike):
         # OpenAI surface's 2.0); clamp so a shared router temperature that's
         # valid for other providers can't trigger a 400 here.
         temperature = max(0.0, min(temperature, 1.0))
-        # Claude 4.7+ deployments (Fable 5 among them) reject the field
-        # outright rather than clamping it, so it has to be left out. A
-        # deployment name we can't recognize is handled at runtime by the
-        # rejection retry below.
-        send_temperature = self._supports_custom_temperature(self.model)
         context_extra = self._build_context_extra(
             patient_context,
             pubmed_context,
@@ -4980,6 +4975,23 @@ class RemoteAzureClaude(RemoteAzureOpenLike):
                 "system": system_prompt,
                 "messages": cleaned_messages,
             }
+            # Claude 4.7+ deployments (Fable 5 among them) reject the field
+            # outright rather than clamping it, so it has to be left out. A
+            # deployment name we can't recognize is handled at runtime by the
+            # rejection retry below.
+            #
+            # Re-read per prompt rather than once per call: parallel_infer
+            # fans out concurrently, so a sibling leg may have recorded the
+            # rejection since this call started, and picking that up here
+            # skips a wasted 400. It cannot close the window entirely --
+            # legs that start together both send the field once, and after
+            # their retries post identical bodies. That costs one duplicate
+            # premium call per system prompt, once per unrecognized
+            # deployment per process; every later appeal takes the
+            # single-leg path in parallel_infer. Closing it fully would need
+            # a pre-flight probe on every deployment or cross-leg locking on
+            # the request path, which costs more than the duplicate it saves.
+            send_temperature = self._supports_custom_temperature(self.model)
             if send_temperature:
                 body["temperature"] = temperature
             attempt_timeout = timeout if timeout is not None else self._timeout
@@ -5001,7 +5013,6 @@ class RemoteAzureClaude(RemoteAzureOpenLike):
                         f"for this deployment from now on."
                     )
                     self._temperature_unsupported_models.add(self.model)
-                    send_temperature = False
                     # Fresh dict rather than popping in place: the sent body may
                     # still be referenced elsewhere (e.g. captured by tests).
                     body = {k: v for k, v in body.items() if k != "temperature"}

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -4805,10 +4805,12 @@ class RemoteAzureClaude(RemoteAzureOpenLike):
 
     # Latest Claude models (cheapest -> premium). Deployment names default to
     # the canonical model ids; override with AZURE_ANTHROPIC_MODELS if your
-    # Foundry deployments use different names. Fable 5 is the most capable (and
-    # priciest, ~2x Opus per token) deployment, so it sorts last: it shares the
-    # "premium" tier with Opus, and cost-ordering breaks the routing tie in
-    # Opus's favor (see MLRouter.best_external_models).
+    # Foundry deployments use different names. The cost column is the router's
+    # rough ordering proxy (see ModelDescription), not a per-token price: Fable
+    # 5 is the most capable and the priciest deployment, so it carries the
+    # highest proxy and sorts last. It shares the "premium" tier with Opus, and
+    # that cost ordering breaks the routing tie in Opus's favor (see
+    # MLRouter.best_external_models).
     DEFAULT_MODELS: ClassVar[List[Tuple[str, int, str]]] = [
         ("claude-haiku-4-5", 55, "speed"),
         ("claude-sonnet-4-6", 95, "quality"),

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -4805,11 +4805,15 @@ class RemoteAzureClaude(RemoteAzureOpenLike):
 
     # Latest Claude models (cheapest -> premium). Deployment names default to
     # the canonical model ids; override with AZURE_ANTHROPIC_MODELS if your
-    # Foundry deployments use different names.
+    # Foundry deployments use different names. Fable 5 is the most capable (and
+    # priciest, ~2x Opus per token) deployment, so it sorts last: it shares the
+    # "premium" tier with Opus, and cost-ordering breaks the routing tie in
+    # Opus's favor (see MLRouter.best_external_models).
     DEFAULT_MODELS: ClassVar[List[Tuple[str, int, str]]] = [
         ("claude-haiku-4-5", 55, "speed"),
         ("claude-sonnet-4-6", 95, "quality"),
         ("claude-opus-4-8", 135, "premium"),
+        ("claude-fable-5", 175, "premium"),
     ]
 
     # Per-subclass rate-limit state (do not share across providers).

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -4169,7 +4169,14 @@ class RateLimitedRemoteOpenLike(RemoteFullOpenLike):
     # (>=101) so internal backends stay preferred. Used to rank the "best"
     # external models for fan-out (MLRouter.best_external_models). Subclasses
     # expose each model's tier via get_tier().
+    #
+    # "frontier" sits above "premium" for the strongest (and priciest) models a
+    # provider offers. Without it every premium model ties at 98 and the
+    # cost-ordered stable sort puts the priciest one last, so a frontier model
+    # would never survive the default limit=3 slice -- registered, probed and
+    # billed, but never actually generating anything.
     _TIER_QUALITY: ClassVar[dict[str, int]] = {
+        "frontier": 100,
         "premium": 98,
         "quality": 92,
         "speed": 80,
@@ -4177,9 +4184,9 @@ class RateLimitedRemoteOpenLike(RemoteFullOpenLike):
     }
 
     def get_tier(self) -> str:
-        """Provider tier (speed/quality/premium/custom). Concrete subclasses
-        override with their own per-model mapping; this default keeps
-        ``quality()`` robust if a subclass omits it."""
+        """Provider tier (speed/quality/premium/frontier/custom). Concrete
+        subclasses override with their own per-model mapping; this default
+        keeps ``quality()`` robust if a subclass omits it."""
         return "unknown"
 
     def quality(self) -> int:
@@ -4767,7 +4774,8 @@ class RemoteAzureOpenLike(RateLimitedRemoteOpenLike):
         return True
 
     def get_tier(self) -> str:
-        """Get the tier (speed/quality/premium/custom) for this model."""
+        """Get the tier (speed/quality/premium/frontier/custom) for this
+        model."""
         for deployment, _cost, tier in self._configured_deployments():
             if deployment == self.model:
                 return tier
@@ -4879,19 +4887,21 @@ class RemoteAzureClaude(RemoteAzureOpenLike):
     # The Messages API requires an explicit max output token budget.
     MAX_OUTPUT_TOKENS: ClassVar[int] = 8192
 
-    # Latest Claude models (cheapest -> premium). Deployment names default to
+    # Latest Claude models (cheapest -> priciest). Deployment names default to
     # the canonical model ids; override with AZURE_ANTHROPIC_MODELS if your
     # Foundry deployments use different names. The cost column is the router's
-    # rough ordering proxy (see ModelDescription), not a per-token price: Fable
-    # 5 is the most capable and the priciest deployment, so it carries the
-    # highest proxy and sorts last. It shares the "premium" tier with Opus, and
-    # that cost ordering breaks the routing tie in Opus's favor (see
-    # MLRouter.best_external_models).
+    # rough ordering proxy (see ModelDescription), not a per-token price.
+    #
+    # Fable 5 is the most capable and the priciest deployment, so it carries
+    # the highest proxy and the "frontier" tier -- which outranks Opus's
+    # "premium" in MLRouter.best_external_models, so it is preferred rather
+    # than merely registered. Cost only breaks ties WITHIN a tier, so leaving
+    # it at "premium" would have kept it out of the default fan-out entirely.
     DEFAULT_MODELS: ClassVar[List[Tuple[str, int, str]]] = [
         ("claude-haiku-4-5", 55, "speed"),
         ("claude-sonnet-4-6", 95, "quality"),
         ("claude-opus-4-8", 135, "premium"),
-        ("claude-fable-5", 175, "premium"),
+        ("claude-fable-5", 175, "frontier"),
     ]
 
     # Per-subclass rate-limit state (do not share across providers).

--- a/tests/async-unit/test_azure_models.py
+++ b/tests/async-unit/test_azure_models.py
@@ -203,7 +203,7 @@ class TestAzureBackends(unittest.TestCase):
 
     @patch.dict(os.environ, AZURE_CLAUDE_ENV)
     def test_claude_models_use_latest_ids(self):
-        """Azure Claude exposes the latest Haiku/Sonnet/Opus-4.8 deployments."""
+        """Azure Claude exposes the latest Haiku/Sonnet/Opus/Fable deployments."""
         names = {m.name for m in RemoteAzureClaude.models()}
         self.assertEqual(
             names,
@@ -211,7 +211,19 @@ class TestAzureBackends(unittest.TestCase):
                 "azure-anthropic/claude-haiku-4-5",
                 "azure-anthropic/claude-sonnet-4-6",
                 "azure-anthropic/claude-opus-4-8",
+                "azure-anthropic/claude-fable-5",
             },
+        )
+
+    @patch.dict(os.environ, AZURE_CLAUDE_ENV)
+    def test_claude_fable_is_priciest_premium_deployment(self):
+        """Fable 5 is premium-tier and sorts last (priciest) in models()."""
+        models = RemoteAzureClaude.models()
+        costs = [m.cost for m in models]
+        self.assertEqual(costs, sorted(costs))  # cheapest -> premium
+        self.assertEqual(models[-1].name, "azure-anthropic/claude-fable-5")
+        self.assertEqual(
+            RemoteAzureClaude(model="claude-fable-5").get_tier(), "premium"
         )
 
     def test_models_disabled_without_env(self):

--- a/tests/async-unit/test_azure_models.py
+++ b/tests/async-unit/test_azure_models.py
@@ -9,11 +9,13 @@ record readable model names, and the ENABLED_REMOTE_MODELS allow-list.
 import asyncio
 import os
 import unittest
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import patch, MagicMock, AsyncMock
 
 import aiohttp
 
 from fighthealthinsurance.ml.ml_models import (
+    _CLAUDE_NO_SAMPLING_PREFIXES,
     ModelDescription,
     RemoteAzureClaude,
     RemoteAzureOpenAI,
@@ -45,6 +47,18 @@ def _clear_azure_env():
         "ENABLED_REMOTE_MODELS",
     ):
         os.environ.pop(k, None)
+
+
+# Provider wording for a temperature rejection. The two surfaces phrase it
+# differently, and both must reach _http_error_indicates_unsupported_temperature.
+OPENAI_TEMPERATURE_REJECTION_TEXT = (
+    "Unsupported value: 'temperature' does not support 0.7 with this "
+    "model. Only the default (1) value is supported."
+)
+ANTHROPIC_TEMPERATURE_REJECTION_TEXT = (
+    '{"type":"error","error":{"type":"invalid_request_error",'
+    '"message":"temperature: Extra inputs are not permitted"}}'
+)
 
 
 class _FakeAiohttpResponse:
@@ -379,10 +393,7 @@ class TestAzureInfer(unittest.TestCase):
         body = self._capture_chat_completions_body("gpt-4.1-mini")
         self.assertIn("temperature", body)
 
-    _TEMPERATURE_REJECTION_TEXT = (
-        "Unsupported value: 'temperature' does not support 0.7 with this "
-        "model. Only the default (1) value is supported."
-    )
+    _TEMPERATURE_REJECTION_TEXT = OPENAI_TEMPERATURE_REJECTION_TEXT
     _OK_COMPLETION = {"choices": [{"message": {"content": "Dear insurer, please."}}]}
 
     @patch.dict(os.environ, AZURE_OPENAI_ENV)
@@ -444,10 +455,6 @@ class TestAzureInfer(unittest.TestCase):
 class TestAzureClaudeMessages(unittest.TestCase):
     """RemoteAzureClaude's Anthropic Messages API transport (Foundry)."""
 
-    _TEMPERATURE_REJECTION_TEXT = (
-        "Unsupported value: 'temperature' does not support 0.7 with this "
-        "model. Only the default (1) value is supported."
-    )
 
     def setUp(self):
         """Reset Claude rate-limiter state and Azure env before each test."""
@@ -540,7 +547,12 @@ class TestAzureClaudeMessages(unittest.TestCase):
             )
             session = _FakeAiohttpSession(response, capture)
             with patch.object(aiohttp, "ClientSession", return_value=session):
-                await m._infer(system_prompts=["x"], prompt="y", **infer_kwargs)
+                result = await m._infer(
+                    system_prompts=["x"], prompt="y", **infer_kwargs
+                )
+            # _infer swallows post-POST failures and returns None, which would
+            # leave the captured body asserting over a crashed call.
+            self.assertEqual(result, ("ok", []))
 
         asyncio.run(run())
         return capture["json"]
@@ -565,8 +577,9 @@ class TestAzureClaudeMessages(unittest.TestCase):
     @patch.dict(os.environ, AZURE_CLAUDE_ENV)
     def test_custom_claude_deployment_temperature_rejection_retries_without(self):
         """A sampling-free Claude behind a custom AZURE_ANTHROPIC_MODELS name
-        can't be recognized by name, so the 400 must trigger a single retry
-        with temperature stripped instead of failing the call."""
+        can't be recognized by name, so the Messages API's own rejection
+        wording must trigger a single retry with temperature stripped instead
+        of failing the call."""
 
         async def run():
             """Queue a temperature-rejection 400 then a 200 and inspect bodies."""
@@ -575,7 +588,7 @@ class TestAzureClaudeMessages(unittest.TestCase):
             session = _FakeSequencedSession(
                 [
                     _FakeAiohttpResponse(
-                        status=400, text=self._TEMPERATURE_REJECTION_TEXT
+                        status=400, text=ANTHROPIC_TEMPERATURE_REJECTION_TEXT
                     ),
                     _FakeAiohttpResponse({"content": [{"type": "text", "text": "ok"}]}),
                 ],
@@ -593,17 +606,89 @@ class TestAzureClaudeMessages(unittest.TestCase):
         asyncio.run(run())
 
     @patch.dict(os.environ, AZURE_CLAUDE_ENV)
-    def test_non_temperature_400_still_propagates(self):
-        """A 400 that isn't a temperature rejection is not retried."""
+    def test_error_body_does_not_overwrite_http_reason_phrase(self):
+        """The provider body rides alongside ClientResponseError.message, never
+        over it: model_health_check._categorize_http_error classifies a 400 as
+        MODEL_NOT_FOUND when .message mentions "model", and every log site and
+        the persisted attempt record interpolate it."""
 
         async def run():
-            """Force an unrelated 400 and assert it raises."""
+            """Force a 400 whose body mentions "model" and inspect the error."""
             m = RemoteAzureClaude(model="claude-sonnet-4-6")
-            response = _FakeAiohttpResponse(status=400, text="invalid_request: nope")
+            response = _FakeAiohttpResponse(
+                status=400,
+                text="max_tokens: 8192 exceeds the maximum for this model",
+            )
             session = _FakeAiohttpSession(response)
+            with patch.object(aiohttp, "ClientSession", return_value=session):
+                with self.assertRaises(aiohttp.ClientResponseError) as ctx:
+                    await m._infer(system_prompts=["x"], prompt="y")
+            self.assertEqual(ctx.exception.message, "error")
+            self.assertIn("max_tokens", getattr(ctx.exception, "fhi_response_body"))
+
+        asyncio.run(run())
+
+    @patch.dict(os.environ, AZURE_CLAUDE_ENV)
+    def test_every_no_sampling_prefix_is_recognized(self):
+        """Each id in _CLAUDE_NO_SAMPLING_PREFIXES must actually be matched — a
+        typo there ships silently and 400s every call to that deployment."""
+        m = RemoteAzureClaude(model="claude-sonnet-4-6")
+        for name in _CLAUDE_NO_SAMPLING_PREFIXES:
+            with self.subTest(model=name):
+                self.assertFalse(m._supports_custom_temperature(name))
+                # Dated snapshot ids of the same model match too.
+                self.assertFalse(m._supports_custom_temperature(f"{name}-20260115"))
+
+    @patch.dict(os.environ, AZURE_CLAUDE_ENV)
+    def test_full_appeal_does_not_fan_out_identical_legs(self):
+        """parallel_infer explores with two temperatures; for a model that
+        drops the field both legs would post the same body, so it must submit
+        one leg instead of paying twice for an identical request."""
+        with patch.object(
+            RemoteAzureClaude, "_blocking_checked_infer", return_value=("x", None)
+        ):
+            fable = RemoteAzureClaude(model="claude-fable-5")
+            sonnet = RemoteAzureClaude(model="claude-sonnet-4-6")
+            executor = ThreadPoolExecutor(max_workers=2)
+            try:
+                kwargs = dict(
+                    prompt="appeal this",
+                    infer_type="full",
+                    patient_context=None,
+                    plan_context=None,
+                    pubmed_context=None,
+                    submit_executor=executor,
+                )
+                fable_calls = len(fable.parallel_infer(**kwargs))
+                sonnet_calls = len(sonnet.parallel_infer(**kwargs))
+            finally:
+                executor.shutdown(wait=True)
+        # Same system prompts either way, so the ratio is the temperature legs.
+        self.assertEqual(sonnet_calls, 2 * fable_calls)
+
+    @patch.dict(os.environ, AZURE_CLAUDE_ENV)
+    def test_non_temperature_400_still_propagates_without_retrying(self):
+        """A 400 that isn't a temperature rejection raises on the first
+        attempt: the classifier matches loosely, so a mismatch would other-
+        wise turn every unrelated 400 into two paid round-trips and poison
+        the deployment's memo."""
+
+        async def run():
+            """Force an unrelated 400 and count the POSTs it produced."""
+            m = RemoteAzureClaude(model="claude-sonnet-4-6")
+            bodies: list = []
+            session = _FakeSequencedSession(
+                [
+                    _FakeAiohttpResponse(status=400, text="invalid_request: nope"),
+                    _FakeAiohttpResponse({"content": [{"type": "text", "text": "ok"}]}),
+                ],
+                bodies,
+            )
             with patch.object(aiohttp, "ClientSession", return_value=session):
                 with self.assertRaises(aiohttp.ClientResponseError):
                     await m._infer(system_prompts=["x"], prompt="y")
+            self.assertEqual(len(bodies), 1)
+            self.assertNotIn("claude-sonnet-4-6", m._temperature_unsupported_models)
 
         asyncio.run(run())
 

--- a/tests/async-unit/test_azure_models.py
+++ b/tests/async-unit/test_azure_models.py
@@ -667,6 +667,79 @@ class TestAzureClaudeMessages(unittest.TestCase):
         self.assertEqual(sonnet_calls, 2 * fable_calls)
 
     @patch.dict(os.environ, AZURE_CLAUDE_ENV)
+    def test_concurrent_legs_rejection_is_picked_up_mid_call(self):
+        """parallel_infer fans out concurrently, so a sibling leg can record a
+        rejection while this call is between system prompts. The memo is
+        re-read per prompt so the next request skips the field instead of
+        spending another 400 to learn what the process already knows."""
+
+        async def run():
+            """Have a sibling record the rejection after the first request."""
+            m = RemoteAzureClaude(model="appeals-fable")
+            bodies: list = []
+
+            class _SiblingLearnsSession(_FakeSequencedSession):
+                """Stand-in whose first POST simulates a concurrent leg
+                recording the deployment as sampling-free."""
+
+                def post(self, url, headers=None, json=None):
+                    """Record the body, then poison the memo like a sibling."""
+                    response = super().post(url, headers=headers, json=json)
+                    m._temperature_unsupported_models.add("appeals-fable")
+                    return response
+
+            ok = {"content": [{"type": "text", "text": ""}]}
+            session = _SiblingLearnsSession(
+                [
+                    _FakeAiohttpResponse(ok),
+                    _FakeAiohttpResponse({"content": [{"type": "text", "text": "ok"}]}),
+                ],
+                bodies,
+            )
+            with patch.object(aiohttp, "ClientSession", return_value=session):
+                result = await m._infer(system_prompts=["a", "b"], prompt="y")
+            self.assertEqual(result, ("ok", []))
+            self.assertEqual(len(bodies), 2)
+            self.assertIn("temperature", bodies[0])
+            self.assertNotIn("temperature", bodies[1])
+
+        asyncio.run(run())
+
+    @patch.dict(os.environ, AZURE_CLAUDE_ENV)
+    def test_learned_rejection_skips_the_field_on_the_next_prompt(self):
+        """A rejection learned on one system prompt stops the field being sent
+        on the next one in the same call."""
+
+        async def run():
+            """Reject the first prompt's request, then inspect both bodies."""
+            m = RemoteAzureClaude(model="appeals-fable")
+            bodies: list = []
+            ok = {"content": [{"type": "text", "text": ""}]}
+            session = _FakeSequencedSession(
+                [
+                    # Prompt 1: rejection, then the stripped retry -- which
+                    # returns no text, so _do_infer moves to prompt 2.
+                    _FakeAiohttpResponse(
+                        status=400, text=ANTHROPIC_TEMPERATURE_REJECTION_TEXT
+                    ),
+                    _FakeAiohttpResponse(ok),
+                    _FakeAiohttpResponse({"content": [{"type": "text", "text": "ok"}]}),
+                ],
+                bodies,
+            )
+            with patch.object(aiohttp, "ClientSession", return_value=session):
+                result = await m._infer(system_prompts=["a", "b"], prompt="y")
+            self.assertEqual(result, ("ok", []))
+            # 1st sent it, 1st retry stripped it, and the 2nd prompt never
+            # sent it again -- three requests, not four.
+            self.assertEqual(len(bodies), 3)
+            self.assertIn("temperature", bodies[0])
+            self.assertNotIn("temperature", bodies[1])
+            self.assertNotIn("temperature", bodies[2])
+
+        asyncio.run(run())
+
+    @patch.dict(os.environ, AZURE_CLAUDE_ENV)
     def test_non_temperature_400_still_propagates_without_retrying(self):
         """A 400 that isn't a temperature rejection raises on the first
         attempt: the classifier matches loosely, so a mismatch would other-

--- a/tests/async-unit/test_azure_models.py
+++ b/tests/async-unit/test_azure_models.py
@@ -230,18 +230,37 @@ class TestAzureBackends(unittest.TestCase):
         )
 
     @patch.dict(os.environ, AZURE_CLAUDE_ENV)
-    def test_claude_fable_is_priciest_premium_deployment(self):
-        """Fable 5 is premium-tier and sorts last (priciest) in models()."""
+    def test_claude_fable_is_the_priciest_deployment(self):
+        """Fable 5 sorts last (priciest) in models()."""
         models = RemoteAzureClaude.models()
         costs = [m.cost for m in models]
-        self.assertEqual(costs, sorted(costs))  # cheapest -> premium
+        self.assertEqual(costs, sorted(costs))  # cheapest -> priciest
         self.assertEqual(models[-1].name, "azure-anthropic/claude-fable-5")
-        # Pin the proxy value: it is what orders Fable behind Opus in the
-        # router's tie-break, so a drift here silently changes routing.
         self.assertEqual(models[-1].cost, 175)
-        self.assertEqual(
-            RemoteAzureClaude(model="claude-fable-5").get_tier(), "premium"
-        )
+
+    @patch.dict(os.environ, AZURE_CLAUDE_ENV)
+    def test_claude_fable_outranks_opus_for_routing(self):
+        """Fable is frontier-tier, which must outrank Opus's premium: cost
+        only breaks ties WITHIN a tier, so an equal tier would sort the
+        priciest model last and keep it out of the default fan-out."""
+        fable = RemoteAzureClaude(model="claude-fable-5")
+        opus = RemoteAzureClaude(model="claude-opus-4-8")
+        self.assertEqual(fable.get_tier(), "frontier")
+        self.assertEqual(opus.get_tier(), "premium")
+        self.assertGreater(fable.quality(), opus.quality())
+        # Still below the internal backends' floor, which stay preferred.
+        self.assertLess(fable.quality(), 101)
+
+    @patch.dict(
+        os.environ,
+        {**AZURE_CLAUDE_ENV, **AZURE_OPENAI_ENV, "ANTHROPIC_API_KEY": "test-key"},
+    )
+    def test_router_picks_fable_in_the_default_fan_out(self):
+        """The tier is only worth anything if the router actually reaches the
+        model: with every provider configured, Fable must survive the default
+        limit=3 slice rather than sorting behind the premium models."""
+        names = [str(m) for m in MLRouter().best_external_models(3)]
+        self.assertIn("azure-anthropic/claude-fable-5", names)
 
     def test_models_disabled_without_env(self):
         """Without env config, providers (and the base) register no models."""

--- a/tests/async-unit/test_azure_models.py
+++ b/tests/async-unit/test_azure_models.py
@@ -222,6 +222,9 @@ class TestAzureBackends(unittest.TestCase):
         costs = [m.cost for m in models]
         self.assertEqual(costs, sorted(costs))  # cheapest -> premium
         self.assertEqual(models[-1].name, "azure-anthropic/claude-fable-5")
+        # Pin the proxy value: it is what orders Fable behind Opus in the
+        # router's tie-break, so a drift here silently changes routing.
+        self.assertEqual(models[-1].cost, 175)
         self.assertEqual(
             RemoteAzureClaude(model="claude-fable-5").get_tier(), "premium"
         )
@@ -441,6 +444,11 @@ class TestAzureInfer(unittest.TestCase):
 class TestAzureClaudeMessages(unittest.TestCase):
     """RemoteAzureClaude's Anthropic Messages API transport (Foundry)."""
 
+    _TEMPERATURE_REJECTION_TEXT = (
+        "Unsupported value: 'temperature' does not support 0.7 with this "
+        "model. Only the default (1) value is supported."
+    )
+
     def setUp(self):
         """Reset Claude rate-limiter state and Azure env before each test."""
         RemoteAzureClaude._rate_limiters.clear()
@@ -516,6 +524,86 @@ class TestAzureClaudeMessages(unittest.TestCase):
             with patch.object(aiohttp, "ClientSession", return_value=session):
                 await m._infer(system_prompts=["x"], prompt="y", temperature=1.8)
             self.assertEqual(capture["json"]["temperature"], 1.0)
+
+        asyncio.run(run())
+
+    def _capture_messages_body(self, model: str, **infer_kwargs) -> dict:
+        """Drive the Messages transport against a fake session and return the
+        captured request body."""
+        capture: dict = {}
+
+        async def run():
+            """Run _infer with a canned 200 Messages response."""
+            m = RemoteAzureClaude(model=model)
+            response = _FakeAiohttpResponse(
+                {"content": [{"type": "text", "text": "ok"}]}
+            )
+            session = _FakeAiohttpSession(response, capture)
+            with patch.object(aiohttp, "ClientSession", return_value=session):
+                await m._infer(system_prompts=["x"], prompt="y", **infer_kwargs)
+
+        asyncio.run(run())
+        return capture["json"]
+
+    @patch.dict(os.environ, AZURE_CLAUDE_ENV)
+    def test_fable_request_omits_temperature(self):
+        """Claude 4.7+ deployments (Fable 5 here) reject the sampling
+        parameters with HTTP 400, so the body must omit temperature."""
+        self.assertNotIn("temperature", self._capture_messages_body("claude-fable-5"))
+
+    @patch.dict(os.environ, AZURE_CLAUDE_ENV)
+    def test_opus_48_request_omits_temperature(self):
+        """The same removal applies to the Opus 4.8 deployment."""
+        self.assertNotIn("temperature", self._capture_messages_body("claude-opus-4-8"))
+
+    @patch.dict(os.environ, AZURE_CLAUDE_ENV)
+    def test_sonnet_46_request_keeps_temperature(self):
+        """Claude 4.6 and older still accept a custom temperature."""
+        body = self._capture_messages_body("claude-sonnet-4-6")
+        self.assertEqual(body["temperature"], 0.7)
+
+    @patch.dict(os.environ, AZURE_CLAUDE_ENV)
+    def test_custom_claude_deployment_temperature_rejection_retries_without(self):
+        """A sampling-free Claude behind a custom AZURE_ANTHROPIC_MODELS name
+        can't be recognized by name, so the 400 must trigger a single retry
+        with temperature stripped instead of failing the call."""
+
+        async def run():
+            """Queue a temperature-rejection 400 then a 200 and inspect bodies."""
+            m = RemoteAzureClaude(model="appeals-fable")
+            bodies: list = []
+            session = _FakeSequencedSession(
+                [
+                    _FakeAiohttpResponse(
+                        status=400, text=self._TEMPERATURE_REJECTION_TEXT
+                    ),
+                    _FakeAiohttpResponse({"content": [{"type": "text", "text": "ok"}]}),
+                ],
+                bodies,
+            )
+            with patch.object(aiohttp, "ClientSession", return_value=session):
+                result = await m._infer(system_prompts=["x"], prompt="y")
+            self.assertEqual(result, ("ok", []))
+            self.assertEqual(len(bodies), 2)
+            self.assertIn("temperature", bodies[0])
+            self.assertNotIn("temperature", bodies[1])
+            # Remembered, so a later call skips the wasted 400 round-trip.
+            self.assertIn("appeals-fable", m._temperature_unsupported_models)
+
+        asyncio.run(run())
+
+    @patch.dict(os.environ, AZURE_CLAUDE_ENV)
+    def test_non_temperature_400_still_propagates(self):
+        """A 400 that isn't a temperature rejection is not retried."""
+
+        async def run():
+            """Force an unrelated 400 and assert it raises."""
+            m = RemoteAzureClaude(model="claude-sonnet-4-6")
+            response = _FakeAiohttpResponse(status=400, text="invalid_request: nope")
+            session = _FakeAiohttpSession(response)
+            with patch.object(aiohttp, "ClientSession", return_value=session):
+                with self.assertRaises(aiohttp.ClientResponseError):
+                    await m._infer(system_prompts=["x"], prompt="y")
 
         asyncio.run(run())
 


### PR DESCRIPTION
## Summary
Registers Claude Fable 5 as an Azure AI Foundry deployment (`azure-anthropic/claude-fable-5`), routes to it via a new tier above `premium`, and fixes the request-shape bugs that enabling it exposed: Claude 4.7+ models reject the sampling parameters outright.

## Changes

**Registration and routing** — `claude-fable-5` added to `RemoteAzureClaude.DEFAULT_MODELS` at cost 175, `frontier` tier. `_TIER_QUALITY` gains a `frontier` rung at 100 above `premium`'s 98, still below the internal backends' floor of 101 so self-hosted models keep priority.

Without the new rung Fable was unreachable: `quality()` comes from the tier, so it tied with Opus 4.8 and gpt-5 at 98, and cost only breaks ties *within* a tier — the stable sort over the cost-ascending list put the priciest model last, behind the `limit=3` slice every generation path uses. It would have been probed, health-checked and billed without ever writing an appeal.

**Temperature is rejected, not clamped** — Claude 4.7 and newer removed `temperature`/`top_p`/`top_k`; sending one is a hard HTTP 400. Without this, every request to the Fable deployment would have failed, and the pre-existing `claude-opus-4-8` default had the same defect.
- `_supports_custom_temperature` recognizes the sampling-free ids (`_CLAUDE_NO_SAMPLING_PREFIXES`), prefix-matched so dated snapshots are covered. The table enumerates released ids rather than deriving a version rule — a model missing from it is not stranded, it costs one 400 and is then learned at runtime.
- `RemoteAzureClaude._do_infer` omits the field for those and keeps it for Claude 4.6 and older, re-reading per system prompt so a concurrent fan-out leg's rejection is picked up mid-call.
- Renamed deployments via `AZURE_ANTHROPIC_MODELS` can't be matched by name, so the Messages transport mirrors the OpenAI path's runtime fallback: a rejection 400 is retried once without the field, sharing the first attempt's timeout budget, and the deployment is remembered.

**Fallout fixed after review**
- The rejection classifier matched only OpenAI's wording, so on the Messages API — which says "temperature: Extra inputs are not permitted" — the fallback could never fire. It now matches both.
- The provider error body rides on a dedicated attribute rather than overwriting `ClientResponseError.message`. That field is the HTTP reason phrase read by every log site, `describe_model_error`, the persisted `ModelAttemptRecord.error_detail`, and `model_health_check._categorize_http_error` — which classifies a 400 as MODEL_NOT_FOUND when it mentions "model", as nearly every Anthropic 400 does. Capped at 4000 chars.
- `parallel_infer` fans out temperatures `[0.6, 0.1]` for full appeals; with the field omitted both legs posted byte-identical bodies. It now submits one leg for models that drop it.
- The duplicated read-body-before-`raise_for_status` block is one shared `_read_error_body` helper across both transports, and a truncated `max_tokens` response logs a warning instead of passing silently as a finished letter.

## Test coverage
Routing (Fable outranks Opus, stays under the internal floor, and a router with every provider configured returns it inside the default `limit=3` fan-out); request bodies for Fable/Opus 4.8 (omitted) and Sonnet 4.6 (kept); the custom-deployment retry under Anthropic wording, its memoization, and its cross-leg pickup; a non-temperature 400 propagating without a retry; error-body vs reason-phrase separation; the fan-out collapse; and a subTest guard over every id in the prefix table. Each behavioral fix was verified to fail against the unpatched source.

## Known limits (deliberate, not oversights)
- **`MAX_OUTPUT_TOKENS` stays 8192 and `MAX_LEN` 200000 for the class.** Fable has always-on thinking drawing from the same output budget and a 1M context window, but both limits are per-class, so changing them affects the Haiku and Sonnet deployments too. A truncated response now logs a warning so this is visible if it bites.
- **One duplicate call is possible on the first appeal to a *renamed* sampling-free deployment**, when both fan-out legs start before either learns the rejection. Closing it needs a pre-flight probe or request-path locking, both of which cost more than the duplicate.

https://claude.ai/code/session_01BEEo3zmqVYivxH7HN6WWEe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `claude-fable-5` Azure deployment.
  * Improved routing to prioritize the highest-capability Claude deployment.
  * Added automatic handling for deployments that reject sampling controls.
  * Improved retry behavior and warnings when responses are truncated.

* **Documentation**
  * Updated setup guidance and documented default Azure Claude deployments to include `claude-fable-5`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->