### PR TITLE
Let staff edit the mailing address in the pro-connector intro flow

### DIFF
--- a/fighthealthinsurance/proconnector.py
+++ b/fighthealthinsurance/proconnector.py
@@ -388,6 +388,62 @@ def build_address_search_link(pro: InterestedProfessional) -> Optional[str]:
     return f"https://www.google.com/search?q={urllib.parse.quote(terms)}"
 
 
+def address_max_length() -> Optional[int]:
+    """Storable length of the mailing address, straight from the column.
+
+    Read from the model rather than restated as a constant so the form cap,
+    the validation message, and the database always agree.
+    """
+    return InterestedProfessional._meta.get_field("address").max_length
+
+
+def clean_address(value: Optional[str]) -> str:
+    """Normalize a staff-entered mailing address for storage.
+
+    Addresses are typed into a multi-line box, so line endings are normalized
+    to ``\\n`` (browsers submit CRLF) and each line is stripped -- keeping the
+    line structure a printed letter needs while leaving no stray carriage
+    returns to leak into the CSV export. Surrounding whitespace goes entirely,
+    because a whitespace-only address is an absent one everywhere else in this
+    workflow (see :func:`build_address_search_link` and the letter view).
+    """
+    text = (value or "").replace("\r\n", "\n").replace("\r", "\n")
+    return "\n".join(line.strip() for line in text.split("\n")).strip()
+
+
+def address_problem(address: str) -> Optional[str]:
+    """First problem with a staff-entered mailing address, or ``None``.
+
+    Only length is checked: addresses are free-form (care-of lines, suites,
+    international formats), so the sole rule is that the value fits the column
+    -- longer input would otherwise be truncated on write by some database
+    backends and silently mail a half-address. An empty address is valid; it
+    means "none on file" and prints the letter's blank guide lines.
+    """
+    max_length = address_max_length()
+    if max_length is not None and len(address) > max_length:
+        return f"Address is too long (max {max_length} characters)."
+    return None
+
+
+def save_address(pro: InterestedProfessional, address: str) -> int:
+    """Store a staff-corrected mailing address on ``pro``; returns rows updated.
+
+    Scoped to this one record, unlike the send/skip helpers that resolve every
+    signup sharing an email. Those are email-scoped because *processing state*
+    must resolve duplicates so an address can never resurface in the queue; a
+    mailing address is not processing state but per-signup data, and the record
+    edited here is exactly the one the printable letter is rendered for. Writing
+    it to duplicate signups would silently overwrite what those professionals
+    submitted, for no workflow gain.
+
+    Written with an UPDATE rather than ``pro.save()`` so a staff address
+    correction can never carry other stale fields from a long-open tab back
+    into the row.
+    """
+    return InterestedProfessional.objects.filter(pk=pro.pk).update(address=address)
+
+
 def describe_known_info(pro: InterestedProfessional) -> str:
     """Plain-text summary of the known fields for the AI prompt.
 

--- a/fighthealthinsurance/proconnector.py
+++ b/fighthealthinsurance/proconnector.py
@@ -437,11 +437,24 @@ def save_address(pro: InterestedProfessional, address: str) -> int:
     it to duplicate signups would silently overwrite what those professionals
     submitted, for no workflow gain.
 
+    Conditional on the record still being unprocessed, for the same reason the
+    send path claims atomically (:func:`claim_email_for_send`): two staff
+    sessions are handed the *same* next record, so a pk-only UPDATE lets the
+    session that goes on to lose the claim -- and is redirected away without
+    sending -- still overwrite the address of a record the winner has already
+    introduced. Returns ``0`` when the record was processed, unsubscribed, or
+    deleted in that window; the caller must not report that as a save.
+
     Written with an UPDATE rather than ``pro.save()`` so a staff address
     correction can never carry other stale fields from a long-open tab back
     into the row.
     """
-    return InterestedProfessional.objects.filter(pk=pro.pk).update(address=address)
+    return InterestedProfessional.objects.filter(
+        pk=pro.pk,
+        proconnector_attempted=False,
+        proconnector_skipped=False,
+        unsubscribed=False,
+    ).update(address=address)
 
 
 def describe_known_info(pro: InterestedProfessional) -> str:

--- a/fighthealthinsurance/staff_views.py
+++ b/fighthealthinsurance/staff_views.py
@@ -49,10 +49,13 @@ from fighthealthinsurance.ml.model_identity import (
 )
 from fighthealthinsurance.proconnector import (
     PROCONNECTOR_INTRO_SUBJECT,
+    address_max_length,
+    address_problem,
     build_intro_letter_blocks,
     build_letter_document_title,
     build_search_links,
     claim_email_for_send,
+    clean_address,
     cofactor_cc_problem,
     default_intro_cc_recipients,
     generate_intro_email,
@@ -68,6 +71,7 @@ from fighthealthinsurance.proconnector import (
     non_spam_interested_professionals,
     queue_proconnector_intro_email,
     quick_intro_block_reason,
+    save_address,
     subject_wording_problem,
     remaining_interested_professionals_count,
     send_proconnector_intro_email,
@@ -1123,6 +1127,13 @@ class ProConnectorProcessView(View):
     the next unprocessed record. Staff can also send a TEST-marked copy of the
     draft to a test address first; that emails nobody else, records nothing on
     the record, and stays on the same record. Nothing is sent automatically.
+
+    The professional's mailing address is editable here too: signups rarely
+    include one, so staff look it up (the page offers an address search link)
+    and save it on the record, which is what the printable intro letter
+    addresses itself from. Saving an address stays on the current record; every
+    other action persists a pending address edit on its way past, so the lookup
+    is never lost to whichever button is pressed next.
     """
 
     template_name = "proconnector.html"
@@ -1136,6 +1147,7 @@ class ProConnectorProcessView(View):
         subject: Optional[str] = None,
         skip_reason: str = "",
         test_email: Optional[str] = None,
+        address: Optional[str] = None,
         error: Optional[str] = None,
         notice: Optional[str] = None,
         status: int = 200,
@@ -1147,6 +1159,11 @@ class ProConnectorProcessView(View):
         ``test_email`` similarly falls back to whatever was posted (preserving
         the field across validation errors), then to the staff member's own
         address so the "send test" button works without retyping it.
+        ``address`` defaults to what is on the record: every POST persists a
+        valid address edit before dispatching (see :meth:`post`), so error
+        re-renders show the saved value without each call site passing it --
+        only a *rejected* address is passed back explicitly, so staff can fix
+        the text they typed rather than the text they replaced.
         """
         if draft is None:
             draft = generate_intro_email(pro)
@@ -1154,6 +1171,8 @@ class ProConnectorProcessView(View):
             test_email = (request.POST.get("test_email") or "").strip() or (
                 getattr(request.user, "email", "") or ""
             )
+        if address is None:
+            address = pro.address or ""
         links = build_search_links(pro)
         context = {
             "title": "Pro Connector",
@@ -1173,6 +1192,11 @@ class ProConnectorProcessView(View):
             "google_address_search_url": links["google_address"],
             "skip_reason": skip_reason,
             "test_email": test_email,
+            # The mailing address is editable here (and only here) so staff can
+            # record what the address lookup turns up; the printable letter
+            # reads it straight off the record.
+            "address": address,
+            "address_max_length": address_max_length(),
             "error": error,
             "notice": notice,
             "remaining_count": remaining_interested_professionals_count(),
@@ -1210,6 +1234,30 @@ class ProConnectorProcessView(View):
             # overwrite; just advance. claim_email_for_send re-checks all three
             # atomically, so this is UX, not the safety net.
             return redirect("proconnector_process")
+
+        # Persist an edited mailing address before dispatching, whichever button
+        # was pressed: send/queue/skip advance to the next record, so an address
+        # staff looked up and typed would otherwise be silently discarded by the
+        # very actions they reach for next. Only the address is written here --
+        # nothing about this claims or processes the record.
+        address_response = self._save_submitted_address(request, pro)
+        if address_response is not None:
+            return address_response
+
+        if action == "save_address":
+            # Stay on this record: the point of saving an address is to then
+            # print the letter for the professional in front of you.
+            return self._render_record(
+                request,
+                pro,
+                **self._posted_edits(request),
+                notice=(
+                    "Mailing address saved; the printable letter will use it."
+                    if pro.address
+                    else "Mailing address cleared; the letter will print blank "
+                    "guide lines to write one on."
+                ),
+            )
 
         if action == "skip":
             skip_reason = (request.POST.get("skip_reason") or "").strip()
@@ -1278,6 +1326,54 @@ class ProConnectorProcessView(View):
 
         # Unknown / missing action -- re-render the current record.
         return self._render_record(request, pro, error="Unknown action.", status=400)
+
+    @staticmethod
+    def _posted_edits(request) -> Dict[str, Any]:
+        """The staff member's typed intro fields, for an edit-preserving re-render.
+
+        The body is passed through unstripped, and as ``None`` when the field is
+        absent from the POST entirely, so :meth:`_render_record` pays for a
+        fresh AI draft only when there was genuinely nothing typed to preserve.
+        """
+        return {
+            "draft": request.POST.get("email_body"),
+            "subject": (request.POST.get("subject") or "").strip()
+            or PROCONNECTOR_INTRO_SUBJECT,
+            "skip_reason": (request.POST.get("skip_reason") or "").strip(),
+        }
+
+    def _save_submitted_address(
+        self, request, pro: InterestedProfessional
+    ) -> Optional[HttpResponse]:
+        """Store the posted mailing address on ``pro``, or return an error page.
+
+        Returns ``None`` when there is nothing to do or the address was saved,
+        and an error ``HttpResponse`` (this record re-rendered, every edit
+        preserved, including the rejected address itself) when the address will
+        not fit the column. ``pro.address`` is updated in memory too, so the
+        same request's address lookup link, "known information" table, and
+        letter card all reflect what was just saved.
+        """
+        posted = request.POST.get("address")
+        if posted is None:
+            # No address field in the POST at all (an older tab, a scripted
+            # submit). Leave whatever is on the record alone.
+            return None
+        address = clean_address(posted)
+        problem = address_problem(address)
+        if problem is not None:
+            return self._render_record(
+                request,
+                pro,
+                **self._posted_edits(request),
+                address=posted,
+                error=problem,
+                status=400,
+            )
+        if address != (pro.address or ""):
+            save_address(pro, address)
+            pro.address = address
+        return None
 
     @staticmethod
     def _intro_form_problem(body: str, subject: str) -> Optional[str]:

--- a/fighthealthinsurance/staff_views.py
+++ b/fighthealthinsurance/staff_views.py
@@ -1130,8 +1130,8 @@ class ProConnectorProcessView(View):
 
     The professional's mailing address is editable here too: signups rarely
     include one, so staff look it up (the page offers an address search link)
-    and save it on the record, which is what the printable intro letter
-    addresses itself from. Saving an address stays on the current record; every
+    and save it on the record, which is the recipient address the printable
+    intro letter prints. Saving an address stays on the current record; every
     other action persists a pending address edit on its way past, so the lookup
     is never lost to whichever button is pressed next.
     """
@@ -1348,11 +1348,14 @@ class ProConnectorProcessView(View):
         """Store the posted mailing address on ``pro``, or return an error page.
 
         Returns ``None`` when there is nothing to do or the address was saved,
-        and an error ``HttpResponse`` (this record re-rendered, every edit
+        an error ``HttpResponse`` (this record re-rendered, every edit
         preserved, including the rejected address itself) when the address will
-        not fit the column. ``pro.address`` is updated in memory too, so the
-        same request's address lookup link, "known information" table, and
-        letter card all reflect what was just saved.
+        not fit the column, and a redirect to the next record when the write is
+        lost -- the record was processed, unsubscribed, or deleted between the
+        eligibility guard in :meth:`post` and the UPDATE. ``pro.address`` is
+        updated in memory on a successful write, so the same request's address
+        lookup link, "known information" table, and letter card all reflect
+        what was just saved.
         """
         posted = request.POST.get("address")
         if posted is None:
@@ -1371,7 +1374,12 @@ class ProConnectorProcessView(View):
                 status=400,
             )
         if address != (pro.address or ""):
-            save_address(pro, address)
+            if save_address(pro, address) == 0:
+                # Another session processed (or deleted) the record in the
+                # window since the guard above. Advance rather than claim a
+                # save that did not happen -- whichever action was pressed
+                # would lose its own claim moments later anyway.
+                return redirect("proconnector_process")
             pro.address = address
         return None
 

--- a/fighthealthinsurance/templates/proconnector.html
+++ b/fighthealthinsurance/templates/proconnector.html
@@ -71,6 +71,9 @@
       font-size: 14px;
     }
     textarea { min-height: 360px; white-space: pre-wrap; }
+    /* The address is a handful of lines, not a letter -- size it to the job so
+       the print button below it stays on screen. */
+    textarea.address { min-height: 5.5em; }
     .disclosure {
       background: #fff8e1;
       border: 1px solid #ffe0a3;
@@ -94,6 +97,9 @@
     button.queue:hover { background-color: #0069d9; }
     button.skip { background-color: #6c757d; color: white; }
     button.skip:hover { background-color: #5a6268; }
+    button.save-address { background-color: #6f42c1; color: white; margin-top: 10px; }
+    button.save-address:hover { background-color: #59339d; }
+    a.edit-link { font-size: 0.85em; margin-left: 8px; color: #007bff; }
     .send-window {
       background: #e7f3ff;
       border: 1px solid #b6d8ff;
@@ -167,7 +173,7 @@
         <tr><th>Most common denial / stated needs</th><td>{% if pro.most_common_denial %}{{ pro.most_common_denial }}{% else %}<span class="muted">(none)</span>{% endif %}</td></tr>
         <tr><th>Notes / comments</th><td>{% if pro.comments %}{{ pro.comments }}{% else %}<span class="muted">(none)</span>{% endif %}</td></tr>
         <tr><th>Phone number</th><td>{% if pro.phone_number %}{{ pro.phone_number }}{% else %}<span class="muted">(none)</span>{% endif %}</td></tr>
-        <tr><th>Address</th><td>{% if pro.address %}{{ pro.address }}{% else %}<span class="muted">(none)</span>{% endif %}</td></tr>
+        <tr><th>Address</th><td>{% if pro.address %}{{ pro.address|linebreaksbr }}{% else %}<span class="muted">(none)</span>{% endif %}<a class="edit-link" href="#address">edit</a></td></tr>
         <tr><th>Paid</th><td>{{ pro.paid|yesno:"Yes,No" }}</td></tr>
         <tr><th>Clicked for paid</th><td>{{ pro.clicked_for_paid|yesno:"Yes,No" }}</td></tr>
         <tr><th>Signup / created date</th><td>{{ pro.signup_date }}</td></tr>
@@ -184,31 +190,52 @@
       {% endif %}
     </div>
 
-    <div class="card">
-      <h2>Physical letter (optional)</h2>
-      <p>
-        For professionals worth reaching by mail as well as email, print a
-        physical introduction letter to send by post. It shares the email's
-        call to action &mdash; reach out to <strong>{{ contact_email }}</strong>
-        to schedule a demo or learn more. Use the <em>Google address</em> link
-        above to find or verify a mailing address.
-      </p>
-      <a class="print-letter" href="{% url 'proconnector_letter' pro.id %}" target="_blank" rel="noopener noreferrer">🖨 Open printable letter &#8599;</a>
-    </div>
+    <!-- One form spans the letter card and the email card so a single submit
+         carries every edit -- including the mailing address, which staff type
+         next to the address lookup that found it. The letter card comes first
+         deliberately: its "Save address" is then the form's default button, so
+         pressing Enter in a text field saves the address rather than firing off
+         an irreversible introduction. -->
+    <form method="post">
+      {% csrf_token %}
+      <input type="hidden" name="interested_professional_id" value="{{ pro.id }}">
 
-    <div class="card">
-      <h2>Introduction email</h2>
-      <div class="disclosure">
-        This draft was generated to help. Review and edit it before sending.
-        The email includes a plain-language disclosure that FHI may receive
-        compensation under our sourcing agreement if the recipient chooses to
-        work with Cofactor AI &mdash; please keep that disclosure in the email.
-        Cofactor AI is described as a sourcing agreement, not a partnership.
+      <div class="card">
+        <h2>Physical letter (optional)</h2>
+        <p>
+          For professionals worth reaching by mail as well as email, print a
+          physical introduction letter to send by post. It shares the email's
+          call to action &mdash; reach out to <strong>{{ contact_email }}</strong>
+          to schedule a demo or learn more. Use the <em>Google address</em> link
+          above to find or verify a mailing address, then save it here so the
+          letter prints already addressed.
+        </p>
+
+        <label for="address">Mailing address (editable)</label>
+        <textarea id="address" name="address" class="address" maxlength="{{ address_max_length }}" placeholder="123 Main St&#10;Suite 400&#10;Springfield, IL 62701">{{ address }}</textarea>
+        <p class="hint">
+          Saved on this record and used to address the printable letter; line
+          breaks are kept as typed. Leave it blank to print blank guide lines to
+          write an address on instead. Saving stays on this record &mdash; and
+          sending, queueing, or skipping saves a pending edit too, so a lookup
+          is never lost.
+        </p>
+        <button type="submit" class="save-address" name="action" value="save_address">Save address</button>
+
+        <p>
+          <a class="print-letter" href="{% url 'proconnector_letter' pro.id %}" target="_blank" rel="noopener noreferrer">🖨 Open printable letter &#8599;</a>
+        </p>
       </div>
 
-      <form method="post">
-        {% csrf_token %}
-        <input type="hidden" name="interested_professional_id" value="{{ pro.id }}">
+      <div class="card">
+        <h2>Introduction email</h2>
+        <div class="disclosure">
+          This draft was generated to help. Review and edit it before sending.
+          The email includes a plain-language disclosure that FHI may receive
+          compensation under our sourcing agreement if the recipient chooses to
+          work with Cofactor AI &mdash; please keep that disclosure in the email.
+          Cofactor AI is described as a sourcing agreement, not a partnership.
+        </div>
 
         <label>To</label>
         <input type="text" class="readonly" value="{{ pro.email }}" readonly>
@@ -259,8 +286,8 @@
             it stays in the queue.
           </p>
         </div>
-      </form>
-    </div>
+      </div>
+    </form>
   {% else %}
     <div class="card">
       <p>🎉 All caught up &mdash; there are no interested professionals left to process.</p>

--- a/fighthealthinsurance/templates/proconnector.html
+++ b/fighthealthinsurance/templates/proconnector.html
@@ -173,7 +173,7 @@
         <tr><th>Most common denial / stated needs</th><td>{% if pro.most_common_denial %}{{ pro.most_common_denial }}{% else %}<span class="muted">(none)</span>{% endif %}</td></tr>
         <tr><th>Notes / comments</th><td>{% if pro.comments %}{{ pro.comments }}{% else %}<span class="muted">(none)</span>{% endif %}</td></tr>
         <tr><th>Phone number</th><td>{% if pro.phone_number %}{{ pro.phone_number }}{% else %}<span class="muted">(none)</span>{% endif %}</td></tr>
-        <tr><th>Address</th><td>{% if pro.address %}{{ pro.address|linebreaksbr }}{% else %}<span class="muted">(none)</span>{% endif %}<a class="edit-link" href="#address">edit</a></td></tr>
+        <tr><th>Address</th><td>{% if pro.address %}{{ pro.address|linebreaksbr }}{% else %}<span class="muted">(none)</span>{% endif %} <a class="edit-link" href="#address">edit</a></td></tr>
         <tr><th>Paid</th><td>{{ pro.paid|yesno:"Yes,No" }}</td></tr>
         <tr><th>Clicked for paid</th><td>{{ pro.clicked_for_paid|yesno:"Yes,No" }}</td></tr>
         <tr><th>Signup / created date</th><td>{{ pro.signup_date }}</td></tr>

--- a/fighthealthinsurance/templates/proconnector_letter.html
+++ b/fighthealthinsurance/templates/proconnector_letter.html
@@ -204,8 +204,9 @@
   {% if not recipient_address %}
     <p class="warning">
       No mailing address on file for this professional, so the letter prints
-      with blank guide lines to write one on. Use the <em>Google address</em>
-      link on the Pro Connector page to look one up before mailing.
+      with blank guide lines to write one on. To print it already addressed,
+      look one up with the <em>Google address</em> link on the Pro Connector
+      page, save it in the mailing address box there, and reload this letter.
     </p>
   {% endif %}
 

--- a/tests/sync/test_proconnector.py
+++ b/tests/sync/test_proconnector.py
@@ -1,8 +1,9 @@
 """Tests for the pro-connector (Cofactor AI) staff workflow.
 
 Covers migration/field defaults, access control, next-record selection, AI
-draft generation with safe fallback, the send / send-failure / skip flows, and
-graceful handling of missing name / organization.
+draft generation with safe fallback, the send / send-failure / skip flows,
+staff editing of the mailing address the printable letter is addressed from,
+and graceful handling of missing name / organization.
 """
 
 import datetime
@@ -23,11 +24,14 @@ from fighthealthinsurance.proconnector import (
     BASE_INTRO_LETTER_SIGNATURE,
     _claims_cofactor_relationship,
     _is_safe_intro_draft,
+    address_max_length,
+    address_problem,
     build_address_search_link,
     build_base_intro_email,
     build_intro_letter_blocks,
     build_letter_document_title,
     build_search_links,
+    clean_address,
     cofactor_cc_problem,
     default_intro_cc_recipients,
     describe_known_info,
@@ -1110,6 +1114,357 @@ class SkipFlowTest(_ProcessViewTestCase):
         response = self._post("skip", interested_professional_id=999999)
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, reverse("proconnector_process"))
+
+# ---------------------------------------------------------------------------
+# Mailing address editing (feeds the printable letter)
+# ---------------------------------------------------------------------------
+class AddressCleaningTest(TestCase):
+    """Normalization applied to a staff-typed address before it is stored."""
+
+    def test_crlf_from_a_browser_textarea_becomes_plain_newlines(self):
+        self.assertEqual(
+            clean_address("123 Main St\r\nSuite 400\r\nSpringfield, IL"),
+            "123 Main St\nSuite 400\nSpringfield, IL",
+        )
+
+    def test_each_line_is_stripped_but_the_line_structure_is_kept(self):
+        self.assertEqual(
+            clean_address("  123 Main St  \n   Springfield, IL  "),
+            "123 Main St\nSpringfield, IL",
+        )
+
+    def test_whitespace_only_address_becomes_empty(self):
+        # A blank-looking address must be *absent*, matching how the letter and
+        # the address lookup already treat one.
+        self.assertEqual(clean_address("   \n\n  "), "")
+
+    def test_none_becomes_empty(self):
+        self.assertEqual(clean_address(None), "")
+
+
+class AddressValidationTest(TestCase):
+    def test_ordinary_address_has_no_problem(self):
+        self.assertIsNone(address_problem("123 Main St\nSpringfield, IL 62701"))
+
+    def test_empty_address_is_allowed(self):
+        # Empty means "none on file" -- the letter prints blank guide lines.
+        self.assertIsNone(address_problem(""))
+
+    def test_address_longer_than_the_column_is_rejected(self):
+        max_length = address_max_length()
+        assert max_length is not None
+        problem = address_problem("x" * (max_length + 1))
+        self.assertIsNotNone(problem)
+        self.assertIn(str(max_length), problem or "")
+
+    def test_address_exactly_at_the_column_length_is_allowed(self):
+        max_length = address_max_length()
+        assert max_length is not None
+        self.assertIsNone(address_problem("x" * max_length))
+
+    def test_cap_comes_from_the_model_column(self):
+        self.assertEqual(
+            address_max_length(),
+            InterestedProfessional._meta.get_field("address").max_length,
+        )
+
+
+@patch(
+    "fighthealthinsurance.staff_views.generate_intro_email",
+    return_value="A draft body with compensation disclosure.",
+)
+class AddressEditingPageTest(_ProcessViewTestCase):
+    def test_page_offers_an_editable_address_field(self, _mock_gen):
+        _make_pro(address="123 Main St, Springfield IL")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'name="address"')
+        self.assertContains(response, 'value="save_address"')
+        self.assertContains(response, "123 Main St, Springfield IL")
+
+    def test_address_field_is_empty_when_none_is_on_file(self, _mock_gen):
+        _make_pro(address="")
+        response = self.client.get(self.url)
+        self.assertContains(response, '<textarea id="address"')
+
+    def test_save_address_is_the_default_button_ahead_of_send(self, _mock_gen):
+        # Implicit submission (Enter in a text field) fires the form's first
+        # submit button, so saving an address must come before the irreversible
+        # send/queue buttons.
+        _make_pro()
+        body = self.client.get(self.url).content.decode()
+        self.assertLess(body.index('value="save_address"'), body.index('value="send"'))
+
+
+class AddressSaveFlowTest(_ProcessViewTestCase):
+    @patch(
+        "fighthealthinsurance.staff_views.generate_intro_email",
+        return_value="A draft body with compensation disclosure.",
+    )
+    def test_save_address_stores_it_and_stays_on_the_record(self, _mock_gen):
+        pro = _make_pro(address="")
+        response = self._post(
+            "save_address",
+            interested_professional_id=pro.id,
+            address="123 Main St\r\nSpringfield, IL 62701",
+            email_body="A draft body with compensation disclosure.",
+        )
+        # Stays put (no redirect) so staff can print the letter next.
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Mailing address saved")
+        pro.refresh_from_db()
+        self.assertEqual(pro.address, "123 Main St\nSpringfield, IL 62701")
+
+    @patch("fighthealthinsurance.staff_views.generate_intro_email")
+    def test_saving_an_address_preserves_the_edited_draft(self, mock_gen):
+        # Re-drafting here would throw away the staff member's edits (and pay
+        # for an inference call) just because they saved an address.
+        pro = _make_pro()
+        response = self._post(
+            "save_address",
+            interested_professional_id=pro.id,
+            address="123 Main St",
+            email_body="My hand-edited body with compensation disclosure.",
+            subject="My subject",
+            skip_reason="maybe later",
+        )
+        self.assertEqual(response.status_code, 200)
+        mock_gen.assert_not_called()
+        self.assertContains(response, "My hand-edited body")
+        self.assertContains(response, "My subject")
+        self.assertContains(response, "maybe later")
+
+    @patch(
+        "fighthealthinsurance.staff_views.generate_intro_email",
+        return_value="A draft body with compensation disclosure.",
+    )
+    def test_save_address_sends_nothing_and_leaves_the_record_in_the_queue(
+        self, _mock_gen
+    ):
+        pro = _make_pro(address="")
+        self._post(
+            "save_address",
+            interested_professional_id=pro.id,
+            address="123 Main St",
+            email_body="A draft body with compensation disclosure.",
+        )
+        pro.refresh_from_db()
+        self.assertFalse(pro.proconnector_attempted)
+        self.assertFalse(pro.proconnector_skipped)
+        self.assertIsNone(pro.proconnector_sent_at)
+        self.assertEqual(len(mail.outbox), 0)
+        self.assertEqual(get_next_interested_professional().pk, pro.pk)
+
+    @patch(
+        "fighthealthinsurance.staff_views.generate_intro_email",
+        return_value="A draft body with compensation disclosure.",
+    )
+    def test_saving_a_blank_address_clears_the_one_on_file(self, _mock_gen):
+        pro = _make_pro(address="123 Main St")
+        response = self._post(
+            "save_address",
+            interested_professional_id=pro.id,
+            address="   ",
+            email_body="A draft body with compensation disclosure.",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Mailing address cleared")
+        pro.refresh_from_db()
+        self.assertEqual(pro.address, "")
+
+    @patch(
+        "fighthealthinsurance.staff_views.generate_intro_email",
+        return_value="A draft body with compensation disclosure.",
+    )
+    def test_overlong_address_is_rejected_and_nothing_is_stored(self, _mock_gen):
+        max_length = address_max_length()
+        assert max_length is not None
+        pro = _make_pro(address="123 Main St")
+        response = self._post(
+            "save_address",
+            interested_professional_id=pro.id,
+            address="x" * (max_length + 1),
+            email_body="A draft body with compensation disclosure.",
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertContains(response, "Address is too long", status_code=400)
+        pro.refresh_from_db()
+        self.assertEqual(pro.address, "123 Main St")
+
+    @patch(
+        "fighthealthinsurance.staff_views.generate_intro_email",
+        return_value="A draft body with compensation disclosure.",
+    )
+    def test_a_rejected_address_is_handed_back_for_editing(self, _mock_gen):
+        # Showing the stored address instead would make staff retype the whole
+        # thing rather than trim what they pasted.
+        max_length = address_max_length()
+        assert max_length is not None
+        pro = _make_pro(address="")
+        typed = "Suite 400 " + "x" * max_length
+        response = self._post(
+            "save_address",
+            interested_professional_id=pro.id,
+            address=typed,
+            email_body="A draft body with compensation disclosure.",
+        )
+        self.assertContains(response, "Suite 400", status_code=400)
+
+    @patch(
+        "fighthealthinsurance.staff_views.generate_intro_email",
+        return_value="A draft body with compensation disclosure.",
+    )
+    def test_address_edit_is_scoped_to_the_shown_record(self, _mock_gen):
+        # Duplicate signups share processing state, but not their own submitted
+        # contact details: correcting one must not overwrite the other's.
+        pro = _make_pro(email="jane@janeclinic.com", address="")
+        duplicate = _make_pro(email="jane@janeclinic.com", address="99 Old Rd")
+        self._post(
+            "save_address",
+            interested_professional_id=pro.id,
+            address="123 Main St",
+            email_body="A draft body with compensation disclosure.",
+        )
+        pro.refresh_from_db()
+        duplicate.refresh_from_db()
+        self.assertEqual(pro.address, "123 Main St")
+        self.assertEqual(duplicate.address, "99 Old Rd")
+
+    @patch(
+        "fighthealthinsurance.staff_views.generate_intro_email",
+        return_value="A draft body with compensation disclosure.",
+    )
+    def test_saved_address_updates_the_address_lookup_link(self, _mock_gen):
+        # With an address on file the lookup verifies *that* address, so the
+        # re-render must not still be searching for one.
+        pro = _make_pro(name="Dr. Jane Smith", business_name="", address="")
+        response = self._post(
+            "save_address",
+            interested_professional_id=pro.id,
+            address="123 Main St",
+            email_body="A draft body with compensation disclosure.",
+        )
+        self.assertContains(response, "search?q=123%20Main%20St")
+
+    def test_saved_address_is_what_the_printable_letter_prints(self):
+        pro = _make_pro(address="")
+        self._post(
+            "save_address",
+            interested_professional_id=pro.id,
+            address="123 Main St\r\nSpringfield, IL 62701",
+            email_body="A draft body with compensation disclosure.",
+        )
+        letter = self.client.get(reverse("proconnector_letter", args=[pro.id]))
+        self.assertContains(letter, "123 Main St")
+        self.assertContains(letter, "Springfield, IL 62701")
+        self.assertNotContains(letter, 'class="address-blank"')
+
+
+class AddressPersistedByOtherActionsTest(_ProcessViewTestCase):
+    """A typed address survives whichever button staff actually press.
+
+    Send / queue / skip advance to the next record, so an address only held in
+    the form would be lost with no way back to it.
+    """
+
+    @patch("fighthealthinsurance.staff_views.send_proconnector_intro_email")
+    def test_send_saves_a_pending_address_edit(self, _mock_send):
+        pro = _make_pro(address="")
+        response = self._post(
+            "send",
+            interested_professional_id=pro.id,
+            address="123 Main St",
+            email_body="Body with compensation disclosure.",
+        )
+        self.assertEqual(response.status_code, 302)
+        pro.refresh_from_db()
+        self.assertEqual(pro.address, "123 Main St")
+        self.assertTrue(pro.proconnector_attempted)
+
+    @patch("fighthealthinsurance.staff_views.queue_proconnector_intro_email")
+    def test_queue_saves_a_pending_address_edit(self, _mock_queue):
+        pro = _make_pro(address="")
+        self._post(
+            "queue",
+            interested_professional_id=pro.id,
+            address="123 Main St",
+            email_body="Body with compensation disclosure.",
+        )
+        pro.refresh_from_db()
+        self.assertEqual(pro.address, "123 Main St")
+
+    def test_skip_saves_a_pending_address_edit(self):
+        pro = _make_pro(address="")
+        self._post(
+            "skip",
+            interested_professional_id=pro.id,
+            address="123 Main St",
+            skip_reason="Not a fit",
+        )
+        pro.refresh_from_db()
+        self.assertEqual(pro.address, "123 Main St")
+        self.assertTrue(pro.proconnector_skipped)
+
+    @patch("fighthealthinsurance.staff_views.send_proconnector_intro_email")
+    def test_address_survives_a_rejected_send(self, mock_send):
+        # The send bounces on the wording rules; the address the staff member
+        # looked up must still be on the record (and on the re-rendered page).
+        pro = _make_pro(address="")
+        response = self._post(
+            "send",
+            interested_professional_id=pro.id,
+            address="123 Main St",
+            email_body="",
+        )
+        self.assertEqual(response.status_code, 400)
+        mock_send.assert_not_called()
+        self.assertContains(response, "123 Main St", status_code=400)
+        pro.refresh_from_db()
+        self.assertEqual(pro.address, "123 Main St")
+        self.assertFalse(pro.proconnector_attempted)
+
+    def test_send_test_saves_a_pending_address_edit(self):
+        pro = _make_pro(address="")
+        response = self._post(
+            "send_test",
+            interested_professional_id=pro.id,
+            address="123 Main St",
+            email_body="Body with compensation disclosure.",
+            test_email="staff@fighthealthinsurance.com",
+        )
+        self.assertEqual(response.status_code, 200)
+        pro.refresh_from_db()
+        self.assertEqual(pro.address, "123 Main St")
+        self.assertFalse(pro.proconnector_attempted)
+
+    @patch("fighthealthinsurance.staff_views.send_proconnector_intro_email")
+    def test_a_post_without_an_address_field_leaves_the_record_alone(self, _mock_send):
+        # An older tab (or a scripted submit) that carries no address field must
+        # not be read as "clear the address".
+        pro = _make_pro(address="123 Main St")
+        self._post(
+            "send",
+            interested_professional_id=pro.id,
+            email_body="Body with compensation disclosure.",
+        )
+        pro.refresh_from_db()
+        self.assertEqual(pro.address, "123 Main St")
+
+    @patch("fighthealthinsurance.staff_views.send_proconnector_intro_email")
+    def test_already_processed_record_is_not_address_edited(self, mock_send):
+        # A stale tab posting against a record another session already sent
+        # must not write to it -- it is no longer this queue's to touch.
+        pro = _make_pro(address="123 Main St", proconnector_attempted=True)
+        response = self._post(
+            "save_address",
+            interested_professional_id=pro.id,
+            address="456 New Ave",
+            email_body="Body with compensation disclosure.",
+        )
+        self.assertEqual(response.status_code, 302)
+        mock_send.assert_not_called()
+        pro.refresh_from_db()
+        self.assertEqual(pro.address, "123 Main St")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/sync/test_proconnector.py
+++ b/tests/sync/test_proconnector.py
@@ -2,8 +2,8 @@
 
 Covers migration/field defaults, access control, next-record selection, AI
 draft generation with safe fallback, the send / send-failure / skip flows,
-staff editing of the mailing address the printable letter is addressed from,
-and graceful handling of missing name / organization.
+staff editing of the mailing address the printable letter is sent to, and
+graceful handling of missing name / organization.
 """
 
 import datetime
@@ -42,6 +42,7 @@ from fighthealthinsurance.proconnector import (
     partner_framing_problem,
     queue_proconnector_intro_email,
     quick_intro_block_reason,
+    save_address,
     send_proconnector_test_email,
 )
 
@@ -1465,6 +1466,83 @@ class AddressPersistedByOtherActionsTest(_ProcessViewTestCase):
         mock_send.assert_not_called()
         pro.refresh_from_db()
         self.assertEqual(pro.address, "123 Main St")
+
+
+class SaveAddressHelperTest(TestCase):
+    """The address write is conditional on the record still being unprocessed.
+
+    Two staff sessions are handed the same next record, so the session that
+    goes on to lose the send claim must not still overwrite the address of a
+    record the winner has already introduced.
+    """
+
+    def test_writes_to_an_unprocessed_record(self):
+        pro = _make_pro(address="")
+        self.assertEqual(save_address(pro, "123 Main St"), 1)
+        pro.refresh_from_db()
+        self.assertEqual(pro.address, "123 Main St")
+
+    def test_does_not_write_to_an_already_sent_record(self):
+        pro = _make_pro(address="123 Main St", proconnector_attempted=True)
+        self.assertEqual(save_address(pro, "456 Other Ave"), 0)
+        pro.refresh_from_db()
+        self.assertEqual(pro.address, "123 Main St")
+
+    def test_does_not_write_to_a_skipped_record(self):
+        pro = _make_pro(address="123 Main St", proconnector_skipped=True)
+        self.assertEqual(save_address(pro, "456 Other Ave"), 0)
+        pro.refresh_from_db()
+        self.assertEqual(pro.address, "123 Main St")
+
+    def test_does_not_write_to_an_unsubscribed_record(self):
+        pro = _make_pro(address="123 Main St", unsubscribed=True)
+        self.assertEqual(save_address(pro, "456 Other Ave"), 0)
+        pro.refresh_from_db()
+        self.assertEqual(pro.address, "123 Main St")
+
+    def test_deleted_record_reports_no_rows_written(self):
+        pro = _make_pro(address="")
+        InterestedProfessional.objects.filter(pk=pro.pk).delete()
+        self.assertEqual(save_address(pro, "123 Main St"), 0)
+
+
+class AddressWriteLostToConcurrentProcessingTest(_ProcessViewTestCase):
+    @patch("fighthealthinsurance.staff_views.save_address", return_value=0)
+    @patch(
+        "fighthealthinsurance.staff_views.generate_intro_email",
+        return_value="A draft body with compensation disclosure.",
+    )
+    def test_lost_write_advances_instead_of_reporting_a_save(
+        self, _mock_gen, _mock_save
+    ):
+        # The record was processed (or deleted) between the eligibility guard
+        # and the UPDATE: telling staff the address was saved would be a lie.
+        pro = _make_pro(address="")
+        response = self._post(
+            "save_address",
+            interested_professional_id=pro.id,
+            address="123 Main St",
+            email_body="A draft body with compensation disclosure.",
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, reverse("proconnector_process"))
+
+    @patch("fighthealthinsurance.staff_views.send_proconnector_intro_email")
+    @patch("fighthealthinsurance.staff_views.save_address", return_value=0)
+    def test_lost_write_stops_the_send_before_it_claims(self, _mock_save, mock_send):
+        # Losing the address write means the record is no longer this session's
+        # to process, so the send must not go out either.
+        pro = _make_pro(address="")
+        response = self._post(
+            "send",
+            interested_professional_id=pro.id,
+            address="123 Main St",
+            email_body="Body with compensation disclosure.",
+        )
+        self.assertEqual(response.status_code, 302)
+        mock_send.assert_not_called()
+        pro.refresh_from_db()
+        self.assertFalse(pro.proconnector_attempted)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The pro-connector page offers a Google address lookup and a printable
introduction letter, but nowhere to record what the lookup finds: signups
rarely include an address, so the letter printed blank guide lines to write
one on by hand every time.

Make the mailing address editable on the processing page. The address box
sits in the physical-letter card, next to the lookup that finds it and the
print button that uses it, inside the page's (now single) form:

  * "Save address" stores it and stays on the current record, so staff can
    print the letter for the professional in front of them.
  * Send / queue / skip persist a pending address edit on their way past --
    those actions advance to the next record, so an address only held in the
    form would otherwise be lost with no way back to it.
  * The letter card comes first in the form, which makes "Save address" the
    default button: pressing Enter in a text field now saves an address
    instead of firing off an irreversible introduction.

Addresses are normalized before storage (CRLF from the textarea becomes \n,
each line stripped, whitespace-only means absent to match how the rest of
the workflow already treats a blank address) and validated against the
column length read from the model. A rejected address is handed back for
editing rather than replaced by the stored one.

The write is scoped to the edited record, unlike the email-scoped send/skip
helpers: processing state must resolve duplicate signups so an address can
never resurface in the queue, but a mailing address is per-signup data and
the edited record is exactly the one the letter is rendered for.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DrHRy2V6ijWS9Pkh1fnKG5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Staff can edit and save a professional’s mailing address directly from the Pro Connector page.
  * Address updates are retained when sending, queuing, skipping, or testing communications.
  * Added validation and formatting, including length limits and line-break cleanup.
  * Added guidance for updating missing addresses before generating letters.

* **Bug Fixes**
  * Prevented invalid address edits from being saved while preserving entered form values.
  * Prevented updates to records that were processed, unsubscribed, or deleted while being edited.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->