### PR TITLE
Make pro connector letters undated and name PDF files by recipient

### DIFF
--- a/fighthealthinsurance/proconnector.py
+++ b/fighthealthinsurance/proconnector.py
@@ -320,8 +320,10 @@ def _letter_title_part(value: Optional[str]) -> str:
     long practice name can't produce an unwieldy name.
     """
     text = _UNSAFE_TITLE_CHARS.sub(" ", (value or "").strip())
-    text = re.sub(r"\s+", " ", text).strip(" .-")
-    return text[:LETTER_TITLE_PART_MAX_LEN].strip()
+    text = re.sub(r"\s+", " ", text)
+    # Strip after the cap too: truncation can otherwise reintroduce a trailing
+    # "." (invalid at the end of a Windows file name) or a dangling "-".
+    return text[:LETTER_TITLE_PART_MAX_LEN].strip(" .-")
 
 
 def build_letter_document_title(pro: InterestedProfessional) -> str:
@@ -334,13 +336,15 @@ def build_letter_document_title(pro: InterestedProfessional) -> str:
     letter body carries no date either). Falls back to the bare prefix when we
     know neither a name nor an organization.
     """
-    parts = [LETTER_TITLE_PREFIX]
+    parts: list[str] = []
     for value in (pro.name, pro.business_name):
         cleaned = _letter_title_part(value)
-        # Skip a business name that just repeats the person's name.
+        # Skip a business name that just repeats the person's name. Only prior
+        # name parts count as duplicates -- an organization actually named
+        # "Letter" must not be swallowed by the prefix.
         if cleaned and cleaned.lower() not in {p.lower() for p in parts}:
             parts.append(cleaned)
-    return " - ".join(parts)
+    return " - ".join([LETTER_TITLE_PREFIX, *parts])
 
 
 def build_search_links(pro: InterestedProfessional) -> dict[str, Optional[str]]:

--- a/fighthealthinsurance/proconnector.py
+++ b/fighthealthinsurance/proconnector.py
@@ -115,6 +115,20 @@ PROCONNECTOR_INTRO_SUBJECT = (
     "An introduction to Cofactor AI from Fight Health Insurance"
 )
 
+# Leading word of the printable letter's document title. Browsers seed the
+# "Save as PDF" file name from the title, so the title is what staff end up
+# with on disk (see build_letter_document_title).
+LETTER_TITLE_PREFIX = "Letter"
+
+# Per-part cap on the letter title, so a very long practice name still yields a
+# manageable file name.
+LETTER_TITLE_PART_MAX_LEN = 60
+
+# Characters that are illegal or awkward in a file name on common platforms;
+# browsers substitute their own placeholder for these, so we replace them with
+# a space first.
+_UNSAFE_TITLE_CHARS = re.compile(r'[\\/:*?"<>|\x00-\x1f]+')
+
 # The approved base email. Staff can edit it before sending, the AI draft is
 # personalized from it, and it is the always-safe fallback when AI drafting is
 # unavailable or produces unsafe output. ``{greeting_name}`` is filled with the
@@ -295,6 +309,38 @@ def build_intro_letter_blocks(pro: InterestedProfessional) -> dict[str, Any]:
         "closing": BASE_INTRO_LETTER_CLOSING,
         "signature": BASE_INTRO_LETTER_SIGNATURE,
     }
+
+
+def _letter_title_part(value: Optional[str]) -> str:
+    """Clean one piece of the letter document title for use in a file name.
+
+    Browsers turn the page title into the suggested "Save as PDF" file name, so
+    characters that are illegal (or merely awkward) in a file name are replaced
+    with a space, runs of whitespace collapse, and the result is capped so a
+    long practice name can't produce an unwieldy name.
+    """
+    text = _UNSAFE_TITLE_CHARS.sub(" ", (value or "").strip())
+    text = re.sub(r"\s+", " ", text).strip(" .-")
+    return text[:LETTER_TITLE_PART_MAX_LEN].strip()
+
+
+def build_letter_document_title(pro: InterestedProfessional) -> str:
+    """Document title (and so print-to-PDF file name) for ``pro``'s letter.
+
+    Staff print these in batches, so the title names the recipient and their
+    organization -- ``Letter - Dr. Jane Smith - Acme Health Clinic`` rather than
+    a stack of identically named files. Deliberately un-dated: letters are
+    printed ahead of time and mailed later, so a date only goes stale (the
+    letter body carries no date either). Falls back to the bare prefix when we
+    know neither a name nor an organization.
+    """
+    parts = [LETTER_TITLE_PREFIX]
+    for value in (pro.name, pro.business_name):
+        cleaned = _letter_title_part(value)
+        # Skip a business name that just repeats the person's name.
+        if cleaned and cleaned.lower() not in {p.lower() for p in parts}:
+            parts.append(cleaned)
+    return " - ".join(parts)
 
 
 def build_search_links(pro: InterestedProfessional) -> dict[str, Optional[str]]:

--- a/fighthealthinsurance/staff_views.py
+++ b/fighthealthinsurance/staff_views.py
@@ -50,6 +50,7 @@ from fighthealthinsurance.ml.model_identity import (
 from fighthealthinsurance.proconnector import (
     PROCONNECTOR_INTRO_SUBJECT,
     build_intro_letter_blocks,
+    build_letter_document_title,
     build_search_links,
     claim_email_for_send,
     cofactor_cc_problem,
@@ -1442,7 +1443,11 @@ class ProConnectorLetterView(View):
             # to the processing page rather than 404 on a transient link.
             return redirect("proconnector_process")
         context = {
-            "title": "Pro Connector Letter",
+            # Browsers seed the print-to-PDF file name from the page title, so
+            # this names the recipient and their organization; staff printing a
+            # batch get distinguishable files instead of a stack of identical
+            # ones.
+            "title": build_letter_document_title(pro),
             "pro": pro,
             # The letter's blocks, laid out by the template so the printed page
             # paginates like a letter -- see build_intro_letter_blocks.
@@ -1452,7 +1457,6 @@ class ProConnectorLetterView(View):
             # processing page already treats it (see build_address_search_link).
             "recipient_address": (pro.address or "").strip(),
             "contact_email": get_professional_cc_email(),
-            "today": timezone.now().date(),
         }
         return render(request, self.template_name, context)
 

--- a/fighthealthinsurance/templates/proconnector_letter.html
+++ b/fighthealthinsurance/templates/proconnector_letter.html
@@ -1,9 +1,9 @@
-<!DOCTYPE html>
+{% load static %}<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{{ title|default:"Pro Connector Letter" }}</title>
+  <title>{{ title|default:"Letter" }}</title>
   <style>
     /* This page exists to be printed and mailed, so the on-screen view is a
        true-to-size US Letter sheet (8.5in x 11in, 1in margins) laid out in the
@@ -84,11 +84,22 @@
     }
 
     .letterhead {
+      display: flex;
+      align-items: center;
+      gap: 12pt;
       border-bottom: 1.5pt solid #000;
       padding-bottom: 7pt;
       margin-bottom: 24pt;
       page-break-inside: avoid;
       break-inside: avoid;
+    }
+    .letterhead img {
+      width: 44pt;
+      height: 44pt;
+      flex: none;
+      /* Keep the mark from being dropped as a "background" graphic. */
+      print-color-adjust: exact;
+      -webkit-print-color-adjust: exact;
     }
     .letterhead .org { font-size: 16pt; font-weight: bold; }
     /* The URL and the contact address are both long unbreakable runs; let
@@ -99,8 +110,6 @@
       overflow-wrap: anywhere;
     }
     .letterhead a { color: #0b4f9e; text-decoration: none; }
-
-    .date { margin: 0 0 22pt; }
 
     .recipient {
       margin: 0 0 24pt;
@@ -188,7 +197,7 @@
       Prints on US Letter with 1&Prime; margins. In the print dialog choose
       <strong>Letter</strong> paper and turn <strong>off</strong> &ldquo;Headers
       and footers&rdquo; so the browser doesn&rsquo;t stamp a URL and date on the
-      page.
+      page. Saving as PDF names the file &ldquo;{{ title }}&rdquo;.
     </p>
   </div>
 
@@ -202,14 +211,15 @@
 
   <main class="sheet">
     <div class="letterhead">
-      <div class="org">Fight Health Insurance</div>
-      <div class="contact">
-        <a href="https://www.fighthealthinsurance.com">www.fighthealthinsurance.com</a>
-        &middot; {{ contact_email }}
+      <img src="{% static 'images/better-logo-optimized.png' %}" alt="">
+      <div>
+        <div class="org">Fight Health Insurance</div>
+        <div class="contact">
+          <a href="https://www.fighthealthinsurance.com">www.fighthealthinsurance.com</a>
+          &middot; {{ contact_email }}
+        </div>
       </div>
     </div>
-
-    <div class="date">{{ today|date:"F j, Y" }}</div>
 
     <div class="recipient">
       {% if pro.name %}<span class="line">{{ pro.name }}</span>{% endif %}

--- a/fighthealthinsurance/templates/proconnector_letter.html
+++ b/fighthealthinsurance/templates/proconnector_letter.html
@@ -1,4 +1,4 @@
-{% load static %}<!DOCTYPE html>
+<!DOCTYPE html>{% load static %}
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -197,7 +197,7 @@
       Prints on US Letter with 1&Prime; margins. In the print dialog choose
       <strong>Letter</strong> paper and turn <strong>off</strong> &ldquo;Headers
       and footers&rdquo; so the browser doesn&rsquo;t stamp a URL and date on the
-      page. Saving as PDF names the file &ldquo;{{ title }}&rdquo;.
+      page. Saving as PDF names the file &ldquo;{{ title|default:"Letter" }}&rdquo;.
     </p>
   </div>
 

--- a/tests/sync/test_proconnector.py
+++ b/tests/sync/test_proconnector.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.core import mail
+from django.template.defaultfilters import date as date_filter
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
@@ -1635,6 +1636,18 @@ class LetterDocumentTitleTest(TestCase):
         self.assertIn("Letter - Dr. Jane Smith - ", title)
         self.assertLessEqual(len(title.split(" - ")[-1]), 60)
 
+    def test_truncation_cannot_leave_a_trailing_dot(self):
+        # A part capped right after a "." would otherwise end the file name
+        # with a dot, which Windows rejects.
+        pro = _make_pro(name="", business_name="A" * 59 + ". Inc")
+        self.assertEqual(build_letter_document_title(pro), "Letter - " + "A" * 59)
+
+    def test_organization_named_letter_is_kept(self):
+        # Deduplication is against the name parts only; the "Letter" prefix
+        # must not swallow an organization actually named Letter.
+        pro = _make_pro(name="", business_name="Letter")
+        self.assertEqual(build_letter_document_title(pro), "Letter - Letter")
+
 
 class LetterViewTest(TestCase):
     def setUp(self):
@@ -1780,9 +1793,12 @@ class LetterViewTest(TestCase):
         # Printed in batches and mailed later, so the letter carries no date.
         _login(self.client, is_staff=True)
         response = self.client.get(self.url)
-        today = timezone.now().date()
-        self.assertNotContains(response, today.strftime("%B %-d, %Y"))
-        self.assertNotContains(response, str(today.year))
+        # The dateline the template used to render (Django's "F j, Y" format);
+        # asserting on the formatted date rather than the bare year keeps the
+        # test from tripping on an unrelated occurrence of the digits.
+        rendered_today = date_filter(timezone.now().date(), "F j, Y")
+        self.assertNotContains(response, rendered_today)
+        self.assertNotContains(response, 'class="date"')
 
     def test_missing_record_redirects_to_process(self):
         _login(self.client, is_staff=True)

--- a/tests/sync/test_proconnector.py
+++ b/tests/sync/test_proconnector.py
@@ -25,6 +25,7 @@ from fighthealthinsurance.proconnector import (
     build_address_search_link,
     build_base_intro_email,
     build_intro_letter_blocks,
+    build_letter_document_title,
     build_search_links,
     cofactor_cc_problem,
     default_intro_cc_recipients,
@@ -1589,6 +1590,52 @@ class IntroLetterWordingTest(TestCase):
         self.assertIsNone(proconnector.intro_wording_problem(_rendered_letter(pro)))
 
 
+class LetterDocumentTitleTest(TestCase):
+    """The title is what the browser suggests as the print-to-PDF file name."""
+
+    def test_title_includes_person_and_organization(self):
+        pro = _make_pro(name="Dr. Jane Smith", business_name="Acme Health Clinic")
+        self.assertEqual(
+            build_letter_document_title(pro),
+            "Letter - Dr. Jane Smith - Acme Health Clinic",
+        )
+
+    def test_title_has_no_date(self):
+        # Letters are printed ahead of time and mailed later, so no date.
+        pro = _make_pro()
+        title = build_letter_document_title(pro)
+        self.assertNotIn(str(timezone.now().year), title)
+
+    def test_title_omits_missing_organization(self):
+        pro = _make_pro(name="Dr. Jane Smith", business_name="")
+        self.assertEqual(build_letter_document_title(pro), "Letter - Dr. Jane Smith")
+
+    def test_title_omits_missing_name(self):
+        pro = _make_pro(name="", business_name="Acme Health Clinic")
+        self.assertEqual(build_letter_document_title(pro), "Letter - Acme Health Clinic")
+
+    def test_title_falls_back_when_nothing_known(self):
+        pro = _make_pro(name="", business_name="")
+        self.assertEqual(build_letter_document_title(pro), "Letter")
+
+    def test_title_does_not_repeat_organization_matching_name(self):
+        pro = _make_pro(name="Jane Smith MD", business_name="jane smith md")
+        self.assertEqual(build_letter_document_title(pro), "Letter - Jane Smith MD")
+
+    def test_title_strips_characters_illegal_in_file_names(self):
+        pro = _make_pro(name="Dr. Jane/Smith", business_name='Acme: "Health" <Clinic>')
+        title = build_letter_document_title(pro)
+        for char in '\\/:*?"<>|':
+            self.assertNotIn(char, title)
+        self.assertEqual(title, "Letter - Dr. Jane Smith - Acme Health Clinic")
+
+    def test_title_collapses_whitespace_and_caps_long_parts(self):
+        pro = _make_pro(name="Dr.   Jane\n Smith", business_name="B" * 200)
+        title = build_letter_document_title(pro)
+        self.assertIn("Letter - Dr. Jane Smith - ", title)
+        self.assertLessEqual(len(title.split(" - ")[-1]), 60)
+
+
 class LetterViewTest(TestCase):
     def setUp(self):
         self.pro = _make_pro(
@@ -1720,6 +1767,22 @@ class LetterViewTest(TestCase):
         _login(self.client, is_staff=True)
         response = self.client.get(self.url)
         self.assertNotContains(response, "No mailing address on file")
+
+    def test_letter_title_names_recipient_and_organization(self):
+        # Browsers name the saved PDF after the document title.
+        _login(self.client, is_staff=True)
+        response = self.client.get(self.url)
+        self.assertContains(
+            response, "<title>Letter - Dr. Jane Smith - Acme Health Clinic</title>"
+        )
+
+    def test_letter_is_not_dated(self):
+        # Printed in batches and mailed later, so the letter carries no date.
+        _login(self.client, is_staff=True)
+        response = self.client.get(self.url)
+        today = timezone.now().date()
+        self.assertNotContains(response, today.strftime("%B %-d, %Y"))
+        self.assertNotContains(response, str(today.year))
 
     def test_missing_record_redirects_to_process(self):
         _login(self.client, is_staff=True)


### PR DESCRIPTION
## Summary
Updates the pro connector letter template and generation to remove the date from printed letters and use the recipient's name and organization as the document title (which browsers use as the default PDF file name when saving).

## Changes

- **Remove date from letters**: Letters are printed in batches and mailed later, so including a date only causes it to go stale. Removed the `<div class="date">` from the template and the `today` context variable from the view.

- **Add `build_letter_document_title()` function**: New helper that generates a descriptive document title like "Letter - Dr. Jane Smith - Acme Health Clinic" for use as the browser's print-to-PDF file name. Includes:
  - Sanitization of illegal/awkward file name characters (`\/:*?"<>|`)
  - Whitespace normalization and collapsing
  - Per-part length capping (60 chars) to prevent unwieldy file names
  - Deduplication when business name matches person's name
  - Fallback to bare "Letter" when neither name nor organization is known
  - Prevention of trailing dots (invalid in Windows file names)

- **Update letter view**: Changed the page title from the static "Pro Connector Letter" to the dynamic result of `build_letter_document_title(pro)`, so staff printing batches get distinguishable files instead of a stack of identically named PDFs.

- **Enhance letterhead styling**: Added flexbox layout to the letterhead to accommodate a logo image alongside the organization name and contact info, with print-color-adjust to preserve colors when printing.

- **Update template instructions**: Clarified in the print instructions that saving as PDF will use the document title as the file name.

## Testing
Added comprehensive test coverage in `LetterDocumentTitleTest` with 9 test cases covering:
- Basic title generation with name and organization
- Absence of dates in the title
- Handling of missing name or organization
- Deduplication of matching names
- Illegal character removal
- Whitespace normalization and truncation
- Edge cases like trailing dots and organizations named "Letter"

Also added integration tests in `LetterViewTest` to verify the title appears in the rendered HTML and that no date is present in the response.

https://claude.ai/code/session_014W8kJtmggZwPLB7CLDXac1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Printable letters now include a professional letterhead logo.
  * PDF filenames are automatically generated from recipient and organization names.
  * Names are cleaned, deduplicated, and formatted for safe, readable filenames, with a fallback title when details are unavailable.
  * Print instructions explain that saving as a PDF uses the document title.

* **Updates**
  * Removed the printed date from printable letters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->