### PR TITLE
Medicaid eligibility: caller-specified years, a year-by-year verdict, and a Medicaid.gov lookup

### DIFF
--- a/fighthealthinsurance/chat/llm_client.py
+++ b/fighthealthinsurance/chat/llm_client.py
@@ -428,10 +428,12 @@ def score_llm_response(
     # prior sank real tool calls (score ~315) under chatty candidates that
     # skipped the tool (~5810). That is how an eligibility verdict invented by
     # a model instead of computed by the checker won a fan-out.
+    prior_applied = 0.0
     if response_text and (context_part or has_tool_call):
-        score += call_score
+        prior_applied = call_score
     else:
-        score += call_score / 100
+        prior_applied = call_score / 100
+    score += prior_applied
 
     # An invented eligibility verdict forfeits the model prior outright, then
     # takes a fixed penalty on top.
@@ -453,8 +455,13 @@ def score_llm_response(
     # able to empty a fan-out and break the turn. When every candidate
     # invents a verdict they are all levelled equally and the best of them
     # still gets delivered.
+    # Subtract exactly what was added: a candidate with no context summary and
+    # no tool call only received call_score/100, so taking back the full
+    # call_score drove it thousands of points below its peers and inverted the
+    # ranking among invented verdicts on model quality -- the opposite of the
+    # "levelled equally" property this is supposed to have.
     if invented_verdict:
-        score -= call_score + INVENTED_ELIGIBILITY_VERDICT_PENALTY
+        score -= prior_applied + INVENTED_ELIGIBILITY_VERDICT_PENALTY
 
     logger.debug(f"Scored response as {score}")
     return score

--- a/fighthealthinsurance/chat/llm_client.py
+++ b/fighthealthinsurance/chat/llm_client.py
@@ -11,10 +11,13 @@ from typing import Awaitable, Callable, Dict, List, Optional, Tuple
 from loguru import logger
 
 from fighthealthinsurance.chat.message_preprocessor import MessageVariant
-from fighthealthinsurance.chat.safety_filters import detect_false_promises
+from fighthealthinsurance.chat.safety_filters import (
+    detect_eligibility_verdict,
+    detect_false_promises,
+)
 from fighthealthinsurance.chat.tools.patterns import (
-    ALL_TOOL_PATTERNS as tools_regex,
     contains_tool_call,
+    count_tool_invocations,
 )
 from fighthealthinsurance.ml.ml_models import RemoteModelLike, repetition_penalty
 
@@ -54,6 +57,13 @@ BAD_CONTEXT_PATTERNS = re.compile(
 
 # Minimum length for a valid LLM response or context
 MIN_RESPONSE_LENGTH = 5
+
+# Penalty for stating a Medicaid/Medicare eligibility verdict that the
+# medicaid_eligibility checker never produced. Sized against the model-quality
+# prior (quality**2 // 5, up to ~8800) rather than against the content
+# signals (~100 each): a smaller nudge left the invented verdict winning on
+# backend preference alone, which is the failure this exists to stop.
+INVENTED_ELIGIBILITY_VERDICT_PENALTY = 2000
 
 # Pattern to detect when the response asks for the patient's name
 ASKS_FOR_PATIENT_NAME = re.compile(
@@ -276,6 +286,7 @@ def score_llm_response(
     chat_history: Optional[List[Dict[str, str]]] = None,
     current_message: Optional[str] = None,
     rejection_stats: Optional[Dict[str, int]] = None,
+    eligibility_verified: bool = False,
 ) -> float:
     """
     Score an LLM response for quality and safety.
@@ -292,6 +303,11 @@ def score_llm_response(
             its "repeated_rejected" counter so the caller can tell "no
             usable response" apart from "responses arrived but all repeated
             earlier replies" and retry with an anti-repeat instruction.
+        eligibility_verified: True when the medicaid_eligibility checker has
+            actually produced a determination for this chat (the tool's
+            follow-up pass, or any later turn in the same session). While
+            False, a candidate that flatly asserts an eligibility verdict is
+            inventing it and gets INVENTED_ELIGIBILITY_VERDICT_PENALTY.
 
     Returns:
         Float score (higher is better, -inf for invalid responses).
@@ -334,11 +350,7 @@ def score_llm_response(
     # writes those. Counted with the same patterns the tool bonus uses (NOT
     # contains_tool_call, which also fires on a bare mention of a token) so
     # only a real call earns the full model prior below.
-    tool_call_matches = (
-        sum(1 for pattern in tools_regex if re.search(pattern, response_text))
-        if response_text
-        else 0
-    )
+    tool_call_matches = count_tool_invocations(response_text)
     has_tool_call = tool_call_matches > 0
 
     # Bonus for being a primary call
@@ -366,6 +378,19 @@ def score_llm_response(
         if detect_false_promises(response_text):
             score -= 200
             logger.warning("Detected false promise in response, penalizing score")
+
+        # Safety: an eligibility verdict the checker never computed is a
+        # guess about someone's health coverage dressed up as a
+        # determination. Penalized hard enough to cross the model-quality
+        # prior (base scores reach ~8800) so an internal-tier candidate that
+        # invents "you qualify for Medicaid" loses to one that either calls
+        # the checker or answers without a verdict.
+        if not eligibility_verified and detect_eligibility_verdict(response_text):
+            score -= INVENTED_ELIGIBILITY_VERDICT_PENALTY
+            logger.warning(
+                "Response asserts a Medicaid/Medicare eligibility verdict the "
+                "checker never computed, penalizing score"
+            )
 
         # Bonus for referencing an uploaded document by name (derived from history)
         if chat_history:
@@ -441,6 +466,7 @@ def create_response_scorer(
     call_labels: Optional[Dict[Awaitable, str]] = None,
     repeat_offenders: Optional[Dict[str, int]] = None,
     score_log: Optional[Dict[Awaitable, float]] = None,
+    eligibility_verified: bool = False,
 ) -> Callable[[Optional[Tuple[Optional[str], Optional[str]]], Awaitable], float]:
     """
     Create a scoring function for use with best_within_timelimit.
@@ -465,6 +491,8 @@ def create_response_scorer(
         score_log: Optional mutable dict; every scored call's final score is
             recorded here (keyed by the original awaitable) so the caller
             can report per-candidate scores in debug output.
+        eligibility_verified: Whether the medicaid_eligibility checker has
+            produced a determination for this chat; see score_llm_response.
 
     Returns:
         Scoring function compatible with best_within_timelimit
@@ -503,6 +531,7 @@ def create_response_scorer(
             chat_history=chat_history,
             current_message=current_message,
             rejection_stats=rejection_stats,
+            eligibility_verified=eligibility_verified,
         )
         if (
             label

--- a/fighthealthinsurance/chat/llm_client.py
+++ b/fighthealthinsurance/chat/llm_client.py
@@ -58,11 +58,11 @@ BAD_CONTEXT_PATTERNS = re.compile(
 # Minimum length for a valid LLM response or context
 MIN_RESPONSE_LENGTH = 5
 
-# Penalty for stating a Medicaid/Medicare eligibility verdict that the
-# medicaid_eligibility checker never produced. Sized against the model-quality
-# prior (quality**2 // 5, up to ~8800) rather than against the content
-# signals (~100 each): a smaller nudge left the invented verdict winning on
-# backend preference alone, which is the failure this exists to stop.
+# Penalty applied ON TOP of forfeiting the model prior when a reply states a
+# Medicaid/Medicare eligibility verdict the checker never produced. The
+# forfeit is what makes the guard hold across backends; this margin keeps an
+# invented verdict below a plain answer from the SAME call, whose content
+# signals would otherwise be identical.
 INVENTED_ELIGIBILITY_VERDICT_PENALTY = 2000
 
 # Pattern to detect when the response asks for the patient's name
@@ -307,7 +307,8 @@ def score_llm_response(
             actually produced a determination for this chat (the tool's
             follow-up pass, or any later turn in the same session). While
             False, a candidate that flatly asserts an eligibility verdict is
-            inventing it and gets INVENTED_ELIGIBILITY_VERDICT_PENALTY.
+            inventing it: it forfeits its model prior and takes
+            INVENTED_ELIGIBILITY_VERDICT_PENALTY on top.
 
     Returns:
         Float score (higher is better, -inf for invalid responses).
@@ -344,6 +345,7 @@ def score_llm_response(
             return float("-inf")
 
     score = 0.0
+    invented_verdict = False
 
     # A tool call is a legitimate reply shape even though it carries no
     # user-facing prose or panda context summary -- the tool's follow-up pass
@@ -381,15 +383,13 @@ def score_llm_response(
 
         # Safety: an eligibility verdict the checker never computed is a
         # guess about someone's health coverage dressed up as a
-        # determination. Penalized hard enough to cross the model-quality
-        # prior (base scores reach ~8800) so an internal-tier candidate that
-        # invents "you qualify for Medicaid" loses to one that either calls
-        # the checker or answers without a verdict.
+        # determination. The prior is FORFEITED below rather than nudged --
+        # see the invented_verdict handling after the base score is added.
         if not eligibility_verified and detect_eligibility_verdict(response_text):
-            score -= INVENTED_ELIGIBILITY_VERDICT_PENALTY
+            invented_verdict = True
             logger.warning(
                 "Response asserts a Medicaid/Medicare eligibility verdict the "
-                "checker never computed, penalizing score"
+                "checker never computed, forfeiting its model prior"
             )
 
         # Bonus for referencing an uploaded document by name (derived from history)
@@ -432,6 +432,29 @@ def score_llm_response(
         score += call_score
     else:
         score += call_score / 100
+
+    # An invented eligibility verdict forfeits the model prior outright, then
+    # takes a fixed penalty on top.
+    #
+    # A fixed nudge alone could not work: the prior is the dominant term and
+    # the gaps between priors are bigger than any constant worth using. One
+    # quality-210 backend contributes BOTH a truncated-history call
+    # (210**2//5 = 8820) and a full-history one (210**2//4 = 11025), so a
+    # 2000-point penalty still left the full-history call's invented verdict
+    # (~9235) beating the truncated call's real checker invocation (~9120) --
+    # the exact swap this guard exists to prevent, from a single backend.
+    # Cross-backend gaps are larger still.
+    #
+    # Forfeiting the prior leaves only the content signals, so an invented
+    # verdict loses to any candidate that either called the checker or
+    # answered without a verdict, whatever backend it came from. It is
+    # deliberately NOT a hard -inf rejection like a repeated reply: the
+    # detector is a regex over free text, and one false positive must not be
+    # able to empty a fan-out and break the turn. When every candidate
+    # invents a verdict they are all levelled equally and the best of them
+    # still gets delivered.
+    if invented_verdict:
+        score -= call_score + INVENTED_ELIGIBILITY_VERDICT_PENALTY
 
     logger.debug(f"Scored response as {score}")
     return score

--- a/fighthealthinsurance/chat/llm_client.py
+++ b/fighthealthinsurance/chat/llm_client.py
@@ -329,6 +329,18 @@ def score_llm_response(
 
     score = 0.0
 
+    # A tool call is a legitimate reply shape even though it carries no
+    # user-facing prose or panda context summary -- the tool's follow-up pass
+    # writes those. Counted with the same patterns the tool bonus uses (NOT
+    # contains_tool_call, which also fires on a bare mention of a token) so
+    # only a real call earns the full model prior below.
+    tool_call_matches = (
+        sum(1 for pattern in tools_regex if re.search(pattern, response_text))
+        if response_text
+        else 0
+    )
+    has_tool_call = tool_call_matches > 0
+
     # Bonus for being a primary call
     if is_primary_call:
         score += 100
@@ -348,9 +360,7 @@ def score_llm_response(
             score -= 75
 
         # Bonus for tool usage (search anywhere in response)
-        for pattern in tools_regex:
-            if re.search(pattern, response_text):
-                score += 100
+        score += 100 * tool_call_matches
 
         # Safety: Penalize false promises
         if detect_false_promises(response_text):
@@ -387,8 +397,13 @@ def score_llm_response(
                 response_text, chat_history or [], current_message
             )
 
-    # Add base quality score from model
-    if response_text and context_part:
+    # Add base quality score from model. A reply with no context summary is
+    # normally half-finished, so it only gets a hundredth of the model
+    # prior -- but a TOOL CALL has no summary by design, and dividing its
+    # prior sank real tool calls (score ~315) under chatty candidates that
+    # skipped the tool (~5810). That is how an eligibility verdict invented by
+    # a model instead of computed by the checker won a fan-out.
+    if response_text and (context_part or has_tool_call):
         score += call_score
     else:
         score += call_score / 100

--- a/fighthealthinsurance/chat/safety_filters.py
+++ b/fighthealthinsurance/chat/safety_filters.py
@@ -8,6 +8,8 @@ Extracted from chat_interface.py for better organization and testability.
 import re
 from typing import Optional, Pattern
 
+from fighthealthinsurance.ml.medicaid_names import MEDICAID_PROGRAM_ALIASES
+
 # Crisis/self-harm detection - phrases indicating the user may need immediate help
 # IMPORTANT: These must be specific enough to NOT block legitimate mental health
 # insurance denial appeals. Someone saying "my coverage for suicidal ideation
@@ -172,3 +174,91 @@ def llm_requested_delete_handoff(text: Optional[str]) -> bool:
     if not text:
         return False
     return bool(_DELETE_DATA_SENTINEL_REGEX.search(text))
+
+
+# Program-eligibility verdicts the model must NOT state on its own. Only the
+# medicaid_eligibility checker can produce one: it applies the FPL tables, the
+# MAGI/ABD/LTC branches and the work-requirement overlay. A model asserting
+# "you are eligible for Medicaid" from the conversation alone is guessing
+# about someone's health coverage, and in the observed fan-out that guess beat
+# the candidate that actually called the checker.
+#
+# These deliberately match only DEFINITE verdicts. Hedged, invitational
+# phrasing ("you may be eligible -- want me to check?") is exactly what the
+# Medicaid path is supposed to say before the checker has run, so it must not
+# be caught; _ELIGIBILITY_HEDGE_REGEX below clears those sentences.
+# The programs a verdict can be about. State names are in here because the
+# system prompt tells the model to use whichever name the user does, so
+# "you qualify for Medi-Cal" is the same claim as "you qualify for Medicaid".
+# Longest-first so the alternation prefers "Medical Assistance Program" over
+# its own prefix.
+_PROGRAM_ALTERNATION = "|".join(
+    re.escape(name)
+    for name in sorted(
+        ("Medicaid", "Medicare", "CHIP", "Medicaid expansion")
+        + MEDICAID_PROGRAM_ALIASES,
+        key=len,
+        reverse=True,
+    )
+)
+
+_ELIGIBILITY_VERDICT_PATTERNS = [
+    # "you are eligible for Medicaid", "you're not eligible for Medicare",
+    # "you are likely ineligible for CHIP"
+    r"\byou(?:'re|\s+are|\s+would\s+be|\s+appear\s+to\s+be|\s+seem\s+to\s+be)"
+    r"(?:\s+(?:not|likely|probably|clearly|definitely|indeed|already))*"
+    rf"\s+(?:in)?eligible\s+for\s+(?:\w+[-\s]+){{0,3}}?(?:{_PROGRAM_ALTERNATION})\b",
+    # "you qualify for Medicaid", "you do not qualify for Medicare"
+    r"\byou(?:\s+(?:do|does|will|would|should|clearly|likely|probably|"
+    r"definitely|already|do\s+not|don't|won't|wouldn't))*"
+    rf"\s+qualif(?:y|ies)\s+for\s+(?:\w+[-\s]+){{0,3}}?(?:{_PROGRAM_ALTERNATION})\b",
+    # "you are Medicaid-eligible", "your household is not MassHealth eligible"
+    r"\b(?:you|your\s+household)\s+(?:is|are)\s+(?:not\s+)?(?:currently\s+)?"
+    rf"(?:{_PROGRAM_ALTERNATION})[- ]eligible\b",
+]
+
+_ELIGIBILITY_VERDICT_REGEX: Pattern[str] = re.compile(
+    r"|".join(rf"(?:{pattern})" for pattern in _ELIGIBILITY_VERDICT_PATTERNS),
+    re.IGNORECASE,
+)
+
+# Anything in the same sentence that turns the verdict back into a
+# possibility, a condition, or an offer to run the real check.
+_ELIGIBILITY_HEDGE_REGEX: Pattern[str] = re.compile(
+    r"\b(?:may|might|could|maybe|perhaps|possibly|potentially|likely\s+to\s+be|"
+    r"if\s+you|whether|depending|depends|assuming|to\s+find\s+out|let(?:'s|\s+us)|"
+    r"want\s+me\s+to|would\s+you\s+like|i\s+can\s+(?:check|run|walk)|"
+    r"can\s+(?:i|we)\s+(?:check|run)|check\s+(?:if|whether|your))\b",
+    re.IGNORECASE,
+)
+
+# Sentence-ish split: a terminator followed by whitespace, or a line break.
+# Bullet lists arrive one verdict per line, so newlines have to split too.
+_SENTENCE_SPLIT_REGEX: Pattern[str] = re.compile(r"(?<=[.!?])\s+|\n+")
+
+
+def detect_eligibility_verdict(text: Optional[str]) -> bool:
+    """
+    Check whether a reply flatly ASSERTS a Medicaid/Medicare eligibility verdict.
+
+    Returns True only for definite claims. A sentence is ignored when it is a
+    question or when it hedges the claim (see _ELIGIBILITY_HEDGE_REGEX), so
+    offering the eligibility check ("you may be eligible -- want me to check?")
+    reads as clean.
+
+    Whether such a verdict is legitimate is the CALLER's call: after the
+    medicaid_eligibility checker has run, restating its determination is the
+    whole point. See score_llm_response, which only penalizes a verdict the
+    checker never computed.
+    """
+    if not text:
+        return False
+    for sentence in _SENTENCE_SPLIT_REGEX.split(text):
+        if not _ELIGIBILITY_VERDICT_REGEX.search(sentence):
+            continue
+        if sentence.rstrip().endswith("?"):
+            continue
+        if _ELIGIBILITY_HEDGE_REGEX.search(sentence):
+            continue
+        return True
+    return False

--- a/fighthealthinsurance/chat/safety_filters.py
+++ b/fighthealthinsurance/chat/safety_filters.py
@@ -192,11 +192,27 @@ def llm_requested_delete_handoff(text: Optional[str]) -> bool:
 # "you qualify for Medi-Cal" is the same claim as "you qualify for Medicaid".
 # Longest-first so the alternation prefers "Medical Assistance Program" over
 # its own prefix.
+# Aliases that are ordinary English before they are program names. They stay
+# in MEDICAID_PROGRAM_ALIASES -- the prompt wants them, because a user saying
+# "STAR" tells the model they are in Texas -- but they are NOT evidence that a
+# sentence is handing down an eligibility verdict. "You qualify for medical
+# assistance benefits" and "you qualify for STAR" were both being read as
+# invented Medicaid verdicts, and a false positive here now costs a candidate
+# its whole model prior, so the detector errs toward missing a verdict about a
+# generically-named program rather than penalizing a legitimate reply.
+_AMBIGUOUS_FOR_VERDICTS = frozenset(
+    {"STAR", "Medical Assistance", "Medical Assistance Program"}
+)
+
 _PROGRAM_ALTERNATION = "|".join(
     re.escape(name)
     for name in sorted(
         ("Medicaid", "Medicare", "CHIP", "Medicaid expansion")
-        + MEDICAID_PROGRAM_ALIASES,
+        + tuple(
+            name
+            for name in MEDICAID_PROGRAM_ALIASES
+            if name not in _AMBIGUOUS_FOR_VERDICTS
+        ),
         key=len,
         reverse=True,
     )
@@ -215,6 +231,19 @@ _ELIGIBILITY_VERDICT_PATTERNS = [
     # "you are Medicaid-eligible", "your household is not MassHealth eligible"
     r"\b(?:you|your\s+household)\s+(?:is|are)\s+(?:not\s+)?(?:currently\s+)?"
     rf"(?:{_PROGRAM_ALTERNATION})[- ]eligible\b",
+    # "you will be approved for Medicaid" -- an approval the model is
+    # predicting rather than one the checker (or an agency) decided.
+    #
+    # Only the FORWARD-LOOKING forms are here. Present and past tense
+    # ("you are approved for Medi-Cal", "you were denied Medicaid coverage")
+    # are usually the model repeating something the USER told it -- this is an
+    # insurance-DENIAL product, so a user's own denial is the normal subject
+    # of the conversation, not a hallucination -- and penalizing that would
+    # cost a correct reply its model prior.
+    r"\byou(?:'ll|\s+will|\s+would|\s+are\s+going\s+to)"
+    r"(?:\s+(?:not|likely|probably|clearly|definitely))*"
+    r"\s+be\s+(?:approved\s+for|denied(?:\s+for)?)\s+"
+    rf"(?:\w+[-\s]+){{0,3}}?(?:{_PROGRAM_ALTERNATION})\b",
 ]
 
 _ELIGIBILITY_VERDICT_REGEX: Pattern[str] = re.compile(

--- a/fighthealthinsurance/chat/safety_filters.py
+++ b/fighthealthinsurance/chat/safety_filters.py
@@ -251,15 +251,42 @@ _ELIGIBILITY_VERDICT_REGEX: Pattern[str] = re.compile(
     re.IGNORECASE,
 )
 
-# Anything in the same sentence that turns the verdict back into a
-# possibility, a condition, or an offer to run the real check.
+# Wording that turns the verdict back into a possibility, a condition, or an
+# offer to run the real check -- but ONLY where it actually scopes the claim.
+# Position matters, and ignoring it broke the detector in both directions:
+#
+#   "You qualify for Medicaid, but check your state's website to confirm."
+#   "You are eligible for Medicaid, though you may need documentation."
+#
+# were both read as hedged and let through, even though the system prompt
+# REQUIRES those caveats on every eligibility answer -- so in practice almost
+# no invented verdict was ever caught. Meanwhile
+#
+#   "You are eligible for Medicaid if your income is under 138% FPL."
+#
+# was flagged as a definite verdict, because `if\s+you\b` cannot match "if
+# your" -- and that is the phrasing the prompt asks for on "what are the
+# income limits?".
 _ELIGIBILITY_HEDGE_REGEX: Pattern[str] = re.compile(
     r"\b(?:may|might|could|maybe|perhaps|possibly|potentially|likely\s+to\s+be|"
-    r"if\s+you|whether|depending|depends|assuming|to\s+find\s+out|let(?:'s|\s+us)|"
+    r"if|whether|depending|depends|assuming|to\s+find\s+out|let(?:'s|\s+us)|"
     r"want\s+me\s+to|would\s+you\s+like|i\s+can\s+(?:check|run|walk)|"
     r"can\s+(?:i|we)\s+(?:check|run)|check\s+(?:if|whether|your))\b",
     re.IGNORECASE,
 )
+
+# A condition ATTACHED to the verdict ("...eligible for Medicaid if your
+# income is under X") still hedges it even though it trails the claim. One
+# that sits in its own clause ("...eligible for Medicaid; if you apply this
+# month, coverage starts right away") does not.
+_ELIGIBILITY_TRAILING_CONDITION_REGEX: Pattern[str] = re.compile(
+    r"\b(?:if|unless|as\s+long\s+as|provided|assuming|depending|whether)\b",
+    re.IGNORECASE,
+)
+
+# What separates the verdict from a following clause. A trailing condition
+# only reaches back to the claim when nothing like this stands between them.
+_CLAUSE_BREAK_REGEX: Pattern[str] = re.compile(r"[,;:]|--|\u2014")
 
 # Sentence-ish split: a terminator followed by whitespace, or a line break.
 # Bullet lists arrive one verdict per line, so newlines have to split too.
@@ -271,9 +298,16 @@ def detect_eligibility_verdict(text: Optional[str]) -> bool:
     Check whether a reply flatly ASSERTS a Medicaid/Medicare eligibility verdict.
 
     Returns True only for definite claims. A sentence is ignored when it is a
-    question or when it hedges the claim (see _ELIGIBILITY_HEDGE_REGEX), so
-    offering the eligibility check ("you may be eligible -- want me to check?")
-    reads as clean.
+    question, when hedging wording SCOPES the claim (anything before the end
+    of the verdict itself), or when a condition is attached directly to it, so
+    offering the eligibility check ("you may be eligible -- want me to
+    check?") and stating a rule ("you are eligible for Medicaid if your income
+    is under 138% FPL") both read as clean.
+
+    Hedging that trails the verdict in its own clause does NOT clear it: the
+    system prompt requires an experimental/confirm-with-your-state caveat on
+    every eligibility answer, so treating those as hedges let essentially
+    every invented verdict through.
 
     Whether such a verdict is legitimate is the CALLER's call: after the
     medicaid_eligibility checker has run, restating its determination is the
@@ -283,11 +317,20 @@ def detect_eligibility_verdict(text: Optional[str]) -> bool:
     if not text:
         return False
     for sentence in _SENTENCE_SPLIT_REGEX.split(text):
-        if not _ELIGIBILITY_VERDICT_REGEX.search(sentence):
+        match = _ELIGIBILITY_VERDICT_REGEX.search(sentence)
+        if not match:
             continue
         if sentence.rstrip().endswith("?"):
             continue
-        if _ELIGIBILITY_HEDGE_REGEX.search(sentence):
+        # Hedging that scopes the claim: everything up to and including the
+        # verdict wording itself.
+        if _ELIGIBILITY_HEDGE_REGEX.search(sentence[: match.end()]):
+            continue
+        # A condition attached to the verdict, i.e. before any clause break.
+        trailing = sentence[match.end() :]
+        clause_break = _CLAUSE_BREAK_REGEX.search(trailing)
+        attached = trailing[: clause_break.start()] if clause_break else trailing
+        if _ELIGIBILITY_TRAILING_CONDITION_REGEX.search(attached):
             continue
         return True
     return False

--- a/fighthealthinsurance/chat/tools/__init__.py
+++ b/fighthealthinsurance/chat/tools/__init__.py
@@ -25,6 +25,7 @@ from .patterns import (
     FINANCIAL_ASSISTANCE_REGEX,
     LOOKUP_PA_REQUIREMENT_REGEX,
     MEDICAID_ELIGIBILITY_REGEX,
+    MEDICAID_GOV_LOOKUP_REGEX,
     MEDICAID_INFO_REGEX,
     PUBMED_QUERY_REGEX,
     RXNORM_LOOKUP_REGEX,
@@ -32,6 +33,7 @@ from .patterns import (
     contains_tool_call,
     count_tool_invocations,
 )
+from .medicaid_gov_tool import MedicaidGovLookupTool
 from .prior_auth_tool import PriorAuthTool
 from .pubmed_tool import PubMedTool
 from .rxnorm_tool import RxNormLookupTool
@@ -42,6 +44,7 @@ __all__ = [
     "PUBMED_QUERY_REGEX",
     "MEDICAID_INFO_REGEX",
     "MEDICAID_ELIGIBILITY_REGEX",
+    "MEDICAID_GOV_LOOKUP_REGEX",
     "CREATE_OR_UPDATE_APPEAL_REGEX",
     "CREATE_OR_UPDATE_PRIOR_AUTH_REGEX",
     "FETCH_DOC_REGEX",
@@ -59,6 +62,7 @@ __all__ = [
     "PubMedTool",
     "MedicaidInfoTool",
     "MedicaidEligibilityTool",
+    "MedicaidGovLookupTool",
     "AppealTool",
     "PriorAuthTool",
     "DocFetcherTool",

--- a/fighthealthinsurance/chat/tools/__init__.py
+++ b/fighthealthinsurance/chat/tools/__init__.py
@@ -29,6 +29,8 @@ from .patterns import (
     PUBMED_QUERY_REGEX,
     RXNORM_LOOKUP_REGEX,
     USPSTF_LOOKUP_REGEX,
+    contains_tool_call,
+    count_tool_invocations,
 )
 from .prior_auth_tool import PriorAuthTool
 from .pubmed_tool import PubMedTool
@@ -49,6 +51,8 @@ __all__ = [
     "CLINICAL_TRIALS_QUERY_REGEX",
     "FINANCIAL_ASSISTANCE_REGEX",
     "ALL_TOOL_PATTERNS",
+    "contains_tool_call",
+    "count_tool_invocations",
     # Tool handlers
     "BaseTool",
     "JsonFollowupTool",

--- a/fighthealthinsurance/chat/tools/medicaid_gov_tool.py
+++ b/fighthealthinsurance/chat/tools/medicaid_gov_tool.py
@@ -1,0 +1,217 @@
+"""Medicaid.gov (and friends) page-lookup tool for the chat interface.
+
+Handles ``medicaid_gov_lookup`` calls: resolves a curated page, an explicit
+allowlisted URL, or a free-text query to a page on Medicaid.gov, fetches it,
+and feeds the text back into the conversation.
+
+Distinct from ``fetch_doc``, which fetches an arbitrary URL the USER shared.
+This tool only ever reaches a small allowlist of public coverage references
+(see ``medicaid_gov_api.ALLOWED_HOSTS``), so the model can go get an
+authoritative answer without being handed a general-purpose fetcher.
+"""
+
+import json
+import re
+from typing import Any, Awaitable, Callable, List, Optional, Tuple
+
+from loguru import logger
+
+from fighthealthinsurance.extralink_fetcher import ExtraLinkFetcher
+
+from .base_tool import BaseTool
+from .doc_fetcher_tool import _sanitize_url_for_display, validate_url
+from .patterns import MEDICAID_GOV_LOOKUP_REGEX
+
+# Characters of page text handed to the LLM. Medicaid.gov pages are wordy and
+# the eligibility-levels table is enormous; this keeps one lookup from eating
+# the whole context window.
+MAX_PAGE_TEXT_LENGTH = 12_000
+
+# Per-session cap. Separate from fetch_doc's budget: these are allowlisted
+# reference pages, not user-supplied URLs, so they get their own (small)
+# allowance rather than competing with documents the user actually shared.
+MAX_LOOKUPS_PER_SESSION = 4
+
+
+class MedicaidGovLookupTool(BaseTool):
+    """
+    Tool handler for Medicaid.gov page lookups.
+
+    Accepted call shapes::
+
+        **medicaid_gov_lookup {"page": "renew_info", "state": "IA"}**
+        **medicaid_gov_lookup {"page": "eligibility_levels"}**
+        **medicaid_gov_lookup {"query": "renewal paperwork"}**
+        **medicaid_gov_lookup {"url": "https://www.medicaid.gov/eligibility"}**
+    """
+
+    pattern = MEDICAID_GOV_LOOKUP_REGEX
+    name = "Medicaid.gov Lookup"
+
+    def __init__(
+        self,
+        send_status_message: Callable[[str], Awaitable[None]],
+        call_llm_callback: Optional[
+            Callable[..., Awaitable[Tuple[Optional[str], Optional[str]]]]
+        ] = None,
+        lookup_count: Optional[list] = None,
+    ):
+        super().__init__(send_status_message)
+        self.call_llm_callback = call_llm_callback
+        self.fetcher = ExtraLinkFetcher()
+        # One-element list owned by the ChatInterface so the cap survives the
+        # tool being rebuilt each turn (same trick as fetch_doc's counter).
+        self._lookup_count = lookup_count if lookup_count is not None else [0]
+
+    @staticmethod
+    def _resolve_target(params: dict) -> Tuple[Optional[str], List[str], str]:
+        """Pick the page to fetch.
+
+        Returns ``(url, other_candidate_urls, how_we_got_there)``.
+        """
+        from fighthealthinsurance.medicaid_gov_api import (
+            is_allowed_url,
+            resolve_curated_source,
+            search_medicaid_gov,
+            suggest_curated_sources,
+        )
+
+        page = params.get("page")
+        if isinstance(page, str) and page.strip():
+            url = resolve_curated_source(page, params.get("state"))
+            if url:
+                return url, [], f'curated page "{page}"'
+
+        url_value = params.get("url")
+        if isinstance(url_value, str) and url_value.strip():
+            candidate = url_value.strip()
+            if is_allowed_url(candidate):
+                return candidate, [], "the URL provided"
+            logger.warning(f"medicaid_gov_lookup refused off-allowlist URL {candidate}")
+
+        query = params.get("query") or params.get("topic")
+        if isinstance(query, str) and query.strip():
+            # Curated pages first: we already know these answer the question,
+            # and several of them are unreachable by slug matching.
+            curated = suggest_curated_sources(query)
+            others = [source.url for source in curated[1:]]
+            hits = search_medicaid_gov(query, limit=4)
+            if curated:
+                return (
+                    curated[0].url,
+                    others + [u for u, _ in hits[:3]],
+                    (f'search for "{query}"'),
+                )
+            if hits:
+                return hits[0][0], [u for u, _ in hits[1:]], f'search for "{query}"'
+
+        return None, [], ""
+
+    async def execute(
+        self,
+        match: re.Match,
+        response_text: str,
+        context: str,
+        model_backends: Any = None,
+        previous_context_summary: str = "",
+        history_for_llm: Any = None,
+        depth: int = 0,
+        is_logged_in: bool = False,
+        is_professional: bool = False,
+        **kwargs,
+    ) -> Tuple[str, str]:
+        from fighthealthinsurance.medicaid_gov_api import curated_source_menu
+
+        cleaned_response = self.clean_response(response_text, match)
+
+        try:
+            params = json.loads(match.group(1).strip())
+        except json.JSONDecodeError as e:
+            logger.warning(f"Invalid JSON in medicaid_gov_lookup: {e}")
+            return cleaned_response, context
+        if not isinstance(params, dict):
+            logger.warning("medicaid_gov_lookup called with non-object JSON")
+            return cleaned_response, context
+
+        url, other_urls, how = self._resolve_target(params)
+        if not url:
+            # Tell the model what it *could* have asked for rather than
+            # failing silently -- a bad page name is a recoverable mistake.
+            return cleaned_response, context + (
+                "\n\nThe medicaid_gov_lookup call didn't name a page we could "
+                "find. Available pages:\n" + curated_source_menu() + "\n"
+                'You can also pass {"query": "..."} to search Medicaid.gov.\n'
+            )
+
+        if self._lookup_count[0] >= MAX_LOOKUPS_PER_SESSION:
+            logger.warning("medicaid_gov_lookup session cap reached")
+            await self.send_status_message(
+                "Medicaid.gov lookup limit reached for this conversation."
+            )
+            return cleaned_response, context
+        self._lookup_count[0] += 1
+
+        safe_url = _sanitize_url_for_display(url)
+        await self.send_status_message(f"Looking up {safe_url}...")
+
+        try:
+            full_text, doc_type = await self.fetcher.fetch_and_extract_text(
+                url, url_validator=validate_url
+            )
+        except Exception as e:
+            logger.warning(f"medicaid_gov_lookup failed to fetch {safe_url}: {e}")
+            await self.send_status_message(f"Couldn't reach {safe_url}.")
+            return cleaned_response, context
+
+        if not full_text or not full_text.strip():
+            await self.send_status_message(f"No readable content at {safe_url}.")
+            return cleaned_response, context
+
+        await self.send_status_message(
+            f"Read {len(full_text)} characters from {safe_url} ({doc_type})."
+        )
+
+        also_lines = ""
+        if other_urls:
+            also_lines = "\nOther pages that may be relevant:\n" + "\n".join(
+                f"- {u}" for u in other_urls[:3]
+            )
+
+        user_question = kwargs.get("current_message_for_llm") or ""
+        question_part = f"\nThe user asked: {user_question}\n" if user_question else ""
+        page_context = (
+            f"\n\nFrom {url} (found via {how}):\n"
+            f"{full_text[:MAX_PAGE_TEXT_LENGTH]}\n"
+            f"{also_lines}\n{question_part}"
+            "Answer the user's question from this page. Link them to the URL "
+            "above so they can read it themselves, and say it's the official "
+            "source. If the page doesn't actually answer what they asked, say "
+            "so rather than stretching it -- and remember state Medicaid "
+            "agencies are the authority on any individual's coverage.\n"
+        )
+
+        if self.call_llm_callback and model_backends:
+            additional_response, additional_context = await self.call_llm_callback(
+                model_backends,
+                page_context,
+                previous_context_summary,
+                history_for_llm,
+                depth=depth + 1,
+                is_logged_in=is_logged_in,
+                is_professional=is_professional,
+                fallback_backends=kwargs.get("fallback_backends"),
+                full_history=kwargs.get("full_history"),
+                # Raw user message, so repeat detection in the recursive pass
+                # keys off what the USER said rather than this tool payload.
+                user_message_for_scoring=kwargs.get("user_message_for_scoring"),
+            )
+            if cleaned_response and additional_response:
+                cleaned_response += additional_response
+            elif additional_response:
+                cleaned_response = additional_response
+            if context and additional_context:
+                context += additional_context
+            elif additional_context:
+                context = additional_context
+
+        return cleaned_response, (context + page_context if context else page_context)

--- a/fighthealthinsurance/chat/tools/medicaid_gov_tool.py
+++ b/fighthealthinsurance/chat/tools/medicaid_gov_tool.py
@@ -153,7 +153,15 @@ class MedicaidGovLookupTool(BaseTool):
         # per-call DB connection cleanup would be pure churn. Bridged rather
         # than awaited inline because a cold-cache walk is seconds of blocking
         # requests, which would freeze every OTHER chat on this worker.
-        url, other_urls, how = await sync_to_async(self._resolve_target)(params)
+        #
+        # thread_sensitive=False for the same reason: the default routes every
+        # such call through ONE shared worker thread, so a cold sitemap walk
+        # would queue up behind (and ahead of) unrelated thread-sensitive work
+        # instead of blocking only itself. Safe here precisely because there's
+        # no ORM or thread-local state to keep on one thread.
+        url, other_urls, how = await sync_to_async(
+            self._resolve_target, thread_sensitive=False
+        )(params)
         if not url:
             # Tell the model what it *could* have asked for rather than
             # failing silently -- a bad page name is a recoverable mistake.

--- a/fighthealthinsurance/chat/tools/medicaid_gov_tool.py
+++ b/fighthealthinsurance/chat/tools/medicaid_gov_tool.py
@@ -14,6 +14,7 @@ import json
 import re
 from typing import Any, Awaitable, Callable, List, Optional, Tuple
 
+from asgiref.sync import sync_to_async
 from loguru import logger
 
 from fighthealthinsurance.extralink_fetcher import ExtraLinkFetcher
@@ -68,6 +69,10 @@ class MedicaidGovLookupTool(BaseTool):
         """Pick the page to fetch.
 
         Returns ``(url, other_candidate_urls, how_we_got_there)``.
+
+        BLOCKING: the ``query`` path walks medicaid.gov's sitemap over the
+        network on a cold cache. ``execute`` bridges this off the event loop;
+        don't call it inline from async code.
         """
         from fighthealthinsurance.medicaid_gov_api import (
             is_allowed_url,
@@ -133,7 +138,22 @@ class MedicaidGovLookupTool(BaseTool):
             logger.warning("medicaid_gov_lookup called with non-object JSON")
             return cleaned_response, context
 
-        url, other_urls, how = self._resolve_target(params)
+        # Budget first: resolving a {"query": ...} call walks the sitemap over
+        # the network, and a session that has spent its allowance shouldn't
+        # pay for a lookup it can't use.
+        if self._lookup_count[0] >= MAX_LOOKUPS_PER_SESSION:
+            logger.warning("medicaid_gov_lookup session cap reached")
+            await self.send_status_message(
+                "Medicaid.gov lookup limit reached for this conversation."
+            )
+            return cleaned_response, context
+
+        # plain sync_to_async, not database_sync_to_async: _resolve_target
+        # does network IO (the sitemap walk) and touches no ORM, so the
+        # per-call DB connection cleanup would be pure churn. Bridged rather
+        # than awaited inline because a cold-cache walk is seconds of blocking
+        # requests, which would freeze every OTHER chat on this worker.
+        url, other_urls, how = await sync_to_async(self._resolve_target)(params)
         if not url:
             # Tell the model what it *could* have asked for rather than
             # failing silently -- a bad page name is a recoverable mistake.
@@ -143,12 +163,6 @@ class MedicaidGovLookupTool(BaseTool):
                 'You can also pass {"query": "..."} to search Medicaid.gov.\n'
             )
 
-        if self._lookup_count[0] >= MAX_LOOKUPS_PER_SESSION:
-            logger.warning("medicaid_gov_lookup session cap reached")
-            await self.send_status_message(
-                "Medicaid.gov lookup limit reached for this conversation."
-            )
-            return cleaned_response, context
         self._lookup_count[0] += 1
 
         safe_url = _sanitize_url_for_display(url)

--- a/fighthealthinsurance/chat/tools/medicaid_tool.py
+++ b/fighthealthinsurance/chat/tools/medicaid_tool.py
@@ -635,6 +635,7 @@ class MedicaidEligibilityTool(BaseTool):
             BASE_ELIGIBILITY_YEAR,
             DEFAULT_TARGET_YEAR,
             WORK_REQUIREMENT_FIRST_YEAR,
+            current_eligibility_year,
         )
 
         if target_year is None:
@@ -650,17 +651,29 @@ class MedicaidEligibilityTool(BaseTool):
                 "requirement applies to them — states must implement it by "
                 "January 1, 2027, a few earlier)"
             )
-        base_label = f"current ({BASE_ELIGIBILITY_YEAR})"
+        # "current" means the calendar year, not the year of the FPL table we
+        # score against. Those drifted apart the moment the table's year
+        # ended, and calling a finished year "current" told people the rules
+        # they live under were the ones that had just been replaced.
+        current_year = current_eligibility_year()
+        base_label = f"current ({current_year})"
         # A user who asked about this year gets one verdict, not the same
         # verdict printed twice under two labels.
-        target_is_separate_year = target_year > BASE_ELIGIBILITY_YEAR
+        target_is_separate_year = target_year > current_year
 
         # Years to report on, ascending. Falls back to the base/target pair
         # when no timeline was supplied. Deduped so a base-year-only check
         # doesn't print the same verdict twice under two labels.
         rows = timeline or [
-            (BASE_ELIGIBILITY_YEAR, eligible_base),
-            (target_year, eligible_target),
+            row
+            for row in (
+                (BASE_ELIGIBILITY_YEAR, eligible_base),
+                (target_year, eligible_target),
+            )
+            # The base row is "the rules before the work requirement". Once
+            # that year is behind us nobody is living under it, so it only
+            # earns a row if the user asked about it by name.
+            if row[0] >= current_year or row[0] == target_year
         ]
         seen_years: set = set()
         deduped_rows = []
@@ -702,7 +715,7 @@ class MedicaidEligibilityTool(BaseTool):
             later_settled = [
                 year
                 for year, probably_eligible in rows
-                if year > BASE_ELIGIBILITY_YEAR and probably_eligible
+                if year > current_year and probably_eligible
             ]
             if later_settled:
                 # The later years clear too. Held back with the base-year
@@ -753,7 +766,7 @@ class MedicaidEligibilityTool(BaseTool):
             verdict_lines = []
             noted_work_req = False
             for year, probably_eligible in rows:
-                label = base_label if year == BASE_ELIGIBILITY_YEAR else str(year)
+                label = base_label if year == current_year else str(year)
                 note = ""
                 if year >= WORK_REQUIREMENT_FIRST_YEAR and not noted_work_req:
                     # Attach the explanation once, to the first year it bites.
@@ -780,7 +793,7 @@ class MedicaidEligibilityTool(BaseTool):
                 if was_eligible:
                     parts.append(
                         f"IMPORTANT -- this CHANGES in {later}: they probably "
-                        f"qualify under the {base_label if earlier == BASE_ELIGIBILITY_YEAR else earlier} "
+                        f"qualify under the {base_label if earlier == current_year else earlier} "
                         f"rules but probably would NOT from {later} on. Lead "
                         "with that, say plainly it's still only an estimate, "
                         "and cover what would keep them covered."
@@ -788,7 +801,7 @@ class MedicaidEligibilityTool(BaseTool):
                 else:
                     parts.append(
                         f"Note this IMPROVES in {later}: they probably would "
-                        f"not qualify under the {base_label if earlier == BASE_ELIGIBILITY_YEAR else earlier} "
+                        f"not qualify under the {base_label if earlier == current_year else earlier} "
                         f"rules but probably would from {later} on. Say so, "
                         "and keep it hedged -- it's an estimate."
                     )
@@ -799,8 +812,8 @@ class MedicaidEligibilityTool(BaseTool):
                 # is the work requirement. Say that plainly rather than
                 # implying we modelled the later year's limits.
                 parts.append(
-                    "Note: future income limits aren't published yet, so "
-                    f"every year above used the current ({BASE_ELIGIBILITY_YEAR}) "
+                    "Note: newer income limits aren't published yet, so "
+                    f"every year above used the {BASE_ELIGIBILITY_YEAR} published "
                     "limits -- what separates the years is the work "
                     "requirement, not the income test. Mention that if the "
                     "answer is close to the line."

--- a/fighthealthinsurance/chat/tools/medicaid_tool.py
+++ b/fighthealthinsurance/chat/tools/medicaid_tool.py
@@ -398,9 +398,27 @@ class MedicaidEligibilityTool(BaseTool):
                 determination_made,
             ) = is_eligible(**loaded)
 
-            # From here on the checker's own output is in play, so the
-            # write-up pass (and the rest of the session) may state a verdict.
-            if self.eligibility_computed is not None:
+            # Has the checker actually produced a verdict the model is
+            # allowed to state? Running the checker is NOT the same as it
+            # reaching an answer, and the invented-verdict penalty keys off
+            # this flag, so flipping it on every call handed out the
+            # exemption in the two cases that need the guard most:
+            #
+            #   * determination_made=False -- a territory, or a required
+            #     answer the user declined. _build_eligibility_info tells the
+            #     model in so many words NOT to say they may be ineligible.
+            #   * mid-interview with nothing settled yet -- a False here means
+            #     "not established", not "no", and jumping to "you don't
+            #     qualify" instead of asking the next question is exactly the
+            #     failure mode.
+            #
+            # An early POSITIVE is different: with questions still outstanding
+            # the checker reports it and the write-up is told to share it, so
+            # that does earn the exemption.
+            checker_produced_verdict = determination_made and (
+                not missing or eligible_base or eligible_target or medicare
+            )
+            if checker_produced_verdict and self.eligibility_computed is not None:
                 self.eligibility_computed[0] = True
 
             info_text = self._build_eligibility_info(
@@ -467,9 +485,11 @@ class MedicaidEligibilityTool(BaseTool):
                     "Medicaid eligibility investigation",
                     history_for_llm,
                     depth=depth + 1,
-                    # This pass is writing up what the checker computed, so a
-                    # verdict in its reply is earned, not invented.
-                    eligibility_verified=True,
+                    # Only exempt this write-up from the invented-verdict
+                    # penalty when the checker actually reached a verdict for
+                    # it to relay; otherwise it is as capable of inventing one
+                    # as any other pass.
+                    eligibility_verified=checker_produced_verdict,
                     is_logged_in=is_logged_in,
                     is_professional=is_professional,
                     fallback_backends=kwargs.get("fallback_backends"),

--- a/fighthealthinsurance/chat/tools/medicaid_tool.py
+++ b/fighthealthinsurance/chat/tools/medicaid_tool.py
@@ -118,12 +118,13 @@ class MedicaidInfoTool(BaseTool):
                     "Medicaid info lookup completed successfully."
                 )
 
-                state_name = medicaid_info_data.get("state", "the state")
+                state = medicaid_info_data.get("state")
+                state_name = state or "the state"
                 medicaid_info_text = (
                     f"Here's the official Medicaid information for {state_name}:\n\n"
                     f"{medicaid_info}\n\n"
                     f" -- use it to answer the question {current_message_for_llm}"
-                    f"\n\n{self._build_eligibility_handoff(state_name)}"
+                    f"\n\n{self._build_eligibility_handoff(state)}"
                 )
 
                 # Call LLM with the Medicaid info context
@@ -205,31 +206,38 @@ class MedicaidInfoTool(BaseTool):
             raise
 
     @staticmethod
-    def _build_eligibility_handoff(state_name: str) -> str:
-        """Guidance that turns a general Medicaid answer into the next step.
+    def _build_eligibility_handoff(state: Optional[str]) -> str:
+        """Guidance that leaves the door open to the eligibility check.
 
         A general "how does Medicaid work in my state?" question used to end
         with contact details and nothing else, so someone who came to us
-        wondering whether they qualify left without ever being offered the
-        check that answers it. The info lookup is the natural jumping-off
-        point, so every successful one now hands the model the handoff.
+        wondering whether they qualify left without ever hearing that we can
+        estimate it. The info lookup is the natural jumping-off point, so
+        every successful one now hands the model the offer.
+
+        It is an OFFER, not a redirect: the wording comes from
+        MEDICAID_ELIGIBILITY_OFFER_RULE, which the system prompt uses too, so
+        the two can't drift into telling the model different things. No tool
+        call is spelled out here -- the model already has the tool's format,
+        and building one by string-concatenating an unescaped state name
+        produced invalid JSON whenever the payload had no "state" key.
         """
-        return (
-            "Then start them down the Medicaid path: after answering, offer "
-            "our EXPERIMENTAL Medicaid/Medicare eligibility check in one "
-            "short sentence (make clear it's experimental, a rough estimate, "
-            "and not an official determination). If they've shown any sign "
-            "of wanting to know whether they qualify -- asking about income "
-            "limits, whether they'd be covered, how to apply, or the work "
-            "requirements -- don't wait for a yes: call "
-            '**medicaid_eligibility {"state": "'
-            + str(state_name)
-            + '"}** now, adding anything '
-            "else they've already told you, and let the tool tell you which "
-            "questions to ask. Never ask eligibility questions before "
-            "calling the tool. If an eligibility check is already underway "
-            "in this conversation, continue it instead of re-offering it."
+        # Imported lazily: ml_models is a heavy module and this file
+        # otherwise stays free of it (same reason medicaid_api is imported
+        # inside execute()).
+        from fighthealthinsurance.ml.ml_models import (
+            MEDICAID_ELIGIBILITY_OFFER_RULE,
         )
+
+        handoff = "Then, after you have answered their question, " + (
+            MEDICAID_ELIGIBILITY_OFFER_RULE
+        )
+        if state:
+            handoff += (
+                f" You already know their state is {state}, so send it in the "
+                "first call along with anything else they have told you."
+            )
+        return handoff
 
 
 class MedicaidEligibilityTool(BaseTool):
@@ -252,6 +260,7 @@ class MedicaidEligibilityTool(BaseTool):
         call_llm_callback: Optional[
             Callable[..., Awaitable[Tuple[Optional[str], Optional[str]]]]
         ] = None,
+        eligibility_computed: Optional[List[bool]] = None,
     ):
         """
         Initialize the Medicaid eligibility tool.
@@ -259,9 +268,16 @@ class MedicaidEligibilityTool(BaseTool):
         Args:
             send_status_message: Async function to send status updates
             call_llm_callback: Callback to call LLM with additional context
+            eligibility_computed: Optional one-element list owned by the
+                ChatInterface, flipped to True once this tool produces a
+                determination. The tool is rebuilt every turn, so the session
+                needs somewhere outside it to remember that a verdict is now
+                legitimate to state (see score_llm_response's invented-verdict
+                penalty).
         """
         super().__init__(send_status_message)
         self.call_llm_callback = call_llm_callback
+        self.eligibility_computed = eligibility_computed
 
     async def execute(
         self,
@@ -340,9 +356,12 @@ class MedicaidEligibilityTool(BaseTool):
         try:
             # Import here to avoid circular imports
             from fighthealthinsurance.medicaid_api import (
+                BASE_ELIGIBILITY_YEAR,
+                WORK_REQUIREMENT_FIRST_YEAR,
                 is_eligible,
                 resolve_target_year,
                 summarize_eligibility_inputs,
+                target_year_requested,
             )
 
             await self.send_status_message("Processing Medicaid eligibility data")
@@ -351,6 +370,16 @@ class MedicaidEligibilityTool(BaseTool):
             # helper the checker uses, so the label we hand the LLM can't
             # claim a different year than the one that was scored.
             target_year = resolve_target_year(loaded.get("target_year"))
+
+            # The checker only projects income limits forward for a year the
+            # user actually named; on the default path both verdicts use the
+            # published table. Recomputed with the same helpers the checker
+            # uses so the caveat we print and the arithmetic it did agree.
+            thresholds_estimated = (
+                target_year_requested(loaded.get("target_year"))
+                and target_year > BASE_ELIGIBILITY_YEAR
+            )
+            work_req_applies = target_year >= WORK_REQUIREMENT_FIRST_YEAR
 
             # What we actually understood from the payload. The LLM parses
             # the user's free text and carries the running answers in its
@@ -369,6 +398,11 @@ class MedicaidEligibilityTool(BaseTool):
                 determination_made,
             ) = is_eligible(**loaded)
 
+            # From here on the checker's own output is in play, so the
+            # write-up pass (and the rest of the session) may state a verdict.
+            if self.eligibility_computed is not None:
+                self.eligibility_computed[0] = True
+
             info_text = self._build_eligibility_info(
                 eligible_base,
                 eligible_target,
@@ -377,26 +411,40 @@ class MedicaidEligibilityTool(BaseTool):
                 missing,
                 determination_made,
                 target_year=target_year,
+                thresholds_estimated=thresholds_estimated,
             )
             if parsed_summary:
                 info_text += "\n\n" + parsed_summary
 
+            # The work-requirement coaching only makes sense for years the
+            # overlay actually applies to. Offering it for a base-year check
+            # told the user to chase 80 hours a month for a rule that isn't
+            # in force in the year they asked about.
+            work_req_advice = (
+                (
+                    f"If the {target_year} work "
+                    "requirement is the barrier, suggest ways to reach 80 "
+                    "qualifying hours a month (work, school, volunteering, or "
+                    "caregiving) and remind them to keep good records -- with "
+                    "empathy, since this is stressful and unfair. "
+                )
+                if work_req_applies
+                else ""
+            )
             action_text = (
                 "\n\nUse this info to either ask the user the next follow-up "
                 "questions (no more than two or three per message, in the "
                 "order listed, rephrased naturally) or deliver the news of "
                 "our determination along with the alternatives. Don't re-ask "
-                "anything the user already answered. Always make it very "
-                "clear that this eligibility check is an EXPERIMENTAL "
-                "feature and only an approximation -- it can be wrong or "
-                "out of date -- and they must contact the state to know for "
-                "sure (you can use the "
+                "anything the user already answered. Never state an "
+                "eligibility answer this check did not produce -- the "
+                "verdicts above are the only ones you may give. Always make "
+                "it very clear that this eligibility check is an "
+                "EXPERIMENTAL feature and only an approximation -- it can be "
+                "wrong or out of date -- and they must contact the state to "
+                "know for sure (you can use the "
                 "medicaid_info tool call to get state-specific contact info "
-                f"to provide to the user). If the {target_year} work "
-                "requirement is the barrier, suggest ways to reach 80 "
-                "qualifying hours a month (work, school, volunteering, or "
-                "caregiving) and remind them to keep good records -- with "
-                "empathy, since this is stressful and unfair. This check "
+                f"to provide to the user). {work_req_advice}This check "
                 f"covered {target_year}; if the user asks about a different "
                 'year, call the tool again with "target_year" set to it '
                 "(along with everything else you already have). Remember to "
@@ -419,6 +467,9 @@ class MedicaidEligibilityTool(BaseTool):
                     "Medicaid eligibility investigation",
                     history_for_llm,
                     depth=depth + 1,
+                    # This pass is writing up what the checker computed, so a
+                    # verdict in its reply is earned, not invented.
+                    eligibility_verified=True,
                     is_logged_in=is_logged_in,
                     is_professional=is_professional,
                     fallback_backends=kwargs.get("fallback_backends"),
@@ -514,6 +565,7 @@ class MedicaidEligibilityTool(BaseTool):
         missing: List[str],
         determination_made: bool = True,
         target_year: Optional[int] = None,
+        thresholds_estimated: bool = False,
     ) -> str:
         """
         Build the eligibility information text passed back to the LLM.
@@ -535,6 +587,10 @@ class MedicaidEligibilityTool(BaseTool):
                 ``resolve_target_year`` returned for this payload, or the
                 label would name a year we didn't score. Defaults to the
                 checker's own default year.
+            thresholds_estimated: True only when the checker projected income
+                limits forward because the USER asked about a future year. On
+                the default path it doesn't, so telling the user the limits
+                were estimated would be describing arithmetic we never did.
 
         Returns:
             Formatted information text
@@ -593,6 +649,16 @@ class MedicaidEligibilityTool(BaseTool):
                     "share that, while noting the questions above are still "
                     "needed to be sure."
                 )
+            if target_is_separate_year and eligible_target:
+                # The target year clears too. Held back with the base-year
+                # positive above, this was the good half of the answer for
+                # someone who asked "will I still qualify in 2028?" and it
+                # sat unsaid behind whatever question was still outstanding.
+                parts.append(
+                    f"They also already look eligible in {target_year}"
+                    f"{work_req_note} -- same caveat, the questions above are "
+                    "still needed to be sure."
+                )
             if medicare:
                 parts.append(
                     "Our data already suggests they may be eligible for medicare."
@@ -638,10 +704,10 @@ class MedicaidEligibilityTool(BaseTool):
                     f"medicaid under the {label} rules{note}."
                 )
 
-            if target_is_separate_year:
-                # The later year's income limits are the published base-year
-                # guidelines rolled forward by an inflation guess, so a
-                # borderline verdict there is softer than it sounds.
+            if thresholds_estimated:
+                # The requested year's income limits are the published
+                # base-year guidelines rolled forward by an inflation guess,
+                # so a borderline verdict there is softer than it sounds.
                 parts.append(
                     f"Note: {target_year} income limits aren't published yet, "
                     f"so we estimated them from the {BASE_ELIGIBILITY_YEAR} "

--- a/fighthealthinsurance/chat/tools/medicaid_tool.py
+++ b/fighthealthinsurance/chat/tools/medicaid_tool.py
@@ -7,7 +7,7 @@ to look up Medicaid information and check eligibility.
 
 import json
 import re
-from typing import Any, Awaitable, Callable, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, List, Optional, Tuple
 
 # Plain asgiref sync_to_async (NOT database_sync_to_async): used below for a
 # non-ORM blocking call, per the repo convention for subprocess/network/file
@@ -18,6 +18,11 @@ from loguru import logger
 
 from .base_tool import BaseTool
 from .patterns import MEDICAID_ELIGIBILITY_REGEX, MEDICAID_INFO_REGEX
+
+if TYPE_CHECKING:
+    # Type-only: medicaid_api pulls in pandas, and the chat tools are
+    # imported on every chat -- the runtime imports stay lazy and local.
+    from fighthealthinsurance.medicaid_api import YearVerdict
 
 
 class MedicaidInfoTool(BaseTool):
@@ -443,7 +448,7 @@ class MedicaidEligibilityTool(BaseTool):
             # told the user to chase 80 hours a month for a rule that isn't
             # in force in the year they asked about.
             years_covered = (
-                ", ".join(str(year) for year, _, _ in timeline)
+                ", ".join(str(row.year) for row in timeline)
                 if timeline
                 else str(target_year)
             )
@@ -599,7 +604,7 @@ class MedicaidEligibilityTool(BaseTool):
         missing: List[str],
         determination_made: bool = True,
         target_year: Optional[int] = None,
-        timeline: Optional[List[Tuple[int, bool, List[str]]]] = None,
+        timeline: Optional[List["YearVerdict"]] = None,
     ) -> str:
         """
         Build the eligibility information text passed back to the LLM.
@@ -621,11 +626,12 @@ class MedicaidEligibilityTool(BaseTool):
                 ``resolve_target_year`` returned for this payload, or the
                 label would name a year we didn't score. Defaults to the
                 checker's own default year.
-            timeline: ``(year, probably_eligible, still_needed)`` rows from
-                ``eligibility_timeline``, ascending. Always rendered in full
-                so a year-over-year change is visible instead of implied. A
-                row with ``still_needed`` is NOT a verdict -- see below.
-                Falls back to the base/target pair when not supplied.
+            timeline: ``YearVerdict`` rows from ``eligibility_timeline``,
+                ascending. Always rendered in full so a year-over-year change
+                is visible instead of implied. A row carrying
+                ``still_needed`` is NOT a verdict, and one flagged
+                ``work_requirement_conditional`` is not a clean pass -- see
+                below. Falls back to the base/target pair when not supplied.
 
         Returns:
             Formatted information text
@@ -636,6 +642,8 @@ class MedicaidEligibilityTool(BaseTool):
             BASE_ELIGIBILITY_YEAR,
             DEFAULT_TARGET_YEAR,
             WORK_REQUIREMENT_FIRST_YEAR,
+            WORK_REQUIREMENT_UNIVERSAL_YEAR,
+            YearVerdict,
             current_eligibility_year,
         )
 
@@ -652,11 +660,11 @@ class MedicaidEligibilityTool(BaseTool):
         # Years to report on, ascending. Falls back to the base/target pair
         # when no timeline was supplied. Deduped so a base-year-only check
         # doesn't print the same verdict twice under two labels.
-        rows: List[Tuple[int, bool, List[str]]] = timeline or [
+        rows: List[YearVerdict] = timeline or [
             row
             for row in (
-                (BASE_ELIGIBILITY_YEAR, eligible_base, []),
-                (target_year, eligible_target, list(missing)),
+                YearVerdict(BASE_ELIGIBILITY_YEAR, eligible_base, []),
+                YearVerdict(target_year, eligible_target, list(missing)),
             )
             # The base row is "the rules before the work requirement". Once
             # that year is behind us nobody is living under it, so it only
@@ -664,11 +672,11 @@ class MedicaidEligibilityTool(BaseTool):
             if row[0] >= current_year or row[0] == target_year
         ]
         seen_years: set = set()
-        deduped_rows: List[Tuple[int, bool, List[str]]] = []
+        deduped_rows: List[YearVerdict] = []
         for row in rows:
-            if row[0] in seen_years:
+            if row.year in seen_years:
                 continue
-            seen_years.add(row[0])
+            seen_years.add(row.year)
             deduped_rows.append(row)
         rows = deduped_rows
 
@@ -682,7 +690,7 @@ class MedicaidEligibilityTool(BaseTool):
         # One shared description of the work-requirement rules so the eligible
         # and not-eligible wordings can't drift apart.
         work_req_note = ""
-        if any(year >= WORK_REQUIREMENT_FIRST_YEAR for year, _, _ in rows):
+        if any(row.year >= WORK_REQUIREMENT_FIRST_YEAR for row in rows):
             work_req_note = (
                 " (once the federal 80-hours-per-month work/community-engagement "
                 "requirement applies to them — states must implement it by "
@@ -690,9 +698,7 @@ class MedicaidEligibilityTool(BaseTool):
             )
         # Any year past the published table's was scored with that table's
         # limits, and we owe the user that fact.
-        scored_beyond_the_table = any(
-            year > BASE_ELIGIBILITY_YEAR for year, _, _ in rows
-        )
+        scored_beyond_the_table = any(row.year > BASE_ELIGIBILITY_YEAR for row in rows)
 
         parts: List[str] = [
             "We're helping figure out if someone is likely eligible for "
@@ -727,9 +733,9 @@ class MedicaidEligibilityTool(BaseTool):
             # that alone. Sharing an early POSITIVE is the point of this
             # branch -- it's the negatives that must never outrun the data.
             later_settled = [
-                year
-                for year, probably_eligible, _ in rows
-                if year > current_year and probably_eligible
+                row.year
+                for row in rows
+                if row.year > current_year and row.probably_eligible
             ]
             if later_settled:
                 # The later years clear too. Held back with the base-year
@@ -780,26 +786,50 @@ class MedicaidEligibilityTool(BaseTool):
             verdict_lines = []
             noted_work_req = False
             unanswered_by_year: List[Tuple[int, List[str]]] = []
-            for year, probably_eligible, still_needed in rows:
-                label = base_label if year == current_year else str(year)
+            for row in rows:
+                label = base_label if row.year == current_year else str(row.year)
                 note = ""
-                if year >= WORK_REQUIREMENT_FIRST_YEAR and not noted_work_req:
+                if (
+                    row.year >= WORK_REQUIREMENT_FIRST_YEAR
+                    and not noted_work_req
+                    # A conditional row spells the requirement out itself, so
+                    # it must not SWALLOW the shared note on the way past --
+                    # doing so left the year the rule actually bites with no
+                    # explanation attached at all.
+                    and not row.work_requirement_conditional
+                ):
                     # Attach the explanation once, to the first year it bites.
                     note = work_req_note
                     noted_work_req = True
-                if still_needed:
+                if row.still_needed:
                     # NOT a verdict. The checker returns False for this year
                     # because it can't score it yet, and printing that as "may
                     # not be eligible" hands the user a denial nobody
                     # computed -- the exact failure the rest of this file
                     # exists to prevent.
-                    unanswered_by_year.append((year, still_needed))
+                    unanswered_by_year.append((row.year, row.still_needed))
                     verdict_lines.append(
                         f"- {label}: NOT ESTABLISHED -- we can't score this "
                         f"year until the questions below are answered{note}"
                     )
                     continue
-                verdict = "could be" if probably_eligible else "may not be"
+                if row.work_requirement_conditional:
+                    # Also not a verdict. They clear the income and category
+                    # tests but fall short on hours in a year the requirement
+                    # has reached some states and not others. "May not be
+                    # eligible" would be a denial for a rule most states
+                    # haven't adopted; a plain "could be" would hide what is
+                    # coming. Say both.
+                    verdict_lines.append(
+                        f"- {label}: they could be eligible on income, BUT they're "
+                        "under 80 qualifying hours a month -- so it depends on "
+                        "whether their state has already started the work "
+                        f"requirement. It applies in every state from January 1, "
+                        f"{WORK_REQUIREMENT_UNIVERSAL_YEAR}. Tell them to check "
+                        "with their state, and do NOT say they're ineligible."
+                    )
+                    continue
+                verdict = "could be" if row.probably_eligible else "may not be"
                 verdict_lines.append(
                     f"- {label}: they {verdict} eligible for medicaid{note}"
                 )
@@ -830,17 +860,20 @@ class MedicaidEligibilityTool(BaseTool):
             # sentences. Someone who probably qualifies today and probably
             # won't once the work requirement applies needs to hear that as
             # the headline, not as a footnote.
-            for (earlier, was_eligible, earlier_needs), (
-                later,
-                now_eligible,
-                later_needs,
-            ) in zip(rows, rows[1:]):
-                if earlier_needs or later_needs:
-                    # One side isn't a verdict, so there is no change to
-                    # announce -- "this CHANGES in 2027" off the back of an
-                    # unanswered question is the denial again, in a louder
-                    # voice.
+            for earlier_row, later_row in zip(rows, rows[1:]):
+                if (
+                    earlier_row.still_needed
+                    or later_row.still_needed
+                    or earlier_row.work_requirement_conditional
+                    or later_row.work_requirement_conditional
+                ):
+                    # One side isn't a settled verdict, so there is no change
+                    # to announce -- "this CHANGES in 2027" off the back of an
+                    # unanswered question, or of a rule that may not have
+                    # reached them, is the denial again in a louder voice.
                     continue
+                earlier, was_eligible = earlier_row.year, earlier_row.probably_eligible
+                later, now_eligible = later_row.year, later_row.probably_eligible
                 if was_eligible == now_eligible:
                     continue
                 if was_eligible:

--- a/fighthealthinsurance/chat/tools/medicaid_tool.py
+++ b/fighthealthinsurance/chat/tools/medicaid_tool.py
@@ -123,6 +123,7 @@ class MedicaidInfoTool(BaseTool):
                     f"Here's the official Medicaid information for {state_name}:\n\n"
                     f"{medicaid_info}\n\n"
                     f" -- use it to answer the question {current_message_for_llm}"
+                    f"\n\n{self._build_eligibility_handoff(state_name)}"
                 )
 
                 # Call LLM with the Medicaid info context
@@ -202,6 +203,33 @@ class MedicaidInfoTool(BaseTool):
                 f"Error processing Medicaid info data: {str(e)}"
             )
             raise
+
+    @staticmethod
+    def _build_eligibility_handoff(state_name: str) -> str:
+        """Guidance that turns a general Medicaid answer into the next step.
+
+        A general "how does Medicaid work in my state?" question used to end
+        with contact details and nothing else, so someone who came to us
+        wondering whether they qualify left without ever being offered the
+        check that answers it. The info lookup is the natural jumping-off
+        point, so every successful one now hands the model the handoff.
+        """
+        return (
+            "Then start them down the Medicaid path: after answering, offer "
+            "our EXPERIMENTAL Medicaid/Medicare eligibility check in one "
+            "short sentence (make clear it's experimental, a rough estimate, "
+            "and not an official determination). If they've shown any sign "
+            "of wanting to know whether they qualify -- asking about income "
+            "limits, whether they'd be covered, how to apply, or the work "
+            "requirements -- don't wait for a yes: call "
+            '**medicaid_eligibility {"state": "'
+            + str(state_name)
+            + '"}** now, adding anything '
+            "else they've already told you, and let the tool tell you which "
+            "questions to ask. Never ask eligibility questions before "
+            "calling the tool. If an eligibility check is already underway "
+            "in this conversation, continue it instead of re-offering it."
+        )
 
 
 class MedicaidEligibilityTool(BaseTool):
@@ -313,10 +341,16 @@ class MedicaidEligibilityTool(BaseTool):
             # Import here to avoid circular imports
             from fighthealthinsurance.medicaid_api import (
                 is_eligible,
+                resolve_target_year,
                 summarize_eligibility_inputs,
             )
 
             await self.send_status_message("Processing Medicaid eligibility data")
+
+            # Which year the second verdict covers. Resolved with the same
+            # helper the checker uses, so the label we hand the LLM can't
+            # claim a different year than the one that was scored.
+            target_year = resolve_target_year(loaded.get("target_year"))
 
             # What we actually understood from the payload. The LLM parses
             # the user's free text and carries the running answers in its
@@ -327,8 +361,8 @@ class MedicaidEligibilityTool(BaseTool):
             )
 
             (
-                eligible_2025,
-                eligible_2026,
+                eligible_base,
+                eligible_target,
                 medicare,
                 alternatives,
                 missing,
@@ -336,12 +370,13 @@ class MedicaidEligibilityTool(BaseTool):
             ) = is_eligible(**loaded)
 
             info_text = self._build_eligibility_info(
-                eligible_2025,
-                eligible_2026,
+                eligible_base,
+                eligible_target,
                 medicare,
                 alternatives,
                 missing,
                 determination_made,
+                target_year=target_year,
             )
             if parsed_summary:
                 info_text += "\n\n" + parsed_summary
@@ -357,12 +392,15 @@ class MedicaidEligibilityTool(BaseTool):
                 "out of date -- and they must contact the state to know for "
                 "sure (you can use the "
                 "medicaid_info tool call to get state-specific contact info "
-                "to provide to the user). If the 2026 work requirement is "
-                "the barrier, suggest ways to reach 80 qualifying hours a "
-                "month (work, school, volunteering, or caregiving) and "
-                "remind them to keep good records -- with empathy, since "
-                "this is stressful and unfair. Remember to use the panda "
-                "emoji and context."
+                f"to provide to the user). If the {target_year} work "
+                "requirement is the barrier, suggest ways to reach 80 "
+                "qualifying hours a month (work, school, volunteering, or "
+                "caregiving) and remind them to keep good records -- with "
+                "empathy, since this is stressful and unfair. This check "
+                f"covered {target_year}; if the user asks about a different "
+                'year, call the tool again with "target_year" set to it '
+                "(along with everything else you already have). Remember to "
+                "use the panda emoji and context."
             )
 
             await self.send_status_message("Formatting response...")
@@ -469,20 +507,22 @@ class MedicaidEligibilityTool(BaseTool):
 
     def _build_eligibility_info(
         self,
-        eligible_2025: bool,
-        eligible_2026: bool,
+        eligible_base: bool,
+        eligible_target: bool,
         medicare: bool,
         alternatives: List[str],
         missing: List[str],
         determination_made: bool = True,
+        target_year: Optional[int] = None,
     ) -> str:
         """
         Build the eligibility information text passed back to the LLM.
 
         Args:
-            eligible_2025: Whether eligible under the 2025 rules
-            eligible_2026: Whether eligible under the 2026 rules (which add
-                the federal work/community-engagement requirement)
+            eligible_base: Whether eligible under today's (base-year) rules
+            eligible_target: Whether eligible in ``target_year`` (which adds
+                the federal work/community-engagement requirement from
+                ``WORK_REQUIREMENT_FIRST_YEAR`` on)
             medicare: Whether eligible for Medicare
             alternatives: List of alternative suggestions
             missing: List of missing-information questions still to ask
@@ -490,17 +530,40 @@ class MedicaidEligibilityTool(BaseTool):
                 person at all (a US territory, or a required answer they
                 declined). A False here must never be rendered as an
                 ineligibility verdict -- that is the whole point of the flag.
+            target_year: The year the second verdict covers -- the user's own
+                year when they asked about one. Must be the year
+                ``resolve_target_year`` returned for this payload, or the
+                label would name a year we didn't score. Defaults to the
+                checker's own default year.
 
         Returns:
             Formatted information text
         """
-        # One shared description of the 2026 rules so the eligible and
-        # not-eligible wordings can't drift apart.
-        work_req_note = (
-            " (once the federal 80-hours-per-month work/community-engagement "
-            "requirement applies to them — states must implement it by "
-            "January 1, 2027, a few earlier)"
+        # Imported lazily like the rest of medicaid_api here: the module
+        # pulls in pandas, and the chat tools are imported on every chat.
+        from fighthealthinsurance.medicaid_api import (
+            BASE_ELIGIBILITY_YEAR,
+            DEFAULT_TARGET_YEAR,
+            WORK_REQUIREMENT_FIRST_YEAR,
         )
+
+        if target_year is None:
+            target_year = DEFAULT_TARGET_YEAR
+
+        # One shared description of the work-requirement rules so the
+        # eligible and not-eligible wordings can't drift apart. Only years
+        # the requirement can apply to get it.
+        work_req_note = ""
+        if target_year >= WORK_REQUIREMENT_FIRST_YEAR:
+            work_req_note = (
+                " (once the federal 80-hours-per-month work/community-engagement "
+                "requirement applies to them — states must implement it by "
+                "January 1, 2027, a few earlier)"
+            )
+        base_label = f"current ({BASE_ELIGIBILITY_YEAR})"
+        # A user who asked about this year gets one verdict, not the same
+        # verdict printed twice under two labels.
+        target_is_separate_year = target_year > BASE_ELIGIBILITY_YEAR
 
         parts: List[str] = [
             "We're helping figure out if someone is likely eligible for "
@@ -523,10 +586,10 @@ class MedicaidEligibilityTool(BaseTool):
             # eligible" sat unsaid behind an unrelated follow-up. Only
             # positives are reported here: a False at this stage means "not
             # established yet", not "no".
-            if eligible_2025:
+            if eligible_base:
                 parts.append(
                     "Based on what we have so far they already look eligible "
-                    "for medicaid under the current (2025) rules -- you can "
+                    f"for medicaid under the {base_label} rules -- you can "
                     "share that, while noting the questions above are still "
                     "needed to be sure."
                 )
@@ -565,14 +628,24 @@ class MedicaidEligibilityTool(BaseTool):
                 alternative_lines = "\n".join(f"- {a}" for a in alternatives)
                 parts.append("Next steps to share:\n" + alternative_lines)
         else:
-            for label, is_eligible_for_year, note in (
-                ("current (2025)", eligible_2025, ""),
-                ("2026", eligible_2026, work_req_note),
-            ):
+            verdicts = [(base_label, eligible_base, "")]
+            if target_is_separate_year:
+                verdicts.append((str(target_year), eligible_target, work_req_note))
+            for label, is_eligible_for_year, note in verdicts:
                 verdict = "could be" if is_eligible_for_year else "may not be"
                 parts.append(
                     f"Our data so far suggests they {verdict} eligible for "
                     f"medicaid under the {label} rules{note}."
+                )
+
+            if target_is_separate_year:
+                # The later year's income limits are the published base-year
+                # guidelines rolled forward by an inflation guess, so a
+                # borderline verdict there is softer than it sounds.
+                parts.append(
+                    f"Note: {target_year} income limits aren't published yet, "
+                    f"so we estimated them from the {BASE_ELIGIBILITY_YEAR} "
+                    "guidelines. Say so if the answer is close to the line."
                 )
 
             if medicare:

--- a/fighthealthinsurance/chat/tools/medicaid_tool.py
+++ b/fighthealthinsurance/chat/tools/medicaid_tool.py
@@ -25,6 +25,28 @@ if TYPE_CHECKING:
     from fighthealthinsurance.medicaid_api import YearVerdict
 
 
+# Every answer this tool produces is an estimate off deliberately simplified
+# rules, against limits that move, in a program whose details vary by state.
+# So every answer has to arrive with the way to check it -- and it is appended
+# to EACH branch rather than stated once at the top, because a model given one
+# blanket caveat in the preamble routinely drops it by the time it writes the
+# sentence that actually matters to the person reading.
+#
+# The pointers are things we can genuinely pull up rather than a vague "look
+# it up", so the offer is worth accepting.
+CONFIRM_WITH_STATE_INSTRUCTION = (
+    "ALWAYS close by telling the user to confirm with their state Medicaid "
+    "agency, whatever the answer was: the state is the only one who can "
+    "actually decide, our rules are simplified, and eligibility limits "
+    "change. Offer to pull up the official pages for them -- "
+    'medicaid_gov_lookup {"page": "renew_info", "state": "<their state>"} '
+    "for their state's Medicaid and renewal hub, or "
+    'medicaid_gov_lookup {"page": "eligibility_levels"} for the official '
+    "income-limit table -- and medicaid_info for state contact details. "
+    "Never present any of this as a decision that has been made."
+)
+
+
 class MedicaidInfoTool(BaseTool):
     """
     Tool handler for Medicaid information lookups.
@@ -474,9 +496,9 @@ class MedicaidEligibilityTool(BaseTool):
                 "it very clear that this eligibility check is an "
                 "EXPERIMENTAL feature and only an approximation -- it can be "
                 "wrong or out of date -- and they must contact the state to "
-                "know for sure (you can use the "
-                "medicaid_info tool call to get state-specific contact info "
-                f"to provide to the user). {work_req_advice}Give the user "
+                "know for sure (medicaid_info gets state-specific contact "
+                "info, and medicaid_gov_lookup pulls up the official pages so "
+                f"they can read the rules themselves). {work_req_advice}Give the user "
                 "EVERY year listed above, not just one -- whether the answer "
                 "holds steady or changes is the most useful thing in this "
                 "check, and if it changes, lead with that. Keep the hedged "
@@ -689,8 +711,15 @@ class MedicaidEligibilityTool(BaseTool):
         #
         # One shared description of the work-requirement rules so the eligible
         # and not-eligible wordings can't drift apart.
+        # Gated on eligible_base as well as the year: when someone fails the
+        # income or category test the work requirement is not what stopped
+        # them, and attaching "(once the 80-hours requirement applies...)" to
+        # an income denial tells them to go chase hours that would not have
+        # changed the answer.
         work_req_note = ""
-        if any(row.year >= WORK_REQUIREMENT_FIRST_YEAR for row in rows):
+        if eligible_base and any(
+            row.year >= WORK_REQUIREMENT_FIRST_YEAR for row in rows
+        ):
             work_req_note = (
                 " (once the federal 80-hours-per-month work/community-engagement "
                 "requirement applies to them — states must implement it by "
@@ -785,6 +814,7 @@ class MedicaidEligibilityTool(BaseTool):
         else:
             verdict_lines = []
             noted_work_req = False
+            noted_not_a_denial = False
             unanswered_by_year: List[Tuple[int, List[str]]] = []
             for row in rows:
                 label = base_label if row.year == current_year else str(row.year)
@@ -829,10 +859,29 @@ class MedicaidEligibilityTool(BaseTool):
                         "with their state, and do NOT say they're ineligible."
                     )
                     continue
-                verdict = "could be" if row.probably_eligible else "may not be"
-                verdict_lines.append(
-                    f"- {label}: they {verdict} eligible for medicaid{note}"
-                )
+                if row.probably_eligible:
+                    verdict_lines.append(
+                        f"- {label}: they could be eligible for medicaid{note}"
+                    )
+                else:
+                    # The negative is the line someone acts on by NOT
+                    # applying, so the reminder rides on the line itself
+                    # rather than waiting for a caveat further down. Spelled
+                    # out once and abbreviated after: repeating the whole
+                    # sentence on every negative row dilutes it.
+                    if noted_not_a_denial:
+                        caveat = " -- again, an estimate, not a denial"
+                    else:
+                        caveat = (
+                            " -- say this is our rough estimate and NOT a "
+                            "denial, and that only their state can decide; "
+                            "people do qualify when a checker like ours says "
+                            "they might not"
+                        )
+                        noted_not_a_denial = True
+                    verdict_lines.append(
+                        f"- {label}: they may not be eligible for medicaid{note}{caveat}"
+                    )
             parts.append(
                 "Our data so far suggests, year by year (every one of these "
                 "is an approximation, not a determination):\n"
@@ -917,5 +966,11 @@ class MedicaidEligibilityTool(BaseTool):
                     "Alternative programs and next steps worth mentioning:\n"
                     f"{alternative_lines}"
                 )
+
+        # Outside the branch chain on purpose: mid-interview, indeterminate
+        # and finished answers all need it, and the one most likely to be
+        # taken as final -- "we couldn't score you" -- is the one that used to
+        # end without it.
+        parts.append(CONFIRM_WITH_STATE_INSTRUCTION)
 
         return "\n\n".join(parts)

--- a/fighthealthinsurance/chat/tools/medicaid_tool.py
+++ b/fighthealthinsurance/chat/tools/medicaid_tool.py
@@ -357,6 +357,7 @@ class MedicaidEligibilityTool(BaseTool):
             # Import here to avoid circular imports
             from fighthealthinsurance.medicaid_api import (
                 WORK_REQUIREMENT_FIRST_YEAR,
+                eligibility_timeline,
                 is_eligible,
                 resolve_target_year,
                 summarize_eligibility_inputs,
@@ -418,6 +419,12 @@ class MedicaidEligibilityTool(BaseTool):
             if checker_produced_verdict and self.eligibility_computed is not None:
                 self.eligibility_computed[0] = True
 
+            # Verdicts for every year worth showing, so a year-over-year
+            # change is rendered rather than left for the user to infer from
+            # two sentences. Skipped when the checker couldn't score this
+            # person at all -- there is nothing to plot.
+            timeline = eligibility_timeline(**loaded) if determination_made else None
+
             info_text = self._build_eligibility_info(
                 eligible_base,
                 eligible_target,
@@ -426,6 +433,7 @@ class MedicaidEligibilityTool(BaseTool):
                 missing,
                 determination_made,
                 target_year=target_year,
+                timeline=timeline,
             )
             if parsed_summary:
                 info_text += "\n\n" + parsed_summary
@@ -434,6 +442,11 @@ class MedicaidEligibilityTool(BaseTool):
             # overlay actually applies to. Offering it for a base-year check
             # told the user to chase 80 hours a month for a rule that isn't
             # in force in the year they asked about.
+            years_covered = (
+                ", ".join(str(year) for year, _ in timeline)
+                if timeline
+                else str(target_year)
+            )
             work_req_advice = (
                 (
                     f"If the {target_year} work "
@@ -458,11 +471,16 @@ class MedicaidEligibilityTool(BaseTool):
                 "wrong or out of date -- and they must contact the state to "
                 "know for sure (you can use the "
                 "medicaid_info tool call to get state-specific contact info "
-                f"to provide to the user). {work_req_advice}This check "
-                f"covered {target_year}; if the user asks about a different "
-                'year, call the tool again with "target_year" set to it '
-                "(along with everything else you already have). Remember to "
-                "use the panda emoji and context."
+                f"to provide to the user). {work_req_advice}Give the user "
+                "EVERY year listed above, not just one -- whether the answer "
+                "holds steady or changes is the most useful thing in this "
+                "check, and if it changes, lead with that. Keep the hedged "
+                'wording ("probably", "could be", "may not be"): none of '
+                f"these are determinations. This check covered {years_covered}"
+                "; if the user asks about a year that isn't listed, call the "
+                'tool again with "target_year" set to it (along with '
+                "everything else you already have). Remember to use the panda "
+                "emoji and context."
             )
 
             await self.send_status_message("Formatting response...")
@@ -581,6 +599,7 @@ class MedicaidEligibilityTool(BaseTool):
         missing: List[str],
         determination_made: bool = True,
         target_year: Optional[int] = None,
+        timeline: Optional[List[Tuple[int, bool]]] = None,
     ) -> str:
         """
         Build the eligibility information text passed back to the LLM.
@@ -602,6 +621,10 @@ class MedicaidEligibilityTool(BaseTool):
                 ``resolve_target_year`` returned for this payload, or the
                 label would name a year we didn't score. Defaults to the
                 checker's own default year.
+            timeline: ``(year, probably_eligible)`` rows from
+                ``eligibility_timeline``, ascending. Always rendered in full
+                so a year-over-year change is visible instead of implied.
+                Falls back to the base/target pair when not supplied.
 
         Returns:
             Formatted information text
@@ -632,6 +655,22 @@ class MedicaidEligibilityTool(BaseTool):
         # verdict printed twice under two labels.
         target_is_separate_year = target_year > BASE_ELIGIBILITY_YEAR
 
+        # Years to report on, ascending. Falls back to the base/target pair
+        # when no timeline was supplied. Deduped so a base-year-only check
+        # doesn't print the same verdict twice under two labels.
+        rows = timeline or [
+            (BASE_ELIGIBILITY_YEAR, eligible_base),
+            (target_year, eligible_target),
+        ]
+        seen_years: set = set()
+        deduped_rows = []
+        for row in rows:
+            if row[0] in seen_years:
+                continue
+            seen_years.add(row[0])
+            deduped_rows.append(row)
+        rows = deduped_rows
+
         parts: List[str] = [
             "We're helping figure out if someone is likely eligible for "
             "Medicaid using our EXPERIMENTAL eligibility checker. Be very "
@@ -660,13 +699,19 @@ class MedicaidEligibilityTool(BaseTool):
                     "share that, while noting the questions above are still "
                     "needed to be sure."
                 )
-            if target_is_separate_year and eligible_target:
-                # The target year clears too. Held back with the base-year
+            later_settled = [
+                year
+                for year, probably_eligible in rows
+                if year > BASE_ELIGIBILITY_YEAR and probably_eligible
+            ]
+            if later_settled:
+                # The later years clear too. Held back with the base-year
                 # positive above, this was the good half of the answer for
                 # someone who asked "will I still qualify in 2028?" and it
                 # sat unsaid behind whatever question was still outstanding.
+                years_text = ", ".join(str(y) for y in later_settled)
                 parts.append(
-                    f"They also already look eligible in {target_year}"
+                    f"They also already look eligible in {years_text}"
                     f"{work_req_note} -- same caveat, the questions above are "
                     "still needed to be sure."
                 )
@@ -705,15 +750,48 @@ class MedicaidEligibilityTool(BaseTool):
                 alternative_lines = "\n".join(f"- {a}" for a in alternatives)
                 parts.append("Next steps to share:\n" + alternative_lines)
         else:
-            verdicts = [(base_label, eligible_base, "")]
-            if target_is_separate_year:
-                verdicts.append((str(target_year), eligible_target, work_req_note))
-            for label, is_eligible_for_year, note in verdicts:
-                verdict = "could be" if is_eligible_for_year else "may not be"
-                parts.append(
-                    f"Our data so far suggests they {verdict} eligible for "
-                    f"medicaid under the {label} rules{note}."
+            verdict_lines = []
+            noted_work_req = False
+            for year, probably_eligible in rows:
+                label = base_label if year == BASE_ELIGIBILITY_YEAR else str(year)
+                note = ""
+                if year >= WORK_REQUIREMENT_FIRST_YEAR and not noted_work_req:
+                    # Attach the explanation once, to the first year it bites.
+                    note = work_req_note
+                    noted_work_req = True
+                verdict = "could be" if probably_eligible else "may not be"
+                verdict_lines.append(
+                    f"- {label}: they {verdict} eligible for medicaid{note}"
                 )
+            parts.append(
+                "Our data so far suggests, year by year (every one of these "
+                "is an approximation, not a determination):\n"
+                + "\n".join(verdict_lines)
+            )
+
+            # The whole reason for showing more than one year: say out loud
+            # when the answer moves, rather than leaving the user to diff two
+            # sentences. Someone who probably qualifies today and probably
+            # won't once the work requirement applies needs to hear that as
+            # the headline, not as a footnote.
+            for (earlier, was_eligible), (later, now_eligible) in zip(rows, rows[1:]):
+                if was_eligible == now_eligible:
+                    continue
+                if was_eligible:
+                    parts.append(
+                        f"IMPORTANT -- this CHANGES in {later}: they probably "
+                        f"qualify under the {base_label if earlier == BASE_ELIGIBILITY_YEAR else earlier} "
+                        f"rules but probably would NOT from {later} on. Lead "
+                        "with that, say plainly it's still only an estimate, "
+                        "and cover what would keep them covered."
+                    )
+                else:
+                    parts.append(
+                        f"Note this IMPROVES in {later}: they probably would "
+                        f"not qualify under the {base_label if earlier == BASE_ELIGIBILITY_YEAR else earlier} "
+                        f"rules but probably would from {later} on. Say so, "
+                        "and keep it hedged -- it's an estimate."
+                    )
 
             if target_is_separate_year:
                 # We do NOT guess at future income limits: the same published
@@ -721,11 +799,11 @@ class MedicaidEligibilityTool(BaseTool):
                 # is the work requirement. Say that plainly rather than
                 # implying we modelled the later year's limits.
                 parts.append(
-                    f"Note: {target_year} income limits aren't published yet, "
-                    f"so this used the current ({BASE_ELIGIBILITY_YEAR}) "
-                    "limits for both years -- the difference between them is "
-                    "the work requirement, not the income test. Mention that "
-                    "if the answer is close to the line."
+                    "Note: future income limits aren't published yet, so "
+                    f"every year above used the current ({BASE_ELIGIBILITY_YEAR}) "
+                    "limits -- what separates the years is the work "
+                    "requirement, not the income test. Mention that if the "
+                    "answer is close to the line."
                 )
 
             if medicare:

--- a/fighthealthinsurance/chat/tools/medicaid_tool.py
+++ b/fighthealthinsurance/chat/tools/medicaid_tool.py
@@ -641,25 +641,12 @@ class MedicaidEligibilityTool(BaseTool):
         if target_year is None:
             target_year = DEFAULT_TARGET_YEAR
 
-        # One shared description of the work-requirement rules so the
-        # eligible and not-eligible wordings can't drift apart. Only years
-        # the requirement can apply to get it.
-        work_req_note = ""
-        if target_year >= WORK_REQUIREMENT_FIRST_YEAR:
-            work_req_note = (
-                " (once the federal 80-hours-per-month work/community-engagement "
-                "requirement applies to them — states must implement it by "
-                "January 1, 2027, a few earlier)"
-            )
         # "current" means the calendar year, not the year of the FPL table we
         # score against. Those drifted apart the moment the table's year
         # ended, and calling a finished year "current" told people the rules
         # they live under were the ones that had just been replaced.
         current_year = current_eligibility_year()
         base_label = f"current ({current_year})"
-        # A user who asked about this year gets one verdict, not the same
-        # verdict printed twice under two labels.
-        target_is_separate_year = target_year > current_year
 
         # Years to report on, ascending. Falls back to the base/target pair
         # when no timeline was supplied. Deduped so a base-year-only check
@@ -683,6 +670,26 @@ class MedicaidEligibilityTool(BaseTool):
             seen_years.add(row[0])
             deduped_rows.append(row)
         rows = deduped_rows
+
+        # Both caveats below are keyed off the years we actually RENDER, not
+        # the year the user named. The timeline shows the work-requirement
+        # year alongside a request for an earlier one, so keying off
+        # target_year alone printed "this CHANGES in 2026" with nothing to say
+        # what changed -- a flip with no stated cause, which is the worst
+        # version of this answer.
+        #
+        # One shared description of the work-requirement rules so the eligible
+        # and not-eligible wordings can't drift apart.
+        work_req_note = ""
+        if any(year >= WORK_REQUIREMENT_FIRST_YEAR for year, _ in rows):
+            work_req_note = (
+                " (once the federal 80-hours-per-month work/community-engagement "
+                "requirement applies to them — states must implement it by "
+                "January 1, 2027, a few earlier)"
+            )
+        # Any year past the published table's was scored with that table's
+        # limits, and we owe the user that fact.
+        scored_beyond_the_table = any(year > BASE_ELIGIBILITY_YEAR for year, _ in rows)
 
         parts: List[str] = [
             "We're helping figure out if someone is likely eligible for "
@@ -806,7 +813,7 @@ class MedicaidEligibilityTool(BaseTool):
                         "and keep it hedged -- it's an estimate."
                     )
 
-            if target_is_separate_year:
+            if scored_beyond_the_table:
                 # We do NOT guess at future income limits: the same published
                 # table scores both years, so the only thing separating them
                 # is the work requirement. Say that plainly rather than

--- a/fighthealthinsurance/chat/tools/medicaid_tool.py
+++ b/fighthealthinsurance/chat/tools/medicaid_tool.py
@@ -356,12 +356,10 @@ class MedicaidEligibilityTool(BaseTool):
         try:
             # Import here to avoid circular imports
             from fighthealthinsurance.medicaid_api import (
-                BASE_ELIGIBILITY_YEAR,
                 WORK_REQUIREMENT_FIRST_YEAR,
                 is_eligible,
                 resolve_target_year,
                 summarize_eligibility_inputs,
-                target_year_requested,
             )
 
             await self.send_status_message("Processing Medicaid eligibility data")
@@ -371,14 +369,6 @@ class MedicaidEligibilityTool(BaseTool):
             # claim a different year than the one that was scored.
             target_year = resolve_target_year(loaded.get("target_year"))
 
-            # The checker only projects income limits forward for a year the
-            # user actually named; on the default path both verdicts use the
-            # published table. Recomputed with the same helpers the checker
-            # uses so the caveat we print and the arithmetic it did agree.
-            thresholds_estimated = (
-                target_year_requested(loaded.get("target_year"))
-                and target_year > BASE_ELIGIBILITY_YEAR
-            )
             work_req_applies = target_year >= WORK_REQUIREMENT_FIRST_YEAR
 
             # What we actually understood from the payload. The LLM parses
@@ -436,7 +426,6 @@ class MedicaidEligibilityTool(BaseTool):
                 missing,
                 determination_made,
                 target_year=target_year,
-                thresholds_estimated=thresholds_estimated,
             )
             if parsed_summary:
                 info_text += "\n\n" + parsed_summary
@@ -592,7 +581,6 @@ class MedicaidEligibilityTool(BaseTool):
         missing: List[str],
         determination_made: bool = True,
         target_year: Optional[int] = None,
-        thresholds_estimated: bool = False,
     ) -> str:
         """
         Build the eligibility information text passed back to the LLM.
@@ -614,10 +602,6 @@ class MedicaidEligibilityTool(BaseTool):
                 ``resolve_target_year`` returned for this payload, or the
                 label would name a year we didn't score. Defaults to the
                 checker's own default year.
-            thresholds_estimated: True only when the checker projected income
-                limits forward because the USER asked about a future year. On
-                the default path it doesn't, so telling the user the limits
-                were estimated would be describing arithmetic we never did.
 
         Returns:
             Formatted information text
@@ -731,14 +715,17 @@ class MedicaidEligibilityTool(BaseTool):
                     f"medicaid under the {label} rules{note}."
                 )
 
-            if thresholds_estimated:
-                # The requested year's income limits are the published
-                # base-year guidelines rolled forward by an inflation guess,
-                # so a borderline verdict there is softer than it sounds.
+            if target_is_separate_year:
+                # We do NOT guess at future income limits: the same published
+                # table scores both years, so the only thing separating them
+                # is the work requirement. Say that plainly rather than
+                # implying we modelled the later year's limits.
                 parts.append(
                     f"Note: {target_year} income limits aren't published yet, "
-                    f"so we estimated them from the {BASE_ELIGIBILITY_YEAR} "
-                    "guidelines. Say so if the answer is close to the line."
+                    f"so this used the current ({BASE_ELIGIBILITY_YEAR}) "
+                    "limits for both years -- the difference between them is "
+                    "the work requirement, not the income test. Mention that "
+                    "if the answer is close to the line."
                 )
 
             if medicare:

--- a/fighthealthinsurance/chat/tools/medicaid_tool.py
+++ b/fighthealthinsurance/chat/tools/medicaid_tool.py
@@ -443,7 +443,7 @@ class MedicaidEligibilityTool(BaseTool):
             # told the user to chase 80 hours a month for a rule that isn't
             # in force in the year they asked about.
             years_covered = (
-                ", ".join(str(year) for year, _ in timeline)
+                ", ".join(str(year) for year, _, _ in timeline)
                 if timeline
                 else str(target_year)
             )
@@ -599,7 +599,7 @@ class MedicaidEligibilityTool(BaseTool):
         missing: List[str],
         determination_made: bool = True,
         target_year: Optional[int] = None,
-        timeline: Optional[List[Tuple[int, bool]]] = None,
+        timeline: Optional[List[Tuple[int, bool, List[str]]]] = None,
     ) -> str:
         """
         Build the eligibility information text passed back to the LLM.
@@ -621,9 +621,10 @@ class MedicaidEligibilityTool(BaseTool):
                 ``resolve_target_year`` returned for this payload, or the
                 label would name a year we didn't score. Defaults to the
                 checker's own default year.
-            timeline: ``(year, probably_eligible)`` rows from
+            timeline: ``(year, probably_eligible, still_needed)`` rows from
                 ``eligibility_timeline``, ascending. Always rendered in full
-                so a year-over-year change is visible instead of implied.
+                so a year-over-year change is visible instead of implied. A
+                row with ``still_needed`` is NOT a verdict -- see below.
                 Falls back to the base/target pair when not supplied.
 
         Returns:
@@ -651,11 +652,11 @@ class MedicaidEligibilityTool(BaseTool):
         # Years to report on, ascending. Falls back to the base/target pair
         # when no timeline was supplied. Deduped so a base-year-only check
         # doesn't print the same verdict twice under two labels.
-        rows = timeline or [
+        rows: List[Tuple[int, bool, List[str]]] = timeline or [
             row
             for row in (
-                (BASE_ELIGIBILITY_YEAR, eligible_base),
-                (target_year, eligible_target),
+                (BASE_ELIGIBILITY_YEAR, eligible_base, []),
+                (target_year, eligible_target, list(missing)),
             )
             # The base row is "the rules before the work requirement". Once
             # that year is behind us nobody is living under it, so it only
@@ -663,7 +664,7 @@ class MedicaidEligibilityTool(BaseTool):
             if row[0] >= current_year or row[0] == target_year
         ]
         seen_years: set = set()
-        deduped_rows = []
+        deduped_rows: List[Tuple[int, bool, List[str]]] = []
         for row in rows:
             if row[0] in seen_years:
                 continue
@@ -681,7 +682,7 @@ class MedicaidEligibilityTool(BaseTool):
         # One shared description of the work-requirement rules so the eligible
         # and not-eligible wordings can't drift apart.
         work_req_note = ""
-        if any(year >= WORK_REQUIREMENT_FIRST_YEAR for year, _ in rows):
+        if any(year >= WORK_REQUIREMENT_FIRST_YEAR for year, _, _ in rows):
             work_req_note = (
                 " (once the federal 80-hours-per-month work/community-engagement "
                 "requirement applies to them — states must implement it by "
@@ -689,7 +690,9 @@ class MedicaidEligibilityTool(BaseTool):
             )
         # Any year past the published table's was scored with that table's
         # limits, and we owe the user that fact.
-        scored_beyond_the_table = any(year > BASE_ELIGIBILITY_YEAR for year, _ in rows)
+        scored_beyond_the_table = any(
+            year > BASE_ELIGIBILITY_YEAR for year, _, _ in rows
+        )
 
         parts: List[str] = [
             "We're helping figure out if someone is likely eligible for "
@@ -719,9 +722,13 @@ class MedicaidEligibilityTool(BaseTool):
                     "share that, while noting the questions above are still "
                     "needed to be sure."
                 )
+            # Positives only, so the completeness guard isn't needed here: a
+            # year we can't score yet comes back False and is excluded by
+            # that alone. Sharing an early POSITIVE is the point of this
+            # branch -- it's the negatives that must never outrun the data.
             later_settled = [
                 year
-                for year, probably_eligible in rows
+                for year, probably_eligible, _ in rows
                 if year > current_year and probably_eligible
             ]
             if later_settled:
@@ -772,13 +779,26 @@ class MedicaidEligibilityTool(BaseTool):
         else:
             verdict_lines = []
             noted_work_req = False
-            for year, probably_eligible in rows:
+            unanswered_by_year: List[Tuple[int, List[str]]] = []
+            for year, probably_eligible, still_needed in rows:
                 label = base_label if year == current_year else str(year)
                 note = ""
                 if year >= WORK_REQUIREMENT_FIRST_YEAR and not noted_work_req:
                     # Attach the explanation once, to the first year it bites.
                     note = work_req_note
                     noted_work_req = True
+                if still_needed:
+                    # NOT a verdict. The checker returns False for this year
+                    # because it can't score it yet, and printing that as "may
+                    # not be eligible" hands the user a denial nobody
+                    # computed -- the exact failure the rest of this file
+                    # exists to prevent.
+                    unanswered_by_year.append((year, still_needed))
+                    verdict_lines.append(
+                        f"- {label}: NOT ESTABLISHED -- we can't score this "
+                        f"year until the questions below are answered{note}"
+                    )
+                    continue
                 verdict = "could be" if probably_eligible else "may not be"
                 verdict_lines.append(
                     f"- {label}: they {verdict} eligible for medicaid{note}"
@@ -789,12 +809,38 @@ class MedicaidEligibilityTool(BaseTool):
                 + "\n".join(verdict_lines)
             )
 
+            if unanswered_by_year:
+                # The questions a later year needs are not in `missing` --
+                # that list belongs to the year the user asked about. Without
+                # them the model is told a year is unscored and given no way
+                # to fix it.
+                needed_lines = []
+                for year, still_needed in unanswered_by_year:
+                    for question in still_needed:
+                        needed_lines.append(f"- ({year}) {question}")
+                parts.append(
+                    "To settle the years marked NOT ESTABLISHED, ask these "
+                    "(two or three at a time, rephrased naturally). Do NOT "
+                    "guess a verdict for those years in the meantime:\n"
+                    + "\n".join(needed_lines)
+                )
+
             # The whole reason for showing more than one year: say out loud
             # when the answer moves, rather than leaving the user to diff two
             # sentences. Someone who probably qualifies today and probably
             # won't once the work requirement applies needs to hear that as
             # the headline, not as a footnote.
-            for (earlier, was_eligible), (later, now_eligible) in zip(rows, rows[1:]):
+            for (earlier, was_eligible, earlier_needs), (
+                later,
+                now_eligible,
+                later_needs,
+            ) in zip(rows, rows[1:]):
+                if earlier_needs or later_needs:
+                    # One side isn't a verdict, so there is no change to
+                    # announce -- "this CHANGES in 2027" off the back of an
+                    # unanswered question is the denial again, in a louder
+                    # voice.
+                    continue
                 if was_eligible == now_eligible:
                     continue
                 if was_eligible:

--- a/fighthealthinsurance/chat/tools/medicaid_tool.py
+++ b/fighthealthinsurance/chat/tools/medicaid_tool.py
@@ -415,8 +415,15 @@ class MedicaidEligibilityTool(BaseTool):
             # An early POSITIVE is different: with questions still outstanding
             # the checker reports it and the write-up is told to share it, so
             # that does earn the exemption.
+            #
+            # `medicare` deliberately does NOT count. The exemption is
+            # program-blind, and the Medicare answer often lands on the very
+            # first call (a 67-year-old's age alone settles it) while every
+            # Medicaid question is still outstanding -- which latched the
+            # session flag and let the rest of the conversation assert
+            # uncomputed MEDICAID verdicts for free.
             checker_produced_verdict = determination_made and (
-                not missing or eligible_base or eligible_target or medicare
+                not missing or eligible_base or eligible_target
             )
             if checker_produced_verdict and self.eligibility_computed is not None:
                 self.eligibility_computed[0] = True

--- a/fighthealthinsurance/chat/tools/patterns.py
+++ b/fighthealthinsurance/chat/tools/patterns.py
@@ -45,6 +45,12 @@ CREATE_OR_UPDATE_PRIOR_AUTH_REGEX = (
     r"^\s*\*{0,4}create_or_update_prior_auth\*{0,4}\s*(\{.*\})\s*$"
 )
 
+# Medicaid.gov page lookup - captures JSON parameters
+# Matches: medicaid_gov_lookup {JSON} or **medicaid_gov_lookup {JSON}**
+# Resolves a curated page, an allowlisted URL, or a free-text query to a
+# page on Medicaid.gov (see medicaid_gov_api).
+MEDICAID_GOV_LOOKUP_REGEX = r"(?:\*\*)?medicaid_gov_lookup\s*(\{[^}]*\})\s*(?:\*\*)?"
+
 # Document fetcher tool - captures JSON with URL
 # Matches: fetch_doc {JSON} or **fetch_doc {JSON}**
 FETCH_DOC_REGEX = r"(?:\*\*)?fetch_doc\s*(\{[^}]*\})\s*(?:\*\*)?"
@@ -131,6 +137,7 @@ ALL_TOOL_PATTERNS = [
     PUBMED_QUERY_REGEX,
     MEDICAID_INFO_REGEX,
     MEDICAID_ELIGIBILITY_REGEX,
+    MEDICAID_GOV_LOOKUP_REGEX,
     CREATE_OR_UPDATE_APPEAL_REGEX,
     CREATE_OR_UPDATE_PRIOR_AUTH_REGEX,
     FETCH_DOC_REGEX,

--- a/fighthealthinsurance/chat/tools/patterns.py
+++ b/fighthealthinsurance/chat/tools/patterns.py
@@ -7,10 +7,23 @@ look up Medicaid info, create/update appeals, etc.)
 """
 
 import re
+from typing import Optional
 
 # PubMed query tool - captures query terms
-# Matches: [pubmed_query: terms], **pubmed query: terms**, etc.
-PUBMED_QUERY_REGEX = r"[\[\*]{0,4}pubmed[ _]?query:?\s*([^*\[\]]+)"
+# Matches: [pubmed query: terms], **pubmed_query: terms**, pubmedquery:[terms]
+# Mirrors RXNORM_LOOKUP_REGEX: a leading `[`/`*` marker or a word boundary, a
+# MANDATORY colon, a non-greedy capture that stops at the closing wrapper /
+# newline / end-of-string, and an optional `[...]` around the terms (the
+# appeal-generation prompt documents that form).
+#
+# The colon used to be optional, which made prose like "I can run a pubmed
+# query for you if that would help" register as a tool call -- both to the
+# handler and to the fan-out's tool-call bonus, so a chatty non-answer could
+# outscore a candidate that actually called a tool.
+PUBMED_QUERY_REGEX = (
+    r"(?:[\[\*]{1,4}|\b)pubmed[ _]?query\s*:\s*\[?"
+    r"([^*\[\]\n]+?)\s*\]?(?:[\]\*]{1,4}|$|(?=\n))"
+)
 
 # Medicaid info lookup tool - captures JSON parameters
 # Matches: medicaid_info {JSON} or **medicaid_info {JSON}**
@@ -18,9 +31,7 @@ MEDICAID_INFO_REGEX = r"(?:\*\*)?medicaid_info\s*(\{[^}]*\})\s*(?:\*\*)?"
 
 # Medicaid eligibility tool - captures JSON parameters
 # Matches: medicaid_eligibility {JSON} or **medicaid_eligibility {JSON}**
-MEDICAID_ELIGIBILITY_REGEX = (
-    r".*?(?:\*\*)?medicaid_eligibility\s*(\{[^}]*\})\s*(?:\*\*)?"
-)
+MEDICAID_ELIGIBILITY_REGEX = r"(?:\*\*)?medicaid_eligibility\s*(\{[^}]*\})\s*(?:\*\*)?"
 
 # Create or update appeal tool - captures JSON with appeal data
 # Matches: create_or_update_appeal {JSON} with optional ** markers
@@ -134,6 +145,28 @@ ALL_TOOL_PATTERNS = [
 # Compiled once: contains_tool_call runs per alternate candidate, and relying
 # on re's bounded internal cache makes that cost implicit.
 _COMPILED_TOOL_PATTERNS = [re.compile(p, TOOL_DETECT_FLAGS) for p in ALL_TOOL_PATTERNS]
+
+
+def count_tool_invocations(text: Optional[str]) -> int:
+    """How many distinct tool patterns ``text`` actually invokes.
+
+    Used by the fan-out scorer for the per-tool-call bonus. Two properties
+    matter and neither is free:
+
+    * It must use TOOL_DETECT_FLAGS, like the handlers do. A flag-less
+      ``re.search`` over the same patterns silently misses every call that
+      isn't at the very start of the reply (CREATE_OR_UPDATE_* are
+      ``^...$``-anchored, which needs MULTILINE) and every case variant.
+    * It counts PATTERNS, not matches, so a reply repeating one tool call
+      five times can't out-bonus a reply that calls two different tools.
+
+    Unlike contains_tool_call this ignores bare token mentions
+    (ACTION_TOKEN_MENTION_RE): mentioning ``create_or_update_appeal`` in prose
+    is not a tool call and shouldn't earn the bonus.
+    """
+    if not text:
+        return 0
+    return sum(1 for p in _COMPILED_TOOL_PATTERNS if p.search(text))
 
 
 def contains_tool_call(text: str) -> bool:

--- a/fighthealthinsurance/chat_interface.py
+++ b/fighthealthinsurance/chat_interface.py
@@ -61,6 +61,7 @@ from fighthealthinsurance.chat.tools import (
     DocFetcherTool,
     FinancialAssistanceTool,
     MedicaidEligibilityTool,
+    MedicaidGovLookupTool,
     MedicaidInfoTool,
     PaRequirementLookupTool,
     PriorAuthTool,
@@ -195,6 +196,9 @@ class ChatInterface:
         # tool is rebuilt per turn. Until it flips, the scorer treats a
         # candidate that asserts an eligibility verdict as inventing one.
         self._eligibility_computed: list[bool] = [False]
+        # Per-session cap for medicaid_gov_lookup, kept out here because the
+        # tool is rebuilt every turn (same shape as _doc_fetch_count).
+        self._medicaid_gov_lookup_count: list[int] = [0]
 
     @staticmethod
     def _append_to_history(chat, role: str, content: str):
@@ -640,6 +644,15 @@ class ChatInterface:
             self.send_status_message, self._call_llm_with_actions
         )
         response_text, context, _ = await medicaid_info_tool.handle(
+            response_text, context, **tool_kwargs
+        )
+
+        medicaid_gov_tool = MedicaidGovLookupTool(
+            self.send_status_message,
+            call_llm_callback=self._call_llm_with_actions,
+            lookup_count=self._medicaid_gov_lookup_count,
+        )
+        response_text, context, _ = await medicaid_gov_tool.handle(
             response_text, context, **tool_kwargs
         )
 

--- a/fighthealthinsurance/chat_interface.py
+++ b/fighthealthinsurance/chat_interface.py
@@ -189,6 +189,12 @@ class ChatInterface:
         # which decays a striking backend's base score so a looping model
         # stops winning every fan-out this session. In-memory only.
         self._repeat_offenders: Dict[str, int] = {}
+        # Set once the medicaid_eligibility checker has actually produced a
+        # determination in this session. Shared with MedicaidEligibilityTool
+        # via a one-element list (same trick as _doc_fetch_count) because the
+        # tool is rebuilt per turn. Until it flips, the scorer treats a
+        # candidate that asserts an eligibility verdict as inventing one.
+        self._eligibility_computed: list[bool] = [False]
 
     @staticmethod
     def _append_to_history(chat, role: str, content: str):
@@ -312,6 +318,7 @@ class ChatInterface:
         full_history: Optional[List[Dict[str, str]]] = None,
         user_message_for_scoring: Optional[str] = None,
         message_variants: Optional[List[MessageVariant]] = None,
+        eligibility_verified: bool = False,
     ) -> Tuple[Optional[str], Optional[str]]:
         """
         Calls the LLM, handles PubMed query requests if present and returns the response.
@@ -337,6 +344,9 @@ class ChatInterface:
                 calls are fanned out per variant and each variant's score_delta is
                 applied so the primary path wins unless it fails. When None (e.g.
                 recursive tool calls), the single current_message_for_llm is used.
+            eligibility_verified: True when this pass is writing up output the
+                medicaid_eligibility checker just produced. OR'd with the
+                session-level flag; see score_llm_response.
         """
         if depth > 3:
             return None, None
@@ -410,6 +420,7 @@ class ChatInterface:
             call_labels=call_labels,
             repeat_offenders=self._repeat_offenders,
             score_log=score_log,
+            eligibility_verified=eligibility_verified or self._eligibility_computed[0],
         )
 
         llm_pass_started = time.monotonic()
@@ -617,7 +628,9 @@ class ChatInterface:
 
         # Recursive tools: medicaid eligibility, medicaid info, pubmed, doc fetcher
         medicaid_elig_tool = MedicaidEligibilityTool(
-            self.send_status_message, self._call_llm_with_actions
+            self.send_status_message,
+            self._call_llm_with_actions,
+            eligibility_computed=self._eligibility_computed,
         )
         response_text, context, _ = await medicaid_elig_tool.handle(
             response_text, context, **tool_kwargs

--- a/fighthealthinsurance/generate_appeal.py
+++ b/fighthealthinsurance/generate_appeal.py
@@ -1521,7 +1521,10 @@ class AppealGenerator(object):
         and broadcasting them across every backend would multiply cost
         without proportional quality gain.
         """
-        best = ml_router.best_internal_model()
+        # general_only=False: these hints steer APPEAL TEXT, so the
+        # appeal-text fine-tune is a legitimate (and often the best) choice
+        # here, unlike the instruction-following callers.
+        best = ml_router.best_internal_model(general_only=False)
         if best is None:
             return None
         for name, instances in ml_router.models_by_name.items():

--- a/fighthealthinsurance/medicaid_api.py
+++ b/fighthealthinsurance/medicaid_api.py
@@ -4,7 +4,7 @@ import re
 from datetime import date
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, NamedTuple, Optional, Sequence, Tuple
 
 import pandas as pd
 from loguru import logger
@@ -516,6 +516,19 @@ BASE_ELIGIBILITY_YEAR = 2026
 # is modelled from 2026 on rather than 2027.
 WORK_REQUIREMENT_FIRST_YEAR = 2026
 
+# ...but "a few started earlier" is not "everyone has started", and we don't
+# track which states went early. Between these two years the requirement is
+# real for some people and not yet in force for most, so a shortfall in that
+# window is reported as CONDITIONAL rather than as a denial: we say it may
+# already apply where they live and will apply everywhere from this year.
+#
+# Getting this wrong is asymmetric. Telling someone "you may not be eligible"
+# for a rule their state hasn't adopted can stop them applying at all, which
+# is the failure this whole product exists to undo. Telling someone they may
+# be eligible when the rule has already reached them costs them an
+# application the state will decide on anyway.
+WORK_REQUIREMENT_UNIVERSAL_YEAR = 2027
+
 DEFAULT_TARGET_YEAR = WORK_REQUIREMENT_FIRST_YEAR
 
 # Past this we would be projecting policy further out than anything we know
@@ -765,15 +778,34 @@ def timeline_years(value: Any = None) -> List[int]:
     """
     current = current_eligibility_year()
     years = {current, resolve_target_year(value)}
-    if WORK_REQUIREMENT_FIRST_YEAR > current:
-        years.add(WORK_REQUIREMENT_FIRST_YEAR)
+    for milestone in (WORK_REQUIREMENT_FIRST_YEAR, WORK_REQUIREMENT_UNIVERSAL_YEAR):
+        if milestone > current:
+            years.add(milestone)
     if len(years) == 1:
         years.add(min(current + 1, MAX_TARGET_YEAR))
     return sorted(years)
 
 
-def eligibility_timeline(**kwargs: Any) -> List[Tuple[int, bool, List[str]]]:
-    """``(year, probably_eligible, still_needed)`` for each timeline year.
+class YearVerdict(NamedTuple):
+    """One row of an eligibility timeline.
+
+    A NamedTuple so rows still unpack and compare like the plain tuples they
+    replaced, while the two things that are NOT verdicts stay named -- both
+    were silently lost when this was a ``(year, bool)`` pair, and both turned
+    into denials nobody computed.
+    """
+
+    year: int
+    probably_eligible: bool
+    # Non-empty means this year is UNSCORED, not negative.
+    still_needed: List[str]
+    # True means the positive above rests on a work requirement that isn't in
+    # force everywhere yet -- report it as conditional, not as a clean pass.
+    work_requirement_conditional: bool = False
+
+
+def eligibility_timeline(**kwargs: Any) -> List[YearVerdict]:
+    """A ``YearVerdict`` for each year in ``timeline_years``.
 
     Runs the checker once per year so a year-over-year change is visible
     rather than implied. ``is_eligible`` is pure and does no IO, so the
@@ -793,13 +825,26 @@ def eligibility_timeline(**kwargs: Any) -> List[Tuple[int, bool, List[str]]]:
     which is a denial nobody computed. Years that still need answers carry
     them here so the renderer can ask instead of concluding.
     """
-    timeline: List[Tuple[int, bool, List[str]]] = []
+    timeline: List[YearVerdict] = []
     for year in timeline_years(kwargs.get("target_year")):
-        _, probably_eligible, _, _, missing, determination_made = is_eligible(
-            **{**kwargs, "target_year": year}
-        )
+        (
+            _,
+            probably_eligible,
+            _,
+            _,
+            missing,
+            determination_made,
+            work_req_conditional,
+        ) = _score_eligibility(**{**kwargs, "target_year": year})
         still_needed = list(missing) if not determination_made or missing else []
-        timeline.append((year, bool(probably_eligible), still_needed))
+        timeline.append(
+            YearVerdict(
+                year=year,
+                probably_eligible=bool(probably_eligible),
+                still_needed=still_needed,
+                work_requirement_conditional=bool(work_req_conditional),
+            )
+        )
     return timeline
 
 
@@ -891,13 +936,26 @@ def _normalize_state(
     raise ValueError(f"Unknown state: {raw}")
 
 
-def is_eligible(
+def is_eligible(**kwargs) -> Tuple[bool, bool, bool, List[str], List[str], bool]:
+    """Approximate Medicaid / Medicare eligibility. See ``_score_eligibility``.
+
+    Thin wrapper so the widely-used six-tuple stays the public shape. The
+    seventh value the scorer computes -- whether the target year's verdict
+    hangs on a work requirement that isn't in force everywhere yet -- is only
+    meaningful to ``eligibility_timeline``, which calls the scorer directly.
+    """
+    return _score_eligibility(**kwargs)[:6]
+
+
+def _score_eligibility(
     **kwargs,
-) -> Tuple[bool, bool, bool, List[str], List[str], bool]:
+) -> Tuple[bool, bool, bool, List[str], List[str], bool, bool]:
     """
     Perform an approximate eligibility check for Medicaid / Medicare based on the provided parameters.
     Returns a tuple of (base-year eligibility, target-year eligibility,
-    medicare, alternatives, missing_info, determination_made).
+    medicare, alternatives, missing_info, determination_made,
+    work_requirement_conditional). Most callers want ``is_eligible``, which
+    drops the last value.
 
     The base year is ``BASE_ELIGIBILITY_YEAR`` (the published FPL table we
     score today's rules against). The target year is whatever the caller
@@ -1159,9 +1217,17 @@ def is_eligible(
         asked_fields.append(field)
         return True
 
+    # Set when the target year's positive verdict rests on a work requirement
+    # that is in force in some states and not others (see
+    # WORK_REQUIREMENT_UNIVERSAL_YEAR). Not a denial and not a clean pass.
+    # Initialised here rather than beside the overlay: the early exits below
+    # (territory, declined required inputs) reach _result long before the
+    # overlay runs.
+    work_req_conditional = False
+
     def _result(
         determination_made: bool = False,
-    ) -> Tuple[bool, bool, bool, List[str], List[str], bool]:
+    ) -> Tuple[bool, bool, bool, List[str], List[str], bool, bool]:
         """Single exit point: casts + dedupes so every return stays consistent.
 
         ``determination_made`` separates "we scored this person and the answer
@@ -1177,6 +1243,7 @@ def is_eligible(
             list(dict.fromkeys(alts)),
             list(dict.fromkeys(missing)),
             determination_made,
+            bool(work_req_conditional),
         )
 
     def magi_expansion_covers(*, require_inputs: bool = False) -> bool:
@@ -1675,8 +1742,21 @@ def is_eligible(
                     avg_monthly >= WORK_REQ_MONTHLY_HOURS
                     and months_meeting >= MIN_MONTHS_MEETING
                 )
-                eligible_target = bool(meets_rule)
-                if not eligible_target:
+                if target_year >= WORK_REQUIREMENT_UNIVERSAL_YEAR:
+                    eligible_target = bool(meets_rule)
+                else:
+                    # Transition window. The requirement is in force in the
+                    # states that went early and nowhere else yet, and we
+                    # don't track which is which -- so a shortfall here is
+                    # NOT a denial. Say the income/category test passed and
+                    # let the renderer carry the "this may already apply
+                    # where you live" caveat.
+                    eligible_target = True
+                    work_req_conditional = not meets_rule
+                # Coaching keys off the hours, not the verdict: in the
+                # transition window the verdict stays positive, but someone
+                # under 80 hours still needs to hear what is coming.
+                if not meets_rule:
                     alts.append(
                         f"For {target_year}, try to reach ~80 hrs/month each month via job, school, or volunteering."
                     )

--- a/fighthealthinsurance/medicaid_api.py
+++ b/fighthealthinsurance/medicaid_api.py
@@ -710,6 +710,47 @@ def resolve_target_year(value: Any) -> int:
     return _parse_target_year(value) or DEFAULT_TARGET_YEAR
 
 
+def timeline_years(value: Any = None) -> List[int]:
+    """The years an estimate should show a verdict for, ascending.
+
+    Always at least two, and always including the year the answer can CHANGE.
+    Showing only "today" and "the year you asked about" hid the transition:
+    someone asking about 2029 saw 2025 and 2029 and never learned that the
+    switch happens in 2026, when the work requirement starts to bite.
+
+    Income limits are identical across years (see BASE_ELIGIBILITY_YEAR), so
+    the work requirement is the only thing that can move a verdict -- which
+    makes ``WORK_REQUIREMENT_FIRST_YEAR`` the one year that always earns a
+    row alongside today's rules and whatever the user asked about.
+    """
+    return sorted(
+        {
+            BASE_ELIGIBILITY_YEAR,
+            WORK_REQUIREMENT_FIRST_YEAR,
+            resolve_target_year(value),
+        }
+    )
+
+
+def eligibility_timeline(**kwargs: Any) -> List[Tuple[int, bool]]:
+    """``(year, probably_eligible)`` for each year in ``timeline_years``.
+
+    Runs the checker once per year so a year-over-year change is visible
+    rather than implied. ``is_eligible`` is pure and does no IO, so the
+    repeat calls are cheap.
+
+    The second element of ``is_eligible``'s result is the right per-year
+    verdict for EVERY year, including the base year: the work overlay is
+    skipped below WORK_REQUIREMENT_FIRST_YEAR, so it collapses to the
+    base-year verdict there.
+    """
+    timeline: List[Tuple[int, bool]] = []
+    for year in timeline_years(kwargs.get("target_year")):
+        _, probably_eligible, *_ = is_eligible(**{**kwargs, "target_year": year})
+        timeline.append((year, bool(probably_eligible)))
+    return timeline
+
+
 def _clean_token(s: str) -> str:
     """Lower, trim, collapse spaces, remove most punctuation except spaces."""
     s = s.strip().lower()

--- a/fighthealthinsurance/medicaid_api.py
+++ b/fighthealthinsurance/medicaid_api.py
@@ -485,8 +485,19 @@ _DECLINE_DEFAULTS: Dict[str, Any] = {
 # Every estimate covers two years: the base year (the published FPL table we
 # actually have, scored under today's rules) and a target year the caller can
 # choose. The target defaults to the first year the federal work requirement
-# can bite, but a user asking "what about 2028?" gets that year instead --
-# thresholds inflated forward and the work overlay applied.
+# can bite, but a user asking "what about 2028?" gets that year instead, with
+# the work overlay applied.
+#
+# Income thresholds are NOT projected forward. We used to roll the FPL table
+# up ~3%/year for future targets, which was wrong twice over: it moved the
+# threshold while leaving the person's income fixed, so it biased everyone
+# toward "more eligible later" on a number we were guessing anyway (real
+# incomes rise too, and largely cancel it). And because the projection only
+# ran for a year the user NAMED, the same person and the same calendar year
+# came out differently depending on how they asked -- $1,810/mo in CA was
+# "may not be eligible" on the default 2026 path and "could be eligible" when
+# they typed "what about 2026?". The work requirement is the difference
+# between the two years that we can actually speak to.
 BASE_ELIGIBILITY_YEAR = 2025
 
 # States must implement the federal work/community-engagement requirement no
@@ -496,18 +507,10 @@ WORK_REQUIREMENT_FIRST_YEAR = 2026
 
 DEFAULT_TARGET_YEAR = WORK_REQUIREMENT_FIRST_YEAR
 
-# Past this we would be extrapolating an inflation guess further than it can
-# mean anything, so a target beyond it is clamped (and the clamp is reported
+# Past this we would be projecting policy further out than anything we know
+# can support, so a target beyond it is clamped (and the clamp is reported
 # back through summarize_eligibility_inputs).
 MAX_TARGET_YEAR = BASE_ELIGIBILITY_YEAR + 10
-
-# Rough annual bump applied to the FPL table and the LTC income cap for years
-# past the published guidelines. A guess, and labelled as one to the user --
-# which is why it is only applied when the user actually asked about a future
-# year. On the default path the two verdicts differ by the work requirement
-# alone, so a guessed inflation number can't manufacture a difference nobody
-# asked about.
-ANNUAL_THRESHOLD_INFLATION = 0.03
 
 # Below this a number isn't a year at all, it's whatever _parse_numeric found
 # in the sentence ("in 3 years", "for the next 5 years").
@@ -705,16 +708,6 @@ def resolve_target_year(value: Any) -> int:
     user sees can't disagree about which year was checked.
     """
     return _parse_target_year(value) or DEFAULT_TARGET_YEAR
-
-
-def target_year_requested(value: Any) -> bool:
-    """Whether the caller actually named a target year we could read.
-
-    Distinguishes "what about 2028?" from the DEFAULT_TARGET_YEAR path. Only
-    the former projects income thresholds forward, so only the former should
-    tell the user the thresholds were estimated.
-    """
-    return _parse_target_year(value) is not None
 
 
 def _clean_token(s: str) -> str:
@@ -920,29 +913,15 @@ def is_eligible(
     # The year the caller wants the second verdict for. Anything we can't
     # read falls back to the default rather than failing the whole check;
     # summarize_eligibility_inputs reports what we actually used.
-    requested_year = _parse_target_year(kwargs.get("target_year"))
-    target_year = requested_year or DEFAULT_TARGET_YEAR
+    target_year = resolve_target_year(kwargs.get("target_year"))
 
-    # Which year's income thresholds the target verdict is scored against.
-    # Only a year the user ASKED about gets projected forward: on the default
-    # path, inflating the table by a guessed 3% could flip someone sitting on
-    # a threshold to "eligible next year, not this year" -- a difference
-    # invented by our own guess, about a year they never mentioned. There the
-    # two verdicts differ by the work requirement and nothing else.
-    threshold_year = (
-        requested_year if requested_year is not None else BASE_ELIGIBILITY_YEAR
-    )
-
-    def inflate(amount: float, year: int) -> float:
-        """Roll a base-year threshold forward to ``year``."""
-        years_out = max(0, year - BASE_ELIGIBILITY_YEAR)
-        return amount * ((1.0 + ANNUAL_THRESHOLD_INFLATION) ** years_out)
-
-    # FPL table for the base year (annual, 48 contiguous states + DC published
-    # guidelines: $15,650 for one person plus $5,500 per additional person).
-    # Alaska and Hawaii run higher; we keep the contiguous values as the
-    # approximation. We'll work monthly: divide by 12. Later years inflate the
-    # thresholds, since their guidelines aren't published yet.
+    # FPL table (annual, 48 contiguous states + DC published guidelines:
+    # $15,650 for one person plus $5,500 per additional person). Alaska and
+    # Hawaii run higher; we keep the contiguous values as the approximation.
+    # We'll work monthly: divide by 12.
+    #
+    # The SAME published table scores every year -- see the note on
+    # BASE_ELIGIBILITY_YEAR for why future years are not projected forward.
     def fpl_annual_base(hh: int) -> float:
         if hh <= 0:
             hh = 1
@@ -950,16 +929,13 @@ def is_eligible(
         add = 5500.0
         return base + add * (hh - 1)
 
-    def pct_fpl(monthly_income: float, hh: int, year: int) -> float:
+    def pct_fpl(monthly_income: float, hh: int) -> float:
         annual = monthly_income * 12.0
-        fpl = inflate(fpl_annual_base(hh), year)
+        fpl = fpl_annual_base(hh)
         return (annual / fpl) * 100.0 if fpl > 0 else 9999.0
 
     # Policy knobs / defaults
-    LTC_INCOME_CAP_BASE = (
-        3000.0  # rough nursing home / HCBS cap (varies by state/waiver)
-    )
-    LTC_INCOME_CAP_TARGET = inflate(LTC_INCOME_CAP_BASE, threshold_year)
+    LTC_INCOME_CAP = 3000.0  # rough nursing home / HCBS cap (varies by state/waiver)
     ABD_ASSET_LIMIT_SINGLE = 2000.0
     ABD_ASSET_LIMIT_MARRIED = 3000.0
     HOME_EQUITY_CAP_DEFAULT = 750000.0
@@ -1107,9 +1083,7 @@ def is_eligible(
             determination_made,
         )
 
-    def magi_expansion_covers(
-        *, require_inputs: bool = False, year: int = BASE_ELIGIBILITY_YEAR
-    ) -> bool:
+    def magi_expansion_covers(*, require_inputs: bool = False) -> bool:
         """Whether ACA expansion covers this adult on income alone.
 
         Expansion (and the 100%-FPL waiver states) apply NO asset test, so
@@ -1120,7 +1094,6 @@ def is_eligible(
 
         ``require_inputs`` guards the stepwise call, which runs before the
         completeness gate and so may not have income or household size yet.
-        ``year`` picks which year's (inflated) FPL table to test against.
         """
         if age is None or not (19 <= age <= 64):
             return False
@@ -1128,7 +1101,7 @@ def is_eligible(
             if require_inputs:
                 return False
             raise AssertionError("scoring call needs income and household size")
-        pct = pct_fpl(monthly_income, household_size, year)
+        pct = pct_fpl(monthly_income, household_size)
         if state in _EXPANSION_STATES and pct <= THRESH_ADULT_MAGI:
             return True
         return state in _WAIVER_100FPL_STATES and pct <= 100.0
@@ -1346,19 +1319,11 @@ def is_eligible(
         return _result()
 
     # ---- with core info present, evaluate categories ----
-    pfpl_base = pct_fpl(monthly_income, household_size, BASE_ELIGIBILITY_YEAR)
-    # When the user asked about a specific future year, its FPL guidelines
-    # aren't published yet, so they're the base table rolled forward: someone
-    # a hair over a threshold today can land under an inflated one, which is
-    # exactly what "will I qualify in 2028?" is asking. On the default path
-    # threshold_year IS the base year, so this is the same number as
-    # pfpl_base and the target verdict differs only by the work overlay.
-    pfpl_target = pct_fpl(monthly_income, household_size, threshold_year)
-
-    # Income-only verdict for the target year, when it can differ from the
-    # base year's. None means "no separate target-year test applied", so the
-    # work overlay starts from the base verdict.
-    target_income_eligible: Optional[bool] = None
+    # One number for every year: the published FPL table is not projected
+    # forward (see BASE_ELIGIBILITY_YEAR). The income test therefore cannot
+    # differ between the base and target years -- the work overlay below is
+    # the only thing that separates the two verdicts.
+    pfpl_base = pct_fpl(monthly_income, household_size)
 
     # Set by the LTC branch below: that branch computes its own target-year verdict
     # (the LTC income cap differs by year), so the work overlay must not
@@ -1374,7 +1339,6 @@ def is_eligible(
     # Category decisions → base-year eligibility (pre-work overlay)
     if is_child:
         eligible_base = pfpl_base <= THRESH_CHILD
-        target_income_eligible = pfpl_target <= THRESH_CHILD
         if not eligible_base:
             alts.append(
                 "CHIP: Children may still qualify for CHIP at higher incomes than Medicaid."
@@ -1383,7 +1347,6 @@ def is_eligible(
         work_req_exempt = True
     elif is_preg:
         eligible_base = pfpl_base <= THRESH_PREG
-        target_income_eligible = pfpl_target <= THRESH_PREG
     elif (
         is_abd_age or is_abd_disability or on_medicare
     ) and applying_reason not in _LTC_REASONS:
@@ -1415,7 +1378,6 @@ def is_eligible(
                 # OVER the ABD limit came back eligible via this pathway,
                 # while declining the question came back "we can't estimate".
                 eligible_base = True
-                target_income_eligible = magi_expansion_covers(year=threshold_year)
             elif not ask("assets_total", _Q_ASSETS):
                 # Declined, and no asset-free pathway applies: an asset test
                 # we cannot run is not a failed asset test. Without this the
@@ -1427,17 +1389,13 @@ def is_eligible(
         else:
             asset_limit = ABD_ASSET_LIMIT_MARRIED if married else ABD_ASSET_LIMIT_SINGLE
             assets_ok = assets_total <= asset_limit
-            income_ok_base = pfpl_base <= 100.0
             # NOTE: medically_needy is a spend-down PATHWAY, not an income
             # waiver -- treating it as one reported six-figure earners as
             # "probably eligible". It stays a suggestion below instead.
-            income_ok_target = pfpl_target <= 100.0
+            income_ok_base = pfpl_base <= 100.0
             eligible_base = assets_ok and income_ok_base
-            target_income_eligible = assets_ok and income_ok_target
             if not eligible_base:
                 eligible_base = magi_expansion_covers()
-            if not target_income_eligible:
-                target_income_eligible = magi_expansion_covers(year=threshold_year)
             if not eligible_base:
                 abd_alternatives()
     elif applying_reason in _LTC_REASONS:
@@ -1464,10 +1422,9 @@ def is_eligible(
         home_ok = True
         if home_owner:
             home_ok = (home_equity or 0.0) <= HOME_EQUITY_CAP_DEFAULT
-        income_ok_base = monthly_income <= LTC_INCOME_CAP_BASE
-        income_ok_target = monthly_income <= LTC_INCOME_CAP_TARGET
+        income_ok_base = monthly_income <= LTC_INCOME_CAP
         eligible_base = assets_ok and home_ok and income_ok_base
-        eligible_target = assets_ok and home_ok and income_ok_target
+        eligible_target = eligible_base
         if not income_ok_base:
             alts.append(
                 "Ask about a Qualified Income Trust (Miller trust) if income is just over the LTC cap."
@@ -1487,12 +1444,10 @@ def is_eligible(
     elif is_adult_magi:
         if state in _EXPANSION_STATES:
             eligible_base = pfpl_base <= THRESH_ADULT_MAGI
-            target_income_eligible = pfpl_target <= THRESH_ADULT_MAGI
         elif state in _WAIVER_100FPL_STATES:
             # No ACA expansion, but adults are covered up to 100% FPL under a
             # waiver (Wisconsin), so there is no coverage gap.
             eligible_base = pfpl_base <= 100.0
-            target_income_eligible = pfpl_target <= 100.0
             if not eligible_base:
                 # Above 100% FPL means marketplace subsidies are available.
                 alts.append(
@@ -1540,20 +1495,16 @@ def is_eligible(
     )
 
     if ltc_evaluated:
-        # The LTC branch computed eligible_target itself (the LTC income cap
-        # differs by year, so income can pass the target year while failing
-        # the base year), and LTC applicants are medically frail -- never
-        # subject them to the work overlay or the not-eligible-in-the-base-year
-        # clamp. Keyed on the branch actually running, NOT on applying_reason:
+        # LTC applicants are medically frail -- never subject them to the
+        # work overlay or the not-eligible-in-the-base-year clamp. Keyed on
+        # the branch actually running, NOT on applying_reason:
         # a child or pregnant LTC applicant is scored by the child/pregnancy
         # branch earlier in the chain, and keying on the reason skipped their
         # exemption entirely, handing a 10-year-old a final "not eligible".
         pass
-    elif not (
-        eligible_base if target_income_eligible is None else target_income_eligible
-    ):
-        # Not eligible on the target year's income test, so the work overlay
-        # can't rescue it.
+    elif not eligible_base:
+        # The income test is year-independent, so failing it fails both years
+        # and the work overlay can't rescue the target year.
         eligible_target = False
     else:
         if exempt:

--- a/fighthealthinsurance/medicaid_api.py
+++ b/fighthealthinsurance/medicaid_api.py
@@ -504,7 +504,12 @@ _DECLINE_DEFAULTS: Dict[str, Any] = {
 # moves past it we keep scoring against the same table (it's the newest one
 # published) but we stop calling it the current year. Use
 # ``current_eligibility_year`` for anything a user reads as "today".
-BASE_ELIGIBILITY_YEAR = 2025
+#
+# Moves with the dollar figures in ``fpl_annual_base``. Leaving it behind
+# while HHS publishes a newer table doesn't just mislabel the answer, it
+# scores people against limits that have been superseded -- and the limits
+# only ever go up, so a stale table denies people who now qualify.
+BASE_ELIGIBILITY_YEAR = 2026
 
 # States must implement the federal work/community-engagement requirement no
 # later than January 1, 2027; a few started earlier, which is why the overlay
@@ -767,8 +772,8 @@ def timeline_years(value: Any = None) -> List[int]:
     return sorted(years)
 
 
-def eligibility_timeline(**kwargs: Any) -> List[Tuple[int, bool]]:
-    """``(year, probably_eligible)`` for each year in ``timeline_years``.
+def eligibility_timeline(**kwargs: Any) -> List[Tuple[int, bool, List[str]]]:
+    """``(year, probably_eligible, still_needed)`` for each timeline year.
 
     Runs the checker once per year so a year-over-year change is visible
     rather than implied. ``is_eligible`` is pure and does no IO, so the
@@ -778,11 +783,23 @@ def eligibility_timeline(**kwargs: Any) -> List[Tuple[int, bool]]:
     verdict for EVERY year, including the base year: the work overlay is
     skipped below WORK_REQUIREMENT_FIRST_YEAR, so it collapses to the
     base-year verdict there.
+
+    The third element is what that year still needs, and dropping it was a
+    bug worth naming: ``is_eligible`` uses ``False`` for BOTH "we scored this
+    and they fall short" and "we can't score this until you answer" -- an
+    unanswered work-hours question sets the target-year flag False on
+    purpose, because the questions ride alongside it. A caller who keeps only
+    the boolean turns "we don't know yet" into "you may not be eligible",
+    which is a denial nobody computed. Years that still need answers carry
+    them here so the renderer can ask instead of concluding.
     """
-    timeline: List[Tuple[int, bool]] = []
+    timeline: List[Tuple[int, bool, List[str]]] = []
     for year in timeline_years(kwargs.get("target_year")):
-        _, probably_eligible, *_ = is_eligible(**{**kwargs, "target_year": year})
-        timeline.append((year, bool(probably_eligible)))
+        _, probably_eligible, _, _, missing, determination_made = is_eligible(
+            **{**kwargs, "target_year": year}
+        )
+        still_needed = list(missing) if not determination_made or missing else []
+        timeline.append((year, bool(probably_eligible), still_needed))
     return timeline
 
 
@@ -992,17 +1009,20 @@ def is_eligible(
     target_year = resolve_target_year(kwargs.get("target_year"))
 
     # FPL table (annual, 48 contiguous states + DC published guidelines:
-    # $15,650 for one person plus $5,500 per additional person). Alaska and
-    # Hawaii run higher; we keep the contiguous values as the approximation.
-    # We'll work monthly: divide by 12.
+    # $15,960 for one person plus $5,680 per additional person -- the 2026 HHS
+    # poverty guidelines, which is what BASE_ELIGIBILITY_YEAR names). Alaska
+    # and Hawaii run higher; we keep the contiguous values as the
+    # approximation. We'll work monthly: divide by 12.
     #
     # The SAME published table scores every year -- see the note on
     # BASE_ELIGIBILITY_YEAR for why future years are not projected forward.
+    # When HHS publishes the next year's guidelines, both numbers here and
+    # BASE_ELIGIBILITY_YEAR move together; they are one fact in two places.
     def fpl_annual_base(hh: int) -> float:
         if hh <= 0:
             hh = 1
-        base = 15650.0
-        add = 5500.0
+        base = 15960.0
+        add = 5680.0
         return base + add * (hh - 1)
 
     def pct_fpl(monthly_income: float, hh: int) -> float:

--- a/fighthealthinsurance/medicaid_api.py
+++ b/fighthealthinsurance/medicaid_api.py
@@ -476,7 +476,34 @@ _DECLINE_DEFAULTS: Dict[str, Any] = {
     # Left indeterminate instead, so it is asked or reported as undetermined.
     "veteran_or_spouse_of_veteran": False,
     "work_req_exempt_2026": False,
+    "work_req_exempt": False,
 }
+
+# ---------------------------------------------------------------------------
+# Which years we score
+# ---------------------------------------------------------------------------
+# Every estimate covers two years: the base year (the published FPL table we
+# actually have, scored under today's rules) and a target year the caller can
+# choose. The target defaults to the first year the federal work requirement
+# can bite, but a user asking "what about 2028?" gets that year instead --
+# thresholds inflated forward and the work overlay applied.
+BASE_ELIGIBILITY_YEAR = 2025
+
+# States must implement the federal work/community-engagement requirement no
+# later than January 1, 2027; a few started earlier, which is why the overlay
+# is modelled from 2026 on rather than 2027.
+WORK_REQUIREMENT_FIRST_YEAR = 2026
+
+DEFAULT_TARGET_YEAR = WORK_REQUIREMENT_FIRST_YEAR
+
+# Past this we would be extrapolating an inflation guess further than it can
+# mean anything, so a target beyond it is clamped (and the clamp is reported
+# back through summarize_eligibility_inputs).
+MAX_TARGET_YEAR = BASE_ELIGIBILITY_YEAR + 10
+
+# Rough annual bump applied to the FPL table and the LTC income cap for years
+# past the published guidelines. A guess, and labelled as one to the user.
+ANNUAL_THRESHOLD_INFLATION = 0.03
 
 # Percent-of-FPL ceilings by category. Module scope because the stepwise
 # question block consults them to skip questions that cannot change the
@@ -531,6 +558,10 @@ _KNOWN_ELIGIBILITY_FIELDS = frozenset(
         "years_worked",
         "on_medicaid_past",
         "work_req_exempt_2026",
+        # Same answer under a year-neutral name, since the target year is now
+        # the caller's choice; both spellings are accepted.
+        "work_req_exempt",
+        "target_year",
         "qualifying_hours_weekly_last_12",
         "avg_monthly_qualifying_hours_last_3mo",
         "avg_weekly_qualifying_hours_last_3mo",
@@ -628,6 +659,37 @@ def _parse_numeric(value: Any) -> Optional[float]:
     return number
 
 
+def _parse_target_year(value: Any) -> Optional[int]:
+    """Parse a caller-supplied target year, or None when there isn't one.
+
+    Accepts what an LLM actually sends for "what about 2027?": an int, a
+    string, or a phrase with the year in it. Two-digit years ("26") are read
+    as this century, and anything outside the range we can model is clamped
+    rather than rejected -- a clamped year still produces a usable estimate,
+    where a rejection would drop the question the user asked.
+    """
+    number = _parse_numeric(value)
+    if number is None:
+        return None
+    year = int(number)
+    if 0 <= year < 100:
+        year += 2000
+    if year < BASE_ELIGIBILITY_YEAR:
+        return BASE_ELIGIBILITY_YEAR
+    if year > MAX_TARGET_YEAR:
+        return MAX_TARGET_YEAR
+    return year
+
+
+def resolve_target_year(value: Any) -> int:
+    """The year the second half of an estimate is scored for.
+
+    Shared by is_eligible and the chat tool so the verdict and the label the
+    user sees can't disagree about which year was checked.
+    """
+    return _parse_target_year(value) or DEFAULT_TARGET_YEAR
+
+
 def _clean_token(s: str) -> str:
     """Lower, trim, collapse spaces, remove most punctuation except spaces."""
     s = s.strip().lower()
@@ -721,8 +783,15 @@ def is_eligible(
 ) -> Tuple[bool, bool, bool, List[str], List[str], bool]:
     """
     Perform an approximate eligibility check for Medicaid / Medicare based on the provided parameters.
-    Returns a tuple of (2025 eligibility, 2026 eligibility, medicare,
-    alternatives, missing_info, determination_made).
+    Returns a tuple of (base-year eligibility, target-year eligibility,
+    medicare, alternatives, missing_info, determination_made).
+
+    The base year is ``BASE_ELIGIBILITY_YEAR`` (the published FPL table we
+    score today's rules against). The target year is whatever the caller
+    passes as ``target_year`` -- a user asking "will I still qualify in
+    2028?" gets 2028 -- and defaults to ``DEFAULT_TARGET_YEAR``. Callers must
+    resolve the same year with ``resolve_target_year`` when labelling the
+    result, so the verdict and the label can't disagree.
 
     IMPORTANT: This uses simplified heuristics. Medicaid rules vary by state and change often.
     Treat results as a best guess only and confirm with state resources.
@@ -731,8 +800,11 @@ def is_eligible(
       - Per the CMS interim final rule (CMS-2454-IFC, June 2026), states must
         implement the requirement no later than JANUARY 1, 2027; a few have
         gone earlier, and states showing good-faith effort can get extensions.
-        The ``eligible_2026`` flag therefore models "eligibility once the work
-        requirement applies to them", not calendar-year 2026 specifically.
+        The target-year flag therefore models "eligibility once the work
+        requirement applies to them" for any target year from
+        ``WORK_REQUIREMENT_FIRST_YEAR`` on, not calendar-year 2026
+        specifically. A target year before that is scored without the
+        overlay.
       - The requirement is 80 qualifying hours PER MONTH, checked at
         application and renewal against a lookback of one to three months
         (states choose), which is why late-2026 activity can already matter.
@@ -761,8 +833,11 @@ def is_eligible(
       - years_worked: int # years you (or spouse/ex-spouse) worked paying medicare taxes
       - on_medicaid_past: bool  # accepted for backwards compatibility; unused
 
-      # 2026 federal work requirement (ALWAYS ASSUMED TRUE):
+      - target_year: int           # year to score the second verdict for (default DEFAULT_TARGET_YEAR)
+
+      # federal work requirement (ALWAYS ASSUMED TRUE):
       - work_req_exempt_2026: Optional[bool]  # if caller knows the person is exempt from work rules
+      - work_req_exempt: Optional[bool]       # year-neutral spelling of the same answer
       - qualifying_hours_weekly_last_12: Optional[Sequence[float]]  # 12 numbers, one per week
       - avg_monthly_qualifying_hours_last_3mo: Optional[float]      # matches how the re-ask question is phrased
       - avg_weekly_qualifying_hours_last_3mo: Optional[float]       # fallback if weekly list not available
@@ -774,7 +849,8 @@ def is_eligible(
       - Pregnant: <= 200% FPL (often higher).
       - ABD & LTC: asset limits approx $2k single / $3k married; LTC income cap ~ $3,000/mo;
         home equity must be below a default cap (use $750k if unknown). Medically-needy may help.
-      - 2026 work overlay: requires >=80 qualifying hours per month across a
+      - Work overlay (target years from WORK_REQUIREMENT_FIRST_YEAR on):
+        requires >=80 qualifying hours per month across a
         3-month lookback. Detailed weekly records are partitioned per month so
         each month is checked on its own; a single monthly average or a 3-month
         total has no per-month detail to check, so it is spread evenly and only
@@ -784,8 +860,8 @@ def is_eligible(
         stalling the determination waiting on an answer that will never come.
 
     Returns:
-      (eligible_2025, eligible_2026, eligible_medicare, alternatives,
-       missing_info, determination_made)
+      (eligible_base_year, eligible_target_year, eligible_medicare,
+       alternatives, missing_info, determination_made)
 
     ``determination_made`` is False when we could not score the person at all
     (US territory, or a required answer the user declined) — distinct from a
@@ -814,11 +890,22 @@ def is_eligible(
         except Exception:
             return None
 
-    # FPL table for 2025 (annual, 48 contiguous states + DC published guidelines:
-    # $15,650 for one person plus $5,500 per additional person). Alaska and
-    # Hawaii run higher; we keep the contiguous values as the approximation.
-    # We'll work monthly: divide by 12. For 2026 we model +3% inflation on thresholds.
-    def fpl_annual_2025(hh: int) -> float:
+    # The year the caller wants the second verdict for. Anything we can't
+    # read falls back to the default rather than failing the whole check;
+    # summarize_eligibility_inputs reports what we actually used.
+    target_year = resolve_target_year(kwargs.get("target_year"))
+
+    def inflate(amount: float, year: int) -> float:
+        """Roll a base-year threshold forward to ``year``."""
+        years_out = max(0, year - BASE_ELIGIBILITY_YEAR)
+        return amount * ((1.0 + ANNUAL_THRESHOLD_INFLATION) ** years_out)
+
+    # FPL table for the base year (annual, 48 contiguous states + DC published
+    # guidelines: $15,650 for one person plus $5,500 per additional person).
+    # Alaska and Hawaii run higher; we keep the contiguous values as the
+    # approximation. We'll work monthly: divide by 12. Later years inflate the
+    # thresholds, since their guidelines aren't published yet.
+    def fpl_annual_base(hh: int) -> float:
         if hh <= 0:
             hh = 1
         base = 15650.0
@@ -827,16 +914,14 @@ def is_eligible(
 
     def pct_fpl(monthly_income: float, hh: int, year: int) -> float:
         annual = monthly_income * 12.0
-        fpl = fpl_annual_2025(hh)
-        if year == 2026:
-            fpl *= 1.03  # simple inflation bump
+        fpl = inflate(fpl_annual_base(hh), year)
         return (annual / fpl) * 100.0 if fpl > 0 else 9999.0
 
     # Policy knobs / defaults
-    LTC_INCOME_CAP_2025 = (
+    LTC_INCOME_CAP_BASE = (
         3000.0  # rough nursing home / HCBS cap (varies by state/waiver)
     )
-    LTC_INCOME_CAP_2026 = LTC_INCOME_CAP_2025 * 1.03
+    LTC_INCOME_CAP_TARGET = inflate(LTC_INCOME_CAP_BASE, target_year)
     ABD_ASSET_LIMIT_SINGLE = 2000.0
     ABD_ASSET_LIMIT_MARRIED = 3000.0
     HOME_EQUITY_CAP_DEFAULT = 750000.0
@@ -922,8 +1007,13 @@ def is_eligible(
     # but no longer changes the result: past Medicaid enrollment does not by
     # itself confer Medicare eligibility.
 
-    # 2026 work requirement inputs
-    work_req_exempt_2026 = get_bool("work_req_exempt_2026")
+    # Work requirement inputs. Either spelling of the exemption answer is
+    # accepted; an explicit True from either one wins.
+    work_req_exempt = get_bool("work_req_exempt_2026")
+    if work_req_exempt is not True:
+        year_neutral_exempt = get_bool("work_req_exempt")
+        if year_neutral_exempt is not None:
+            work_req_exempt = bool(work_req_exempt) or year_neutral_exempt
     weekly_hours = get_seq_of_floats("qualifying_hours_weekly_last_12")
     avg_weekly_hours = get_float("avg_weekly_qualifying_hours_last_3mo")
     avg_monthly_hours = get_float("avg_monthly_qualifying_hours_last_3mo")
@@ -941,8 +1031,8 @@ def is_eligible(
     # ---- track outputs ----
     missing: List[str] = []
     alts: List[str] = []
-    eligible_2025 = False
-    eligible_2026 = False
+    eligible_base = False
+    eligible_target = False
     eligible_medicare = False
 
     def ask(field: str, question: str) -> bool:
@@ -971,15 +1061,17 @@ def is_eligible(
         confident "may not be eligible".
         """
         return (
-            bool(eligible_2025),
-            bool(eligible_2026),
+            bool(eligible_base),
+            bool(eligible_target),
             bool(eligible_medicare),
             list(dict.fromkeys(alts)),
             list(dict.fromkeys(missing)),
             determination_made,
         )
 
-    def magi_expansion_covers(*, require_inputs: bool = False) -> bool:
+    def magi_expansion_covers(
+        *, require_inputs: bool = False, year: int = BASE_ELIGIBILITY_YEAR
+    ) -> bool:
         """Whether ACA expansion covers this adult on income alone.
 
         Expansion (and the 100%-FPL waiver states) apply NO asset test, so
@@ -990,6 +1082,7 @@ def is_eligible(
 
         ``require_inputs`` guards the stepwise call, which runs before the
         completeness gate and so may not have income or household size yet.
+        ``year`` picks which year's (inflated) FPL table to test against.
         """
         if age is None or not (19 <= age <= 64):
             return False
@@ -997,7 +1090,7 @@ def is_eligible(
             if require_inputs:
                 return False
             raise AssertionError("scoring call needs income and household size")
-        pct = pct_fpl(monthly_income, household_size, 2025)
+        pct = pct_fpl(monthly_income, household_size, year)
         if state in _EXPANSION_STATES and pct <= THRESH_ADULT_MAGI:
             return True
         return state in _WAIVER_100FPL_STATES and pct <= 100.0
@@ -1215,9 +1308,19 @@ def is_eligible(
         return _result()
 
     # ---- with core info present, evaluate categories ----
-    pfpl_2025 = pct_fpl(monthly_income, household_size, 2025)
+    pfpl_base = pct_fpl(monthly_income, household_size, BASE_ELIGIBILITY_YEAR)
+    # The target year's FPL guidelines aren't published yet, so they're the
+    # base table rolled forward. Someone a hair over a threshold today can
+    # land under an inflated one, which is exactly what "will I qualify in
+    # 2028?" is asking -- so the categories below score both years.
+    pfpl_target = pct_fpl(monthly_income, household_size, target_year)
 
-    # Set by the LTC branch below: that branch computes its own 2026 verdict
+    # Income-only verdict for the target year, when it can differ from the
+    # base year's. None means "no separate target-year test applied", so the
+    # work overlay starts from the base verdict.
+    target_income_eligible: Optional[bool] = None
+
+    # Set by the LTC branch below: that branch computes its own target-year verdict
     # (the LTC income cap differs by year), so the work overlay must not
     # recompute it -- but only when the branch actually ran.
     ltc_evaluated = False
@@ -1228,17 +1331,19 @@ def is_eligible(
     is_abd_disability = bool(receiving_ssdi)
     is_preg = bool(pregnant)
 
-    # Category decisions → 2025 base eligibility (pre-work overlay)
+    # Category decisions → base-year eligibility (pre-work overlay)
     if is_child:
-        eligible_2025 = pfpl_2025 <= THRESH_CHILD
-        if not eligible_2025:
+        eligible_base = pfpl_base <= THRESH_CHILD
+        target_income_eligible = pfpl_target <= THRESH_CHILD
+        if not eligible_base:
             alts.append(
                 "CHIP: Children may still qualify for CHIP at higher incomes than Medicaid."
             )
         # skip work overlay for children
-        work_req_exempt_2026 = True
+        work_req_exempt = True
     elif is_preg:
-        eligible_2025 = pfpl_2025 <= THRESH_PREG
+        eligible_base = pfpl_base <= THRESH_PREG
+        target_income_eligible = pfpl_target <= THRESH_PREG
     elif (
         is_abd_age or is_abd_disability or on_medicare
     ) and applying_reason not in _LTC_REASONS:
@@ -1269,7 +1374,8 @@ def is_eligible(
                 # a wrong answer -- the same person who reported assets far
                 # OVER the ABD limit came back eligible via this pathway,
                 # while declining the question came back "we can't estimate".
-                eligible_2025 = True
+                eligible_base = True
+                target_income_eligible = magi_expansion_covers(year=target_year)
             elif not ask("assets_total", _Q_ASSETS):
                 # Declined, and no asset-free pathway applies: an asset test
                 # we cannot run is not a failed asset test. Without this the
@@ -1281,14 +1387,18 @@ def is_eligible(
         else:
             asset_limit = ABD_ASSET_LIMIT_MARRIED if married else ABD_ASSET_LIMIT_SINGLE
             assets_ok = assets_total <= asset_limit
-            income_ok_2025 = pfpl_2025 <= 100.0
+            income_ok_base = pfpl_base <= 100.0
             # NOTE: medically_needy is a spend-down PATHWAY, not an income
             # waiver -- treating it as one reported six-figure earners as
             # "probably eligible". It stays a suggestion below instead.
-            eligible_2025 = assets_ok and income_ok_2025
-            if not eligible_2025:
-                eligible_2025 = magi_expansion_covers()
-            if not eligible_2025:
+            income_ok_target = pfpl_target <= 100.0
+            eligible_base = assets_ok and income_ok_base
+            target_income_eligible = assets_ok and income_ok_target
+            if not eligible_base:
+                eligible_base = magi_expansion_covers()
+            if not target_income_eligible:
+                target_income_eligible = magi_expansion_covers(year=target_year)
+            if not eligible_base:
                 abd_alternatives()
     elif applying_reason in _LTC_REASONS:
         ltc_evaluated = True
@@ -1314,11 +1424,11 @@ def is_eligible(
         home_ok = True
         if home_owner:
             home_ok = (home_equity or 0.0) <= HOME_EQUITY_CAP_DEFAULT
-        income_ok_2025 = monthly_income <= LTC_INCOME_CAP_2025
-        income_ok_2026 = monthly_income <= LTC_INCOME_CAP_2026
-        eligible_2025 = assets_ok and home_ok and income_ok_2025
-        eligible_2026 = assets_ok and home_ok and income_ok_2026
-        if not income_ok_2025:
+        income_ok_base = monthly_income <= LTC_INCOME_CAP_BASE
+        income_ok_target = monthly_income <= LTC_INCOME_CAP_TARGET
+        eligible_base = assets_ok and home_ok and income_ok_base
+        eligible_target = assets_ok and home_ok and income_ok_target
+        if not income_ok_base:
             alts.append(
                 "Ask about a Qualified Income Trust (Miller trust) if income is just over the LTC cap."
             )
@@ -1336,12 +1446,14 @@ def is_eligible(
             )
     elif is_adult_magi:
         if state in _EXPANSION_STATES:
-            eligible_2025 = pfpl_2025 <= THRESH_ADULT_MAGI
+            eligible_base = pfpl_base <= THRESH_ADULT_MAGI
+            target_income_eligible = pfpl_target <= THRESH_ADULT_MAGI
         elif state in _WAIVER_100FPL_STATES:
             # No ACA expansion, but adults are covered up to 100% FPL under a
             # waiver (Wisconsin), so there is no coverage gap.
-            eligible_2025 = pfpl_2025 <= 100.0
-            if not eligible_2025:
+            eligible_base = pfpl_base <= 100.0
+            target_income_eligible = pfpl_target <= 100.0
+            if not eligible_base:
                 # Above 100% FPL means marketplace subsidies are available.
                 alts.append(
                     "Above your state's 100% FPL waiver limit—consider ACA marketplace subsidies (available starting at 100% FPL)."
@@ -1351,8 +1463,8 @@ def is_eligible(
                         "If you’re a caretaker relative, check caretaker-relative Medicaid rules in your state."
                     )
         else:
-            eligible_2025 = False
-            if pfpl_2025 >= 100.0:
+            eligible_base = False
+            if pfpl_base >= 100.0:
                 alts.append(
                     "In non-expansion states, childless adults often aren’t eligible—consider ACA marketplace subsidies (available starting at 100% FPL)."
                 )
@@ -1365,7 +1477,10 @@ def is_eligible(
                     "If you’re a caretaker relative, check caretaker-relative Medicaid rules in your state."
                 )
 
-    # ---- 2026 eligibility = 2025 base eligibility + federal work overlay ----
+    # ---- target-year eligibility = base eligibility + federal work overlay ----
+    # The overlay only applies from WORK_REQUIREMENT_FIRST_YEAR on, so a user
+    # who asked about the current year gets their base verdict back rather
+    # than being quizzed about work hours that don't apply to them yet.
     # Exemptions (if caller knows): pregnancy, SSDI/disabled, Medicare, ESRD/ALS,
     # children, and 65+ (the requirement targets able-bodied adults 19-64) are
     # treated as exempt by default.
@@ -1378,24 +1493,31 @@ def is_eligible(
         or has_esrd_or_als
         or applying_reason in _LTC_REASONS
     )
-    exempt = (work_req_exempt_2026 is True) or presumed_exempt
+    exempt = (
+        (work_req_exempt is True)
+        or presumed_exempt
+        or target_year < WORK_REQUIREMENT_FIRST_YEAR
+    )
 
     if ltc_evaluated:
-        # The LTC branch computed eligible_2026 itself (the LTC income cap
-        # differs by year, so income can pass 2026 while failing 2025), and
-        # LTC applicants are medically frail -- never subject them to the
-        # work overlay or the not-eligible-2025 clamp. Keyed on the branch
-        # actually running, NOT on applying_reason: a child or pregnant LTC
-        # applicant is scored by the child/pregnancy branch earlier in the
-        # chain, and keying on the reason skipped their exemption entirely,
-        # handing a 10-year-old a final "not eligible in 2026".
+        # The LTC branch computed eligible_target itself (the LTC income cap
+        # differs by year, so income can pass the target year while failing
+        # the base year), and LTC applicants are medically frail -- never
+        # subject them to the work overlay or the not-eligible-in-the-base-year
+        # clamp. Keyed on the branch actually running, NOT on applying_reason:
+        # a child or pregnant LTC applicant is scored by the child/pregnancy
+        # branch earlier in the chain, and keying on the reason skipped their
+        # exemption entirely, handing a 10-year-old a final "not eligible".
         pass
-    elif not eligible_2025:
-        # If not eligible in 2025, they won't be in 2026 either (even before work overlay).
-        eligible_2026 = False
+    elif not (
+        eligible_base if target_income_eligible is None else target_income_eligible
+    ):
+        # Not eligible on the target year's income test, so the work overlay
+        # can't rescue it.
+        eligible_target = False
     else:
         if exempt:
-            eligible_2026 = True
+            eligible_target = True
         else:
             # We need a 3-month lookback assessment for 80 hours per month
             def compute_monthly_sums() -> Optional[List[float]]:
@@ -1442,18 +1564,19 @@ def is_eligible(
             if monthly_data is None:
                 asked_avg = ask(
                     "avg_monthly_qualifying_hours_last_3mo",
-                    "For 2026, about how many qualifying hours per month (work, school, volunteering, or caregiving) do you average?",
+                    f"For {target_year}, about how many qualifying hours per month (work, school, volunteering, or caregiving) do you average?",
                 )
                 asked_total = ask(
                     "total_qualifying_hours_last_3mo",
                     "If easier, share your total qualifying hours over the last 3 months.",
                 )
-                eligible_2026 = False  # unknown until we get this
+                eligible_target = False  # unknown until we get this
                 if not asked_avg and not asked_total:
                     # Both hour questions declined, so there is no way to
                     # apply the 80-hrs/month rule. Without this the "unknown"
                     # above shipped as a confident "may not be eligible under
-                    # the 2026 rules" to someone who just couldn't estimate.
+                    # the target year's rules" to someone who just couldn't
+                    # estimate.
                     indeterminate.append("qualifying work hours")
             else:
                 # Check monthly requirement
@@ -1465,10 +1588,10 @@ def is_eligible(
                     avg_monthly >= WORK_REQ_MONTHLY_HOURS
                     and months_meeting >= MIN_MONTHS_MEETING
                 )
-                eligible_2026 = bool(meets_rule)
-                if not eligible_2026:
+                eligible_target = bool(meets_rule)
+                if not eligible_target:
                     alts.append(
-                        "For 2026, try to reach ~80 hrs/month each month via job, school, or volunteering."
+                        f"For {target_year}, try to reach ~80 hrs/month each month via job, school, or volunteering."
                     )
                     alts.append(
                         "Keep good records (pay stubs, schedules, volunteer logs)—we know this is frustrating."
@@ -1488,7 +1611,7 @@ def is_eligible(
         alts.append(
             "Since there’s veteran status in the household, compare with VA health benefits."
         )
-    if not eligible_2025 or not eligible_2026:
+    if not eligible_base or not eligible_target:
         alts.extend(
             [
                 "Visit your state Medicaid page for exact rules and to apply.",
@@ -1499,7 +1622,7 @@ def is_eligible(
         )
 
     # If we found no path and also have no further questions, route to a professional.
-    no_path = not eligible_2025 and not eligible_2026
+    no_path = not eligible_base and not eligible_target
     if no_path and not missing:
         alts.append(
             "We can’t find a pathway with the current info—consider speaking with a benefits navigator or attorney."
@@ -1552,6 +1675,7 @@ _BOOL_FIELDS = frozenset(
         "esrd",
         "on_medicaid_past",
         "work_req_exempt_2026",
+        "work_req_exempt",
     }
 )
 _INT_FIELDS = frozenset(
@@ -1595,7 +1719,15 @@ def summarize_eligibility_inputs(kwargs: Dict[str, Any]) -> Dict[str, Any]:
             continue
         if raw is None:
             continue
-        if name == "state":
+        if name == "target_year":
+            # Echo the year we will actually score (clamped/normalized), so
+            # the model doesn't keep believing in a year we can't model.
+            year = _parse_target_year(raw)
+            if year is None:
+                unreadable.append(name)
+            else:
+                recorded[name] = year
+        elif name == "state":
             try:
                 normalized: Any = _normalize_state(raw)
             except ValueError:

--- a/fighthealthinsurance/medicaid_api.py
+++ b/fighthealthinsurance/medicaid_api.py
@@ -502,8 +502,16 @@ DEFAULT_TARGET_YEAR = WORK_REQUIREMENT_FIRST_YEAR
 MAX_TARGET_YEAR = BASE_ELIGIBILITY_YEAR + 10
 
 # Rough annual bump applied to the FPL table and the LTC income cap for years
-# past the published guidelines. A guess, and labelled as one to the user.
+# past the published guidelines. A guess, and labelled as one to the user --
+# which is why it is only applied when the user actually asked about a future
+# year. On the default path the two verdicts differ by the work requirement
+# alone, so a guessed inflation number can't manufacture a difference nobody
+# asked about.
 ANNUAL_THRESHOLD_INFLATION = 0.03
+
+# Below this a number isn't a year at all, it's whatever _parse_numeric found
+# in the sentence ("in 3 years", "for the next 5 years").
+_MIN_PLAUSIBLE_YEAR = 1900
 
 # Percent-of-FPL ceilings by category. Module scope because the stepwise
 # question block consults them to skip questions that cannot change the
@@ -673,7 +681,16 @@ def _parse_target_year(value: Any) -> Optional[int]:
         return None
     year = int(number)
     if 0 <= year < 100:
+        # A two-digit year, but only if it can BE one: "26" is 2026, while
+        # the 3 that _parse_numeric pulls out of "in 3 years" is not 2003.
+        # Reading it as one used to clamp to the base year, which quietly
+        # switched the work-requirement overlay off for a user who was
+        # asking about a year the overlay applies to.
         year += 2000
+        if year < BASE_ELIGIBILITY_YEAR:
+            return None
+    elif year < _MIN_PLAUSIBLE_YEAR:
+        return None
     if year < BASE_ELIGIBILITY_YEAR:
         return BASE_ELIGIBILITY_YEAR
     if year > MAX_TARGET_YEAR:
@@ -688,6 +705,16 @@ def resolve_target_year(value: Any) -> int:
     user sees can't disagree about which year was checked.
     """
     return _parse_target_year(value) or DEFAULT_TARGET_YEAR
+
+
+def target_year_requested(value: Any) -> bool:
+    """Whether the caller actually named a target year we could read.
+
+    Distinguishes "what about 2028?" from the DEFAULT_TARGET_YEAR path. Only
+    the former projects income thresholds forward, so only the former should
+    tell the user the thresholds were estimated.
+    """
+    return _parse_target_year(value) is not None
 
 
 def _clean_token(s: str) -> str:
@@ -893,7 +920,18 @@ def is_eligible(
     # The year the caller wants the second verdict for. Anything we can't
     # read falls back to the default rather than failing the whole check;
     # summarize_eligibility_inputs reports what we actually used.
-    target_year = resolve_target_year(kwargs.get("target_year"))
+    requested_year = _parse_target_year(kwargs.get("target_year"))
+    target_year = requested_year or DEFAULT_TARGET_YEAR
+
+    # Which year's income thresholds the target verdict is scored against.
+    # Only a year the user ASKED about gets projected forward: on the default
+    # path, inflating the table by a guessed 3% could flip someone sitting on
+    # a threshold to "eligible next year, not this year" -- a difference
+    # invented by our own guess, about a year they never mentioned. There the
+    # two verdicts differ by the work requirement and nothing else.
+    threshold_year = (
+        requested_year if requested_year is not None else BASE_ELIGIBILITY_YEAR
+    )
 
     def inflate(amount: float, year: int) -> float:
         """Roll a base-year threshold forward to ``year``."""
@@ -921,7 +959,7 @@ def is_eligible(
     LTC_INCOME_CAP_BASE = (
         3000.0  # rough nursing home / HCBS cap (varies by state/waiver)
     )
-    LTC_INCOME_CAP_TARGET = inflate(LTC_INCOME_CAP_BASE, target_year)
+    LTC_INCOME_CAP_TARGET = inflate(LTC_INCOME_CAP_BASE, threshold_year)
     ABD_ASSET_LIMIT_SINGLE = 2000.0
     ABD_ASSET_LIMIT_MARRIED = 3000.0
     HOME_EQUITY_CAP_DEFAULT = 750000.0
@@ -1309,11 +1347,13 @@ def is_eligible(
 
     # ---- with core info present, evaluate categories ----
     pfpl_base = pct_fpl(monthly_income, household_size, BASE_ELIGIBILITY_YEAR)
-    # The target year's FPL guidelines aren't published yet, so they're the
-    # base table rolled forward. Someone a hair over a threshold today can
-    # land under an inflated one, which is exactly what "will I qualify in
-    # 2028?" is asking -- so the categories below score both years.
-    pfpl_target = pct_fpl(monthly_income, household_size, target_year)
+    # When the user asked about a specific future year, its FPL guidelines
+    # aren't published yet, so they're the base table rolled forward: someone
+    # a hair over a threshold today can land under an inflated one, which is
+    # exactly what "will I qualify in 2028?" is asking. On the default path
+    # threshold_year IS the base year, so this is the same number as
+    # pfpl_base and the target verdict differs only by the work overlay.
+    pfpl_target = pct_fpl(monthly_income, household_size, threshold_year)
 
     # Income-only verdict for the target year, when it can differ from the
     # base year's. None means "no separate target-year test applied", so the
@@ -1375,7 +1415,7 @@ def is_eligible(
                 # OVER the ABD limit came back eligible via this pathway,
                 # while declining the question came back "we can't estimate".
                 eligible_base = True
-                target_income_eligible = magi_expansion_covers(year=target_year)
+                target_income_eligible = magi_expansion_covers(year=threshold_year)
             elif not ask("assets_total", _Q_ASSETS):
                 # Declined, and no asset-free pathway applies: an asset test
                 # we cannot run is not a failed asset test. Without this the
@@ -1397,7 +1437,7 @@ def is_eligible(
             if not eligible_base:
                 eligible_base = magi_expansion_covers()
             if not target_income_eligible:
-                target_income_eligible = magi_expansion_covers(year=target_year)
+                target_income_eligible = magi_expansion_covers(year=threshold_year)
             if not eligible_base:
                 abd_alternatives()
     elif applying_reason in _LTC_REASONS:

--- a/fighthealthinsurance/medicaid_api.py
+++ b/fighthealthinsurance/medicaid_api.py
@@ -1,6 +1,7 @@
 import difflib
 import json
 import re
+from datetime import date
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple
@@ -498,6 +499,11 @@ _DECLINE_DEFAULTS: Dict[str, Any] = {
 # "may not be eligible" on the default 2026 path and "could be eligible" when
 # they typed "what about 2026?". The work requirement is the difference
 # between the two years that we can actually speak to.
+#
+# This is the year of the PUBLISHED FPL TABLE, not "now" -- once the calendar
+# moves past it we keep scoring against the same table (it's the newest one
+# published) but we stop calling it the current year. Use
+# ``current_eligibility_year`` for anything a user reads as "today".
 BASE_ELIGIBILITY_YEAR = 2025
 
 # States must implement the federal work/community-engagement requirement no
@@ -511,6 +517,24 @@ DEFAULT_TARGET_YEAR = WORK_REQUIREMENT_FIRST_YEAR
 # can support, so a target beyond it is clamped (and the clamp is reported
 # back through summarize_eligibility_inputs).
 MAX_TARGET_YEAR = BASE_ELIGIBILITY_YEAR + 10
+
+
+def current_eligibility_year() -> int:
+    """The year to present as "today" in a verdict.
+
+    Kept separate from ``BASE_ELIGIBILITY_YEAR``, which names the published
+    FPL table we score against. The two were the same thing until the
+    calendar moved past the table, at which point labelling every answer
+    "current (2025)" -- and printing a verdict row for a year that had
+    already ended -- was telling people about rules that were no longer the
+    ones they live under.
+
+    Floored at the table year (we can't score anything earlier) and capped at
+    ``MAX_TARGET_YEAR`` so a wildly wrong system clock can't push the whole
+    timeline past what we model.
+    """
+    return min(max(BASE_ELIGIBILITY_YEAR, date.today().year), MAX_TARGET_YEAR)
+
 
 # Below this a number isn't a year at all, it's whatever _parse_numeric found
 # in the sentence ("in 3 years", "for the next 5 years").
@@ -720,16 +744,27 @@ def timeline_years(value: Any = None) -> List[int]:
 
     Income limits are identical across years (see BASE_ELIGIBILITY_YEAR), so
     the work requirement is the only thing that can move a verdict -- which
-    makes ``WORK_REQUIREMENT_FIRST_YEAR`` the one year that always earns a
-    row alongside today's rules and whatever the user asked about.
+    makes ``WORK_REQUIREMENT_FIRST_YEAR`` the one year that earns a row
+    alongside today's rules and whatever the user asked about, for as long as
+    it is still ahead of us. Once it isn't, it's just today's rules and there
+    is nothing to flag.
+
+    Anchored on ``current_eligibility_year``, not the FPL table's year: a row
+    for a year that has already ended is noise at best, and labelled
+    "current" it is wrong.
+
+    Never a single year. Once the work-requirement year is behind us the set
+    above can collapse to just "now", and "will this still be true next year?"
+    is the question people are actually asking -- so next year gets a row and
+    answers it out loud instead of leaving it implied.
     """
-    return sorted(
-        {
-            BASE_ELIGIBILITY_YEAR,
-            WORK_REQUIREMENT_FIRST_YEAR,
-            resolve_target_year(value),
-        }
-    )
+    current = current_eligibility_year()
+    years = {current, resolve_target_year(value)}
+    if WORK_REQUIREMENT_FIRST_YEAR > current:
+        years.add(WORK_REQUIREMENT_FIRST_YEAR)
+    if len(years) == 1:
+        years.add(min(current + 1, MAX_TARGET_YEAR))
+    return sorted(years)
 
 
 def eligibility_timeline(**kwargs: Any) -> List[Tuple[int, bool]]:

--- a/fighthealthinsurance/medicaid_gov_api.py
+++ b/fighthealthinsurance/medicaid_gov_api.py
@@ -1,0 +1,398 @@
+"""Lookups against Medicaid.gov and a few other trusted coverage references.
+
+Two things live here:
+
+* A small registry of CURATED pages we point people at often -- the renewal
+  hub and its per-state pages, the official income-eligibility table, and a
+  couple of federal-poverty-level references. These are named so the model
+  asks for ``renew_info`` rather than trying to remember a 130-character URL.
+* A search over Medicaid.gov backed by its SITEMAP.
+
+Why the sitemap and not the site's own search box: medicaid.gov runs Google
+Vertex AI Search, which renders results client-side from a credentialed
+datastore -- there is no public query endpoint -- and ``/search/`` is
+``Disallow``ed in their robots.txt besides. The sitemap is the sanctioned
+index of the same pages, so matching against it gets us "look up a page on
+medicaid.gov" without scraping a search UI we are asked not to touch.
+"""
+
+from __future__ import annotations
+
+import re
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence, Tuple
+from urllib.parse import urlparse
+
+import requests
+from django.core.cache import cache
+from loguru import logger
+
+MEDICAID_GOV = "https://www.medicaid.gov"
+SITEMAP_INDEX_URL = f"{MEDICAID_GOV}/sitemap.xml"
+
+# Hosts this module is allowed to hand back. Everything here is a public
+# government or non-profit coverage reference; the chat tool refuses anything
+# else so a model can't turn this into a general-purpose fetcher.
+ALLOWED_HOSTS = frozenset(
+    {
+        "www.medicaid.gov",
+        "medicaid.gov",
+        "www.coveredca.com",
+        "coveredca.com",
+        "www.healthinsurance.org",
+        "healthinsurance.org",
+    }
+)
+
+# Paths medicaid.gov's robots.txt asks crawlers to stay out of. Checked
+# against sitemap entries and explicit URLs alike -- the sitemap shouldn't
+# contain these, but a model guessing a URL might.
+_DISALLOWED_PREFIXES = (
+    "/core/",
+    "/profiles/",
+    "/admin/",
+    "/comment/reply/",
+    "/filter/tips",
+    "/node/",
+    "/search/",
+    "/taxonomy/",
+    "/themes/",
+    "/libraries/",
+    "/modules/",
+    "/devel/",
+    "/user/",
+    "/index.php/",
+)
+
+_SITEMAP_CACHE_KEY = "medicaid_gov_sitemap_urls_v1"
+_SITEMAP_CACHE_SECONDS = 60 * 60 * 24  # the sitemap's lastmod moves daily
+_SITEMAP_TIMEOUT_SECONDS = 20
+# The index paginates at 1,500 URLs a page; cap the walk so a sitemap that
+# grows unexpectedly can't turn one lookup into a crawl.
+_MAX_SITEMAP_PAGES = 10
+
+_SITEMAP_NS = {"s": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+
+
+@dataclass(frozen=True)
+class CuratedSource:
+    """A page we hand out by name instead of by URL."""
+
+    key: str
+    url: str
+    description: str
+    # When set, ``state`` picks a per-state variant of the page.
+    state_url_template: Optional[str] = None
+
+
+CURATED_SOURCES: Dict[str, CuratedSource] = {
+    "renew_info": CuratedSource(
+        key="renew_info",
+        url=f"{MEDICAID_GOV}/renew-info",
+        description=(
+            "Official Medicaid/CHIP renewal hub -- how to keep coverage, what "
+            "the state will mail you, and what to do if you're disenrolled."
+        ),
+        state_url_template=f"{MEDICAID_GOV}/renew-info/{{state}}/",
+    ),
+    "eligibility_levels": CuratedSource(
+        key="eligibility_levels",
+        url=(
+            f"{MEDICAID_GOV}/medicaid/national-medicaid-chip-program-information"
+            "/medicaid-childrens-health-insurance-program-basic-health-program"
+            "-eligibility-levels"
+        ),
+        description=(
+            "Official Medicaid / CHIP / Basic Health Program income "
+            "eligibility levels by state and category."
+        ),
+    ),
+    "fpl_chart": CuratedSource(
+        key="fpl_chart",
+        url="https://www.coveredca.com/pdfs/FPL-chart.pdf",
+        description=(
+            "Covered California's federal-poverty-level chart (PDF) -- FPL "
+            "dollar amounts by household size and percentage band."
+        ),
+    ),
+    "fpl_glossary": CuratedSource(
+        key="fpl_glossary",
+        url="https://www.healthinsurance.org/glossary/federal-poverty-level/",
+        description=(
+            "Plain-language explanation of what the federal poverty level is "
+            "and how coverage programs use it."
+        ),
+    ),
+}
+
+
+# Phrasings that should land on a curated page even though they don't appear
+# in any URL slug. The sitemap carries no page titles, so slug matching alone
+# misses the way people actually ask ("my coverage is ending" is nowhere in
+# "/renew-info"). Keyword -> curated key.
+_CURATED_ALIASES: Dict[str, Tuple[str, ...]] = {
+    "renew_info": (
+        "renew",
+        "renewal",
+        "redetermination",
+        "recertification",
+        "keep my coverage",
+        "coverage ending",
+        "coverage is ending",
+        "coverage ends",
+        "lose my coverage",
+        "losing coverage",
+        "disenrolled",
+        "terminated",
+        "paperwork",
+    ),
+    "eligibility_levels": (
+        "income limit",
+        "income limits",
+        "eligibility level",
+        "eligibility levels",
+        "how much can i make",
+        "income threshold",
+        "qualify income",
+    ),
+    "fpl_chart": (
+        "fpl chart",
+        "poverty level chart",
+        "poverty guidelines",
+        "fpl table",
+        "percent of poverty",
+    ),
+    "fpl_glossary": (
+        "federal poverty level",
+        "what is fpl",
+        "poverty level mean",
+    ),
+}
+
+
+def suggest_curated_sources(query: str) -> List[CuratedSource]:
+    """Curated pages whose subject matches ``query``, best first.
+
+    Checked before the sitemap: these are the pages we already know answer
+    the question, and slug matching would not find several of them.
+    """
+    if not query or not isinstance(query, str):
+        return []
+    lowered = query.lower()
+    scored: List[Tuple[int, CuratedSource]] = []
+    for key, aliases in _CURATED_ALIASES.items():
+        source = CURATED_SOURCES.get(key)
+        if source is None:
+            continue
+        hits = sum(1 for alias in aliases if alias in lowered)
+        if hits:
+            scored.append((hits, source))
+    scored.sort(key=lambda pair: (-pair[0], pair[1].key))
+    return [source for _, source in scored]
+
+
+def is_allowed_url(url: str) -> bool:
+    """Whether ``url`` is an https page on an allowed host and not robots-blocked."""
+    if not url:
+        return False
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        return False
+    host = (parsed.hostname or "").lower()
+    if host not in ALLOWED_HOSTS:
+        return False
+    if host.endswith("medicaid.gov"):
+        path = parsed.path or "/"
+        if any(path.startswith(prefix) for prefix in _DISALLOWED_PREFIXES):
+            return False
+    return True
+
+
+def resolve_curated_source(page: str, state: Optional[str] = None) -> Optional[str]:
+    """URL for a curated page name, optionally its per-state variant.
+
+    ``state`` accepts anything ``medicaid_api`` can normalize -- a full name,
+    a postal code, or a state program name like "Medi-Cal" -- so the model
+    doesn't have to convert "Iowa" to "ia" itself.
+    """
+    if not page or not isinstance(page, str):
+        return None
+    source = CURATED_SOURCES.get(page.strip().lower().replace("-", "_"))
+    if source is None:
+        return None
+
+    if state and source.state_url_template:
+        # Imported here: medicaid_api pulls in pandas, and this module is
+        # imported by the chat tools on every chat.
+        from fighthealthinsurance.medicaid_api import _normalize_state
+
+        try:
+            code = _normalize_state(state)
+        except ValueError:
+            code = None
+        if code:
+            return source.state_url_template.format(state=code)
+        # An unreadable state falls back to the national page rather than
+        # guessing a slug that would 404.
+        logger.debug(f"medicaid_gov: could not resolve state {state!r}, using national")
+    return source.url
+
+
+def curated_source_menu() -> str:
+    """One line per curated page, for the tool's own error/help text."""
+    lines = []
+    for source in CURATED_SOURCES.values():
+        suffix = ' (accepts "state")' if source.state_url_template else ""
+        lines.append(f'- "{source.key}"{suffix}: {source.description}')
+    return "\n".join(lines)
+
+
+def _fetch_sitemap_urls() -> List[str]:
+    """Every content URL in medicaid.gov's sitemap, cached for a day."""
+    cached = cache.get(_SITEMAP_CACHE_KEY)
+    if cached is not None:
+        return list(cached)
+
+    urls: List[str] = []
+    try:
+        index = requests.get(SITEMAP_INDEX_URL, timeout=_SITEMAP_TIMEOUT_SECONDS)
+        index.raise_for_status()
+        root = ET.fromstring(index.content)
+        pages = [
+            loc.text.strip()
+            for loc in root.findall(".//s:sitemap/s:loc", _SITEMAP_NS)
+            if loc.text
+        ]
+        if not pages:
+            # A flat sitemap rather than an index.
+            pages = [SITEMAP_INDEX_URL]
+
+        for page_url in pages[:_MAX_SITEMAP_PAGES]:
+            page = requests.get(page_url, timeout=_SITEMAP_TIMEOUT_SECONDS)
+            page.raise_for_status()
+            page_root = ET.fromstring(page.content)
+            for loc in page_root.findall(".//s:url/s:loc", _SITEMAP_NS):
+                if loc.text:
+                    candidate = loc.text.strip()
+                    if is_allowed_url(candidate):
+                        urls.append(candidate)
+    except Exception as e:
+        logger.warning(f"medicaid_gov: sitemap fetch failed: {e}")
+        # Cache the failure briefly so a site outage doesn't make every chat
+        # turn pay the timeout.
+        cache.set(_SITEMAP_CACHE_KEY, [], 300)
+        return []
+
+    urls = sorted(set(urls))
+    cache.set(_SITEMAP_CACHE_KEY, urls, _SITEMAP_CACHE_SECONDS)
+    logger.debug(f"medicaid_gov: cached {len(urls)} sitemap URLs")
+    return urls
+
+
+_WORD_RE = re.compile(r"[a-z0-9]+")
+# Words that appear in half the site's slugs and so tell us nothing about
+# which page the user wants.
+_STOPWORDS = frozenset(
+    {
+        "a",
+        "an",
+        "and",
+        "are",
+        "as",
+        "at",
+        "be",
+        "by",
+        "can",
+        "chip",
+        "do",
+        "does",
+        "for",
+        "from",
+        "get",
+        "how",
+        "i",
+        "in",
+        "is",
+        "it",
+        "me",
+        "medicaid",
+        "my",
+        "of",
+        "on",
+        "or",
+        "programs",
+        "state",
+        "states",
+        "the",
+        "to",
+        "what",
+        "when",
+        "where",
+        "which",
+        "who",
+        "will",
+        "with",
+        "you",
+        "your",
+    }
+)
+
+
+def _slug_words(url: str) -> List[str]:
+    return _WORD_RE.findall(urlparse(url).path.lower())
+
+
+# Shortest prefix we'll treat as a word match. Long enough that "car" does
+# not match "caregiver", short enough that "renew"/"renewal" and
+# "apply"/"application" connect -- URL slugs and the way people phrase
+# questions rarely agree on suffixes.
+_MIN_PREFIX_MATCH = 4
+
+
+def _words_match(query_word: str, slug_word: str) -> bool:
+    if query_word == slug_word:
+        return True
+    shorter, longer = sorted((query_word, slug_word), key=len)
+    return len(shorter) >= _MIN_PREFIX_MATCH and longer.startswith(shorter)
+
+
+def _score(query_words: Sequence[str], url: str) -> float:
+    """How well ``url``'s slug matches the query. 0 means no match."""
+    slug = _slug_words(url)
+    if not slug:
+        return 0.0
+    hits = [w for w in query_words if any(_words_match(w, s) for s in slug)]
+    if not hits:
+        return 0.0
+    # Coverage of the query matters most; shallow pages break ties, since
+    # /renew-info beats /renew-info/some/deep/child for a general question.
+    coverage = len(hits) / len(query_words)
+    depth_penalty = 1.0 + 0.08 * max(0, len(slug) - len(hits))
+    return coverage / depth_penalty
+
+
+def search_medicaid_gov(query: str, limit: int = 5) -> List[Tuple[str, float]]:
+    """Rank medicaid.gov pages against ``query``, best first.
+
+    Matches on URL slugs from the sitemap -- see the module docstring for why
+    this stands in for the site's own (credentialed, robots-blocked) search.
+    Returns ``(url, score)`` pairs; an empty list means nothing matched or the
+    sitemap was unreachable.
+    """
+    if not query or not isinstance(query, str):
+        return []
+    query_words = [
+        w for w in _WORD_RE.findall(query.lower()) if w not in _STOPWORDS and len(w) > 2
+    ]
+    if not query_words:
+        return []
+
+    scored = []
+    for url in _fetch_sitemap_urls():
+        score = _score(query_words, url)
+        if score > 0:
+            scored.append((url, score))
+
+    scored.sort(key=lambda pair: (-pair[1], len(pair[0]), pair[0]))
+    return scored[: max(1, limit)]

--- a/fighthealthinsurance/medicaid_gov_api.py
+++ b/fighthealthinsurance/medicaid_gov_api.py
@@ -276,13 +276,32 @@ def _parse_sitemap_xml(content: bytes) -> ET.Element:
       Current expat refuses external entities and is no longer vulnerable to
       the classic expansion attacks, but rejecting the declaration outright
       costs nothing and doesn't depend on the parser version underneath us.
+
+    The declaration scan covers the WHOLE document, not a prefix of it: a
+    long enough leading comment pushes ``<!DOCTYPE`` past any fixed window,
+    and a guard you can walk around with padding is not a guard. The size cap
+    runs first, so the scan is bounded.
     """
     if len(content) > _MAX_SITEMAP_BYTES:
         raise ValueError(f"sitemap document too large ({len(content)} bytes)")
-    head = content[:2048].lower()
-    if b"<!doctype" in head or b"<!entity" in head:
+    lowered = content.lower()
+    if b"<!doctype" in lowered or b"<!entity" in lowered:
         raise ValueError("sitemap document carries a doctype/entity declaration")
     return ET.fromstring(content)
+
+
+def _is_allowed_sitemap_url(url: str) -> bool:
+    """Whether ``url`` is a sitemap document we're willing to go fetch.
+
+    The child sitemap URLs come out of remote XML, so they are attacker-shaped
+    input the moment anything upstream of us is wrong. Without this a spoofed
+    or compromised index turns one lookup into a request at whatever host it
+    names -- a server-side request forgery with our credentials-bearing
+    network position behind it.
+    """
+    if not is_allowed_url(url):
+        return False
+    return (urlparse(url).hostname or "").lower().endswith("medicaid.gov")
 
 
 def _fetch_sitemap_urls() -> List[str]:
@@ -296,9 +315,31 @@ def _fetch_sitemap_urls() -> List[str]:
         return list(cached)
 
     deadline = time.monotonic() + _SITEMAP_TOTAL_BUDGET_SECONDS
+
+    def remaining() -> float:
+        return deadline - time.monotonic()
+
+    def _get(url: str):
+        """One budgeted request. Never outlives the walk's deadline.
+
+        The per-request timeout alone doesn't bound the walk: a request that
+        starts a hair before the deadline still runs the full timeout past it.
+        Redirects are off because the whole point of the host check below is
+        that we choose what we connect to -- a 302 would hand that choice back
+        to whoever served the sitemap.
+        """
+        left = remaining()
+        if left <= 0:
+            raise TimeoutError("sitemap walk budget exhausted")
+        return requests.get(
+            url,
+            timeout=min(_SITEMAP_TIMEOUT_SECONDS, left),
+            allow_redirects=False,
+        )
+
     urls: List[str] = []
     try:
-        index = requests.get(SITEMAP_INDEX_URL, timeout=_SITEMAP_TIMEOUT_SECONDS)
+        index = _get(SITEMAP_INDEX_URL)
         index.raise_for_status()
         root = _parse_sitemap_xml(index.content)
         pages = [
@@ -311,7 +352,7 @@ def _fetch_sitemap_urls() -> List[str]:
             pages = [SITEMAP_INDEX_URL]
 
         for page_url in pages[:_MAX_SITEMAP_PAGES]:
-            if time.monotonic() >= deadline:
+            if remaining() <= 0:
                 # Out of time. Keep what we have rather than dropping the
                 # lookup: a partial index still answers most queries, and the
                 # person is waiting on a chat reply.
@@ -321,7 +362,12 @@ def _fetch_sitemap_urls() -> List[str]:
                     f"{len(urls)} URLs collected"
                 )
                 break
-            page = requests.get(page_url, timeout=_SITEMAP_TIMEOUT_SECONDS)
+            if not _is_allowed_sitemap_url(page_url):
+                logger.warning(
+                    f"medicaid_gov: refusing off-host sitemap entry {page_url}"
+                )
+                continue
+            page = _get(page_url)
             page.raise_for_status()
             page_root = _parse_sitemap_xml(page.content)
             for loc in page_root.findall(".//s:url/s:loc", _SITEMAP_NS):
@@ -432,8 +478,8 @@ def search_medicaid_gov(query: str, limit: int = 5) -> List[Tuple[str, float]]:
 
     Blocking on a cold cache (it walks the sitemap); bridge off the event
     loop rather than awaiting it inline.
-    Returns ``(url, score)`` pairs; an empty list means nothing matched or the
-    sitemap was unreachable.
+    Returns ``(url, score)`` pairs; an empty list means nothing matched, the
+    sitemap was unreachable, or the caller asked for nothing (``limit=0``).
     """
     if not query or not isinstance(query, str):
         return []
@@ -450,4 +496,4 @@ def search_medicaid_gov(query: str, limit: int = 5) -> List[Tuple[str, float]]:
             scored.append((url, score))
 
     scored.sort(key=lambda pair: (-pair[1], len(pair[0]), pair[0]))
-    return scored[: max(1, limit)]
+    return scored[: max(0, limit)]

--- a/fighthealthinsurance/medicaid_gov_api.py
+++ b/fighthealthinsurance/medicaid_gov_api.py
@@ -19,6 +19,7 @@ medicaid.gov" without scraping a search UI we are asked not to touch.
 from __future__ import annotations
 
 import re
+import time
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Sequence, Tuple
@@ -67,10 +68,22 @@ _DISALLOWED_PREFIXES = (
 
 _SITEMAP_CACHE_KEY = "medicaid_gov_sitemap_urls_v1"
 _SITEMAP_CACHE_SECONDS = 60 * 60 * 24  # the sitemap's lastmod moves daily
-_SITEMAP_TIMEOUT_SECONDS = 20
+# Per-request timeout. Deliberately short: this runs while a person is
+# waiting on a chat reply, so a slow upstream should cost us the lookup, not
+# the turn.
+_SITEMAP_TIMEOUT_SECONDS = 5
+# Whole-walk budget. The per-request timeout alone bounds nothing useful --
+# _MAX_SITEMAP_PAGES + 1 requests that each take just under the timeout still
+# add up to a minute -- so the walk also stops once this much has elapsed and
+# uses whatever it collected.
+_SITEMAP_TOTAL_BUDGET_SECONDS = 15
 # The index paginates at 1,500 URLs a page; cap the walk so a sitemap that
 # grows unexpectedly can't turn one lookup into a crawl.
 _MAX_SITEMAP_PAGES = 10
+# Largest sitemap document we will parse. medicaid.gov's pages run well under
+# a megabyte; anything far larger is a mistake or a malicious response, and
+# handing it to the XML parser is how you turn a lookup into an OOM.
+_MAX_SITEMAP_BYTES = 8 * 1024 * 1024
 
 _SITEMAP_NS = {"s": "http://www.sitemaps.org/schemas/sitemap/0.9"}
 
@@ -197,7 +210,10 @@ def is_allowed_url(url: str) -> bool:
     if not url:
         return False
     parsed = urlparse(url)
-    if parsed.scheme not in ("http", "https"):
+    # https only. Every curated source is https, and these pages are the
+    # authority we quote to people about their coverage -- fetching one over
+    # cleartext would let anything on the path rewrite the answer.
+    if parsed.scheme != "https":
         return False
     host = (parsed.hostname or "").lower()
     if host not in ALLOWED_HOSTS:
@@ -248,17 +264,43 @@ def curated_source_menu() -> str:
     return "\n".join(lines)
 
 
+def _parse_sitemap_xml(content: bytes) -> ET.Element:
+    """Parse a sitemap document, refusing anything that isn't plain XML.
+
+    Two guards, both because this is remote content we don't control:
+
+    * A size cap, so an unexpectedly enormous (or hostile) response can't be
+      handed to the parser to expand in memory.
+    * No document type declaration. Sitemaps have no DTD, so a ``<!DOCTYPE``
+      or ``<!ENTITY`` here is either a mistake or an entity-expansion attempt.
+      Current expat refuses external entities and is no longer vulnerable to
+      the classic expansion attacks, but rejecting the declaration outright
+      costs nothing and doesn't depend on the parser version underneath us.
+    """
+    if len(content) > _MAX_SITEMAP_BYTES:
+        raise ValueError(f"sitemap document too large ({len(content)} bytes)")
+    head = content[:2048].lower()
+    if b"<!doctype" in head or b"<!entity" in head:
+        raise ValueError("sitemap document carries a doctype/entity declaration")
+    return ET.fromstring(content)
+
+
 def _fetch_sitemap_urls() -> List[str]:
-    """Every content URL in medicaid.gov's sitemap, cached for a day."""
+    """Every content URL in medicaid.gov's sitemap, cached for a day.
+
+    Blocking: does network IO with ``requests``. Callers on the event loop
+    must bridge (see ``MedicaidGovLookupTool._resolve_target``).
+    """
     cached = cache.get(_SITEMAP_CACHE_KEY)
     if cached is not None:
         return list(cached)
 
+    deadline = time.monotonic() + _SITEMAP_TOTAL_BUDGET_SECONDS
     urls: List[str] = []
     try:
         index = requests.get(SITEMAP_INDEX_URL, timeout=_SITEMAP_TIMEOUT_SECONDS)
         index.raise_for_status()
-        root = ET.fromstring(index.content)
+        root = _parse_sitemap_xml(index.content)
         pages = [
             loc.text.strip()
             for loc in root.findall(".//s:sitemap/s:loc", _SITEMAP_NS)
@@ -269,9 +311,19 @@ def _fetch_sitemap_urls() -> List[str]:
             pages = [SITEMAP_INDEX_URL]
 
         for page_url in pages[:_MAX_SITEMAP_PAGES]:
+            if time.monotonic() >= deadline:
+                # Out of time. Keep what we have rather than dropping the
+                # lookup: a partial index still answers most queries, and the
+                # person is waiting on a chat reply.
+                logger.warning(
+                    f"medicaid_gov: sitemap walk hit its "
+                    f"{_SITEMAP_TOTAL_BUDGET_SECONDS}s budget with "
+                    f"{len(urls)} URLs collected"
+                )
+                break
             page = requests.get(page_url, timeout=_SITEMAP_TIMEOUT_SECONDS)
             page.raise_for_status()
-            page_root = ET.fromstring(page.content)
+            page_root = _parse_sitemap_xml(page.content)
             for loc in page_root.findall(".//s:url/s:loc", _SITEMAP_NS):
                 if loc.text:
                     candidate = loc.text.strip()
@@ -377,6 +429,9 @@ def search_medicaid_gov(query: str, limit: int = 5) -> List[Tuple[str, float]]:
 
     Matches on URL slugs from the sitemap -- see the module docstring for why
     this stands in for the site's own (credentialed, robots-blocked) search.
+
+    Blocking on a cold cache (it walks the sitemap); bridge off the event
+    loop rather than awaiting it inline.
     Returns ``(url, score)`` pairs; an empty list means nothing matched or the
     sitemap was unreachable.
     """

--- a/fighthealthinsurance/medicaid_gov_api.py
+++ b/fighthealthinsurance/medicaid_gov_api.py
@@ -87,6 +87,19 @@ _MAX_SITEMAP_BYTES = 8 * 1024 * 1024
 
 _SITEMAP_NS = {"s": "http://www.sitemaps.org/schemas/sitemap/0.9"}
 
+# Encodings a document can declare for itself that the XML parser will then
+# honour. The doctype scan has to look for its marker in each of them: the
+# bytes we search are whatever the server sent, not UTF-8, and a scan that
+# only knows one encoding is a guard with a documented way around it.
+# ASCII/latin-1 are byte-identical to UTF-8 for these markers.
+_DECLARATION_SCAN_ENCODINGS = (
+    "utf-8",
+    "utf-16-le",
+    "utf-16-be",
+    "utf-32-le",
+    "utf-32-be",
+)
+
 
 @dataclass(frozen=True)
 class CuratedSource:
@@ -281,12 +294,26 @@ def _parse_sitemap_xml(content: bytes) -> ET.Element:
     long enough leading comment pushes ``<!DOCTYPE`` past any fixed window,
     and a guard you can walk around with padding is not a guard. The size cap
     runs first, so the scan is bounded.
+
+    It also scans for the marker in every encoding the parser will accept,
+    not just the one we can read by eye. A UTF-16 document declares its own
+    encoding and the parser honours it, so ``<!DOCTYPE`` arrives as
+    ``<\x00!\x00D\x00...`` and sails straight past a plain byte search --
+    the guard looked like it held while the document parsed with its entities
+    intact.
     """
     if len(content) > _MAX_SITEMAP_BYTES:
         raise ValueError(f"sitemap document too large ({len(content)} bytes)")
+    # bytes.lower() only touches ASCII bytes, so it lowercases the marker's
+    # characters in the wide encodings too and leaves their padding alone.
     lowered = content.lower()
-    if b"<!doctype" in lowered or b"<!entity" in lowered:
-        raise ValueError("sitemap document carries a doctype/entity declaration")
+    for encoding in _DECLARATION_SCAN_ENCODINGS:
+        for marker in ("<!doctype", "<!entity"):
+            if marker.encode(encoding) in lowered:
+                raise ValueError(
+                    "sitemap document carries a doctype/entity declaration "
+                    f"({encoding})"
+                )
     return ET.fromstring(content)
 
 

--- a/fighthealthinsurance/ml/medicaid_names.py
+++ b/fighthealthinsurance/ml/medicaid_names.py
@@ -1,0 +1,49 @@
+"""State-by-state names for Medicaid, shared by the prompt and the filters.
+
+Medicaid is called something different in most states, and the system prompt
+tells the model to use whichever name the user does. Two other places have to
+know the same list:
+
+* ``ml_models`` builds the "medicaid can go by many names" reminder from it.
+* ``chat.safety_filters.detect_eligibility_verdict`` has to recognize a
+  verdict about a state program ("you qualify for Medi-Cal") as the same
+  claim as one about "Medicaid" -- otherwise the invented-verdict penalty
+  misses exactly the phrasing the prompt encourages.
+
+Stdlib-only and dependency-free on purpose: safety_filters is imported from
+inside the chat package, which ml_models must not import back.
+"""
+
+# Ordered longest-name-first is NOT required here (the consumers build their
+# own alternations), but the list is kept alphabetical so additions are easy
+# to spot in review.
+MEDICAID_PROGRAM_ALIASES: tuple[str, ...] = (
+    "Apple Health",
+    "Cardinal Care",
+    "DenaliCare",
+    "Diamond State Health Plan",
+    "Equality Care",
+    "Forward Health",
+    "Green Mountain Care",
+    "Health First Colorado",
+    "HealthChoice Illinois",
+    "Healthy Connections",
+    "Hoosier Healthwise",
+    "Husky Health",
+    "Iowa Medicaid",
+    "Kansas Medical Assistance Program",
+    "MaineCare",
+    "MassHealth",
+    "Med-QUEST",
+    "Medi-Cal",
+    "Medical Assistance",
+    "Medical Assistance Program",
+    "MO HealthNet",
+    "New York State Medicaid",
+    "NJ FamilyCare",
+    "SoonerCare",
+    "STAR",
+    "STAR+PLUS",
+    "TennCare",
+    "Turquoise Care",
+)

--- a/fighthealthinsurance/ml/ml_inference.py
+++ b/fighthealthinsurance/ml/ml_inference.py
@@ -35,7 +35,10 @@ async def infer_with_fallback(
     against a specific list (e.g. external models) instead.
     """
     if models is None:
-        models = ml_router.internal_models_by_cost[:model_count]
+        # General-purpose only: every caller of this helper is asking a model
+        # to follow instructions (extract fields, classify, summarize), which
+        # the appeal-text fine-tunes answer with stray digits and blank lines.
+        models = ml_router.general_purpose_internal_models()[:model_count]
     for model in models:
         try:
             result = await asyncio.wait_for(

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -1290,7 +1290,9 @@ Pages you can ask for by name:
 
 You can also pass **medicaid_gov_lookup {"query": "renewal paperwork"}** to search Medicaid.gov, or {"url": "https://www.medicaid.gov/..."} for a specific Medicaid.gov page.
 
-Use this when someone needs the OFFICIAL wording — renewal deadlines, income tables, what a notice means — rather than answering from memory. It reads the real page, so cite the URL it returns. It cannot look up an individual's case: only their state agency can do that."""
+Use this when someone needs the OFFICIAL wording — renewal deadlines, income tables, what a notice means — rather than answering from memory. It reads the real page, so cite the URL it returns. It cannot look up an individual's case: only their state agency can do that.
+
+Offer it proactively after you've given someone an eligibility estimate, or an answer about income limits, deadlines, or what a notice means. Everything we tell them is an estimate off simplified rules; the official page is the thing they can actually check it against, and their own state agency is the only one who decides. Give them the link, don't just describe it."""
 
         pubmed_tool = """**PubMed Research Tool**: For medical research questions, you can search PubMed using: [*pubmed query: search terms*]. This provides access to recent medical literature and research. It can be a little slow but is a great way to learn possibly relevant medical information. Pubmed is not good for insurance information."""
 

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -864,6 +864,20 @@ class RemoteModelLike(DenialBase):
     def quality(self) -> int:
         return 100
 
+    def supports_general_instructions(self) -> bool:
+        """Whether this backend can follow arbitrary instructions.
+
+        True for general-purpose models: they can hold a chat turn, emit a
+        tool call, extract an entity, or summarize. False for narrow
+        fine-tunes that only reliably produce the one artifact they were
+        trained on (the appeal/prior-auth text), which answer everything
+        else with filler or digit soup. Those stay eligible for generation
+        and are kept out of the conversational/extraction fan-outs, where a
+        garbage candidate costs a slot, a timeout, and occasionally the
+        race.
+        """
+        return True
+
     def get_max_context(self) -> int:
         """Return the maximum context length in tokens for this model."""
         if hasattr(self, "max_len"):
@@ -1215,6 +1229,7 @@ Rules for medicaid questions:
 - NEVER provide generic Medicaid information, websites, or advice
 - NEVER mix tool calls with long explanations
 - The tool provides ALL necessary information, although you can reformat it's output.
+- After you have delivered the state information, close with ONE short sentence offering our experimental eligibility check (see the eligibility tool above) — say plainly that it's experimental and only a rough estimate, not an official determination.
 
 CORRECT Examples:
 User: "medicaid info in california" → Response: **medicaid_info {"state": "California", "topic": "", "limit": 5}**
@@ -1229,7 +1244,7 @@ WRONG Examples:
             + MEDICAID_WORK_REQUIREMENTS_BLOCK
             + """
 
-RULE: Do NOT add any conversational text, questions, or additional explanations when providing work requirements information. Use ONLY the text above.
+RULE: Do NOT add any conversational text, questions, or additional explanations when providing work requirements information. Use the text above, followed at most by ONE short sentence offering the experimental eligibility check (e.g. "I can run our experimental eligibility check with you to estimate how this affects you — it's a rough estimate, not an official determination."). Nothing else.
 """
         )
         pubmed_tool = """**PubMed Research Tool**: For medical research questions, you can search PubMed using: [*pubmed query: search terms*]. This provides access to recent medical literature and research. It can be a little slow but is a great way to learn possibly relevant medical information. Pubmed is not good for insurance information."""
@@ -1294,7 +1309,7 @@ At each step add the user's new answers to the parameters you've already collect
 
 Rules for medicaid eligibility:
 
-Call the tool, and the tool will tell you what other information is required until it eventually says probably eligible under today's rules only, probably eligible under today's rules and with the 2026 work requirements, or can't find eligibility. In any case you can send them to https://www.fighthealthinsurance.com/faq/medicaid/ once done along with the state specific medicaid information (see the next tool). You can suggest things like "maybe school or volunteering" to help get someone up to the 80 hours. Remind people to keep good records (while expressing empathy that this is unfair).
+Call the tool, and the tool will tell you what other information is required until it eventually says probably eligible under today's rules only, probably eligible under today's rules and in the year being checked (by default 2026, with the work requirements), or can't find eligibility. The tool tells you which year it scored — use that year in your answer, never a different one. In any case you can send them to https://www.fighthealthinsurance.com/faq/medicaid/ once done along with the state specific medicaid information (see the next tool). You can suggest things like "maybe school or volunteering" to help get someone up to the 80 hours. Remind people to keep good records (while expressing empathy that this is unfair).
 
 Possible kwargs (all optional; function will ask for missing, step-by-step):
       - state: str
@@ -1316,8 +1331,10 @@ Possible kwargs (all optional; function will ask for missing, step-by-step):
       - esrd: bool
       - ssdi_length: int # how many MONTHS they have been receiving SSDI
       - years_worked: int # how many years you or your spouse worked and paid medicare taxes
-      # 2026 federal work / community engagement requirement (80 qualifying hours per month;
-      # hours from work, school, volunteering, or caregiving all count):
+      - target_year: int  # which year to check besides today's rules (defaults to 2026)
+      # federal work / community engagement requirement (80 qualifying hours per month;
+      # hours from work, school, volunteering, or caregiving all count -- it applies from
+      # 2026 on, so a target_year of 2025 is checked without it):
       - work_req_exempt_2026: bool                    # true if you know they're exempt (pregnant, disabled/medically frail, on medicare, etc.)
       - avg_monthly_qualifying_hours_last_3mo: float  # average qualifying hours per MONTH (the units the tool asks in)
       - avg_weekly_qualifying_hours_last_3mo: float   # or average per WEEK -- watch the units, never put a monthly number here
@@ -1329,6 +1346,7 @@ Possible kwargs (all optional; function will ask for missing, step-by-step):
 - Numbers: a plain number with no currency symbol, comma, or unit. ("about twelve hundred a month" -> `"monthly_income": 1200`.)
 - State: the state name or its 2-letter code. If they name their program (Medi-Cal, MassHealth, TennCare, Apple Health...) infer the state yourself.
 - Hours: mind the units — `avg_monthly_qualifying_hours_last_3mo` is per MONTH, `avg_weekly_qualifying_hours_last_3mo` is per WEEK.
+- Year: every check covers today's rules plus one other year. If the user names a year ("what about 2028?", "will I still qualify next year?", "when the work requirements start"), send it as a 4-digit `target_year` — convert relative phrases yourself, and re-send the same `target_year` on every following call so the estimate doesn't silently switch years mid-conversation. Leave it out when they haven't asked about a particular year. If they ask about several years, run the check once per year and say which is which.
 
 **When the user can't answer**, send the string `"unknown"` for that parameter (e.g. `"assets_total": "unknown"`). That tells us to stop asking it and either assume the conservative answer or explain what we can't determine. Never invent a value, and never silently drop the question — an unanswered question comes back every turn.
 
@@ -1364,6 +1382,14 @@ We have a selection of tools to help you. You should try and use these tools whe
 For eligibility determinations if you have a tool you must use the tool rather than guessing on your own.
 This means if someone asks if their eligible for medical, medicaid, medicare, or similar you must use the tool.
 You can call these tools, but not the person chatting with you. So, for example, you can offer to lookup more info for them.
+
+***THE MEDICAID PATH***
+Most people asking about Medicaid in general ("what is Medicaid?", "how do I apply?", "what are the income limits?", "what are these work requirements?") really want to know whether THEY can get covered, so a general answer is the start of the path, not the end of it:
+1. Answer what they actually asked (using medicaid_info for anything state-specific, or the work requirements text above).
+2. Then offer the EXPERIMENTAL eligibility check in one short sentence, making clear it's a rough estimate and not an official determination.
+3. The moment they show any interest — "yes", "how do I know?", "would I qualify?", "what are the limits for me?", asking about their own income, household, or coverage — call **medicaid_eligibility** with everything you already know (at minimum the state, plus their target year if they named one). Do NOT ask them eligibility questions first; the tool tells you which questions to ask.
+4. Keep going: each answer they give goes back into the tool call along with everything collected so far, until the tool gives a determination. Then finish with the state contact info from **medicaid_info** and https://www.fighthealthinsurance.com/faq/medicaid/ .
+Don't re-offer the check if one is already underway in this conversation — just continue it. And don't push it on someone who has said no or who is asking about something else entirely.
 """
             medicaid_names_reminder = """
 Remember that medicaid can go by many names, including but not limited to: DenaliCare, Medi-Cal, Health First Colorado, Husky Health, Diamond State Health Plan, Med-QUEST, Medical Assistance Program, HealthChoice Illinois, Hoosier Healthwise, Iowa Medicaid, Kansas Medical Assistance Program, MaineCare, MassHealth, MO HealthNet, NJ FamilyCare, Turquoise Care, New York State Medicaid, SoonerCare, Medical Assistance, Healthy Connections, TennCare, STAR+PLUS, Green Mountain Care, Cardinal Care, Apple Health, Forward Health, STAR, and Equality Care. You can use these names to infer which state a person is in (although confirming that theyr'e in the state can be good to do).
@@ -3842,6 +3868,16 @@ class RemoteHealthInsurance(RemoteFullOpenLike):
 
     @property
     def external(self):
+        return False
+
+    def supports_general_instructions(self) -> bool:
+        """fhi-legacy is an appeal-text fine-tune, not a general model.
+
+        Asked to hold a chat turn it returns blank lines and stray digits
+        ("1.50, 777&#2,302,36,..."), so it was contributing a guaranteed-dead
+        candidate to every chat fan-out. It stays in the appeal and prior-auth
+        pools, which are the job it was actually trained for.
+        """
         return False
 
     @classmethod

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -1280,6 +1280,18 @@ RULE: Do NOT add any conversational text, questions, or additional explanations 
             + """ Nothing else.
 """
         )
+        medicaid_gov_tool = """**Medicaid.gov Lookup**: To read an official page from Medicaid.gov (or a trusted federal-poverty-level reference) and answer from it, use: **medicaid_gov_lookup {"page": "renew_info", "state": "Iowa"}**
+
+Pages you can ask for by name:
+- "renew_info" — the official renewal hub: how to keep coverage, what the state mails you, what to do if you were disenrolled. Pass "state" (any spelling, or a program name like Medi-Cal) for that state's renewal page.
+- "eligibility_levels" — the official Medicaid/CHIP/BHP income eligibility levels by state and category.
+- "fpl_chart" — federal-poverty-level dollar amounts by household size and percentage band.
+- "fpl_glossary" — plain-language explanation of what the federal poverty level is.
+
+You can also pass **medicaid_gov_lookup {"query": "renewal paperwork"}** to search Medicaid.gov, or {"url": "https://www.medicaid.gov/..."} for a specific Medicaid.gov page.
+
+Use this when someone needs the OFFICIAL wording — renewal deadlines, income tables, what a notice means — rather than answering from memory. It reads the real page, so cite the URL it returns. It cannot look up an individual's case: only their state agency can do that."""
+
         pubmed_tool = """**PubMed Research Tool**: For medical research questions, you can search PubMed using: [*pubmed query: search terms*]. This provides access to recent medical literature and research. It can be a little slow but is a great way to learn possibly relevant medical information. Pubmed is not good for insurance information."""
 
         clinical_trials_tool = """**ClinicalTrials.gov Tool**: When an insurer denies a treatment as "experimental" or "investigational", you can check the public trial registry using: [*clinical trials query: search terms*]. The system returns clinicaltrialscontext:[...] with NCT IDs, study phases, status, conditions, interventions, and a brief summary you can cite.
@@ -1405,6 +1417,7 @@ We have a selection of tools to help you. You should try and use these tools whe
 
 {medicaid_eligibility_tool}
 {medicaid_resources_tool}
+{medicaid_gov_tool}
 {pubmed_tool}
 {uspstf_tool}
 {clinical_trials_tool}

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -100,6 +100,7 @@ CleanerUtils.is_valid_url = classmethod(  # type: ignore[assignment,method-assig
 )
 
 from fighthealthinsurance.exec import *
+from fighthealthinsurance.ml.medicaid_names import MEDICAID_PROGRAM_ALIASES
 from fighthealthinsurance.ml.bad_output_utils import (
     is_bad_output,
     strip_boilerplate_service,
@@ -130,6 +131,34 @@ MEDICAID_WORK_REQUIREMENTS_BLOCK = """New federal rules require many adults (age
 - State-specific details may vary
 
 For detailed information and state-specific details, visit: [Medicaid Work Requirements FAQ](/faq/medicaid/)"""
+
+
+# How we invite someone into the eligibility check. Four places have to say
+# the same thing -- the medicaid_info rules, the work-requirements rule, step
+# 2 of THE MEDICAID PATH, and the handoff MedicaidInfoTool appends to a
+# successful lookup -- so the wording lives here instead of being retyped
+# (and drifting) in each of them.
+#
+# It is an OFFER. Someone who asked "what is Medicaid?" wants an answer to
+# that question; being marched into an eligibility interview instead is worse
+# service, not better. The tool only starts once they show they want it.
+MEDICAID_ELIGIBILITY_OFFER_INSTRUCTION = (
+    "close with ONE short sentence offering our EXPERIMENTAL Medicaid/Medicare "
+    "eligibility check — say plainly that it is experimental, only a rough "
+    "estimate, and not an official determination"
+)
+
+MEDICAID_ELIGIBILITY_OFFER_RULE = (
+    MEDICAID_ELIGIBILITY_OFFER_INSTRUCTION + ". Offer it, don't push it: make it "
+    "an invitation, and drop it if they decline or move on to something else. "
+    "If they take you up on it — or have already shown they want to know "
+    "whether they qualify (asking about income limits, whether they'd be "
+    "covered, or how the work requirements apply to them) — call "
+    "**medicaid_eligibility** with everything you already know and let the "
+    "tool tell you which questions to ask; never ask eligibility questions "
+    "before calling it. If a check is already underway in this conversation, "
+    "continue it instead of re-offering it."
+)
 
 
 # ---------------------------------------------------------------------------
@@ -1224,12 +1253,14 @@ When possible even if the user has not explicitily provided the state if they're
 This means, for example, you get the phone number for medical (california medicaid) by calling this tool and looking at the response.
 
 Rules for medicaid questions:
-- If user mentions Medicaid/Medicare + state → ONLY respond with the tool call, no other text
+- If user mentions Medicaid/Medicare + state → ONLY respond with the tool call, no other text. The tool comes back with the state's information and you write the actual answer then — so the rules below about what the answer contains apply to THAT message, not to this one.
 - If user mentions Medicaid/Medicare but no state → Ask "Which state?" then ONLY use tool call
 - NEVER provide generic Medicaid information, websites, or advice
 - NEVER mix tool calls with long explanations
 - The tool provides ALL necessary information, although you can reformat it's output.
-- After you have delivered the state information, close with ONE short sentence offering our experimental eligibility check (see the eligibility tool above) — say plainly that it's experimental and only a rough estimate, not an official determination.
+- After you have delivered the state information, """
+            + MEDICAID_ELIGIBILITY_OFFER_RULE
+            + """
 
 CORRECT Examples:
 User: "medicaid info in california" → Response: **medicaid_info {"state": "California", "topic": "", "limit": 5}**
@@ -1244,7 +1275,9 @@ WRONG Examples:
             + MEDICAID_WORK_REQUIREMENTS_BLOCK
             + """
 
-RULE: Do NOT add any conversational text, questions, or additional explanations when providing work requirements information. Use the text above, followed at most by ONE short sentence offering the experimental eligibility check (e.g. "I can run our experimental eligibility check with you to estimate how this affects you — it's a rough estimate, not an official determination."). Nothing else.
+RULE: Do NOT add any conversational text, questions, or additional explanations when providing work requirements information. Use the text above, then """
+            + MEDICAID_ELIGIBILITY_OFFER_RULE
+            + """ Nothing else.
 """
         )
         pubmed_tool = """**PubMed Research Tool**: For medical research questions, you can search PubMed using: [*pubmed query: search terms*]. This provides access to recent medical literature and research. It can be a little slow but is a great way to learn possibly relevant medical information. Pubmed is not good for insurance information."""
@@ -1291,7 +1324,7 @@ Use this tool when the user asks about cost, affordability, copay assistance, "h
 
 THIS ELIGIBILITY CHECK IS AN EXPERIMENTAL FEATURE. Every time you start an eligibility check or deliver an estimate, tell the user in plain language that this is an experimental feature that can be wrong or out of date, that it is only a rough estimate and NOT an official eligibility determination, and that only their state Medicaid agency can determine eligibility for real. Do not let a whole eligibility conversation go by without this being said clearly.
 
-ONLY USE THIS TOOL WHEN ASKED IF SOMEONE IS ELIGIBLE FOR MEDICARE/MEDICAID
+USE THIS TOOL WHENEVER SOMEONE WANTS TO KNOW WHETHER THEY CAN GET MEDICAID/MEDICARE — they asked outright, they said yes to your offer of the check, or they asked something only a check can answer ("would I qualify?", "what are the limits for someone like me?", "do the work requirements apply to me?"). Don't run it on someone who only wanted to know what Medicaid is and hasn't shown any interest in it, and NEVER state or guess an eligibility verdict yourself — the only eligibility answer you may give is the one this tool returns.
 
 When the user asks whether they qualify or are eligible for Medicaid or Medicare, use **medicaid_eligibility** — NOT medicaid_info, even when they also name their state. medicaid_info is only for looking up a state's contact info and resources, which is a good follow-up AFTER the eligibility check.
 
@@ -1384,15 +1417,15 @@ This means if someone asks if their eligible for medical, medicaid, medicare, or
 You can call these tools, but not the person chatting with you. So, for example, you can offer to lookup more info for them.
 
 ***THE MEDICAID PATH***
-Most people asking about Medicaid in general ("what is Medicaid?", "how do I apply?", "what are the income limits?", "what are these work requirements?") really want to know whether THEY can get covered, so a general answer is the start of the path, not the end of it:
-1. Answer what they actually asked (using medicaid_info for anything state-specific, or the work requirements text above).
-2. Then offer the EXPERIMENTAL eligibility check in one short sentence, making clear it's a rough estimate and not an official determination.
-3. The moment they show any interest — "yes", "how do I know?", "would I qualify?", "what are the limits for me?", asking about their own income, household, or coverage — call **medicaid_eligibility** with everything you already know (at minimum the state, plus their target year if they named one). Do NOT ask them eligibility questions first; the tool tells you which questions to ask.
+A lot of people asking about Medicaid in general ("what is Medicaid?", "how do I apply?", "what are the income limits?", "what are these work requirements?") are really wondering whether THEY can get covered — and some just want the general answer. So answer the question first, and leave the door open:
+1. Answer what they actually asked (using medicaid_info for anything state-specific, or the work requirements text above). This is the part they came for — answer it properly, don't cut it short to get to the check.
+2. Then {MEDICAID_ELIGIBILITY_OFFER_RULE}
+3. Once they show interest — "yes", "how do I know?", "would I qualify?", "what are the limits for me?", asking about their own income, household, or coverage — call **medicaid_eligibility** with everything you already know (at minimum the state, plus their target year if they named one). Do NOT ask them eligibility questions first; the tool tells you which questions to ask.
 4. Keep going: each answer they give goes back into the tool call along with everything collected so far, until the tool gives a determination. Then finish with the state contact info from **medicaid_info** and https://www.fighthealthinsurance.com/faq/medicaid/ .
-Don't re-offer the check if one is already underway in this conversation — just continue it. And don't push it on someone who has said no or who is asking about something else entirely.
+Plenty of people just want the answer to their question. If they say no, ignore the offer, or move on to something else, let it go and help them with what they actually asked.
 """
-            medicaid_names_reminder = """
-Remember that medicaid can go by many names, including but not limited to: DenaliCare, Medi-Cal, Health First Colorado, Husky Health, Diamond State Health Plan, Med-QUEST, Medical Assistance Program, HealthChoice Illinois, Hoosier Healthwise, Iowa Medicaid, Kansas Medical Assistance Program, MaineCare, MassHealth, MO HealthNet, NJ FamilyCare, Turquoise Care, New York State Medicaid, SoonerCare, Medical Assistance, Healthy Connections, TennCare, STAR+PLUS, Green Mountain Care, Cardinal Care, Apple Health, Forward Health, STAR, and Equality Care. You can use these names to infer which state a person is in (although confirming that theyr'e in the state can be good to do).
+            medicaid_names_reminder = f"""
+Remember that medicaid can go by many names, including but not limited to: {", ".join(MEDICAID_PROGRAM_ALIASES)}. You can use these names to infer which state a person is in (although confirming that theyr'e in the state can be good to do).
 """
         else:
             # Only include PubMed tool for non-Medicaid conversations

--- a/fighthealthinsurance/ml/ml_router.py
+++ b/fighthealthinsurance/ml/ml_router.py
@@ -279,7 +279,11 @@ class MLRouter(object):
         general = [m for m in candidates if m.supports_general_instructions()]
         if not general:
             if candidates:
-                logger.debug(
+                # WARNING, not DEBUG: falling back means an instruction-following
+                # path is about to be served by an appeal-text fine-tune, which
+                # is the failure this filter exists to prevent. It is still
+                # better than routing nowhere, but it should be visible.
+                logger.warning(
                     f"MLRouter: no general-purpose backend for {context}; "
                     f"falling back to {[str(m) for m in candidates]}"
                 )
@@ -630,15 +634,29 @@ class MLRouter(object):
         # fhi backend (dict insertion order used to vary with registration
         # order). Narrow fine-tunes are excluded first, so a deployment where
         # the appeal-only backend sorts first doesn't double IT for chat.
-        fhi_models = sorted(
-            name
-            for name, backends in self.models_by_name.items()
-            if name.startswith("fhi-")
-            and any(m.supports_general_instructions() for m in backends)
+        fhi_names = sorted(
+            name for name in self.models_by_name if name.startswith("fhi-")
         )
-        if fhi_models:
+        general_fhi_names = [
+            name
+            for name in fhi_names
+            if any(m.supports_general_instructions() for m in self.models_by_name[name])
+        ]
+        # Fail open like the other filters: a deployment whose only fhi
+        # backend is the appeal fine-tune should still get its doubled chat
+        # slot rather than silently losing it.
+        chosen_fhi_names = general_fhi_names or fhi_names
+        if chosen_fhi_names:
+            # Filtered again per INSTANCE, not just per name: a name can hold
+            # a mix of backends, and _general_purpose_only logs (and fails
+            # open) if they are all narrow.
             models += (
-                self._filter_available(self.models_by_name[fhi_models[0]], "chat-fhi")
+                self._general_purpose_only(
+                    self._filter_available(
+                        self.models_by_name[chosen_fhi_names[0]], "chat-fhi"
+                    ),
+                    "chat-fhi",
+                )
                 * 2
             )
         if use_external:
@@ -794,11 +812,33 @@ class MLRouter(object):
 
         return None
 
-    def best_internal_model(self) -> Optional[RemoteModelLike]:
-        """Return the highest-quality internal model available, or None."""
+    def general_purpose_internal_models(self) -> list[RemoteModelLike]:
+        """Internal backends that follow instructions, cheapest-first.
+
+        The default pool for one-shot inference helpers (entity extraction,
+        document/policy parsing, chat synthesis). Fails open, so it is never
+        empty when ``internal_models_by_cost`` isn't.
+        """
+        return self._general_purpose_only(
+            self.internal_models_by_cost, "internal-inference"
+        )
+
+    def best_internal_model(
+        self, *, general_only: bool = True
+    ) -> Optional[RemoteModelLike]:
+        """Return the highest-quality internal model available, or None.
+
+        ``general_only`` (the default) skips the appeal-text fine-tunes,
+        which is what every instruction-following caller wants. Appeal and
+        prior-auth GENERATION must pass ``general_only=False`` -- there the
+        fine-tune is the point.
+        """
         if not self.internal_models_by_cost:
             return None
-        return max(self.internal_models_by_cost, key=lambda m: m.quality())
+        candidates: Sequence[RemoteModelLike] = self.internal_models_by_cost
+        if general_only:
+            candidates = self._general_purpose_only(candidates, "best-internal")
+        return max(candidates, key=lambda m: m.quality())
 
     def cheapest(self, name: str) -> list[RemoteModelLike]:
         try:

--- a/fighthealthinsurance/ml/ml_router.py
+++ b/fighthealthinsurance/ml/ml_router.py
@@ -261,6 +261,31 @@ class MLRouter(object):
             return candidates
         return available
 
+    def _general_purpose_only(
+        self, models: Sequence[RemoteModelLike], context: str
+    ) -> list[RemoteModelLike]:
+        """Drop backends that only produce their fine-tuned artifact.
+
+        Chat turns, tool calls, entity extraction, QA and summarization all
+        need a model that follows instructions; the appeal-text fine-tunes
+        (fhi-legacy) answer those with blank lines and stray digits, which
+        cost a fan-out slot and a full timeout every time. Generation paths
+        (appeals, prior auth) deliberately do NOT call this.
+
+        Fails open like ``_filter_available``: if every candidate is narrow,
+        keep them rather than returning nothing to route to.
+        """
+        candidates = list(models)
+        general = [m for m in candidates if m.supports_general_instructions()]
+        if not general:
+            if candidates:
+                logger.debug(
+                    f"MLRouter: no general-purpose backend for {context}; "
+                    f"falling back to {[str(m) for m in candidates]}"
+                )
+            return candidates
+        return general
+
     def _get_forced_models(
         self, task_description: str = "", *, use_external: bool = True
     ) -> Optional[list[RemoteModelLike]]:
@@ -330,10 +355,16 @@ class MLRouter(object):
     def entity_extract_backends(self, use_external) -> list[RemoteModelLike]:
         """Backends for entity extraction."""
         if use_external:
-            return self._filter_available(self.all_models_by_cost, "entity-extract")
+            return self._general_purpose_only(
+                self._filter_available(self.all_models_by_cost, "entity-extract"),
+                "entity-extract",
+            )
         else:
-            return self._filter_available(
-                self.internal_models_by_cost, "entity-extract-internal"
+            return self._general_purpose_only(
+                self._filter_available(
+                    self.internal_models_by_cost, "entity-extract-internal"
+                ),
+                "entity-extract-internal",
             )
 
     def generate_text_backends(
@@ -493,7 +524,9 @@ class MLRouter(object):
 
         models: list[RemoteModelLike] = []
         # Always include internal FHI models for question generation
-        models += self._filter_available(self.internal_models_by_cost, "full-qa")[:3]
+        models += self._general_purpose_only(
+            self._filter_available(self.internal_models_by_cost, "full-qa"), "full-qa"
+        )[:3]
 
         if use_external:
             # Add a cheap external generalist if available (successor to the
@@ -527,7 +560,10 @@ class MLRouter(object):
         """
         models: list[RemoteModelLike] = []
         # Always include internal FHI models
-        models += self._filter_available(self.internal_models_by_cost, "partial-qa")
+        models += self._general_purpose_only(
+            self._filter_available(self.internal_models_by_cost, "partial-qa"),
+            "partial-qa",
+        )
         return models
 
     def full_find_citation_backends(self, use_external=False) -> list[RemoteModelLike]:
@@ -592,9 +628,13 @@ class MLRouter(object):
         models = []
         # Try each fhi model twice. Sorted so every pod doubles the SAME
         # fhi backend (dict insertion order used to vary with registration
-        # order).
+        # order). Narrow fine-tunes are excluded first, so a deployment where
+        # the appeal-only backend sorts first doesn't double IT for chat.
         fhi_models = sorted(
-            name for name in self.models_by_name.keys() if name.startswith("fhi-")
+            name
+            for name, backends in self.models_by_name.items()
+            if name.startswith("fhi-")
+            and any(m.supports_general_instructions() for m in backends)
         )
         if fhi_models:
             models += (
@@ -608,8 +648,9 @@ class MLRouter(object):
         # wrong end of the list when strong and weak internals coexist. The
         # sort is stable over the cost ordering, so equal-quality models
         # still resolve cheapest-first.
-        internal_available = self._filter_available(
-            self.internal_models_by_cost, "chat-internal"
+        internal_available = self._general_purpose_only(
+            self._filter_available(self.internal_models_by_cost, "chat-internal"),
+            "chat-internal",
         )
         internal_to_add = sorted(internal_available, key=lambda m: -m.quality())[:6]
         models += internal_to_add
@@ -727,8 +768,11 @@ class MLRouter(object):
                 "skipping summarization and returning None."
             )
             return None
-        models = self._filter_available(
-            self.internal_models_by_cost, "summarize-chat-history"
+        models = self._general_purpose_only(
+            self._filter_available(
+                self.internal_models_by_cost, "summarize-chat-history"
+            ),
+            "summarize-chat-history",
         )[:2]
         for m in models:
             try:
@@ -790,8 +834,9 @@ class MLRouter(object):
         # would silently return None. Gated on availability AND on
         # use_external so a PHI caller (or a sweep-marked-down DeepInfra)
         # doesn't add a doomed/disallowed call before the internal fallbacks.
-        internal_pool = self._filter_available(
-            self.internal_models_by_cost, "summarize"
+        internal_pool = self._general_purpose_only(
+            self._filter_available(self.internal_models_by_cost, "summarize"),
+            "summarize",
         )
         if use_external and "google/gemma-4-26B-A4B-it" in self.models_by_name:
             models = [

--- a/fighthealthinsurance/static/faq/medicaid-work-requirements-faq.md
+++ b/fighthealthinsurance/static/faq/medicaid-work-requirements-faq.md
@@ -67,7 +67,7 @@ You have the right to appeal a denial or termination. This is often called a "fa
 
 #### Immediate Steps to Take:
 1.  **Update your contact information** with your state's Medicaid agency so you don't miss important notices.
-2.  **Review your eligibility status** and see if you qualify for an exemption.
+2.  **Review your eligibility status** and see if you qualify for an exemption. Not sure where you stand? Our [experimental eligibility check](/chat?microsite_slug=medicaid-eligibility) walks through it with you — it's a rough estimate, not an official determination, so confirm anything it tells you with your state.
 3.  **Document your work activities**, school enrollment, or volunteer hours thoroughly.
 4.  **Respond quickly** to any mail or requests from the Medicaid office.
 5.  **Know your appeal rights** in case your coverage is unfairly terminated.
@@ -114,6 +114,9 @@ Regardless of work requirements:
 
 ### Where Can I Get Help? {#where-can-i-get-help}
 If you need assistance, start by calling your state Medicaid agency. You can also reach out to the following resources:
+
+#### Not sure whether you'll still qualify?
+Our free, **experimental** [Medicaid eligibility check](/chat?microsite_slug=medicaid-eligibility) asks a few questions about your state, household, income, and situation and estimates whether you may qualify — under today's rules and once the work requirements apply. It is an estimate only, **not** an official eligibility determination: only your state Medicaid agency can decide for real.
 
 #### Legal Resources:
 - **State legal aid programs** and community health groups may be able to help.

--- a/fighthealthinsurance/static/faq/medicaid-work-requirements-faq.md
+++ b/fighthealthinsurance/static/faq/medicaid-work-requirements-faq.md
@@ -67,7 +67,7 @@ You have the right to appeal a denial or termination. This is often called a "fa
 
 #### Immediate Steps to Take:
 1.  **Update your contact information** with your state's Medicaid agency so you don't miss important notices.
-2.  **Review your eligibility status** and see if you qualify for an exemption. Not sure where you stand? Our [experimental eligibility check](/chat?microsite_slug=medicaid-eligibility) walks through it with you — it's a rough estimate, not an official determination, so confirm anything it tells you with your state.
+2.  **Review your eligibility status** and see if you qualify for an exemption. Not sure where you stand? Our [experimental eligibility check](/chat) walks through it with you — it's a rough estimate, not an official determination, so confirm anything it tells you with your state.
 3.  **Document your work activities**, school enrollment, or volunteer hours thoroughly.
 4.  **Respond quickly** to any mail or requests from the Medicaid office.
 5.  **Know your appeal rights** in case your coverage is unfairly terminated.
@@ -116,7 +116,7 @@ Regardless of work requirements:
 If you need assistance, start by calling your state Medicaid agency. You can also reach out to the following resources:
 
 #### Not sure whether you'll still qualify?
-Our free, **experimental** [Medicaid eligibility check](/chat?microsite_slug=medicaid-eligibility) asks a few questions about your state, household, income, and situation and estimates whether you may qualify — under today's rules and once the work requirements apply. It is an estimate only, **not** an official eligibility determination: only your state Medicaid agency can decide for real.
+Our free, **experimental** [Medicaid eligibility check](/chat) asks a few questions about your state, household, income, and situation and estimates whether you may qualify — under today's rules and once the work requirements apply. It is an estimate only, **not** an official eligibility determination: only your state Medicaid agency can decide for real.
 
 #### Legal Resources:
 - **State legal aid programs** and community health groups may be able to help.

--- a/tests/async-unit/test_ml_router.py
+++ b/tests/async-unit/test_ml_router.py
@@ -278,6 +278,86 @@ class TestMLRouterChatBackends(unittest.TestCase):
         self.assertEqual(models, [strong_pricier, weak_cheap])
 
 
+class TestMLRouterAppealOnlyBackends(unittest.TestCase):
+    """The appeal-text fine-tune stays out of the instruction-following pools.
+
+    fhi-legacy answers a chat turn with blank lines and stray digits, so every
+    fan-out that included it spent a slot and a timeout on a dead candidate --
+    and on at least one turn a hallucinated reply beat the real tool call.
+    """
+
+    def setUp(self):
+        self.router = MLRouter()
+        self.general = self._internal(quality=200, general=True)
+        self.appeal_only = self._internal(quality=101, general=False)
+        self.router.internal_models_by_cost = [self.appeal_only, self.general]
+        self.router.all_models_by_cost = [self.appeal_only, self.general]
+        self.router.models_by_name = {
+            "fhi-legacy": [self.appeal_only],
+            "fhi-2025": [self.general],
+        }
+
+    @staticmethod
+    def _internal(quality: int, general: bool) -> MagicMock:
+        model = MagicMock(spec=RemoteModelLike)
+        model.external = False
+        model.quality.return_value = quality
+        model.is_available.return_value = True
+        model.health_checked_live = True
+        model.supports_general_instructions.return_value = general
+        return model
+
+    def test_chat_excludes_the_appeal_only_backend(self):
+        models = self.router.get_chat_backends(use_external=False)
+        self.assertNotIn(self.appeal_only, models)
+        self.assertIn(self.general, models)
+
+    def test_chat_doubles_a_general_fhi_backend_not_the_appeal_only_one(self):
+        # "fhi-2025" sorts after "fhi-legacy", so name order alone would have
+        # doubled the appeal-only backend for every chat turn.
+        models = self.router.get_chat_backends(use_external=False)
+        self.assertEqual(models.count(self.general), 3)
+
+    def test_entity_extraction_excludes_the_appeal_only_backend(self):
+        self.assertNotIn(
+            self.appeal_only, self.router.entity_extract_backends(use_external=False)
+        )
+        self.assertNotIn(
+            self.appeal_only, self.router.entity_extract_backends(use_external=True)
+        )
+
+    def test_qa_excludes_the_appeal_only_backend(self):
+        self.assertNotIn(self.appeal_only, self.router.partial_qa_backends())
+        self.assertNotIn(
+            self.appeal_only, self.router.full_qa_backends(use_external=False)
+        )
+
+    def test_generation_still_uses_the_appeal_only_backend(self):
+        # It is the model actually fine-tuned for this, so appeals and prior
+        # auth keep it.
+        self.assertIn(self.appeal_only, self.router.get_prior_auth_backends())
+        self.assertIn(
+            self.appeal_only, self.router.generate_text_backends(use_external=False)
+        )
+
+    def test_fails_open_when_every_backend_is_appeal_only(self):
+        # Better a long-shot candidate than no chat at all.
+        self.router.internal_models_by_cost = [self.appeal_only]
+        self.router.models_by_name = {"fhi-legacy": [self.appeal_only]}
+
+        self.assertIn(self.appeal_only, self.router.get_chat_backends())
+
+
+class TestAppealOnlyModelCapability(unittest.TestCase):
+    """The capability flag itself, on the classes that set it."""
+
+    def test_legacy_fhi_backend_is_not_general_purpose(self):
+        self.assertFalse(RemoteHealthInsurance.supports_general_instructions(None))
+
+    def test_models_are_general_purpose_by_default(self):
+        self.assertTrue(RemoteModelLike.supports_general_instructions(None))
+
+
 class TestMLRouterBestExternalModels(unittest.TestCase):
     """Tests for MLRouter.best_external_models (quality + health selection)."""
 

--- a/tests/async-unit/test_ml_router.py
+++ b/tests/async-unit/test_ml_router.py
@@ -313,10 +313,47 @@ class TestMLRouterAppealOnlyBackends(unittest.TestCase):
         self.assertIn(self.general, models)
 
     def test_chat_doubles_a_general_fhi_backend_not_the_appeal_only_one(self):
-        # "fhi-2025" sorts after "fhi-legacy", so name order alone would have
-        # doubled the appeal-only backend for every chat turn.
+        # The doubled chat slot is picked by sorted name order, so give the
+        # appeal-only backend the name that sorts FIRST -- otherwise the
+        # assertion passes whether or not the capability filter runs.
+        self.router.models_by_name = {
+            "fhi-aaa-appeal": [self.appeal_only],
+            "fhi-zzz-chat": [self.general],
+        }
+
         models = self.router.get_chat_backends(use_external=False)
+
         self.assertEqual(models.count(self.general), 3)
+        self.assertNotIn(self.appeal_only, models)
+
+    def test_chat_keeps_the_doubled_slot_when_every_fhi_backend_is_narrow(self):
+        # Fail open: a deployment whose only fhi backend is the appeal
+        # fine-tune should still get its doubled slot rather than silently
+        # dropping it.
+        self.router.internal_models_by_cost = [self.appeal_only]
+        self.router.all_models_by_cost = [self.appeal_only]
+        self.router.models_by_name = {"fhi-legacy": [self.appeal_only]}
+
+        models = self.router.get_chat_backends(use_external=False)
+
+        self.assertGreaterEqual(models.count(self.appeal_only), 2)
+
+    def test_best_internal_model_skips_the_appeal_only_backend(self):
+        # The appeal fine-tune is not the strongest here, but this also has
+        # to hold when it is -- quality alone would pick it for chat
+        # synthesis and document parsing.
+        self.appeal_only.quality.return_value = 999
+        self.assertIs(self.router.best_internal_model(), self.general)
+
+    def test_generation_can_still_ask_for_the_appeal_only_backend(self):
+        self.appeal_only.quality.return_value = 999
+        self.assertIs(
+            self.router.best_internal_model(general_only=False), self.appeal_only
+        )
+
+    def test_general_purpose_internal_models_excludes_the_appeal_only_backend(self):
+        pool = self.router.general_purpose_internal_models()
+        self.assertEqual(pool, [self.general])
 
     def test_entity_extraction_excludes_the_appeal_only_backend(self):
         self.assertNotIn(
@@ -351,11 +388,26 @@ class TestMLRouterAppealOnlyBackends(unittest.TestCase):
 class TestAppealOnlyModelCapability(unittest.TestCase):
     """The capability flag itself, on the classes that set it."""
 
+    @staticmethod
+    def _bare(cls):
+        # The backends' __init__ wants live config; the capability flag is a
+        # property of the class, so an uninitialized instance is enough (and
+        # is a real instance, unlike passing None as self).
+        return object.__new__(cls)
+
     def test_legacy_fhi_backend_is_not_general_purpose(self):
-        self.assertFalse(RemoteHealthInsurance.supports_general_instructions(None))
+        self.assertFalse(
+            self._bare(RemoteHealthInsurance).supports_general_instructions()
+        )
 
     def test_models_are_general_purpose_by_default(self):
-        self.assertTrue(RemoteModelLike.supports_general_instructions(None))
+        # RemoteModelLike is abstract, so a new backend that inherits the
+        # default without overriding it is what we actually want to check.
+        class _NewBackend(RemoteModelLike):
+            async def _infer(self, *args, **kwargs):  # pragma: no cover
+                return None
+
+        self.assertTrue(self._bare(_NewBackend).supports_general_instructions())
 
 
 class TestMLRouterBestExternalModels(unittest.TestCase):

--- a/tests/async/test_ml_models.py
+++ b/tests/async/test_ml_models.py
@@ -395,6 +395,77 @@ class TestMedicaidDetection(TestCase):
         self.assertFalse(result, "Should not detect Medicaid without keywords")
 
 
+class TestMedicaidPathPrompt(TestCase):
+    """The Medicaid tool prompt has to route general questions into the check.
+
+    Someone who asks "what is Medicaid?" or "what are the work requirements?"
+    is usually trying to find out whether they can get covered, so the prompt
+    tells the model to answer, offer the experimental check, and then call the
+    tool -- rather than ending at a phone number.
+    """
+
+    def _medicaid_system_prompt(self) -> str:
+        model = RemoteOpenLike(
+            api_base="http://test.com",
+            token="test_token",
+            model="test_model",
+            system_prompts_map={"test": ["test prompt"]},
+        )
+
+        captured: dict[str, str] = {}
+
+        async def capture(*args, **kwargs):
+            captured["system_prompt"] = kwargs["system_prompts"][0]
+            return ("An answer 🐼 context", [])
+
+        with patch.object(model, "_infer", side_effect=capture):
+            asyncio.run(
+                model.generate_chat_response(
+                    "What is Medicaid?",
+                    is_medicaid_related=True,
+                )
+            )
+
+        return captured["system_prompt"]
+
+    def test_prompt_describes_the_medicaid_path(self):
+        prompt = self._medicaid_system_prompt()
+        self.assertIn("THE MEDICAID PATH", prompt)
+
+    def test_prompt_starts_the_eligibility_tool_after_general_info(self):
+        prompt = self._medicaid_system_prompt()
+        self.assertIn("medicaid_eligibility", prompt)
+        self.assertIn("offer the EXPERIMENTAL eligibility check", prompt)
+
+    def test_prompt_documents_the_target_year_parameter(self):
+        prompt = self._medicaid_system_prompt()
+        self.assertIn("target_year", prompt)
+
+    def test_non_medicaid_chats_do_not_get_the_medicaid_path(self):
+        model = RemoteOpenLike(
+            api_base="http://test.com",
+            token="test_token",
+            model="test_model",
+            system_prompts_map={"test": ["test prompt"]},
+        )
+
+        captured: dict[str, str] = {}
+
+        async def capture(*args, **kwargs):
+            captured["system_prompt"] = kwargs["system_prompts"][0]
+            return ("An answer 🐼 context", [])
+
+        with patch.object(model, "_infer", side_effect=capture):
+            asyncio.run(
+                model.generate_chat_response(
+                    "Help me appeal my knee surgery denial",
+                    is_medicaid_related=False,
+                )
+            )
+
+        self.assertNotIn("THE MEDICAID PATH", captured["system_prompt"])
+
+
 class TestRemoteFullOpenLike(TestCase):
     """Test for the RemoteFullOpenLike class."""
 

--- a/tests/async/test_ml_models.py
+++ b/tests/async/test_ml_models.py
@@ -5,6 +5,7 @@ import asyncio
 from typing import Optional, Tuple, List
 
 from fighthealthinsurance.ml.ml_models import (
+    MEDICAID_ELIGIBILITY_OFFER_INSTRUCTION,
     RemoteOpenLike,
     ModelDescription,
     RemoteModel,
@@ -432,10 +433,22 @@ class TestMedicaidPathPrompt(TestCase):
         prompt = self._medicaid_system_prompt()
         self.assertIn("THE MEDICAID PATH", prompt)
 
-    def test_prompt_starts_the_eligibility_tool_after_general_info(self):
+    def test_prompt_offers_the_eligibility_check_after_general_info(self):
         prompt = self._medicaid_system_prompt()
         self.assertIn("medicaid_eligibility", prompt)
-        self.assertIn("offer the EXPERIMENTAL eligibility check", prompt)
+        self.assertIn(MEDICAID_ELIGIBILITY_OFFER_INSTRUCTION, prompt)
+
+    def test_prompt_frames_the_check_as_an_offer_not_a_redirect(self):
+        # Someone asking "what is Medicaid?" doesn't necessarily want an
+        # eligibility interview; the prompt has to answer them first and let
+        # the offer go if they aren't interested.
+        prompt = self._medicaid_system_prompt()
+        self.assertIn("Offer it, don't push it", prompt)
+        self.assertIn("let it go and help them with what they actually asked", prompt)
+
+    def test_prompt_forbids_stating_an_uncomputed_verdict(self):
+        prompt = self._medicaid_system_prompt()
+        self.assertIn("NEVER state or guess an eligibility verdict yourself", prompt)
 
     def test_prompt_documents_the_target_year_parameter(self):
         prompt = self._medicaid_system_prompt()

--- a/tests/sync/test_chat_safety.py
+++ b/tests/sync/test_chat_safety.py
@@ -5,6 +5,7 @@ from django.test import TestCase
 from fighthealthinsurance.chat.safety_filters import (
     detect_crisis_keywords,
     detect_delete_data_request,
+    detect_eligibility_verdict,
     detect_false_promises,
     llm_requested_delete_handoff,
     CRISIS_RESOURCES,
@@ -409,3 +410,63 @@ class TestPromptTemplateSentinelCoupling(TestCase):
         from fighthealthinsurance.prompt_templates import DELETE_DATA_INSTRUCTION
 
         self.assertTrue(llm_requested_delete_handoff(DELETE_DATA_INSTRUCTION))
+
+
+class TestEligibilityVerdictDetection(TestCase):
+    """Only the medicaid_eligibility checker may hand down a verdict.
+
+    The scorer uses this to descore a reply that states one the checker never
+    computed, so what counts as "a verdict" has to be the definite claims and
+    nothing else -- the Medicaid path deliberately has the model float the
+    possibility before the check runs.
+    """
+
+    def test_definite_verdicts_are_detected(self):
+        verdicts = [
+            "Based on what you told me, you are eligible for Medicaid.",
+            "Unfortunately you do not qualify for Medicaid in Texas.",
+            "Good news: you qualify for Medicaid expansion coverage.",
+            "You're not eligible for Medicare at your age.",
+            "Your household is Medicaid-eligible.",
+        ]
+        for text in verdicts:
+            with self.subTest(text=text):
+                self.assertTrue(detect_eligibility_verdict(text))
+
+    def test_hedged_offers_are_not_verdicts(self):
+        offers = [
+            "You may be eligible for Medicaid — want me to run our "
+            "experimental check?",
+            "You might qualify for Medicaid depending on your income.",
+            "I can check if you are eligible for Medicaid.",
+            "If you are eligible for Medicaid, the state will mail you a card.",
+        ]
+        for text in offers:
+            with self.subTest(text=text):
+                self.assertFalse(detect_eligibility_verdict(text))
+
+    def test_questions_are_not_verdicts(self):
+        self.assertFalse(detect_eligibility_verdict("Are you eligible for Medicaid?"))
+
+    def test_general_medicaid_information_is_not_a_verdict(self):
+        self.assertFalse(
+            detect_eligibility_verdict(
+                "Medicaid is a joint federal and state program that covers "
+                "low-income adults, children, pregnant people, and people "
+                "with disabilities."
+            )
+        )
+
+    def test_a_verdict_later_in_a_reply_is_still_detected(self):
+        # The reply that beat the real tool call opened with a friendly
+        # paragraph and put the invented verdict at the bottom.
+        reply = (
+            "Thanks for sharing all that — I know this is stressful.\n\n"
+            "Here is what Medicaid covers in California.\n\n"
+            "You qualify for Medi-Cal."
+        )
+        self.assertTrue(detect_eligibility_verdict(reply))
+
+    def test_empty_text_is_not_a_verdict(self):
+        self.assertFalse(detect_eligibility_verdict(""))
+        self.assertFalse(detect_eligibility_verdict(None))

--- a/tests/sync/test_chat_safety.py
+++ b/tests/sync/test_chat_safety.py
@@ -514,6 +514,36 @@ class TestEligibilityVerdictDetection(TestCase):
             with self.subTest(text=text):
                 self.assertTrue(detect_eligibility_verdict(text))
 
+    def test_a_required_caveat_does_not_launder_a_verdict(self):
+        # The system prompt REQUIRES an experimental / confirm-with-your-state
+        # caveat on every eligibility answer, so treating trailing hedges as
+        # hedges let essentially every invented verdict through.
+        for text in (
+            "You qualify for Medicaid, but you should check your state's "
+            "website to confirm.",
+            "Based on this you are eligible for Medicaid, though you may need "
+            "to provide documentation.",
+            "You are eligible for Medicaid; if you apply this month coverage "
+            "starts right away.",
+            "Good news: you qualify for Medicaid expansion coverage. This is "
+            "an experimental estimate, so confirm with your state.",
+        ):
+            with self.subTest(text=text):
+                self.assertTrue(detect_eligibility_verdict(text))
+
+    def test_a_condition_attached_to_the_verdict_still_hedges_it(self):
+        # Stating the rule is what the Medicaid path asks for on "what are the
+        # income limits?". "if your" also has to work -- the old `if\s+you\b`
+        # could not match it.
+        for text in (
+            "You are eligible for Medicaid if your income is under 138% FPL.",
+            "You are eligible for Medicaid if you make under $1,800 a month.",
+            "You qualify for Medicaid as long as your household stays under "
+            "the limit.",
+        ):
+            with self.subTest(text=text):
+                self.assertFalse(detect_eligibility_verdict(text))
+
     def test_empty_text_is_not_a_verdict(self):
         self.assertFalse(detect_eligibility_verdict(""))
         self.assertFalse(detect_eligibility_verdict(None))

--- a/tests/sync/test_chat_safety.py
+++ b/tests/sync/test_chat_safety.py
@@ -467,6 +467,53 @@ class TestEligibilityVerdictDetection(TestCase):
         )
         self.assertTrue(detect_eligibility_verdict(reply))
 
+    def test_forward_looking_approval_and_denial_are_verdicts(self):
+        # Predicting an agency decision is at least as much of an invention
+        # as predicting eligibility.
+        for text in (
+            "You will be approved for Medicaid.",
+            "You'll be denied Medicaid.",
+            "You would be denied for Medicare.",
+            "You are going to be approved for MassHealth.",
+        ):
+            with self.subTest(text=text):
+                self.assertTrue(detect_eligibility_verdict(text))
+
+    def test_past_and_present_approval_is_not_a_verdict(self):
+        # This is an insurance-DENIAL product: a user's own approval or
+        # denial is the normal subject of the conversation, so the model
+        # repeating it back is not a hallucination. A false positive costs a
+        # correct reply its entire model prior.
+        for text in (
+            "You were denied Medicaid coverage last year.",
+            "You are approved for Medi-Cal, so your refills are covered.",
+            "Your surgery was denied by your insurer.",
+        ):
+            with self.subTest(text=text):
+                self.assertFalse(detect_eligibility_verdict(text))
+
+    def test_generically_named_programs_do_not_trigger_a_verdict(self):
+        # "STAR" and "Medical Assistance" are ordinary English before they
+        # are program names; treating them as verdict evidence penalized
+        # sentences that were not eligibility determinations at all.
+        for text in (
+            "You qualify for STAR.",
+            "You qualify for medical assistance benefits.",
+        ):
+            with self.subTest(text=text):
+                self.assertFalse(detect_eligibility_verdict(text))
+
+    def test_distinctively_named_programs_still_trigger_a_verdict(self):
+        # The ambiguity carve-out must not blunt the state names that are
+        # unmistakably Medicaid.
+        for text in (
+            "You qualify for MassHealth.",
+            "You are eligible for TennCare.",
+            "You qualify for Apple Health.",
+        ):
+            with self.subTest(text=text):
+                self.assertTrue(detect_eligibility_verdict(text))
+
     def test_empty_text_is_not_a_verdict(self):
         self.assertFalse(detect_eligibility_verdict(""))
         self.assertFalse(detect_eligibility_verdict(None))

--- a/tests/sync/test_chat_tools.py
+++ b/tests/sync/test_chat_tools.py
@@ -683,7 +683,10 @@ class TestMedicaidTargetYear(TestCase):
         self.assertEqual(info.count("could be eligible for medicaid"), 1)
         self.assertNotIn("work/community-engagement", info)
 
-    def test_future_year_thresholds_are_flagged_as_estimates(self):
+    def test_a_future_year_says_current_limits_were_used(self):
+        # We do not model the later year's income limits, so the note has to
+        # say what actually happened: the same published table scored both
+        # years and the work requirement is the only difference.
         info = self.tool._build_eligibility_info(
             eligible_base=False,
             eligible_target=False,
@@ -691,22 +694,19 @@ class TestMedicaidTargetYear(TestCase):
             alternatives=[],
             missing=[],
             target_year=2029,
-            thresholds_estimated=True,
         )
 
         self.assertIn("aren't published yet", info)
+        self.assertIn("the work requirement, not the income test", info)
 
-    def test_default_year_is_not_described_as_an_estimated_threshold(self):
-        # The checker only projects income limits forward for a year the user
-        # named, so on the default path there is no estimate to disclaim --
-        # saying there was described arithmetic we never did.
+    def test_a_base_year_check_has_no_second_year_note(self):
         info = self.tool._build_eligibility_info(
             eligible_base=True,
-            eligible_target=False,
+            eligible_target=True,
             medicare=False,
             alternatives=[],
             missing=[],
-            target_year=DEFAULT_TARGET_YEAR,
+            target_year=BASE_ELIGIBILITY_YEAR,
         )
 
         self.assertNotIn("aren't published yet", info)

--- a/tests/sync/test_chat_tools.py
+++ b/tests/sync/test_chat_tools.py
@@ -573,7 +573,7 @@ class TestMedicaidEligibilityTool(TestCase):
         self.assertNotIn("If denied", info)
 
     def test_indeterminate_result_is_not_rendered_as_a_denial(self):
-        """"Couldn't score them" must not become "may not be eligible"."""
+        """ "Couldn't score them" must not become "may not be eligible"."""
         info = self.tool._build_eligibility_info(
             eligible_base=False,
             eligible_target=False,
@@ -614,7 +614,12 @@ class TestMedicaidEligibilityTool(TestCase):
     def test_parsed_summary_echoes_recorded_values(self):
         """The LLM keeps its own context, so it must see what we recorded."""
         text = self.tool._build_parsed_summary(
-            {"recorded": {"state": "ca"}, "unreadable": [], "unrecognized": [], "declined": []}
+            {
+                "recorded": {"state": "ca"},
+                "unreadable": [],
+                "unrecognized": [],
+                "declined": [],
+            }
         )
 
         self.assertIn("state: ca", text)
@@ -622,7 +627,12 @@ class TestMedicaidEligibilityTool(TestCase):
     def test_parsed_summary_flags_unrecognized_parameters(self):
         """A silently dropped key looks to the model just like acceptance."""
         text = self.tool._build_parsed_summary(
-            {"recorded": {}, "unreadable": [], "unrecognized": ["income"], "declined": []}
+            {
+                "recorded": {},
+                "unreadable": [],
+                "unrecognized": ["income"],
+                "declined": [],
+            }
         )
 
         self.assertIn("income", text)
@@ -630,7 +640,12 @@ class TestMedicaidEligibilityTool(TestCase):
 
     def test_parsed_summary_tells_llm_not_to_reask_declined_fields(self):
         text = self.tool._build_parsed_summary(
-            {"recorded": {}, "unreadable": [], "unrecognized": [], "declined": ["assets_total"]}
+            {
+                "recorded": {},
+                "unreadable": [],
+                "unrecognized": [],
+                "declined": ["assets_total"],
+            }
         )
 
         self.assertIn("don't ask about those again", text)
@@ -715,6 +730,30 @@ class TestMedicaidTargetYear(TestCase):
         self.assertIn(f"current ({current}): they could be eligible", info)
         self.assertIn(f"{current + 1}: they may not be eligible", info)
         self.assertIn(f"{current + 3}: they may not be eligible", info)
+
+    def test_a_change_shown_in_the_timeline_always_says_what_caused_it(self):
+        # Asking about a pre-work-requirement year still renders the
+        # work-requirement year beside it. Keying the caveats off the year the
+        # user NAMED printed "this CHANGES in 2026" with nothing to say what
+        # changed -- a flip with no stated cause.
+        from fighthealthinsurance.medicaid_api import WORK_REQUIREMENT_FIRST_YEAR
+
+        info = self.tool._build_eligibility_info(
+            eligible_base=True,
+            eligible_target=False,
+            medicare=False,
+            alternatives=[],
+            missing=[],
+            target_year=BASE_ELIGIBILITY_YEAR,
+            timeline=[
+                (BASE_ELIGIBILITY_YEAR, True),
+                (WORK_REQUIREMENT_FIRST_YEAR, False),
+            ],
+        )
+
+        self.assertIn(f"this CHANGES in {WORK_REQUIREMENT_FIRST_YEAR}", info)
+        self.assertIn("work/community-engagement", info)
+        self.assertIn("aren't published yet", info)
 
     def test_a_finished_year_is_never_labelled_current(self):
         # The FPL table's year stops being "today" once the calendar passes
@@ -977,12 +1016,16 @@ class TestEligibilityVerifiedFlag(TestCase):
 
     def test_final_ineligible_determination_earns_the_exemption(self):
         # A computed "no" is still a verdict the model may relay.
-        flag, kwargs = self._run((False, False, False, ["Try the marketplace"], [], True))
+        flag, kwargs = self._run(
+            (False, False, False, ["Try the marketplace"], [], True)
+        )
         self.assertTrue(flag)
         self.assertTrue(kwargs["eligibility_verified"])
 
     def test_mid_interview_with_nothing_settled_does_not(self):
-        flag, kwargs = self._run((False, False, False, [], ["What is your income?"], True))
+        flag, kwargs = self._run(
+            (False, False, False, [], ["What is your income?"], True)
+        )
         self.assertFalse(flag)
         self.assertFalse(kwargs["eligibility_verified"])
 
@@ -990,7 +1033,9 @@ class TestEligibilityVerifiedFlag(TestCase):
         # The checker reports an already-settled positive while questions are
         # outstanding, and _build_eligibility_info tells the model to share
         # it -- penalizing that would fight our own tool output.
-        flag, kwargs = self._run((True, False, False, [], ["What is your income?"], True))
+        flag, kwargs = self._run(
+            (True, False, False, [], ["What is your income?"], True)
+        )
         self.assertTrue(flag)
         self.assertTrue(kwargs["eligibility_verified"])
 
@@ -1445,9 +1490,16 @@ class TestMedicaidDeclinedAnswerRoundTrip(TestCase):
 
     def test_resending_the_unknown_marker_keeps_the_question_suppressed(self):
         first = dict(
-            state="ca", age=66, married=False, household_size=1,
-            monthly_income=900, children_in_household=0, pregnant=False,
-            receiving_ssdi=False, on_medicare=False, years_worked=40,
+            state="ca",
+            age=66,
+            married=False,
+            household_size=1,
+            monthly_income=900,
+            children_in_household=0,
+            pregnant=False,
+            receiving_ssdi=False,
+            on_medicare=False,
+            years_worked=40,
             assets_total="unknown",
         )
         # What the echo tells the model to send back, plus the declined marker

--- a/tests/sync/test_chat_tools.py
+++ b/tests/sync/test_chat_tools.py
@@ -811,6 +811,80 @@ class TestMedicaidInfoStartsTheEligibilityPath(TestCase):
         self.assertIn("medicaid_eligibility", captured["message"])
 
 
+class TestEligibilityVerifiedFlag(TestCase):
+    """Running the checker is not the same as the checker reaching a verdict.
+
+    The flag exempts a reply from the invented-verdict penalty, so it must
+    only be set once there is a real determination to relay. Setting it on
+    every call handed out the exemption in exactly the cases the guard exists
+    for -- a mid-interview model jumping to "you don't qualify", or one
+    ignoring "we could NOT produce an estimate for this person".
+    """
+
+    def _run(self, verdict):
+        """Execute the tool with a stubbed checker, return (flag, kwargs)."""
+        computed = [False]
+        tool = MedicaidEligibilityTool(AsyncMock(), eligibility_computed=computed)
+        call = '**medicaid_eligibility {"state": "CA"}**'
+        match = tool.detect(call)
+        self.assertIsNotNone(match)
+
+        captured: dict = {}
+
+        async def fake_call_llm(model_backends, message, *args, **kwargs):
+            captured.update(kwargs)
+            return ("ok", "")
+
+        tool.call_llm_callback = fake_call_llm
+        with patch(
+            "fighthealthinsurance.medicaid_api.is_eligible", return_value=verdict
+        ):
+            asyncio.run(
+                tool.execute(
+                    match,
+                    call,
+                    "",
+                    model_backends=["backend"],
+                    current_message_for_llm="Am I eligible?",
+                    history_for_llm=[],
+                )
+            )
+        return computed[0], captured
+
+    def test_final_determination_earns_the_exemption(self):
+        flag, kwargs = self._run((True, True, False, [], [], True))
+        self.assertTrue(flag)
+        self.assertTrue(kwargs["eligibility_verified"])
+
+    def test_final_ineligible_determination_earns_the_exemption(self):
+        # A computed "no" is still a verdict the model may relay.
+        flag, kwargs = self._run((False, False, False, ["Try the marketplace"], [], True))
+        self.assertTrue(flag)
+        self.assertTrue(kwargs["eligibility_verified"])
+
+    def test_mid_interview_with_nothing_settled_does_not(self):
+        flag, kwargs = self._run((False, False, False, [], ["What is your income?"], True))
+        self.assertFalse(flag)
+        self.assertFalse(kwargs["eligibility_verified"])
+
+    def test_mid_interview_positive_does_earn_the_exemption(self):
+        # The checker reports an already-settled positive while questions are
+        # outstanding, and _build_eligibility_info tells the model to share
+        # it -- penalizing that would fight our own tool output.
+        flag, kwargs = self._run((True, False, False, [], ["What is your income?"], True))
+        self.assertTrue(flag)
+        self.assertTrue(kwargs["eligibility_verified"])
+
+    def test_unscoreable_person_does_not_earn_the_exemption(self):
+        # determination_made=False: a territory, or a declined required
+        # answer. The info text explicitly says not to call them ineligible.
+        flag, kwargs = self._run(
+            (False, False, False, ["Contact your territory's agency"], [], False)
+        )
+        self.assertFalse(flag)
+        self.assertFalse(kwargs["eligibility_verified"])
+
+
 class TestDocFetcherPatterns(TestCase):
     """Test FETCH_DOC_REGEX pattern matching."""
 

--- a/tests/sync/test_chat_tools.py
+++ b/tests/sync/test_chat_tools.py
@@ -821,6 +821,100 @@ class TestMedicaidTargetYear(TestCase):
 
         self.assertNotIn("CHANGES in", info)
 
+    def test_every_branch_tells_them_to_confirm_with_the_state(self):
+        # Every answer is an estimate off simplified rules against limits that
+        # move. The branch most likely to be taken as final -- "we couldn't
+        # score you" -- is the one that used to end without any pointer at
+        # all.
+        from fighthealthinsurance.chat.tools.medicaid_tool import (
+            CONFIRM_WITH_STATE_INSTRUCTION,
+        )
+
+        branches = {
+            "mid-interview": dict(
+                eligible_base=False,
+                eligible_target=False,
+                missing=["What is your household size?"],
+                determination_made=True,
+            ),
+            "indeterminate": dict(
+                eligible_base=False,
+                eligible_target=False,
+                missing=[],
+                determination_made=False,
+            ),
+            "settled": dict(
+                eligible_base=True,
+                eligible_target=True,
+                missing=[],
+                determination_made=True,
+            ),
+        }
+        for name, kwargs in branches.items():
+            with self.subTest(branch=name):
+                info = self.tool._build_eligibility_info(
+                    medicare=False, alternatives=[], **kwargs
+                )
+                self.assertIn(CONFIRM_WITH_STATE_INSTRUCTION, info)
+
+    def test_a_negative_verdict_carries_its_own_caveat(self):
+        # The negative is the line someone acts on by NOT applying, so the
+        # reminder rides on that line rather than waiting for a caveat
+        # further down that the model may never reach.
+        current = current_eligibility_year()
+        info = self.tool._build_eligibility_info(
+            eligible_base=False,
+            eligible_target=False,
+            medicare=False,
+            alternatives=[],
+            missing=[],
+            target_year=current,
+            timeline=[YearVerdict(current, False, [])],
+        )
+
+        line = next(
+            row for row in info.splitlines() if row.startswith(f"- current ({current})")
+        )
+        self.assertIn("NOT a denial", line)
+        self.assertIn("only their state can decide", line)
+
+    def test_an_income_denial_does_not_blame_the_work_requirement(self):
+        # Failing the income test is not the work requirement's doing.
+        # Attaching "(once the 80-hours requirement applies...)" to an income
+        # denial tells someone to go chase hours that would not have changed
+        # the answer.
+        current = current_eligibility_year()
+        info = self.tool._build_eligibility_info(
+            eligible_base=False,
+            eligible_target=False,
+            medicare=False,
+            alternatives=[],
+            missing=[],
+            target_year=current,
+            timeline=[YearVerdict(current, False, [])],
+        )
+
+        self.assertNotIn("work/community-engagement", info)
+
+    def test_a_repeated_negative_does_not_repeat_the_whole_caveat(self):
+        # Two rows carrying the same long sentence dilutes it.
+        current = current_eligibility_year()
+        info = self.tool._build_eligibility_info(
+            eligible_base=True,
+            eligible_target=False,
+            medicare=False,
+            alternatives=[],
+            missing=[],
+            target_year=current + 1,
+            timeline=[
+                YearVerdict(current, False, []),
+                YearVerdict(current + 1, False, []),
+            ],
+        )
+
+        self.assertEqual(info.count("people do qualify when a checker"), 1)
+        self.assertIn("again, an estimate, not a denial", info)
+
     def test_a_transition_year_shortfall_is_conditional_not_a_denial(self):
         # The work requirement has reached the states that went early and
         # nowhere else yet. "May not be eligible" would be a denial for a

--- a/tests/sync/test_chat_tools.py
+++ b/tests/sync/test_chat_tools.py
@@ -28,6 +28,7 @@ from fighthealthinsurance.chat.tools import (
 from fighthealthinsurance.medicaid_api import (
     BASE_ELIGIBILITY_YEAR,
     DEFAULT_TARGET_YEAR,
+    YearVerdict,
     current_eligibility_year,
     is_eligible,
     summarize_eligibility_inputs,
@@ -710,7 +711,7 @@ class TestMedicaidTargetYear(TestCase):
             alternatives=[],
             missing=[],
             target_year=earlier,
-            timeline=[(earlier, True, [])],
+            timeline=[YearVerdict(earlier, True, [])],
         )
 
         self.assertNotIn("work/community-engagement", info)
@@ -741,9 +742,9 @@ class TestMedicaidTargetYear(TestCase):
             missing=[],
             target_year=current + 3,
             timeline=[
-                (current, True, []),
-                (current + 1, False, []),
-                (current + 3, False, []),
+                YearVerdict(current, True, []),
+                YearVerdict(current + 1, False, []),
+                YearVerdict(current + 3, False, []),
             ],
         )
 
@@ -766,8 +767,8 @@ class TestMedicaidTargetYear(TestCase):
             missing=[],
             target_year=WORK_REQUIREMENT_FIRST_YEAR - 1,
             timeline=[
-                (WORK_REQUIREMENT_FIRST_YEAR - 1, True, []),
-                (WORK_REQUIREMENT_FIRST_YEAR, False, []),
+                YearVerdict(WORK_REQUIREMENT_FIRST_YEAR - 1, True, []),
+                YearVerdict(WORK_REQUIREMENT_FIRST_YEAR, False, []),
             ],
         )
 
@@ -788,8 +789,10 @@ class TestMedicaidTargetYear(TestCase):
             missing=[],
             target_year=current + 1,
             timeline=[
-                (current, True, []),
-                (current + 1, False, ["About how many qualifying hours a month?"]),
+                YearVerdict(current, True, []),
+                YearVerdict(
+                    current + 1, False, ["About how many qualifying hours a month?"]
+                ),
             ],
         )
 
@@ -809,8 +812,79 @@ class TestMedicaidTargetYear(TestCase):
             missing=[],
             target_year=current + 1,
             timeline=[
-                (current, True, []),
-                (current + 1, False, ["About how many qualifying hours a month?"]),
+                YearVerdict(current, True, []),
+                YearVerdict(
+                    current + 1, False, ["About how many qualifying hours a month?"]
+                ),
+            ],
+        )
+
+        self.assertNotIn("CHANGES in", info)
+
+    def test_a_transition_year_shortfall_is_conditional_not_a_denial(self):
+        # The work requirement has reached the states that went early and
+        # nowhere else yet. "May not be eligible" would be a denial for a
+        # rule most states haven't adopted; a plain "could be" would hide
+        # what's coming. The row has to say both.
+        from fighthealthinsurance.medicaid_api import WORK_REQUIREMENT_UNIVERSAL_YEAR
+
+        current = current_eligibility_year()
+        info = self.tool._build_eligibility_info(
+            eligible_base=True,
+            eligible_target=True,
+            medicare=False,
+            alternatives=[],
+            missing=[],
+            target_year=current,
+            timeline=[
+                YearVerdict(current, True, [], work_requirement_conditional=True)
+            ],
+        )
+
+        self.assertIn("could be eligible on income", info)
+        self.assertIn("under 80 qualifying hours", info)
+        self.assertIn("whether their state has already started", info)
+        self.assertIn(f"January 1, {WORK_REQUIREMENT_UNIVERSAL_YEAR}", info)
+        self.assertNotIn("they may not be eligible for medicaid", info)
+
+    def test_a_conditional_row_does_not_swallow_the_work_requirement_note(self):
+        # The shared explanation is attached once, to the first year the rule
+        # bites. A conditional row spells it out itself -- if it consumed the
+        # note on the way past, the year the rule actually bites was left
+        # with no explanation at all.
+        current = current_eligibility_year()
+        info = self.tool._build_eligibility_info(
+            eligible_base=True,
+            eligible_target=False,
+            medicare=False,
+            alternatives=[],
+            missing=[],
+            target_year=current + 1,
+            timeline=[
+                YearVerdict(current, True, [], work_requirement_conditional=True),
+                YearVerdict(current + 1, False, []),
+            ],
+        )
+
+        self.assertIn(
+            f"{current + 1}: they may not be eligible for medicaid (once the federal",
+            info,
+        )
+
+    def test_a_conditional_year_does_not_trigger_a_change_callout(self):
+        # A flip announced off a rule that may not have reached them is the
+        # same uncomputed denial in a louder voice.
+        current = current_eligibility_year()
+        info = self.tool._build_eligibility_info(
+            eligible_base=True,
+            eligible_target=True,
+            medicare=False,
+            alternatives=[],
+            missing=[],
+            target_year=current + 1,
+            timeline=[
+                YearVerdict(current, True, [], work_requirement_conditional=True),
+                YearVerdict(current + 1, False, []),
             ],
         )
 
@@ -831,7 +905,10 @@ class TestMedicaidTargetYear(TestCase):
             alternatives=[],
             missing=[],
             target_year=current,
-            timeline=[(BASE_ELIGIBILITY_YEAR, True, []), (current, True, [])],
+            timeline=[
+                YearVerdict(BASE_ELIGIBILITY_YEAR, True, []),
+                YearVerdict(current, True, []),
+            ],
         )
 
         self.assertIn(f"current ({current})", info)
@@ -867,7 +944,7 @@ class TestMedicaidTargetYear(TestCase):
             alternatives=[],
             missing=[],
             target_year=2026,
-            timeline=[(2025, True, []), (2026, False, [])],
+            timeline=[YearVerdict(2025, True, []), YearVerdict(2026, False, [])],
         )
 
         self.assertIn("this CHANGES in 2026", info)
@@ -881,7 +958,7 @@ class TestMedicaidTargetYear(TestCase):
             alternatives=[],
             missing=[],
             target_year=2026,
-            timeline=[(2025, False, []), (2026, True, [])],
+            timeline=[YearVerdict(2025, False, []), YearVerdict(2026, True, [])],
         )
 
         self.assertIn("IMPROVES in 2026", info)
@@ -894,7 +971,7 @@ class TestMedicaidTargetYear(TestCase):
             alternatives=[],
             missing=[],
             target_year=2026,
-            timeline=[(2025, True, []), (2026, True, [])],
+            timeline=[YearVerdict(2025, True, []), YearVerdict(2026, True, [])],
         )
 
         self.assertNotIn("CHANGES in", info)
@@ -910,7 +987,7 @@ class TestMedicaidTargetYear(TestCase):
             alternatives=[],
             missing=[],
             target_year=2026,
-            timeline=[(2025, True, []), (2026, False, [])],
+            timeline=[YearVerdict(2025, True, []), YearVerdict(2026, False, [])],
         )
 
         self.assertIn("an approximation, not a determination", info)

--- a/tests/sync/test_chat_tools.py
+++ b/tests/sync/test_chat_tools.py
@@ -25,6 +25,8 @@ from fighthealthinsurance.chat.tools import (
     USPSTFLookupTool,
 )
 from fighthealthinsurance.medicaid_api import (
+    BASE_ELIGIBILITY_YEAR,
+    DEFAULT_TARGET_YEAR,
     is_eligible,
     summarize_eligibility_inputs,
 )
@@ -433,8 +435,8 @@ class TestMedicaidEligibilityTool(TestCase):
     def test_build_eligibility_info_eligible(self):
         """Test eligibility info text generation for eligible user."""
         info = self.tool._build_eligibility_info(
-            eligible_2025=True,
-            eligible_2026=True,
+            eligible_base=True,
+            eligible_target=True,
             medicare=False,
             alternatives=[],
             missing=[],
@@ -447,8 +449,8 @@ class TestMedicaidEligibilityTool(TestCase):
     def test_build_eligibility_info_with_missing(self):
         """Test eligibility info text when questions are missing."""
         info = self.tool._build_eligibility_info(
-            eligible_2025=False,
-            eligible_2026=False,
+            eligible_base=False,
+            eligible_target=False,
             medicare=False,
             alternatives=[],
             missing=["income", "household_size"],
@@ -459,8 +461,8 @@ class TestMedicaidEligibilityTool(TestCase):
     def test_build_eligibility_info_lists_questions_not_python_repr(self):
         """Missing questions render as a readable list, not a list repr."""
         info = self.tool._build_eligibility_info(
-            eligible_2025=False,
-            eligible_2026=False,
+            eligible_base=False,
+            eligible_target=False,
             medicare=False,
             alternatives=[],
             missing=["What state do you live in?", "How old are you?"],
@@ -472,8 +474,8 @@ class TestMedicaidEligibilityTool(TestCase):
     def test_build_eligibility_info_flags_experimental_when_asking(self):
         """The LLM is told to disclose the experimental status while asking."""
         info = self.tool._build_eligibility_info(
-            eligible_2025=False,
-            eligible_2026=False,
+            eligible_base=False,
+            eligible_target=False,
             medicare=False,
             alternatives=[],
             missing=["What state do you live in?"],
@@ -484,8 +486,8 @@ class TestMedicaidEligibilityTool(TestCase):
     def test_build_eligibility_info_flags_experimental_on_verdict(self):
         """The LLM is told to disclose the experimental status with verdicts."""
         info = self.tool._build_eligibility_info(
-            eligible_2025=True,
-            eligible_2026=True,
+            eligible_base=True,
+            eligible_target=True,
             medicare=False,
             alternatives=[],
             missing=[],
@@ -496,8 +498,8 @@ class TestMedicaidEligibilityTool(TestCase):
     def test_build_eligibility_info_paces_questions(self):
         """The LLM is told to ask only a few questions at a time."""
         info = self.tool._build_eligibility_info(
-            eligible_2025=False,
-            eligible_2026=False,
+            eligible_base=False,
+            eligible_target=False,
             medicare=False,
             alternatives=[],
             missing=["q1", "q2", "q3", "q4"],
@@ -508,8 +510,8 @@ class TestMedicaidEligibilityTool(TestCase):
     def test_build_eligibility_info_reports_settled_verdict_while_asking(self):
         """A determination already reached isn't withheld behind a question."""
         info = self.tool._build_eligibility_info(
-            eligible_2025=True,
-            eligible_2026=False,
+            eligible_base=True,
+            eligible_target=False,
             medicare=True,
             alternatives=[],
             missing=["Do you have ALS?"],
@@ -521,8 +523,8 @@ class TestMedicaidEligibilityTool(TestCase):
     def test_build_eligibility_info_holds_alternatives_until_verdict(self):
         """Denial-flavored next steps don't surface mid-interview."""
         info = self.tool._build_eligibility_info(
-            eligible_2025=True,
-            eligible_2026=False,
+            eligible_base=True,
+            eligible_target=False,
             medicare=False,
             alternatives=["If denied, you can appeal; gather documentation."],
             missing=["Do you have ALS?"],
@@ -533,8 +535,8 @@ class TestMedicaidEligibilityTool(TestCase):
     def test_indeterminate_result_is_not_rendered_as_a_denial(self):
         """"Couldn't score them" must not become "may not be eligible"."""
         info = self.tool._build_eligibility_info(
-            eligible_2025=False,
-            eligible_2026=False,
+            eligible_base=False,
+            eligible_target=False,
             medicare=False,
             alternatives=["Contact your territory's Medicaid agency."],
             missing=[],
@@ -547,8 +549,8 @@ class TestMedicaidEligibilityTool(TestCase):
     def test_indeterminate_result_still_reports_medicare(self):
         """Medicare is federal, so a territory resident still gets that answer."""
         info = self.tool._build_eligibility_info(
-            eligible_2025=False,
-            eligible_2026=False,
+            eligible_base=False,
+            eligible_target=False,
             medicare=True,
             alternatives=[],
             missing=[],
@@ -559,8 +561,8 @@ class TestMedicaidEligibilityTool(TestCase):
 
     def test_scored_ineligible_still_reads_as_a_verdict(self):
         info = self.tool._build_eligibility_info(
-            eligible_2025=False,
-            eligible_2026=False,
+            eligible_base=False,
+            eligible_target=False,
             medicare=False,
             alternatives=[],
             missing=[],
@@ -596,8 +598,8 @@ class TestMedicaidEligibilityTool(TestCase):
     def test_build_eligibility_info_lists_alternatives_not_python_repr(self):
         """Alternatives render as a readable list, not a list repr."""
         info = self.tool._build_eligibility_info(
-            eligible_2025=False,
-            eligible_2026=False,
+            eligible_base=False,
+            eligible_target=False,
             medicare=False,
             alternatives=["Consider CHIP for the kids."],
             missing=[],
@@ -605,6 +607,123 @@ class TestMedicaidEligibilityTool(TestCase):
 
         self.assertIn("- Consider CHIP for the kids.", info)
         self.assertNotIn("['Consider", info)
+
+
+class TestMedicaidTargetYear(TestCase):
+    """The user picks which year the second verdict covers."""
+
+    def setUp(self):
+        self.tool = MedicaidEligibilityTool(AsyncMock())
+
+    def test_verdict_names_the_requested_year(self):
+        info = self.tool._build_eligibility_info(
+            eligible_base=True,
+            eligible_target=False,
+            medicare=False,
+            alternatives=[],
+            missing=[],
+            target_year=2028,
+        )
+
+        self.assertIn("2028", info)
+        self.assertNotIn("the 2026 rules", info)
+
+    def test_current_year_target_is_reported_once(self):
+        # Asking about this year should not produce the same verdict twice
+        # under two labels, nor a work requirement that doesn't apply yet.
+        info = self.tool._build_eligibility_info(
+            eligible_base=True,
+            eligible_target=True,
+            medicare=False,
+            alternatives=[],
+            missing=[],
+            target_year=BASE_ELIGIBILITY_YEAR,
+        )
+
+        self.assertEqual(info.count("could be eligible for medicaid"), 1)
+        self.assertNotIn("work/community-engagement", info)
+
+    def test_future_year_thresholds_are_flagged_as_estimates(self):
+        info = self.tool._build_eligibility_info(
+            eligible_base=False,
+            eligible_target=False,
+            medicare=False,
+            alternatives=[],
+            missing=[],
+            target_year=2029,
+        )
+
+        self.assertIn("aren't published yet", info)
+
+    def test_default_target_year_still_covers_the_work_requirement(self):
+        info = self.tool._build_eligibility_info(
+            eligible_base=True,
+            eligible_target=False,
+            medicare=False,
+            alternatives=[],
+            missing=[],
+        )
+
+        self.assertIn(str(DEFAULT_TARGET_YEAR), info)
+        self.assertIn("work/community-engagement", info)
+
+
+class TestMedicaidInfoStartsTheEligibilityPath(TestCase):
+    """A general Medicaid answer has to lead somewhere.
+
+    Someone who asks how Medicaid works in their state is usually trying to
+    find out whether they can get covered, so the info lookup hands the model
+    the next step instead of ending at a phone number.
+    """
+
+    def setUp(self):
+        self.handoff = MedicaidInfoTool._build_eligibility_handoff("California")
+
+    def test_handoff_names_the_eligibility_tool(self):
+        self.assertIn("medicaid_eligibility", self.handoff)
+
+    def test_handoff_carries_the_state_we_just_looked_up(self):
+        self.assertIn("California", self.handoff)
+
+    def test_handoff_calls_the_check_experimental(self):
+        self.assertIn("EXPERIMENTAL", self.handoff)
+
+    def test_handoff_forbids_questions_before_the_tool_call(self):
+        self.assertIn("Never ask eligibility questions before", self.handoff)
+
+    def test_handoff_does_not_restart_a_check_already_underway(self):
+        self.assertIn("already underway", self.handoff)
+
+    def test_lookup_result_carries_the_handoff(self):
+        # The guidance is only useful if it actually rides along with the
+        # info the model is answering from.
+        tool = MedicaidInfoTool(AsyncMock())
+        match = tool.detect('**medicaid_info {"state": "California"}**')
+        self.assertIsNotNone(match)
+
+        with patch(
+            "fighthealthinsurance.medicaid_api.get_medicaid_info",
+            return_value="Call 1-800-555-0100 to apply.",
+        ):
+            captured = {}
+
+            async def fake_call_llm(model_backends, message, *args, **kwargs):
+                captured["message"] = message
+                return ("ok", "")
+
+            tool.call_llm_callback = fake_call_llm
+            asyncio.run(
+                tool.execute(
+                    match,
+                    '**medicaid_info {"state": "California"}**',
+                    "",
+                    model_backends=["backend"],
+                    current_message_for_llm="How does Medi-Cal work?",
+                    history_for_llm=[],
+                )
+            )
+
+        self.assertIn("medicaid_eligibility", captured["message"])
 
 
 class TestDocFetcherPatterns(TestCase):
@@ -1061,8 +1180,8 @@ class TestMedicaidIndeterminateWithQuestions(TestCase):
         # An unscorable result that still has an outstanding question -- the
         # territory case, where Medicare may yet resolve.
         self.indeterminate_info = self.tool._build_eligibility_info(
-            eligible_2025=False,
-            eligible_2026=False,
+            eligible_base=False,
+            eligible_target=False,
             medicare=False,
             alternatives=["Contact your territory's Medicaid agency."],
             missing=["How old are you?"],
@@ -1079,8 +1198,8 @@ class TestMedicaidIndeterminateWithQuestions(TestCase):
 
     def test_a_scored_result_does_not_get_the_cannot_estimate_banner(self):
         info = self.tool._build_eligibility_info(
-            eligible_2025=True,
-            eligible_2026=True,
+            eligible_base=True,
+            eligible_target=True,
             medicare=False,
             alternatives=["Visit your state Medicaid page."],
             missing=["How old are you?"],

--- a/tests/sync/test_chat_tools.py
+++ b/tests/sync/test_chat_tools.py
@@ -28,6 +28,7 @@ from fighthealthinsurance.chat.tools import (
 from fighthealthinsurance.medicaid_api import (
     BASE_ELIGIBILITY_YEAR,
     DEFAULT_TARGET_YEAR,
+    current_eligibility_year,
     is_eligible,
     summarize_eligibility_inputs,
 )
@@ -483,8 +484,7 @@ class TestMedicaidEligibilityTool(TestCase):
         )
 
         self.assertIn("eligible for medicaid", info.lower())
-        self.assertIn("2025", info)
-        self.assertIn("2026", info)
+        self.assertIn(f"current ({current_eligibility_year()})", info)
 
     def test_build_eligibility_info_with_missing(self):
         """Test eligibility info text when questions are missing."""
@@ -668,9 +668,10 @@ class TestMedicaidTargetYear(TestCase):
         self.assertIn("2028", info)
         self.assertNotIn("the 2026 rules", info)
 
-    def test_current_year_target_is_reported_once(self):
-        # Asking about this year should not produce the same verdict twice
-        # under two labels, nor a work requirement that doesn't apply yet.
+    def test_a_pre_work_requirement_target_is_reported_once(self):
+        # Asking about a year before the work requirement should not produce
+        # the same verdict twice under two labels, nor a caveat about a
+        # requirement that didn't apply in that year.
         info = self.tool._build_eligibility_info(
             eligible_base=True,
             eligible_target=True,
@@ -700,19 +701,61 @@ class TestMedicaidTargetYear(TestCase):
         self.assertIn("the work requirement, not the income test", info)
 
     def test_every_timeline_year_is_rendered(self):
+        current = current_eligibility_year()
         info = self.tool._build_eligibility_info(
             eligible_base=True,
             eligible_target=False,
             medicare=False,
             alternatives=[],
             missing=[],
-            target_year=2029,
-            timeline=[(2025, True), (2026, False), (2029, False)],
+            target_year=current + 3,
+            timeline=[(current, True), (current + 1, False), (current + 3, False)],
         )
 
-        self.assertIn("current (2025): they could be eligible", info)
-        self.assertIn("2026: they may not be eligible", info)
-        self.assertIn("2029: they may not be eligible", info)
+        self.assertIn(f"current ({current}): they could be eligible", info)
+        self.assertIn(f"{current + 1}: they may not be eligible", info)
+        self.assertIn(f"{current + 3}: they may not be eligible", info)
+
+    def test_a_finished_year_is_never_labelled_current(self):
+        # The FPL table's year stops being "today" once the calendar passes
+        # it. Labelling it "current" told people the rules they live under
+        # were the ones that had just been replaced.
+        current = current_eligibility_year()
+        if BASE_ELIGIBILITY_YEAR >= current:
+            self.skipTest("the published FPL table is still the current year")
+
+        info = self.tool._build_eligibility_info(
+            eligible_base=True,
+            eligible_target=True,
+            medicare=False,
+            alternatives=[],
+            missing=[],
+            target_year=current,
+            timeline=[(BASE_ELIGIBILITY_YEAR, True), (current, True)],
+        )
+
+        self.assertIn(f"current ({current})", info)
+        self.assertNotIn(f"current ({BASE_ELIGIBILITY_YEAR})", info)
+        self.assertIn(f"{BASE_ELIGIBILITY_YEAR}: they could be eligible", info)
+
+    def test_a_finished_base_year_is_dropped_when_no_timeline_is_given(self):
+        # Direct callers that pass no timeline used to get a row for the FPL
+        # table's year regardless of whether it had already ended.
+        current = current_eligibility_year()
+        if BASE_ELIGIBILITY_YEAR >= current:
+            self.skipTest("the published FPL table is still the current year")
+
+        info = self.tool._build_eligibility_info(
+            eligible_base=True,
+            eligible_target=False,
+            medicare=False,
+            alternatives=[],
+            missing=[],
+            target_year=current,
+        )
+
+        self.assertNotIn(f"{BASE_ELIGIBILITY_YEAR}: they", info)
+        self.assertIn(f"current ({current}): they may not be eligible", info)
 
     def test_a_year_over_year_change_is_called_out(self):
         # The reason for showing more than one year at all: don't leave the

--- a/tests/sync/test_chat_tools.py
+++ b/tests/sync/test_chat_tools.py
@@ -16,6 +16,7 @@ from fighthealthinsurance.chat.tools import (
     RXNORM_LOOKUP_REGEX,
     USPSTF_LOOKUP_REGEX,
     BaseTool,
+    count_tool_invocations,
     ClinicalTrialsTool,
     PubMedTool,
     MedicaidInfoTool,
@@ -52,6 +53,45 @@ class TestToolPatterns(TestCase):
             match = re.search(PUBMED_QUERY_REGEX, text, re.IGNORECASE)
             self.assertIsNotNone(match, f"Failed to match: {text}")
             self.assertEqual(match.group(1).strip(), expected_query)
+
+    def test_pubmed_query_pattern_ignores_prose(self):
+        """An offer to search is not a search.
+
+        The colon used to be optional, so "I can run a pubmed query for you"
+        fired the handler AND earned the fan-out's tool-call bonus -- letting
+        a candidate that offered to use a tool outscore one that used it.
+        """
+        prose = [
+            "I can run a pubmed query for you if that would help.",
+            "Want me to do a pubmed query?",
+            "A PubMed query might turn up supporting studies.",
+        ]
+        for text in prose:
+            with self.subTest(text=text):
+                self.assertIsNone(re.search(PUBMED_QUERY_REGEX, text, re.IGNORECASE))
+
+    def test_count_tool_invocations_counts_distinct_tools(self):
+        text = (
+            "Let me look at a couple of things.\n"
+            '**medicaid_eligibility {"state": "CA"}**\n'
+            "[*pubmed query: metformin*]"
+        )
+        self.assertEqual(count_tool_invocations(text), 2)
+
+    def test_count_tool_invocations_finds_an_anchored_call_after_prose(self):
+        # CREATE_OR_UPDATE_* are `^...$`-anchored, so a flag-less re.search
+        # only ever saw them at the very start of a reply.
+        text = 'Sure, here it is.\n**create_or_update_appeal**{"a": 1}\n'
+        self.assertEqual(count_tool_invocations(text), 1)
+
+    def test_count_tool_invocations_ignores_a_bare_mention(self):
+        self.assertEqual(
+            count_tool_invocations("I will use create_or_update_appeal shortly"), 0
+        )
+
+    def test_count_tool_invocations_handles_empty_input(self):
+        self.assertEqual(count_tool_invocations(""), 0)
+        self.assertEqual(count_tool_invocations(None), 0)
 
     def test_clinical_trials_query_pattern(self):
         """Test ClinicalTrials.gov query pattern matches various formats."""
@@ -651,9 +691,40 @@ class TestMedicaidTargetYear(TestCase):
             alternatives=[],
             missing=[],
             target_year=2029,
+            thresholds_estimated=True,
         )
 
         self.assertIn("aren't published yet", info)
+
+    def test_default_year_is_not_described_as_an_estimated_threshold(self):
+        # The checker only projects income limits forward for a year the user
+        # named, so on the default path there is no estimate to disclaim --
+        # saying there was described arithmetic we never did.
+        info = self.tool._build_eligibility_info(
+            eligible_base=True,
+            eligible_target=False,
+            medicare=False,
+            alternatives=[],
+            missing=[],
+            target_year=DEFAULT_TARGET_YEAR,
+        )
+
+        self.assertNotIn("aren't published yet", info)
+
+    def test_target_year_positive_is_reported_mid_interview(self):
+        # The base-year positive was already shared while questions were
+        # outstanding; the target-year one sat unsaid behind them, which is
+        # the half someone asking "will I still qualify in 2029?" wanted.
+        info = self.tool._build_eligibility_info(
+            eligible_base=True,
+            eligible_target=True,
+            medicare=False,
+            alternatives=[],
+            missing=["What is your household size?"],
+            target_year=2029,
+        )
+
+        self.assertIn("already look eligible in 2029", info)
 
     def test_default_target_year_still_covers_the_work_requirement(self):
         info = self.tool._build_eligibility_info(
@@ -689,7 +760,21 @@ class TestMedicaidInfoStartsTheEligibilityPath(TestCase):
         self.assertIn("EXPERIMENTAL", self.handoff)
 
     def test_handoff_forbids_questions_before_the_tool_call(self):
-        self.assertIn("Never ask eligibility questions before", self.handoff)
+        self.assertIn("never ask eligibility questions before", self.handoff)
+
+    def test_handoff_offers_rather_than_forces_the_check(self):
+        # Someone who asked what Medicaid is may just want that answered;
+        # the handoff has to read as an invitation, not a redirect.
+        self.assertIn("Offer it, don't push it", self.handoff)
+        self.assertIn("drop it if they decline", self.handoff)
+
+    def test_handoff_omits_the_state_line_when_none_was_given(self):
+        # The old handoff pasted the state into a literal JSON tool call, so
+        # a lookup with no "state" key emitted **medicaid_eligibility
+        # {"state": "the state"}** -- a made-up value the model then re-sent.
+        handoff = MedicaidInfoTool._build_eligibility_handoff(None)
+        self.assertNotIn("You already know their state", handoff)
+        self.assertNotIn("the state", handoff)
 
     def test_handoff_does_not_restart_a_check_already_underway(self):
         self.assertIn("already underway", self.handoff)

--- a/tests/sync/test_chat_tools.py
+++ b/tests/sync/test_chat_tools.py
@@ -875,6 +875,17 @@ class TestEligibilityVerifiedFlag(TestCase):
         self.assertTrue(flag)
         self.assertTrue(kwargs["eligibility_verified"])
 
+    def test_medicare_only_positive_does_not_earn_the_exemption(self):
+        # A 67-year-old's age settles Medicare on the very first call while
+        # every Medicaid question is still outstanding. The exemption is
+        # program-blind, so latching it there let the rest of the session
+        # assert uncomputed MEDICAID verdicts for free.
+        flag, kwargs = self._run(
+            (False, False, True, [], ["What is your monthly income?"], True)
+        )
+        self.assertFalse(flag)
+        self.assertFalse(kwargs["eligibility_verified"])
+
     def test_unscoreable_person_does_not_earn_the_exemption(self):
         # determination_made=False: a territory, or a declined required
         # answer. The info text explicitly says not to call them ineligible.

--- a/tests/sync/test_chat_tools.py
+++ b/tests/sync/test_chat_tools.py
@@ -699,6 +699,82 @@ class TestMedicaidTargetYear(TestCase):
         self.assertIn("aren't published yet", info)
         self.assertIn("the work requirement, not the income test", info)
 
+    def test_every_timeline_year_is_rendered(self):
+        info = self.tool._build_eligibility_info(
+            eligible_base=True,
+            eligible_target=False,
+            medicare=False,
+            alternatives=[],
+            missing=[],
+            target_year=2029,
+            timeline=[(2025, True), (2026, False), (2029, False)],
+        )
+
+        self.assertIn("current (2025): they could be eligible", info)
+        self.assertIn("2026: they may not be eligible", info)
+        self.assertIn("2029: they may not be eligible", info)
+
+    def test_a_year_over_year_change_is_called_out(self):
+        # The reason for showing more than one year at all: don't leave the
+        # user to diff two sentences.
+        info = self.tool._build_eligibility_info(
+            eligible_base=True,
+            eligible_target=False,
+            medicare=False,
+            alternatives=[],
+            missing=[],
+            target_year=2026,
+            timeline=[(2025, True), (2026, False)],
+        )
+
+        self.assertIn("this CHANGES in 2026", info)
+        self.assertIn("probably would NOT from 2026 on", info)
+
+    def test_an_improvement_is_called_out_too(self):
+        info = self.tool._build_eligibility_info(
+            eligible_base=False,
+            eligible_target=True,
+            medicare=False,
+            alternatives=[],
+            missing=[],
+            target_year=2026,
+            timeline=[(2025, False), (2026, True)],
+        )
+
+        self.assertIn("IMPROVES in 2026", info)
+
+    def test_a_steady_timeline_has_no_change_callout(self):
+        info = self.tool._build_eligibility_info(
+            eligible_base=True,
+            eligible_target=True,
+            medicare=False,
+            alternatives=[],
+            missing=[],
+            target_year=2026,
+            timeline=[(2025, True), (2026, True)],
+        )
+
+        self.assertNotIn("CHANGES in", info)
+        self.assertNotIn("IMPROVES in", info)
+
+    def test_the_verdicts_stay_hedged(self):
+        # "Keeping the probably words going" -- none of these are
+        # determinations and the wording must not harden into one.
+        info = self.tool._build_eligibility_info(
+            eligible_base=True,
+            eligible_target=False,
+            medicare=False,
+            alternatives=[],
+            missing=[],
+            target_year=2026,
+            timeline=[(2025, True), (2026, False)],
+        )
+
+        self.assertIn("an approximation, not a determination", info)
+        self.assertIn("could be eligible", info)
+        self.assertIn("may not be eligible", info)
+        self.assertIn("probably", info)
+
     def test_a_base_year_check_has_no_second_year_note(self):
         info = self.tool._build_eligibility_info(
             eligible_base=True,

--- a/tests/sync/test_chat_tools.py
+++ b/tests/sync/test_chat_tools.py
@@ -683,10 +683,9 @@ class TestMedicaidTargetYear(TestCase):
         self.assertIn("2028", info)
         self.assertNotIn("the 2026 rules", info)
 
-    def test_a_pre_work_requirement_target_is_reported_once(self):
-        # Asking about a year before the work requirement should not produce
-        # the same verdict twice under two labels, nor a caveat about a
-        # requirement that didn't apply in that year.
+    def test_the_table_year_target_is_reported_once(self):
+        # Asking about the year we score against should not produce the same
+        # verdict twice under two labels.
         info = self.tool._build_eligibility_info(
             eligible_base=True,
             eligible_target=True,
@@ -697,6 +696,23 @@ class TestMedicaidTargetYear(TestCase):
         )
 
         self.assertEqual(info.count("could be eligible for medicaid"), 1)
+
+    def test_a_pre_work_requirement_year_gets_no_work_requirement_caveat(self):
+        # Coaching someone to chase 80 hours a month for a rule that wasn't
+        # in force in the year they asked about is noise at best.
+        from fighthealthinsurance.medicaid_api import WORK_REQUIREMENT_FIRST_YEAR
+
+        earlier = WORK_REQUIREMENT_FIRST_YEAR - 1
+        info = self.tool._build_eligibility_info(
+            eligible_base=True,
+            eligible_target=True,
+            medicare=False,
+            alternatives=[],
+            missing=[],
+            target_year=earlier,
+            timeline=[(earlier, True, [])],
+        )
+
         self.assertNotIn("work/community-engagement", info)
 
     def test_a_future_year_says_current_limits_were_used(self):
@@ -724,7 +740,11 @@ class TestMedicaidTargetYear(TestCase):
             alternatives=[],
             missing=[],
             target_year=current + 3,
-            timeline=[(current, True), (current + 1, False), (current + 3, False)],
+            timeline=[
+                (current, True, []),
+                (current + 1, False, []),
+                (current + 3, False, []),
+            ],
         )
 
         self.assertIn(f"current ({current}): they could be eligible", info)
@@ -744,16 +764,57 @@ class TestMedicaidTargetYear(TestCase):
             medicare=False,
             alternatives=[],
             missing=[],
-            target_year=BASE_ELIGIBILITY_YEAR,
+            target_year=WORK_REQUIREMENT_FIRST_YEAR - 1,
             timeline=[
-                (BASE_ELIGIBILITY_YEAR, True),
-                (WORK_REQUIREMENT_FIRST_YEAR, False),
+                (WORK_REQUIREMENT_FIRST_YEAR - 1, True, []),
+                (WORK_REQUIREMENT_FIRST_YEAR, False, []),
             ],
         )
 
         self.assertIn(f"this CHANGES in {WORK_REQUIREMENT_FIRST_YEAR}", info)
         self.assertIn("work/community-engagement", info)
-        self.assertIn("aren't published yet", info)
+
+    def test_a_year_we_cannot_score_yet_is_not_reported_as_ineligible(self):
+        # is_eligible returns False for BOTH "scored, falls short" and "can't
+        # score until you answer" -- an unanswered work-hours question sets
+        # the flag False on purpose. Rendering that as "may not be eligible"
+        # hands the user a denial nobody computed.
+        current = current_eligibility_year()
+        info = self.tool._build_eligibility_info(
+            eligible_base=True,
+            eligible_target=False,
+            medicare=False,
+            alternatives=[],
+            missing=[],
+            target_year=current + 1,
+            timeline=[
+                (current, True, []),
+                (current + 1, False, ["About how many qualifying hours a month?"]),
+            ],
+        )
+
+        self.assertIn(f"{current + 1}: NOT ESTABLISHED", info)
+        self.assertNotIn(f"{current + 1}: they may not be eligible", info)
+        self.assertIn("About how many qualifying hours a month?", info)
+
+    def test_an_unscored_year_does_not_trigger_a_change_callout(self):
+        # "this CHANGES in <year>" off the back of an unanswered question is
+        # the same uncomputed denial in a louder voice.
+        current = current_eligibility_year()
+        info = self.tool._build_eligibility_info(
+            eligible_base=True,
+            eligible_target=False,
+            medicare=False,
+            alternatives=[],
+            missing=[],
+            target_year=current + 1,
+            timeline=[
+                (current, True, []),
+                (current + 1, False, ["About how many qualifying hours a month?"]),
+            ],
+        )
+
+        self.assertNotIn("CHANGES in", info)
 
     def test_a_finished_year_is_never_labelled_current(self):
         # The FPL table's year stops being "today" once the calendar passes
@@ -770,7 +831,7 @@ class TestMedicaidTargetYear(TestCase):
             alternatives=[],
             missing=[],
             target_year=current,
-            timeline=[(BASE_ELIGIBILITY_YEAR, True), (current, True)],
+            timeline=[(BASE_ELIGIBILITY_YEAR, True, []), (current, True, [])],
         )
 
         self.assertIn(f"current ({current})", info)
@@ -806,7 +867,7 @@ class TestMedicaidTargetYear(TestCase):
             alternatives=[],
             missing=[],
             target_year=2026,
-            timeline=[(2025, True), (2026, False)],
+            timeline=[(2025, True, []), (2026, False, [])],
         )
 
         self.assertIn("this CHANGES in 2026", info)
@@ -820,7 +881,7 @@ class TestMedicaidTargetYear(TestCase):
             alternatives=[],
             missing=[],
             target_year=2026,
-            timeline=[(2025, False), (2026, True)],
+            timeline=[(2025, False, []), (2026, True, [])],
         )
 
         self.assertIn("IMPROVES in 2026", info)
@@ -833,7 +894,7 @@ class TestMedicaidTargetYear(TestCase):
             alternatives=[],
             missing=[],
             target_year=2026,
-            timeline=[(2025, True), (2026, True)],
+            timeline=[(2025, True, []), (2026, True, [])],
         )
 
         self.assertNotIn("CHANGES in", info)
@@ -849,7 +910,7 @@ class TestMedicaidTargetYear(TestCase):
             alternatives=[],
             missing=[],
             target_year=2026,
-            timeline=[(2025, True), (2026, False)],
+            timeline=[(2025, True, []), (2026, False, [])],
         )
 
         self.assertIn("an approximation, not a determination", info)

--- a/tests/sync/test_llm_client.py
+++ b/tests/sync/test_llm_client.py
@@ -127,6 +127,48 @@ class TestBadPatterns(TestCase):
 class TestScoreLlmResponse(TestCase):
     """Test LLM response scoring."""
 
+    def test_tool_call_keeps_the_full_model_prior(self):
+        """A bare tool call is a finished reply, not a truncated one.
+
+        The model prior is normally divided by 100 when a candidate has no
+        panda context summary, on the theory that it's half-generated. A tool
+        call never has one -- the tool's follow-up pass writes it -- so that
+        division sank real tool calls under chatty candidates that skipped
+        the tool and invented an answer instead.
+        """
+        tool_call = ('**medicaid_eligibility {"state": "CA"}**', None)
+        prose_without_context = ("Here is a fairly long chatty answer.", None)
+
+        tool_score = score_llm_response(tool_call, 8000)
+        prose_score = score_llm_response(prose_without_context, 8000)
+
+        self.assertGreater(tool_score, prose_score)
+        self.assertGreater(tool_score, 8000)
+
+    def test_tool_call_outranks_an_answer_that_skipped_the_tool(self):
+        # The observed failure: a local model's invented eligibility verdict
+        # (with a context summary) beat the tool call that would have computed
+        # one, so the checker never ran.
+        tool_call = ('**medicaid_eligibility {"state": "CA", "age": 39}**', None)
+        invented_verdict = (
+            "Based on what you've told me you're likely eligible under today's rules.",
+            "Medicaid eligibility for California",
+        )
+
+        self.assertGreater(
+            score_llm_response(tool_call, 8000),
+            score_llm_response(invented_verdict, 8000),
+        )
+
+    def test_missing_context_still_penalized_without_a_tool_call(self):
+        with_context = ("A helpful answer for the user.", "Context summary")
+        without_context = ("A helpful answer for the user.", None)
+
+        self.assertGreater(
+            score_llm_response(with_context, 8000),
+            score_llm_response(without_context, 8000),
+        )
+
     def test_none_result_returns_negative_inf(self):
         """None result should return -inf."""
         score = score_llm_response(None, 100)

--- a/tests/sync/test_llm_client.py
+++ b/tests/sync/test_llm_client.py
@@ -22,6 +22,7 @@ from fighthealthinsurance.chat.llm_client import (
     REPEAT_OFFENDER_DECAY,
     BAD_RESPONSE_PATTERNS,
     BAD_CONTEXT_PATTERNS,
+    INVENTED_ELIGIBILITY_VERDICT_PENALTY,
 )
 from tests.chat_fixtures import CANNED_MEDICAID_REPLY, FRESH_REPLY, LOOPED_REPLY
 
@@ -158,6 +159,62 @@ class TestScoreLlmResponse(TestCase):
         self.assertGreater(
             score_llm_response(tool_call, 8000),
             score_llm_response(invented_verdict, 8000),
+        )
+
+    def test_invented_eligibility_verdict_is_penalized(self):
+        # Only the medicaid_eligibility checker can produce a verdict. A model
+        # asserting one from the conversation alone is guessing about
+        # someone's health coverage.
+        invented = (
+            "Good news — based on your income you are eligible for Medicaid.",
+            "Medicaid eligibility for California",
+        )
+        neutral = (
+            "Medicaid income limits vary by state and household size.",
+            "Medicaid eligibility for California",
+        )
+
+        self.assertEqual(
+            score_llm_response(neutral, 8000) - score_llm_response(invented, 8000),
+            INVENTED_ELIGIBILITY_VERDICT_PENALTY,
+        )
+
+    def test_verdict_is_not_penalized_once_the_checker_has_run(self):
+        # After the tool computes a determination, relaying it is the point.
+        verdict = (
+            "Good news — based on your income you are eligible for Medicaid.",
+            "Medicaid eligibility for California",
+        )
+
+        self.assertGreater(
+            score_llm_response(verdict, 8000, eligibility_verified=True),
+            score_llm_response(verdict, 8000),
+        )
+
+    def test_offering_the_check_is_not_a_verdict(self):
+        # The Medicaid path asks the model to say exactly this before the
+        # checker has run, so penalizing it would fight our own prompt.
+        offer = (
+            "You may be eligible for Medicaid — want me to run our "
+            "experimental eligibility check with you?",
+            "Medicaid question",
+        )
+
+        self.assertEqual(
+            score_llm_response(offer, 8000),
+            score_llm_response(offer, 8000, eligibility_verified=True),
+        )
+
+    def test_invented_verdict_loses_to_the_tool_call_that_would_compute_it(self):
+        tool_call = ('**medicaid_eligibility {"state": "CA", "age": 39}**', None)
+        invented = (
+            "Based on your income you do not qualify for Medicaid in California.",
+            "Medicaid eligibility for California",
+        )
+
+        self.assertGreater(
+            score_llm_response(tool_call, 8000),
+            score_llm_response(invented, 8000),
         )
 
     def test_missing_context_still_penalized_without_a_tool_call(self):

--- a/tests/sync/test_llm_client.py
+++ b/tests/sync/test_llm_client.py
@@ -208,6 +208,18 @@ class TestScoreLlmResponse(TestCase):
         # A better backend buys an invented verdict nothing at all.
         self.assertEqual(low_prior, high_prior)
 
+    def test_invented_verdict_without_context_is_not_double_penalized(self):
+        # A candidate with no context summary and no tool call only receives
+        # call_score/100, so taking back the full call_score drove it
+        # thousands of points below its peers and ranked invented verdicts by
+        # model quality -- the inverse of the intended levelling.
+        no_context = ("Based on your income you do not qualify for Medicaid.", None)
+
+        strong = score_llm_response(no_context, 11000)
+        weak = score_llm_response(no_context, 2000)
+
+        self.assertEqual(strong, weak)
+
     def test_invented_verdict_is_not_hard_rejected(self):
         # Deliberately not -inf: the detector is a regex over free text, and
         # one false positive must not be able to empty a fan-out.

--- a/tests/sync/test_llm_client.py
+++ b/tests/sync/test_llm_client.py
@@ -176,8 +176,47 @@ class TestScoreLlmResponse(TestCase):
 
         self.assertEqual(
             score_llm_response(neutral, 8000) - score_llm_response(invented, 8000),
-            INVENTED_ELIGIBILITY_VERDICT_PENALTY,
+            8000 + INVENTED_ELIGIBILITY_VERDICT_PENALTY,
         )
+
+    def test_invented_verdict_loses_to_a_higher_prior_tool_call(self):
+        # The failure a fixed nudge could not stop: ONE quality-210 backend
+        # contributes a truncated-history call (210**2//5 = 8820) and a
+        # full-history one (210**2//4 = 11025). A 2000-point penalty left the
+        # full-history invented verdict beating the truncated call's real
+        # checker invocation, so the prior is forfeited instead.
+        tool_call = ('**medicaid_eligibility {"state": "CA"}**', None)
+        invented = (
+            "Based on your income you do not qualify for Medicaid in California.",
+            "Medicaid eligibility for California",
+        )
+
+        self.assertGreater(
+            score_llm_response(tool_call, 210**2 // 5),
+            score_llm_response(invented, 210**2 // 4),
+        )
+
+    def test_invented_verdict_forfeits_the_model_prior(self):
+        invented = (
+            "Based on your income you do not qualify for Medicaid.",
+            "Medicaid eligibility",
+        )
+
+        low_prior = score_llm_response(invented, 2000)
+        high_prior = score_llm_response(invented, 11000)
+
+        # A better backend buys an invented verdict nothing at all.
+        self.assertEqual(low_prior, high_prior)
+
+    def test_invented_verdict_is_not_hard_rejected(self):
+        # Deliberately not -inf: the detector is a regex over free text, and
+        # one false positive must not be able to empty a fan-out.
+        invented = (
+            "Based on your income you do not qualify for Medicaid.",
+            "Medicaid eligibility",
+        )
+
+        self.assertNotEqual(score_llm_response(invented, 8000), float("-inf"))
 
     def test_verdict_is_not_penalized_once_the_checker_has_run(self):
         # After the tool computes a determination, relaying it is the point.

--- a/tests/sync/test_medicaid_eligibility_api.py
+++ b/tests/sync/test_medicaid_eligibility_api.py
@@ -248,7 +248,9 @@ class TestQuestionFlow(SimpleTestCase):
     def test_string_no_is_treated_as_no(self):
         # Review regression: bool("no") is True, so LLM string booleans
         # flipped answers. A string "no" must behave like False.
-        eligible_2025, _, _, _, _, _ = is_eligible(**_answers(state="tx", pregnant="no"))
+        eligible_2025, _, _, _, _, _ = is_eligible(
+            **_answers(state="tx", pregnant="no")
+        )
         self.assertFalse(eligible_2025)
 
     def test_string_false_work_exemption_is_not_treated_as_exempt(self):
@@ -318,9 +320,7 @@ class TestLlmPayloadParsing(SimpleTestCase):
         # Review finding: the territory exit returned False/False with no
         # questions left, which the chat tool rendered as a confident "may
         # not be eligible" -- contradicting the alternative it returned.
-        _, _, _, _, _, determination_made = is_eligible(
-            state="Puerto Rico", age=30
-        )
+        _, _, _, _, _, determination_made = is_eligible(state="Puerto Rico", age=30)
         self.assertFalse(determination_made)
 
     def test_territory_resident_still_gets_a_medicare_answer(self):
@@ -375,7 +375,7 @@ class TestUnknownAnswerChannel(SimpleTestCase):
 
 
 class TestIndeterminateResults(SimpleTestCase):
-    """"Couldn't score them" must never be rendered as "not eligible"."""
+    """ "Couldn't score them" must never be rendered as "not eligible"."""
 
     def test_scored_ineligible_is_a_determination(self):
         _, _, _, _, _, determination_made = is_eligible(
@@ -535,7 +535,9 @@ class TestMedicarePathways(SimpleTestCase):
         # was reported not Medicare-eligible (the enrolled branch was only
         # reachable through the other pathways).
         _, _, medicare, _, _, _ = is_eligible(
-            **_answers(age=40, monthly_income=800.0, on_medicare=True, assets_total=500.0)
+            **_answers(
+                age=40, monthly_income=800.0, on_medicare=True, assets_total=500.0
+            )
         )
         self.assertTrue(medicare)
 
@@ -552,7 +554,9 @@ class TestMedicarePathways(SimpleTestCase):
                 assets_total=500.0,
             )
         )
-        self.assertTrue(any("months have you been receiving SSDI" in q for q in missing))
+        self.assertTrue(
+            any("months have you been receiving SSDI" in q for q in missing)
+        )
         # No definitive verdict while that question is outstanding.
         self.assertFalse(medicare)
 
@@ -644,7 +648,9 @@ class TestLongTermCareFlow(SimpleTestCase):
         # Review regression: the LTC ask-for-more-info early return clobbered
         # an already-computed Medicare verdict back to False.
         _, _, medicare, _, missing, _ = is_eligible(
-            **self._ltc_answers(assets_total=None, home_owner=None, living_situation=None)
+            **self._ltc_answers(
+                assets_total=None, home_owner=None, living_situation=None
+            )
         )
         self.assertTrue(medicare)
         self.assertTrue(len(missing) > 0)
@@ -686,9 +692,7 @@ class TestLongTermCareFlow(SimpleTestCase):
         self.assertTrue(eligible_2025)
 
     def test_income_over_ltc_cap_suggests_miller_trust(self):
-        _, _, _, alts, _, _ = is_eligible(
-            **self._ltc_answers(monthly_income=3500.0)
-        )
+        _, _, _, alts, _, _ = is_eligible(**self._ltc_answers(monthly_income=3500.0))
         self.assertTrue(any("Miller trust" in a for a in alts))
 
 
@@ -922,8 +926,12 @@ class TestSpendDownSuggestion(SimpleTestCase):
     def test_not_suggested_in_a_state_without_the_program(self):
         *_, alts, _, _ = is_eligible(
             **_answers(
-                state="tx", age=70, monthly_income=3000, on_medicare=True,
-                assets_total=50000, years_worked=40,
+                state="tx",
+                age=70,
+                monthly_income=3000,
+                on_medicare=True,
+                assets_total=50000,
+                years_worked=40,
             )
         )
         for alt in alts:
@@ -932,8 +940,12 @@ class TestSpendDownSuggestion(SimpleTestCase):
     def test_suggested_in_a_state_with_the_program(self):
         *_, alts, _, _ = is_eligible(
             **_answers(
-                state="ca", age=70, monthly_income=3000, on_medicare=True,
-                assets_total=50000, years_worked=40,
+                state="ca",
+                age=70,
+                monthly_income=3000,
+                on_medicare=True,
+                assets_total=50000,
+                years_worked=40,
             )
         )
         self.assertTrue(
@@ -1003,8 +1015,11 @@ class TestDisabledButNotOnSsdi(SimpleTestCase):
         # ssdi_length question is asked, so don't conclude anything yet.
         *_, missing, _ = is_eligible(
             **_answers(
-                age=66, receiving_ssdi=True, on_medicare=False,
-                years_worked=5, assets_total=500,
+                age=66,
+                receiving_ssdi=True,
+                on_medicare=False,
+                years_worked=5,
+                assets_total=500,
             )
         )
         self.assertIn("How many months have you been receiving SSDI?", missing)
@@ -1066,8 +1081,12 @@ class TestAssetTestIsSkippedWhenIrrelevant(SimpleTestCase):
         # Texas has no expansion pathway, so the asset test genuinely applies.
         *_, missing, _ = is_eligible(
             **_answers(
-                state="tx", age=40, receiving_ssdi=True, ssdi_length=6,
-                on_medicare=False, avg_monthly_qualifying_hours_last_3mo=100,
+                state="tx",
+                age=40,
+                receiving_ssdi=True,
+                ssdi_length=6,
+                on_medicare=False,
+                avg_monthly_qualifying_hours_last_3mo=100,
             )
         )
         self.assertTrue(any("assets" in q.lower() for q in missing))
@@ -1122,7 +1141,9 @@ class TestLongTermCareReasonIsRecognized(SimpleTestCase):
 
     def test_an_ordinary_application_is_not_treated_as_long_term_care(self):
         self.assertEqual(_normalize_applying_reason("standard"), "standard")
-        self.assertEqual(_normalize_applying_reason("applying for medicaid"), "standard")
+        self.assertEqual(
+            _normalize_applying_reason("applying for medicaid"), "standard"
+        )
         self.assertEqual(_normalize_applying_reason(None), "standard")
 
 
@@ -1168,12 +1189,17 @@ class TestTargetYear(SimpleTestCase):
         _, _, _, _, missing, _ = is_eligible(**_answers(target_year=2028))
         self.assertTrue(any("2028" in q for q in missing))
 
-    def test_a_target_year_before_the_work_requirement_skips_the_hours_question(self):
-        _, eligible_target, _, _, missing, _ = is_eligible(
-            **_answers(target_year=BASE_ELIGIBILITY_YEAR)
+    def test_a_year_below_the_published_table_clamps_up_to_it(self):
+        # We can't score a year the published table doesn't cover, so a
+        # request for one is answered for the table's year instead.
+        #
+        # A consequence worth stating: while the table year and
+        # WORK_REQUIREMENT_FIRST_YEAR coincide, NO reachable target year is
+        # free of the work overlay -- the clamp lands exactly on the year the
+        # requirement starts.
+        self.assertEqual(
+            resolve_target_year(BASE_ELIGIBILITY_YEAR - 1), BASE_ELIGIBILITY_YEAR
         )
-        self.assertFalse(any("qualifying hours" in q for q in missing))
-        self.assertTrue(eligible_target)
 
     def test_a_later_target_year_still_applies_the_work_overlay(self):
         _, eligible_target, _, _, missing, _ = is_eligible(**_answers(target_year=2030))
@@ -1201,8 +1227,9 @@ class TestTargetYear(SimpleTestCase):
         # a number we were guessing, and -- because it only ran for a year the
         # user NAMED -- gave the same person two answers for the same
         # calendar year depending on how they asked.
+        # 138% of the 2026 one-person guideline ($15,960) is $1,835.40/mo.
         just_over = dict(
-            monthly_income=1810.0,
+            monthly_income=1850.0,
             avg_monthly_qualifying_hours_last_3mo=100,
         )
         for target_year in (None, 2026, 2030):
@@ -1252,17 +1279,34 @@ class TestTargetYear(SimpleTestCase):
         self.assertGreater(len(years), 1)
         self.assertEqual(years[0], current)
 
-    def test_the_timeline_renders_a_year_over_year_change(self):
-        # No qualifying hours: probably eligible under the pre-work-requirement
-        # rules, probably not once the requirement applies. That flip is the
-        # point of the timeline.
-        timeline = eligibility_timeline(
-            **_answers(target_year=BASE_ELIGIBILITY_YEAR)
-        )
-        verdicts = dict(timeline)
+    def test_a_year_needing_work_hours_comes_back_unsettled_not_denied(self):
+        # No qualifying hours supplied. is_eligible reports False for those
+        # years because it CANNOT score them yet -- the questions ride
+        # alongside. A caller that keeps only the boolean turns "we don't
+        # know" into "you may not be eligible", a denial nobody computed.
+        timeline = eligibility_timeline(**_answers(target_year=2030))
 
-        self.assertTrue(verdicts[BASE_ELIGIBILITY_YEAR])
-        self.assertFalse(verdicts[WORK_REQUIREMENT_FIRST_YEAR])
+        overlay_rows = [
+            row for row in timeline if row[0] >= WORK_REQUIREMENT_FIRST_YEAR
+        ]
+        self.assertTrue(overlay_rows)
+        for year, probably_eligible, still_needed in overlay_rows:
+            with self.subTest(year=year):
+                self.assertFalse(probably_eligible)
+                self.assertTrue(
+                    any("qualifying hours" in q for q in still_needed),
+                    f"{year} reported a verdict it could not have computed",
+                )
+
+    def test_supplying_the_hours_settles_those_years(self):
+        timeline = eligibility_timeline(
+            **_answers(target_year=2030, avg_monthly_qualifying_hours_last_3mo=100)
+        )
+
+        for year, probably_eligible, still_needed in timeline:
+            with self.subTest(year=year):
+                self.assertEqual(still_needed, [])
+                self.assertTrue(probably_eligible)
 
     def test_the_timeline_holds_steady_when_nothing_changes(self):
         timeline = eligibility_timeline(
@@ -1270,15 +1314,16 @@ class TestTargetYear(SimpleTestCase):
         )
 
         self.assertGreater(len(timeline), 1)
-        self.assertTrue(all(probably_eligible for _, probably_eligible in timeline))
+        self.assertTrue(all(probably_eligible for _, probably_eligible, _ in timeline))
+        self.assertTrue(all(not still_needed for _, _, still_needed in timeline))
         self.assertEqual(timeline[0][0], current_eligibility_year())
 
     def test_a_named_year_matches_the_default_path_for_that_year(self):
-        # The regression that motivated dropping the projection: $1,810/mo in
-        # CA read "may not be eligible" on the default 2026 path and "could be
-        # eligible" when the user typed "what about 2026?".
+        # The regression that motivated dropping the projection: an income in
+        # CA read "may not be eligible" on the default path and "could be
+        # eligible" when the user typed the year out.
         common = dict(
-            monthly_income=1810.0,
+            monthly_income=1850.0,
             avg_monthly_qualifying_hours_last_3mo=100,
         )
         default_path = is_eligible(**_answers(**common))

--- a/tests/sync/test_medicaid_eligibility_api.py
+++ b/tests/sync/test_medicaid_eligibility_api.py
@@ -11,9 +11,13 @@ never going to be asked (the pre-2026-08 stall bugs).
 from django.test import SimpleTestCase
 
 from fighthealthinsurance.medicaid_api import (
+    BASE_ELIGIBILITY_YEAR,
+    DEFAULT_TARGET_YEAR,
+    MAX_TARGET_YEAR,
     _normalize_applying_reason,
     get_medicaid_info,
     is_eligible,
+    resolve_target_year,
     summarize_eligibility_inputs,
 )
 
@@ -1114,3 +1118,80 @@ class TestLongTermCareReasonIsRecognized(SimpleTestCase):
         self.assertEqual(_normalize_applying_reason("standard"), "standard")
         self.assertEqual(_normalize_applying_reason("applying for medicaid"), "standard")
         self.assertEqual(_normalize_applying_reason(None), "standard")
+
+
+class TestTargetYear(SimpleTestCase):
+    """The caller picks which year the second verdict covers.
+
+    "Will I still qualify in 2028?" is one of the most common Medicaid
+    questions, and it used to be unanswerable: the checker only ever scored
+    2026 and the year in the wording was a constant.
+    """
+
+    def test_default_target_year_is_unchanged(self):
+        self.assertEqual(resolve_target_year(None), DEFAULT_TARGET_YEAR)
+
+    def test_a_year_the_user_named_is_used(self):
+        self.assertEqual(resolve_target_year("2028"), 2028)
+        self.assertEqual(resolve_target_year("what about 2029?"), 2029)
+
+    def test_two_digit_years_are_read_as_this_century(self):
+        self.assertEqual(resolve_target_year(27), 2027)
+
+    def test_years_we_cannot_model_are_clamped(self):
+        self.assertEqual(resolve_target_year(1998), BASE_ELIGIBILITY_YEAR)
+        self.assertEqual(resolve_target_year(2199), MAX_TARGET_YEAR)
+
+    def test_an_unreadable_year_falls_back_to_the_default(self):
+        self.assertEqual(resolve_target_year("sometime soon"), DEFAULT_TARGET_YEAR)
+
+    def test_work_hours_question_names_the_requested_year(self):
+        _, _, _, _, missing, _ = is_eligible(**_answers(target_year=2028))
+        self.assertTrue(any("2028" in q for q in missing))
+
+    def test_a_target_year_before_the_work_requirement_skips_the_hours_question(self):
+        _, eligible_target, _, _, missing, _ = is_eligible(
+            **_answers(target_year=BASE_ELIGIBILITY_YEAR)
+        )
+        self.assertFalse(any("qualifying hours" in q for q in missing))
+        self.assertTrue(eligible_target)
+
+    def test_a_later_target_year_still_applies_the_work_overlay(self):
+        _, eligible_target, _, _, missing, _ = is_eligible(**_answers(target_year=2030))
+        self.assertFalse(eligible_target)
+        self.assertTrue(any("qualifying hours" in q for q in missing))
+
+        _, eligible_with_hours, _, _, _, _ = is_eligible(
+            **_answers(target_year=2030, avg_monthly_qualifying_hours_last_3mo=100)
+        )
+        self.assertTrue(eligible_with_hours)
+
+    def test_target_year_is_echoed_back_normalized(self):
+        summary = summarize_eligibility_inputs({"state": "ca", "target_year": "2027"})
+        self.assertEqual(summary["recorded"]["target_year"], 2027)
+        self.assertNotIn("target_year", summary["unrecognized"])
+
+    def test_an_unreadable_target_year_is_reported(self):
+        summary = summarize_eligibility_inputs({"target_year": "whenever"})
+        self.assertIn("target_year", summary["unreadable"])
+
+    def test_later_year_thresholds_are_inflated(self):
+        # Right above the 138% FPL line today (1 person, $15,650/yr base):
+        # the same income clears an inflated later-year threshold, which is
+        # what makes asking about a future year worth anything.
+        just_over = dict(
+            monthly_income=1810.0,
+            avg_monthly_qualifying_hours_last_3mo=100,
+        )
+        eligible_base, eligible_target, _, _, _, _ = is_eligible(
+            **_answers(target_year=2030, **just_over)
+        )
+        self.assertFalse(eligible_base)
+        self.assertTrue(eligible_target)
+
+    def test_the_year_neutral_work_exemption_spelling_is_accepted(self):
+        _, eligible_target, _, _, missing, _ = is_eligible(
+            **_answers(work_req_exempt=True)
+        )
+        self.assertTrue(eligible_target)
+        self.assertFalse(any("qualifying hours" in q for q in missing))

--- a/tests/sync/test_medicaid_eligibility_api.py
+++ b/tests/sync/test_medicaid_eligibility_api.py
@@ -17,8 +17,10 @@ from fighthealthinsurance.medicaid_api import (
     _normalize_applying_reason,
     get_medicaid_info,
     is_eligible,
+    eligibility_timeline,
     resolve_target_year,
     summarize_eligibility_inputs,
+    timeline_years,
 )
 
 
@@ -1211,6 +1213,35 @@ class TestTargetYear(SimpleTestCase):
                 )
                 self.assertFalse(eligible_base)
                 self.assertFalse(eligible_target)
+
+    def test_the_timeline_always_includes_the_year_the_answer_can_change(self):
+        # Showing only "today" and "the year you asked about" hid the
+        # transition: someone asking about 2029 saw 2025 and 2029 and never
+        # learned the switch happens in 2026.
+        self.assertEqual(timeline_years(None), [BASE_ELIGIBILITY_YEAR, 2026])
+        self.assertEqual(timeline_years(2029), [BASE_ELIGIBILITY_YEAR, 2026, 2029])
+
+    def test_the_timeline_is_never_a_single_year(self):
+        # A base-year-only request still has to show what happens next.
+        self.assertEqual(
+            timeline_years(BASE_ELIGIBILITY_YEAR), [BASE_ELIGIBILITY_YEAR, 2026]
+        )
+
+    def test_the_timeline_renders_a_year_over_year_change(self):
+        # No qualifying hours: probably eligible today, probably not once the
+        # work requirement applies. That flip is the point of the timeline.
+        timeline = eligibility_timeline(**_answers(target_year=2029))
+
+        self.assertEqual(
+            timeline, [(BASE_ELIGIBILITY_YEAR, True), (2026, False), (2029, False)]
+        )
+
+    def test_the_timeline_holds_steady_when_nothing_changes(self):
+        timeline = eligibility_timeline(
+            **_answers(avg_monthly_qualifying_hours_last_3mo=100)
+        )
+
+        self.assertEqual(timeline, [(BASE_ELIGIBILITY_YEAR, True), (2026, True)])
 
     def test_a_named_year_matches_the_default_path_for_that_year(self):
         # The regression that motivated dropping the projection: $1,810/mo in

--- a/tests/sync/test_medicaid_eligibility_api.py
+++ b/tests/sync/test_medicaid_eligibility_api.py
@@ -19,7 +19,6 @@ from fighthealthinsurance.medicaid_api import (
     is_eligible,
     resolve_target_year,
     summarize_eligibility_inputs,
-    target_year_requested,
 )
 
 
@@ -625,27 +624,17 @@ class TestLongTermCareFlow(SimpleTestCase):
         self.assertTrue(eligible_2026)
         self.assertFalse(any("hours" in q for q in missing))
 
-    def test_ltc_income_between_year_caps_keeps_requested_year_eligibility(self):
-        # Review regression: the work overlay's not-eligible-2025 clamp
-        # discarded the LTC branch's own target-year result. $3,050/month is
-        # over the $3,000 base-year cap but under the cap projected forward
-        # to the year the user asked about.
-        eligible_base, eligible_target, _, _, _, _ = is_eligible(
-            **self._ltc_answers(monthly_income=3050.0, target_year=2026)
-        )
-        self.assertFalse(eligible_base)
-        self.assertTrue(eligible_target)
-
-    def test_ltc_income_over_the_cap_does_not_flip_on_the_default_path(self):
-        # Nobody asked about a future year here, so the only thing separating
-        # the two verdicts should be the work requirement. Projecting the
-        # income cap forward anyway turned a guessed 3% bump into "not
-        # eligible now, eligible next year" for someone on the line.
-        eligible_base, eligible_target, _, _, _, _ = is_eligible(
-            **self._ltc_answers(monthly_income=3050.0)
-        )
-        self.assertFalse(eligible_base)
-        self.assertFalse(eligible_target)
+    def test_ltc_income_over_the_cap_fails_both_years(self):
+        # The LTC cap is not projected forward either, so $3,050/month against
+        # the $3,000 cap fails whichever year is asked about. It used to clear
+        # an inflated cap and report "not eligible now, eligible next year".
+        for kwargs in ({}, {"target_year": 2026}, {"target_year": 2030}):
+            with self.subTest(**kwargs):
+                eligible_base, eligible_target, _, _, _, _ = is_eligible(
+                    **self._ltc_answers(monthly_income=3050.0, **kwargs)
+                )
+                self.assertFalse(eligible_base)
+                self.assertFalse(eligible_target)
 
     def test_ltc_missing_info_return_preserves_medicare_verdict(self):
         # Review regression: the LTC ask-for-more-info early return clobbered
@@ -1161,11 +1150,11 @@ class TestTargetYear(SimpleTestCase):
         # asking about a year it very much applies to. No readable year
         # means the default, not a wrong one.
         self.assertEqual(resolve_target_year("in 3 years"), DEFAULT_TARGET_YEAR)
-        self.assertEqual(resolve_target_year("for the next 5 years"), DEFAULT_TARGET_YEAR)
-        self.assertFalse(target_year_requested("in 3 years"))
+        self.assertEqual(
+            resolve_target_year("for the next 5 years"), DEFAULT_TARGET_YEAR
+        )
 
     def test_a_real_two_digit_year_still_works(self):
-        self.assertTrue(target_year_requested("28"))
         self.assertEqual(resolve_target_year("28"), 2028)
 
     def test_an_unreadable_year_falls_back_to_the_default(self):
@@ -1201,32 +1190,40 @@ class TestTargetYear(SimpleTestCase):
         summary = summarize_eligibility_inputs({"target_year": "whenever"})
         self.assertIn("target_year", summary["unreadable"])
 
-    def test_later_year_thresholds_are_inflated(self):
-        # Right above the 138% FPL line today (1 person, $15,650/yr base):
-        # the same income clears an inflated later-year threshold, which is
-        # what makes asking about a future year worth anything.
+    def test_income_thresholds_are_never_projected_forward(self):
+        # Just above the 138% FPL line (1 person, $15,650/yr): the answer must
+        # not change with the year. Rolling the table up ~3%/year while
+        # leaving income fixed biased everyone toward "more eligible later" on
+        # a number we were guessing, and -- because it only ran for a year the
+        # user NAMED -- gave the same person two answers for the same
+        # calendar year depending on how they asked.
         just_over = dict(
             monthly_income=1810.0,
             avg_monthly_qualifying_hours_last_3mo=100,
         )
-        eligible_base, eligible_target, _, _, _, _ = is_eligible(
-            **_answers(target_year=2030, **just_over)
-        )
-        self.assertFalse(eligible_base)
-        self.assertTrue(eligible_target)
+        for target_year in (None, 2026, 2030):
+            overrides = dict(just_over)
+            if target_year is not None:
+                overrides["target_year"] = target_year
+            with self.subTest(target_year=target_year):
+                eligible_base, eligible_target, _, _, _, _ = is_eligible(
+                    **_answers(**overrides)
+                )
+                self.assertFalse(eligible_base)
+                self.assertFalse(eligible_target)
 
-    def test_the_default_path_does_not_inflate_income_thresholds(self):
-        # Same income as test_later_year_thresholds_are_inflated, but nobody
-        # asked about a future year. Rolling the table forward anyway turned
-        # our own 3% guess into "not eligible now, eligible next year".
-        eligible_base, eligible_target, _, _, _, _ = is_eligible(
-            **_answers(
-                monthly_income=1810.0,
-                avg_monthly_qualifying_hours_last_3mo=100,
-            )
+    def test_a_named_year_matches_the_default_path_for_that_year(self):
+        # The regression that motivated dropping the projection: $1,810/mo in
+        # CA read "may not be eligible" on the default 2026 path and "could be
+        # eligible" when the user typed "what about 2026?".
+        common = dict(
+            monthly_income=1810.0,
+            avg_monthly_qualifying_hours_last_3mo=100,
         )
-        self.assertFalse(eligible_base)
-        self.assertFalse(eligible_target)
+        default_path = is_eligible(**_answers(**common))
+        named_year = is_eligible(**_answers(target_year=2026, **common))
+
+        self.assertEqual(default_path[:2], named_year[:2])
 
     def test_the_year_neutral_work_exemption_spelling_is_accepted(self):
         _, eligible_target, _, _, missing, _ = is_eligible(

--- a/tests/sync/test_medicaid_eligibility_api.py
+++ b/tests/sync/test_medicaid_eligibility_api.py
@@ -15,6 +15,7 @@ from fighthealthinsurance.medicaid_api import (
     DEFAULT_TARGET_YEAR,
     MAX_TARGET_YEAR,
     WORK_REQUIREMENT_FIRST_YEAR,
+    WORK_REQUIREMENT_UNIVERSAL_YEAR,
     _normalize_applying_reason,
     current_eligibility_year,
     get_medicaid_info,
@@ -59,22 +60,28 @@ class TestExpansionAdultFlow(SimpleTestCase):
         self.assertTrue(eligible_2025 or len(missing) > 0)
 
     def test_2026_requires_work_hours_question(self):
-        _, eligible_2026, _, _, missing, _ = is_eligible(**_answers())
-        self.assertFalse(eligible_2026)
+        _, eligible_target, _, _, missing, _ = is_eligible(**_answers())
+        self.assertFalse(eligible_target)
         self.assertTrue(any("qualifying hours" in q for q in missing))
 
     def test_2026_eligible_with_sufficient_hours(self):
-        _, eligible_2026, _, _, missing, _ = is_eligible(
-            **_answers(avg_weekly_qualifying_hours_last_3mo=25.0)
+        _, eligible_target, _, _, missing, _ = is_eligible(
+            **_answers(
+                target_year=WORK_REQUIREMENT_UNIVERSAL_YEAR,
+                avg_weekly_qualifying_hours_last_3mo=25.0,
+            )
         )
-        self.assertTrue(eligible_2026)
+        self.assertTrue(eligible_target)
         self.assertEqual(missing, [])
 
-    def test_2026_not_eligible_with_insufficient_hours(self):
-        _, eligible_2026, _, alts, _, _ = is_eligible(
-            **_answers(avg_weekly_qualifying_hours_last_3mo=10.0)
+    def test_not_eligible_with_insufficient_hours(self):
+        _, eligible_target, _, alts, _, _ = is_eligible(
+            **_answers(
+                target_year=WORK_REQUIREMENT_UNIVERSAL_YEAR,
+                avg_weekly_qualifying_hours_last_3mo=10.0,
+            )
         )
-        self.assertFalse(eligible_2026)
+        self.assertFalse(eligible_target)
         self.assertTrue(any("80" in a for a in alts))
 
     def test_massachusetts_is_an_expansion_state(self):
@@ -116,7 +123,7 @@ class TestExpansionAdultFlow(SimpleTestCase):
         # Review regression: answering yes to SSDI routed 19-64 adults into
         # the asset-tested ABD branch only; SSDI receipt does not bar the
         # MAGI expansion pathway (income-only, up to 138% FPL).
-        eligible_2025, eligible_2026, _, _, _, _ = is_eligible(
+        eligible_2025, eligible_target, _, _, _, _ = is_eligible(
             **_answers(
                 state="co",
                 monthly_income=1500.0,
@@ -127,21 +134,27 @@ class TestExpansionAdultFlow(SimpleTestCase):
             )
         )
         self.assertTrue(eligible_2025)
-        self.assertTrue(eligible_2026)
+        self.assertTrue(eligible_target)
 
-    def test_monthly_hours_below_threshold_is_not_eligible_2026(self):
+    def test_monthly_hours_below_threshold_is_not_eligible(self):
         # Review regression: the tool asks for hours per MONTH but only a
         # per-week kwarg existed, inviting a 4x unit error.
-        _, eligible_2026, _, _, _, _ = is_eligible(
-            **_answers(avg_monthly_qualifying_hours_last_3mo=60.0)
+        _, eligible_target, _, _, _, _ = is_eligible(
+            **_answers(
+                target_year=WORK_REQUIREMENT_UNIVERSAL_YEAR,
+                avg_monthly_qualifying_hours_last_3mo=60.0,
+            )
         )
-        self.assertFalse(eligible_2026)
+        self.assertFalse(eligible_target)
 
-    def test_monthly_hours_above_threshold_is_eligible_2026(self):
-        _, eligible_2026, _, _, _, _ = is_eligible(
-            **_answers(avg_monthly_qualifying_hours_last_3mo=90.0)
+    def test_monthly_hours_above_threshold_is_eligible(self):
+        _, eligible_target, _, _, _, _ = is_eligible(
+            **_answers(
+                target_year=WORK_REQUIREMENT_UNIVERSAL_YEAR,
+                avg_monthly_qualifying_hours_last_3mo=90.0,
+            )
         )
-        self.assertTrue(eligible_2026)
+        self.assertTrue(eligible_target)
 
     def test_weekly_hours_list_agrees_with_weekly_average(self):
         # Review regression: the scalar path used a 13-week quarter while the
@@ -149,10 +162,16 @@ class TestExpansionAdultFlow(SimpleTestCase):
         # got opposite verdicts depending on which kwarg the model filled --
         # and the user with detailed records got the harsher answer.
         _, from_average, _, _, _, _ = is_eligible(
-            **_answers(avg_weekly_qualifying_hours_last_3mo=19.5)
+            **_answers(
+                target_year=WORK_REQUIREMENT_UNIVERSAL_YEAR,
+                avg_weekly_qualifying_hours_last_3mo=19.5,
+            )
         )
         _, from_list, _, _, _, _ = is_eligible(
-            **_answers(qualifying_hours_weekly_last_12=[19.5] * 12)
+            **_answers(
+                target_year=WORK_REQUIREMENT_UNIVERSAL_YEAR,
+                qualifying_hours_weekly_last_12=[19.5] * 12,
+            )
         )
         self.assertEqual(from_average, from_list)
 
@@ -160,33 +179,42 @@ class TestExpansionAdultFlow(SimpleTestCase):
         # Review finding: averaging the whole window and repeating it let
         # [60]*4 + [0]*8 -- two genuinely empty months -- pass a rule that
         # requires each month to reach 80 hours.
-        _, eligible_2026, _, _, _, _ = is_eligible(
-            **_answers(qualifying_hours_weekly_last_12=[60.0] * 4 + [0.0] * 8)
+        _, eligible_target, _, _, _, _ = is_eligible(
+            **_answers(
+                target_year=WORK_REQUIREMENT_UNIVERSAL_YEAR,
+                qualifying_hours_weekly_last_12=[60.0] * 4 + [0.0] * 8,
+            )
         )
-        self.assertFalse(eligible_2026)
+        self.assertFalse(eligible_target)
 
     def test_weekly_hours_list_does_not_drop_extra_weeks(self):
         # Bucketing by index silently discarded anything past the 12th entry.
-        _, eligible_2026, _, _, _, _ = is_eligible(
-            **_answers(qualifying_hours_weekly_last_12=[0.0] * 4 + [10.0] * 12)
+        _, eligible_target, _, _, _, _ = is_eligible(
+            **_answers(
+                target_year=WORK_REQUIREMENT_UNIVERSAL_YEAR,
+                qualifying_hours_weekly_last_12=[0.0] * 4 + [10.0] * 12,
+            )
         )
-        self.assertFalse(eligible_2026)
+        self.assertFalse(eligible_target)
 
     def test_weekly_hours_use_thirteen_week_quarter(self):
         # Review regression: 4-weeks-per-month undercounted real months by
         # ~8%. 19 hrs/week is ~82.3 hrs per calendar month, which meets 80.
-        _, eligible_2026, _, _, _, _ = is_eligible(
-            **_answers(avg_weekly_qualifying_hours_last_3mo=19.0)
+        _, eligible_target, _, _, _, _ = is_eligible(
+            **_answers(
+                target_year=WORK_REQUIREMENT_UNIVERSAL_YEAR,
+                avg_weekly_qualifying_hours_last_3mo=19.0,
+            )
         )
-        self.assertTrue(eligible_2026)
+        self.assertTrue(eligible_target)
 
     def test_esrd_patient_exempt_from_work_requirement(self):
         # Review regression: ESRD/ALS (medically frail) were subjected to the
         # 2026 work-hours demand.
-        _, eligible_2026, _, _, missing, _ = is_eligible(
+        _, eligible_target, _, _, missing, _ = is_eligible(
             **_answers(esrd=True, on_medicare=False, assets_total=500.0)
         )
-        self.assertTrue(eligible_2026)
+        self.assertTrue(eligible_target)
         self.assertFalse(any("hours" in q for q in missing))
 
 
@@ -256,10 +284,10 @@ class TestQuestionFlow(SimpleTestCase):
     def test_string_false_work_exemption_is_not_treated_as_exempt(self):
         # Review regression: work_req_exempt_2026="false" was truthy and
         # skipped the work-hours questions entirely.
-        _, eligible_2026, _, _, missing, _ = is_eligible(
+        _, eligible_target, _, _, missing, _ = is_eligible(
             **_answers(work_req_exempt_2026="false")
         )
-        self.assertFalse(eligible_2026)
+        self.assertFalse(eligible_target)
         self.assertTrue(any("hours" in q for q in missing))
 
     def test_home_equity_question_asked_only_once(self):
@@ -578,7 +606,7 @@ class TestMedicarePathways(SimpleTestCase):
         # Review regression: receiving_ssdi=False silently discarded
         # disabled=True, dropping the disability pathway and its work
         # exemption.
-        eligible_2025, eligible_2026, _, _, _, _ = is_eligible(
+        eligible_2025, eligible_target, _, _, _, _ = is_eligible(
             **_answers(
                 state="tx",
                 monthly_income=800.0,
@@ -590,7 +618,7 @@ class TestMedicarePathways(SimpleTestCase):
             )
         )
         self.assertTrue(eligible_2025)
-        self.assertTrue(eligible_2026)
+        self.assertTrue(eligible_target)
 
 
 class TestLongTermCareFlow(SimpleTestCase):
@@ -619,17 +647,17 @@ class TestLongTermCareFlow(SimpleTestCase):
     def test_eligible_ltc_applicant_is_exempt_from_2026_work_overlay(self):
         # Split from the asset test: 2026 exemption is a distinct rule
         # (LTC applicants are medically frail, never asked for work hours).
-        _, eligible_2026, _, _, missing, _ = is_eligible(**self._ltc_answers())
-        self.assertTrue(eligible_2026)
+        _, eligible_target, _, _, missing, _ = is_eligible(**self._ltc_answers())
+        self.assertTrue(eligible_target)
         self.assertFalse(any("hours" in q for q in missing))
 
     def test_under_65_ltc_applicant_not_asked_for_work_hours(self):
         # Review regression: a 55-year-old permanent nursing-home resident
         # was subjected to the 80-hours-per-month work requirement.
-        _, eligible_2026, _, _, missing, _ = is_eligible(
+        _, eligible_target, _, _, missing, _ = is_eligible(
             **self._ltc_answers(age=55, on_medicare=False)
         )
-        self.assertTrue(eligible_2026)
+        self.assertTrue(eligible_target)
         self.assertFalse(any("hours" in q for q in missing))
 
     def test_ltc_income_over_the_cap_fails_both_years(self):
@@ -658,20 +686,20 @@ class TestLongTermCareFlow(SimpleTestCase):
     def test_child_ltc_applicant_keeps_2026_exemption(self):
         # Review regression: the overlay's LTC bypass keyed on applying_reason,
         # but children are matched earlier in the category chain, so the LTC
-        # branch never ran and eligible_2026 kept its False initializer --
+        # branch never ran and eligible_target kept its False initializer --
         # telling a 10-year-old in a nursing home they may lose coverage in
         # 2026 for not working 80 hours a month, with no question left.
-        _, eligible_2026, _, _, missing, _ = is_eligible(
+        _, eligible_target, _, _, missing, _ = is_eligible(
             **self._ltc_answers(age=10, on_medicare=False, children_in_household=1)
         )
-        self.assertTrue(eligible_2026)
+        self.assertTrue(eligible_target)
         self.assertEqual(missing, [])
 
     def test_pregnant_ltc_applicant_keeps_2026_exemption(self):
-        _, eligible_2026, _, _, _, _ = is_eligible(
+        _, eligible_target, _, _, _, _ = is_eligible(
             **self._ltc_answers(age=30, pregnant=True, on_medicare=False)
         )
-        self.assertTrue(eligible_2026)
+        self.assertTrue(eligible_target)
 
     def test_living_situation_does_not_block_the_determination(self):
         # It gated the whole LTC verdict but nothing ever read it, costing
@@ -703,7 +731,7 @@ class TestAbdPathway(SimpleTestCase):
         # Review finding: medically-needy is a spend-down PATHWAY, not an
         # income waiver -- treating it as one reported a $120k/yr earner in
         # New York as "probably eligible" in both years.
-        eligible_2025, eligible_2026, _, _, _, _ = is_eligible(
+        eligible_2025, eligible_target, _, _, _, _ = is_eligible(
             **_answers(
                 state="ny",
                 age=70,
@@ -713,7 +741,7 @@ class TestAbdPathway(SimpleTestCase):
             )
         )
         self.assertFalse(eligible_2025)
-        self.assertFalse(eligible_2026)
+        self.assertFalse(eligible_target)
 
     def test_medically_needy_state_still_suggests_spend_down(self):
         _, _, _, alts, _, _ = is_eligible(
@@ -1259,14 +1287,18 @@ class TestTargetYear(SimpleTestCase):
         # as that year is still ahead of them.
         current = current_eligibility_year()
         far = current + 3
+        milestones = sorted(
+            {
+                year
+                for year in (
+                    WORK_REQUIREMENT_FIRST_YEAR,
+                    WORK_REQUIREMENT_UNIVERSAL_YEAR,
+                )
+                if year > current
+            }
+        )
 
-        if WORK_REQUIREMENT_FIRST_YEAR > current:
-            self.assertEqual(
-                timeline_years(far), [current, WORK_REQUIREMENT_FIRST_YEAR, far]
-            )
-        else:
-            # The transition has arrived; there is no future change to flag.
-            self.assertEqual(timeline_years(far), [current, far])
+        self.assertEqual(timeline_years(far), sorted({current, *milestones, far}))
 
     def test_the_timeline_is_never_a_single_year(self):
         # "Will this still be true next year?" is the question people are
@@ -1287,15 +1319,15 @@ class TestTargetYear(SimpleTestCase):
         timeline = eligibility_timeline(**_answers(target_year=2030))
 
         overlay_rows = [
-            row for row in timeline if row[0] >= WORK_REQUIREMENT_FIRST_YEAR
+            row for row in timeline if row.year >= WORK_REQUIREMENT_FIRST_YEAR
         ]
         self.assertTrue(overlay_rows)
-        for year, probably_eligible, still_needed in overlay_rows:
-            with self.subTest(year=year):
-                self.assertFalse(probably_eligible)
+        for row in overlay_rows:
+            with self.subTest(year=row.year):
+                self.assertFalse(row.probably_eligible)
                 self.assertTrue(
-                    any("qualifying hours" in q for q in still_needed),
-                    f"{year} reported a verdict it could not have computed",
+                    any("qualifying hours" in q for q in row.still_needed),
+                    f"{row.year} reported a verdict it could not have computed",
                 )
 
     def test_supplying_the_hours_settles_those_years(self):
@@ -1303,10 +1335,45 @@ class TestTargetYear(SimpleTestCase):
             **_answers(target_year=2030, avg_monthly_qualifying_hours_last_3mo=100)
         )
 
-        for year, probably_eligible, still_needed in timeline:
-            with self.subTest(year=year):
-                self.assertEqual(still_needed, [])
-                self.assertTrue(probably_eligible)
+        for row in timeline:
+            with self.subTest(year=row.year):
+                self.assertEqual(row.still_needed, [])
+                self.assertTrue(row.probably_eligible)
+                self.assertFalse(row.work_requirement_conditional)
+
+    def test_a_shortfall_before_the_universal_year_is_conditional_not_a_denial(self):
+        # The requirement reaches the states that went early and nowhere else
+        # yet, and we don't track which. Reporting "may not be eligible" for a
+        # rule most states haven't adopted can stop someone applying at all.
+        timeline = eligibility_timeline(
+            **_answers(
+                target_year=WORK_REQUIREMENT_UNIVERSAL_YEAR,
+                avg_monthly_qualifying_hours_last_3mo=10,
+            )
+        )
+        by_year = {row.year: row for row in timeline}
+
+        transition = by_year.get(WORK_REQUIREMENT_FIRST_YEAR)
+        if transition is not None:
+            self.assertTrue(transition.probably_eligible)
+            self.assertTrue(transition.work_requirement_conditional)
+
+        # ...and from the universal year it is a real verdict again.
+        universal = by_year[WORK_REQUIREMENT_UNIVERSAL_YEAR]
+        self.assertFalse(universal.probably_eligible)
+        self.assertFalse(universal.work_requirement_conditional)
+
+    def test_a_shortfall_still_earns_the_coaching_in_the_transition_window(self):
+        # The verdict stays positive there, but someone under 80 hours still
+        # needs to hear what is coming.
+        _, _, _, alts, _, _ = is_eligible(
+            **_answers(
+                target_year=WORK_REQUIREMENT_FIRST_YEAR,
+                avg_monthly_qualifying_hours_last_3mo=10,
+            )
+        )
+
+        self.assertTrue(any("80" in a for a in alts))
 
     def test_the_timeline_holds_steady_when_nothing_changes(self):
         timeline = eligibility_timeline(
@@ -1314,9 +1381,9 @@ class TestTargetYear(SimpleTestCase):
         )
 
         self.assertGreater(len(timeline), 1)
-        self.assertTrue(all(probably_eligible for _, probably_eligible, _ in timeline))
-        self.assertTrue(all(not still_needed for _, _, still_needed in timeline))
-        self.assertEqual(timeline[0][0], current_eligibility_year())
+        self.assertTrue(all(row.probably_eligible for row in timeline))
+        self.assertTrue(all(not row.still_needed for row in timeline))
+        self.assertEqual(timeline[0].year, current_eligibility_year())
 
     def test_a_named_year_matches_the_default_path_for_that_year(self):
         # The regression that motivated dropping the projection: an income in

--- a/tests/sync/test_medicaid_eligibility_api.py
+++ b/tests/sync/test_medicaid_eligibility_api.py
@@ -14,7 +14,9 @@ from fighthealthinsurance.medicaid_api import (
     BASE_ELIGIBILITY_YEAR,
     DEFAULT_TARGET_YEAR,
     MAX_TARGET_YEAR,
+    WORK_REQUIREMENT_FIRST_YEAR,
     _normalize_applying_reason,
+    current_eligibility_year,
     get_medicaid_info,
     is_eligible,
     eligibility_timeline,
@@ -1214,34 +1216,62 @@ class TestTargetYear(SimpleTestCase):
                 self.assertFalse(eligible_base)
                 self.assertFalse(eligible_target)
 
+    def test_the_timeline_starts_at_the_current_year_not_the_fpl_table_year(self):
+        # The FPL table's year is the year we SCORE against; it stops being
+        # "today" the moment the calendar passes it. Anchoring the timeline
+        # there printed a verdict row for a year that had already ended.
+        current = current_eligibility_year()
+
+        self.assertGreaterEqual(current, BASE_ELIGIBILITY_YEAR)
+        self.assertEqual(min(timeline_years(None)), current)
+
     def test_the_timeline_always_includes_the_year_the_answer_can_change(self):
-        # Showing only "today" and "the year you asked about" hid the
-        # transition: someone asking about 2029 saw 2025 and 2029 and never
-        # learned the switch happens in 2026.
-        self.assertEqual(timeline_years(None), [BASE_ELIGIBILITY_YEAR, 2026])
-        self.assertEqual(timeline_years(2029), [BASE_ELIGIBILITY_YEAR, 2026, 2029])
+        # Showing only "today" and "the year you asked about" hides the
+        # transition: someone asking about a far year should still learn that
+        # the switch happens when the work requirement starts -- for as long
+        # as that year is still ahead of them.
+        current = current_eligibility_year()
+        far = current + 3
+
+        if WORK_REQUIREMENT_FIRST_YEAR > current:
+            self.assertEqual(
+                timeline_years(far), [current, WORK_REQUIREMENT_FIRST_YEAR, far]
+            )
+        else:
+            # The transition has arrived; there is no future change to flag.
+            self.assertEqual(timeline_years(far), [current, far])
 
     def test_the_timeline_is_never_a_single_year(self):
-        # A base-year-only request still has to show what happens next.
-        self.assertEqual(
-            timeline_years(BASE_ELIGIBILITY_YEAR), [BASE_ELIGIBILITY_YEAR, 2026]
-        )
+        # "Will this still be true next year?" is the question people are
+        # actually asking, so it always gets an answer -- even when today and
+        # the year they asked about are the same year.
+        current = current_eligibility_year()
+
+        years = timeline_years(current)
+
+        self.assertGreater(len(years), 1)
+        self.assertEqual(years[0], current)
 
     def test_the_timeline_renders_a_year_over_year_change(self):
-        # No qualifying hours: probably eligible today, probably not once the
-        # work requirement applies. That flip is the point of the timeline.
-        timeline = eligibility_timeline(**_answers(target_year=2029))
-
-        self.assertEqual(
-            timeline, [(BASE_ELIGIBILITY_YEAR, True), (2026, False), (2029, False)]
+        # No qualifying hours: probably eligible under the pre-work-requirement
+        # rules, probably not once the requirement applies. That flip is the
+        # point of the timeline.
+        timeline = eligibility_timeline(
+            **_answers(target_year=BASE_ELIGIBILITY_YEAR)
         )
+        verdicts = dict(timeline)
+
+        self.assertTrue(verdicts[BASE_ELIGIBILITY_YEAR])
+        self.assertFalse(verdicts[WORK_REQUIREMENT_FIRST_YEAR])
 
     def test_the_timeline_holds_steady_when_nothing_changes(self):
         timeline = eligibility_timeline(
             **_answers(avg_monthly_qualifying_hours_last_3mo=100)
         )
 
-        self.assertEqual(timeline, [(BASE_ELIGIBILITY_YEAR, True), (2026, True)])
+        self.assertGreater(len(timeline), 1)
+        self.assertTrue(all(probably_eligible for _, probably_eligible in timeline))
+        self.assertEqual(timeline[0][0], current_eligibility_year())
 
     def test_a_named_year_matches_the_default_path_for_that_year(self):
         # The regression that motivated dropping the projection: $1,810/mo in

--- a/tests/sync/test_medicaid_eligibility_api.py
+++ b/tests/sync/test_medicaid_eligibility_api.py
@@ -19,6 +19,7 @@ from fighthealthinsurance.medicaid_api import (
     is_eligible,
     resolve_target_year,
     summarize_eligibility_inputs,
+    target_year_requested,
 )
 
 
@@ -624,15 +625,27 @@ class TestLongTermCareFlow(SimpleTestCase):
         self.assertTrue(eligible_2026)
         self.assertFalse(any("hours" in q for q in missing))
 
-    def test_ltc_income_between_year_caps_keeps_2026_eligibility(self):
+    def test_ltc_income_between_year_caps_keeps_requested_year_eligibility(self):
         # Review regression: the work overlay's not-eligible-2025 clamp
-        # discarded the LTC branch's own 2026 result. $3,050/month is over
-        # the $3,000 2025 cap but under the inflated 2026 cap.
-        eligible_2025, eligible_2026, _, _, _, _ = is_eligible(
+        # discarded the LTC branch's own target-year result. $3,050/month is
+        # over the $3,000 base-year cap but under the cap projected forward
+        # to the year the user asked about.
+        eligible_base, eligible_target, _, _, _, _ = is_eligible(
+            **self._ltc_answers(monthly_income=3050.0, target_year=2026)
+        )
+        self.assertFalse(eligible_base)
+        self.assertTrue(eligible_target)
+
+    def test_ltc_income_over_the_cap_does_not_flip_on_the_default_path(self):
+        # Nobody asked about a future year here, so the only thing separating
+        # the two verdicts should be the work requirement. Projecting the
+        # income cap forward anyway turned a guessed 3% bump into "not
+        # eligible now, eligible next year" for someone on the line.
+        eligible_base, eligible_target, _, _, _, _ = is_eligible(
             **self._ltc_answers(monthly_income=3050.0)
         )
-        self.assertFalse(eligible_2025)
-        self.assertTrue(eligible_2026)
+        self.assertFalse(eligible_base)
+        self.assertFalse(eligible_target)
 
     def test_ltc_missing_info_return_preserves_medicare_verdict(self):
         # Review regression: the LTC ask-for-more-info early return clobbered
@@ -1142,6 +1155,19 @@ class TestTargetYear(SimpleTestCase):
         self.assertEqual(resolve_target_year(1998), BASE_ELIGIBILITY_YEAR)
         self.assertEqual(resolve_target_year(2199), MAX_TARGET_YEAR)
 
+    def test_a_relative_phrase_is_not_read_as_a_two_digit_year(self):
+        # "in 3 years" used to parse as 2003, clamp to the base year, and
+        # silently switch the work-requirement overlay off for someone
+        # asking about a year it very much applies to. No readable year
+        # means the default, not a wrong one.
+        self.assertEqual(resolve_target_year("in 3 years"), DEFAULT_TARGET_YEAR)
+        self.assertEqual(resolve_target_year("for the next 5 years"), DEFAULT_TARGET_YEAR)
+        self.assertFalse(target_year_requested("in 3 years"))
+
+    def test_a_real_two_digit_year_still_works(self):
+        self.assertTrue(target_year_requested("28"))
+        self.assertEqual(resolve_target_year("28"), 2028)
+
     def test_an_unreadable_year_falls_back_to_the_default(self):
         self.assertEqual(resolve_target_year("sometime soon"), DEFAULT_TARGET_YEAR)
 
@@ -1188,6 +1214,19 @@ class TestTargetYear(SimpleTestCase):
         )
         self.assertFalse(eligible_base)
         self.assertTrue(eligible_target)
+
+    def test_the_default_path_does_not_inflate_income_thresholds(self):
+        # Same income as test_later_year_thresholds_are_inflated, but nobody
+        # asked about a future year. Rolling the table forward anyway turned
+        # our own 3% guess into "not eligible now, eligible next year".
+        eligible_base, eligible_target, _, _, _, _ = is_eligible(
+            **_answers(
+                monthly_income=1810.0,
+                avg_monthly_qualifying_hours_last_3mo=100,
+            )
+        )
+        self.assertFalse(eligible_base)
+        self.assertFalse(eligible_target)
 
     def test_the_year_neutral_work_exemption_spelling_is_accepted(self):
         _, eligible_target, _, _, missing, _ = is_eligible(

--- a/tests/sync/test_medicaid_gov_lookup.py
+++ b/tests/sync/test_medicaid_gov_lookup.py
@@ -1,0 +1,247 @@
+"""Tests for Medicaid.gov page lookup (curated pages + sitemap search)."""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from django.core.cache import cache
+from django.test import TestCase
+
+from fighthealthinsurance.chat.tools import MedicaidGovLookupTool
+from fighthealthinsurance.medicaid_gov_api import (
+    CURATED_SOURCES,
+    is_allowed_url,
+    resolve_curated_source,
+    search_medicaid_gov,
+    suggest_curated_sources,
+)
+
+
+class TestCuratedSources(TestCase):
+    """Named pages, so the model asks for "renew_info" not a 130-char URL."""
+
+    def test_national_renewal_page(self):
+        self.assertEqual(
+            resolve_curated_source("renew_info"),
+            "https://www.medicaid.gov/renew-info",
+        )
+
+    def test_per_state_renewal_page(self):
+        self.assertEqual(
+            resolve_curated_source("renew_info", "Iowa"),
+            "https://www.medicaid.gov/renew-info/ia/",
+        )
+
+    def test_state_program_names_resolve(self):
+        # The model shouldn't have to convert "Medi-Cal" to "ca" itself.
+        self.assertEqual(
+            resolve_curated_source("renew_info", "Medi-Cal"),
+            "https://www.medicaid.gov/renew-info/ca/",
+        )
+
+    def test_an_unreadable_state_falls_back_to_the_national_page(self):
+        # Better than guessing a slug that would 404.
+        self.assertEqual(
+            resolve_curated_source("renew_info", "Atlantis"),
+            "https://www.medicaid.gov/renew-info",
+        )
+
+    def test_a_state_on_a_page_without_state_variants_is_ignored(self):
+        self.assertEqual(
+            resolve_curated_source("eligibility_levels", "Iowa"),
+            CURATED_SOURCES["eligibility_levels"].url,
+        )
+
+    def test_hyphenated_and_cased_page_names_are_accepted(self):
+        self.assertEqual(
+            resolve_curated_source("Renew-Info"),
+            "https://www.medicaid.gov/renew-info",
+        )
+
+    def test_unknown_page_returns_none(self):
+        self.assertIsNone(resolve_curated_source("not_a_page"))
+        self.assertIsNone(resolve_curated_source(""))
+
+
+class TestAllowlist(TestCase):
+    """The tool must never become a general-purpose fetcher."""
+
+    def test_allowed_reference_hosts(self):
+        for url in (
+            "https://www.medicaid.gov/eligibility",
+            "https://www.coveredca.com/pdfs/FPL-chart.pdf",
+            "https://www.healthinsurance.org/glossary/federal-poverty-level/",
+        ):
+            with self.subTest(url=url):
+                self.assertTrue(is_allowed_url(url))
+
+    def test_other_hosts_are_refused(self):
+        self.assertFalse(is_allowed_url("https://evil.example.com/x"))
+        self.assertFalse(is_allowed_url("https://medicaid.gov.evil.example.com/x"))
+
+    def test_non_http_schemes_are_refused(self):
+        self.assertFalse(is_allowed_url("file:///etc/passwd"))
+        self.assertFalse(is_allowed_url(""))
+
+    def test_robots_disallowed_paths_are_refused(self):
+        # medicaid.gov's robots.txt asks crawlers to stay out of these.
+        for path in ("/search/content", "/admin/config", "/node/123", "/user/login"):
+            with self.subTest(path=path):
+                self.assertFalse(is_allowed_url(f"https://www.medicaid.gov{path}"))
+
+
+class TestCuratedSuggestions(TestCase):
+    """The sitemap carries no page titles, so phrasing needs its own routing."""
+
+    def test_renewal_phrasings_reach_the_renewal_hub(self):
+        for query in (
+            "renewal paperwork",
+            "my coverage is ending",
+            "I got disenrolled",
+            "redetermination notice",
+        ):
+            with self.subTest(query=query):
+                keys = [s.key for s in suggest_curated_sources(query)]
+                self.assertIn("renew_info", keys)
+
+    def test_income_phrasings_reach_the_eligibility_table(self):
+        keys = [s.key for s in suggest_curated_sources("what income limits apply")]
+        self.assertIn("eligibility_levels", keys)
+
+    def test_poverty_level_phrasings_reach_an_fpl_reference(self):
+        keys = [s.key for s in suggest_curated_sources("what is the federal poverty level")]
+        self.assertIn("fpl_glossary", keys)
+
+    def test_an_unrelated_question_suggests_nothing(self):
+        self.assertEqual(suggest_curated_sources("who won the world series"), [])
+
+
+class TestSitemapSearch(TestCase):
+    """Slug matching over the sitemap stands in for the site's own search.
+
+    medicaid.gov runs a credentialed Vertex AI Search widget and disallows
+    /search/ in robots.txt, so the sitemap is the sanctioned index.
+    """
+
+    SITEMAP = [
+        "https://www.medicaid.gov/renew-info",
+        "https://www.medicaid.gov/eligibility",
+        "https://www.medicaid.gov/medicaid/eligibility-policy",
+        "https://www.medicaid.gov/chip/state-program-information/chip-spa",
+    ]
+
+    def setUp(self):
+        cache.clear()
+        patcher = patch(
+            "fighthealthinsurance.medicaid_gov_api._fetch_sitemap_urls",
+            return_value=self.SITEMAP,
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_ranks_matching_pages(self):
+        results = search_medicaid_gov("eligibility policy")
+        self.assertTrue(results)
+        self.assertEqual(results[0][0], "https://www.medicaid.gov/medicaid/eligibility-policy")
+
+    def test_word_variants_match_slugs(self):
+        # "renewal" has to reach "/renew-info"; slugs and questions rarely
+        # agree on suffixes.
+        results = search_medicaid_gov("renewal")
+        self.assertEqual(results[0][0], "https://www.medicaid.gov/renew-info")
+
+    def test_generic_words_alone_match_nothing(self):
+        # Every slug contains "medicaid"; matching on it ranks the whole site.
+        self.assertEqual(search_medicaid_gov("medicaid"), [])
+
+    def test_empty_query_matches_nothing(self):
+        self.assertEqual(search_medicaid_gov(""), [])
+        self.assertEqual(search_medicaid_gov("  "), [])
+
+    def test_limit_is_respected(self):
+        self.assertLessEqual(len(search_medicaid_gov("eligibility", limit=1)), 1)
+
+
+def _run_tool(params_json, *, lookup_count=None, fetch_text="Official page text."):
+    """Execute one medicaid_gov_lookup call, returning the LLM-facing message."""
+    tool = MedicaidGovLookupTool(AsyncMock(), lookup_count=lookup_count)
+    call = f"**medicaid_gov_lookup {params_json}**"
+    match = tool.detect(call)
+    assert match is not None, f"pattern did not match {call}"
+
+    captured = {}
+
+    async def fake_llm(model_backends, message, *args, **kwargs):
+        captured["message"] = message
+        return ("ok", "")
+
+    tool.call_llm_callback = fake_llm
+
+    async def fake_fetch(url, **kwargs):
+        captured["url"] = url
+        return fetch_text, "html"
+
+    with patch.object(tool.fetcher, "fetch_and_extract_text", side_effect=fake_fetch):
+        _, context = asyncio.run(
+            tool.execute(
+                match,
+                call,
+                "",
+                model_backends=["backend"],
+                current_message_for_llm="When do I have to renew?",
+            )
+        )
+    return captured, context
+
+
+class TestMedicaidGovLookupTool(TestCase):
+    def setUp(self):
+        cache.clear()
+
+    def test_a_curated_page_is_fetched_and_handed_to_the_model(self):
+        captured, context = _run_tool('{"page": "renew_info", "state": "IA"}')
+
+        self.assertEqual(captured["url"], "https://www.medicaid.gov/renew-info/ia/")
+        self.assertIn("Official page text.", captured["message"])
+        self.assertIn("renew-info/ia", context)
+
+    def test_the_users_question_rides_along(self):
+        captured, _ = _run_tool('{"page": "renew_info"}')
+        self.assertIn("When do I have to renew?", captured["message"])
+
+    def test_an_off_allowlist_url_is_never_fetched(self):
+        captured, _ = _run_tool('{"url": "https://evil.example.com/x"}')
+        self.assertNotIn("url", captured)
+
+    def test_an_allowlisted_url_is_fetched(self):
+        captured, _ = _run_tool('{"url": "https://www.medicaid.gov/eligibility"}')
+        self.assertEqual(captured["url"], "https://www.medicaid.gov/eligibility")
+
+    def test_an_unknown_page_returns_the_menu_instead_of_failing_silently(self):
+        captured, context = _run_tool('{"page": "does_not_exist"}')
+
+        self.assertNotIn("url", captured)
+        self.assertIn("renew_info", context)
+        self.assertIn("eligibility_levels", context)
+
+    def test_the_session_cap_is_enforced(self):
+        from fighthealthinsurance.chat.tools.medicaid_gov_tool import (
+            MAX_LOOKUPS_PER_SESSION,
+        )
+
+        count = [MAX_LOOKUPS_PER_SESSION]
+        captured, _ = _run_tool('{"page": "renew_info"}', lookup_count=count)
+
+        self.assertNotIn("url", captured)
+
+    def test_malformed_json_is_ignored(self):
+        tool = MedicaidGovLookupTool(AsyncMock())
+        call = '**medicaid_gov_lookup {"page": }**'
+        match = tool.detect(call)
+        self.assertIsNotNone(match)
+        cleaned, context = asyncio.run(tool.execute(match, call, "seed"))
+        self.assertEqual(context, "seed")
+
+    def test_an_empty_page_is_not_passed_off_as_an_answer(self):
+        captured, context = _run_tool('{"page": "renew_info"}', fetch_text="   ")
+        self.assertNotIn("message", captured)
+        self.assertEqual(context, "")

--- a/tests/sync/test_medicaid_gov_lookup.py
+++ b/tests/sync/test_medicaid_gov_lookup.py
@@ -213,6 +213,32 @@ class TestSitemapParsing(TestCase):
         with self.assertRaises(ValueError):
             _parse_sitemap_xml(xml)
 
+    def test_a_utf16_declaration_is_refused(self):
+        # A document declares its own encoding and the parser honours it, so
+        # in UTF-16 the marker arrives as b"<\x00!\x00D\x00..." and sails
+        # past a plain byte search -- the guard looks like it holds while the
+        # document parses with its entities intact.
+        for encoding in ("utf-16", "utf-16-le", "utf-16-be"):
+            with self.subTest(encoding=encoding):
+                xml = (
+                    '<?xml version="1.0" encoding="UTF-16"?>'
+                    '<!DOCTYPE urlset [<!ENTITY v "renew-info">]>'
+                    "<urlset><url><loc>&v;</loc></url></urlset>"
+                ).encode(encoding)
+                with self.assertRaises(ValueError):
+                    _parse_sitemap_xml(xml)
+
+    def test_a_plain_utf16_sitemap_still_parses(self):
+        # The encoding itself isn't the problem -- only a declaration in it.
+        xml = (
+            '<?xml version="1.0" encoding="UTF-16"?>'
+            '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+            "<url><loc>https://www.medicaid.gov/renew-info</loc></url>"
+            "</urlset>"
+        ).encode("utf-16")
+
+        self.assertIsNotNone(_parse_sitemap_xml(xml))
+
     def test_an_oversized_document_is_refused(self):
         from fighthealthinsurance.medicaid_gov_api import _MAX_SITEMAP_BYTES
 

--- a/tests/sync/test_medicaid_gov_lookup.py
+++ b/tests/sync/test_medicaid_gov_lookup.py
@@ -116,7 +116,9 @@ class TestCuratedSuggestions(TestCase):
         self.assertIn("eligibility_levels", keys)
 
     def test_poverty_level_phrasings_reach_an_fpl_reference(self):
-        keys = [s.key for s in suggest_curated_sources("what is the federal poverty level")]
+        keys = [
+            s.key for s in suggest_curated_sources("what is the federal poverty level")
+        ]
         self.assertIn("fpl_glossary", keys)
 
     def test_an_unrelated_question_suggests_nothing(self):
@@ -149,7 +151,9 @@ class TestSitemapSearch(TestCase):
     def test_ranks_matching_pages(self):
         results = search_medicaid_gov("eligibility policy")
         self.assertTrue(results)
-        self.assertEqual(results[0][0], "https://www.medicaid.gov/medicaid/eligibility-policy")
+        self.assertEqual(
+            results[0][0], "https://www.medicaid.gov/medicaid/eligibility-policy"
+        )
 
     def test_word_variants_match_slugs(self):
         # "renewal" has to reach "/renew-info"; slugs and questions rarely
@@ -167,6 +171,10 @@ class TestSitemapSearch(TestCase):
 
     def test_limit_is_respected(self):
         self.assertLessEqual(len(search_medicaid_gov("eligibility", limit=1)), 1)
+
+    def test_a_zero_limit_returns_nothing(self):
+        # "at most N results" has to mean it at zero too.
+        self.assertEqual(search_medicaid_gov("eligibility", limit=0), [])
 
 
 class TestSitemapParsing(TestCase):
@@ -188,6 +196,19 @@ class TestSitemapParsing(TestCase):
             b'<?xml version="1.0"?>'
             b'<!DOCTYPE urlset [<!ENTITY lol "lol">]>'
             b"<urlset><url><loc>&lol;</loc></url></urlset>"
+        )
+        with self.assertRaises(ValueError):
+            _parse_sitemap_xml(xml)
+
+    def test_a_doctype_after_a_long_comment_is_still_refused(self):
+        # A fixed inspection window is a guard you can walk around with
+        # padding: a long enough leading comment pushes the declaration past
+        # any prefix scan.
+        xml = (
+            b'<?xml version="1.0"?>'
+            b"<!--" + b"x" * 4096 + b"-->"
+            b'<!DOCTYPE urlset [<!ENTITY v "renew-info">]>'
+            b"<urlset><url><loc>&v;</loc></url></urlset>"
         )
         with self.assertRaises(ValueError):
             _parse_sitemap_xml(xml)
@@ -232,9 +253,64 @@ class TestSitemapWalkBudget(TestCase):
             with patch.object(medicaid_gov_api.requests, "get", side_effect=fake_get):
                 urls = medicaid_gov_api._fetch_sitemap_urls()
 
-        # The index is fetched; the per-page walk never starts.
+        # No budget, no requests -- not even the index. A per-request timeout
+        # alone doesn't bound the walk: a request that starts a hair before
+        # the deadline still runs the full timeout past it.
+        self.assertEqual(responses, [])
+        self.assertEqual(urls, [])
+
+    def test_an_off_host_sitemap_entry_is_never_requested(self):
+        # Child sitemap URLs come out of remote XML. Without a host check a
+        # spoofed index turns one lookup into a request at whatever host it
+        # names.
+        from fighthealthinsurance import medicaid_gov_api
+
+        evil_index = (
+            b'<?xml version="1.0"?>'
+            b'<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+            b"<sitemap><loc>https://evil.example.com/sitemap-1.xml</loc></sitemap>"
+            b"</sitemapindex>"
+        )
+        responses = []
+
+        class _Response:
+            def __init__(self, content):
+                self.content = content
+
+            def raise_for_status(self):
+                return None
+
+        def fake_get(url, **kwargs):
+            responses.append(url)
+            return _Response(evil_index)
+
+        with patch.object(medicaid_gov_api.requests, "get", side_effect=fake_get):
+            urls = medicaid_gov_api._fetch_sitemap_urls()
+
         self.assertEqual(responses, [medicaid_gov_api.SITEMAP_INDEX_URL])
         self.assertEqual(urls, [])
+
+    def test_redirects_are_not_followed(self):
+        # The host check only means something if we choose what we connect
+        # to; a 302 would hand that choice back to whoever served the sitemap.
+        from fighthealthinsurance import medicaid_gov_api
+
+        seen = {}
+
+        class _Response:
+            content = self.INDEX
+
+            def raise_for_status(self):
+                return None
+
+        def fake_get(url, **kwargs):
+            seen.update(kwargs)
+            return _Response()
+
+        with patch.object(medicaid_gov_api.requests, "get", side_effect=fake_get):
+            medicaid_gov_api._fetch_sitemap_urls()
+
+        self.assertFalse(seen.get("allow_redirects", True))
 
 
 def _run_tool(params_json, *, lookup_count=None, fetch_text="Official page text."):

--- a/tests/sync/test_medicaid_gov_lookup.py
+++ b/tests/sync/test_medicaid_gov_lookup.py
@@ -9,6 +9,7 @@ from django.test import TestCase
 from fighthealthinsurance.chat.tools import MedicaidGovLookupTool
 from fighthealthinsurance.medicaid_gov_api import (
     CURATED_SOURCES,
+    _parse_sitemap_xml,
     is_allowed_url,
     resolve_curated_source,
     search_medicaid_gov,
@@ -81,6 +82,13 @@ class TestAllowlist(TestCase):
     def test_non_http_schemes_are_refused(self):
         self.assertFalse(is_allowed_url("file:///etc/passwd"))
         self.assertFalse(is_allowed_url(""))
+
+    def test_cleartext_http_is_refused(self):
+        # These pages are the authority we quote to people about their
+        # coverage; over cleartext anything on the path can rewrite the
+        # answer. Every curated source is https.
+        self.assertFalse(is_allowed_url("http://www.medicaid.gov/renew-info"))
+        self.assertTrue(is_allowed_url("https://www.medicaid.gov/renew-info"))
 
     def test_robots_disallowed_paths_are_refused(self):
         # medicaid.gov's robots.txt asks crawlers to stay out of these.
@@ -161,6 +169,74 @@ class TestSitemapSearch(TestCase):
         self.assertLessEqual(len(search_medicaid_gov("eligibility", limit=1)), 1)
 
 
+class TestSitemapParsing(TestCase):
+    """The sitemap is remote content we don't control, so parse it warily."""
+
+    def test_a_plain_sitemap_parses(self):
+        xml = (
+            b'<?xml version="1.0"?>'
+            b'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+            b"<url><loc>https://www.medicaid.gov/renew-info</loc></url>"
+            b"</urlset>"
+        )
+        self.assertIsNotNone(_parse_sitemap_xml(xml))
+
+    def test_a_doctype_declaration_is_refused(self):
+        # Sitemaps have no DTD, so one here is a mistake or an
+        # entity-expansion attempt.
+        xml = (
+            b'<?xml version="1.0"?>'
+            b'<!DOCTYPE urlset [<!ENTITY lol "lol">]>'
+            b"<urlset><url><loc>&lol;</loc></url></urlset>"
+        )
+        with self.assertRaises(ValueError):
+            _parse_sitemap_xml(xml)
+
+    def test_an_oversized_document_is_refused(self):
+        from fighthealthinsurance.medicaid_gov_api import _MAX_SITEMAP_BYTES
+
+        with self.assertRaises(ValueError):
+            _parse_sitemap_xml(b"<urlset/>" + b" " * (_MAX_SITEMAP_BYTES + 1))
+
+
+class TestSitemapWalkBudget(TestCase):
+    """A slow upstream should cost us the lookup, not the whole chat turn."""
+
+    INDEX = (
+        b'<?xml version="1.0"?>'
+        b'<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+        b"<sitemap><loc>https://www.medicaid.gov/sitemap-1.xml</loc></sitemap>"
+        b"</sitemapindex>"
+    )
+
+    def setUp(self):
+        cache.clear()
+
+    def test_the_walk_stops_once_the_budget_is_spent(self):
+        from fighthealthinsurance import medicaid_gov_api
+
+        responses = []
+
+        class _Response:
+            def __init__(self, content):
+                self.content = content
+
+            def raise_for_status(self):
+                return None
+
+        def fake_get(url, **kwargs):
+            responses.append(url)
+            return _Response(self.INDEX)
+
+        with patch.object(medicaid_gov_api, "_SITEMAP_TOTAL_BUDGET_SECONDS", 0):
+            with patch.object(medicaid_gov_api.requests, "get", side_effect=fake_get):
+                urls = medicaid_gov_api._fetch_sitemap_urls()
+
+        # The index is fetched; the per-page walk never starts.
+        self.assertEqual(responses, [medicaid_gov_api.SITEMAP_INDEX_URL])
+        self.assertEqual(urls, [])
+
+
 def _run_tool(params_json, *, lookup_count=None, fetch_text="Official page text."):
     """Execute one medicaid_gov_lookup call, returning the LLM-facing message."""
     tool = MedicaidGovLookupTool(AsyncMock(), lookup_count=lookup_count)
@@ -232,6 +308,33 @@ class TestMedicaidGovLookupTool(TestCase):
         captured, _ = _run_tool('{"page": "renew_info"}', lookup_count=count)
 
         self.assertNotIn("url", captured)
+
+    def test_a_capped_session_does_no_network_work_at_all(self):
+        # Resolving a {"query": ...} call walks the sitemap over the network.
+        # A session that has spent its allowance must not pay for a lookup it
+        # cannot use.
+        from fighthealthinsurance.chat.tools.medicaid_gov_tool import (
+            MAX_LOOKUPS_PER_SESSION,
+        )
+
+        with patch(
+            "fighthealthinsurance.medicaid_gov_api._fetch_sitemap_urls",
+            return_value=[],
+        ) as sitemap:
+            _run_tool(
+                '{"query": "eligibility policy"}',
+                lookup_count=[MAX_LOOKUPS_PER_SESSION],
+            )
+
+        sitemap.assert_not_called()
+
+    def test_a_failed_resolution_does_not_spend_the_budget(self):
+        # A bad page name is a recoverable mistake -- the model gets the menu
+        # back and can try again.
+        count = [0]
+        _run_tool('{"page": "does_not_exist"}', lookup_count=count)
+
+        self.assertEqual(count, [0])
 
     def test_malformed_json_is_ignored(self):
         tool = MedicaidGovLookupTool(AsyncMock())


### PR DESCRIPTION
## Summary

The eligibility checker used to score one year and hand back one boolean. It now takes a caller-specified target year, returns a verdict for every year worth showing, and refuses to state a verdict it did not compute. Alongside it, a new `medicaid_gov_lookup` tool reads official pages so answers can point at the source rather than at our estimate of it.

## Eligibility

**Caller-specified target years.** `is_eligible()` accepts `target_year`; "will I still qualify in 2028?" is answered for 2028. `resolve_target_year()` is shared by the checker and the chat tool so the year scored and the year labelled cannot disagree. Year parsing is lenient about format but not plausibility: "26" reads as 2026, out-of-range *years* clamp, but a value that cannot be a year (the `3` in "in 3 years") falls back to the default rather than being read as 2003 and clamped — which silently switched the work-requirement overlay off.

**Income thresholds are never projected forward.** An earlier revision rolled the FPL table up ~3%/year for future targets. That moved the threshold while leaving the person's income fixed, biasing every borderline case toward "more eligible later" on a guessed number — and because it only ran for a year the user *named*, the same person got two different answers for the same calendar year depending on how they asked. The published table now scores every year.

**The table is the published 2026 HHS guideline** ($15,960 for one person in the 48 contiguous states + DC, plus $5,680 per additional person). We were still on 2025's $15,650/$5,500. The limits only ever go up, so a stale table denies people who now qualify. `BASE_ELIGIBILITY_YEAR` names the table's year and moves with the dollar figures; `current_eligibility_year()` is what a user reads as "today". Conflating the two meant every answer was labelled "current (2025)" once the calendar passed it.

**A verdict for every year worth showing.** `eligibility_timeline()` returns a `YearVerdict` per year — today, the year the answer can change while that's still ahead, and whatever the user asked about — so a year-over-year change is rendered rather than left to be inferred from two sentences. Never a single row: "will this still be true next year?" gets an explicit answer.

**Two things that are not verdicts, and used to be reported as denials:**

- *Unscored years.* `is_eligible` returns `False` for both "scored, falls short" and "can't score until you answer" — an unanswered work-hours question sets the flag False on purpose, because the questions ride alongside it. Keeping only the boolean turned "we don't know" into "you may not be eligible". Rows now carry what each year still needs, render as NOT ESTABLISHED with those questions attached, and cannot trigger a change callout.
- *The work-requirement transition.* CMS (CMS-2454-IFC) requires states to implement no later than January 1, 2027; only a few went earlier, and we don't track which. `WORK_REQUIREMENT_UNIVERSAL_YEAR` (2027) joins `WORK_REQUIREMENT_FIRST_YEAR` (2026): hours are still asked for from 2026, but a shortfall in the window between them reads as conditional — "could be eligible on income, BUT under 80 hours, so it depends whether their state has started" — rather than as a verdict. From 2027 it is a real verdict again.

The reasoning behind that last choice is asymmetric harm: telling someone "you may not be eligible" for a rule their state hasn't adopted can stop them applying at all, which is the failure this product exists to undo. The opposite error costs them an application the state was going to decide on anyway. Per-state effective dates would beat both and are worth doing if a data source exists.

**Every answer arrives with the way to check it.** The caveats existed but sat in the preamble, where a model routinely drops them before writing the line that matters. Every branch — mid-interview, indeterminate, finished — now closes by telling the user to confirm with their state and offering to pull up the official pages. Negatives carry their own caveat inline, because a negative is the line someone acts on by *not applying*. The work-requirement note is gated on passing the income test, so an income denial no longer blames a rule that had nothing to do with it.

## Medicaid.gov lookup

`medicaid_gov_lookup` reads official pages: the renewal hub (with per-state variants), the Medicaid/CHIP/BHP income-eligibility table, and two federal-poverty-level references. Free-text queries resolve through curated aliases first, then a sitemap-backed search.

Not the site's own search box: medicaid.gov runs Google Vertex AI Search, which renders results client-side from a credentialed datastore with no public query endpoint, and `/search/` is `Disallow`ed in their robots.txt. The sitemap is the sanctioned index of the same pages.

Hardening, in the order it matters:

- Resolution runs off the event loop (plain asgiref `sync_to_async`, `thread_sensitive=False` — network work, no ORM, and the default would queue a cold sitemap walk against unrelated work on one shared thread). The per-session cap is checked *before* resolution, so a spent session does no network work.
- Child sitemap URLs come out of remote XML, so they are host-checked before any request and redirects are off — the host check only means something if we choose what we connect to.
- Sitemap documents are size-capped, and refused if they carry a `<!DOCTYPE`/`<!ENTITY` declaration. The scan covers the whole document in every encoding a document can declare for itself; a prefix scan in one encoding is a guard with two documented ways around it.
- https-only allowlist. The walk has a total wall-clock budget and every request gets `min(timeout, remaining)`; a per-request timeout alone doesn't bound a walk.

## Scoring and safety

`detect_eligibility_verdict()` catches definite eligibility claims the model states without the checker running. Hedging has to *scope* the claim to clear it: a trailing "confirm with your state" caveat (which the prompt requires on every eligibility answer) no longer launders a verdict, while a condition attached to it ("...if your income is under 138% FPL") still does. Forward-looking approvals and denials count; present and past tense deliberately do not, since in an insurance-denial product those usually restate the user's own history.

An invented verdict forfeits its model prior *plus* a fixed penalty. A fixed nudge alone could not work: one backend contributes both a truncated-history call (`quality**2//5`) and a full-history one (`quality**2//4`), and that intra-backend gap exceeds any constant worth using. The exemption is granted only once the checker has actually reached a verdict.

`count_tool_invocations()` counts distinct tools invoked, so a reply repeating one call five times can't out-bonus one calling two tools. `PUBMED_QUERY_REGEX` requires a colon, so prose like "I can run a pubmed query for you" is no longer a tool call.

## Elsewhere

`_general_purpose_only()` excludes appeal-only fine-tunes (fhi-legacy) from instruction-following paths (chat, entity extraction, QA) where they emit blank lines and stray digits; generation paths deliberately bypass it, and selection fails open when no general-purpose model exists.

Medicaid program aliases moved to `medicaid_names.py`, shared by the prompt and the safety filters. Generically-named ones (`STAR`, `Medical Assistance`) are excluded from verdict detection so ordinary English doesn't trip the penalty.

## Known follow-up

Both remote-XML parse sites (`medicaid_gov_api` and `pubmed_tools`) use stdlib `ElementTree`. Two rounds of encoding-shaped bypasses on the hand-rolled guard argue for migrating both to `defusedxml` — as its own change, since converting one of two sites leaves the codebase ambiguous about which parser is the safe one.

https://claude.ai/code/session_01MQWwj9LqRoXM2q27SgUr2f