### PR TITLE
Serve the Temporal Web UI read-only behind the staff login

### DIFF
--- a/fighthealthinsurance/settings.py
+++ b/fighthealthinsurance/settings.py
@@ -129,6 +129,9 @@ class Base(Configuration):
     TEMPORAL_HOST = os.getenv("TEMPORAL_HOST", "localhost:7233")
     TEMPORAL_NAMESPACE = os.getenv("TEMPORAL_NAMESPACE", "default")
     TEMPORAL_TASK_QUEUE = os.getenv("TEMPORAL_TASK_QUEUE", "fhi-fax")
+    # In-cluster address of the Temporal Web UI, reached only through the
+    # staff-only reverse proxy at /timbit/temporal/ (never exposed directly).
+    TEMPORAL_UI_UPSTREAM = os.getenv("TEMPORAL_UI_UPSTREAM", "http://temporal-web:8080")
     # TLS for a self-hosted / Cloud cluster. When TEMPORAL_TLS is true and both
     # the cert and key paths are set the client uses mTLS; otherwise it uses
     # server-side TLS.

--- a/fighthealthinsurance/staff_views.py
+++ b/fighthealthinsurance/staff_views.py
@@ -1762,8 +1762,18 @@ class TemporalUIProxyView(View):
                 content_type="text/plain",
             )
 
+        def stream():
+            # Close the upstream response even if the client stops reading
+            # partway: Django closes this generator on response close, which
+            # runs the finally, so a pooled requests connection is never
+            # left behind.
+            try:
+                yield from upstream_resp.iter_content(chunk_size=64 * 1024)
+            finally:
+                upstream_resp.close()
+
         response = StreamingHttpResponse(
-            upstream_resp.iter_content(chunk_size=64 * 1024),
+            stream(),
             status=upstream_resp.status_code,
             content_type=upstream_resp.headers.get(
                 "Content-Type", "application/octet-stream"

--- a/fighthealthinsurance/staff_views.py
+++ b/fighthealthinsurance/staff_views.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from django.db import transaction
 from django.db.models import Count, QuerySet
 from django.db.models.functions import Lower
-from django.http import HttpResponse, StreamingHttpResponse
+from django.http import HttpResponse, HttpResponseBase, StreamingHttpResponse
 from django.shortcuts import redirect, render
 from django.utils import timezone
 from django.views import View, generic
@@ -1716,21 +1716,25 @@ class TemporalUIProxyView(View):
     # content-length, content-encoding) is dropped since we re-stream.
     PASS_HEADERS = ("Cache-Control", "ETag", "Last-Modified", "Content-Disposition")
 
-    def get(self, request, path: str = "") -> HttpResponse:
+    def get(self, request, path: str = "") -> HttpResponseBase:
         return self._proxy(request, path)
 
-    def head(self, request, path: str = "") -> HttpResponse:
+    def head(self, request, path: str = "") -> HttpResponseBase:
         return self._proxy(request, path)
 
-    def _proxy(self, request, path: str) -> HttpResponse:
+    def _proxy(self, request, path: str) -> HttpResponseBase:
         from django.conf import settings
 
-        if request.path.rstrip("/") == self.PUBLIC_PATH and not request.path.endswith("/"):
+        if request.path.rstrip("/") == self.PUBLIC_PATH and not request.path.endswith(
+            "/"
+        ):
             return redirect(self.PUBLIC_PATH + "/")
         if ".." in path.split("/") or path.startswith("/"):
             return HttpResponse("bad path", status=400, content_type="text/plain")
 
-        upstream = getattr(settings, "TEMPORAL_UI_UPSTREAM", "http://temporal-web:8080").rstrip("/")
+        upstream = getattr(
+            settings, "TEMPORAL_UI_UPSTREAM", "http://temporal-web:8080"
+        ).rstrip("/")
         url = f"{upstream}{self.PUBLIC_PATH}/{path}"
         if request.META.get("QUERY_STRING"):
             url = f"{url}?{request.META['QUERY_STRING']}"
@@ -1743,20 +1747,27 @@ class TemporalUIProxyView(View):
 
         try:
             upstream_resp = _temporal_ui_request(
-                request.method, url, headers=headers, stream=True,
-                timeout=(3, 30), allow_redirects=False,
+                request.method,
+                url,
+                headers=headers,
+                stream=True,
+                timeout=(3, 30),
+                allow_redirects=False,
             )
         except requests.RequestException as e:
             logger.warning(f"Temporal UI upstream unreachable: {e}")
             return HttpResponse(
                 "Temporal UI is not reachable from the web pod right now.",
-                status=502, content_type="text/plain",
+                status=502,
+                content_type="text/plain",
             )
 
         response = StreamingHttpResponse(
             upstream_resp.iter_content(chunk_size=64 * 1024),
             status=upstream_resp.status_code,
-            content_type=upstream_resp.headers.get("Content-Type", "application/octet-stream"),
+            content_type=upstream_resp.headers.get(
+                "Content-Type", "application/octet-stream"
+            ),
         )
         for name in self.PASS_HEADERS:
             if name in upstream_resp.headers:
@@ -1764,5 +1775,7 @@ class TemporalUIProxyView(View):
         location = upstream_resp.headers.get("Location")
         if location:
             # Keep redirects on our side of the proxy.
-            response["Location"] = location[len(upstream):] if location.startswith(upstream) else location
+            response["Location"] = (
+                location[len(upstream) :] if location.startswith(upstream) else location
+            )
         return response

--- a/fighthealthinsurance/staff_views.py
+++ b/fighthealthinsurance/staff_views.py
@@ -13,6 +13,7 @@ from django.utils import timezone
 from django.views import View, generic
 
 import ray
+import requests
 from loguru import logger
 
 from fighthealthinsurance import common_view_logic, forms as core_forms
@@ -1686,4 +1687,82 @@ class ProConnectorExtractCSVView(View):
         response["Content-Disposition"] = (
             'attachment; filename="interested_professionals.csv"'
         )
+        return response
+
+
+def _temporal_ui_request(method: str, url: str, **kwargs: Any) -> requests.Response:
+    """Single seam for the proxy's upstream call (patched in tests)."""
+    return requests.request(method, url, **kwargs)
+
+
+class TemporalUIProxyView(View):
+    """Staff-only, read-only reverse proxy for the Temporal Web UI.
+
+    The Temporal UI is a ClusterIP service with no auth of its own, so it is
+    never exposed directly. This view serves it under ``/timbit/temporal/``
+    behind the same staff login as the rest of the dashboard, forwarding only
+    GET/HEAD to a fixed in-cluster upstream (``settings.TEMPORAL_UI_UPSTREAM``).
+
+    The UI runs with ``TEMPORAL_UI_PUBLIC_PATH=/timbit/temporal`` so its assets
+    and API calls come back through this view, and with
+    ``TEMPORAL_DISABLE_WRITE_ACTIONS`` so nothing state-changing is offered.
+    GET-only means that, even with no CSRF check on the proxied paths, no
+    workflow action can pass through here.
+    """
+
+    http_method_names = ["get", "head"]
+    PUBLIC_PATH = "/timbit/temporal"
+    # Response headers worth passing back; everything else (hop-by-hop,
+    # content-length, content-encoding) is dropped since we re-stream.
+    PASS_HEADERS = ("Cache-Control", "ETag", "Last-Modified", "Content-Disposition")
+
+    def get(self, request, path: str = "") -> HttpResponse:
+        return self._proxy(request, path)
+
+    def head(self, request, path: str = "") -> HttpResponse:
+        return self._proxy(request, path)
+
+    def _proxy(self, request, path: str) -> HttpResponse:
+        from django.conf import settings
+
+        if request.path.rstrip("/") == self.PUBLIC_PATH and not request.path.endswith("/"):
+            return redirect(self.PUBLIC_PATH + "/")
+        if ".." in path.split("/") or path.startswith("/"):
+            return HttpResponse("bad path", status=400, content_type="text/plain")
+
+        upstream = getattr(settings, "TEMPORAL_UI_UPSTREAM", "http://temporal-web:8080").rstrip("/")
+        url = f"{upstream}{self.PUBLIC_PATH}/{path}"
+        if request.META.get("QUERY_STRING"):
+            url = f"{url}?{request.META['QUERY_STRING']}"
+
+        headers = {"Accept-Encoding": "identity"}
+        for name in ("Accept", "Accept-Language", "If-None-Match", "If-Modified-Since"):
+            value = request.headers.get(name)
+            if value:
+                headers[name] = value
+
+        try:
+            upstream_resp = _temporal_ui_request(
+                request.method, url, headers=headers, stream=True,
+                timeout=(3, 30), allow_redirects=False,
+            )
+        except requests.RequestException as e:
+            logger.warning(f"Temporal UI upstream unreachable: {e}")
+            return HttpResponse(
+                "Temporal UI is not reachable from the web pod right now.",
+                status=502, content_type="text/plain",
+            )
+
+        response = StreamingHttpResponse(
+            upstream_resp.iter_content(chunk_size=64 * 1024),
+            status=upstream_resp.status_code,
+            content_type=upstream_resp.headers.get("Content-Type", "application/octet-stream"),
+        )
+        for name in self.PASS_HEADERS:
+            if name in upstream_resp.headers:
+                response[name] = upstream_resp.headers[name]
+        location = upstream_resp.headers.get("Location")
+        if location:
+            # Keep redirects on our side of the proxy.
+            response["Location"] = location[len(upstream):] if location.startswith(upstream) else location
         return response

--- a/fighthealthinsurance/templates/staff_dashboard.html
+++ b/fighthealthinsurance/templates/staff_dashboard.html
@@ -85,6 +85,12 @@
         </a>
       </li>
       <li>
+        <a href="{% url 'temporal_ui' path='' %}">
+          <strong>Temporal Web UI (view-only)</strong>
+          <div class="link-description">Fax workflow runs and full event histories, proxied behind this login; write actions are disabled</div>
+        </a>
+      </li>
+      <li>
         <a href="{% url 'admin_model_query' %}">
           <strong>Query a Model Backend</strong>
           <div class="link-description">Send an ad-hoc prompt to one specific ML backend (no router fan-out or fallback) and capture the raw response</div>

--- a/fighthealthinsurance/urls.py
+++ b/fighthealthinsurance/urls.py
@@ -78,6 +78,16 @@ urlpatterns: List[Union[URLPattern, URLResolver]] = [
         name="admin_status",
     ),
     path(
+        "timbit/temporal",
+        staff_member_required(staff_views.TemporalUIProxyView.as_view()),
+        name="temporal_ui_root",
+    ),
+    re_path(
+        r"^timbit/temporal/(?P<path>.*)$",
+        staff_member_required(staff_views.TemporalUIProxyView.as_view()),
+        name="temporal_ui",
+    ),
+    path(
         "timbit/help/model_query",
         staff_member_required(staff_views.AdminModelQueryView.as_view()),
         name="admin_model_query",

--- a/k8s/temporal/README.md
+++ b/k8s/temporal/README.md
@@ -177,6 +177,21 @@ kubectl -n totallylegitco exec -i deploy/temporal-admintools -- \
   temporal operator cluster health --address temporal-frontend:7233
 ```
 
+## Web UI
+
+The Temporal Web UI (`temporal-web`, a ClusterIP Service) has no auth of its
+own and gets no ingress. Staff reach it at **`/timbit/temporal/`** on the app,
+which is a read-only reverse proxy in Django (`TemporalUIProxyView` in
+`staff_views.py`) behind the usual `staff_member_required` login. Two chart
+env vars in `values.yaml` make that work: `TEMPORAL_UI_PUBLIC_PATH` so the
+UI's assets and API calls use the proxied prefix, and
+`TEMPORAL_DISABLE_WRITE_ACTIONS` so the UI offers no terminate/signal/reset
+buttons (the proxy also forwards only GET/HEAD). Changing either is a
+`helm upgrade` (above). Direct access for debugging still works with
+`kubectl -n totallylegitco port-forward svc/temporal-web 8080:8080`, but note
+the UI then expects to be served under the public path, i.e.
+`http://localhost:8080/timbit/temporal/`.
+
 ## Rollback
 
 Set `TEMPORAL_ENABLED=false` (or scale the worker to 0). Fax dispatch falls

--- a/k8s/temporal/values.yaml
+++ b/k8s/temporal/values.yaml
@@ -64,6 +64,13 @@ server:
 # Temporal Web UI (browse/inspect workflows). Expose via the existing ingress.
 web:
   enabled: true
+  # Served through the staff-only Django reverse proxy at /timbit/temporal/
+  # (see README "Web UI"); the UI never gets its own ingress.
+  additionalEnv:
+    - name: TEMPORAL_UI_PUBLIC_PATH
+      value: /timbit/temporal
+    - name: TEMPORAL_DISABLE_WRITE_ACTIONS
+      value: "true"
 
 # Monitoring: chart >= 1.0 no longer bundles Prometheus/Grafana; wire
 # Temporal's metrics into the existing Prometheus later if wanted.

--- a/tests/sync/test_temporal_ui_proxy.py
+++ b/tests/sync/test_temporal_ui_proxy.py
@@ -19,9 +19,14 @@ class _FakeUpstream:
         self.status_code = status
         self._body = body
         self.headers = {"Content-Type": "text/html; charset=utf-8", **(headers or {})}
+        self.closed = False
 
     def iter_content(self, chunk_size=None):
         yield self._body
+        yield b"<!-- tail -->"
+
+    def close(self):
+        self.closed = True
 
 
 class TemporalUIProxyAccessTest(TestCase):
@@ -98,6 +103,25 @@ class TemporalUIProxyStaffTest(TestCase):
         response = self.client.get(reverse("temporal_ui", kwargs={"path": ""}))
         self.assertEqual(response.status_code, 502)
         self.assertIn(b"not reachable", response.content)
+
+    @mock.patch(_UPSTREAM_CALL)
+    def test_upstream_is_closed_when_the_client_stops_reading(self, upstream):
+        fake = _FakeUpstream()
+        upstream.return_value = fake
+        response = self.client.get(reverse("temporal_ui", kwargs={"path": ""}))
+        chunks = iter(response.streaming_content)
+        next(chunks)  # read one chunk of two, then walk away
+        self.assertFalse(fake.closed)
+        response.close()  # what Django does when the connection ends
+        self.assertTrue(fake.closed)
+
+    @mock.patch(_UPSTREAM_CALL)
+    def test_upstream_is_closed_after_full_read(self, upstream):
+        fake = _FakeUpstream()
+        upstream.return_value = fake
+        response = self.client.get(reverse("temporal_ui", kwargs={"path": ""}))
+        b"".join(response.streaming_content)
+        self.assertTrue(fake.closed)
 
     @mock.patch(_UPSTREAM_CALL)
     def test_upstream_redirect_is_rewritten_to_our_side(self, upstream):

--- a/tests/sync/test_temporal_ui_proxy.py
+++ b/tests/sync/test_temporal_ui_proxy.py
@@ -1,0 +1,100 @@
+"""Tests for the staff-only, read-only Temporal Web UI reverse proxy."""
+
+from unittest import mock
+
+import requests
+from django.contrib.auth import get_user_model
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+User = get_user_model()
+
+_UPSTREAM_CALL = "fighthealthinsurance.staff_views._temporal_ui_request"
+
+
+class _FakeUpstream:
+    """Minimal stand-in for a requests.Response in stream mode."""
+
+    def __init__(self, status=200, body=b"<html>ui</html>", headers=None):
+        self.status_code = status
+        self._body = body
+        self.headers = {"Content-Type": "text/html; charset=utf-8", **(headers or {})}
+
+    def iter_content(self, chunk_size=None):
+        yield self._body
+
+
+class TemporalUIProxyAccessTest(TestCase):
+    def test_anonymous_is_redirected_to_login(self):
+        response = self.client.get(reverse("temporal_ui", kwargs={"path": ""}))
+        self.assertEqual(response.status_code, 302)
+
+    def test_non_staff_is_redirected(self):
+        User.objects.create_user(username="plain", password="pw123", is_staff=False)
+        self.client.login(username="plain", password="pw123")
+        response = self.client.get(reverse("temporal_ui", kwargs={"path": ""}))
+        self.assertEqual(response.status_code, 302)
+
+
+@override_settings(TEMPORAL_UI_UPSTREAM="http://temporal-web.test:8080")
+class TemporalUIProxyStaffTest(TestCase):
+    def setUp(self):
+        User.objects.create_user(username="staff", password="pw123", is_staff=True)
+        self.client.login(username="staff", password="pw123")
+
+    @mock.patch(_UPSTREAM_CALL)
+    def test_forwards_get_under_public_path_and_streams_body(self, upstream):
+        upstream.return_value = _FakeUpstream(
+            headers={"Cache-Control": "no-cache", "Content-Length": "999", "Connection": "keep-alive"}
+        )
+        response = self.client.get(
+            reverse("temporal_ui", kwargs={"path": "workflows"}) + "?namespace=default"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(b"".join(response.streaming_content), b"<html>ui</html>")
+        self.assertEqual(response["Content-Type"], "text/html; charset=utf-8")
+        self.assertEqual(response["Cache-Control"], "no-cache")
+        # Hop-by-hop / length headers are not copied through a re-streamed body.
+        self.assertNotIn("Connection", response)
+        self.assertNotIn("Content-Length", response)
+        method, url = upstream.call_args.args
+        self.assertEqual(method, "GET")
+        self.assertEqual(url, "http://temporal-web.test:8080/timbit/temporal/workflows?namespace=default")
+        self.assertEqual(upstream.call_args.kwargs["headers"]["Accept-Encoding"], "identity")
+        self.assertFalse(upstream.call_args.kwargs["allow_redirects"])
+
+    @mock.patch(_UPSTREAM_CALL)
+    def test_root_without_slash_redirects_to_slash(self, upstream):
+        response = self.client.get(reverse("temporal_ui_root"))
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], "/timbit/temporal/")
+        upstream.assert_not_called()
+
+    @mock.patch(_UPSTREAM_CALL)
+    def test_only_get_and_head_pass_through(self, upstream):
+        response = self.client.post(reverse("temporal_ui", kwargs={"path": "api/v1/workflows"}))
+        self.assertEqual(response.status_code, 405)
+        upstream.assert_not_called()
+
+    @mock.patch(_UPSTREAM_CALL)
+    def test_path_traversal_is_rejected(self, upstream):
+        response = self.client.get("/timbit/temporal/../../timbit/admin/")
+        self.assertIn(response.status_code, (400, 404))
+        upstream.assert_not_called()
+
+    @mock.patch(_UPSTREAM_CALL, side_effect=requests.ConnectionError("boom"))
+    def test_unreachable_upstream_is_a_502_not_a_crash(self, upstream):
+        response = self.client.get(reverse("temporal_ui", kwargs={"path": ""}))
+        self.assertEqual(response.status_code, 502)
+        self.assertIn(b"not reachable", response.content)
+
+    @mock.patch(_UPSTREAM_CALL)
+    def test_upstream_redirect_is_rewritten_to_our_side(self, upstream):
+        upstream.return_value = _FakeUpstream(
+            status=302,
+            body=b"",
+            headers={"Location": "http://temporal-web.test:8080/timbit/temporal/namespaces/default"},
+        )
+        response = self.client.get(reverse("temporal_ui", kwargs={"path": ""}))
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], "/timbit/temporal/namespaces/default")

--- a/tests/sync/test_temporal_ui_proxy.py
+++ b/tests/sync/test_temporal_ui_proxy.py
@@ -45,7 +45,11 @@ class TemporalUIProxyStaffTest(TestCase):
     @mock.patch(_UPSTREAM_CALL)
     def test_forwards_get_under_public_path_and_streams_body(self, upstream):
         upstream.return_value = _FakeUpstream(
-            headers={"Cache-Control": "no-cache", "Content-Length": "999", "Connection": "keep-alive"}
+            headers={
+                "Cache-Control": "no-cache",
+                "Content-Length": "999",
+                "Connection": "keep-alive",
+            }
         )
         response = self.client.get(
             reverse("temporal_ui", kwargs={"path": "workflows"}) + "?namespace=default"
@@ -59,8 +63,13 @@ class TemporalUIProxyStaffTest(TestCase):
         self.assertNotIn("Content-Length", response)
         method, url = upstream.call_args.args
         self.assertEqual(method, "GET")
-        self.assertEqual(url, "http://temporal-web.test:8080/timbit/temporal/workflows?namespace=default")
-        self.assertEqual(upstream.call_args.kwargs["headers"]["Accept-Encoding"], "identity")
+        self.assertEqual(
+            url,
+            "http://temporal-web.test:8080/timbit/temporal/workflows?namespace=default",
+        )
+        self.assertEqual(
+            upstream.call_args.kwargs["headers"]["Accept-Encoding"], "identity"
+        )
         self.assertFalse(upstream.call_args.kwargs["allow_redirects"])
 
     @mock.patch(_UPSTREAM_CALL)
@@ -72,7 +81,9 @@ class TemporalUIProxyStaffTest(TestCase):
 
     @mock.patch(_UPSTREAM_CALL)
     def test_only_get_and_head_pass_through(self, upstream):
-        response = self.client.post(reverse("temporal_ui", kwargs={"path": "api/v1/workflows"}))
+        response = self.client.post(
+            reverse("temporal_ui", kwargs={"path": "api/v1/workflows"})
+        )
         self.assertEqual(response.status_code, 405)
         upstream.assert_not_called()
 
@@ -93,7 +104,9 @@ class TemporalUIProxyStaffTest(TestCase):
         upstream.return_value = _FakeUpstream(
             status=302,
             body=b"",
-            headers={"Location": "http://temporal-web.test:8080/timbit/temporal/namespaces/default"},
+            headers={
+                "Location": "http://temporal-web.test:8080/timbit/temporal/namespaces/default"
+            },
         )
         response = self.client.get(reverse("temporal_ui", kwargs={"path": ""}))
         self.assertEqual(response.status_code, 302)

--- a/tests/sync/test_temporal_ui_proxy.py
+++ b/tests/sync/test_temporal_ui_proxy.py
@@ -60,7 +60,9 @@ class TemporalUIProxyStaffTest(TestCase):
             reverse("temporal_ui", kwargs={"path": "workflows"}) + "?namespace=default"
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(b"".join(response.streaming_content), b"<html>ui</html>")
+        self.assertEqual(
+            b"".join(response.streaming_content), b"<html>ui</html><!-- tail -->"
+        )
         self.assertEqual(response["Content-Type"], "text/html; charset=utf-8")
         self.assertEqual(response["Cache-Control"], "no-cache")
         # Hop-by-hop / length headers are not copied through a re-streamed body.


### PR DESCRIPTION
The Temporal UI is a ClusterIP service with no auth of its own, so until now the only way to see workflow histories was a kubectl port-forward. Add a staff-only reverse proxy at /timbit/temporal/ (TemporalUIProxyView): forwards GET/HEAD only, to a fixed in-cluster upstream (settings.TEMPORAL_UI_UPSTREAM), streams the response, drops hop-by-hop headers, rewrites upstream redirects back to our side, and turns an unreachable upstream into a 502 instead of a crash. Linked from the staff dashboard.

The chart side sets TEMPORAL_UI_PUBLIC_PATH=/timbit/temporal so the UI's assets and API calls route through the proxy, and
TEMPORAL_DISABLE_WRITE_ACTIONS so no terminate/signal/reset is offered; both land with a helm upgrade (README, new Web UI section). GET-only plus the write-actions flag means nothing state-changing can pass through the proxy.

Tests: login gating, upstream URL and header handling, root redirect, method restriction, path traversal, 502 on connection errors, redirect rewriting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a staff-only, view-only Temporal Web UI accessible from the System Status dashboard.
  * Temporal workflow runs and event histories can now be viewed securely through the application.
  * Write actions are disabled, and access is limited to read-only requests.

* **Documentation**
  * Added deployment and troubleshooting guidance for the Temporal Web UI integration.

* **Bug Fixes**
  * Added handling for invalid paths and unavailable Temporal UI services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->