### PR TITLE
Fix sqlite table locks in async tests via transaction cleanup

### DIFF
--- a/tests/async/test_leaked_transaction_cleanup.py
+++ b/tests/async/test_leaked_transaction_cleanup.py
@@ -1,0 +1,54 @@
+"""Regression test for the between-test cleanup in ``tests/conftest.py``.
+
+A plain ``async def`` test runs every native async ORM call and every
+``database_sync_to_async`` body on asgiref's process-wide
+``SyncToAsync.single_thread_executor``. If a call there leaves its connection
+mid-transaction -- an ``atomic`` whose COMMIT failed, or one whose awaiting task
+was abandoned when the event loop closed -- nothing clears it: Django refuses to
+close an in-memory sqlite connection, because closing would destroy the
+database. The open transaction holds a sqlite table lock, so the next
+``transaction=True`` test dies in its teardown flush ("Database ... couldn't be
+flushed") and the rows that flush failed to delete leak into every later test.
+
+``_rollback_leaked_transactions`` is what breaks that chain, so it has its own
+test: the fixture that calls it only shows up as a mystery flake far away.
+"""
+
+import pytest
+from asgiref.sync import sync_to_async
+
+from fighthealthinsurance.models import ChooserTask
+from tests.conftest import _rollback_leaked_transactions
+
+
+def _abandon_an_open_transaction() -> int:
+    """Leave this thread's connection mid-transaction; return the written pk."""
+    from django.db import transaction
+
+    transaction.atomic().__enter__()  # deliberately never exited
+    task = ChooserTask.objects.create(
+        task_type="appeal", status="READY", source="synthetic"
+    )
+    return task.pk
+
+
+def _in_transaction() -> bool:
+    from django.db import connection
+
+    return bool(connection.connection and connection.connection.in_transaction)
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_abandoned_transaction_is_rolled_back_on_the_executor_thread():
+    # Every sync_to_async call below lands on the same thread-sensitive
+    # executor, so they all see the one connection under test.
+    pk = await sync_to_async(_abandon_an_open_transaction)()
+    assert await sync_to_async(_in_transaction)() is True
+
+    await sync_to_async(_rollback_leaked_transactions)()
+
+    assert await sync_to_async(_in_transaction)() is False
+    # The abandoned write went with it, so the table lock is gone and the next
+    # test's teardown flush can run.
+    assert not await ChooserTask.objects.filter(pk=pk).aexists()

--- a/tests/async/test_leaked_transaction_cleanup.py
+++ b/tests/async/test_leaked_transaction_cleanup.py
@@ -33,6 +33,7 @@ def _abandon_an_open_transaction() -> int:
 
 
 def _in_transaction() -> bool:
+    """Whether the calling thread's connection is mid-transaction."""
     from django.db import connection
 
     return bool(connection.connection and connection.connection.in_transaction)
@@ -41,14 +42,16 @@ def _in_transaction() -> bool:
 @pytest.mark.asyncio
 @pytest.mark.django_db(transaction=True)
 async def test_abandoned_transaction_is_rolled_back_on_the_executor_thread():
-    # Every sync_to_async call below lands on the same thread-sensitive
-    # executor, so they all see the one connection under test.
-    pk = await sync_to_async(_abandon_an_open_transaction)()
-    assert await sync_to_async(_in_transaction)() is True
+    """The cleanup ends an abandoned transaction and undoes its write."""
+    # thread_sensitive is spelled out because the test depends on it: it is what
+    # puts every call below on the one thread-sensitive executor, so they all
+    # see the same connection.
+    pk = await sync_to_async(_abandon_an_open_transaction, thread_sensitive=True)()
+    assert await sync_to_async(_in_transaction, thread_sensitive=True)() is True
 
-    await sync_to_async(_rollback_leaked_transactions)()
+    await sync_to_async(_rollback_leaked_transactions, thread_sensitive=True)()
 
-    assert await sync_to_async(_in_transaction)() is False
+    assert await sync_to_async(_in_transaction, thread_sensitive=True)() is False
     # The abandoned write went with it, so the table lock is gone and the next
     # test's teardown flush can run.
     assert not await ChooserTask.objects.filter(pk=pk).aexists()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,11 +137,12 @@ def _rollback_leaked_transactions() -> None:
                 continue
             # Reset Django's own transaction bookkeeping first: a block that
             # never unwound leaves in_atomic_block set, and rollback() refuses
-            # to run inside one.
+            # to run inside one. needs_rollback is deliberately left alone --
+            # rollback() clears it itself once it succeeds, so a rollback that
+            # raises leaves the connection honestly marked as still dirty.
             conn.in_atomic_block = False
             conn.savepoint_ids = []
             conn.atomic_blocks = []
-            conn.needs_rollback = False
             conn.rollback()
             conn.set_autocommit(True)
         except Exception:
@@ -178,9 +179,12 @@ def _settle_thread_sensitive_db_work():
     own is exactly a barrier: every call queued ahead of it has finished by the
     time it runs. The task then rolls back whatever was left open.
 
-    Defined ahead of ``_drain_fire_and_forget_threads`` deliberately: teardown
-    runs in reverse order, so those threads are joined first and the DB work
-    they queued onto this same executor is drained here.
+    ``_drain_fire_and_forget_threads`` requests this fixture so that the two run
+    in the right order: teardown is the reverse of setup, so those threads are
+    joined first and the DB work they queued onto this same executor is drained
+    here. Pytest orders same-scope autouse fixtures with no dependency between
+    them arbitrarily, so the request is what makes that hold -- not the order
+    they appear in this file.
     """
     yield
     try:
@@ -199,7 +203,7 @@ def _settle_thread_sensitive_db_work():
 
 
 @pytest.fixture(autouse=True)
-def _drain_fire_and_forget_threads():
+def _drain_fire_and_forget_threads(_settle_thread_sensitive_db_work):
     """Drain fire-and-forget background threads at the end of each test.
 
     ``fire_and_forget_in_new_threadpool`` runs coroutines -- often sqlite writes,
@@ -210,6 +214,11 @@ def _drain_fire_and_forget_threads():
     threads at teardown (which runs before the next class's setUpClass) keeps
     that work inside the test that started it. The per-thread timeout is a safety
     cap; leaked threads normally finish in milliseconds.
+
+    Requests ``_settle_thread_sensitive_db_work`` only for the ordering: these
+    threads queue their DB work onto that same executor, so they must be joined
+    before it is drained, and requesting the fixture is what puts this teardown
+    ahead of that one.
     """
     yield
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,6 +121,83 @@ def _stub_denied_items_analysis_dispatch():
         yield
 
 
+def _rollback_leaked_transactions() -> None:
+    """Roll back any transaction left open on the calling thread's connections.
+
+    Runs inside the thread that owns the connections -- a sqlite connection may
+    only be rolled back from its own thread.
+    """
+    from django.db import connections
+
+    for conn in connections.all(initialized_only=True):
+        try:
+            raw = conn.connection
+            # in_transaction is sqlite's; other backends just fall through.
+            if raw is None or not raw.in_transaction:
+                continue
+            # Reset Django's own transaction bookkeeping first: a block that
+            # never unwound leaves in_atomic_block set, and rollback() refuses
+            # to run inside one.
+            conn.in_atomic_block = False
+            conn.savepoint_ids = []
+            conn.atomic_blocks = []
+            conn.needs_rollback = False
+            conn.rollback()
+            conn.set_autocommit(True)
+        except Exception:
+            # Best effort: a connection we can't reset is no worse than the
+            # one we started with.
+            pass
+
+
+@pytest.fixture(autouse=True)
+def _settle_thread_sensitive_db_work():
+    """Drain asgiref's shared thread-sensitive executor at the end of each test.
+
+    In a plain ``async def`` test (nothing wraps it in ``async_to_sync``), the
+    native async ORM and ``database_sync_to_async`` both run their sync body on
+    asgiref's process-wide ``SyncToAsync.single_thread_executor``. Two things
+    leak out of a test that way:
+
+    * a call whose awaiting task was abandoned when the test's event loop closed
+      keeps running there afterwards, so its queries can still be in flight
+      during the next test, and
+    * that thread's connection can be left mid-transaction -- an ``atomic``
+      whose COMMIT failed against a lock the main thread held, say. Django never
+      closes an in-memory sqlite connection (closing would destroy the
+      database), so ``close_old_connections`` doesn't drop the broken one the
+      way it would in production, and nothing else clears it.
+
+    Either one holds a sqlite table lock, and shared-cache sqlite answers a
+    conflicting lock with an immediate "database table is locked" rather than
+    honouring the busy timeout. The next ``transaction=True`` test then dies in
+    its teardown flush ("Database ... couldn't be flushed") and the rows that
+    flush failed to delete leak into every test after it.
+
+    The executor is a single-worker FIFO queue, so waiting on one task of our
+    own is exactly a barrier: every call queued ahead of it has finished by the
+    time it runs. The task then rolls back whatever was left open.
+
+    Defined ahead of ``_drain_fire_and_forget_threads`` deliberately: teardown
+    runs in reverse order, so those threads are joined first and the DB work
+    they queued onto this same executor is drained here.
+    """
+    yield
+    try:
+        from asgiref.sync import SyncToAsync
+    except Exception:
+        return
+    executor = getattr(SyncToAsync, "single_thread_executor", None)
+    if executor is None:
+        return
+    try:
+        executor.submit(_rollback_leaked_transactions).result(timeout=10.0)
+    except Exception:
+        # Draining is best effort: if the queued work is itself blocked on a
+        # lock this test still holds, timing out leaves us no worse off.
+        pass
+
+
 @pytest.fixture(autouse=True)
 def _drain_fire_and_forget_threads():
     """Drain fire-and-forget background threads at the end of each test.


### PR DESCRIPTION
## Summary

The async CI job had been failing intermittently for days: every `django_db(transaction=True)` test in one xdist worker erroring in teardown with `CommandError: Database file:memorydb_default?mode=memory&cache=shared couldn't be flushed`, followed by assertion failures counting the rows that failed flush left behind (`assert 6 == 2` in `tests/async/test_chooser_refill.py`).

## Changes

- **`_rollback_leaked_transactions()`**: New helper that rolls back a transaction left open on the calling thread's connections. Resets Django's transaction bookkeeping (`in_atomic_block`, `savepoint_ids`, `atomic_blocks`) first, since a block that never unwound leaves `in_atomic_block` set and `rollback()` refuses to run inside one. `needs_rollback` is deliberately left alone — `rollback()` clears it itself on success, so a rollback that raises leaves the connection honestly marked as still dirty.

- **`_settle_thread_sensitive_db_work` fixture**: New autouse fixture that drains asgiref's `SyncToAsync.single_thread_executor` at the end of each test. The executor is a single-worker FIFO queue, so waiting on one submitted task is a barrier: every call queued ahead of it has finished by the time it runs. The task then rolls back whatever was left open. `_drain_fire_and_forget_threads` requests this fixture, which is what pins the teardown order (drain threads, then settle the executor) — pytest orders same-scope autouse fixtures with no dependency between them arbitrarily.

- **`test_leaked_transaction_cleanup.py`**: New regression test covering the cleanup helper — abandon an open transaction on the executor thread, confirm it is open, run the cleanup, confirm the transaction and its uncommitted write are gone.

## Root cause

In a plain `async def` test the native async ORM and `database_sync_to_async` both run their sync body on asgiref's process-wide `SyncToAsync.single_thread_executor`. When a call there leaves that thread's connection mid-transaction — an `atomic` whose COMMIT failed, or work abandoned when the test's event loop closed — nothing clears it: Django refuses to close an in-memory sqlite connection because closing would destroy the database, so `close_old_connections()` can't drop the broken one the way it does against a real database. The open transaction holds a table lock, and shared-cache sqlite answers a conflicting lock with an immediate "database table is locked" instead of honouring the busy timeout, so the next test's teardown flush dies and its rows leak into everything after it.

A sqlite statement trace of the executor connection during a failing run caught exactly that: `BEGIN`, `INSERT`, then later statements with no `COMMIT` in between.

## Validation

A probe that abandons an open transaction reproduced the CI failure deterministically (same flush error, same `assert 6 == 1` shape). `--setup-show` confirms the fixture ordering, including that both drains land ahead of pytest-django's `_django_db_helper` teardown, where the flush lives:

```
SETUP    F _django_db_helper (fixtures used: django_db_blocker, django_db_setup)
SETUP    F _settle_thread_sensitive_db_work
SETUP    F _drain_fire_and_forget_threads (fixtures used: _settle_thread_sensitive_db_work)
TEARDOWN F _drain_fire_and_forget_threads
TEARDOWN F _settle_thread_sensitive_db_work
TEARDOWN F _django_db_helper
```

Locally the async suite went from failing roughly one run in three to 10/10 green; sync, async-unit, sync-actor, selenium, black and mypy all pass.

https://claude.ai/code/session_01E6JRrHbbeg1cL1xe1iKxNe
