### PR TITLE
Chat pipeline review fixes: 

### DIFF
--- a/docs/chat-pipeline.md
+++ b/docs/chat-pipeline.md
@@ -263,7 +263,7 @@ Three levels, in increasing detail:
    - `debug_llm_input` — the EXACT wrapped message, context summary,
      history counts, variants, state hint;
    - `debug_llm_result` — picked/runner-up models and scores, per-candidate
-     score log, closely_tied, alternate_offered, rejected repeats, current
+     score log, closely_tied, alternate_candidate, rejected repeats, current
      repeat-offender strikes, retry path, allow_repeated_reply, elapsed.
    The frontend logs both to the console AND renders them as a collapsed
    "🔧 Debug" panel under the assistant message they produced, so

--- a/fhi_users/audit.py
+++ b/fhi_users/audit.py
@@ -332,6 +332,26 @@ def get_user_agent(request: Union[HttpRequest, "DRFRequest"]) -> str:
     return str(ua)[:500] if ua else ""
 
 
+def _parse_ip_literal(ip_address: Optional[str]) -> Optional[str]:
+    """Validate a client-supplied address before it reaches the geo parser.
+
+    The callers derive this from X-Forwarded-For / X-Real-IP, which are
+    client-supplied and never validated upstream, so reject anything that is
+    not a literal IP address and bound the work an arbitrary header value can
+    cause. Returns the stripped literal, or None if it isn't one.
+    """
+    if not ip_address:
+        return None
+    candidate = str(ip_address).strip()
+    if len(candidate) > 45:  # longest possible IPv6 form
+        return None
+    try:
+        ipaddress.ip_address(candidate)
+    except ValueError:
+        return None
+    return candidate
+
+
 def get_asn_info(ip_address: Optional[str]) -> tuple[str, str]:
     """
     Get ASN information for an IP address.
@@ -345,14 +365,15 @@ def get_asn_info(ip_address: Optional[str]) -> tuple[str, str]:
     state guess; with the key unset this returns empty strings — the
     pre-geoip2fast behavior.
     """
-    if not ip_address:
+    candidate = _parse_ip_literal(ip_address)
+    if candidate is None:
         return ("", "")
 
     reader = _get_geo_reader()
     if reader is None:
         return ("", "")
     try:
-        result = reader.lookup(str(ip_address).strip())
+        result = reader.lookup(candidate)
         if result is None:
             return ("", "")
         # geoip2fast (1.2.x) exposes asn_name and asn_cidr but NO numeric
@@ -368,62 +389,27 @@ def get_asn_info(ip_address: Optional[str]) -> tuple[str, str]:
 
 # --- IP -> US state guess (for chat context, transient only) ---
 
-# 2-letter postal code -> full state name, used to normalize whatever the geo
-# database returns into the full name the chat/Medicaid tooling expects.
-_US_STATE_NAMES_BY_CODE = {
-    "AL": "Alabama",
-    "AK": "Alaska",
-    "AZ": "Arizona",
-    "AR": "Arkansas",
-    "CA": "California",
-    "CO": "Colorado",
-    "CT": "Connecticut",
-    "DE": "Delaware",
-    "DC": "District of Columbia",
-    "FL": "Florida",
-    "GA": "Georgia",
-    "HI": "Hawaii",
-    "ID": "Idaho",
-    "IL": "Illinois",
-    "IN": "Indiana",
-    "IA": "Iowa",
-    "KS": "Kansas",
-    "KY": "Kentucky",
-    "LA": "Louisiana",
-    "ME": "Maine",
-    "MD": "Maryland",
-    "MA": "Massachusetts",
-    "MI": "Michigan",
-    "MN": "Minnesota",
-    "MS": "Mississippi",
-    "MO": "Missouri",
-    "MT": "Montana",
-    "NE": "Nebraska",
-    "NV": "Nevada",
-    "NH": "New Hampshire",
-    "NJ": "New Jersey",
-    "NM": "New Mexico",
-    "NY": "New York",
-    "NC": "North Carolina",
-    "ND": "North Dakota",
-    "OH": "Ohio",
-    "OK": "Oklahoma",
-    "OR": "Oregon",
-    "PA": "Pennsylvania",
-    "RI": "Rhode Island",
-    "SC": "South Carolina",
-    "SD": "South Dakota",
-    "TN": "Tennessee",
-    "TX": "Texas",
-    "UT": "Utah",
-    "VT": "Vermont",
-    "VA": "Virginia",
-    "WA": "Washington",
-    "WV": "West Virginia",
-    "WI": "Wisconsin",
-    "WY": "Wyoming",
-}
-_US_STATE_NAMES = {name.lower(): name for name in _US_STATE_NAMES_BY_CODE.values()}
+# code -> full state name and lowercased-name -> canonical name, used to
+# normalize whatever the geo database returns into the full name the
+# chat/Medicaid tooling expects. Derived (lazily, on first lookup) from the
+# Medicaid tooling's canonical state map: this file used to carry a third
+# hand-typed 51-entry copy, which could silently drift from the map the
+# chat/Medicaid layer actually matches the hint against. The import happens
+# inside the helper because medicaid_api pulls in pandas, which must not
+# become an import-time dependency of this audit/middleware module.
+_us_state_tables: Optional[tuple[dict, dict]] = None
+
+
+def _get_us_state_tables() -> tuple[dict, dict]:
+    global _us_state_tables
+    if _us_state_tables is None:
+        from fighthealthinsurance.medicaid_api import _ABBR_TO_NAME
+
+        by_code = {code.upper(): name for code, name in _ABBR_TO_NAME.items()}
+        by_lower_name = {name.lower(): name for name in by_code.values()}
+        _us_state_tables = (by_code, by_lower_name)
+    return _us_state_tables
+
 
 # The configuration key that switches IP geo lookups on: path to a
 # geoip2fast CITY-level database (state guessing needs subdivision data,
@@ -582,9 +568,10 @@ def _normalize_state_guess(value: str) -> Optional[str]:
     # Some databases prefix subdivision codes with the country ("US-CA").
     if "-" in cleaned:
         cleaned = cleaned.rsplit("-", 1)[-1].strip()
+    by_code, by_lower_name = _get_us_state_tables()
     if len(cleaned) == 2:
-        return _US_STATE_NAMES_BY_CODE.get(cleaned.upper())
-    return _US_STATE_NAMES.get(cleaned.lower())
+        return by_code.get(cleaned.upper())
+    return by_lower_name.get(cleaned.lower())
 
 
 def guess_us_state(ip_address: Optional[str]) -> Optional[str]:
@@ -599,18 +586,8 @@ def guess_us_state(ip_address: Optional[str]) -> Optional[str]:
     a transient guess: present it to the model as unconfirmed and never
     persist it for anonymous users.
     """
-    if not ip_address:
-        return None
-    # The caller derives this from X-Forwarded-For / X-Real-IP, which are
-    # client-supplied and never validated upstream, so reject anything that
-    # is not a literal IP address before it reaches the third-party parser
-    # (and bound the work an arbitrary header value can cause).
-    candidate = str(ip_address).strip()
-    if len(candidate) > 45:  # longest possible IPv6 form
-        return None
-    try:
-        ipaddress.ip_address(candidate)
-    except ValueError:
+    candidate = _parse_ip_literal(ip_address)
+    if candidate is None:
         return None
     reader = _get_geo_reader()
     if reader is None:

--- a/fighthealthinsurance/chat/chat_persistence.py
+++ b/fighthealthinsurance/chat/chat_persistence.py
@@ -32,9 +32,18 @@ from loguru import logger
 # PriorAuthRequest pks are UUIDs, and `#\d+` silently missed every legacy
 # prior-auth note whose UUID starts with a hex letter -- rendering the
 # internal note as a user bubble and letting previews/titles pick it up.
+# Each kind gets its OWN id shape rather than a shared `#[0-9a-fA-F-]+`: a
+# loose hex-or-hyphen run also matched things we never generate ("Appeal
+# #deadbeef") and, without an end guard, matched a PREFIX of a longer id
+# ("Appeal #12f" via `#12`) -- both of which hide a user-authored message
+# from replay, REST previews and titles.
 _LEGACY_INTERNAL_NOTE_RE = re.compile(
     r"^(?:Linked this chat to|This chat is already linked to)\s+"
-    r"(?:Appeal|Prior Auth Request)\s+#[0-9a-fA-F-]+",
+    r"(?:Appeal\s+#[0-9]+"
+    r"|Prior Auth Request\s+#[0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}"
+    r"-[0-9a-fA-F]{12})"
+    # Nothing id-shaped may follow, or a partial match of a longer id counts.
+    r"(?![\w-])",
 )
 
 

--- a/fighthealthinsurance/chat/chat_persistence.py
+++ b/fighthealthinsurance/chat/chat_persistence.py
@@ -25,12 +25,16 @@ from loguru import logger
 
 # Legacy shape of the LLM-context-only link notes, from before they carried an
 # explicit `internal` flag. Deliberately anchored to the FULL generated shape
-# ("... Appeal #12", "... Prior Auth Request #3") rather than the bare prefix:
-# the prefix alone is text a user can type, and matching it hid their own
-# message from their own replay while every server-side view still had it.
+# ("... Appeal #12", "... Prior Auth Request #3f2a...") rather than the bare
+# prefix: the prefix alone is text a user can type, and matching it hid their
+# own message from their own replay while every server-side view still had it.
+# The id part must accept UUIDs, not just integers: Appeal pks are ints but
+# PriorAuthRequest pks are UUIDs, and `#\d+` silently missed every legacy
+# prior-auth note whose UUID starts with a hex letter -- rendering the
+# internal note as a user bubble and letting previews/titles pick it up.
 _LEGACY_INTERNAL_NOTE_RE = re.compile(
     r"^(?:Linked this chat to|This chat is already linked to)\s+"
-    r"(?:Appeal|Prior Auth Request)\s+#\d+",
+    r"(?:Appeal|Prior Auth Request)\s+#[0-9a-fA-F-]+",
 )
 
 
@@ -50,11 +54,25 @@ def is_internal_history_message(message: Dict[str, Any]) -> bool:
     return bool(_LEGACY_INTERNAL_NOTE_RE.match(content))
 
 
+def iter_visible_history(
+    history: Optional[List[Dict[str, Any]]],
+):
+    """Lazily yield history entries that are not LLM-context-only.
+
+    Prefer this in consumers that stop at the first match (chat previews,
+    titles): ``visible_history`` materializes a full filtered copy, which is
+    O(history) per chat just to find one message.
+    """
+    for m in history or []:
+        if not is_internal_history_message(m):
+            yield m
+
+
 def visible_history(
     history: Optional[List[Dict[str, Any]]],
 ) -> List[Dict[str, Any]]:
     """History with LLM-context-only messages removed."""
-    return [m for m in (history or []) if not is_internal_history_message(m)]
+    return list(iter_visible_history(history))
 
 
 def merge_new_messages(

--- a/fighthealthinsurance/chat/context_manager.py
+++ b/fighthealthinsurance/chat/context_manager.py
@@ -31,11 +31,17 @@ EARLIER_SUMMARY_LABEL = "Earlier conversation summary: "
 ADDITIONAL_CONTEXT_SEPARATOR = "\n\nAdditional context: "
 
 # Wrapper labels chat_interface adds when it hands two stored summaries to the
-# LLM. They must be recognized here so a stale summary block wrapped in them is
-# still stripped (and so a label left dangling by a strip is cleaned up).
+# LLM (exported so chat_interface builds its wrapper from the SAME strings this
+# module strips -- a wording tweak on one side silently broke the strip). They
+# must be recognized here so a stale summary block wrapped in them is still
+# stripped (and so a label left dangling by a strip is cleaned up), and they
+# BOUND a stale block: content after them is newer than the block and must
+# survive.
+PREVIOUS_SUMMARY_WRAPPER_LABEL = "Previous context summary:"
+MOST_RECENT_SUMMARY_WRAPPER_LABEL = "Most recent context summary:"
 _SUMMARY_WRAPPER_LABELS = (
-    "Previous context summary:",
-    "Most recent context summary:",
+    PREVIOUS_SUMMARY_WRAPPER_LABEL,
+    MOST_RECENT_SUMMARY_WRAPPER_LABEL,
 )
 
 
@@ -59,10 +65,26 @@ def strip_previous_summary_blocks(existing_summary: Optional[str]) -> Optional[s
     if index < 0:
         return existing_summary
     head = existing_summary[:index]
-    # Everything from the label onward is the stale summary, except any
-    # "Additional context:" tail it carried (which may itself nest more).
-    rest = existing_summary[index:].split(ADDITIONAL_CONTEXT_SEPARATOR, 1)
-    tail = strip_previous_summary_blocks(rest[1]) if len(rest) > 1 else None
+    # Everything from the label onward is the stale summary, up to whichever
+    # comes first of its "Additional context:" tail (which may itself nest
+    # more) or the next wrapper label. The wrapper labels introduce content
+    # NEWER than the stale block -- chat_interface's "Most recent context
+    # summary:" section carries the latest per-turn context -- so treating
+    # the whole remainder as stale whenever the block had no
+    # Additional-context tail silently discarded the newest summary.
+    block = existing_summary[index:]
+    cut: Optional[Tuple[int, int]] = None  # (boundary_pos, resume_pos)
+    sep_index = block.find(ADDITIONAL_CONTEXT_SEPARATOR)
+    if sep_index >= 0:
+        cut = (sep_index, sep_index + len(ADDITIONAL_CONTEXT_SEPARATOR))
+    for label in _SUMMARY_WRAPPER_LABELS:
+        label_index = block.find(label, len(EARLIER_SUMMARY_LABEL))
+        if label_index >= 0 and (cut is None or label_index < cut[0]):
+            # Resume after the label itself: the dangling-label cleanup
+            # below only handles labels at the END of a part, and the label
+            # describes the pairing we are dismantling anyway.
+            cut = (label_index, label_index + len(label))
+    tail = strip_previous_summary_blocks(block[cut[1] :]) if cut else None
     parts = []
     for part in (head, tail):
         if not part:

--- a/fighthealthinsurance/chat/llm_client.py
+++ b/fighthealthinsurance/chat/llm_client.py
@@ -34,6 +34,7 @@ from fighthealthinsurance.ml.response_similarity import (
     normalize_text,
     response_similarity,
     user_requested_repeat,
+    user_requested_transformation,
 )
 from fighthealthinsurance.utils import ensure_message_alternation
 
@@ -148,6 +149,17 @@ def find_repeated_reply(
         return None
     if is_canned_reply(response_text):
         return None
+    # A faithful transformation (proofread / fix the grammar / "now
+    # reformat it into three paragraphs") is SUPPOSED to read nearly the
+    # same as the text being transformed -- the user's pasted message OR
+    # our own previous reply, and normalize_text collapses exactly the
+    # differences a reformat introduces. So BOTH rungs stand down on
+    # transform requests: with only the echoes-the-user rung exempted,
+    # every faithful iterative edit of our last answer was still
+    # hard-rejected and the anti-repeat retry steered models AWAY from
+    # the requested output.
+    if current_message and user_requested_transformation(current_message):
+        return None
     if current_message and is_mostly_repeated(response_text, current_message):
         return "echoes_user_message"
     if not chat_history:
@@ -188,6 +200,15 @@ def compute_repetition_penalty(
         return 0.0
 
     if not chat_history and not current_message:
+        return 0.0
+
+    # Transform requests expect output that reads like existing text (the
+    # user's paste or our previous reply), so similarity is compliance, not
+    # looping. Without this the soft -400/-500 penalties made the compliant
+    # candidate lose to one that ignored the request even after the hard
+    # rung (find_repeated_reply) stood down -- content-quality deltas
+    # between candidates are only ~100 points.
+    if current_message and user_requested_transformation(current_message):
         return 0.0
 
     penalty = 0.0
@@ -373,7 +394,10 @@ def score_llm_response(
         if BAD_RESPONSE_PATTERNS.search(response_text):
             score -= 75
 
-        # Bonus for tool usage (search anywhere in response)
+        # Bonus for tool usage (search anywhere in response).
+        # count_tool_invocations applies TOOL_DETECT_FLAGS, which the
+        # ^...$-anchored patterns need -- a flag-less search only ever
+        # matched a tool call at the very start of the reply.
         score += 100 * tool_call_matches
 
         # Safety: Penalize false promises
@@ -416,8 +440,15 @@ def score_llm_response(
                 "Response asks for patient name, penalizing (known client-side)"
             )
 
-        # Penalize responses that repeat previous messages
-        if chat_history or current_message:
+        # Penalize responses that repeat previous messages -- unless the
+        # user explicitly asked for a repeat: every other rung of the
+        # ladder (hard rejection, self-heal, retry last-resort penalty) is
+        # exempted on those turns, and leaving this -400/-500 nudge in
+        # place made the compliant repeat lose to a candidate that ignored
+        # the user's request.
+        if (chat_history or current_message) and not user_requested_repeat(
+            current_message
+        ):
             score += compute_repetition_penalty(
                 response_text, chat_history or [], current_message
             )

--- a/fighthealthinsurance/chat/retry_handler.py
+++ b/fighthealthinsurance/chat/retry_handler.py
@@ -75,52 +75,69 @@ def create_simple_retry_scorer(
             _extract_document_names_from_history(chat_history) if chat_history else []
         )
     ]
+    # Invariant across the whole scoring pass (current_message is fixed at
+    # scorer creation), so evaluate the regex once instead of twice per
+    # candidate -- and keep the raw-message semantics in ONE place: the
+    # anti-repeat retry note itself contains "send it again", so any future
+    # call site handed a wrapped message would silently disarm the ladder.
+    repeat_requested = user_requested_repeat(current_message)
 
     def score_fn(
         result: Optional[Tuple[Optional[str], Optional[str]]],
         original_task: Awaitable,
     ) -> float:
-        score: float = call_scores.get(original_task, 0)
-
         if result is None:
             return float("-inf")
 
         response_text, context_part = result
 
-        if not response_text and not context_part:
+        # retry_llm_with_fallback can only deliver the winner's response
+        # text (it re-validates its length after selection and never
+        # consults the runner-up), so a candidate without usable text must
+        # lose to ANY deliverable answer regardless of its backend's base
+        # score. Adding the base score first let a high-quality backend's
+        # ("", context) tuple -- e.g. a reply that was only a panda context
+        # summary -- outrank a real fallback answer and collapse the whole
+        # retry to (None, None).
+        if not response_text or len(response_text.strip()) <= MIN_RESPONSE_LENGTH:
             return float("-inf")
 
-        # Bonus for having a response
-        if response_text and len(response_text) > MIN_RESPONSE_LENGTH:
-            score += 100
-            # Safety check
-            if detect_false_promises(response_text):
-                score -= 200
+        # Every candidate from here on has a deliverable response (the guard
+        # above), so the old flat "has a response" bonus was a constant
+        # offset and is gone.
+        score: float = call_scores.get(original_task, 0)
 
-            # Bonus for referencing an uploaded document by name
-            response_lower = response_text.lower()
-            for doc_name in doc_names_lower:
-                if doc_name in response_lower:
-                    score += 150
-                    break
+        # Safety check
+        if detect_false_promises(response_text):
+            score -= 200
 
-            # Always penalize asking for patient name — it's known client-side
-            if ASKS_FOR_PATIENT_NAME.search(response_text):
-                score -= 200
+        # Bonus for referencing an uploaded document by name
+        response_lower = response_text.lower()
+        for doc_name in doc_names_lower:
+            if doc_name in response_lower:
+                score += 150
+                break
 
-            # Penalize responses that repeat previous messages
-            if chat_history or current_message:
-                score += compute_repetition_penalty(
-                    response_text, chat_history or [], current_message
-                )
+        # Always penalize asking for patient name — it's known client-side
+        if ASKS_FOR_PATIENT_NAME.search(response_text):
+            score -= 200
 
-            # A retry candidate that still (nearly) repeats a recent reply
-            # loses to ANY non-repeating candidate, but stays deliverable
-            # as the absolute last resort (finite penalty, not -inf).
-            if not user_requested_repeat(current_message) and find_repeated_reply(
-                response_text, chat_history, current_message
-            ):
-                score += REPEAT_LAST_RESORT_PENALTY
+        # Penalize responses that repeat previous messages -- unless the
+        # user explicitly asked for a repeat, where the compliant candidate
+        # must not lose to one that ignores the request (mirrors the
+        # exemption on the last-resort penalty below).
+        if (chat_history or current_message) and not repeat_requested:
+            score += compute_repetition_penalty(
+                response_text, chat_history or [], current_message
+            )
+
+        # A retry candidate that still (nearly) repeats a recent reply loses
+        # to ANY non-repeating candidate, but stays deliverable as the
+        # absolute last resort (finite penalty, not -inf).
+        if not repeat_requested and find_repeated_reply(
+            response_text, chat_history, current_message
+        ):
+            score += REPEAT_LAST_RESORT_PENALTY
 
         # Small bonus for context
         if context_part and len(context_part) > MIN_RESPONSE_LENGTH:

--- a/fighthealthinsurance/chat/tools/medicaid_tool.py
+++ b/fighthealthinsurance/chat/tools/medicaid_tool.py
@@ -755,6 +755,16 @@ class MedicaidEligibilityTool(BaseTool):
         # Any year past the published table's was scored with that table's
         # limits, and we owe the user that fact.
         scored_beyond_the_table = any(row.year > BASE_ELIGIBILITY_YEAR for row in rows)
+        # One shared wording, like work_req_note above: every branch that
+        # reports a year-labeled verdict owes the same caveat, and two copies
+        # would drift.
+        beyond_the_table_note = (
+            "Note: newer income limits aren't published yet, so "
+            f"every year above used the {BASE_ELIGIBILITY_YEAR} published "
+            "limits -- what separates the years is the work "
+            "requirement, not the income test. Mention that if the "
+            "answer is close to the line."
+        )
 
         parts: List[str] = [
             "We're helping figure out if someone is likely eligible for "
@@ -855,6 +865,12 @@ class MedicaidEligibilityTool(BaseTool):
                     "they already look eligible under those — you can share "
                     "that result."
                 )
+                if scored_beyond_the_table:
+                    # A caller-named future year lands here today (rows is
+                    # the base/target pair whenever determination_made is
+                    # False), so a positive above can be labeled with a year
+                    # whose income limits are not published yet.
+                    parts.append(beyond_the_table_note)
             if medicare:
                 parts.append(
                     "We were able to check Medicare, and our data suggests "
@@ -998,13 +1014,7 @@ class MedicaidEligibilityTool(BaseTool):
                 # table scores both years, so the only thing separating them
                 # is the work requirement. Say that plainly rather than
                 # implying we modelled the later year's limits.
-                parts.append(
-                    "Note: newer income limits aren't published yet, so "
-                    f"every year above used the {BASE_ELIGIBILITY_YEAR} published "
-                    "limits -- what separates the years is the work "
-                    "requirement, not the income test. Mention that if the "
-                    "answer is close to the line."
-                )
+                parts.append(beyond_the_table_note)
 
             if medicare:
                 parts.append("Our data suggests they may be eligible for medicare.")

--- a/fighthealthinsurance/chat/tools/medicaid_tool.py
+++ b/fighthealthinsurance/chat/tools/medicaid_tool.py
@@ -129,13 +129,40 @@ class MedicaidInfoTool(BaseTool):
             await self.send_status_message("Processing Medicaid info lookup data...")
 
             # Import here to avoid circular imports
-            from fighthealthinsurance.medicaid_api import get_medicaid_info
+            from fighthealthinsurance.medicaid_api import (
+                MedicaidDataUnavailableError,
+                get_medicaid_info,
+            )
 
             # get_medicaid_info does blocking pandas/IO work (no ORM, so
             # plain sync_to_async is right; database_sync_to_async is
             # reserved for ORM-touching callables). Running it inline blocked
             # the event loop -- freezing every OTHER chat on this worker.
-            medicaid_info = await sync_to_async(get_medicaid_info)(medicaid_info_data)
+            try:
+                medicaid_info = await sync_to_async(get_medicaid_info)(
+                    medicaid_info_data
+                )
+            except MedicaidDataUnavailableError as unavailable:
+                # The state WAS understood -- what's missing is OUR data (a
+                # territory with no resources row, or the CSV is broken).
+                # Falling through to the None path below re-asked "Which
+                # state are you in?" forever against a user who had already
+                # answered, with no way to ever succeed.
+                logger.warning(f"Medicaid info unavailable: {unavailable}")
+                await self.send_status_message(
+                    f"No Medicaid contact data available for {unavailable.state}."
+                )
+                # Like the None branch below, this propagates as the
+                # assistant's reply, so it must read as something we'd say
+                # to the user.
+                return (
+                    f"I wasn't able to pull up the official Medicaid contact "
+                    f"information for {unavailable.state}. Your best bet is "
+                    f'to search for "{unavailable.state} Medicaid" to find '
+                    f"the official agency site, or dial 211 for local help "
+                    f"with applying.",
+                    context,
+                )
             logger.debug(
                 f"Got Medicaid info response: {medicaid_info[:200] if medicaid_info else 'None'}..."
             )
@@ -803,6 +830,30 @@ class MedicaidEligibilityTool(BaseTool):
                 "situation isn't something our checker can estimate and point "
                 "them at the next step below."
             )
+            # Sub-checks that DID complete with a firm positive are real
+            # answers -- e.g. only the 2026 work-hours answer or the
+            # Medicare-side years-worked answer was declined, while the
+            # 2025-rules check finished with a yes. Hiding those behind the
+            # blanket "no estimate" withheld a computed verdict from someone
+            # the checker did score (mirrors the "we were able to check
+            # Medicare" report below). Only positives: a False here means
+            # "not established", not "no".
+            established = [
+                label
+                for label, is_eligible_for_year in (
+                    ("current (2025)", eligible_2025),
+                    ("2026", eligible_2026),
+                )
+                if is_eligible_for_year
+            ]
+            if established:
+                parts.append(
+                    "We WERE able to check the "
+                    + " and ".join(established)
+                    + " Medicaid rules though, and based on what we have "
+                    "they already look eligible under those — you can share "
+                    "that result."
+                )
             if medicare:
                 parts.append(
                     "We were able to check Medicare, and our data suggests "

--- a/fighthealthinsurance/chat/tools/medicaid_tool.py
+++ b/fighthealthinsurance/chat/tools/medicaid_tool.py
@@ -831,25 +831,26 @@ class MedicaidEligibilityTool(BaseTool):
                 "them at the next step below."
             )
             # Sub-checks that DID complete with a firm positive are real
-            # answers -- e.g. only the 2026 work-hours answer or the
+            # answers -- e.g. only the work-hours answer or the
             # Medicare-side years-worked answer was declined, while the
-            # 2025-rules check finished with a yes. Hiding those behind the
-            # blanket "no estimate" withheld a computed verdict from someone
-            # the checker did score (mirrors the "we were able to check
-            # Medicare" report below). Only positives: a False here means
-            # "not established", not "no".
-            established = [
-                label
-                for label, is_eligible_for_year in (
-                    ("current (2025)", eligible_2025),
-                    ("2026", eligible_2026),
-                )
-                if is_eligible_for_year
+            # current-rules check finished with a yes. Hiding those behind
+            # the blanket "no estimate" withheld a computed verdict from
+            # someone the checker did score (mirrors the "we were able to
+            # check Medicare" report below). Only positives: a False here
+            # means "not established", not "no".
+            #
+            # Same labels and same positives-only rule as the missing-answers
+            # branch above: `timeline` is None whenever determination_made is
+            # False, so `rows` here is the base/target fallback pair.
+            established = ([base_label] if eligible_base else []) + [
+                str(row.year)
+                for row in rows
+                if row.year > current_year and row.probably_eligible
             ]
             if established:
                 parts.append(
                     "We WERE able to check the "
-                    + " and ".join(established)
+                    + ", ".join(established)
                     + " Medicaid rules though, and based on what we have "
                     "they already look eligible under those — you can share "
                     "that result."

--- a/fighthealthinsurance/chat/tools/patterns.py
+++ b/fighthealthinsurance/chat/tools/patterns.py
@@ -31,6 +31,12 @@ MEDICAID_INFO_REGEX = r"(?:\*\*)?medicaid_info\s*(\{[^}]*\})\s*(?:\*\*)?"
 
 # Medicaid eligibility tool - captures JSON parameters
 # Matches: medicaid_eligibility {JSON} or **medicaid_eligibility {JSON}**
+#
+# Deliberately no leading `.*?`: detection uses re.search, which already
+# scans from every position, so the prefix bought nothing for matching --
+# but under the DOTALL detect flags it made every scan of a NON-matching
+# reply quadratic, and made group(0)-based cleaning swallow the model's
+# prose before the call instead of just the call.
 MEDICAID_ELIGIBILITY_REGEX = r"(?:\*\*)?medicaid_eligibility\s*(\{[^}]*\})\s*(?:\*\*)?"
 
 # Create or update appeal tool - captures JSON with appeal data

--- a/fighthealthinsurance/chat_interface.py
+++ b/fighthealthinsurance/chat_interface.py
@@ -1417,6 +1417,13 @@ class ChatInterface:
             logger.debug(f"Models tried for failed chat {chat.id}: {primary_models}")
         finally:
             heartbeat_task.cancel()
+            # Backstop for the once-per-turn loop metric. The depth-0 exits
+            # inside _call_llm_with_actions record it themselves, but a tool
+            # handler raising -- or the turn budget above firing -- unwinds
+            # past them, losing the metric for a turn that DID reject
+            # repeats. The helper clears its own flag, so this no-ops
+            # whenever the turn already recorded.
+            self._record_turn_repeat_metric(0)
 
         if final_response_text:
             if should_store_summary(chat.summary_for_next_call, final_context_part):

--- a/fighthealthinsurance/chat_interface.py
+++ b/fighthealthinsurance/chat_interface.py
@@ -315,6 +315,20 @@ class ChatInterface:
             )
         return "; ".join(parts) if parts else None
 
+    def _record_turn_repeat_metric(self, depth: int) -> None:
+        """Record the once-per-turn loop-alerting metric for this turn.
+
+        Called at every depth-0 exit of _call_llm_with_actions, including the
+        no-response one: a turn where every candidate was rejected as a
+        repeat AND the retry delivered nothing is the loudest possible loop,
+        and skipping it there reported "loops never happen" in exactly that
+        case. Clears the accumulator so the two exits can't double-count.
+        """
+        if depth != 0 or not self._turn_saw_repeats:
+            return
+        self._turn_saw_repeats = False
+        record_chat_repeat("rejected_candidates")
+
     async def _call_llm_with_actions(
         self,
         model_backends: List[RemoteModelLike],
@@ -536,6 +550,10 @@ class ChatInterface:
 
         if not response_text:
             logger.debug("Got empty response from LLM")
+            # This exit is the WORST case for the loop metric -- every
+            # candidate rejected as a repeat and the retry delivering
+            # nothing -- so it must not be the one path that skips it.
+            self._record_turn_repeat_metric(depth)
             return None, None
 
         # Capture a presentable runner-up as a side-by-side alternate answer
@@ -752,8 +770,7 @@ class ChatInterface:
 
         # One count per turn, covering the primary pass AND every recursive
         # tool pass (each ORs into the accumulator above).
-        if depth == 0 and self._turn_saw_repeats:
-            record_chat_repeat("rejected_candidates")
+        self._record_turn_repeat_metric(depth)
 
         logger.debug(f"Return with context length {len(context) if context else 0}.")
         return response_text, context

--- a/fighthealthinsurance/chat_interface.py
+++ b/fighthealthinsurance/chat_interface.py
@@ -18,11 +18,11 @@ from fighthealthinsurance import settings
 from fighthealthinsurance.chat.chat_persistence import (
     apersist_chat_turn,
     apersist_microsite_context,
-    is_internal_history_message,
     visible_history,
 )
 from fighthealthinsurance.chat.context_manager import (
-    MISSING_CONTEXT_PREFIX,
+    MOST_RECENT_SUMMARY_WRAPPER_LABEL,
+    PREVIOUS_SUMMARY_WRAPPER_LABEL,
     background_generate_summary,
     bound_summary_context,
     make_placeholder,
@@ -37,6 +37,7 @@ from fighthealthinsurance.chat.llm_client import (
     find_repeated_reply,
     scores_closely_tied,
     user_requested_repeat,
+    user_requested_transformation,
 )
 from fighthealthinsurance.chat.message_preprocessor import (
     MessageVariant,
@@ -91,7 +92,7 @@ from fighthealthinsurance.models import (
     PolicyDocument,
     PriorAuthRequest,
 )
-from fighthealthinsurance.microsites import get_microsite
+from fighthealthinsurance.microsites import ATTRIBUTION_ONLY_SLUGS, get_microsite
 from fighthealthinsurance.prompt_templates import (
     DELETE_DATA_INSTRUCTION,
     get_intro_template,
@@ -185,6 +186,11 @@ class ChatInterface:
         # offered to the client as a side-by-side alternate when presentable
         # AND closely tied with the winner (see scores_closely_tied).
         self._candidate_alternate: Optional[str] = None
+        # Whether any pass of the turn in flight (the primary pass or a
+        # recursive tool pass) hard-rejected a repeated candidate. Reset by
+        # _call_llm_with_actions at depth 0, ORed into at every depth, and
+        # recorded as ONE loop-alerting metric hit per turn.
+        self._turn_saw_repeats: bool = False
         # Per-session strike counts for backends whose candidates were
         # hard-rejected as repeats (label -> count). Shared with the scorer,
         # which decays a striking backend's base score so a looping model
@@ -354,6 +360,14 @@ class ChatInterface:
         """
         if depth > 3:
             return None, None
+        if depth == 0:
+            # Turn-scoped accumulator (same pattern as _candidate_alternate:
+            # one turn in flight per instance). Recursive tool passes run
+            # this method with their own local rejection_stats, so counting
+            # per depth inflated the loop-alerting metric, and gating on
+            # depth==0 alone made it blind to repeats rejected only inside
+            # a tool's follow-up pass.
+            self._turn_saw_repeats = False
         chat = self.chat
         history = history_for_llm
 
@@ -366,13 +380,17 @@ class ChatInterface:
             else current_message_for_llm
         )
 
-        # Did the user explicitly ask for a repeat? Derived from the RAW
-        # message (scoring_message) BEFORE prompt wrapping -- the wrapped
+        # Did the user explicitly ask for a repeat -- or for a transformation
+        # (proofread / reformat), whose faithful output also legitimately
+        # resembles a recent message? Derived from the RAW message
+        # (scoring_message) BEFORE prompt wrapping -- the wrapped
         # current_message_for_llm contains system-injected text that itself
         # says "repeat", so testing it there would always match. Forwarded to
         # the backends so their per-backend self-heal loop doesn't fight the
         # user's request (the scorers make the same check independently).
-        allow_repeat = user_requested_repeat(scoring_message)
+        allow_repeat = user_requested_repeat(
+            scoring_message
+        ) or user_requested_transformation(scoring_message)
 
         # Build LLM calls using the extracted module. When message variants are
         # supplied (top-level user turn), fan out per variant and apply each
@@ -472,8 +490,10 @@ class ChatInterface:
         # "loops never happen" exactly when a backend started looping.
         saw_repeats = bool(rejection_stats.get("repeated_rejected"))
         if saw_repeats:
-            # Counted once per turn (the stat itself is per candidate).
-            record_chat_repeat("rejected_candidates")
+            # Counted once per turn (the stat itself is per candidate):
+            # accumulate here at every depth, recorded by depth 0 at the
+            # end of the turn -- see the accumulator's comment above.
+            self._turn_saw_repeats = True
             logger.info(
                 f"Chat {chat.id}: primary pass rejected "
                 f"{rejection_stats['repeated_rejected']} repeated "
@@ -582,7 +602,13 @@ class ChatInterface:
                         "runner_up_model": runner_up_model,
                         "runner_up_score": runner_up_score,
                         "closely_tied": closely_tied,
-                        "alternate_offered": bool(self._candidate_alternate),
+                        # "candidate", not "offered": this frame is sent
+                        # before tool processing and the delivery-time
+                        # presentability check, either of which can still
+                        # drop the alternate -- claiming "offered" here sent
+                        # debugging down the wrong path when no alternate
+                        # reached the client.
+                        "alternate_candidate": bool(self._candidate_alternate),
                         "candidate_count": len(calls),
                         "scored_candidates": scored_candidates,
                         "rejected_repeats": rejection_stats.get("repeated_rejected", 0),
@@ -724,6 +750,11 @@ class ChatInterface:
         if depth == 0 and response_text != response_before_tools:
             self._candidate_alternate = None
 
+        # One count per turn, covering the primary pass AND every recursive
+        # tool pass (each ORs into the accumulator above).
+        if depth == 0 and self._turn_saw_repeats:
+            record_chat_repeat("rejected_candidates")
+
         logger.debug(f"Return with context length {len(context) if context else 0}.")
         return response_text, context
 
@@ -819,7 +850,15 @@ class ChatInterface:
         is_new_chat = not bool(chat.chat_history)
 
         # Load microsite context on first interaction (before linking may return early)
-        if is_new_chat and chat.microsite_slug:
+        # Attribution-only slugs (e.g. the medicaid-eligibility funnel) are
+        # persisted for attribution but by design have no Microsite entry to
+        # load context from -- warning on them made every legitimate funnel
+        # visitor look like an invalid/attacker-supplied slug in the logs.
+        if (
+            is_new_chat
+            and chat.microsite_slug
+            and chat.microsite_slug not in ATTRIBUTION_ONLY_SLUGS
+        ):
             try:
                 microsite = get_microsite(chat.microsite_slug)
                 if microsite:
@@ -990,7 +1029,7 @@ class ChatInterface:
             # Transactional merge against the fresh row (see apersist_chat_turn).
             # The link note is context for the LLM, not something the user
             # typed: flag it internal so replays don't render it as a user
-            # bubble (see _is_internal_history_message).
+            # bubble (see chat_persistence.is_internal_history_message).
             self.chat = chat = await apersist_chat_turn(
                 chat,
                 new_messages=[
@@ -1028,9 +1067,13 @@ class ChatInterface:
             if len(chat.summary_for_next_call) > 1:
                 prev_summary = chat.summary_for_next_call[-2]
                 if prev_summary and str(prev_summary).strip():
+                    # Built from context_manager's exported labels: its
+                    # strip_previous_summary_blocks recognizes these exact
+                    # strings as block boundaries, so a wording tweak here
+                    # would silently break the strip.
                     current_llm_context = (
-                        f"Previous context summary:\n{prev_summary}\n\n"
-                        f"Most recent context summary:\n{current_llm_context}"
+                        f"{PREVIOUS_SUMMARY_WRAPPER_LABEL}\n{prev_summary}\n\n"
+                        f"{MOST_RECENT_SUMMARY_WRAPPER_LABEL}\n{current_llm_context}"
                     )
             # Bound the accreted context: summaries nest labels over long
             # chats ("Earlier conversation summary: ... Additional context:
@@ -1493,15 +1536,6 @@ class ChatInterface:
                 message_chars=len(user_message or ""),
             )
             await self.send_error_message(err_msg)
-
-    # Legacy prefixes of internal (LLM-context-only) user-role messages that
-    # predate the explicit "internal" flag; matched so old chats don't replay
-    # them either.
-    @classmethod
-    def _is_internal_history_message(cls, message: Dict[str, Any]) -> bool:
-        """Messages stored purely as LLM context (e.g. the appeal-linking
-        notes recorded with role=user) must not replay as user bubbles."""
-        return is_internal_history_message(message)
 
     async def replay_chat_history(self):
         """Sends the existing chat history to the client, minus internal

--- a/fighthealthinsurance/medicaid_api.py
+++ b/fighthealthinsurance/medicaid_api.py
@@ -2,7 +2,6 @@ import difflib
 import json
 import re
 from datetime import date
-from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, List, NamedTuple, Optional, Sequence, Tuple
 
@@ -12,6 +11,29 @@ from loguru import logger
 # Look for data/ next to the repo root
 DATA_DIR = Path(__file__).resolve().parent.parent / "data"
 DEFAULT_FILE = "medicaid_resources.csv"
+
+
+class MedicaidDataUnavailableError(Exception):
+    """The state WAS understood but no contact-info row could be produced.
+
+    Distinct from ``get_medicaid_info``'s ``None`` return, which means "we
+    could not tell which state was meant" and which the chat tool renders as
+    "Which state are you in?". Re-asking cannot fix a missing/unreadable CSV
+    or a territory with no resources row, so conflating the two looped the
+    tool on the state question against a user who had already answered it.
+    """
+
+    def __init__(self, state: str, reason: str) -> None:
+        self.state = state
+        self.reason = reason
+        # Pass the real init args to Exception so args round-trips: with a
+        # single formatted string there, unpickling re-called __init__(msg)
+        # and raised TypeError (missing 'reason') the moment this crossed a
+        # pickle boundary (Ray, multiprocessing, an enqueued log sink).
+        super().__init__(state, reason)
+
+    def __str__(self) -> str:
+        return f"No Medicaid resource data for {self.state}: {self.reason}"
 
 
 def _explode_scraped_faq(df: pd.DataFrame) -> pd.DataFrame:
@@ -581,44 +603,6 @@ _MEDICARE_QUESTION_FIELDS = frozenset(
         "ssdi_length",
         "esrd",
         "als",
-    }
-)
-
-# Every kwarg is_eligible reads. Anything else the model sends is silently
-# ignored today, which looks to the model like the answer was accepted -- so
-# summarize_eligibility_inputs reports the strays back to it.
-_KNOWN_ELIGIBILITY_FIELDS = frozenset(
-    {
-        "state",
-        "married",
-        "age",
-        "pregnant",
-        "receiving_ssdi",
-        "disabled",
-        "ssdi_length",
-        "on_medicare",
-        "veteran_or_spouse_of_veteran",
-        "living_situation",
-        "applying_reason",
-        "household_size",
-        "monthly_income",
-        "assets_total",
-        "home_owner",
-        "home_equity",
-        "children_in_household",
-        "als",
-        "esrd",
-        "years_worked",
-        "on_medicaid_past",
-        "work_req_exempt_2026",
-        # Same answer under a year-neutral name, since the target year is now
-        # the caller's choice; both spellings are accepted.
-        "work_req_exempt",
-        "target_year",
-        "qualifying_hours_weekly_last_12",
-        "avg_monthly_qualifying_hours_last_3mo",
-        "avg_weekly_qualifying_hours_last_3mo",
-        "total_qualifying_hours_last_3mo",
     }
 )
 
@@ -1804,7 +1788,9 @@ def _score_eligibility(
     return _result(determination_made=not indeterminate)
 
 
-@lru_cache(maxsize=1)
+_medicaid_resources_cache: "Optional[pd.DataFrame]" = None
+
+
 def _load_medicaid_resources() -> "Optional[pd.DataFrame]":
     """Read the Medicaid resources CSV once per process.
 
@@ -1815,7 +1801,15 @@ def _load_medicaid_resources() -> "Optional[pd.DataFrame]":
     process, so callers must treat it as read-only: slice and filter (which
     build new objects) rather than mutating in place. An ``inplace=True``
     rename or a column assignment here would corrupt every later lookup.
+
+    Only successful reads are cached: the previous ``lru_cache`` also
+    latched the ``None`` from a missing file or transient read failure for
+    the life of the process, so one bad read at startup reported "no data"
+    forever even after the file was fine.
     """
+    global _medicaid_resources_cache
+    if _medicaid_resources_cache is not None:
+        return _medicaid_resources_cache
     file_path = DATA_DIR / DEFAULT_FILE
     if not file_path.exists():
         matches = list(DATA_DIR.glob("*medicaid*.csv"))
@@ -1823,10 +1817,11 @@ def _load_medicaid_resources() -> "Optional[pd.DataFrame]":
             return None
         file_path = matches[0]
     try:
-        return pd.read_csv(file_path)
+        _medicaid_resources_cache = pd.read_csv(file_path)
     except Exception:
         logger.opt(exception=True).warning("Could not read Medicaid resources CSV")
         return None
+    return _medicaid_resources_cache
 
 
 _BOOL_FIELDS = frozenset(
@@ -1857,6 +1852,30 @@ _FLOAT_FIELDS = frozenset(
         "avg_weekly_qualifying_hours_last_3mo",
         "total_qualifying_hours_last_3mo",
     }
+)
+
+# Every kwarg is_eligible reads. Anything else the model sends is silently
+# ignored today, which looks to the model like the answer was accepted -- so
+# summarize_eligibility_inputs reports the strays back to it. Derived from
+# the typed field sets above (plus the free-form fields) so a field added to
+# one list cannot silently be missing from the other -- a hand-maintained
+# copy here either reported a real field as "unrecognized" or echoed an
+# unknown one back unnormalized.
+_KNOWN_ELIGIBILITY_FIELDS = (
+    _BOOL_FIELDS
+    | _INT_FIELDS
+    | _FLOAT_FIELDS
+    | frozenset(
+        {
+            "state",
+            "living_situation",
+            "applying_reason",
+            "qualifying_hours_weekly_last_12",
+            # Normalized by _parse_target_year rather than one of the typed
+            # sets above, so it has to be listed here explicitly.
+            "target_year",
+        }
+    )
 )
 
 
@@ -1935,6 +1954,11 @@ def get_medicaid_info(query: Dict[str, Any]) -> Optional[str]:
     the user which state they're in. (Returning prose here would be
     indistinguishable from data: the chat tool wraps any string it gets in
     "Here's the official Medicaid information for X".)
+
+    Raises MedicaidDataUnavailableError when the state WAS determined but no
+    data exists for it (territory with no CSV row, or the CSV itself is
+    missing/unreadable): re-asking the state can never fix those, so they
+    must not read as "which state?" to the caller.
     """
     raw_state = str(query.get("state") or query.get("State") or "").strip()
     if not raw_state:
@@ -1959,7 +1983,10 @@ def get_medicaid_info(query: Dict[str, Any]) -> Optional[str]:
 
     df = _load_medicaid_resources()
     if df is None:
-        return None
+        # The CSV is missing or unreadable. This used to return the same
+        # None as "unknown state", so the tool re-asked the user's state
+        # forever when the real problem was the data file.
+        raise MedicaidDataUnavailableError(state, "resources CSV missing or unreadable")
 
     # Filter by state
     if state and "state" in df.columns:
@@ -1970,9 +1997,11 @@ def get_medicaid_info(query: Dict[str, Any]) -> Optional[str]:
         # a display name but have no entry in medicaid_resources.csv, and the
         # caller wraps whatever comes back as "Here's the official Medicaid
         # information for X:" -- so returning prose here presented "no data
-        # found" to the model as retrieved data. None routes it to the same
-        # re-ask/decline path as an unrecognized state.
-        return None
+        # found" to the model as retrieved data. Returning None was no better:
+        # it read as "which state?", re-asking a question the user had already
+        # answered with no way to ever succeed. Raise so the caller can say
+        # something useful instead.
+        raise MedicaidDataUnavailableError(state, "no resources row for this state")
 
     # Focus on the most important contact info
     important_cols = [

--- a/fighthealthinsurance/microsites.py
+++ b/fighthealthinsurance/microsites.py
@@ -472,8 +472,19 @@ def get_microsite(slug: str) -> Optional[Microsite]:
 ATTRIBUTION_ONLY_SLUGS = frozenset({"medicaid-eligibility"})
 
 
-def is_valid_attribution_slug(slug: str) -> bool:
-    """Whether ``slug`` may be recorded as a chat's microsite_slug."""
+def is_valid_attribution_slug(slug: Any) -> bool:
+    """Whether ``slug`` may be recorded as a chat's microsite_slug.
+
+    Takes ``Any`` rather than ``str`` on purpose: the websocket entry point
+    hands this straight through from client JSON, where the value can be any
+    JSON type. The membership test below raises TypeError on an unhashable
+    one ({"microsite_slug": {}}), which took the whole frame down with an
+    internal error instead of ignoring the slug like any other invalid value.
+    Rejecting non-strings here keeps every caller safe rather than making
+    each remember the guard.
+    """
+    if not isinstance(slug, str):
+        return False
     return slug in ATTRIBUTION_ONLY_SLUGS or get_microsite(slug) is not None
 
 

--- a/fighthealthinsurance/microsites.py
+++ b/fighthealthinsurance/microsites.py
@@ -463,6 +463,20 @@ def get_microsite(slug: str) -> Optional[Microsite]:
     return None
 
 
+# Attribution-only funnel slugs: landing pages (e.g. /medicaid-eligibility)
+# that funnel users into chat without being content microsites -- there is no
+# Microsite entry and no generated microsite page for them. Chat entry points
+# validate incoming microsite_slug values with is_valid_attribution_slug so
+# these funnels keep their attribution instead of being warned about as
+# invalid and nulled before OngoingChat.microsite_slug is persisted.
+ATTRIBUTION_ONLY_SLUGS = frozenset({"medicaid-eligibility"})
+
+
+def is_valid_attribution_slug(slug: str) -> bool:
+    """Whether ``slug`` may be recorded as a chat's microsite_slug."""
+    return slug in ATTRIBUTION_ONLY_SLUGS or get_microsite(slug) is not None
+
+
 def get_all_microsites() -> dict[str, Microsite]:
     """
     Get all available microsites.

--- a/fighthealthinsurance/middleware/MetricsAccessMiddleware.py
+++ b/fighthealthinsurance/middleware/MetricsAccessMiddleware.py
@@ -108,14 +108,18 @@ class MetricsAccessMiddleware:
             + tuple(getattr(settings, "METRICS_ALLOWED_FORWARDED_CIDRS", None) or ())
         )
         self._metrics_path_cache: Optional[str] = None
-        if iscoroutinefunction(self.get_response):
+        # Fixed at construction time; evaluating iscoroutinefunction on every
+        # request added avoidable per-request work to the hottest path (this
+        # middleware runs first, on every request).
+        self._async_mode = iscoroutinefunction(self.get_response)
+        if self._async_mode:
             markcoroutinefunction(self)
 
     def __call__(self, request: HttpRequest):
         # Under ASGI the caller awaits us, so the block has to happen inside
         # the coroutine -- returning a plain response here would not be
         # awaitable.
-        if iscoroutinefunction(self.get_response):
+        if self._async_mode:
             return self.__acall__(request)
         if self._should_block(request):
             return HttpResponseNotFound()
@@ -128,15 +132,19 @@ class MetricsAccessMiddleware:
         return cast(HttpResponse, response)
 
     def _metrics_path(self) -> str:
+        # Cached already rstripped: the comparison in _should_block runs on
+        # every request, so it should cost one string compare, not a rstrip
+        # of an invariant value each time.
         if self._metrics_path_cache is None:
             try:
-                self._metrics_path_cache = reverse("prometheus-django-metrics")
+                resolved = reverse("prometheus-django-metrics")
             except NoReverseMatch:
-                self._metrics_path_cache = self._DEFAULT_METRICS_PATH
+                resolved = self._DEFAULT_METRICS_PATH
+            self._metrics_path_cache = resolved.rstrip("/")
         return self._metrics_path_cache
 
     def _should_block(self, request: HttpRequest) -> bool:
-        if request.path.rstrip("/") != self._metrics_path().rstrip("/"):
+        if request.path.rstrip("/") != self._metrics_path():
             return False
         return not self._is_allowed(request)
 
@@ -174,6 +182,14 @@ class MetricsAccessMiddleware:
         client cannot choose it. X-Forwarded-For is the fallback, and there only
         the LAST entry is the one the ingress added -- earlier entries may have
         been sent by the client.
+
+        CAVEAT: both properties hold only under ingress-nginx's default
+        header-replacing configuration with the ingress as the outermost
+        proxy. With ``use-forwarded-headers: true`` (common behind a cloud
+        LB) or any additional trusted proxy hop in front of the ingress,
+        these headers become client-influenced and this allowlist must not
+        be the only barrier -- re-check this exception before making either
+        of those changes.
         """
         candidate = str(request.META.get("HTTP_X_REAL_IP", "")).strip()
         if not candidate:

--- a/fighthealthinsurance/ml/response_similarity.py
+++ b/fighthealthinsurance/ml/response_similarity.py
@@ -84,25 +84,43 @@ CANNED_REPLY_SIGNATURES = (
 # the topic of the conversation. Erring toward not-matching is the safe
 # direction: it keeps loop protection on.
 _REPEAT_VERB = r"(?:repeat|say|send|resend|re-send|show|write|state|tell)"
+# Nouns that can only mean text WE already produced. Procedure, document and
+# product nouns ("the MRI", "the fax", "the prescription") are deliberately
+# absent: those are the topic of the conversation or a thing to do, not our
+# text, and treating them as repeat targets switches the ladder off on
+# ordinary clinical turns.
+_PRIOR_CONTENT_NOUN = (
+    r"(?:question|answer|response|reply|message|summary|list|steps?"
+    r"|options?|info(?:rmation)?|instructions?)"
+)
+# The object of a repeat request: a pronoun standing in for what we just
+# said, or a named piece of prior content ("your last reply", "the previous
+# answer"). Shared by every branch below so the ones that ask for a target
+# cannot drift apart on what counts as one.
+_PRIOR_CONTENT_OBJ = (
+    rf"(?:that|it|this|those|above|the\s+above"
+    rf"|(?:the\s+)?(?:last|previous|prior)(?:\s+{_PRIOR_CONTENT_NOUN})?"
+    rf"|(?:your|my|the)\s+(?:last\s+|previous\s+|prior\s+)?{_PRIOR_CONTENT_NOUN})"
+)
 USER_REQUESTED_REPEAT_RE = re.compile(
     r"(?:"
     # "repeat that", "repeat your last reply", "repeat the above". A bare
     # "repeat the <anything>" is NOT enough -- "I need to repeat the MRI"
-    # is procedure talk -- so "the" must introduce a reference to something
-    # we previously said.
-    r"\brepeat\s+(?:that|it|this|those|your|last|previous|above"
-    r"|the\s+(?:above|last|previous|question|answer|response|reply"
-    r"|message|summary|list|steps?|options?|info(?:rmation)?|instructions?))\b"
-    # "say that again", "send it again", "show me that one more time". The
-    # object must be a reference to prior content (that/it/this): with any
-    # words allowed between verb and "again", ordinary denial vocabulary
-    # matched ("My STATE denied my Medicaid AGAIN", "TELL them AGAIN") and
-    # switched the whole ladder off on exactly the turns most likely to be
-    # mid-loop.
-    rf"|\b{_REPEAT_VERB}\s+(?:me\s+)?(?:that|it|this)\b"
+    # is procedure talk -- so the object must reference something we said.
+    rf"\brepeat\s+{_PRIOR_CONTENT_OBJ}\b"
+    # "say that again", "send your last reply again", "state the answer once
+    # more". The object must reference prior content: with any words allowed
+    # between verb and "again", ordinary denial vocabulary matched ("My STATE
+    # denied my Medicaid AGAIN", "TELL them AGAIN") and switched the whole
+    # ladder off on exactly the turns most likely to be mid-loop.
+    rf"|\b{_REPEAT_VERB}\s+(?:me\s+)?{_PRIOR_CONTENT_OBJ}\b"
     r"[^.?!\n]{0,20}?\b(?:again|one more time|once more)\b"
-    # "can you repeat", "could you please repeat"
-    r"|\b(?:can|could|would|will|please|plz)\s+(?:you\s+)?(?:please\s+)?repeat\b"
+    # "can you repeat that", "could you please repeat the answer" -- and a
+    # bare "can you repeat?" only when the request ENDS there. The polite
+    # prefix used to accept any object at all, so "Can you repeat the MRI?"
+    # matched: the one shape this whole predicate exists to exclude.
+    rf"|\b(?:can|could|would|will|please|plz)\s+(?:you\s+)?(?:please\s+)?repeat"
+    rf"(?:\s+{_PRIOR_CONTENT_OBJ}\b|\s*[.?!]*\s*$)"
     # "resend it", "re-send that" -- but NOT "resend the fax to my doctor",
     # which asks us to send a document, not to say something again.
     r"|\bre-?send\s+(?:that|it|this)\b"
@@ -125,8 +143,21 @@ USER_REQUESTED_REPEAT_RE = re.compile(
 # allow_repeated_reply. Without that every correct candidate got -inf and
 # the anti-repeat retry actively steered models AWAY from the right answer.
 # Scoped narrowly per NOTE 2's err-toward-not-matching principle.
+
+# A transformation request is addressed to US: an imperative, or a polite
+# ask. Without this frame the bare verbs below matched questions ABOUT
+# rewriting -- "Should I reformat my appeal?", "Will my insurer rephrase the
+# denial?" -- and switched the whole ladder off on ordinary advice turns.
+_TRANSFORM_REQUEST_FRAME = (
+    # Opens the message or a new sentence/clause (imperative), ...
+    r"(?:^\s*|[.?!\n]\s*"
+    # ... or follows a request marker ("please reformat", "now rephrase"), ...
+    r"|\b(?:please|plz|now|then|also|and)\s+(?:please\s+)?"
+    # ... or "can you"/"could you please".
+    r"|\b(?:can|could|would|will)\s+you\s+(?:please\s+)?)"
+)
 TRANSFORM_REQUEST_RE = re.compile(
-    r"(?:"
+    _TRANSFORM_REQUEST_FRAME + r"(?:"
     # Verbs that are only ever about editing text.
     r"\b(?:proofread|copy-?edit|re-?word|rephrase|reformat)\b"
     # Generic verbs, only when aimed at language mechanics.

--- a/fighthealthinsurance/ml/response_similarity.py
+++ b/fighthealthinsurance/ml/response_similarity.py
@@ -86,10 +86,21 @@ CANNED_REPLY_SIGNATURES = (
 _REPEAT_VERB = r"(?:repeat|say|send|resend|re-send|show|write|state|tell)"
 USER_REQUESTED_REPEAT_RE = re.compile(
     r"(?:"
-    # "repeat that", "repeat your last reply", "repeat the above"
-    r"\brepeat\s+(?:that|it|this|those|your|the|last|previous|above)\b"
-    # "say that again", "send it again", "show me that one more time"
-    rf"|\b{_REPEAT_VERB}\b[^.?!\n]{{0,40}}?\b(?:again|one more time|once more)\b"
+    # "repeat that", "repeat your last reply", "repeat the above". A bare
+    # "repeat the <anything>" is NOT enough -- "I need to repeat the MRI"
+    # is procedure talk -- so "the" must introduce a reference to something
+    # we previously said.
+    r"\brepeat\s+(?:that|it|this|those|your|last|previous|above"
+    r"|the\s+(?:above|last|previous|question|answer|response|reply"
+    r"|message|summary|list|steps?|options?|info(?:rmation)?|instructions?))\b"
+    # "say that again", "send it again", "show me that one more time". The
+    # object must be a reference to prior content (that/it/this): with any
+    # words allowed between verb and "again", ordinary denial vocabulary
+    # matched ("My STATE denied my Medicaid AGAIN", "TELL them AGAIN") and
+    # switched the whole ladder off on exactly the turns most likely to be
+    # mid-loop.
+    rf"|\b{_REPEAT_VERB}\s+(?:me\s+)?(?:that|it|this)\b"
+    r"[^.?!\n]{0,20}?\b(?:again|one more time|once more)\b"
     # "can you repeat", "could you please repeat"
     r"|\b(?:can|could|would|will|please|plz)\s+(?:you\s+)?(?:please\s+)?repeat\b"
     # "resend it", "re-send that" -- but NOT "resend the fax to my doctor",
@@ -103,6 +114,36 @@ USER_REQUESTED_REPEAT_RE = re.compile(
     r")",
     re.IGNORECASE,
 )
+
+
+# When the user asks us to TRANSFORM text (proofread, fix the grammar,
+# reformat) -- their own paste OR our previous reply ("now reformat it") --
+# a faithful transformation is SUPPOSED to read nearly the same as the text
+# being transformed. So the whole anti-repeat ladder stands down on these
+# turns: the hard rejection in find_repeated_reply (both rungs), the soft
+# compute_repetition_penalty, and the backends' self-heal loop via
+# allow_repeated_reply. Without that every correct candidate got -inf and
+# the anti-repeat retry actively steered models AWAY from the right answer.
+# Scoped narrowly per NOTE 2's err-toward-not-matching principle.
+TRANSFORM_REQUEST_RE = re.compile(
+    r"(?:"
+    # Verbs that are only ever about editing text.
+    r"\b(?:proofread|copy-?edit|re-?word|rephrase|reformat)\b"
+    # Generic verbs, only when aimed at language mechanics.
+    r"|\b(?:fix|correct|check|clean\s*up|edit|rewrite|revise|polish|improve)\b"
+    r"[^.?!\n]{0,60}?"
+    r"\b(?:grammar|spelling|punctuation|typos?|wording|phrasing|formatting)\b"
+    # "rewrite this", "edit the following", "polish my draft"
+    r"|\b(?:rewrite|revise|edit|polish)\s+(?:this|my|the\s+(?:following"
+    r"|below|above|text|letter|draft|email|message|paragraph|appeal))\b"
+    r")",
+    re.IGNORECASE,
+)
+
+
+def user_requested_transformation(message: Optional[str]) -> bool:
+    """True when the user asked us to edit/rework text they provided."""
+    return bool(message and TRANSFORM_REQUEST_RE.search(message))
 
 
 def is_canned_reply(text: Optional[str]) -> bool:

--- a/fighthealthinsurance/rest_views.py
+++ b/fighthealthinsurance/rest_views.py
@@ -84,7 +84,7 @@ from fighthealthinsurance.websockets import (
 
 from .common_view_logic import AppealAssemblyHelper
 from .utils import is_convertible_to_int, is_valid_denial_id
-from fighthealthinsurance.chat.chat_persistence import visible_history
+from fighthealthinsurance.chat.chat_persistence import iter_visible_history
 
 appeal_assembly_helper = AppealAssemblyHelper()
 pubmed_tools = PubMedTools()
@@ -133,8 +133,10 @@ class ChatViewSet(viewsets.ViewSet):
             if chat.chat_history and len(chat.chat_history) > 0:
                 # Skip LLM-context-only notes: they are stored with role=user
                 # but were never typed, so they made appeal-linked chats show
-                # a preview of internal system text.
-                for message in visible_history(chat.chat_history):
+                # a preview of internal system text. Lazy iterator: we only
+                # need the first visible user message, not a filtered copy of
+                # each chat's whole history.
+                for message in iter_visible_history(chat.chat_history):
                     if message.get("role") == "user":
                         content = message.get("content", "")
                         first_message_preview = content[:100] + (
@@ -198,7 +200,7 @@ class ChatViewSet(viewsets.ViewSet):
         # Try to find the first user message (internal LLM-context notes are
         # stored with role=user but were never typed, so they must not become
         # the chat's title).
-        for message in visible_history(chat.chat_history):
+        for message in iter_visible_history(chat.chat_history):
             if message.get("role") == "user":
                 content = message.get("content", "")
                 # Extract first line or first few words

--- a/fighthealthinsurance/settings.py
+++ b/fighthealthinsurance/settings.py
@@ -68,6 +68,11 @@ def _env_flag(name: str, default: str = "0") -> bool:
     return (os.getenv(name) or default).strip().lower() in ("1", "true", "yes", "on")
 
 
+def _env_list(name: str) -> list:
+    """Parse a comma-separated env var into a list of stripped entries."""
+    return [item.strip() for item in (os.getenv(name) or "").split(",") if item.strip()]
+
+
 # This pod's own IP, from the downward API (k8s/deploy.yaml). Needed in
 # ALLOWED_HOSTS so the Prometheus PodMonitor -- which scrapes pods by IP, making
 # the pod IP the Host header -- isn't rejected as a DisallowedHost. Empty
@@ -188,11 +193,9 @@ class Base(Configuration):
     # Demo-request notifications always go to support42@; additional recipients
     # can be configured via the DEMO_REQUEST_EXTRA_NOTIFICATION_EMAILS env var
     # (comma-separated).
-    DEMO_REQUEST_NOTIFICATION_EMAILS = ["support42@fighthealthinsurance.com"] + [
-        e.strip()
-        for e in os.getenv("DEMO_REQUEST_EXTRA_NOTIFICATION_EMAILS", "").split(",")
-        if e.strip()
-    ]
+    DEMO_REQUEST_NOTIFICATION_EMAILS = [
+        "support42@fighthealthinsurance.com"
+    ] + _env_list("DEMO_REQUEST_EXTRA_NOTIFICATION_EMAILS")
 
     # Professional-signup notifications — the web /pro_version interest form and
     # the Fight Paperwork (FPW) REST professional sign-up endpoint — default to
@@ -202,13 +205,7 @@ class Base(Configuration):
     PROFESSIONAL_SIGNUP_NOTIFICATION_EMAILS = [
         "support42@fighthealthinsurance.com",
         "professional@fighthealthinsurance.com",
-    ] + [
-        e.strip()
-        for e in os.getenv("PROFESSIONAL_SIGNUP_EXTRA_NOTIFICATION_EMAILS", "").split(
-            ","
-        )
-        if e.strip()
-    ]
+    ] + _env_list("PROFESSIONAL_SIGNUP_EXTRA_NOTIFICATION_EMAILS")
 
     # Session cookie configs
     SESSION_COOKIE_SECURE = True  # https only (up to the browser to enforce)
@@ -579,21 +576,13 @@ class Base(Configuration):
     # defaults are what "inside the cluster" means; override with a comma
     # separated METRICS_ALLOWED_CIDRS on clusters with public pod CIDRs.
     # Unset (the normal case) leaves the middleware on its own defaults.
-    METRICS_ALLOWED_CIDRS = [
-        cidr.strip()
-        for cidr in os.getenv("METRICS_ALLOWED_CIDRS", "").split(",")
-        if cidr.strip()
-    ]
+    METRICS_ALLOWED_CIDRS = _env_list("METRICS_ALLOWED_CIDRS")
 
     # External monitors allowed to fetch /metrics *through* the ingress, on top
     # of UptimeRobot's published probe addresses (which the middleware always
     # honors -- see fighthealthinsurance/uptimerobot_ips.py). Matched against
     # the client address the ingress observed, not the peer address.
-    METRICS_ALLOWED_FORWARDED_CIDRS = [
-        cidr.strip()
-        for cidr in os.getenv("METRICS_ALLOWED_FORWARDED_CIDRS", "").split(",")
-        if cidr.strip()
-    ]
+    METRICS_ALLOWED_FORWARDED_CIDRS = _env_list("METRICS_ALLOWED_FORWARDED_CIDRS")
 
     # STRIPE SETTINGS
     STRIPE_LIVE_MODE = False

--- a/fighthealthinsurance/static/js/chat_interface.tsx
+++ b/fighthealthinsurance/static/js/chat_interface.tsx
@@ -593,6 +593,30 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ defaultProcedure, default
           chatId = null;
         }
 
+        // The /medicaid-eligibility landing CTA promises an eligibility
+        // check. Like the explain-denial flow above, the click is an
+        // explicit request to start this flow, so start a fresh chat:
+        // replaying a stored chat instead silently skipped the kickoff
+        // branch below for anyone who had chatted before, dropping them in
+        // their old conversation with no eligibility check.
+        if (micrositeSlug === "medicaid-eligibility" && !hasSentInitialMessage.current) {
+          console.log("Starting new chat for the medicaid-eligibility check");
+          localStorage.removeItem("fhi_chat_id");
+          chatId = null;
+          // Keep React state in step so a message or file upload sent before
+          // the first server frame can't carry the abandoned chat's id.
+          setState((prev) => ({ ...prev, chatId: null }));
+          // One-shot trigger: the slug otherwise stays in the URL for the
+          // whole session (consent round-trip re-appends it), so without
+          // this every reload wiped fhi_chat_id again and orphaned the
+          // in-progress interview. The chat row's attribution is already
+          // persisted server-side at creation, so the URL param is no
+          // longer needed once the kickoff has fired.
+          const url = new URL(window.location.href);
+          url.searchParams.delete("microsite_slug");
+          window.history.replaceState(null, "", url.toString());
+        }
+
         if (chatId) {
           console.log("Replaying chat history for chat ID:", chatId);
           ws.send(

--- a/fighthealthinsurance/templates/chat_consent.html
+++ b/fighthealthinsurance/templates/chat_consent.html
@@ -39,19 +39,10 @@ Terms of Service & Setup - FightHealthInsurance Chat Assistant (Alpha)
             <form method="post" id="user_consent_form">
               {% csrf_token %}
               
-              <!-- Hidden fields to preserve microsite parameters -->
-              {% if default_procedure %}
-              <input type="hidden" name="default_procedure" value="{{ default_procedure }}">
-              {% endif %}
-              {% if default_condition %}
-              <input type="hidden" name="default_condition" value="{{ default_condition }}">
-              {% endif %}
-              {% if microsite_slug %}
-              <input type="hidden" name="microsite_slug" value="{{ microsite_slug }}">
-              {% endif %}
-              {% if microsite_title %}
-              <input type="hidden" name="microsite_title" value="{{ microsite_title }}">
-              {% endif %}
+              <!-- Funnel params (CHAT_FUNNEL_PARAMS) preserved as hidden fields -->
+              {% for name, value in funnel_params %}
+              <input type="hidden" name="{{ name }}" value="{{ value }}">
+              {% endfor %}
               {% if denial_text %}
               <textarea name="denial_text" class="d-none">{{ denial_text }}</textarea>
               {% endif %}

--- a/fighthealthinsurance/templates/chat_redirect.html
+++ b/fighthealthinsurance/templates/chat_redirect.html
@@ -13,18 +13,10 @@
         {% if initial_message %}
         <textarea name="initial_message" style="display:none;">{{ initial_message }}</textarea>
         {% endif %}
-        {% if default_procedure %}
-        <input type="hidden" name="default_procedure" value="{{ default_procedure }}">
-        {% endif %}
-        {% if default_condition %}
-        <input type="hidden" name="default_condition" value="{{ default_condition }}">
-        {% endif %}
-        {% if microsite_slug %}
-        <input type="hidden" name="microsite_slug" value="{{ microsite_slug }}">
-        {% endif %}
-        {% if microsite_title %}
-        <input type="hidden" name="microsite_title" value="{{ microsite_title }}">
-        {% endif %}
+        {# Funnel params (CHAT_FUNNEL_PARAMS) preserved as hidden fields #}
+        {% for name, value in funnel_params %}
+        <input type="hidden" name="{{ name }}" value="{{ value }}">
+        {% endfor %}
     </form>
     <script>
         // Auto-submit the form

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -1878,9 +1878,9 @@ class InitialProcessView(generic.FormView):
             "microsite_slug"
         ) or self.request.GET.get("microsite_slug", "")
         if microsite_slug:
-            from fighthealthinsurance.microsites import get_microsite
+            from fighthealthinsurance.microsites import is_valid_attribution_slug
 
-            if get_microsite(microsite_slug):
+            if is_valid_attribution_slug(microsite_slug):
                 cleaned_data["microsite_slug"] = microsite_slug
             else:
                 logger.warning(f"Invalid microsite_slug received: {microsite_slug}")
@@ -2487,6 +2487,47 @@ class CompletePaymentView(View):
             return None, ("An internal error occurred", 500)
 
 
+# Funnel params forwarded from microsites / landing CTAs that must survive the
+# consent round-trip back to /chat. Every hop uses this list: the consent
+# redirect, ChatUserConsentView's success URL, and the hidden fields that
+# chat_consent.html / chat_redirect.html render by looping over the
+# ``funnel_params`` pairs -- so a param added here is forwarded everywhere.
+CHAT_FUNNEL_PARAMS = (
+    "default_procedure",
+    "default_condition",
+    "medicare",
+    "microsite_slug",
+    "microsite_title",
+)
+
+
+def _funnel_params_from(*sources) -> list:
+    """(name, value) pairs for the funnel params present in the QueryDicts.
+
+    Earlier sources win: ``_funnel_params_from(request.GET, request.POST)``
+    reads GET first and falls back to POST, so the pre-consent redirect (GET
+    CTA links) and the consent form round-trip (hidden POST fields) forward
+    the same set -- these used to be several hand-maintained loops that
+    drifted.
+    """
+    params = []
+    for param in CHAT_FUNNEL_PARAMS:
+        for source in sources:
+            value = source.get(param)
+            if value:
+                params.append((param, value))
+                break
+    return params
+
+
+def _with_funnel_params(url: str, request) -> str:
+    """Append the funnel params present on the request (GET, then POST)."""
+    params = _funnel_params_from(request.GET, request.POST)
+    if params:
+        url = f"{url}?{urlencode(params)}"
+    return url
+
+
 @ensure_csrf_cookie
 def chat_interface_view(request):
     """
@@ -2504,20 +2545,21 @@ def chat_interface_view(request):
     # If the user hasn't completed the consent process, redirect to the consent form
     if not consent_completed:
         logger.debug("Chat interface: redirecting to consent form (not yet completed)")
-        return redirect("chat_consent")
+        # Forward the funnel params: ChatUserConsentView re-emits them as
+        # hidden fields and get_success_url carries them back to /chat --
+        # but only when they arrive on ITS query string. A bare redirect
+        # dropped them, so first-time visitors from a microsite or the
+        # medicaid-eligibility landing CTA (exactly the users who have not
+        # consented yet) lost their default_procedure/microsite_slug kickoff.
+        return redirect(_with_funnel_params(reverse("chat_consent"), request))
 
-    # Check for default_procedure and default_condition from microsite URL params
-    # Check both GET and POST since consent form could send either way
-    default_procedure = request.GET.get("default_procedure") or request.POST.get(
-        "default_procedure", ""
-    )
-    default_condition = request.GET.get("default_condition") or request.POST.get(
-        "default_condition", ""
-    )
-    medicare = request.GET.get("medicare") or request.POST.get("medicare", "")
-    microsite_slug = request.GET.get("microsite_slug") or request.POST.get(
-        "microsite_slug", ""
-    )
+    # Funnel params from the microsite / landing CTA (GET) or the consent
+    # form round-trip (hidden POST fields).
+    funnel = dict(_funnel_params_from(request.GET, request.POST))
+    default_procedure = funnel.get("default_procedure", "")
+    default_condition = funnel.get("default_condition", "")
+    medicare = funnel.get("medicare", "")
+    microsite_slug = funnel.get("microsite_slug", "")
 
     # Check for denial text from POST (from chat consent form) or session (from explain denial page)
     # Check POST first to avoid popping session unnecessarily
@@ -2570,39 +2612,16 @@ class ChatUserConsentView(FormView):
     )
 
     def get_success_url(self):
-        """Preserve query parameters when redirecting to chat."""
-        # Get the base success URL
-        url = self.success_url
-
-        # Preserve microsite-related query parameters
-        query_params = []
-        for param in [
-            "default_procedure",
-            "default_condition",
-            "microsite_slug",
-            "microsite_title",
-        ]:
-            value = self.request.GET.get(param) or self.request.POST.get(param)
-            if value:
-                from urllib.parse import urlencode
-
-                query_params.append((param, value))
-
-        if query_params:
-            from urllib.parse import urlencode
-
-            url = f"{url}?{urlencode(query_params)}"
-
-        return url
+        """Preserve the funnel query parameters when redirecting to chat."""
+        return _with_funnel_params(self.success_url, self.request)
 
     def get_context_data(self, **kwargs):
         """Pass query parameters to template so they can be preserved in hidden fields."""
         context = super().get_context_data(**kwargs)
-        # Add microsite params to context so they can be included as hidden fields
-        context["default_procedure"] = self.request.GET.get("default_procedure", "")
-        context["default_condition"] = self.request.GET.get("default_condition", "")
-        context["microsite_slug"] = self.request.GET.get("microsite_slug", "")
-        context["microsite_title"] = self.request.GET.get("microsite_title", "")
+        # Funnel params rendered as hidden fields (the template loops over
+        # the pairs, so a param added to CHAT_FUNNEL_PARAMS is forwarded
+        # without touching the template).
+        context["funnel_params"] = _funnel_params_from(self.request.GET)
         # Check if coming from explain denial
         context["explain_denial"] = self.request.GET.get("explain_denial", "") == "true"
         # Get denial text from session if available (from explain denial page)
@@ -2628,11 +2647,8 @@ class ChatUserConsentView(FormView):
             # Render an auto-submit form to POST data to chat
             context = {
                 "denial_text": denial_text,
-                "default_procedure": self.request.POST.get("default_procedure", ""),
-                "default_condition": self.request.POST.get("default_condition", ""),
-                "microsite_slug": self.request.POST.get("microsite_slug", ""),
-                "microsite_title": self.request.POST.get("microsite_title", ""),
                 "chat_url": reverse("chat"),
+                "funnel_params": _funnel_params_from(self.request.POST),
             }
             return render(self.request, "chat_redirect.html", context)
 

--- a/fighthealthinsurance/websockets.py
+++ b/fighthealthinsurance/websockets.py
@@ -1464,7 +1464,13 @@ class OngoingChatConsumer(PerConnectionThreadSensitiveMixin, AsyncWebsocketConsu
             if not is_valid_attribution_slug(microsite_slug):
                 # An empty string is just "no slug", not an attacker probe.
                 if microsite_slug:
-                    logger.warning(f"Invalid microsite_slug received: {microsite_slug}")
+                    # Bounded and repr'd like the chat_id above: this is raw
+                    # client input, so an arbitrarily long value (or one
+                    # carrying newlines) must not reach the log verbatim.
+                    logger.warning(
+                        f"Invalid microsite_slug received: "
+                        f"{str(microsite_slug)[:64]!r}"
+                    )
                 microsite_slug = None
 
         logger.debug(

--- a/fighthealthinsurance/websockets.py
+++ b/fighthealthinsurance/websockets.py
@@ -1452,11 +1452,19 @@ class OngoingChatConsumer(PerConnectionThreadSensitiveMixin, AsyncWebsocketConsu
 
         # Validate microsite_slug if provided (attribution-only funnel slugs
         # like medicaid-eligibility are valid too -- see microsites.py).
-        if microsite_slug:
+        # `is not None`, not truthiness: this comes straight from client JSON
+        # and can be ANY JSON type, so anything that isn't a valid slug is
+        # dropped here rather than carried into persistence.
+        # is_valid_attribution_slug rejects non-strings instead of raising on
+        # its set-membership test -- an unhashable value ({"microsite_slug":
+        # {}}) used to answer the frame with an internal error.
+        if microsite_slug is not None:
             from fighthealthinsurance.microsites import is_valid_attribution_slug
 
             if not is_valid_attribution_slug(microsite_slug):
-                logger.warning(f"Invalid microsite_slug received: {microsite_slug}")
+                # An empty string is just "no slug", not an attacker probe.
+                if microsite_slug:
+                    logger.warning(f"Invalid microsite_slug received: {microsite_slug}")
                 microsite_slug = None
 
         logger.debug(

--- a/fighthealthinsurance/websockets.py
+++ b/fighthealthinsurance/websockets.py
@@ -1383,6 +1383,9 @@ class OngoingChatConsumer(PerConnectionThreadSensitiveMixin, AsyncWebsocketConsu
         message_raw = data.get("message", data.get("content", None))
         message: str = message_raw if isinstance(message_raw, str) else ""
         chat_id = data.get("chat_id", self.chat_id)
+        replay_requested = data.get("replay", False)
+        iterate_on_appeal = data.get("iterate_on_appeal")
+        iterate_on_prior_auth = data.get("iterate_on_prior_auth")
 
         # Lightweight side-by-side answer feedback: which answer the user
         # preferred. Metrics + log only (bounded label set) -- no LLM turn.
@@ -1393,23 +1396,40 @@ class OngoingChatConsumer(PerConnectionThreadSensitiveMixin, AsyncWebsocketConsu
                 if isinstance(answer_feedback, dict)
                 else None
             )
-            record_answer_feedback(preferred)
-            # chat_id is raw client input: bound and repr it so an
-            # attacker-supplied value can't inject newlines (forged log
-            # records) or flood the log pipeline with one huge line.
-            logger.info(
-                f"chat ws: answer feedback preferred={str(preferred)[:16]!r} "
-                f"chat_id={str(chat_id)[:64]!r}"
-            )
+            # Only count feedback for the chat THIS socket has open: the
+            # real client sends feedback on the same connection the answer
+            # arrived on. Without the gate this branch ran before any
+            # identity/chat validation, so any anonymous connection could
+            # loop forged "alternate preferred" frames and skew the
+            # model-preference signal (and use the INFO line as a
+            # log-volume lever).
+            if chat_id and self.chat_id and str(chat_id) == str(self.chat_id):
+                record_answer_feedback(preferred)
+                # chat_id is raw client input: bound and repr it so an
+                # attacker-supplied value can't inject newlines (forged log
+                # records) or flood the log pipeline with one huge line.
+                logger.info(
+                    f"chat ws: answer feedback preferred={str(preferred)[:16]!r} "
+                    f"chat_id={str(chat_id)[:64]!r}"
+                )
+            else:
+                logger.debug(
+                    f"chat ws: ignoring answer feedback for foreign/unknown "
+                    f"chat_id={str(chat_id)[:64]!r}"
+                )
             # Only short-circuit when the frame carries nothing else. A frame
             # batching feedback with a real message used to have the message
             # silently dropped -- no reply, no error, and the client's
-            # spinner never cleared.
-            if not message and not data.get("replay", False):
+            # spinner never cleared. Empty-message frames are also the
+            # documented carrier for appeal/prior-auth linking (see the
+            # validation below), so those must not short-circuit either.
+            if (
+                not message
+                and not replay_requested
+                and not iterate_on_appeal
+                and not iterate_on_prior_auth
+            ):
                 return
-        replay_requested = data.get("replay", False)
-        iterate_on_appeal = data.get("iterate_on_appeal")
-        iterate_on_prior_auth = data.get("iterate_on_prior_auth")
         is_patient = data.get(
             "is_patient", False
         )  # New parameter to identify patient users
@@ -1430,11 +1450,12 @@ class OngoingChatConsumer(PerConnectionThreadSensitiveMixin, AsyncWebsocketConsu
         # to DEBUG deployments and staff users).
         debug_requested = bool(data.get("debug", False))
 
-        # Validate microsite_slug if provided
+        # Validate microsite_slug if provided (attribution-only funnel slugs
+        # like medicaid-eligibility are valid too -- see microsites.py).
         if microsite_slug:
-            from fighthealthinsurance.microsites import get_microsite
+            from fighthealthinsurance.microsites import is_valid_attribution_slug
 
-            if not get_microsite(microsite_slug):
+            if not is_valid_attribution_slug(microsite_slug):
                 logger.warning(f"Invalid microsite_slug received: {microsite_slug}")
                 microsite_slug = None
 
@@ -1494,10 +1515,16 @@ class OngoingChatConsumer(PerConnectionThreadSensitiveMixin, AsyncWebsocketConsu
                     # Authenticated patient — derive email from user account
                     email = user.email
 
-            # Extract tracking info from websocket scope (privacy-aware)
-            tracking_info = extract_tracking_info_from_scope(
-                scope=self.scope, is_professional=(chat_type == ChatType.PROFESSIONAL)
-            )
+            # Extract tracking info from websocket scope (privacy-aware).
+            # Plain asgiref sync_to_async (no ORM): get_asn_info's first
+            # lookup blocks on the shared geo-reader lock -- held for the
+            # full multi-second database parse while the startup warm-up
+            # thread runs -- so calling it inline froze every websocket on
+            # the worker during the startup window (the state_hint call
+            # below was already offloaded; this path was not).
+            tracking_info = await sync_to_async(
+                extract_tracking_info_from_scope, thread_sensitive=False
+            )(scope=self.scope, is_professional=(chat_type == ChatType.PROFESSIONAL))
             if str(email or "").strip().lower() == "testing@example.com":
                 tracking_info.ip_address = _get_client_ip_from_scope(self.scope)
 

--- a/tests/async-unit/test_chat_ws_answer_feedback.py
+++ b/tests/async-unit/test_chat_ws_answer_feedback.py
@@ -4,6 +4,11 @@ A lightweight ``{"answer_feedback": {"preferred": ...}}`` frame records
 which of the two side-by-side answers the user preferred. It must not start
 an LLM turn, must not require message content, and must collapse arbitrary
 client-supplied values into a bounded metric label set.
+
+Feedback only counts for the chat THIS socket has open (the real client
+sends it on the connection the answer arrived on): without that gate any
+anonymous connection could loop forged "alternate preferred" frames and
+skew the model-preference signal before any identity/chat validation ran.
 """
 
 import pytest
@@ -11,6 +16,19 @@ from channels.testing import WebsocketCommunicator
 from prometheus_client import REGISTRY
 
 from fighthealthinsurance.websockets import OngoingChatConsumer
+
+OPEN_CHAT_ID = "feedback-chat-1"
+
+
+class _ConsumerWithOpenChat(OngoingChatConsumer):
+    """Consumer that already resolved a chat on this connection.
+
+    ``chat_id`` is a class-level default on OngoingChatConsumer, normally
+    assigned per-instance once the chat is created/replayed; presetting it
+    here stands in for that handshake without running an LLM turn.
+    """
+
+    chat_id = OPEN_CHAT_ID
 
 
 def _feedback_metric(preferred):
@@ -27,7 +45,7 @@ def _feedback_metric(preferred):
 async def test_answer_feedback_records_metric_without_llm_turn():
     before = _feedback_metric("alternate")
     communicator = WebsocketCommunicator(
-        OngoingChatConsumer.as_asgi(), "/ws/ongoing-chat/"
+        _ConsumerWithOpenChat.as_asgi(), "/ws/ongoing-chat/"
     )
     connected, _ = await communicator.connect()
     assert connected
@@ -35,6 +53,7 @@ async def test_answer_feedback_records_metric_without_llm_turn():
         await communicator.send_json_to(
             {
                 "answer_feedback": {"preferred": "alternate"},
+                "chat_id": OPEN_CHAT_ID,
                 "session_key": "feedback-test",
             }
         )
@@ -52,7 +71,7 @@ async def test_answer_feedback_records_metric_without_llm_turn():
 async def test_answer_feedback_bounds_unexpected_values():
     before = _feedback_metric("other")
     communicator = WebsocketCommunicator(
-        OngoingChatConsumer.as_asgi(), "/ws/ongoing-chat/"
+        _ConsumerWithOpenChat.as_asgi(), "/ws/ongoing-chat/"
     )
     connected, _ = await communicator.connect()
     assert connected
@@ -60,6 +79,7 @@ async def test_answer_feedback_bounds_unexpected_values():
         await communicator.send_json_to(
             {
                 "answer_feedback": {"preferred": "x" * 500},
+                "chat_id": OPEN_CHAT_ID,
                 "session_key": "feedback-test-2",
             }
         )
@@ -68,3 +88,53 @@ async def test_answer_feedback_bounds_unexpected_values():
         await communicator.disconnect()
 
     assert _feedback_metric("other") == before + 1
+
+
+@pytest.mark.django_db
+@pytest.mark.asyncio
+async def test_answer_feedback_without_open_chat_is_ignored():
+    """A connection that never resolved a chat cannot pump the metric."""
+    before = _feedback_metric("alternate")
+    communicator = WebsocketCommunicator(
+        OngoingChatConsumer.as_asgi(), "/ws/ongoing-chat/"
+    )
+    connected, _ = await communicator.connect()
+    assert connected
+    try:
+        await communicator.send_json_to(
+            {
+                "answer_feedback": {"preferred": "alternate"},
+                "session_key": "feedback-test-3",
+            }
+        )
+        # Still silent -- ignored, not an error.
+        assert await communicator.receive_nothing(timeout=0.5)
+    finally:
+        await communicator.disconnect()
+
+    assert _feedback_metric("alternate") == before
+
+
+@pytest.mark.django_db
+@pytest.mark.asyncio
+async def test_answer_feedback_for_foreign_chat_is_ignored():
+    """Feedback naming a chat other than this socket's does not count."""
+    before = _feedback_metric("alternate")
+    communicator = WebsocketCommunicator(
+        _ConsumerWithOpenChat.as_asgi(), "/ws/ongoing-chat/"
+    )
+    connected, _ = await communicator.connect()
+    assert connected
+    try:
+        await communicator.send_json_to(
+            {
+                "answer_feedback": {"preferred": "alternate"},
+                "chat_id": "some-other-chat",
+                "session_key": "feedback-test-4",
+            }
+        )
+        assert await communicator.receive_nothing(timeout=0.5)
+    finally:
+        await communicator.disconnect()
+
+    assert _feedback_metric("alternate") == before

--- a/tests/async-unit/test_model_backend_health.py
+++ b/tests/async-unit/test_model_backend_health.py
@@ -41,8 +41,14 @@ def _clear_provider_env(monkeypatch):
         "PERPLEXITY_API",
         "AZURE_OPENAI_API_KEY",
         "AZURE_OPENAI_ENDPOINT",
+        "AZURE_OPENAI_MODELS",
         "AZURE_ANTHROPIC_API_KEY",
         "AZURE_ANTHROPIC_ENDPOINT",
+        # The deployment-list overrides reshape the Azure model catalogs
+        # (not just configuration state), and tox passes the developer's
+        # shell through (passenv = *) — leaving them set breaks the
+        # catalog-shape expectations below.
+        "AZURE_ANTHROPIC_MODELS",
         "HEALTH_BACKEND_HOST",
         "HEALTH_BACKUP_BACKEND_HOST",
         "NEW_HEALTH_BACKEND_HOST",

--- a/tests/async/test_chat_loop_prevention.py
+++ b/tests/async/test_chat_loop_prevention.py
@@ -11,7 +11,6 @@ state hint, and the LLM-input debug frame.
 import typing
 from unittest.mock import AsyncMock, patch
 
-from asgiref.sync import sync_to_async
 from django.contrib.auth import get_user_model
 from prometheus_client import REGISTRY
 from rest_framework.test import APITestCase
@@ -54,7 +53,7 @@ def _metric(name, labels=None):
 
 
 async def _make_chat(username, npi, chat_history=None):
-    user = await sync_to_async(User.objects.create_user)(
+    user = await User.objects.acreate_user(
         username=username, password="testpass", email=f"{username}@example.com"
     )
     professional = await ProfessionalUser.objects.acreate(
@@ -382,7 +381,7 @@ class ChatDebugFrameTest(APITestCase):
         assert result["runner_up_model"] == "second-model"
         assert result["picked_score"] > result["runner_up_score"]
         assert result["closely_tied"] is True
-        assert result["alternate_offered"] is True
+        assert result["alternate_candidate"] is True
         assert result["candidate_count"] == 2
         assert result["rejected_repeats"] == 0
         assert result["retry_used"] is False

--- a/tests/async/test_chat_loop_prevention.py
+++ b/tests/async/test_chat_loop_prevention.py
@@ -161,6 +161,37 @@ class ChatRepeatRejectionTest(APITestCase):
             == rejected_before + 1
         )
 
+    async def test_metric_recorded_when_tool_processing_raises(self):
+        """A raising tool handler unwinds past the in-method exits.
+
+        The turn still rejected repeats, so the loop metric must survive the
+        exception -- handle_chat_message's finally is the backstop.
+        """
+        user, chat = await _make_chat(
+            "loopbreak_toolraise", "9999930011", chat_history=_seed_history()
+        )
+        recorder = _FrameRecorder()
+        interface = ChatInterface(send_json_message_func=recorder, chat=chat, user=user)
+        model = RecordingChatModel()
+
+        rejected_before = _metric(
+            "fhi_chat_repeated_responses_total", {"action": "rejected_candidates"}
+        )
+
+        with _patched_router([model]), _PATCH_FIRE_AND_FORGET, patch(
+            "fighthealthinsurance.chat_interface.AppealTool.handle",
+            side_effect=RuntimeError("tool blew up"),
+        ):
+            await interface.handle_chat_message("CA")
+
+        assert (
+            _metric(
+                "fhi_chat_repeated_responses_total",
+                {"action": "rejected_candidates"},
+            )
+            == rejected_before + 1
+        )
+
     async def test_terse_reply_gets_bridge_note(self):
         """A short answer right after an assistant question carries the
         system bridge note into the model call."""

--- a/tests/async/test_chat_loop_prevention.py
+++ b/tests/async/test_chat_loop_prevention.py
@@ -126,6 +126,41 @@ class ChatRepeatRejectionTest(APITestCase):
         assistant_msgs = [m for m in fresh.chat_history if m.get("role") == "assistant"]
         assert assistant_msgs[-1]["content"] == FRESH_REPLY
 
+    async def test_metric_recorded_when_the_turn_delivers_nothing(self):
+        """The loudest loop is the one that never produces a reply.
+
+        Every candidate rejected as a repeat AND the retry delivering nothing
+        returns early, before tool processing -- so the once-per-turn metric
+        used to be skipped in exactly the case it exists to alert on,
+        reporting "loops never happen" while a backend looped itself dry.
+        """
+        user, chat = await _make_chat(
+            "loopbreak_nodeliver", "9999930010", chat_history=_seed_history()
+        )
+        recorder = _FrameRecorder()
+        interface = ChatInterface(send_json_message_func=recorder, chat=chat, user=user)
+        # Primary pass loops (hard-rejected); the anti-repeat retry then comes
+        # back empty, so no candidate is deliverable and the turn returns
+        # early -- the shape the metric used to miss.
+        model = RecordingChatModel(looped_reply=LOOPED_REPLY, fresh_reply="")
+
+        rejected_before = _metric(
+            "fhi_chat_repeated_responses_total", {"action": "rejected_candidates"}
+        )
+
+        with _patched_router([model]), _PATCH_FIRE_AND_FORGET:
+            await interface.handle_chat_message("CA")
+
+        delivered = [f["content"] for f in recorder.content_frames()]
+        assert LOOPED_REPLY not in delivered, f"delivered the looped reply: {delivered}"
+        assert (
+            _metric(
+                "fhi_chat_repeated_responses_total",
+                {"action": "rejected_candidates"},
+            )
+            == rejected_before + 1
+        )
+
     async def test_terse_reply_gets_bridge_note(self):
         """A short answer right after an assistant question carries the
         system bridge note into the model call."""

--- a/tests/selenium/test_selenium_chat_status.py
+++ b/tests/selenium/test_selenium_chat_status.py
@@ -475,12 +475,15 @@ class SeleniumChatStatusMessagesTest(FHISeleniumBase, StaticLiveServerTestCase):
             return toggle ? toggle.checked : null;
         """)
 
+        # Clean up BEFORE asserting: with cleanup as the last statement it
+        # only ran when the assertion passed, so a regression here leaked
+        # the stray value into sibling tests and buried the one real
+        # failure under cascading ones.
+        self.execute_script("localStorage.removeItem('fhi_use_external_models');")
+
         assert (
             is_checked is False
         ), f"Unrecognized stored value should not opt in, got checked={is_checked}"
-
-        # Clean up so we don't leak the stray value into sibling tests
-        self.execute_script("localStorage.removeItem('fhi_use_external_models');")
 
     def test_external_models_toggled_off_is_respected(self):
         """Test that explicitly disabling external models is saved and respected."""

--- a/tests/sync/test_backfill_model_metadata.py
+++ b/tests/sync/test_backfill_model_metadata.py
@@ -5,7 +5,9 @@ is unambiguously inferable; NULLs stay NULL (the dashboard's "(unknown)"
 bucket) and ambiguous/unrecognized strings are left untouched and reported.
 """
 
+import os
 from io import StringIO
+from unittest.mock import patch
 
 from django.core.management import call_command
 from django.test import TestCase
@@ -20,6 +22,18 @@ from fighthealthinsurance.models import (
 
 class BackfillModelMetadataTest(TestCase):
     def setUp(self):
+        # The Azure backend catalogs honor the AZURE_*_MODELS deployment
+        # overrides, and tox passes the developer's shell through
+        # (passenv = *), so e.g. AZURE_ANTHROPIC_MODELS=claude-opus-4-8
+        # would shrink the azure-anthropic catalog and break the ambiguity
+        # expectations below. Pin the overrides empty so the catalogs use
+        # DEFAULT_MODELS regardless of the local environment.
+        env_patch = patch.dict(
+            os.environ,
+            {"AZURE_ANTHROPIC_MODELS": "", "AZURE_OPENAI_MODELS": ""},
+        )
+        env_patch.start()
+        self.addCleanup(env_patch.stop)
         self.denial = Denial.objects.create(
             hashed_email="hash",
             denial_text="denied",

--- a/tests/sync/test_chat_persistence_bounds.py
+++ b/tests/sync/test_chat_persistence_bounds.py
@@ -30,6 +30,29 @@ class MergeNewMessagesInternalFlagTest(TestCase):
         history = merge_new_messages([], [{"role": "user", "content": "hello there"}])
         self.assertNotIn("internal", history[0])
 
+    def test_legacy_note_with_uuid_id_is_internal(self):
+        """PriorAuthRequest pks are UUIDs (Appeal pks are ints); the legacy
+        pattern's `#\\d+` silently missed every un-flagged prior-auth note
+        whose UUID starts with a hex letter, rendering internal system text
+        as a user bubble and letting previews/titles pick it up."""
+        for note in (
+            "Linked this chat to Prior Auth Request "
+            "#f3a91c2e-1d5b-4e6f-9a3c-2b7d8e4f5a6b, details are ...",
+            "This chat is already linked to Prior Auth Request "
+            "#03a91c2e-1d5b-4e6f-9a3c-2b7d8e4f5a6b, current details are ...",
+            "Linked this chat to Appeal #12 -- details",
+        ):
+            with self.subTest(note=note):
+                self.assertTrue(
+                    is_internal_history_message({"role": "user", "content": note})
+                )
+        # A user's own message about their prior auth still is NOT internal.
+        self.assertFalse(
+            is_internal_history_message(
+                {"role": "user", "content": "I linked my prior auth already"}
+            )
+        )
+
     def test_tail_dedup_still_applies(self):
         history = [{"role": "user", "content": "CA", "timestamp": "t"}]
         merged = merge_new_messages(history, [{"role": "user", "content": "CA"}])

--- a/tests/sync/test_chat_persistence_bounds.py
+++ b/tests/sync/test_chat_persistence_bounds.py
@@ -53,6 +53,28 @@ class MergeNewMessagesInternalFlagTest(TestCase):
             )
         )
 
+    def test_malformed_ids_are_not_internal(self):
+        """Each kind's id must match its REAL format.
+
+        A shared hex-or-hyphen run matched ids we never generate, and without
+        an end guard it matched a PREFIX of a longer one -- either way hiding
+        a user-authored message from replay, REST previews and titles.
+        """
+        for note in (
+            # Appeal pks are ints, never hex.
+            "Linked this chat to Appeal #deadbeef -- details",
+            # Partial id: `#12` must not match through the trailing `f`.
+            "Linked this chat to Appeal #12f -- details",
+            "This chat is already linked to Appeal #12-3 -- details",
+            # Prior auth pks are full UUIDs, not a truncated one.
+            "Linked this chat to Prior Auth Request #f3a91c2e-1d5b, details",
+            "Linked this chat to Prior Auth Request #12345, details",
+        ):
+            with self.subTest(note=note):
+                self.assertFalse(
+                    is_internal_history_message({"role": "user", "content": note})
+                )
+
     def test_tail_dedup_still_applies(self):
         history = [{"role": "user", "content": "CA", "timestamp": "t"}]
         merged = merge_new_messages(history, [{"role": "user", "content": "CA"}])

--- a/tests/sync/test_chat_tools.py
+++ b/tests/sync/test_chat_tools.py
@@ -617,14 +617,15 @@ class TestMedicaidEligibilityTool(TestCase):
     def test_indeterminate_result_still_reports_firm_positive_verdicts(self):
         """A sub-check that DID finish with a yes is a real answer.
 
-        Declining only the 2026 work-hours question (or the Medicare-side
+        Declining only the work-hours question (or the Medicare-side
         years-worked question) makes determination_made False, but the
-        2025-rules check may have completed with a firm positive -- hiding
-        it behind the blanket "no estimate" withheld a computed verdict.
+        current-rules check may have completed with a firm positive --
+        hiding it behind the blanket "no estimate" withheld a computed
+        verdict.
         """
         info = self.tool._build_eligibility_info(
-            eligible_2025=True,
-            eligible_2026=False,
+            eligible_base=True,
+            eligible_target=False,
             medicare=False,
             alternatives=["We could not check qualifying work hours."],
             missing=[],
@@ -632,7 +633,33 @@ class TestMedicaidEligibilityTool(TestCase):
         )
 
         self.assertIn("could NOT produce a Medicaid estimate", info)
-        self.assertIn("current (2025)", info)
+        self.assertIn(f"current ({current_eligibility_year()})", info)
+        self.assertIn("already look eligible", info)
+        self.assertNotIn("may not be eligible", info)
+
+    def test_indeterminate_result_reports_later_years_that_settled(self):
+        """The later-year positives in a supplied timeline are reported too.
+
+        Same rule as the missing-answers branch: only positives, since a year
+        we could not score comes back False and drops out on that alone.
+        """
+        current = current_eligibility_year()
+        info = self.tool._build_eligibility_info(
+            eligible_base=False,
+            eligible_target=True,
+            medicare=False,
+            alternatives=["We could not check qualifying work hours."],
+            missing=[],
+            determination_made=False,
+            target_year=current + 1,
+            timeline=[
+                YearVerdict(current, False, []),
+                YearVerdict(current + 1, True, []),
+            ],
+        )
+
+        self.assertIn("could NOT produce a Medicaid estimate", info)
+        self.assertIn(f"{current + 1}", info)
         self.assertIn("already look eligible", info)
         self.assertNotIn("may not be eligible", info)
 

--- a/tests/sync/test_chat_tools.py
+++ b/tests/sync/test_chat_tools.py
@@ -662,6 +662,25 @@ class TestMedicaidEligibilityTool(TestCase):
         self.assertIn(f"{current + 1}", info)
         self.assertIn("already look eligible", info)
         self.assertNotIn("may not be eligible", info)
+        # A year past the published table earns the same caveat the full
+        # verdict gives it: the positive above was scored with the published
+        # year's income limits, not that year's.
+        self.assertIn("newer income limits aren't published yet", info)
+
+    def test_indeterminate_positive_for_the_published_year_needs_no_caveat(self):
+        """The caveat is for years scored past the published table only."""
+        info = self.tool._build_eligibility_info(
+            eligible_base=True,
+            eligible_target=False,
+            medicare=False,
+            alternatives=["We could not check qualifying work hours."],
+            missing=[],
+            determination_made=False,
+            target_year=BASE_ELIGIBILITY_YEAR,
+        )
+
+        self.assertIn("already look eligible", info)
+        self.assertNotIn("newer income limits aren't published yet", info)
 
     def test_scored_ineligible_still_reads_as_a_verdict(self):
         """A completed check that came back negative is a firm answer."""

--- a/tests/sync/test_chat_tools.py
+++ b/tests/sync/test_chat_tools.py
@@ -474,6 +474,20 @@ class TestMedicaidEligibilityTool(TestCase):
         self.assertIsNotNone(match)
         self.assertIn("income", match.group(1))
 
+    def test_detect_mid_prose_and_clean_keeps_preamble(self):
+        """The pattern matches a call embedded in prose, and cleaning removes
+        only the call — not the model's prose before it. (The pattern used to
+        carry a leading `.*?`, which swallowed the preamble into group(0) and
+        made every scan of a non-matching reply quadratic under DOTALL.)"""
+        text = 'Let me check that. medicaid_eligibility {"income": 25000} Done.'
+        matches = self.tool.detect_all(text)
+
+        self.assertEqual(len(matches), 1)
+        cleaned = self.tool.clean_all_matches(text, matches)
+        self.assertIn("Let me check that.", cleaned)
+        self.assertIn("Done.", cleaned)
+        self.assertNotIn("medicaid_eligibility", cleaned)
+
     def test_build_eligibility_info_eligible(self):
         """Test eligibility info text generation for eligible user."""
         info = self.tool._build_eligibility_info(
@@ -600,7 +614,30 @@ class TestMedicaidEligibilityTool(TestCase):
 
         self.assertIn("may be eligible for it", info)
 
+    def test_indeterminate_result_still_reports_firm_positive_verdicts(self):
+        """A sub-check that DID finish with a yes is a real answer.
+
+        Declining only the 2026 work-hours question (or the Medicare-side
+        years-worked question) makes determination_made False, but the
+        2025-rules check may have completed with a firm positive -- hiding
+        it behind the blanket "no estimate" withheld a computed verdict.
+        """
+        info = self.tool._build_eligibility_info(
+            eligible_2025=True,
+            eligible_2026=False,
+            medicare=False,
+            alternatives=["We could not check qualifying work hours."],
+            missing=[],
+            determination_made=False,
+        )
+
+        self.assertIn("could NOT produce a Medicaid estimate", info)
+        self.assertIn("current (2025)", info)
+        self.assertIn("already look eligible", info)
+        self.assertNotIn("may not be eligible", info)
+
     def test_scored_ineligible_still_reads_as_a_verdict(self):
+        """A completed check that came back negative is a firm answer."""
         info = self.tool._build_eligibility_info(
             eligible_base=False,
             eligible_target=False,

--- a/tests/sync/test_context_manager.py
+++ b/tests/sync/test_context_manager.py
@@ -575,6 +575,22 @@ class TestSummaryStripHandlesRealCallerShapes:
         plain = "User asked about a knee MRI denial from Blue Shield."
         assert strip_previous_summary_blocks(plain) == plain
 
+    def test_tailless_stale_block_does_not_swallow_newest_section(self):
+        """A stale block with NO Additional-context tail used to consume
+        everything after it -- including the "Most recent context summary:"
+        section holding the newest per-turn context (collected eligibility
+        answers etc.), which was silently discarded and the loss persisted
+        back into summary_for_next_call."""
+        existing = (
+            "Previous context summary:\n"
+            "Earlier conversation summary: OLD SUMMARY\n\n"
+            "Most recent context summary:\n"
+            "state=CA, income=$1200/mo"
+        )
+        stripped = strip_previous_summary_blocks(existing)
+
+        assert stripped == "state=CA, income=$1200/mo"
+
     def test_bare_summary_leaves_nothing(self):
         assert (
             strip_previous_summary_blocks("Earlier conversation summary: OLD") is None

--- a/tests/sync/test_llm_client.py
+++ b/tests/sync/test_llm_client.py
@@ -572,6 +572,46 @@ class TestFindRepeatedReply(TestCase):
         self.assertIsNone(find_repeated_reply("", self._history(), "CA"))
         self.assertIsNone(find_repeated_reply(FRESH_REPLY, None, None))
 
+    def test_transform_of_pasted_text_not_flagged_as_echo(self):
+        """A faithful edit of user-pasted text legitimately echoes the paste."""
+        paste = "Fix the grammar of this: " + LOOPED_REPLY
+        self.assertIsNone(find_repeated_reply(LOOPED_REPLY, [], paste))
+
+    def test_iterative_edit_of_own_reply_not_flagged(self):
+        """"Now reformat it" makes output that normalizes equal to our last
+        reply -- normalize_text collapses exactly the differences a reformat
+        introduces, so the own-reply rung must stand down too."""
+        self.assertIsNone(
+            find_repeated_reply(
+                LOOPED_REPLY,
+                self._history(),
+                "Now reformat it into three paragraphs",
+            )
+        )
+
+
+class TestTransformRequestSoftPenalty(TestCase):
+    """compute_repetition_penalty stands down entirely on transform requests:
+    similarity to the paste or to our previous reply is compliance, and the
+    -400/-500 penalties otherwise beat the ~100-point content-quality deltas
+    even after the hard rung stands down."""
+
+    def test_no_penalty_for_faithful_transform_of_paste(self):
+        paste = "Please proofread this and fix the grammar: " + LOOPED_REPLY
+        self.assertEqual(compute_repetition_penalty(LOOPED_REPLY, [], paste), 0.0)
+
+    def test_no_penalty_for_iterative_edit_of_own_reply(self):
+        history = [
+            {"role": "user", "content": "draft an appeal for the MRI denial"},
+            {"role": "assistant", "content": LOOPED_REPLY},
+        ]
+        self.assertEqual(
+            compute_repetition_penalty(
+                LOOPED_REPLY, history, "now rephrase it a bit more formally"
+            ),
+            0.0,
+        )
+
 
 class TestHardRepeatRejection(TestCase):
     """score_llm_response must hard-reject (-inf) near-verbatim repeats.

--- a/tests/sync/test_medicaid_eligibility_api.py
+++ b/tests/sync/test_medicaid_eligibility_api.py
@@ -16,6 +16,7 @@ from fighthealthinsurance.medicaid_api import (
     MAX_TARGET_YEAR,
     WORK_REQUIREMENT_FIRST_YEAR,
     WORK_REQUIREMENT_UNIVERSAL_YEAR,
+    MedicaidDataUnavailableError,
     _normalize_applying_reason,
     current_eligibility_year,
     get_medicaid_info,
@@ -799,12 +800,18 @@ class TestGetMedicaidInfo(SimpleTestCase):
         # emitted a header promising data it structurally could not deliver.
         self.assertNotIn("MISC", get_medicaid_info({"state": "ca"}))
 
-    def test_territory_with_no_csv_row_returns_none(self):
+    def test_territory_with_no_csv_row_raises_data_unavailable(self):
         # PR/GU/VI/AS/MP normalize to a display name but have no row in
         # medicaid_resources.csv. Returning "No Medicaid data found for X."
         # here handed the caller prose it wraps as "Here's the official
-        # Medicaid information for Puerto Rico:" -- presenting a miss as data.
-        self.assertIsNone(get_medicaid_info({"state": "Puerto Rico"}))
+        # Medicaid information for Puerto Rico:" -- presenting a miss as
+        # data. Returning None was no better: None means "which state?" to
+        # the chat tool, which re-asked a question the user had already
+        # answered, forever. A dedicated error lets the tool say something
+        # useful instead.
+        with self.assertRaises(MedicaidDataUnavailableError) as caught:
+            get_medicaid_info({"state": "Puerto Rico"})
+        self.assertEqual(caught.exception.state, "Puerto Rico")
 
 
 class TestDeclinedAnswersDoNotBecomeVerdicts(SimpleTestCase):

--- a/tests/sync/test_medicaid_eligibility_landing_page.py
+++ b/tests/sync/test_medicaid_eligibility_landing_page.py
@@ -60,6 +60,32 @@ class TestMedicaidEligibilityLandingPage(TestCase):
         self.assertIn("80 hours per month", self.content)
 
 
+class TestMedicaidEligibilityFunnelIntoChat(TestCase):
+    """The CTA's microsite_slug must survive the whole path into chat."""
+
+    def test_slug_is_a_valid_attribution_slug(self):
+        # The websocket consumer and denial form validate microsite_slug
+        # before persisting it; the landing slug is attribution-only (no
+        # Microsite entry), so it needs the explicit allowlist -- otherwise
+        # the whole funnel's attribution was nulled with a warning per frame.
+        from fighthealthinsurance.microsites import is_valid_attribution_slug
+
+        self.assertTrue(is_valid_attribution_slug("medicaid-eligibility"))
+        self.assertFalse(is_valid_attribution_slug("not-a-real-slug"))
+
+    def test_consent_redirect_preserves_funnel_params(self):
+        # First-time visitors (no consent yet) are redirected to the consent
+        # form; a bare redirect dropped the query string, so the consent
+        # form's hidden fields were empty and the post-consent chat lost the
+        # eligibility kickoff.
+        response = Client().get(
+            reverse("chat"), {"microsite_slug": "medicaid-eligibility"}
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertIn(reverse("chat_consent"), response["Location"])
+        self.assertIn("microsite_slug=medicaid-eligibility", response["Location"])
+
+
 class TestMedicaidEligibilityPageStaging(TestCase):
     """The staging flag controls both routing and discoverability."""
 

--- a/tests/sync/test_medicaid_eligibility_landing_page.py
+++ b/tests/sync/test_medicaid_eligibility_landing_page.py
@@ -73,6 +73,19 @@ class TestMedicaidEligibilityFunnelIntoChat(TestCase):
         self.assertTrue(is_valid_attribution_slug("medicaid-eligibility"))
         self.assertFalse(is_valid_attribution_slug("not-a-real-slug"))
 
+    def test_non_string_slugs_are_rejected_not_raised_on(self):
+        """The websocket hands this through from raw client JSON.
+
+        The membership test raises TypeError on an unhashable value, which
+        answered a frame carrying {"microsite_slug": {}} with an internal
+        error instead of ignoring the slug like any other invalid one.
+        """
+        from fighthealthinsurance.microsites import is_valid_attribution_slug
+
+        for value in ({"x": 1}, ["medicaid-eligibility"], 12, True, None):
+            with self.subTest(value=value):
+                self.assertFalse(is_valid_attribution_slug(value))
+
     def test_consent_redirect_preserves_funnel_params(self):
         # First-time visitors (no consent yet) are redirected to the consent
         # form; a bare redirect dropped the query string, so the consent

--- a/tests/sync/test_response_similarity.py
+++ b/tests/sync/test_response_similarity.py
@@ -183,6 +183,12 @@ class TestUserRequestedRepeatPrecision(TestCase):
         "My state denied my Medicaid again, what can I do?",
         "I need to repeat the MRI but insurance denied it",
         "Please tell them again that this is urgent",
+        # The polite prefix ("can you repeat ...") used to accept ANY object,
+        # so the one shape this predicate exists to exclude slipped through
+        # whenever the user was merely polite about it.
+        "Can you repeat the MRI?",
+        "Do I need to repeat the colonoscopy?",
+        "could you repeat the bloodwork if the first one was inconclusive",
     )
 
     EXPLICIT_REQUESTS = (
@@ -198,6 +204,16 @@ class TestUserRequestedRepeatPrecision(TestCase):
         "state that again",
         "tell me that again",
         "show me that one more time",
+        # A bare polite ask, with the request ending there.
+        "could you repeat?",
+        # Named prior content, not just a pronoun: these are ordinary ways to
+        # ask for our last answer back, and returning False on them let the
+        # anti-repeat scorer steer the model away from the user's request.
+        "send your last reply again",
+        "show me the previous answer again",
+        "state the answer once more",
+        "repeat your answer",
+        "repeat the previous response",
     )
 
     def test_clinical_mentions_do_not_disable_the_ladder(self):
@@ -225,6 +241,9 @@ class TestTransformRequestExemption(TestCase):
         "reformat my appeal so I can send it",
         "check the spelling in the letter below",
         "copy-edit the following",
+        # Iterating on our own previous reply.
+        "Now reformat it into three paragraphs",
+        "now rephrase it a bit more formally",
     )
 
     NON_TRANSFORM_MESSAGES = (
@@ -233,6 +252,12 @@ class TestTransformRequestExemption(TestCase):
         "How do I improve my chances of approval?",
         "I want to check whether I might be eligible for Medicaid",
         "Can you help me appeal this denial?",
+        # Questions ABOUT rewriting are not requests to rewrite. The bare
+        # verbs used to match these and stand the whole ladder down on an
+        # ordinary advice turn.
+        "Should I reformat my appeal?",
+        "Will my insurer rephrase the denial?",
+        "Do they reformat denials before sending them?",
     )
 
     def test_transform_requests_are_recognized(self):

--- a/tests/sync/test_response_similarity.py
+++ b/tests/sync/test_response_similarity.py
@@ -16,6 +16,7 @@ from fighthealthinsurance.ml.response_similarity import (
     response_similarity,
     sequence_similarity,
     user_requested_repeat,
+    user_requested_transformation,
 )
 from fighthealthinsurance.ml.ml_models import MEDICAID_WORK_REQUIREMENTS_BLOCK
 from tests.chat_fixtures import CANNED_MEDICAID_REPLY, LOOPED_REPLY
@@ -175,6 +176,13 @@ class TestUserRequestedRepeatPrecision(TestCase):
         "The insurer keeps denying repeat imaging",
         "Can you resend the fax to my doctor?",
         "I filed an appeal one more time last month",
+        # Verb + "again" with arbitrary words between is ordinary denial
+        # vocabulary, not a repeat request -- these used to match and switch
+        # the whole ladder off on exactly the turns most likely to be
+        # mid-loop.
+        "My state denied my Medicaid again, what can I do?",
+        "I need to repeat the MRI but insurance denied it",
+        "Please tell them again that this is urgent",
     )
 
     EXPLICIT_REQUESTS = (
@@ -187,6 +195,9 @@ class TestUserRequestedRepeatPrecision(TestCase):
         "one more time please",
         "resend it",
         "show that again",
+        "state that again",
+        "tell me that again",
+        "show me that one more time",
     )
 
     def test_clinical_mentions_do_not_disable_the_ladder(self):
@@ -198,6 +209,41 @@ class TestUserRequestedRepeatPrecision(TestCase):
         for message in self.EXPLICIT_REQUESTS:
             with self.subTest(message=message):
                 self.assertTrue(user_requested_repeat(message))
+
+
+class TestTransformRequestExemption(TestCase):
+    """A faithful transformation (proofread / fix the grammar / reformat) of
+    the user's paste or of our previous reply is SUPPOSED to read nearly the
+    same as the source text, so the anti-repeat ladder stands down on
+    transform requests -- but only on explicit ones, per the
+    err-toward-not-matching rule."""
+
+    TRANSFORM_REQUESTS = (
+        "Can you fix the grammar of this: We was denied coverage for the MRI",
+        "proofread this and correct any typos",
+        "Please rewrite this paragraph so it sounds more professional",
+        "reformat my appeal so I can send it",
+        "check the spelling in the letter below",
+        "copy-edit the following",
+    )
+
+    NON_TRANSFORM_MESSAGES = (
+        "They denied the claim and won't fix the billing error",
+        "My doctor said she would revise the prior auth request",
+        "How do I improve my chances of approval?",
+        "I want to check whether I might be eligible for Medicaid",
+        "Can you help me appeal this denial?",
+    )
+
+    def test_transform_requests_are_recognized(self):
+        for message in self.TRANSFORM_REQUESTS:
+            with self.subTest(message=message):
+                self.assertTrue(user_requested_transformation(message))
+
+    def test_ordinary_messages_keep_the_ladder_armed(self):
+        for message in self.NON_TRANSFORM_MESSAGES:
+            with self.subTest(message=message):
+                self.assertFalse(user_requested_transformation(message))
 
 
 class TestCannedReplyRequiresTheWholeBlock(TestCase):

--- a/tests/sync/test_rest_api.py
+++ b/tests/sync/test_rest_api.py
@@ -48,6 +48,25 @@ else:
     User = get_user_model()
 
 
+def assert_letter_like(content: str) -> None:
+    """Assert generated appeal text is shaped like an appeal letter.
+
+    These end-to-end tests run against live model backends, and models
+    legitimately vary the opening: some start straight at the salutation,
+    others emit a letterhead (sender/date/recipient block, "Re:" line)
+    first — a shape the cleaning pipeline explicitly supports. So accept a
+    letter that either opens with a salutation or carries a letterhead /
+    salutation / "Re:" line near the top, instead of pinning the exact
+    first word of live LLM output.
+    """
+    stripped = content.lstrip()
+    head_lines = [line.strip().lstrip("*_# ") for line in stripped.splitlines()[:15]]
+    assert stripped.startswith("Dear") or any(
+        line.startswith(("Dear", "Re:", "Appeals Department"))
+        for line in head_lines
+    ), f"Appeal should open like a letter (salutation or letterhead): {stripped[:200]!r}"
+
+
 class DenialLongEmployerName(APITestCase):
     """Test denial with long employer name."""
 
@@ -316,7 +335,7 @@ class DenialEndToEnd(APITestCase):
         )
         # It's a streaming response with one per new line
         appeal = json.loads(responses[0])
-        assert appeal["content"].lstrip().startswith("Dear")
+        assert_letter_like(appeal["content"])
         # Now lets go ahead and provide follow up
         denial = await Denial.objects.aget(denial_id=denial_id)
         followup_url = reverse("followups-list")
@@ -451,9 +470,7 @@ class DenialEndToEnd(APITestCase):
         assert (
             len(appeal_contents) >= 1
         ), f"Should have received at least one appeal in {responses}"
-        assert (
-            appeal_contents[0].lstrip().startswith("Dear")
-        ), "Appeal should start with 'Dear'"
+        assert_letter_like(appeal_contents[0])
 
 
 class StreamingAppealsRestFallbackTest(APITestCase):

--- a/tests/sync/test_retry_anti_repeat.py
+++ b/tests/sync/test_retry_anti_repeat.py
@@ -76,6 +76,43 @@ class TestRetryScorerRepeatPenalty:
         repeat_score = scorer((LOOPED_REPLY, "ctx"), None)
         assert repeat_score > REPEAT_LAST_RESORT_PENALTY / 2
 
+    def test_requested_repeat_not_soft_penalized_below_fresh(self):
+        """When the user explicitly asks for a repeat, the compliant repeat
+        must not lose to a candidate that ignores the request: the soft
+        compute_repetition_penalty (-400/-500) has to stand down along with
+        the hard rungs."""
+        scorer = create_simple_retry_scorer(
+            call_scores={},
+            chat_history=CHAT_HISTORY,
+            current_message="can you repeat that?",
+        )
+        repeat_score = scorer((LOOPED_REPLY, "ctx"), None)
+        fresh_score = scorer((FRESH_REPLY, "ctx"), None)
+        assert repeat_score >= fresh_score - 1
+
+    def test_empty_response_scores_below_any_real_answer(self):
+        """A ('', context) tuple -- e.g. a reply that was only a panda
+        context summary -- can never be delivered (the post-selection
+        length check discards it), so it must lose to ANY real answer no
+        matter how high its backend's base score. It used to keep the full
+        base score, win selection, and collapse the retry to (None, None)."""
+
+        async def high_base():  # pragma: no cover - never awaited
+            return None
+
+        task = high_base()
+        try:
+            scorer = create_simple_retry_scorer(
+                call_scores={task: 100000},
+                chat_history=CHAT_HISTORY,
+                current_message="CA",
+            )
+            assert scorer(("", "a long context part " * 10), task) == float("-inf")
+            assert scorer(("   ", "ctx"), task) == float("-inf")
+            assert scorer((FRESH_REPLY, None), None) > float("-inf")
+        finally:
+            task.close()
+
 
 class TestRetryAntiRepeatInstruction:
     """retry_llm_with_fallback(anti_repeat=True) changes what the model sees."""


### PR DESCRIPTION
funnel params, anti-repeat exemptions, Medicaid status improvmenets

Medicaid-eligibility funnel into chat
- chat_interface_view dropped every query param on its consent redirect, so first-time visitors from a microsite or the /medicaid-eligibility CTA (exactly the users who have not consented yet) lost their kickoff. Forward them via one CHAT_FUNNEL_PARAMS list shared by the redirect, the consent view's success URL, and both templates' hidden fields (now rendered by a loop instead of hand-listed names); `medicare` is forwarded too.
- microsites.is_valid_attribution_slug accepts attribution-only slugs (medicaid-eligibility has no Microsite entry); the websocket consumer and denial form used get_microsite() to validate, nulling the funnel's attribution with a warning per frame. ChatInterface skips microsite context loading for those slugs instead of warning.
- chat_interface.tsx starts a fresh chat for the medicaid-eligibility CTA (a stored chat id silently skipped the kickoff) and strips the slug from the URL afterwards so reloads don't orphan the in-progress interview.

Anti-repeat ladder
- New user_requested_transformation(): proofread/fix-the-grammar/reformat requests legitimately produce output resembling the paste or our previous reply, so find_repeated_reply, compute_repetition_penalty, and the backends' allow_repeated_reply all stand down on those turns.
- user_requested_repeat no longer matches "<verb> ... again" with arbitrary words in between ("my state denied my Medicaid again", "repeat the MRI"), which switched the ladder off on the turns most likely to be mid-loop.
- score_llm_response and the retry scorer skip the soft repetition penalty when the user asked for a repeat, so the compliant candidate stops losing to one that ignores the request.
- Retry scorer: a candidate without deliverable text scores -inf (the post-selection length check could never deliver it, and its base score let it win and collapse the retry to (None, None)); the now-constant "has a response" bonus is gone.
- Tool-usage bonus in score_llm_response uses TOOL_DETECT_FLAGS (several patterns are ^/$-anchored, so it only ever fired at the reply start).
- MEDICAID_ELIGIBILITY_REGEX drops its leading `.*?`, which made every scan of a non-matching reply quadratic under DOTALL and swallowed the model's preamble when cleaning.
- The rejected-repeats loop metric is recorded once per turn across the primary and recursive tool passes (was per depth). debug_llm_result's `alternate_offered` is renamed `alternate_candidate`: it is sent before tool processing / presentability checks can still drop the alternate.

Medicaid data
- get_medicaid_info raises MedicaidDataUnavailableError when the state was understood but there is no data (territory without a CSV row, CSV missing or unreadable) instead of returning None, which the chat tool rendered as "Which state are you in?" forever. The tool now tells the user we have no contact data for that state.
- _load_medicaid_resources only caches successful reads (lru_cache latched a transient None for the process lifetime).
- _KNOWN_ELIGIBILITY_FIELDS is derived from the typed field sets instead of a hand-maintained copy that could drift.
- MedicaidEligibilityTool reports sub-checks that finished with a firm positive even when the overall determination is indeterminate.

Context / persistence
- strip_previous_summary_blocks: a stale block with no "Additional context" tail swallowed everything after it, including the "Most recent context summary:" section holding the newest per-turn context. Wrapper labels now bound the stale block, and chat_interface builds its wrapper from the labels context_manager exports.
- The legacy internal-note regex accepted only `#\d+` ids; PriorAuthRequest pks are UUIDs, so those notes replayed as user bubbles and leaked into previews/titles. iter_visible_history lets the chat list/title paths stop at the first visible message instead of copying the whole history.

Websocket / audit / middleware / settings
- Answer-feedback frames only count for the chat this socket has open, and empty-message frames carrying appeal/prior-auth linking no longer short-circuit on the feedback branch.
- extract_tracking_info_from_scope is offloaded with sync_to_async (its first geo lookup blocks on the reader lock during startup warm-up).
- audit.py validates X-Forwarded-For/X-Real-IP literals in one helper for both get_asn_info and guess_us_state, and derives its state tables from medicaid_api's canonical map instead of a third hand-typed copy.
- MetricsAccessMiddleware caches its async-mode check and the rstripped metrics path; documents the ingress-header assumptions.
- settings._env_list replaces four copies of the comma-split env parsing.

Tests: cover each of the above; AZURE_*_MODELS overrides are cleared in the backend-catalog tests since tox passes the developer's shell through; the live-backend REST tests accept letterhead-style appeal openings.


Claude-Session: https://claude.ai/code/session_017TDnpMcjQCFeSUDuB9ni6M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat better supports requests to repeat, edit, reformat, or rewrite content without suppressing valid responses.
  * Medicaid guidance reports confirmed eligibility findings and offers alternative help when state data is unavailable.
  * Eligibility landing-page attribution and funnel details are preserved through chat setup.
* **Bug Fixes**
  * Improved handling of conversation summaries, internal notes, feedback, and appeal/prior-authorization interactions.
  * Prevented stale summaries and previous chats from overwriting newer content or reappearing unexpectedly.
* **Documentation**
  * Updated debug-result terminology from “alternate offered” to “alternate candidate.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->