### PR TITLE
Deploy the Temporal fax worker with every prod deploy

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -132,6 +132,13 @@ envsubst < k8s/ray/cluster.yaml | kubectl apply -f -
 # Deploy a staging env
 envsubst < k8s/deploy.yaml | kubectl apply -f -
 
+# The Temporal fax worker (k8s/temporal/worker.yaml) runs the same app image as
+# the web pods and has to roll with every prod deploy. It was applied by hand at
+# Temporal go-live and nothing here re-applied it, so by 2026-08-26 it was two
+# versions behind prod (v0.22.4a-dev vs v0.23.1a-dev). Same ${FHI_BASE}/${FHI_VERSION}
+# substitution as the manifests above.
+envsubst < k8s/temporal/worker.yaml | kubectl apply -f -
+
 # In-cluster scraping of the app's /metrics (which is no longer reachable from
 # the internet -- see docs/metrics-endpoint-access.md). The apply is skipped
 # only where the Prometheus operator's CRD is absent; every other failure (bad


### PR DESCRIPTION
build.sh applied every manifest except k8s/temporal/worker.yaml, so the fax worker was rolled once by hand at go-live and then left behind: on 2026-08-26 it was running v0.22.4a-dev while the web pods ran v0.23.1a-dev. Apply it right after deploy.yaml with the same FHI_BASE/FHI_VERSION substitution.

 This applies worker.yaml right after deploy.yaml, with the same ${FHI_BASE}/${FHI_VERSION} substitution as the other manifests, so the worker tracks prod from now on. No behavior change for anything else in the script.
 

Not in this PR: Temporal's own Helm values (#929) stay on the helm upgrade path per k8s/temporal/README.md; build.sh deliberately doesn't manage Helm releases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Production deployments now automatically apply the Temporal fax worker configuration.
  * Fax processing services are available as part of the production deployment workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->