### PR TITLE
Add agent-readable site: llms.txt, markdown twins, Organization schema

### DIFF
--- a/fighthealthinsurance/agent_docs.py
+++ b/fighthealthinsurance/agent_docs.py
@@ -321,6 +321,8 @@ class MarkdownTwinView(View):
     http_method_names = ["get", "head"]
 
     def get(self, request: HttpRequest, path: str) -> HttpResponse:
+        if not path:  # "/.md": the root's twin is /index.md only
+            raise Http404("No markdown twin for this page")
         source = source_path_for("/" + path + ".md")
         try:
             match = resolve(source)

--- a/fighthealthinsurance/agent_docs.py
+++ b/fighthealthinsurance/agent_docs.py
@@ -1,0 +1,499 @@
+"""Agent-readable twins of the public site (llms.txt v2).
+
+Humans get HTML. Agents get the same page as markdown at ``<url>.md``
+(directory-style URLs use ``<url>index.md``), advertised from every eligible
+page's ``<head>`` via ``<link rel="alternate" type="text/markdown">``, and a
+site index at ``/llms.txt`` advertised via ``<link rel="describedby">``.
+
+Only public content pages are eligible: the static pages the sitemap already
+advertises, blog posts, state help pages and microsites. Everything in the
+appeal flow, the staff area and the API is refused with a 404 before the
+underlying view is ever called.
+
+Same-URL content negotiation (``Accept: text/markdown``) is deliberately not
+done here. The site sits behind Cloudflare's cache, which keys on the URL and
+does not honor ``Vary: Accept``, so a markdown response could be cached and
+handed to a browser. Distinct ``.md`` URLs cannot collide that way.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Optional
+
+from django.contrib.staticfiles.storage import staticfiles_storage
+from django.http import Http404, HttpRequest, HttpResponse
+from django.urls import Resolver404, resolve, reverse
+from django.views import View
+from django.views.decorators.cache import cache_control, cache_page
+
+from bs4 import BeautifulSoup, NavigableString, Tag
+from loguru import logger
+
+from fighthealthinsurance.sitemap import StaticViewSitemap
+
+CANONICAL_ORIGIN = "https://www.fighthealthinsurance.com"
+MARKDOWN_CONTENT_TYPE = "text/markdown; charset=utf-8"
+
+# Public content pages that are not in the static sitemap list but still
+# belong in the agent-readable set. Parameterised names (blog-post, state_help,
+# microsite) cover every instance of that route.
+EXTRA_TWIN_URL_NAMES = frozenset(
+    {
+        "about-ai",
+        "how-to-help",
+        "blog-post",
+        "state_help_index",
+        "state_help",
+        "smtp-domain-faq",
+        "microsite",
+    }
+)
+
+# Short notes for the llms.txt page list, keyed by URL name. Pages without an
+# entry are listed by URL alone.
+PAGE_NOTES: dict[str, tuple[str, str]] = {
+    "root": (
+        "Home",
+        "what the tool does and how to start an appeal from a photo of the denial",
+    ),
+    "about": ("About us", "who makes this and why it exists"),
+    "about-ai": ("About our AI", "how the models are used and what they cannot do"),
+    "how-to-help": ("How to help", "ways to support the project"),
+    "faq": ("FAQ", "common questions about appeals and about using the tool"),
+    "medicaid-faq": ("Medicaid work requirements FAQ", ""),
+    "smtp-domain-faq": (
+        "Email domain FAQ",
+        "why our emails come from the domains they do",
+    ),
+    "denial-language-library": (
+        "Denial language library",
+        "common phrases insurers use in denials and what they mean",
+    ),
+    "preparing-2026": ("Preparing for 2026", "insurance changes to plan for"),
+    "turning-26": ("Turning 26", "coverage options when you age off a parent's plan"),
+    "medicaid-eligibility": ("Medicaid eligibility", ""),
+    "other-resources": ("Other resources", "organizations and tools beyond this site"),
+    "pbs-newshour": ("As seen on PBS NewsHour", ""),
+    "media-references": ("Media references", "press coverage"),
+    "blog": ("Blog", "index of posts"),
+    "microsite_directory": (
+        "Condition and procedure guides",
+        "index of the microsites",
+    ),
+    "state_help_index": (
+        "Help by state",
+        "index of state-level regulators and appeal rights",
+    ),
+    "contact": ("Contact", ""),
+    "tos": ("Terms of service", ""),
+    "privacy_policy": ("Privacy policy", ""),
+    "mhmda": ("Washington MHMDA notice", "consumer health data disclosures"),
+}
+
+_STRIP_TAGS = (
+    "script",
+    "style",
+    "noscript",
+    "nav",
+    "form",
+    "button",
+    "input",
+    "select",
+    "textarea",
+    "svg",
+    "iframe",
+    "img",
+    "video",
+    "audio",
+    "canvas",
+    "template",
+)
+_INLINE_TAGS = frozenset(
+    {
+        "a",
+        "strong",
+        "b",
+        "em",
+        "i",
+        "code",
+        "span",
+        "small",
+        "sup",
+        "sub",
+        "abbr",
+        "u",
+        "s",
+    }
+)
+_HEADING = re.compile(r"^h([1-6])$")
+
+
+def static_twin_url_names() -> frozenset[str]:
+    """URL names eligible for a markdown twin."""
+    return frozenset(StaticViewSitemap().items()) | EXTRA_TWIN_URL_NAMES
+
+
+def twin_eligible(url_name: Optional[str]) -> bool:
+    return bool(url_name) and url_name in static_twin_url_names()
+
+
+def twin_path_for(path: str) -> str:
+    """Markdown twin path for a page path: ``/about`` -> ``/about.md``,
+    ``/`` -> ``/index.md``, ``/blog/x/`` -> ``/blog/x/index.md``."""
+    if path.endswith("/"):
+        return path + "index.md"
+    return path + ".md"
+
+
+def source_path_for(twin_path: str) -> str:
+    """Inverse of :func:`twin_path_for`."""
+    if not twin_path.endswith(".md"):
+        raise ValueError(twin_path)
+    base = twin_path[: -len(".md")]
+    if base == "/index" or base.endswith("/index"):
+        return base[: -len("index")]
+    return base
+
+
+# ---------------------------------------------------------------------------
+# HTML -> markdown
+# ---------------------------------------------------------------------------
+
+
+def _absolute(href: str, origin: str) -> str:
+    if href.startswith(("http://", "https://", "mailto:", "tel:")):
+        return href
+    if href.startswith("/"):
+        return origin + href
+    return f"{origin}/{href}"
+
+
+def _text(node: NavigableString) -> str:
+    return re.sub(r"\s+", " ", str(node))
+
+
+def _render(node: Any, origin: str, list_depth: int = 0) -> str:
+    """Render a BeautifulSoup node to markdown. Block elements own their own
+    surrounding blank lines; inline elements return bare text."""
+    if isinstance(node, NavigableString):
+        if type(node) is not NavigableString:  # comments, CDATA, doctype
+            return ""
+        return _text(node)
+    if not isinstance(node, Tag):
+        return ""
+    name = node.name.lower()
+    if name in _STRIP_TAGS or node.get("aria-hidden") == "true":
+        return ""
+    if name == "br":
+        return "\n"
+    if name == "hr":
+        return "\n\n---\n\n"
+    if name == "pre":
+        return "\n\n```\n" + str(node.get_text()).strip("\n") + "\n```\n\n"
+
+    children = "".join(_render(c, origin, list_depth) for c in node.children)
+    heading = _HEADING.match(name)
+    if heading:
+        text = children.strip()
+        return f"\n\n{'#' * int(heading.group(1))} {text}\n\n" if text else ""
+    if name == "p":
+        return "\n\n" + children.strip() + "\n\n"
+    if name == "blockquote":
+        body = children.strip()
+        return "\n\n" + "\n".join("> " + line for line in body.splitlines()) + "\n\n"
+    if name in ("ul", "ol"):
+        items = []
+        for i, li in enumerate(node.find_all("li", recursive=False), start=1):
+            marker = f"{i}." if name == "ol" else "-"
+            body = _render_children(li, origin, list_depth + 1).strip()
+            body = body.replace("\n\n", "\n").replace(
+                "\n", "\n" + "  " * (list_depth + 1)
+            )
+            items.append("  " * list_depth + f"{marker} {body}")
+        return "\n\n" + "\n".join(items) + "\n\n"
+    if name == "li":
+        return children
+    if name == "a":
+        text = children.strip()
+        href = node.get("href")
+        if not text:
+            return ""
+        if not isinstance(href, str) or href.startswith(("#", "javascript:")):
+            return text
+        return f"[{text}]({_absolute(href, origin)})"
+    if name in ("strong", "b"):
+        text = children.strip()
+        return f"**{text}**" if text else ""
+    if name in ("em", "i"):
+        text = children.strip()
+        return f"*{text}*" if text else ""
+    if name == "code":
+        return f"`{children.strip()}`"
+    if name == "table":
+        return _render_table(node, origin)
+    if name in _INLINE_TAGS:
+        return children
+    # Generic block container (div, section, article, header, footer, ...):
+    # separate from neighbours so adjacent text does not run together.
+    return "\n\n" + children + "\n\n"
+
+
+def _render_children(node: Tag, origin: str, list_depth: int) -> str:
+    return "".join(_render(c, origin, list_depth) for c in node.children)
+
+
+def _render_table(table: Tag, origin: str) -> str:
+    rows = []
+    for tr in table.find_all("tr"):
+        cells = [
+            " ".join(_render_children(td, origin, 0).split())
+            for td in tr.find_all(["th", "td"], recursive=False)
+        ]
+        if cells:
+            rows.append(cells)
+    if not rows:
+        return ""
+    width = max(len(r) for r in rows)
+    rows = [r + [""] * (width - len(r)) for r in rows]
+    out = ["| " + " | ".join(rows[0]) + " |", "|" + " --- |" * width]
+    out += ["| " + " | ".join(r) + " |" for r in rows[1:]]
+    return "\n\n" + "\n".join(out) + "\n\n"
+
+
+def _tidy(markdown: str) -> str:
+    markdown = re.sub(r"[ \t]+\n", "\n", markdown)
+    markdown = re.sub(r"\n[ \t]+(?=\S)", "\n", markdown)
+    markdown = re.sub(r"\n{3,}", "\n\n", markdown)
+    return markdown.strip() + "\n"
+
+
+def html_to_markdown(html: str, page_url: str, origin: str = CANONICAL_ORIGIN) -> str:
+    """Convert a rendered page to markdown: the ``<main>`` content only, with
+    a small header (title, description, URL, site index) on top."""
+    soup = BeautifulSoup(html, "html.parser")
+    title = soup.title.get_text(" ", strip=True) if soup.title else ""
+    title = re.sub(r"\s+", " ", title)
+    description = ""
+    meta = soup.find("meta", attrs={"name": "description"})
+    if isinstance(meta, Tag):
+        content = meta.get("content")
+        if isinstance(content, str):
+            description = re.sub(r"\s+", " ", content).strip()
+
+    main = soup.find("main") or soup.body or soup
+    body = _tidy(_render(main, origin))
+
+    head: list[str] = []
+    if title and not body.startswith("# "):
+        head += [f"# {title}", ""]
+    if description:
+        head += [f"> {description}", ""]
+    head += [
+        f"- URL: {page_url}",
+        f"- Site index for agents: {origin}{reverse('llms_txt')}",
+        "",
+    ]
+    return "\n".join(head) + "\n" + body
+
+
+# ---------------------------------------------------------------------------
+# Views
+# ---------------------------------------------------------------------------
+
+
+def _read_static_text(name: str) -> Optional[str]:
+    try:
+        with staticfiles_storage.open(name, "r") as f:
+            contents = f.read()
+        if not isinstance(contents, str):
+            contents = contents.decode("utf-8")
+        return str(contents)
+    except Exception as e:  # missing file, bad encoding: fall back to HTML
+        logger.warning(f"Could not read static file {name}: {e}")
+        return None
+
+
+class MarkdownTwinView(View):
+    """Serve ``<page>.md`` for an eligible public page."""
+
+    http_method_names = ["get", "head"]
+
+    def get(self, request: HttpRequest, path: str) -> HttpResponse:
+        source = source_path_for("/" + path + ".md")
+        try:
+            match = resolve(source)
+        except Resolver404:
+            raise Http404("No such page")
+        if not twin_eligible(match.url_name):
+            raise Http404("No markdown twin for this page")
+
+        page_url = CANONICAL_ORIGIN + source
+        markdown: Optional[str] = None
+        if match.url_name == "blog-post":
+            slug = match.kwargs.get("slug", "")
+            if re.match(r"^[a-zA-Z0-9_-]+$", slug):
+                # Blog posts are written in markdown; hand over the source.
+                markdown = _read_static_text(f"blog/{slug}.md")
+                if markdown is not None:
+                    markdown = markdown.rstrip("\n") + (
+                        f"\n\n- URL: {page_url}\n"
+                        f"- Site index for agents: {CANONICAL_ORIGIN}{reverse('llms_txt')}\n"
+                    )
+
+        if markdown is None:
+            request.resolver_match = match
+            page = match.func(request, *match.args, **match.kwargs)
+            if hasattr(page, "render") and callable(page.render):
+                page = page.render()
+            if page.status_code != 200 or not page.get("Content-Type", "").startswith(
+                "text/html"
+            ):
+                raise Http404("Page did not render")
+            markdown = html_to_markdown(page.content.decode("utf-8"), page_url)
+
+        response = HttpResponse(markdown, content_type=MARKDOWN_CONTENT_TYPE)
+        response["Link"] = f'<{reverse("llms_txt")}>; rel="describedby"'
+        response["Cache-Control"] = "public, max-age=1800"
+        return response
+
+
+def _blog_posts() -> list[dict[str, Any]]:
+    raw = _read_static_text("blog_posts.json")
+    if not raw:
+        return []
+    try:
+        posts = json.loads(raw)
+    except json.JSONDecodeError as e:
+        logger.warning(f"Could not parse blog_posts.json: {e}")
+        return []
+    return (
+        [p for p in posts if isinstance(p, dict) and p.get("slug")]
+        if isinstance(posts, list)
+        else []
+    )
+
+
+def _twin_link(url_name: str, **kwargs: Any) -> str:
+    return CANONICAL_ORIGIN + twin_path_for(reverse(url_name, kwargs=kwargs or None))
+
+
+def build_llms_txt() -> str:
+    lines = [
+        "# Fight Health Insurance",
+        "",
+        "> Fight Health Insurance is a free tool that helps patients appeal health "
+        "insurance denials. Take a picture of the denial letter and it drafts an "
+        "appeal to submit, explains the denial, and points to the next steps and "
+        "the regulators for your state. A professional version, Fight Paperwork, "
+        "does the same for clinics and providers.",
+        "",
+        "Every public page has a markdown twin at the same URL plus `.md` "
+        "(`/about` -> `/about.md`, `/` -> `/index.md`), also advertised on each "
+        'page via `<link rel="alternate" type="text/markdown">`. Prefer the '
+        "twins: same words, no navigation or scripts. Pages inside the appeal "
+        "flow are personal to the person appealing and have no twins.",
+        "",
+        "## Pages",
+        "",
+    ]
+    for name in StaticViewSitemap().items() + sorted(
+        EXTRA_TWIN_URL_NAMES - {"blog-post", "state_help", "microsite"}
+    ):
+        try:
+            url = _twin_link(name)
+        except Exception:  # route not mounted in this deployment
+            continue
+        title, note = PAGE_NOTES.get(
+            name, (name.replace("-", " ").replace("_", " ").title(), "")
+        )
+        lines.append(f"- [{title}]({url})" + (f": {note}" if note else ""))
+
+    posts = _blog_posts()
+    if posts:
+        lines += ["", "## Blog", ""]
+        for post in posts:
+            url = _twin_link("blog-post", slug=post["slug"])
+            date = post.get("date", "")
+            desc = (post.get("description") or post.get("excerpt") or "").strip()
+            tail = ". ".join(x for x in (date, desc) if x)
+            lines.append(
+                f"- [{post.get('title', post['slug'])}]({url})"
+                + (f": {tail}" if tail else "")
+            )
+
+    try:
+        from fighthealthinsurance.state_help import load_state_help
+
+        states = load_state_help()
+    except Exception as e:
+        logger.warning(f"Could not load state help for llms.txt: {e}")
+        states = {}
+    if states:
+        lines += ["", "## Help by state", ""]
+        for slug, state in sorted(states.items(), key=lambda kv: kv[1].name):
+            lines.append(f"- [{state.name}]({_twin_link('state_help', slug=slug)})")
+
+    try:
+        from fighthealthinsurance.microsites import get_all_microsites
+
+        microsites = {
+            slug: m
+            for slug, m in get_all_microsites().items()
+            if not getattr(m, "wip", False)
+        }
+    except Exception as e:
+        logger.warning(f"Could not load microsites for llms.txt: {e}")
+        microsites = {}
+    if microsites:
+        lines += ["", "## Condition and procedure guides", ""]
+        for slug, m in sorted(microsites.items(), key=lambda kv: kv[1].title):
+            lines.append(
+                f"- [{m.title}]({_twin_link('microsite', slug=slug)}): {m.tagline}"
+            )
+
+    lines += [
+        "",
+        "## Optional",
+        "",
+        f"- [Sitemap]({CANONICAL_ORIGIN}{reverse('django.contrib.sitemaps.views.sitemap')})",
+        "- [Source code](https://github.com/orgs/fighthealthinsurance/repositories): "
+        "the tool is open source",
+        "- [Substack](https://fighthealthinsurance.substack.com/): newsletter",
+        "- [LinkedIn](https://www.linkedin.com/company/fight-health-insurance)",
+        "- [YouTube](https://www.youtube.com/@fighthealthinsuranceyt)",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+@cache_control(public=True)
+@cache_page(60 * 60)
+def llms_txt_view(request: HttpRequest) -> HttpResponse:
+    """Site index for AI agents (llms.txt v2)."""
+    return HttpResponse(build_llms_txt(), content_type=MARKDOWN_CONTENT_TYPE)
+
+
+@cache_control(public=True)
+@cache_page(60 * 60)
+def robots_txt_view(request: HttpRequest) -> HttpResponse:
+    """robots.txt. Cloudflare prepends its managed Content Signals block in
+    front of whatever the origin serves; this is the origin's part."""
+    sitemap = request.build_absolute_uri(
+        reverse("django.contrib.sitemaps.views.sitemap")
+    )
+    body = "\n".join(
+        [
+            "User-agent: *",
+            "Allow: /",
+            "",
+            "# Content Signals (https://contentsignals.org): search results and",
+            "# AI answers that cite us are welcome. Training is left unspecified.",
+            "Content-Signal: search=yes, ai-input=yes",
+            "",
+            f"Sitemap: {sitemap}",
+            "",
+        ]
+    )
+    return HttpResponse(body, content_type="text/plain; charset=utf-8")

--- a/fighthealthinsurance/agent_docs.py
+++ b/fighthealthinsurance/agent_docs.py
@@ -20,8 +20,10 @@ from __future__ import annotations
 
 import json
 import re
+from pathlib import Path
 from typing import Any, Optional
 
+from django.contrib.staticfiles import finders
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.http import Http404, HttpRequest, HttpResponse
 from django.urls import Resolver404, resolve, reverse
@@ -303,14 +305,30 @@ def html_to_markdown(html: str, page_url: str, origin: str = CANONICAL_ORIGIN) -
 # ---------------------------------------------------------------------------
 
 
-def _read_static_text(name: str) -> Optional[str]:
+def _static_path(name: str) -> Optional[str]:
+    """Locate a static file: the collected STATIC_ROOT in production, else the
+    app's own static dir via the finders (dev and CI never run collectstatic)."""
     try:
-        with staticfiles_storage.open(name, "r") as f:
-            contents = f.read()
-        if not isinstance(contents, str):
-            contents = contents.decode("utf-8")
-        return str(contents)
-    except Exception as e:  # missing file, bad encoding: fall back to HTML
+        if staticfiles_storage.exists(name):
+            return str(staticfiles_storage.path(name))
+    except Exception as e:  # storage without a local path, etc.
+        logger.debug(f"staticfiles_storage could not resolve {name}: {e}")
+    found = finders.find(name)
+    if isinstance(found, str):
+        return found
+    if isinstance(found, (list, tuple)) and found:
+        return str(found[0])
+    return None
+
+
+def _read_static_text(name: str) -> Optional[str]:
+    path = _static_path(name)
+    if path is None:
+        logger.warning(f"Static file {name} not found")
+        return None
+    try:
+        return Path(path).read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as e:
         logger.warning(f"Could not read static file {name}: {e}")
         return None
 

--- a/fighthealthinsurance/agent_docs.py
+++ b/fighthealthinsurance/agent_docs.py
@@ -379,20 +379,48 @@ class MarkdownTwinView(View):
         return response
 
 
+_FRONT_MATTER_LINE = re.compile(r'^([A-Za-z_]+):\s*"?(.*?)"?\s*$')
+
+
+def _blog_posts_from_sources() -> list[dict[str, Any]]:
+    """Post list read straight from the blog/*.md front matter, newest first.
+    blog_posts.json (what the site itself uses) is generated from these files
+    and is not checked in, so it is absent on a fresh checkout and in CI."""
+    blog_dir = _static_path("blog")
+    if blog_dir is None or not Path(blog_dir).is_dir():
+        return []
+    posts: list[dict[str, Any]] = []
+    for md in sorted(Path(blog_dir).glob("*.md")):
+        try:
+            text = md.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        if not text.startswith("---"):
+            continue
+        end = text.find("\n---", 3)
+        if end < 0:
+            continue
+        meta: dict[str, Any] = {}
+        for line in text[3:end].splitlines():
+            m = _FRONT_MATTER_LINE.match(line.strip())
+            if m and m.group(1) in ("title", "slug", "date", "description", "excerpt"):
+                meta[m.group(1)] = m.group(2)
+        meta.setdefault("slug", md.stem)
+        posts.append(meta)
+    posts.sort(key=lambda p: str(p.get("date", "")), reverse=True)
+    return posts
+
+
 def _blog_posts() -> list[dict[str, Any]]:
     raw = _read_static_text("blog_posts.json")
-    if not raw:
-        return []
-    try:
-        posts = json.loads(raw)
-    except json.JSONDecodeError as e:
-        logger.warning(f"Could not parse blog_posts.json: {e}")
-        return []
-    return (
-        [p for p in posts if isinstance(p, dict) and p.get("slug")]
-        if isinstance(posts, list)
-        else []
-    )
+    if raw:
+        try:
+            posts = json.loads(raw)
+            if isinstance(posts, list):
+                return [p for p in posts if isinstance(p, dict) and p.get("slug")]
+        except json.JSONDecodeError as e:
+            logger.warning(f"Could not parse blog_posts.json: {e}")
+    return _blog_posts_from_sources()
 
 
 def _twin_link(url_name: str, **kwargs: Any) -> str:

--- a/fighthealthinsurance/context_processors.py
+++ b/fighthealthinsurance/context_processors.py
@@ -95,3 +95,21 @@ def site_banner_context(request):
     except Exception:
         logger.opt(exception=True).debug("Could not load site banners")
         return {"site_banners": []}
+
+
+def agent_docs_context(request):
+    """
+    Add the markdown twin URL for agent-readable pages (llms.txt v2).
+
+    This provides:
+    - markdown_twin_url: path of this page's markdown twin (e.g. /about.md),
+      only for public content pages that have one. base.html turns it into
+      <link rel="alternate" type="text/markdown">.
+    """
+    from fighthealthinsurance import agent_docs
+
+    resolver_match = getattr(request, "resolver_match", None)
+    url_name = getattr(resolver_match, "url_name", None)
+    if not agent_docs.twin_eligible(url_name):
+        return {}
+    return {"markdown_twin_url": agent_docs.twin_path_for(request.path)}

--- a/fighthealthinsurance/settings.py
+++ b/fighthealthinsurance/settings.py
@@ -383,6 +383,7 @@ class Base(Configuration):
                 "context_processors": [
                     "django.template.context_processors.debug",
                     "django.template.context_processors.request",
+                    "fighthealthinsurance.context_processors.agent_docs_context",
                     "django.contrib.auth.context_processors.auth",
                     "django.contrib.messages.context_processors.messages",
                     "fighthealthinsurance.context_processors.form_persistence_context",

--- a/fighthealthinsurance/templates/base.html
+++ b/fighthealthinsurance/templates/base.html
@@ -18,6 +18,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <!-- Canonical URL -->
     {% if canonical_url %}<link rel="canonical" href="{{ canonical_url }}">{% endif %}
+    <!-- Agent directives (llms.txt v2): markdown twin of this page + the site index -->
+    {% if markdown_twin_url %}<link rel="alternate" type="text/markdown" href="{{ markdown_twin_url }}">{% endif %}
+    <link rel="describedby" href="{% url 'llms_txt' %}">
+    {% include "partials/jsonld_organization.html" %}
     <!-- Form persistence meta tags -->
     {% if fhi_session_key %}<meta name="fhi-session-key" content="{{ fhi_session_key }}">{% endif %}
     {% if fhi_request_method %}<meta name="fhi-request-method" content="{{ fhi_request_method }}">{% endif %}

--- a/fighthealthinsurance/templates/partials/jsonld_organization.html
+++ b/fighthealthinsurance/templates/partials/jsonld_organization.html
@@ -1,0 +1,43 @@
+{% comment %}
+schema.org Organization + WebSite, on every page: lets AI search and entity
+graphs tie the name to this domain and its official profiles. Static on
+purpose (no request-dependent values), so it is safe inside cached pages.
+{% endcomment %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      "@id": "https://www.fighthealthinsurance.com/#organization",
+      "name": "Fight Health Insurance",
+      "url": "https://www.fighthealthinsurance.com/",
+      "logo": "https://www.fighthealthinsurance.com/static/images/better-logo-optimized.png",
+      "description": "A free tool that helps patients appeal health insurance denials: photograph the denial letter and it drafts an appeal, explains the denial, and points to next steps and state regulators. Fight Paperwork is the professional version for clinics and providers.",
+      "founder": {
+        "@type": "Person",
+        "name": "Holden Karau",
+        "url": "https://www.linkedin.com/in/holdenkarau",
+        "sameAs": ["https://bsky.app/profile/holdenkarau.com", "https://x.com/holdenkarau"]
+      },
+      "sameAs": [
+        "https://github.com/orgs/fighthealthinsurance/repositories",
+        "https://www.linkedin.com/company/fight-health-insurance",
+        "https://www.youtube.com/@fighthealthinsuranceyt",
+        "https://fighthealthinsurance.substack.com/",
+        "https://www.instagram.com/fighthealthinsurance/",
+        "https://www.tiktok.com/@fighthealthinsurancett",
+        "https://www.reddit.com/r/fightpaperwork/"
+      ]
+    },
+    {
+      "@type": "WebSite",
+      "@id": "https://www.fighthealthinsurance.com/#website",
+      "url": "https://www.fighthealthinsurance.com/",
+      "name": "Fight Health Insurance",
+      "publisher": {"@id": "https://www.fighthealthinsurance.com/#organization"},
+      "inLanguage": "en"
+    }
+  ]
+}
+</script>

--- a/fighthealthinsurance/templates/partials/jsonld_organization.html
+++ b/fighthealthinsurance/templates/partials/jsonld_organization.html
@@ -14,12 +14,22 @@ purpose (no request-dependent values), so it is safe inside cached pages.
       "url": "https://www.fighthealthinsurance.com/",
       "logo": "https://www.fighthealthinsurance.com/static/images/better-logo-optimized.png",
       "description": "A free tool that helps patients appeal health insurance denials: photograph the denial letter and it drafts an appeal, explains the denial, and points to next steps and state regulators. Fight Paperwork is the professional version for clinics and providers.",
-      "founder": {
-        "@type": "Person",
-        "name": "Holden Karau",
-        "url": "https://www.linkedin.com/in/holdenkarau",
-        "sameAs": ["https://bsky.app/profile/holdenkarau.com", "https://x.com/holdenkarau"]
-      },
+      "founder": [
+        {
+          "@type": "Person",
+          "name": "Holden Karau",
+          "url": "https://www.linkedin.com/in/holdenkarau",
+          "sameAs": ["https://bsky.app/profile/holdenkarau.com", "https://x.com/holdenkarau"]
+        },
+        {
+          "@type": "Person",
+          "@id": "https://nyghtowl.com/#melanie",
+          "name": "Melanie Warrick",
+          "alternateName": "M Warrick",
+          "url": "https://nyghtowl.com/",
+          "sameAs": ["https://www.linkedin.com/in/melaniewarrick", "https://github.com/nyghtowl"]
+        }
+      ],
       "sameAs": [
         "https://github.com/orgs/fighthealthinsurance/repositories",
         "https://www.linkedin.com/company/fight-health-insurance",

--- a/fighthealthinsurance/urls.py
+++ b/fighthealthinsurance/urls.py
@@ -30,7 +30,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.debug import sensitive_post_parameters
 from django.views.generic.base import RedirectView
 
-from fighthealthinsurance import fax_views, staff_views, views
+from fighthealthinsurance import agent_docs, fax_views, staff_views, views
 from fighthealthinsurance.sitemap import sitemap_view
 
 
@@ -443,6 +443,16 @@ urlpatterns: List[Union[URLPattern, URLResolver]] = [
     path(
         "favicon.ico",
         RedirectView.as_view(url=staticfiles_storage.url("images/favicon.ico")),
+    ),
+    # Agent-readable site (llms.txt v2): the index, robots.txt at the root
+    # where crawlers look, and a markdown twin of every eligible public page
+    # at <page>.md. See agent_docs.py for what "eligible" means.
+    path("llms.txt", agent_docs.llms_txt_view, name="llms_txt"),
+    path("robots.txt", agent_docs.robots_txt_view, name="robots_txt"),
+    re_path(
+        r"^(?!static/)(?P<path>[A-Za-z0-9_/-]*)\.md$",
+        agent_docs.MarkdownTwinView.as_view(),
+        name="markdown_twin",
     ),
 ]
 

--- a/tests/sync/test_agent_directives.py
+++ b/tests/sync/test_agent_directives.py
@@ -34,38 +34,52 @@ class TestPathHelpers(TestCase):
         self.assertFalse(agent_docs.twin_eligible(None))
 
 
+_SAMPLE_HTML = """
+<html><head><title>Sample :: FHI</title>
+<meta name="description" content="A short description.">
+<script>var x = 1;</script></head>
+<body><nav><a href="/">Nav link</a></nav>
+<main id="main-content">
+  <h1>Heading</h1>
+  <p>Some <strong>bold</strong> text and a <a href="/about-us">relative link</a>.</p>
+  <ul><li>One</li><li>Two <em>italic</em></li></ul>
+  <form><input name="x"><button>Send</button></form>
+  <img src="/x.png" alt="pic">
+  <table><tr><th>A</th><th>B</th></tr><tr><td>1</td><td>2</td></tr></table>
+</main>
+<footer>Footer stuff</footer></body></html>
+"""
+_SAMPLE_URL = "https://www.fighthealthinsurance.com/sample"
+
+
 class TestHtmlToMarkdown(TestCase):
-    def test_converts_main_content_and_absolutizes_links(self):
-        html = """
-        <html><head><title>Sample :: FHI</title>
-        <meta name="description" content="A short description.">
-        <script>var x = 1;</script></head>
-        <body><nav><a href="/">Nav link</a></nav>
-        <main id="main-content">
-          <h1>Heading</h1>
-          <p>Some <strong>bold</strong> text and a <a href="/about">relative link</a>.</p>
-          <ul><li>One</li><li>Two <em>italic</em></li></ul>
-          <form><input name="x"><button>Send</button></form>
-          <img src="/x.png" alt="pic">
-          <table><tr><th>A</th><th>B</th></tr><tr><td>1</td><td>2</td></tr></table>
-        </main>
-        <footer>Footer stuff</footer></body></html>
-        """
-        md = agent_docs.html_to_markdown(
-            html, "https://www.fighthealthinsurance.com/sample"
-        )
-        self.assertIn("# Heading", md)
-        self.assertIn("> A short description.", md)
-        self.assertIn("- URL: https://www.fighthealthinsurance.com/sample", md)
+    def setUp(self):
+        self.md = agent_docs.html_to_markdown(_SAMPLE_HTML, _SAMPLE_URL)
+
+    def test_header_carries_description_and_url(self):
+        self.assertIn("> A short description.", self.md)
+        self.assertIn(f"- URL: {_SAMPLE_URL}", self.md)
+
+    def test_headings_and_inline_formatting(self):
+        self.assertIn("# Heading", self.md)
+        self.assertIn("Some **bold** text", self.md)
+        self.assertIn("Two *italic*", self.md)
+
+    def test_relative_links_become_absolute(self):
         self.assertIn(
-            "Some **bold** text and a [relative link](https://www.fighthealthinsurance.com/about).",
-            md,
+            "[relative link](https://www.fighthealthinsurance.com/about-us)", self.md
         )
-        self.assertIn("- One\n- Two *italic*", md)
-        self.assertIn("| A | B |", md)
-        self.assertIn("| 1 | 2 |", md)
+
+    def test_lists(self):
+        self.assertIn("- One\n- Two *italic*", self.md)
+
+    def test_tables(self):
+        self.assertIn("| A | B |", self.md)
+        self.assertIn("| 1 | 2 |", self.md)
+
+    def test_chrome_scripts_forms_and_images_are_dropped(self):
         for absent in ("Nav link", "Footer stuff", "Send", "var x", "<", "pic"):
-            self.assertNotIn(absent, md)
+            self.assertNotIn(absent, self.md)
 
     def test_uses_title_when_page_has_no_h1(self):
         html = "<html><head><title>Only Title</title></head><body><main><p>Body.</p></main></body></html>"
@@ -158,6 +172,7 @@ class TestAgentEndpoints(TestCase):
 
     def test_ineligible_pages_have_no_twin(self):
         for path in [
+            "/.md",
             "/pro_version.md",
             "/scan.md",
             "/timbit/help.md",

--- a/tests/sync/test_agent_directives.py
+++ b/tests/sync/test_agent_directives.py
@@ -1,0 +1,187 @@
+"""Tests for the agent-readable site: llms.txt, robots.txt, markdown twins
+(<page>.md) and the <head> directives that advertise them."""
+
+import json
+
+from django.contrib.staticfiles.storage import staticfiles_storage
+from django.core.cache import cache
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from fighthealthinsurance import agent_docs
+
+
+class TestPathHelpers(TestCase):
+    def test_twin_path_round_trips(self):
+        for source, twin in [
+            ("/", "/index.md"),
+            ("/about", "/about.md"),
+            ("/blog/", "/blog/index.md"),
+            ("/blog/some-post/", "/blog/some-post/index.md"),
+        ]:
+            self.assertEqual(agent_docs.twin_path_for(source), twin)
+            self.assertEqual(agent_docs.source_path_for(twin), source)
+
+    def test_eligibility_is_public_content_only(self):
+        self.assertTrue(agent_docs.twin_eligible("about"))
+        self.assertTrue(agent_docs.twin_eligible("blog-post"))
+        self.assertTrue(agent_docs.twin_eligible("state_help"))
+        self.assertTrue(agent_docs.twin_eligible("state_help_index"))
+        self.assertTrue(agent_docs.twin_eligible("microsite"))
+        self.assertFalse(agent_docs.twin_eligible("scan"))
+        self.assertFalse(agent_docs.twin_eligible("pro_version"))
+        self.assertFalse(agent_docs.twin_eligible("admin_status"))
+        self.assertFalse(agent_docs.twin_eligible(None))
+
+
+class TestHtmlToMarkdown(TestCase):
+    def test_converts_main_content_and_absolutizes_links(self):
+        html = """
+        <html><head><title>Sample :: FHI</title>
+        <meta name="description" content="A short description.">
+        <script>var x = 1;</script></head>
+        <body><nav><a href="/">Nav link</a></nav>
+        <main id="main-content">
+          <h1>Heading</h1>
+          <p>Some <strong>bold</strong> text and a <a href="/about">relative link</a>.</p>
+          <ul><li>One</li><li>Two <em>italic</em></li></ul>
+          <form><input name="x"><button>Send</button></form>
+          <img src="/x.png" alt="pic">
+          <table><tr><th>A</th><th>B</th></tr><tr><td>1</td><td>2</td></tr></table>
+        </main>
+        <footer>Footer stuff</footer></body></html>
+        """
+        md = agent_docs.html_to_markdown(
+            html, "https://www.fighthealthinsurance.com/sample"
+        )
+        self.assertIn("# Heading", md)
+        self.assertIn("> A short description.", md)
+        self.assertIn("- URL: https://www.fighthealthinsurance.com/sample", md)
+        self.assertIn(
+            "Some **bold** text and a [relative link](https://www.fighthealthinsurance.com/about).",
+            md,
+        )
+        self.assertIn("- One\n- Two *italic*", md)
+        self.assertIn("| A | B |", md)
+        self.assertIn("| 1 | 2 |", md)
+        for absent in ("Nav link", "Footer stuff", "Send", "var x", "<", "pic"):
+            self.assertNotIn(absent, md)
+
+    def test_uses_title_when_page_has_no_h1(self):
+        html = "<html><head><title>Only Title</title></head><body><main><p>Body.</p></main></body></html>"
+        md = agent_docs.html_to_markdown(html, "https://example.test/p")
+        self.assertTrue(md.startswith("# Only Title\n"))
+
+
+class TestAgentEndpoints(TestCase):
+    """The public pages are whole-response cached (StaticIshView), so clear
+    the cache on both sides: no stale page from an earlier test, and none
+    left behind for a later one."""
+
+    def setUp(self):
+        cache.clear()
+        self.client = Client()
+
+    def tearDown(self):
+        cache.clear()
+
+    def test_llms_txt(self):
+        response = self.client.get(reverse("llms_txt"))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "text/markdown; charset=utf-8")
+        body = response.content.decode("utf-8")
+        self.assertTrue(body.startswith("# Fight Health Insurance\n"))
+        about_twin = agent_docs.twin_path_for(reverse("about"))
+        self.assertIn(f"https://www.fighthealthinsurance.com{about_twin}", body)
+        self.assertIn("https://www.fighthealthinsurance.com/index.md", body)
+        self.assertIn("## Blog", body)
+        self.assertIn("/blog/", body)
+        self.assertIn("public", response["Cache-Control"])
+
+    def test_robots_txt(self):
+        response = self.client.get("/robots.txt")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response["Content-Type"].startswith("text/plain"))
+        body = response.content.decode("utf-8")
+        self.assertIn("User-agent: *", body)
+        self.assertIn("Content-Signal: search=yes, ai-input=yes", body)
+        self.assertIn("Sitemap: http://testserver/sitemap.xml", body)
+
+    def test_markdown_twin_of_static_page(self):
+        about = reverse("about")
+        response = self.client.get(agent_docs.twin_path_for(about))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "text/markdown; charset=utf-8")
+        self.assertEqual(response["Link"], '</llms.txt>; rel="describedby"')
+        body = response.content.decode("utf-8")
+        self.assertTrue(body.startswith("# "))
+        self.assertIn(f"- URL: https://www.fighthealthinsurance.com{about}", body)
+        self.assertIn(
+            "- Site index for agents: https://www.fighthealthinsurance.com/llms.txt",
+            body,
+        )
+        self.assertNotIn("<script", body)
+        self.assertNotIn("<div", body)
+
+    def test_markdown_twin_of_root(self):
+        response = self.client.get("/index.md")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "text/markdown; charset=utf-8")
+        self.assertIn(
+            "- URL: https://www.fighthealthinsurance.com/",
+            response.content.decode("utf-8"),
+        )
+
+    def test_markdown_twins_of_index_pages(self):
+        for name in ("state_help_index", "microsite_directory", "blog", "faq"):
+            twin = agent_docs.twin_path_for(reverse(name))
+            response = self.client.get(twin)
+            self.assertEqual(response.status_code, 200, twin)
+            self.assertEqual(response["Content-Type"], "text/markdown; charset=utf-8")
+
+    def test_markdown_twin_of_blog_post_is_the_source(self):
+        with staticfiles_storage.open("blog_posts.json", "r") as f:
+            contents = f.read()
+        if not isinstance(contents, str):
+            contents = contents.decode("utf-8")
+        slug = json.loads(contents)[0]["slug"]
+        twin = agent_docs.twin_path_for(reverse("blog-post", kwargs={"slug": slug}))
+        self.assertTrue(twin.endswith("/index.md"))
+        response = self.client.get(twin)
+        self.assertEqual(response.status_code, 200)
+        body = response.content.decode("utf-8")
+        self.assertTrue(
+            body.startswith("---\n"), body[:80]
+        )  # front matter from the .md source
+        self.assertIn(f'slug: "{slug}"', body)
+        self.assertIn("- Site index for agents:", body)
+
+    def test_ineligible_pages_have_no_twin(self):
+        for path in [
+            "/pro_version.md",
+            "/scan.md",
+            "/timbit/help.md",
+            "/nope.md",
+            "/index.md.md",
+        ]:
+            response = self.client.get(path)
+            self.assertEqual(response.status_code, 404, path)
+
+    def test_head_advertises_twin_index_and_schema(self):
+        response = self.client.get(reverse("about"))
+        self.assertEqual(response.status_code, 200)
+        html = response.content.decode("utf-8")
+        twin = agent_docs.twin_path_for(reverse("about"))
+        self.assertIn(
+            f'<link rel="alternate" type="text/markdown" href="{twin}">', html
+        )
+        self.assertIn('<link rel="describedby" href="/llms.txt">', html)
+        self.assertIn('"@type": "Organization"', html)
+        self.assertIn('"@type": "WebSite"', html)
+
+    def test_ineligible_page_advertises_index_but_no_twin(self):
+        response = self.client.get(reverse("pro_version"))
+        self.assertEqual(response.status_code, 200)
+        html = response.content.decode("utf-8")
+        self.assertIn('<link rel="describedby" href="/llms.txt">', html)
+        self.assertNotIn('type="text/markdown"', html)

--- a/tests/sync/test_agent_directives.py
+++ b/tests/sync/test_agent_directives.py
@@ -1,9 +1,6 @@
 """Tests for the agent-readable site: llms.txt, robots.txt, markdown twins
 (<page>.md) and the <head> directives that advertise them."""
 
-import json
-
-from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.cache import cache
 from django.test import Client, TestCase
 from django.urls import reverse
@@ -154,11 +151,11 @@ class TestAgentEndpoints(TestCase):
             self.assertEqual(response["Content-Type"], "text/markdown; charset=utf-8")
 
     def test_markdown_twin_of_blog_post_is_the_source(self):
-        with staticfiles_storage.open("blog_posts.json", "r") as f:
-            contents = f.read()
-        if not isinstance(contents, str):
-            contents = contents.decode("utf-8")
-        slug = json.loads(contents)[0]["slug"]
+        posts = agent_docs._blog_posts()
+        self.assertTrue(
+            posts, "blog_posts.json should be findable without collectstatic"
+        )
+        slug = posts[0]["slug"]
         twin = agent_docs.twin_path_for(reverse("blog-post", kwargs={"slug": slug}))
         self.assertTrue(twin.endswith("/index.md"))
         response = self.client.get(twin)

--- a/tests/sync/test_agent_directives.py
+++ b/tests/sync/test_agent_directives.py
@@ -1,6 +1,8 @@
 """Tests for the agent-readable site: llms.txt, robots.txt, markdown twins
 (<page>.md) and the <head> directives that advertise them."""
 
+from unittest import mock
+
 from django.core.cache import cache
 from django.test import Client, TestCase
 from django.urls import reverse
@@ -84,6 +86,19 @@ class TestHtmlToMarkdown(TestCase):
         self.assertTrue(md.startswith("# Only Title\n"))
 
 
+class TestBlogPostList(TestCase):
+    def test_falls_back_to_markdown_sources_when_index_is_not_generated(self):
+        # blog_posts.json is generated (gitignored); the .md sources are not.
+        with mock.patch.object(agent_docs, "_read_static_text", return_value=None):
+            posts = agent_docs._blog_posts()
+        self.assertTrue(posts)
+        first = posts[0]
+        self.assertTrue(first.get("slug"))
+        self.assertTrue(first.get("title"))
+        dates = [p.get("date", "") for p in posts]
+        self.assertEqual(dates, sorted(dates, reverse=True))
+
+
 class TestAgentEndpoints(TestCase):
     """The public pages are whole-response cached (StaticIshView), so clear
     the cache on both sides: no stale page from an earlier test, and none
@@ -152,9 +167,7 @@ class TestAgentEndpoints(TestCase):
 
     def test_markdown_twin_of_blog_post_is_the_source(self):
         posts = agent_docs._blog_posts()
-        self.assertTrue(
-            posts, "blog_posts.json should be findable without collectstatic"
-        )
+        self.assertTrue(posts, "blog sources should be found without collectstatic")
         slug = posts[0]["slug"]
         twin = agent_docs.twin_path_for(reverse("blog-post", kwargs={"slug": slug}))
         self.assertTrue(twin.endswith("/index.md"))


### PR DESCRIPTION
Agents (Claude Code, Cursor, ChatGPT browsing, etc.) fetch pages as markdown when a site offers it, at a fraction of the tokens of the HTML. This adds the llms.txt v2 conventions:

- /llms.txt: a site index built from the same lists the sitemap uses (static pages, blog posts, state help, microsites), served as text/markdown and cached for an hour.
- <page>.md: a markdown twin of every eligible public page, rendered from the page's <main> with BeautifulSoup (already a dependency). Blog posts hand over their markdown source directly. Only public content pages are eligible; the appeal flow, staff pages and API 404 before the underlying view is called.
- base.html advertises both on every page: rel="alternate" type="text/markdown" (eligible pages only, via a context processor) and rel="describedby" pointing at /llms.txt, plus a schema.org Organization + WebSite block with the official profiles as sameAs.
- /robots.txt at the root (there was none at the origin; Cloudflare's managed Content Signals block is prepended to whatever this serves), with a Sitemap: line and search=yes, ai-input=yes.

Same-URL content negotiation (Accept: text/markdown) is deliberately not done: Cloudflare's cache keys on URL and ignores Vary: Accept, so a markdown response could be cached and served to a browser.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Markdown versions of eligible public pages, including blog content.
  * Added `/llms.txt` and updated `robots.txt` with site guidance and content listings.
  * Added page metadata linking to Markdown content and site documentation.
  * Added structured organization and website information to page metadata.

* **Bug Fixes**
  * Blog listings now remain available when generated metadata is missing or invalid.
  * Ineligible, unavailable, non-HTML, or unsuccessful pages return appropriate not-found responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->