### PR TITLE
Add GeoIP city database fetch with pinned digest verification

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -179,3 +179,5 @@ a.tr
 !./latest_logs
 # Exclude test coverage reports
 reports/
+# GeoIP city database; the image fetches its own verified copy at build time
+geoip_data

--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,6 @@ default/
 .claude/worktrees/
 # Vendored Claude Code skills (tooling, not product code)
 .claude/skills/
+
+# GeoIP city database fetched by scripts/fetch_geoip_db.sh (see README "GeoIP")
+geoip_data

--- a/README.md
+++ b/README.md
@@ -146,36 +146,48 @@ export FHI_GEOIP_CITY_DB=/path/to/geoip2fast-city-asn-ipv6.dat.gz
 ```
 
 The `geoip2fast` package itself is installed via `requirements.txt`, but it
-only bundles country/ASN databases — state (subdivision) data requires a
-city-level file downloaded from the geoip2fast releases. Use the
-`-city-asn-ipv6` variant so ASN lookups work too:
+only bundles country/ASN databases — state (subdivision) data requires the
+city-level `-city-asn-ipv6` file, which also carries the ASN data.
+`scripts/fetch_geoip_db.sh` is the one place that knows how to get it, so dev
+boxes and images install identical, identically-verified bytes:
 
 ```bash
-# Pin a specific release tag, never the moving `LATEST`.
-GEOIP2FAST_RELEASE=v1.2.2
-curl -L -o geoip2fast-city-asn-ipv6.dat.gz \
-  "https://github.com/rabuchaim/geoip2fast/releases/download/${GEOIP2FAST_RELEASE}/geoip2fast-city-asn-ipv6.dat.gz"
-
-# Verify against a digest you already trust. GEOIP2FAST_SHA256 must come from
-# somewhere INDEPENDENT of this download -- the value published by the project
-# for this tag, or one you recorded on a trusted machine and then stored in
-# the repo / your secrets manager. Deriving it from the file you just fetched
-# (sha256sum file > file.sha256 && sha256sum -c) verifies nothing: a swapped
-# asset passes its own checksum.
-GEOIP2FAST_SHA256=<expected-digest-for-${GEOIP2FAST_RELEASE}>
-echo "${GEOIP2FAST_SHA256}  geoip2fast-city-asn-ipv6.dat.gz" | sha256sum -c - \
-  || { echo "GeoIP database failed checksum -- refusing to install"; exit 1; }
-
-export FHI_GEOIP_CITY_DB="$PWD/geoip2fast-city-asn-ipv6.dat.gz"
+scripts/fetch_geoip_db.sh                 # -> geoip_data/ (gitignored)
+scripts/fetch_geoip_db.sh --print-sha     # digest only, installs nothing
 ```
+
+It downloads the file, checks it against the digest pinned in
+`scripts/geoip2fast-city-asn-ipv6.sha256`, and installs nothing at all on a
+mismatch (a previously installed copy that no longer matches is removed too).
+Re-running is a no-op once the file is in place.
+
+* **Local dev:** `scripts/run_local.sh` runs the fetch (in parallel with the
+  other startup work) and exports `FHI_GEOIP_CITY_DB` when the file is there.
+  Nothing to do by hand.
+* **Deployments:** `k8s/Dockerfile` runs the same script at build time into
+  `/opt/geoip/`, root-owned and read-only to the app, and bakes
+  `ENV FHI_GEOIP_CITY_DB` into the image. No runtime download, nothing to
+  mount, and the bytes are fixed at build time. Kubernetes needs no extra
+  config; a pod picks it up from the image.
+
+Upstream publishes these databases only under the moving `LATEST` tag, so the
+pinned digest — not a version tag — is what makes the fetch reproducible: a
+republished asset fails verification loudly instead of swapping itself in. When
+you deliberately move to a newer release, record the new digest with
+`--print-sha` **on a machine and network you trust** and commit it. A build
+with no digest pinned, an unreachable upstream, or a republished (mismatching)
+asset still succeeds; it just ships without the database and the app warns at
+startup. Pass `--require` where shipping without it should fail instead.
 
 > **Treat this file as trusted code, not data.** geoip2fast loads the database
 > with `pickle.load()`, so anything that can replace the file (a swapped
 > release asset, a MITM on a build box, write access to the deployment volume)
 > can execute code inside the web process — which holds DB credentials and the
-> PHI field-encryption keys. Pin the release, verify the checksum before the
-> file reaches a server, and give the mounted path the same write protections
-> you give application code.
+> PHI field-encryption keys. That is what the pinned digest protects, which is
+> why bytes that fail verification are never installed -- and a stale copy that
+> stops matching is removed -- even though a missing database is otherwise
+> tolerated, and why the file is baked into the image instead of downloaded at
+> pod start.
 
 **Soft fail:** when `FHI_GEOIP_CITY_DB` is unset (or the file is missing /
 unreadable, or the package isn't installed) nothing breaks — the state guess

--- a/docs/chat-pipeline.md
+++ b/docs/chat-pipeline.md
@@ -271,35 +271,31 @@ Three levels, in increasing detail:
 
 ## 8. Known gaps and roadmap (prioritized)
 
-1. **Ship the city DB in k8s.** guess_us_state and ASN tracking soft-fail
-   without FHI_GEOIP_CITY_DB (startup warns exactly this); the chart
-   doesn't yet mount a geoip2fast city database. Low effort, unlocks the
-   state hint in prod.
-2. **Streaming responses.** The infra streams status heartbeats but final
+1. **Streaming responses.** The infra streams status heartbeats but final
    answers arrive whole. Token streaming from the winning backend would
    cut perceived latency drastically — but it collides with fan-out
    scoring (you can't score a stream you haven't finished). A pragmatic
    shape: keep the fan-out for the first N seconds, then stream the
    leader's remainder. Biggest UX win, medium-large effort.
-3. **Legacy backend prompt shape.** RemoteHealthInsurance
+2. **Legacy backend prompt shape.** RemoteHealthInsurance
    (supports_system=False) receives the system prompt folded into the
    final user message. It's quality 101 so it rarely wins, but its calls
    burn capacity; consider dropping it from the chat pool entirely.
-4. **Retry-button double turns.** The client retry sends the same message
+3. **Retry-button double turns.** The client retry sends the same message
    again; the server merges duplicates at persist time (serial + deduped)
    but the second LLM turn still runs. An in-flight turn-id (client echoes
    it, server drops re-submits of a live turn) would make retry free.
-5. **Per-model win/lose metrics.** The debug frame reports the picked
+4. **Per-model win/lose metrics.** The debug frame reports the picked
    model; promote that to a bounded-cardinality counter
    (fhi_chat_model_wins_total{model}) so the quality map can be tuned
    from dashboards, not log greps. (Deliberately deferred: needs a label
    allowlist to keep cardinality bounded.)
-6. **Summarization model diversity.** summarize_chat_history routes to one
+5. **Summarization model diversity.** summarize_chat_history routes to one
    summarizer; a bad summary quietly poisons every later turn's context.
    Cheap guard: score summaries with the repetition detector before
    storing (a summary that mostly repeats the raw history is fine; one
    that repeats the model's last REPLY is the poison case).
-7. **Evaluation harness.** The loop bug shipped because nothing exercised
+6. **Evaluation harness.** The loop bug shipped because nothing exercised
    multi-turn conversations against scripted "sticky" backends. The test
    suite now covers the ladder with RecordingChatModel; a nightly
    scripted-conversation eval against the real internal backends (no

--- a/fighthealthinsurance/ml/health_status.py
+++ b/fighthealthinsurance/ml/health_status.py
@@ -137,6 +137,20 @@ class _HealthStatus:
         """
         self._ensure_sweep_scheduled(refresh_now=True)
 
+    def _background_sweep_enabled(self) -> bool:
+        """Whether the recurring background sweep should run in this config.
+
+        Disabled in the ``Test*`` configs: the sweep re-arms itself on a timer
+        thread for the life of the process and writes the cross-pod alert
+        throttle row on every pass, so its writes land in the middle of
+        unrelated tests and can lock the table against a
+        ``TransactionTestCase`` teardown flush. Callers that need a real
+        measurement (``get_snapshot``) still sweep synchronously.
+        """
+        from django.conf import settings
+
+        return bool(getattr(settings, "ML_HEALTH_BACKGROUND_SWEEP", True))
+
     def _ensure_sweep_scheduled(self, refresh_now: bool) -> None:
         """Kick off the recurring sweep exactly once (idempotent, non-blocking).
 
@@ -145,7 +159,7 @@ class _HealthStatus:
         start the timer chain, because the caller already refreshed
         synchronously and the snapshot is warm.
         """
-        if self._sweep_started:
+        if self._sweep_started or not self._background_sweep_enabled():
             return
         with self._start_lock:
             if self._sweep_started:
@@ -159,7 +173,13 @@ class _HealthStatus:
             self._schedule_refresh()
 
     def _schedule_refresh(self):
-        """Schedule the next refresh."""
+        """Schedule the next refresh.
+
+        No-ops when the background sweep is disabled, so a direct ``_refresh``
+        call can't arm a timer chain the config asked us not to run.
+        """
+        if not self._background_sweep_enabled():
+            return
         try:
             interval = 5 if self._fast_mode else REFRESH_INTERVAL_SECONDS
             self._timer = threading.Timer(interval, self._refresh)

--- a/fighthealthinsurance/settings.py
+++ b/fighthealthinsurance/settings.py
@@ -489,6 +489,15 @@ class Base(Configuration):
     # form, so every test that files a denial would start one.
     SPECULATIVE_APPEALS_PRECOMPUTE = True
 
+    # Run the recurring background model-health sweep (see
+    # ml.health_status). Off in the Test* configs: the sweep re-arms itself on
+    # a timer thread for the life of the process and writes to the DB on every
+    # pass (the cross-pod alert throttle row), so its writes land in the middle
+    # of unrelated tests and can lock the table against TransactionTestCase's
+    # teardown flush. Tests that care call get_snapshot() directly, which still
+    # sweeps synchronously.
+    ML_HEALTH_BACKGROUND_SWEEP = True
+
     # Per-WebSocket-connection ThreadSensitiveContext (see
     # websockets.PerConnectionThreadSensitiveMixin): without it every
     # thread_sensitive=True bridge in the process shares asgiref's single
@@ -817,6 +826,8 @@ class Test(Dev):
     SITE_BANNER_BACKGROUND_REFRESH = False
     # No speculative precompute in tests (see Base).
     SPECULATIVE_APPEALS_PRECOMPUTE = False
+    # No recurring background health sweep in tests (see Base).
+    ML_HEALTH_BACKGROUND_SWEEP = False
     # Keep thread-sensitive bridge routing on the test thread (see Base).
     WS_PER_CONNECTION_THREAD_SENSITIVE = False
 
@@ -847,6 +858,8 @@ class TestSync(Dev):
     SITE_BANNER_BACKGROUND_REFRESH = False
     # No speculative precompute in tests (see Base).
     SPECULATIVE_APPEALS_PRECOMPUTE = False
+    # No recurring background health sweep in tests (see Base).
+    ML_HEALTH_BACKGROUND_SWEEP = False
     # Keep thread-sensitive bridge routing on the test thread (see Base).
     WS_PER_CONNECTION_THREAD_SENSITIVE = False
 
@@ -884,6 +897,8 @@ class TestActor(Dev):
     SITE_BANNER_BACKGROUND_REFRESH = False
     # No speculative precompute in tests (see Base).
     SPECULATIVE_APPEALS_PRECOMPUTE = False
+    # No recurring background health sweep in tests (see Base).
+    ML_HEALTH_BACKGROUND_SWEEP = False
     # Keep thread-sensitive bridge routing on the test thread (see Base).
     WS_PER_CONNECTION_THREAD_SENSITIVE = False
 

--- a/k8s/Dockerfile
+++ b/k8s/Dockerfile
@@ -32,6 +32,22 @@ RUN export PATH=/root/.local/bin:$PATH && \
     uv pip install --system -r /opt/fighthealthinsurance/requirements.txt && \
     uv pip install --system -r /opt/fighthealthinsurance/deploy-requirements.txt
 RUN mkdir -p /external_data
+# GeoIP city database (chat US-state hint + ASN tracking). Fetched and
+# sha256-verified at build time from the digest pinned in the repo, so the
+# bytes geoip2fast later unpickles are the ones we reviewed -- no runtime
+# download, no writable path, root-owned and world-readable like the rest of
+# the application code. A build with no pinned digest, an unreachable
+# upstream, or a republished LATEST asset that no longer matches the pin
+# still succeeds and simply ships without the database (unverified bytes are
+# never installed); the app soft-fails and warns at startup, naming the path
+# below. Add --require here to make shipping without it fail the build
+# instead. Web-image only:
+# both callers (websockets.py, rest_views.py) run in the web process, so the
+# ray image does not need the database.
+COPY scripts/fetch_geoip_db.sh scripts/geoip2fast-city-asn-ipv6.sha256 /opt/fighthealthinsurance/scripts/
+RUN /opt/fighthealthinsurance/scripts/fetch_geoip_db.sh \
+    --dest /opt/geoip/geoip2fast-city-asn-ipv6.dat.gz
+ENV FHI_GEOIP_CITY_DB=/opt/geoip/geoip2fast-city-asn-ipv6.dat.gz
 # We copy static early ish since it could also be cached nicely
 # Remember to update the combined ray docker file for these copies
 ADD --chown=www-data:www-data static /opt/fighthealthinsurance/static

--- a/scripts/fetch_geoip_db.sh
+++ b/scripts/fetch_geoip_db.sh
@@ -1,0 +1,190 @@
+#!/bin/bash
+# Fetch and verify the geoip2fast CITY database that FHI_GEOIP_CITY_DB points at.
+#
+# Why this exists: the pip package only bundles country/ASN databases, so
+# guess_us_state (chat state hint) and get_asn_info soft-fail -- returning
+# nothing and logging one startup warning -- until a city-level file is
+# installed. This script is the single place that knows where that file comes
+# from, so scripts/run_local.sh (dev) and k8s/Dockerfile (deployments) install
+# the identical, identically-verified bytes.
+#
+# SECURITY: geoip2fast loads this file with pickle.load(), so whoever controls
+# its bytes controls the web process -- which holds the DB credentials and the
+# PHI field-encryption keys. Treat it as code, not data:
+#   * the digest is pinned in scripts/geoip2fast-city-asn-ipv6.sha256,
+#   * bytes that fail verification are never installed (and a pre-existing
+#     copy that no longer matches is removed, so nothing downstream can
+#     export a path to unverified bytes),
+#   * with no digest pinned we install nothing at all unless a human passes
+#     --allow-unverified, which is for a dev box and never for an image.
+# A mismatch exits non-zero only under --require: like a failed download it
+# otherwise leaves the app to soft-fail and warn, so a republished upstream
+# LATEST asset degrades the feature instead of blocking every image build.
+# Record the digest on a machine you trust with `--print-sha` and commit it;
+# deriving it from a download this script just made verifies nothing.
+#
+# Usage:
+#   fetch_geoip_db.sh [--dest PATH] [--require] [--allow-unverified]
+#   fetch_geoip_db.sh --print-sha
+#
+#   --dest PATH          Where to install (default: geoip_data/ in the repo).
+#   --require            Exit non-zero if the database was not installed.
+#                        Use in a build that must not ship without GeoIP.
+#   --allow-unverified   Install even with no pinned digest. Dev boxes only;
+#                        also settable as GEOIP_ALLOW_UNVERIFIED=1.
+#   --print-sha          Download to a temp file, print its sha256, and exit
+#                        without installing anything.
+#
+# Environment overrides:
+#   GEOIP2FAST_DB_URL     Where to download from (e.g. an internal mirror).
+#   GEOIP2FAST_DB_SHA256  Expected digest; wins over the pinned file.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel 2>/dev/null || dirname "${SCRIPT_DIR}")"
+
+DB_FILENAME="geoip2fast-city-asn-ipv6.dat.gz"
+# geoip2fast publishes the databases under the moving LATEST tag -- that is the
+# URL the package's own updater uses (GEOIP_UPDATE_DAT_URL in geoip2fast.py).
+# The pinned digest, not the tag, is what makes a fetch reproducible here: a
+# republished LATEST asset fails verification instead of landing silently.
+DEFAULT_URL="https://github.com/rabuchaim/geoip2fast/releases/download/LATEST/${DB_FILENAME}"
+DB_URL="${GEOIP2FAST_DB_URL:-${DEFAULT_URL}}"
+SHA_FILE="${SCRIPT_DIR}/${DB_FILENAME%.dat.gz}.sha256"
+
+DEST="${REPO_ROOT}/geoip_data/${DB_FILENAME}"
+REQUIRE=false
+ALLOW_UNVERIFIED="${GEOIP_ALLOW_UNVERIFIED:-0}"
+PRINT_SHA=false
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dest)
+      shift
+      [ $# -gt 0 ] || { echo "--dest needs a path" >&2; exit 2; }
+      DEST="$1"
+      ;;
+    --require) REQUIRE=true ;;
+    --allow-unverified) ALLOW_UNVERIFIED=1 ;;
+    --print-sha) PRINT_SHA=true ;;
+    -h|--help)
+      # The usage block from this file's own header comment.
+      awk '/^# Usage:/,/^$/ {sub(/^# ?/, ""); print}' "${BASH_SOURCE[0]}"
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+# sha256sum on Linux, shasum on macOS. Prints the bare digest for a file.
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d' ' -f1
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | cut -d' ' -f1
+  else
+    echo "Neither sha256sum nor shasum is available; cannot verify the GeoIP database" >&2
+    return 1
+  fi
+}
+
+# The pinned digest: first non-comment, non-empty token in the sha file.
+pinned_sha() {
+  [ -f "${SHA_FILE}" ] || return 0
+  grep -v '^[[:space:]]*#' "${SHA_FILE}" | tr -s '[:space:]' '\n' | grep -m1 '^[0-9a-fA-F]\{64\}$' || true
+}
+
+download_to() {
+  local target="$1"
+  echo "Downloading GeoIP city database from ${DB_URL}"
+  curl -fsSL --retry 3 --retry-delay 5 -o "${target}" "${DB_URL}"
+}
+
+# Normalize to lowercase: pinned_sha and the env override both accept
+# uppercase hex (PowerShell/certutil emit it), but sha256sum prints lowercase
+# and the comparisons below are string equality.
+EXPECTED_SHA="$(printf '%s' "${GEOIP2FAST_DB_SHA256:-$(pinned_sha)}" | tr '[:upper:]' '[:lower:]')"
+
+if [ "${PRINT_SHA}" = true ]; then
+  TMP_SHA_FILE="$(mktemp)"
+  trap 'rm -f "${TMP_SHA_FILE}"' EXIT
+  download_to "${TMP_SHA_FILE}" || { echo "Download failed" >&2; exit 1; }
+  echo "sha256 of ${DB_URL}:"
+  sha256_of "${TMP_SHA_FILE}"
+  echo "Record this in ${SHA_FILE} only if this machine and network are ones you trust."
+  exit 0
+fi
+
+not_installed() {
+  # $1: why. Loud, actionable, and fatal only under --require, so an
+  # unpinned build still produces an image (the app soft-fails and warns).
+  echo "GeoIP city database NOT installed: $1" >&2
+  echo "  Chat state guessing and ASN lookups will return nothing." >&2
+  echo "  See the README 'GeoIP' section to pin a digest and enable them." >&2
+  if [ "${REQUIRE}" = true ]; then
+    exit 1
+  fi
+  exit 0
+}
+
+if [ -z "${EXPECTED_SHA}" ] && [ "${ALLOW_UNVERIFIED}" != "1" ]; then
+  not_installed "no digest is pinned in ${SHA_FILE} (record one with '$0 --print-sha')"
+fi
+
+# Already installed and matching: nothing to do. Re-running is free.
+if [ -f "${DEST}" ]; then
+  if [ -z "${EXPECTED_SHA}" ]; then
+    echo "GeoIP city database already present (unverified): ${DEST}"
+    exit 0
+  fi
+  ACTUAL_SHA="$(sha256_of "${DEST}")" || exit 1
+  if [ "${ACTUAL_SHA}" = "${EXPECTED_SHA}" ]; then
+    echo "GeoIP city database already installed and verified: ${DEST}"
+    exit 0
+  fi
+  echo "Existing ${DEST} does not match the pinned digest; removing and re-downloading" >&2
+  # Remove it NOW, not after a successful re-download: if the download below
+  # fails, leaving the mismatching file behind would let run_local.sh's
+  # file-exists check export FHI_GEOIP_CITY_DB for bytes that just failed
+  # verification -- the exact pickle.load() path the pin exists to block.
+  rm -f "${DEST}" || exit 1
+fi
+
+mkdir -p "$(dirname "${DEST}")" || exit 1
+TMP_FILE="$(mktemp "$(dirname "${DEST}")/.geoip2fast.XXXXXX")" || exit 1
+trap 'rm -f "${TMP_FILE}"' EXIT
+
+if ! download_to "${TMP_FILE}"; then
+  not_installed "download from ${DB_URL} failed"
+fi
+
+if [ -n "${EXPECTED_SHA}" ]; then
+  ACTUAL_SHA="$(sha256_of "${TMP_FILE}")" || exit 1
+  if [ "${ACTUAL_SHA}" != "${EXPECTED_SHA}" ]; then
+    echo "GeoIP database failed checksum -- refusing to install" >&2
+    echo "  expected ${EXPECTED_SHA}" >&2
+    echo "  actual   ${ACTUAL_SHA}" >&2
+    echo "  Upstream publishes under the moving LATEST tag, so this usually" >&2
+    echo "  means they republished the asset; if you deliberately want the" >&2
+    echo "  new release, re-pin ${SHA_FILE}." >&2
+    rm -f "${TMP_FILE}"
+    # Same exit contract as a failed download: the unverified bytes are gone
+    # either way, and only --require turns "no database" into a hard failure.
+    not_installed "downloaded file failed sha256 verification"
+  fi
+else
+  echo "WARNING: installing an UNVERIFIED GeoIP database (--allow-unverified)." >&2
+  echo "         Never do this for an image or anything that reaches a server." >&2
+fi
+
+# Read-only for everyone but the owner: the web process only ever reads it,
+# and geoip2fast unpickles it, so a writable path is a code-execution path.
+chmod 0644 "${TMP_FILE}" || exit 1
+mv "${TMP_FILE}" "${DEST}" || exit 1
+trap - EXIT
+echo "GeoIP city database installed: ${DEST}"

--- a/scripts/fetch_geoip_db.sh
+++ b/scripts/fetch_geoip_db.sh
@@ -102,7 +102,11 @@ pinned_sha() {
 download_to() {
   local target="$1"
   echo "Downloading GeoIP city database from ${DB_URL}"
-  curl -fsSL --retry 3 --retry-delay 5 -o "${target}" "${DB_URL}"
+  # Finite deadlines so a host that accepts the connection and then stalls
+  # still reaches the soft-fail path (the file is ~21MB; 300s is generous)
+  # instead of hanging run_local.sh's wait or a Docker RUN layer forever.
+  curl -fsSL --connect-timeout 10 --max-time 300 --retry 3 --retry-delay 5 \
+    -o "${target}" "${DB_URL}"
 }
 
 # Normalize to lowercase: pinned_sha and the env override both accept

--- a/scripts/geoip2fast-city-asn-ipv6.sha256
+++ b/scripts/geoip2fast-city-asn-ipv6.sha256
@@ -1,0 +1,30 @@
+# Pinned sha256 of the geoip2fast city+ASN database (geoip2fast-city-asn-ipv6.dat.gz)
+# that FHI_GEOIP_CITY_DB points at. scripts/fetch_geoip_db.sh refuses to install
+# anything whose digest does not match the value below, and installs nothing at
+# all if this file holds no digest.
+#
+# geoip2fast loads the database with pickle.load(), so its bytes run as code
+# inside the web process -- which holds the DB credentials and the PHI
+# field-encryption keys. That is what this pin is protecting.
+#
+# Provenance of the value below: downloaded 2026-08-23 from
+#   https://github.com/rabuchaim/geoip2fast/releases/download/LATEST/geoip2fast-city-asn-ipv6.dat.gz
+# 20988890 bytes, self-described (its `info` field) as
+#   MAXMIND:GeoLite2-CityASN-IPv4IPv6-en-20260605
+# with top-level sections country/city/asn/ipv6 -- i.e. the city+ASN+IPv6 build
+# both features need. Disassembling all 22,144,910 pickle opcodes found no
+# code-execution opcode (no GLOBAL/STACK_GLOBAL/REDUCE/INST/OBJ/NEWOBJ/BUILD),
+# so this particular file is pure data -- which is a property of these bytes,
+# not of whatever the URL serves next, hence the pin.
+# RE-VERIFY IT YOURSELF before you trust it in production:
+#
+#     scripts/fetch_geoip_db.sh --print-sha
+#
+# on a machine and network you trust, and compare. If your digest differs, do
+# NOT deploy it -- either upstream republished the moving LATEST asset (re-pin
+# deliberately, after checking what changed) or something rewrote the download.
+#
+# Upstream publishes these databases only under the moving LATEST tag, so a
+# republished file surfaces here as a checksum failure -- loud, and never a
+# silent swap. Re-pin whenever you intentionally move to a newer release.
+60205b43af2b9d04374cb5528ae31a6c2a9cc96cb20478b80016c2b8f457b04b

--- a/scripts/run_local.sh
+++ b/scripts/run_local.sh
@@ -14,6 +14,7 @@
 
 
 SCRIPT_DIR="$(dirname "$0")"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 if [ ! -f "cert.pem" ]; then
   "${SCRIPT_DIR}/install.sh"
@@ -170,6 +171,23 @@ backup_pid=$!
 check_alpha_backend &
 alpha_pid=$!
 
+# 2b) GeoIP city database (background). Without it the chat's US-state hint and
+# ASN tracking soft-fail and the server warns at startup. The fetch is
+# sha256-verified against the digest pinned in the repo and is a no-op once the
+# file is in place, so this costs nothing after the first run. It installs
+# nothing when no digest is pinned -- set GEOIP_ALLOW_UNVERIFIED=1 to override
+# that on a dev box (never for anything that reaches a server).
+GEOIP_DB="${REPO_ROOT}/geoip_data/geoip2fast-city-asn-ipv6.dat.gz"
+fetch_geoip_db() {
+  "${SCRIPT_DIR}/fetch_geoip_db.sh" --dest "${GEOIP_DB}" || true
+  if [ -f "${GEOIP_DB}" ]; then
+    echo "export FHI_GEOIP_CITY_DB=${GEOIP_DB}" > "$TMPDIR/geoip"
+  fi
+}
+
+fetch_geoip_db &
+geoip_pid=$!
+
 # 3) DB setup (background, unless FAST mode)
 if [ "$FAST" != "FAST" ]; then
   python manage.py setup_local_db &
@@ -178,7 +196,7 @@ fi
 
 # Wait for all parallel tasks
 wait "$static_pid" || { echo "Static build failed!"; exit 1; }
-wait "$vllm_pid" "$slipstream_pid" "$backup_pid" "$alpha_pid" 2>/dev/null || true
+wait "$vllm_pid" "$slipstream_pid" "$backup_pid" "$alpha_pid" "$geoip_pid" 2>/dev/null || true
 if [ -n "$db_pid" ]; then
   wait "$db_pid" || { echo "DB setup failed!"; exit 1; }
 fi

--- a/scripts/run_local.sh
+++ b/scripts/run_local.sh
@@ -181,7 +181,9 @@ GEOIP_DB="${REPO_ROOT}/geoip_data/geoip2fast-city-asn-ipv6.dat.gz"
 fetch_geoip_db() {
   "${SCRIPT_DIR}/fetch_geoip_db.sh" --dest "${GEOIP_DB}" || true
   if [ -f "${GEOIP_DB}" ]; then
-    echo "export FHI_GEOIP_CITY_DB=${GEOIP_DB}" > "$TMPDIR/geoip"
+    # %q-escape the path: this file gets source'd below, and a checkout under
+    # a directory with spaces would otherwise break the export.
+    printf 'export FHI_GEOIP_CITY_DB=%q\n' "${GEOIP_DB}" > "$TMPDIR/geoip"
   fi
 }
 

--- a/tests/async/test_clinicaltrials_integration.py
+++ b/tests/async/test_clinicaltrials_integration.py
@@ -66,6 +66,20 @@ def _mock_session_returning(payload: Dict[str, Any]):
 class TestFindTrialsForQuery:
     """End-to-end behavior of find_trials_for_query with DB cache."""
 
+    @pytest.fixture(autouse=True)
+    def _clear_trial_cache(self, transactional_db):
+        """Start every test from an empty trial cache.
+
+        These tests assert on cache *misses* (an HTTP fetch happened) as much
+        as on hits, so one leaked ``ClinicalTrialQueryData`` row -- e.g. from a
+        previous attempt whose teardown flush lost a race for the sqlite table
+        lock -- silently turns the first call into a cache hit and fails the
+        assertion for reasons that have nothing to do with the code.
+        """
+        ClinicalTrialQueryData.objects.all().delete()
+        ClinicalTrial.objects.all().delete()
+        yield
+
     async def test_fetches_and_caches_trials(self):
         tools = ClinicalTrialsTools()
         payload = _make_studies_payload(["NCT11111111", "NCT22222222"])
@@ -164,12 +178,6 @@ class TestFindTrialsForQuery:
     async def test_find_trials_for_denial_writes_audit_row_and_global_cache(self):
         """find_trials_for_denial must write a global cache row that the next
         call can hit, plus a separate denial-scoped audit row."""
-        # Drop any leftover cache rows for this query (a failed flush in a
-        # previous attempt leaks rows across the rerun) so the cache-miss
-        # and row-count assertions below start from a clean slate.
-        await ClinicalTrialQueryData.objects.filter(
-            query="pembrolizumab melanoma"
-        ).adelete()
         tools = ClinicalTrialsTools()
         denial = await Denial.objects.acreate(
             procedure="pembrolizumab",
@@ -191,10 +199,6 @@ class TestFindTrialsForQuery:
         assert [t.nct_id for t in trials_again] == ["NCT55555555"]
         assert session_factory.call_count == 1
         # One global cache row + two denial-scoped audit rows (one per call).
-        # Scope the global count to this test's query: with
-        # transaction=True cleanup is a table flush, and if a previous
-        # test's flush failed (e.g. transient sqlite table lock) its global
-        # rows survive into the rerun and an unscoped count flakes.
         global_rows = await ClinicalTrialQueryData.objects.filter(
             denial_id__isnull=True,
             query="pembrolizumab melanoma",

--- a/tests/async/test_health_status.py
+++ b/tests/async/test_health_status.py
@@ -2,7 +2,7 @@ import datetime
 import time
 from unittest import mock
 from django.core import mail
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.utils import timezone
 
 from fighthealthinsurance.ml.ml_router import ml_router
@@ -356,3 +356,50 @@ class TestHealthStatus(TestCase):
             m for m in mail.outbox if "internal models are dead" in m.subject.lower()
         ]
         assert len(alerts) == 1
+
+
+class TestBackgroundSweepGate(TestCase):
+    """``ML_HEALTH_BACKGROUND_SWEEP`` gates the self-re-arming timer chain.
+
+    The sweep writes the cross-pod alert-throttle row on every pass, so left
+    running under the test configs it lands DB writes in the middle of
+    unrelated tests and can lock the table against the teardown flush.
+    """
+
+    def _make_status(self):
+        from fighthealthinsurance.ml.health_status import _HealthStatus
+
+        return _HealthStatus()
+
+    @override_settings(ML_HEALTH_BACKGROUND_SWEEP=False)
+    def test_ensure_started_is_noop_when_disabled(self):
+        status = self._make_status()
+        with mock.patch(
+            "fighthealthinsurance.ml.health_status.threading.Thread"
+        ) as thread:
+            status.ensure_started()
+        thread.assert_not_called()
+        assert status._sweep_started is False
+
+    @override_settings(ML_HEALTH_BACKGROUND_SWEEP=False)
+    def test_schedule_refresh_arms_no_timer_when_disabled(self):
+        """A direct ``_refresh`` (what the alert tests drive) must not leave a
+        timer behind that fires during some later test."""
+        status = self._make_status()
+        with mock.patch(
+            "fighthealthinsurance.ml.health_status.threading.Timer"
+        ) as timer:
+            status._schedule_refresh()
+        timer.assert_not_called()
+        assert status._timer is None
+
+    @override_settings(ML_HEALTH_BACKGROUND_SWEEP=True)
+    def test_ensure_started_starts_the_sweep_exactly_once_when_enabled(self):
+        status = self._make_status()
+        with mock.patch(
+            "fighthealthinsurance.ml.health_status.threading.Thread"
+        ) as thread:
+            status.ensure_started()
+            status.ensure_started()  # idempotent
+        thread.assert_called_once()
+        thread.return_value.start.assert_called_once()


### PR DESCRIPTION
## Summary

Adds a secure, reproducible mechanism for fetching and verifying the geoip2fast city database that enables US state guessing and ASN tracking in the chat interface. The database is downloaded once, verified against a pinned SHA256 digest, and cached locally. This unblocks the feature in both development and Kubernetes deployments.

## Key Changes

- **`scripts/fetch_geoip_db.sh`** (new): Standalone script that downloads the geoip2fast city+ASN database, verifies it against a pinned digest, and installs it to a configurable location. Treats the database as trusted code (since geoip2fast unpickles it), refusing to install unverified bytes. Supports `--print-sha` for recording new digests, `--require` for build-time enforcement, and `--allow-unverified` for dev-only overrides.

- **`scripts/geoip2fast-city-asn-ipv6.sha256`** (new): Pinned SHA256 digest of the database file, with extensive comments explaining the security model and provenance. The digest is what makes fetches reproducible; a republished upstream LATEST asset fails verification loudly instead of swapping in silently.

- **`scripts/run_local.sh`**: Runs the fetch script in parallel during startup (no-op after first run) and exports `FHI_GEOIP_CITY_DB` when the file is present. Dev boxes get the database automatically with no manual steps.

- **`k8s/Dockerfile`**: Runs the fetch at build time into `/opt/geoip/`, baking the verified bytes into the image. No runtime download, no writable path, and the database is fixed at build time. Kubernetes needs no extra config; pods pick it up from the image.

- **`README.md`**: Replaces manual download instructions with a reference to the script. Explains the security model (pickle.load() means the file runs as code), the role of the pinned digest, and the soft-fail behavior when the database is missing.

- **`fighthealthinsurance/settings.py`**: Adds `ML_HEALTH_BACKGROUND_SWEEP` setting (default True) to gate the recurring background health-status sweep. Disabled in Test configs to prevent timer threads and DB writes from interfering with test teardown.

- **`fighthealthinsurance/ml/health_status.py`**: Respects the `ML_HEALTH_BACKGROUND_SWEEP` setting; `ensure_started()` and `_schedule_refresh()` become no-ops when disabled. Tests that need a real measurement still call `get_snapshot()` directly, which sweeps synchronously.

- **`tests/async/test_health_status.py`**: New test class `TestBackgroundSweepGate` verifies that the background sweep respects the setting and doesn't arm timers when disabled.

- **`tests/async/test_clinicaltrials_integration.py`**: Adds a pytest fixture `_clear_trial_cache` (autouse) to clear the trial cache before each test, eliminating flaky assertions caused by leaked rows from previous test runs. Removes manual cleanup code from individual tests.

- **`.gitignore` and `.dockerignore`**: Ignore the `geoip_data/` directory (where the script installs the database locally).

- **`docs/chat-pipeline.md`**: Removes "Ship the city DB in k8s" from the roadmap (now done) and renumbers remaining items.

## Notable Implementation Details

- **Security model**: The pinned digest is the sole source of truth. Bytes that fail verification are never installed; a previously installed copy that no longer matches is removed immediately (before any re-download attempt) to prevent downstream code from exporting a path to unverified bytes.

- **Soft-fail by default**: A missing database, unreachable upstream, or republished LATEST asset that no longer matches the pin all succeed gracefully — the app soft-fails and warns at startup. Pass `--require` to make shipping without the database fail the build instead.

- **Reproducibility**: The moving `LATEST` tag is what upstream publishes; the pinned digest is what makes the fetch reproducible. A republished asset surfaces as a check

https://claude.ai/code/session_01Qs5cFf3CgnUVXF1G8c8ZF2