### PR TITLE
Show Temporal fax workflows on the staff status page

### DIFF
--- a/fighthealthinsurance/staff_views.py
+++ b/fighthealthinsurance/staff_views.py
@@ -312,8 +312,15 @@ class AdminStatusView(generic.TemplateView):
                 client = await get_temporal_client()
                 counts: Dict[str, int] = {}
                 for status in statuses:
+                    # Running is a live state, so count every open run; the
+                    # terminal states are bounded to the last seven days.
+                    scope = (
+                        "WorkflowType='SendFaxWorkflow'"
+                        if status == "Running"
+                        else base
+                    )
                     result = await client.count_workflows(
-                        f"{base} AND ExecutionStatus='{status}'"
+                        f"{scope} AND ExecutionStatus='{status}'"
                     )
                     counts[status] = int(result.count)
                 recent: List[Dict[str, Any]] = []

--- a/fighthealthinsurance/staff_views.py
+++ b/fighthealthinsurance/staff_views.py
@@ -150,6 +150,7 @@ class AdminStatusView(generic.TemplateView):
         ctx["actors"] = self._actor_status()
         ctx["fax"] = self._fax_backend_status()
         ctx["fax_queue"] = self._fax_queue_status()
+        ctx["temporal"] = self._temporal_status()
         ctx["storage"] = self._storage_status()
         return ctx
 
@@ -262,6 +263,90 @@ class AdminStatusView(generic.TemplateView):
             ).count()
         except Exception as e:
             logger.opt(exception=True).error("Error computing fax queue status")
+            out["ok"] = False
+            out["error"] = str(e)
+        return out
+
+    @staticmethod
+    def _temporal_status() -> Dict[str, Any]:
+        """Temporal fax orchestration: connectivity, recent SendFaxWorkflow runs.
+
+        Answers "is Temporal up and is it doing the fax work?" from the same
+        client the app dispatches through (``temporal_client``), so what this
+        shows is what the web pods actually see. The Temporal Web UI is
+        deliberately not exposed outside the cluster; this section carries the
+        numbers on-call needs and points at the port-forward for the rest.
+
+        Bounded: one connection plus a handful of visibility queries under a
+        single timeout, so a wedged frontend degrades to an error row.
+        """
+        from django.conf import settings
+
+        enabled = bool(getattr(settings, "TEMPORAL_ENABLED", False))
+        out: Dict[str, Any] = {
+            "ok": True,
+            "error": None,
+            "enabled": enabled,
+            "host": getattr(settings, "TEMPORAL_HOST", None),
+            "namespace": getattr(settings, "TEMPORAL_NAMESPACE", None),
+            "task_queue": getattr(settings, "TEMPORAL_TASK_QUEUE", None),
+            "counts": {},
+            "recent": [],
+        }
+        if not enabled:
+            return out
+        try:
+            import asyncio
+
+            from asgiref.sync import async_to_sync
+
+            from fighthealthinsurance.temporal_client import get_temporal_client
+
+            since = (timezone.now() - datetime.timedelta(days=7)).strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            )
+            base = f"WorkflowType='SendFaxWorkflow' AND StartTime > '{since}'"
+            statuses = ("Running", "Completed", "Failed", "TimedOut", "Terminated")
+
+            async def gather() -> Dict[str, Any]:
+                client = await get_temporal_client()
+                counts: Dict[str, int] = {}
+                for status in statuses:
+                    result = await client.count_workflows(
+                        f"{base} AND ExecutionStatus='{status}'"
+                    )
+                    counts[status] = int(result.count)
+                recent: List[Dict[str, Any]] = []
+                async for wf in client.list_workflows(
+                    "WorkflowType='SendFaxWorkflow' ORDER BY StartTime DESC",
+                    page_size=10,
+                ):
+                    duration = None
+                    if wf.start_time and wf.close_time:
+                        duration = round(
+                            (wf.close_time - wf.start_time).total_seconds()
+                        )
+                    recent.append(
+                        {
+                            "id": wf.id,
+                            "status": wf.status.name if wf.status else "UNKNOWN",
+                            "started": wf.start_time,
+                            "closed": wf.close_time,
+                            "duration_s": duration,
+                        }
+                    )
+                    if len(recent) >= 10:
+                        break
+                return {"counts": counts, "recent": recent}
+
+            async def bounded() -> Dict[str, Any]:
+                return await asyncio.wait_for(gather(), timeout=8.0)
+
+            data = async_to_sync(bounded)()
+            out["counts"] = data["counts"]
+            out["recent"] = data["recent"]
+        except Exception as e:
+            logger.opt(exception=True).warning("Temporal status check failed")
             out["ok"] = False
             out["error"] = str(e)
         return out

--- a/fighthealthinsurance/templates/admin_status.html
+++ b/fighthealthinsurance/templates/admin_status.html
@@ -192,6 +192,66 @@
     {% endif %}
   </div>
 
+  {# ---------------- Temporal ---------------- #}
+  <div class="status-section">
+    <h2>⏱️ Temporal (fax workflows)</h2>
+    {% if not temporal.enabled %}
+      <p class="summary-line"><span class="badge">DISABLED</span> <span class="pill">TEMPORAL_ENABLED is off; faxes use the Ray path</span></p>
+    {% elif temporal.error %}
+      <p class="summary-line"><span class="badge bad">ERROR</span> <span class="error-text">{{ temporal.error }}</span></p>
+    {% else %}
+      <p class="summary-line">
+        <span class="badge ok">CONNECTED</span>
+        {% if temporal.host %}<span class="pill">{{ temporal.host }}</span>{% endif %}
+        {% if temporal.namespace %}<span class="pill">ns: {{ temporal.namespace }}</span>{% endif %}
+        {% if temporal.task_queue %}<span class="pill">queue: {{ temporal.task_queue }}</span>{% endif %}
+      </p>
+      <div class="stat-grid">
+        <div class="stat-card {% if temporal.counts.Running %}alert{% endif %}">
+          <div class="value">{{ temporal.counts.Running|default:0 }}</div>
+          <div class="label">Running now</div>
+        </div>
+        <div class="stat-card">
+          <div class="value">{{ temporal.counts.Completed|default:0 }}</div>
+          <div class="label">Completed (last 7 days)</div>
+        </div>
+        <div class="stat-card {% if temporal.counts.Failed %}alert{% endif %}">
+          <div class="value">{{ temporal.counts.Failed|default:0 }}</div>
+          <div class="label">Failed (last 7 days)</div>
+        </div>
+        <div class="stat-card {% if temporal.counts.TimedOut or temporal.counts.Terminated %}alert{% endif %}">
+          <div class="value">{{ temporal.counts.TimedOut|default:0 }} / {{ temporal.counts.Terminated|default:0 }}</div>
+          <div class="label">Timed out / terminated (last 7 days)</div>
+        </div>
+      </div>
+      <table class="status">
+        <thead>
+          <tr><th>Workflow</th><th>Status</th><th>Started</th><th>Duration</th></tr>
+        </thead>
+        <tbody>
+        {% for wf in temporal.recent %}
+          <tr>
+            <td><code>{{ wf.id }}</code></td>
+            <td>
+              {% if wf.status == "COMPLETED" %}<span class="badge ok">{{ wf.status }}</span>
+              {% elif wf.status == "RUNNING" %}<span class="badge">{{ wf.status }}</span>
+              {% else %}<span class="badge bad">{{ wf.status }}</span>{% endif %}
+            </td>
+            <td>{{ wf.started|date:"Y-m-d H:i" }}</td>
+            <td>{% if wf.duration_s is not None %}{{ wf.duration_s }}s{% else %}&mdash;{% endif %}</td>
+          </tr>
+        {% empty %}
+          <tr><td colspan="4">No SendFaxWorkflow runs recorded yet.</td></tr>
+        {% endfor %}
+        </tbody>
+      </table>
+      <p class="summary-line">
+        <span class="pill">Full event histories: the Temporal Web UI is cluster-internal by design.</span>
+        <code>kubectl -n totallylegitco port-forward svc/temporal-web 8080:8080</code> then <code>http://localhost:8080</code>
+      </p>
+    {% endif %}
+  </div>
+
   {# ---------------- Storage ---------------- #}
   <div class="status-section">
     <h2>💾 External Storage</h2>

--- a/fighthealthinsurance/templates/admin_status.html
+++ b/fighthealthinsurance/templates/admin_status.html
@@ -196,7 +196,7 @@
   <div class="status-section">
     <h2>⏱️ Temporal (fax workflows)</h2>
     {% if not temporal.enabled %}
-      <p class="summary-line"><span class="badge">DISABLED</span> <span class="pill">TEMPORAL_ENABLED is off; faxes use the Ray path</span></p>
+      <p class="summary-line"><span class="badge unknown">DISABLED</span> <span class="pill">TEMPORAL_ENABLED is off; faxes use the Ray path</span></p>
     {% elif temporal.error %}
       <p class="summary-line"><span class="badge bad">ERROR</span> <span class="error-text">{{ temporal.error }}</span></p>
     {% else %}
@@ -234,7 +234,7 @@
             <td><code>{{ wf.id }}</code></td>
             <td>
               {% if wf.status == "COMPLETED" %}<span class="badge ok">{{ wf.status }}</span>
-              {% elif wf.status == "RUNNING" %}<span class="badge">{{ wf.status }}</span>
+              {% elif wf.status == "RUNNING" %}<span class="badge warn">{{ wf.status }}</span>
               {% else %}<span class="badge bad">{{ wf.status }}</span>{% endif %}
             </td>
             <td>{{ wf.started|date:"Y-m-d H:i" }}</td>

--- a/tests/sync/test_admin_status.py
+++ b/tests/sync/test_admin_status.py
@@ -178,9 +178,15 @@ class _FakeWorkflow:
 
 
 class _FakeTemporalClient:
-    """Stands in for a temporalio Client: two completed runs, one listed."""
+    """Stands in for a temporalio Client: two completed runs, one listed.
+
+    Records every visibility query so tests can check their shape.
+    """
+
+    queries: list = []
 
     async def count_workflows(self, query):
+        self.queries.append(query)
         return _FakeCount(2 if "Completed" in query else 0)
 
     def list_workflows(self, query, page_size=10):
@@ -242,6 +248,11 @@ class AdminStatusTemporalTest(TestCase):
         self.assertEqual(t["counts"]["Failed"], 0)
         self.assertEqual(len(t["recent"]), 1)
         self.assertEqual(t["recent"][0]["duration_s"], 42)
+        # Running is a live count (no time window); terminal states are 7-day scoped.
+        running = [q for q in _FakeTemporalClient.queries if "Running" in q]
+        completed = [q for q in _FakeTemporalClient.queries if "Completed" in q]
+        self.assertTrue(running and all("StartTime" not in q for q in running))
+        self.assertTrue(completed and all("StartTime" in q for q in completed))
         self.assertContains(response, "CONNECTED")
         self.assertContains(response, "send-fax-test-1234")
 

--- a/tests/sync/test_admin_status.py
+++ b/tests/sync/test_admin_status.py
@@ -183,7 +183,8 @@ class _FakeTemporalClient:
     Records every visibility query so tests can check their shape.
     """
 
-    queries: list = []
+    def __init__(self):
+        self.queries: list = []
 
     async def count_workflows(self, query):
         self.queries.append(query)
@@ -196,8 +197,13 @@ class _FakeTemporalClient:
         return gen()
 
 
+_FAKE_CLIENTS: list = []  # every fake handed to the view, newest last
+
+
 async def _fake_get_client():
-    return _FakeTemporalClient()
+    client = _FakeTemporalClient()
+    _FAKE_CLIENTS.append(client)
+    return client
 
 
 async def _broken_get_client():
@@ -211,6 +217,7 @@ class AdminStatusTemporalTest(TestCase):
     def setUp(self):
         User.objects.create_user(username="staff", password="pw123", is_staff=True)
         self.client.login(username="staff", password="pw123")
+        _FAKE_CLIENTS.clear()
 
     def _get(self):
         with mock.patch(_MODELS, return_value=[]), mock.patch(
@@ -249,8 +256,10 @@ class AdminStatusTemporalTest(TestCase):
         self.assertEqual(len(t["recent"]), 1)
         self.assertEqual(t["recent"][0]["duration_s"], 42)
         # Running is a live count (no time window); terminal states are 7-day scoped.
-        running = [q for q in _FakeTemporalClient.queries if "Running" in q]
-        completed = [q for q in _FakeTemporalClient.queries if "Completed" in q]
+        self.assertEqual(len(_FAKE_CLIENTS), 1)
+        queries = _FAKE_CLIENTS[0].queries
+        running = [q for q in queries if "Running" in q]
+        completed = [q for q in queries if "Completed" in q]
         self.assertTrue(running and all("StartTime" not in q for q in running))
         self.assertTrue(completed and all("StartTime" in q for q in completed))
         self.assertContains(response, "CONNECTED")

--- a/tests/sync/test_admin_status.py
+++ b/tests/sync/test_admin_status.py
@@ -158,6 +158,94 @@ class AdminStatusFaxQueueTest(TestCase):
         self.assertEqual(q["failures_recent"], 1)  # E
 
 
+_TEMPORAL_CLIENT = "fighthealthinsurance.temporal_client.get_temporal_client"
+
+
+class _FakeCount:
+    def __init__(self, count):
+        self.count = count
+
+
+class _FakeStatus:
+    name = "COMPLETED"
+
+
+class _FakeWorkflow:
+    id = "send-fax-test-1234"
+    status = _FakeStatus()
+    start_time = timezone.now() - datetime.timedelta(seconds=42)
+    close_time = timezone.now()
+
+
+class _FakeTemporalClient:
+    """Stands in for a temporalio Client: two completed runs, one listed."""
+
+    async def count_workflows(self, query):
+        return _FakeCount(2 if "Completed" in query else 0)
+
+    def list_workflows(self, query, page_size=10):
+        async def gen():
+            yield _FakeWorkflow()
+
+        return gen()
+
+
+async def _fake_get_client():
+    return _FakeTemporalClient()
+
+
+async def _broken_get_client():
+    raise RuntimeError("temporal-frontend unreachable")
+
+
+class AdminStatusTemporalTest(TestCase):
+    """The Temporal section must reflect the flag, degrade on errors, and
+    never raise."""
+
+    def setUp(self):
+        User.objects.create_user(username="staff", password="pw123", is_staff=True)
+        self.client.login(username="staff", password="pw123")
+
+    def _get(self):
+        with mock.patch(_MODELS, return_value=[]), mock.patch(
+            _ACTORS, return_value={"alive_actors": 0, "total_actors": 0, "details": []}
+        ), mock.patch(_FAX, return_value=_ok_fax_backends()):
+            return self.client.get(reverse("admin_status"))
+
+    @override_settings(TEMPORAL_ENABLED=False)
+    @mock.patch(_TEMPORAL_CLIENT)
+    def test_disabled_makes_no_connection(self, mock_client):
+        response = self._get()
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "DISABLED")
+        self.assertFalse(response.context["temporal"]["enabled"])
+        mock_client.assert_not_called()
+
+    @override_settings(TEMPORAL_ENABLED=True)
+    @mock.patch(_TEMPORAL_CLIENT, new=_broken_get_client)
+    def test_unreachable_frontend_is_an_error_row(self):
+        response = self._get()
+        self.assertEqual(response.status_code, 200)
+        t = response.context["temporal"]
+        self.assertFalse(t["ok"])
+        self.assertIn("unreachable", t["error"])
+        self.assertContains(response, "ERROR")
+
+    @override_settings(TEMPORAL_ENABLED=True)
+    @mock.patch(_TEMPORAL_CLIENT, new=_fake_get_client)
+    def test_healthy_client_renders_counts_and_recent_runs(self):
+        response = self._get()
+        self.assertEqual(response.status_code, 200)
+        t = response.context["temporal"]
+        self.assertTrue(t["ok"])
+        self.assertEqual(t["counts"]["Completed"], 2)
+        self.assertEqual(t["counts"]["Failed"], 0)
+        self.assertEqual(len(t["recent"]), 1)
+        self.assertEqual(t["recent"][0]["duration_s"], 42)
+        self.assertContains(response, "CONNECTED")
+        self.assertContains(response, "send-fax-test-1234")
+
+
 class AdminStatusStorageTest(TestCase):
     """_storage_status must degrade to an error row, never raise."""
 


### PR DESCRIPTION
The Temporal Web UI is cluster-internal by design, so on-call had no view of whether Temporal was up or what the fax workflows were doing without a port-forward. Add a section to /timbit/help/status that uses the app's own temporal_client (so it reflects what the web pods see): connection + host/ namespace/queue, 7-day counts by status, the last ten SendFaxWorkflow runs with durations, and the port-forward line for full event histories. Bounded by a single timeout and isolated like the other subsystem checks. Tests cover the disabled flag (no connection made), an unreachable frontend (error row), and a healthy client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Temporal status monitoring to the admin dashboard.
  * Displays connection details, workflow counts, and up to 10 recent fax workflows with status and duration.
  * Counts active workflows across all currently running executions and completed workflows from the past 7 days.
  * Provides guidance for opening the Temporal Web UI.

* **Bug Fixes**
  * Clearly reports unavailable Temporal services without interrupting the dashboard.
  * Shows Temporal as disabled when the integration is turned off.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->