### PR TITLE
Add appeal letter fallback for failed chat turns

### DIFF
--- a/fighthealthinsurance/chat/appeal_letter_generator.py
+++ b/fighthealthinsurance/chat/appeal_letter_generator.py
@@ -23,7 +23,7 @@ dedicated appeal pipeline -- instead. Two callers:
 import re
 import time
 from dataclasses import replace
-from typing import TYPE_CHECKING, Any, List, Optional
+from typing import TYPE_CHECKING, Any, List, NamedTuple, Optional
 
 from channels.db import database_sync_to_async
 from loguru import logger
@@ -54,6 +54,18 @@ _SUBSTITUTABLE_FIELDS = ("insurance_company", "claim_id", "diagnosis", "procedur
 # UNKNOWN is the extractor's explicit "couldn't tell" marker; substituting it
 # into a letter would be worse than leaving the fill-in-the-blank placeholder.
 _UNSET_FIELD_VALUES = (None, "", "UNKNOWN")
+
+
+class DraftedLetter(NamedTuple):
+    """A produced appeal letter plus whether it reached the Appeal row.
+
+    ``saved_to_appeal`` lets callers word their reply honestly: a letter
+    whose ``appeal.asave()`` failed is still delivered, but must not be
+    presented as "saved to Appeal #N".
+    """
+
+    text: str
+    saved_to_appeal: bool
 
 
 def looks_like_letter_request(text: Optional[str]) -> bool:
@@ -260,7 +272,7 @@ async def draft_letter_for_chat(
     use_external: bool,
     prefer_existing: bool = False,
     deadline_seconds: Optional[float] = None,
-) -> Optional[str]:
+) -> Optional[DraftedLetter]:
     """Produce an appeal letter for a chat-linked appeal and persist it.
 
     ``prefer_existing=True`` serves an already-generated ProposedAppeal
@@ -271,7 +283,9 @@ async def draft_letter_for_chat(
 
     On success the letter is saved to ``appeal.appeal_text`` and, for a
     newly generated letter, recorded as a ProposedAppeal row for the same
-    provenance the wizard flow gets. Returns the letter text, or None.
+    provenance the wizard flow gets. Returns a ``DraftedLetter`` (text plus
+    whether the appeal save succeeded), or None when no letter could be
+    produced.
     """
     from fighthealthinsurance.models import ProposedAppeal
 
@@ -312,12 +326,14 @@ async def draft_letter_for_chat(
                 f"{getattr(denial, 'denial_id', None)}"
             )
 
+    saved_to_appeal = False
     try:
         appeal.appeal_text = letter
         await appeal.asave()
+        saved_to_appeal = True
     except Exception:
         logger.opt(exception=True).warning(
             f"chat letter: could not save letter to appeal "
             f"{getattr(appeal, 'id', None)}; delivering it unpersisted"
         )
-    return letter
+    return DraftedLetter(text=letter, saved_to_appeal=saved_to_appeal)

--- a/fighthealthinsurance/chat/appeal_letter_generator.py
+++ b/fighthealthinsurance/chat/appeal_letter_generator.py
@@ -57,15 +57,19 @@ _UNSET_FIELD_VALUES = (None, "", "UNKNOWN")
 
 
 class DraftedLetter(NamedTuple):
-    """A produced appeal letter plus whether it reached the Appeal row.
+    """A produced appeal letter plus how it relates to the Appeal row.
 
     ``saved_to_appeal`` lets callers word their reply honestly: a letter
-    whose ``appeal.asave()`` failed is still delivered, but must not be
-    presented as "saved to Appeal #N".
+    that is not on the appeal is still delivered, but must not be presented
+    as "saved to Appeal #N". ``preserved_existing`` distinguishes WHY it
+    wasn't saved -- the appeal already carried a real (possibly
+    user-edited) letter that a reserve draft must not clobber -- from a
+    plain save failure, so callers can word the two differently.
     """
 
     text: str
     saved_to_appeal: bool
+    preserved_existing: bool = False
 
 
 def looks_like_letter_request(text: Optional[str]) -> bool:
@@ -102,6 +106,11 @@ def substitute_denial_fields(letter: str, denial: Any) -> str:
         value = getattr(denial, field, None)
         if value in _UNSET_FIELD_VALUES:
             continue
+        # Mirror sub_in_appeals' guard: extractors sometimes stuff the
+        # insurance company name into claim_id, and substituting that would
+        # assert a wrong claim id in a letter the user may send as-is.
+        if field == "claim_id" and value == getattr(denial, "insurance_company", None):
+            continue
         result = result.replace("{" + field + "}", str(value))
     return result
 
@@ -115,13 +124,19 @@ async def find_reserve_letter(denial: Any) -> Optional[str]:
     only read -- reserve promotion bookkeeping belongs to the appeal wizard
     flow (AppealsBackendHelper), not chat.
     """
+    from fighthealthinsurance.common_view_logic import deliverable_candidates
     from fighthealthinsurance.models import ProposedAppeal
 
+    # deliverable_candidates pushes the cheap runt filter into SQL (raw
+    # length upper-bounds meaningful length), so a pile of junk drafts --
+    # exactly what a degraded-model period produces -- can't fill the
+    # bounded window and evict the one deliverable reserve.
+    # is_real_appeal below stays the authority on what is served.
     rows = [
         row
-        async for row in ProposedAppeal.objects.filter(for_denial=denial)
-        .exclude(appeal_text__isnull=True)
-        .order_by("speculative", "-created_at")[:10]
+        async for row in deliverable_candidates(
+            ProposedAppeal.objects.filter(for_denial=denial)
+        ).order_by("speculative", "-created_at")[:10]
     ]
     for speculative_group in (False, True):
         candidates = [
@@ -283,9 +298,11 @@ async def draft_letter_for_chat(
 
     On success the letter is saved to ``appeal.appeal_text`` and, for a
     newly generated letter, recorded as a ProposedAppeal row for the same
-    provenance the wizard flow gets. Returns a ``DraftedLetter`` (text plus
-    whether the appeal save succeeded), or None when no letter could be
-    produced.
+    provenance the wizard flow gets -- EXCEPT that a reserve draft never
+    overwrites an appeal that already carries a real letter (the user may
+    have edited it on the appeal page; only an explicitly generated fresh
+    draft may replace it). Returns a ``DraftedLetter`` (text plus how it
+    relates to the appeal row), or None when no letter could be produced.
     """
     from fighthealthinsurance.models import ProposedAppeal
 
@@ -325,6 +342,19 @@ async def draft_letter_for_chat(
                 f"chat letter: could not record ProposedAppeal for denial "
                 f"{getattr(denial, 'denial_id', None)}"
             )
+
+    # A reserve (not freshly generated) letter must not clobber a real
+    # letter already on the appeal -- the user may have edited that one on
+    # the appeal page, and no prior version is kept. Deliver the reserve in
+    # chat instead and let the caller word it honestly.
+    if generated_item is None and is_real_appeal(appeal.appeal_text):
+        logger.info(
+            f"chat letter: appeal {getattr(appeal, 'id', None)} already has "
+            f"a real letter; serving the reserve without overwriting it"
+        )
+        return DraftedLetter(
+            text=letter, saved_to_appeal=False, preserved_existing=True
+        )
 
     saved_to_appeal = False
     try:

--- a/fighthealthinsurance/chat/appeal_letter_generator.py
+++ b/fighthealthinsurance/chat/appeal_letter_generator.py
@@ -1,0 +1,323 @@
+"""Draft an appeal letter for a chat through the appeal-generation pipeline.
+
+The chat models historically wrote appeal letters inline (inside a
+``create_or_update_appeal`` payload). A full letter is the longest, most
+failure-prone generation a chat backend performs, and when every chat model
+fails the user gets a bare "all models are experiencing issues" error on
+exactly the turn that matters most ("Please go ahead and draft a letter.").
+
+This module routes letter drafting to ``AppealGenerator.make_appeals`` -- the
+dedicated appeal pipeline -- instead. Two callers:
+
+* ``GenerateAppealLetterTool``: the chat LLM emits a small
+  ``**generate_appeal_letter {...}**`` call instead of writing the letter
+  itself, so the chat pass stays short while appeal-tuned models write the
+  letter.
+* The total-failure fallback in ``ChatInterface.handle_chat_message``: when
+  every chat model failed on a turn that asked for a letter, the pipeline can
+  often still deliver -- it has no chat-style repeat-rejection failure mode,
+  its specialized denial-type templates need no model at all, and any
+  precomputed ``ProposedAppeal`` reserve is served straight from the DB.
+"""
+
+import re
+import time
+from dataclasses import replace
+from typing import TYPE_CHECKING, Any, List, Optional
+
+from channels.db import database_sync_to_async
+from loguru import logger
+
+from fighthealthinsurance.exec import bridge_executor
+from fighthealthinsurance.ml.ml_models import _env_float
+from fighthealthinsurance.utils import is_real_appeal
+
+if TYPE_CHECKING:
+    from fighthealthinsurance.generate_appeal import GeneratedAppeal
+
+# A conservative "the user is asking us to produce the letter itself" test,
+# used only by the total-failure fallback (where the alternative is an error
+# message, so a rare false positive still hands the user something useful).
+# Requires a drafting verb and a letter/appeal noun in the same clause;
+# "how do I appeal?" or a bare "draft" alone does not match.
+_LETTER_REQUEST_RE = re.compile(
+    r"\b(?:draft|write|generate|create|compose|prepare|redo|redraft|rewrite)"
+    r"\b[^.!?\n]{0,80}?\b(?:appeal|letter)\b",
+    re.IGNORECASE,
+)
+
+# Placeholders the specialized static templates (and occasionally models)
+# leave for downstream substitution; mirrors the fields
+# AppealsBackendHelper.sub_in_appeals fills on the wizard path.
+_SUBSTITUTABLE_FIELDS = ("insurance_company", "claim_id", "diagnosis", "procedure")
+
+# UNKNOWN is the extractor's explicit "couldn't tell" marker; substituting it
+# into a letter would be worse than leaving the fill-in-the-blank placeholder.
+_UNSET_FIELD_VALUES = (None, "", "UNKNOWN")
+
+
+def looks_like_letter_request(text: Optional[str]) -> bool:
+    """Whether a user message asks us to draft/write an appeal letter."""
+    if not text:
+        return False
+    return bool(_LETTER_REQUEST_RE.search(text))
+
+
+def denial_has_letter_context(denial: Any) -> bool:
+    """Whether a denial carries enough substance to draft a letter from.
+
+    Any one of denial text, procedure, or diagnosis is workable -- the
+    pipeline's prompt degrades gracefully -- but with none of them every
+    model would be asked to write a letter about nothing.
+    """
+    if denial is None:
+        return False
+    return bool(
+        (denial.denial_text or "").strip()
+        or (denial.procedure or "").strip()
+        or (denial.diagnosis or "").strip()
+    )
+
+
+def substitute_denial_fields(letter: str, denial: Any) -> str:
+    """Fill ``{insurance_company}``-style placeholders from the denial.
+
+    Unknown fields keep their placeholder so the letter reads as a
+    fill-in-the-blank draft rather than silently asserting wrong values.
+    """
+    result = letter
+    for field in _SUBSTITUTABLE_FIELDS:
+        value = getattr(denial, field, None)
+        if value in _UNSET_FIELD_VALUES:
+            continue
+        result = result.replace("{" + field + "}", str(value))
+    return result
+
+
+async def find_reserve_letter(denial: Any) -> Optional[str]:
+    """Best already-generated ProposedAppeal text for ``denial``, or None.
+
+    Zero model calls: this is the rescue path for total model failure. Live
+    (non-speculative) rows are preferred over the speculative precompute
+    reserve; within a group the longest deliverable letter wins. Rows are
+    only read -- reserve promotion bookkeeping belongs to the appeal wizard
+    flow (AppealsBackendHelper), not chat.
+    """
+    from fighthealthinsurance.models import ProposedAppeal
+
+    rows = [
+        row
+        async for row in ProposedAppeal.objects.filter(for_denial=denial)
+        .exclude(appeal_text__isnull=True)
+        .order_by("speculative", "-created_at")[:10]
+    ]
+    for speculative_group in (False, True):
+        candidates = [
+            row.appeal_text
+            for row in rows
+            if row.speculative == speculative_group and is_real_appeal(row.appeal_text)
+        ]
+        if candidates:
+            return max(candidates, key=len)
+    return None
+
+
+async def generate_letter_for_denial(
+    denial: Any,
+    *,
+    use_external: bool = False,
+    deadline_seconds: Optional[float] = None,
+) -> Optional["GeneratedAppeal"]:
+    """Run the appeal-generation pipeline for ``denial`` and return one letter.
+
+    Blocking model work (``make_appeals`` runs its ladder synchronously and
+    returns a lazy iterator whose ``next()`` blocks on model futures) is
+    bridged onto ``bridge_executor``, same as the speculative precompute.
+    The first deliverable model-written letter wins (completion order == the
+    fastest healthy model, which is what a waiting chat user needs); the
+    specialized static templates serve as the zero-model fallback.
+
+    Returns the winning ``GeneratedAppeal`` (its ``text`` already has known
+    denial fields substituted) so callers can persist real provenance.
+    ``use_external`` is applied to the in-memory denial only -- it reflects
+    this chat session's consent and must not rewrite the denial's stored
+    opt-in. Never raises; a failed run returns None.
+    """
+    if deadline_seconds is None:
+        deadline_seconds = _env_float("FHI_CHAT_LETTER_DEADLINE", 75.0)
+    started = time.monotonic()
+    try:
+        # Lazy imports: common_view_logic pulls in a large graph and this
+        # module is imported from the chat tool package (see the speculative
+        # helper for the same pattern).
+        from fighthealthinsurance.common_view_logic import appealGenerator
+        from fighthealthinsurance.generate_appeal import (
+            AppealTemplateGenerator,
+            GeneratedAppeal,
+            detect_specialized_templates,
+        )
+
+        specialized_templates = detect_specialized_templates(
+            denial.denial_text,
+            denial.procedure,
+            denial.diagnosis,
+        )
+        non_ai_appeals: List[str] = []
+        for template in specialized_templates:
+            try:
+                non_ai_appeals.append(template.static_appeal())
+            except Exception as e:
+                logger.opt(exception=True).warning(
+                    f"chat letter: failed to render specialized template "
+                    f"{template.name}: {e}"
+                )
+
+        diagnostics: dict = {}
+
+        # A model item at least this long is accepted the moment it arrives
+        # (chat shows ONE letter, so latency matters); anything shorter --
+        # e.g. a medically_necessary one-liner passed through the empty
+        # template generator -- only wins at exhaustion if nothing longer
+        # (a full letter, a specialized static template) showed up.
+        min_letter_chars = int(_env_float("FHI_CHAT_LETTER_MIN_CHARS", 350.0))
+
+        def _drain() -> Optional[GeneratedAppeal]:
+            """Blocking: run the models and pull the first usable letter.
+
+            Chat-session consent (in-memory only; never saved -- make_appeals
+            reads use_external for its backup call list).
+            """
+            denial.use_external = use_external
+            best: Optional[GeneratedAppeal] = None
+            for item in appealGenerator.make_appeals(
+                denial,
+                AppealTemplateGenerator([], [], []),
+                # NOT passing medical_reasons: with an empty template
+                # generator make_appeals would surface each raw reason
+                # string as an "appeal". Chat context reaches the models
+                # through denial.qa_context instead.
+                non_ai_appeals=non_ai_appeals,
+                specialized_templates=specialized_templates or None,
+                diagnostics_sink=diagnostics,
+                # Tags the persisted ModelCallAttempt rows so a chat-driven
+                # generation can be told apart from the wizard's live run
+                # and the background precompute when debugging a denial.
+                run_kind="chat",
+                deadline=time.monotonic() + deadline_seconds,
+            ):
+                if not is_real_appeal(item.text):
+                    continue
+                if item.model_name and len(item.text) >= min_letter_chars:
+                    return item
+                if best is None or len(item.text) > len(best.text):
+                    best = item
+            return best
+
+        # thread_sensitive=False + bridge_executor: a minutes-long drain must
+        # not serialize behind (or starve) other bridged hops -- same shape
+        # as SpeculativeAppealsHelper._generate_drafts.
+        item: Optional[GeneratedAppeal] = await database_sync_to_async(
+            _drain,
+            thread_sensitive=False,
+            executor=bridge_executor,
+        )()
+
+        # make_appeals flushed what it knew before handing back its lazy
+        # iterator; the drain above consumed more of it, so flush the late
+        # per-model outcome records too.
+        recorder = diagnostics.get("attempt_recorder")
+        if recorder is not None:
+            await database_sync_to_async(
+                recorder.flush,
+                thread_sensitive=False,
+                executor=bridge_executor,
+            )()
+
+        logger.info(
+            f"chat letter: generation for denial {denial.denial_id} "
+            f"{'produced a letter' if item else 'produced nothing'} in "
+            f"{time.monotonic() - started:.1f}s "
+            f"(model={item.model_name if item else None}, "
+            f"winning_stage={diagnostics.get('winning_stage')}, "
+            f"models_tried={diagnostics.get('models_tried')})"
+        )
+        if item:
+            return replace(item, text=substitute_denial_fields(item.text, denial))
+        return None
+    except Exception as e:
+        logger.opt(exception=True).error(
+            f"chat letter: generation failed for denial "
+            f"{getattr(denial, 'denial_id', None)} after "
+            f"{time.monotonic() - started:.1f}s: {e}"
+        )
+        return None
+
+
+async def draft_letter_for_chat(
+    *,
+    appeal: Any,
+    denial: Any,
+    use_external: bool,
+    prefer_existing: bool = False,
+    deadline_seconds: Optional[float] = None,
+) -> Optional[str]:
+    """Produce an appeal letter for a chat-linked appeal and persist it.
+
+    ``prefer_existing=True`` serves an already-generated ProposedAppeal
+    first and only generates when none exists -- the total-failure fallback
+    uses it because a DB read is the one step guaranteed to work while
+    models are down. The tool path generates first (the user just asked for
+    a fresh draft) and falls back to the reserve.
+
+    On success the letter is saved to ``appeal.appeal_text`` and, for a
+    newly generated letter, recorded as a ProposedAppeal row for the same
+    provenance the wizard flow gets. Returns the letter text, or None.
+    """
+    from fighthealthinsurance.models import ProposedAppeal
+
+    letter: Optional[str] = None
+    generated_item: Optional["GeneratedAppeal"] = None
+    if prefer_existing:
+        reserve = await find_reserve_letter(denial)
+        if reserve:
+            letter = substitute_denial_fields(reserve, denial)
+    if not letter:
+        generated_item = await generate_letter_for_denial(
+            denial,
+            use_external=use_external,
+            deadline_seconds=deadline_seconds,
+        )
+        if generated_item:
+            letter = generated_item.text
+    if not letter and not prefer_existing:
+        reserve = await find_reserve_letter(denial)
+        if reserve:
+            letter = substitute_denial_fields(reserve, denial)
+    if not letter:
+        return None
+
+    if generated_item:
+        try:
+            await ProposedAppeal.objects.acreate(
+                appeal_text=letter,
+                for_denial=denial,
+                model_name=generated_item.model_name,
+                synthesized=generated_item.synthesized,
+                context_level=generated_item.context_level,
+            )
+        except Exception:
+            # Provenance only -- the user still gets their letter.
+            logger.opt(exception=True).warning(
+                f"chat letter: could not record ProposedAppeal for denial "
+                f"{getattr(denial, 'denial_id', None)}"
+            )
+
+    try:
+        appeal.appeal_text = letter
+        await appeal.asave()
+    except Exception:
+        logger.opt(exception=True).warning(
+            f"chat letter: could not save letter to appeal "
+            f"{getattr(appeal, 'id', None)}; delivering it unpersisted"
+        )
+    return letter

--- a/fighthealthinsurance/chat/appeal_letter_generator.py
+++ b/fighthealthinsurance/chat/appeal_letter_generator.py
@@ -208,6 +208,16 @@ async def generate_letter_for_denial(
         # (a full letter, a specialized static template) showed up.
         min_letter_chars = int(_env_float("FHI_CHAT_LETTER_MIN_CHARS", 350.0))
 
+        # Absolute, and computed HERE rather than inside _drain: the drain
+        # may wait for a letter_executor thread first, and a deadline
+        # started on the far side of that wait would ignore the queue time
+        # -- defeating the caller's clamp to the remaining turn budget, and
+        # letting a task that was queued (and by then abandoned) hold its
+        # thread for the FULL window while others wait behind it. Against an
+        # absolute mark, a drain that reaches a thread past its deadline
+        # exits immediately instead.
+        drain_deadline = started + deadline_seconds
+
         def _drain() -> Optional[GeneratedAppeal]:
             """Blocking: run the models and pull the first usable letter.
 
@@ -230,7 +240,7 @@ async def generate_letter_for_denial(
                 # generation can be told apart from the wizard's live run
                 # and the background precompute when debugging a denial.
                 run_kind="chat",
-                deadline=time.monotonic() + deadline_seconds,
+                deadline=drain_deadline,
             ):
                 if not is_real_appeal(item.text):
                     continue

--- a/fighthealthinsurance/chat/appeal_letter_generator.py
+++ b/fighthealthinsurance/chat/appeal_letter_generator.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING, Any, List, NamedTuple, Optional
 from channels.db import database_sync_to_async
 from loguru import logger
 
-from fighthealthinsurance.exec import bridge_executor
+from fighthealthinsurance.exec import bridge_executor, letter_executor
 from fighthealthinsurance.ml.ml_models import _env_float
 from fighthealthinsurance.utils import is_real_appeal
 
@@ -240,13 +240,15 @@ async def generate_letter_for_denial(
                     best = item
             return best
 
-        # thread_sensitive=False + bridge_executor: a minutes-long drain must
-        # not serialize behind (or starve) other bridged hops -- same shape
-        # as SpeculativeAppealsHelper._generate_drafts.
+        # thread_sensitive=False so concurrent drains don't serialize on one
+        # shared thread; letter_executor (not bridge_executor) so a burst of
+        # long drains -- a degraded-model period fires many fallbacks at
+        # once -- is capped by its small pool instead of crowding out the
+        # bridge pool's short hops.
         item: Optional[GeneratedAppeal] = await database_sync_to_async(
             _drain,
             thread_sensitive=False,
-            executor=bridge_executor,
+            executor=letter_executor,
         )()
 
         # make_appeals flushed what it knew before handing back its lazy
@@ -359,7 +361,11 @@ async def draft_letter_for_chat(
     saved_to_appeal = False
     try:
         appeal.appeal_text = letter
-        await appeal.asave()
+        # Field-limited: `appeal` was read before drafting started, which can
+        # run for the whole deadline -- a full save would write every column
+        # from that stale snapshot over any concurrent update. mod_date is
+        # auto_now and must be listed to keep updating under update_fields.
+        await appeal.asave(update_fields=["appeal_text", "mod_date"])
         saved_to_appeal = True
     except Exception:
         logger.opt(exception=True).warning(

--- a/fighthealthinsurance/chat/tools/__init__.py
+++ b/fighthealthinsurance/chat/tools/__init__.py
@@ -13,6 +13,7 @@ from .base_tool import BaseTool
 from .clinical_trials_tool import ClinicalTrialsTool
 from .doc_fetcher_tool import DocFetcherTool
 from .financial_assistance_tool import FinancialAssistanceTool
+from .generate_appeal_letter_tool import GenerateAppealLetterTool
 from .json_followup_tool import JsonFollowupTool
 from .medicaid_tool import MedicaidEligibilityTool, MedicaidInfoTool
 from .pa_requirement_tool import PaRequirementLookupTool
@@ -22,6 +23,7 @@ from .patterns import (
     CREATE_OR_UPDATE_APPEAL_REGEX,
     CREATE_OR_UPDATE_PRIOR_AUTH_REGEX,
     FETCH_DOC_REGEX,
+    GENERATE_APPEAL_LETTER_REGEX,
     FINANCIAL_ASSISTANCE_REGEX,
     LOOKUP_PA_REQUIREMENT_REGEX,
     MEDICAID_ELIGIBILITY_REGEX,
@@ -47,6 +49,7 @@ __all__ = [
     "MEDICAID_GOV_LOOKUP_REGEX",
     "CREATE_OR_UPDATE_APPEAL_REGEX",
     "CREATE_OR_UPDATE_PRIOR_AUTH_REGEX",
+    "GENERATE_APPEAL_LETTER_REGEX",
     "FETCH_DOC_REGEX",
     "RXNORM_LOOKUP_REGEX",
     "USPSTF_LOOKUP_REGEX",
@@ -64,6 +67,7 @@ __all__ = [
     "MedicaidEligibilityTool",
     "MedicaidGovLookupTool",
     "AppealTool",
+    "GenerateAppealLetterTool",
     "PriorAuthTool",
     "DocFetcherTool",
     "RxNormLookupTool",

--- a/fighthealthinsurance/chat/tools/appeal_tool.py
+++ b/fighthealthinsurance/chat/tools/appeal_tool.py
@@ -30,6 +30,11 @@ class AppealTool(BaseTool):
 
     pattern = CREATE_OR_UPDATE_APPEAL_REGEX
     detect_flags: int = re.DOTALL | re.MULTILINE | re.IGNORECASE
+    # The pattern is ^...$-anchored, so every scan needs MULTILINE -- the
+    # base default (no MULTILINE) made the on-error strip in
+    # BaseTool.handle miss a call that follows a line of prose, leaking raw
+    # tool syntax (and its JSON payload) into the chat when execute raised.
+    detect_all_flags: int = re.DOTALL | re.MULTILINE | re.IGNORECASE
     name = "Appeal"
 
     def __init__(

--- a/fighthealthinsurance/chat/tools/appeal_tool.py
+++ b/fighthealthinsurance/chat/tools/appeal_tool.py
@@ -49,8 +49,20 @@ class AppealTool(BaseTool):
 
     def strip_calls_on_error(self, response_text: str) -> str:
         """Span-bounded on-error strip: the greedy DOTALL pattern would also
-        delete the text (and any other pending tool call) between two calls."""
-        return strip_anchored_calls(self, response_text)
+        delete the text (and any other pending tool call) between two calls.
+
+        ``empty_fallback`` covers a reply that was nothing BUT the failed
+        call: returning the original text there (the base behavior) would
+        hand the user the raw token and its payload.
+        """
+        return strip_anchored_calls(
+            self,
+            response_text,
+            empty_fallback=(
+                "Sorry -- I hit a problem saving those appeal details. "
+                "Could you tell me again what you'd like recorded?"
+            ),
+        )
 
     def __init__(
         self,

--- a/fighthealthinsurance/chat/tools/appeal_tool.py
+++ b/fighthealthinsurance/chat/tools/appeal_tool.py
@@ -13,7 +13,12 @@ from loguru import logger
 
 from fighthealthinsurance.utils import aget_related
 
-from .base_tool import BaseTool, is_safe_tool_field, settable_model_fields
+from .base_tool import (
+    BaseTool,
+    is_safe_tool_field,
+    parse_anchored_json_payload,
+    settable_model_fields,
+)
 from .patterns import CREATE_OR_UPDATE_APPEAL_REGEX
 
 
@@ -80,10 +85,12 @@ class AppealTool(BaseTool):
             await self.send_error_message("Cannot create appeal: no chat context")
             return response_text, context
 
-        json_data = match.group(1).strip()
-
         try:
-            appeal_data = json.loads(json_data)
+            # Precise payload + span: the greedy anchored pattern can
+            # over-capture into a later tool call on another line (see
+            # parse_anchored_json_payload); replacing call_span rather than
+            # match.group(0) keeps that later call intact for its own handler.
+            appeal_data, call_span = parse_anchored_json_payload(response_text, match)
             await self.send_status_message("Processing update appeal data...")
 
             appeal, denial = await self._get_or_create_appeal(chat, appeal_data)
@@ -94,7 +101,7 @@ class AppealTool(BaseTool):
                 await denial.asave()
 
                 cleaned_response = response_text.replace(
-                    match.group(0),
+                    call_span,
                     f"I've created/updated [Appeal #{appeal.id}]({self.domain}/appeals/{appeal.id}) for you.",
                 )
                 await self.send_status_message(
@@ -103,18 +110,22 @@ class AppealTool(BaseTool):
                 return cleaned_response, context
             else:
                 cleaned_response = response_text.replace(
-                    match.group(0),
+                    call_span,
                     "I couldn't create or update the appeal.",
                 )
                 await self.send_status_message("Failed to create or update appeal.")
                 return cleaned_response, context
 
         except json.JSONDecodeError as e:
+            # No payload content in the log or the error frame: the appeal
+            # JSON carries medical/claim details (PHI) -- sizes only.
             logger.warning(
-                f"Invalid JSON data {e} in create_or_update_appeal token: {json_data}"
+                f"Invalid JSON in create_or_update_appeal token "
+                f"({len(match.group(1))} chars): {e.msg} at pos {e.pos}"
             )
             await self.send_error_message(
-                f"Error processing appeal data: Invalid JSON format {e} -- {json_data}"
+                "Error processing appeal data: the appeal details were not "
+                "valid JSON. Please try again."
             )
             raise
 

--- a/fighthealthinsurance/chat/tools/appeal_tool.py
+++ b/fighthealthinsurance/chat/tools/appeal_tool.py
@@ -18,6 +18,7 @@ from .base_tool import (
     is_safe_tool_field,
     parse_anchored_json_payload,
     settable_model_fields,
+    strip_anchored_calls,
 )
 from .patterns import CREATE_OR_UPDATE_APPEAL_REGEX
 
@@ -41,6 +42,15 @@ class AppealTool(BaseTool):
     # tool syntax (and its JSON payload) into the chat when execute raised.
     detect_all_flags: int = re.DOTALL | re.MULTILINE | re.IGNORECASE
     name = "Appeal"
+    # Models legitimately emit several update calls in one reply; since
+    # execute() replaces only the exact call span, each remaining call must
+    # get its own pass or it renders as raw tool syntax.
+    max_calls_per_reply: int = 3
+
+    def strip_calls_on_error(self, response_text: str) -> str:
+        """Span-bounded on-error strip: the greedy DOTALL pattern would also
+        delete the text (and any other pending tool call) between two calls."""
+        return strip_anchored_calls(self, response_text)
 
     def __init__(
         self,
@@ -100,9 +110,13 @@ class AppealTool(BaseTool):
                 await appeal.asave()
                 await denial.asave()
 
+                # count=1: byte-identical duplicate calls each get their own
+                # pass via max_calls_per_reply instead of one replacement
+                # landing at every occurrence.
                 cleaned_response = response_text.replace(
                     call_span,
                     f"I've created/updated [Appeal #{appeal.id}]({self.domain}/appeals/{appeal.id}) for you.",
+                    1,
                 )
                 await self.send_status_message(
                     f"Appeal #{appeal.id} has been created/updated successfully."
@@ -112,6 +126,7 @@ class AppealTool(BaseTool):
                 cleaned_response = response_text.replace(
                     call_span,
                     "I couldn't create or update the appeal.",
+                    1,
                 )
                 await self.send_status_message("Failed to create or update appeal.")
                 return cleaned_response, context

--- a/fighthealthinsurance/chat/tools/base_tool.py
+++ b/fighthealthinsurance/chat/tools/base_tool.py
@@ -280,6 +280,17 @@ class BaseTool(ABC):
                     match, response_text, context, **kwargs
                 )
                 handled = True
+            if handled and self.max_calls_per_reply > 1 and self.detect(response_text):
+                # Calls past the per-reply cap are stripped rather than left
+                # to render as raw tool syntax (with their JSON payloads).
+                # Only for multi-call tools: they override
+                # strip_calls_on_error with span-bounded removal, and
+                # single-call tools keep their historical behavior.
+                logger.info(
+                    f"{self.name}: more than {self.max_calls_per_reply} calls "
+                    f"in one reply; stripping the rest"
+                )
+                response_text = self.strip_calls_on_error(response_text)
             return response_text, context, handled
 
         except Exception as e:

--- a/fighthealthinsurance/chat/tools/base_tool.py
+++ b/fighthealthinsurance/chat/tools/base_tool.py
@@ -78,6 +78,43 @@ def parse_anchored_json_payload(text: str, match: re.Match[str]) -> Tuple[dict, 
     return payload, text[match.start() : start + end]
 
 
+def remove_anchored_call(text: str, match: re.Match[str]) -> str:
+    """Remove ONE anchored ``**tool**{...}`` call from ``text`` precisely.
+
+    Uses the raw_decode span when the payload parses; for an undecodable
+    payload the removal is bounded at the first line end inside the greedy
+    capture (the documented call format is one-line JSON), so unlike a
+    ``re.sub`` over the greedy DOTALL pattern it can never swallow prose or
+    a later tool call that happens to end in ``}``.
+    """
+    start = match.start()
+    try:
+        _, span = parse_anchored_json_payload(text, match)
+        end = start + len(span)
+    except json.JSONDecodeError:
+        newline = text.find("\n", match.start(1))
+        end = newline if newline != -1 else len(text)
+    return text[:start] + text[end:]
+
+
+def strip_anchored_calls(tool: "BaseTool", response_text: str) -> str:
+    """Span-bounded removal of every remaining call of ``tool`` in the text.
+
+    The anchored tools' error/straggler cleanup: bounded loop of
+    ``remove_anchored_call`` so nothing between calls is lost. Falls back to
+    the original text when stripping would leave nothing (matching the
+    ``BaseTool.handle`` error-path semantics).
+    """
+    text = response_text
+    for _ in range(8):
+        match = tool.detect(text)
+        if not match:
+            break
+        text = remove_anchored_call(text, match)
+    text = text.strip()
+    return text or response_text
+
+
 class BaseTool(ABC):
     """
     Abstract base class for chat tool handlers.
@@ -98,6 +135,15 @@ class BaseTool(ABC):
 
     # Human-readable name for status messages
     name: str = "Tool"
+
+    # How many calls of THIS tool ``handle`` may execute in one reply. Most
+    # tools keep 1 -- their handlers either process every match internally
+    # via detect_all (medicaid, financial assistance) or run a recursive
+    # LLM pass that supersedes the reply. The anchored JSON tools raise it:
+    # since their execute() replaces only the exact call span, a second
+    # call in the same reply would otherwise survive unexecuted and render
+    # as raw tool syntax.
+    max_calls_per_reply: int = 1
 
     def __init__(
         self,
@@ -191,11 +237,29 @@ class BaseTool(ABC):
         """
         pass
 
+    def strip_calls_on_error(self, response_text: str) -> str:
+        """Remove this tool's raw syntax after execute() failed.
+
+        Default: regex-sub every match of the pattern. The anchored JSON
+        tools override this with span-bounded removal (strip_anchored_calls)
+        because a greedy DOTALL sub over their pattern would also delete
+        the text BETWEEN two calls -- including a different pending tool
+        call. Falls back to the original text when stripping leaves nothing.
+        """
+        stripped = re.sub(
+            self.pattern, "", response_text, flags=self.detect_all_flags
+        ).strip()
+        return stripped or response_text
+
     async def handle(
         self, response_text: str, context: str, **kwargs
     ) -> Tuple[str, str, bool]:
         """
         Detect and handle this tool if present in the response.
+
+        Executes up to ``max_calls_per_reply`` calls of this tool (each pass
+        re-detects against the updated text, so an execute() that replaces
+        its call span lets the next call be found).
 
         Args:
             response_text: The LLM response text
@@ -205,16 +269,18 @@ class BaseTool(ABC):
         Returns:
             Tuple of (updated_response_text, updated_context, was_handled)
         """
+        handled = False
         try:
-            match = self.detect(response_text)
-            if not match:
-                return response_text, context, False
-
-            logger.debug(f"{self.name} tool detected in response")
-            updated_response, updated_context = await self.execute(
-                match, response_text, context, **kwargs
-            )
-            return updated_response, updated_context, True
+            for _ in range(max(1, self.max_calls_per_reply)):
+                match = self.detect(response_text)
+                if not match:
+                    break
+                logger.debug(f"{self.name} tool detected in response")
+                response_text, context = await self.execute(
+                    match, response_text, context, **kwargs
+                )
+                handled = True
+            return response_text, context, handled
 
         except Exception as e:
             logger.opt(exception=True).warning(f"Error executing {self.name} tool: {e}")
@@ -229,11 +295,7 @@ class BaseTool(ABC):
             # {...}` in the chat because a tool blew up mid-execution.
             cleaned_response = response_text
             try:
-                stripped = re.sub(
-                    self.pattern, "", response_text, flags=self.detect_all_flags
-                ).strip()
-                if stripped:
-                    cleaned_response = stripped
+                cleaned_response = self.strip_calls_on_error(response_text)
             except Exception:
                 logger.debug(f"{self.name}: could not strip tool syntax on error")
             return cleaned_response, context, True

--- a/fighthealthinsurance/chat/tools/base_tool.py
+++ b/fighthealthinsurance/chat/tools/base_tool.py
@@ -97,21 +97,34 @@ def remove_anchored_call(text: str, match: re.Match[str]) -> str:
     return text[:start] + text[end:]
 
 
-def strip_anchored_calls(tool: "BaseTool", response_text: str) -> str:
+def strip_anchored_calls(
+    tool: "BaseTool", response_text: str, notice: Optional[str] = None
+) -> str:
     """Span-bounded removal of every remaining call of ``tool`` in the text.
 
     The anchored tools' error/straggler cleanup: bounded loop of
     ``remove_anchored_call`` so nothing between calls is lost. Falls back to
     the original text when stripping would leave nothing (matching the
     ``BaseTool.handle`` error-path semantics).
+
+    ``notice`` is appended ONCE when anything was actually stripped. Pass it
+    whenever the dropped calls carried work that was never done: the
+    stripped reply is what the user reads AND what is persisted to
+    chat_history, so with no notice the model sees its call as accepted and
+    never retries it. The error path passes None -- a status message has
+    already gone out there.
     """
     text = response_text
+    removed = 0
     for _ in range(8):
         match = tool.detect(text)
         if not match:
             break
         text = remove_anchored_call(text, match)
+        removed += 1
     text = text.strip()
+    if removed and notice:
+        text = f"{text}\n\n{notice}" if text else notice
     return text or response_text
 
 
@@ -251,6 +264,21 @@ class BaseTool(ABC):
         ).strip()
         return stripped or response_text
 
+    def dropped_calls_notice(self) -> str:
+        """Sentence appended when calls past ``max_calls_per_reply`` are
+        dropped from a SUCCESSFUL reply.
+
+        Those calls carried updates that were never applied, and the reply
+        (minus them) is what both the user reads and the model sees in the
+        history, so saying nothing would leave the user thinking the change
+        landed and the model with no reason to retry.
+        """
+        return (
+            f"(Note: I could only apply the first {self.max_calls_per_reply} "
+            f"updates in one go, so anything after that hasn't been saved -- "
+            f"tell me what else to change and I'll take care of it.)"
+        )
+
     async def handle(
         self, response_text: str, context: str, **kwargs
     ) -> Tuple[str, str, bool]:
@@ -281,16 +309,19 @@ class BaseTool(ABC):
                 )
                 handled = True
             if handled and self.max_calls_per_reply > 1 and self.detect(response_text):
-                # Calls past the per-reply cap are stripped rather than left
-                # to render as raw tool syntax (with their JSON payloads).
-                # Only for multi-call tools: they override
-                # strip_calls_on_error with span-bounded removal, and
-                # single-call tools keep their historical behavior.
+                # Calls past the per-reply cap are stripped (with a notice
+                # saying they were not applied) rather than left to render
+                # as raw tool syntax with their JSON payloads. Gated on
+                # max_calls_per_reply > 1, i.e. the anchored JSON tools:
+                # span-bounded removal assumes their `**tool**{...}` shape,
+                # and single-call tools keep their historical behavior.
                 logger.info(
                     f"{self.name}: more than {self.max_calls_per_reply} calls "
                     f"in one reply; stripping the rest"
                 )
-                response_text = self.strip_calls_on_error(response_text)
+                response_text = strip_anchored_calls(
+                    self, response_text, notice=self.dropped_calls_notice()
+                )
             return response_text, context, handled
 
         except Exception as e:

--- a/fighthealthinsurance/chat/tools/base_tool.py
+++ b/fighthealthinsurance/chat/tools/base_tool.py
@@ -5,6 +5,7 @@ Tool handlers process specific "tool calls" that the LLM includes in responses.
 Each tool can detect its pattern in text, execute the tool action, and format results.
 """
 
+import json
 import re
 from abc import ABC, abstractmethod
 from typing import Awaitable, Callable, List, Optional, Set, Tuple
@@ -47,6 +48,34 @@ def is_safe_tool_field(key: str, allowed: Set[str]) -> bool:
     if not key or key.startswith("_") or key.endswith("_id"):
         return False
     return key in allowed
+
+
+def parse_anchored_json_payload(text: str, match: re.Match[str]) -> Tuple[dict, str]:
+    """Parse the JSON payload of an anchored ``**tool**{...}`` call precisely.
+
+    The anchored patterns (create_or_update_appeal / _prior_auth /
+    generate_appeal_letter) capture ``(\\{.*\\})`` under DOTALL, so when two
+    tool calls share a reply the greedy group runs from the first call's
+    ``{`` through the LAST ``}`` in the text -- ``json.loads`` on the group
+    then fails and BOTH calls get stripped. Instead, decode from the
+    captured group's start with ``raw_decode``, which stops at the end of
+    the first complete JSON value (same approach as FinancialAssistanceTool
+    / the PA-requirement lookup). Returns ``(payload, call_span)`` where
+    ``call_span`` is the exact ``**tool**{...}`` substring of ``text`` to
+    replace -- handlers must replace it rather than ``match.group(0)``,
+    whose over-capture would swallow the text between the calls.
+
+    Raises ``json.JSONDecodeError`` for an undecodable or non-object
+    payload. NOTE for callers: the payload can carry medical/claim details,
+    so error paths must not log it or echo it back -- log sizes only.
+    """
+    start = match.start(1)
+    payload, end = json.JSONDecoder().raw_decode(text[start:])
+    if not isinstance(payload, dict):
+        raise json.JSONDecodeError(
+            "tool payload must be a JSON object", text[start : start + end], 0
+        )
+    return payload, text[match.start() : start + end]
 
 
 class BaseTool(ABC):

--- a/fighthealthinsurance/chat/tools/base_tool.py
+++ b/fighthealthinsurance/chat/tools/base_tool.py
@@ -78,34 +78,59 @@ def parse_anchored_json_payload(text: str, match: re.Match[str]) -> Tuple[dict, 
     return payload, text[match.start() : start + end]
 
 
-def remove_anchored_call(text: str, match: re.Match[str]) -> str:
+def remove_anchored_call(
+    text: str, match: re.Match[str], tool: Optional["BaseTool"] = None
+) -> str:
     """Remove ONE anchored ``**tool**{...}`` call from ``text`` precisely.
 
-    Uses the raw_decode span when the payload parses; for an undecodable
-    payload the removal is bounded at the first line end inside the greedy
-    capture (the documented call format is one-line JSON), so unlike a
-    ``re.sub`` over the greedy DOTALL pattern it can never swallow prose or
-    a later tool call that happens to end in ``}``.
+    Uses the raw_decode span when the payload parses. When it does NOT
+    parse, the removal runs to the last ``}`` of the broken body -- bounded
+    by where the next call of ``tool`` starts, so it still can't swallow a
+    later tool call the way a ``re.sub`` over the greedy DOTALL pattern
+    would. Cutting at the first newline instead (as this used to) left the
+    rest of a pretty-printed malformed payload behind, putting its
+    contents -- possibly medical detail -- in the reply and in chat
+    history. Without ``tool`` the bound is the end of the text.
     """
     start = match.start()
     try:
         _, span = parse_anchored_json_payload(text, match)
-        end = start + len(span)
+        return text[:start] + text[start + len(span) :]
     except json.JSONDecodeError:
-        newline = text.find("\n", match.start(1))
-        end = newline if newline != -1 else len(text)
+        pass
+
+    body_start = match.start(1)
+    # Never reach past the next call of this tool: it gets its own removal.
+    limit = len(text)
+    if tool is not None:
+        following = tool.detect(text[body_start + 1 :])
+        if following:
+            limit = body_start + 1 + following.start()
+    close = text.rfind("}", body_start, limit)
+    if close != -1:
+        end = close + 1
+    else:
+        # No closing brace at all (a truncated payload): fall back to the
+        # line bound, which at least takes the token and what follows it.
+        newline = text.find("\n", body_start)
+        end = min(newline if newline != -1 else limit, limit)
     return text[:start] + text[end:]
 
 
 def strip_anchored_calls(
-    tool: "BaseTool", response_text: str, notice: Optional[str] = None
+    tool: "BaseTool",
+    response_text: str,
+    notice: Optional[str] = None,
+    empty_fallback: Optional[str] = None,
 ) -> str:
-    """Span-bounded removal of every remaining call of ``tool`` in the text.
+    """Span-bounded removal of EVERY remaining call of ``tool`` in the text.
 
-    The anchored tools' error/straggler cleanup: bounded loop of
-    ``remove_anchored_call`` so nothing between calls is lost. Falls back to
-    the original text when stripping would leave nothing (matching the
-    ``BaseTool.handle`` error-path semantics).
+    The anchored tools' error/straggler cleanup: a loop of
+    ``remove_anchored_call`` so nothing between calls is lost. It runs until
+    no call is left rather than for a fixed number of rounds -- a fixed cap
+    returned the calls past it as raw syntax, payload included. Each removal
+    strictly shortens the text, so the loop terminates; the progress check
+    is defensive only.
 
     ``notice`` is appended ONCE when anything was actually stripped. Pass it
     whenever the dropped calls carried work that was never done: the
@@ -113,19 +138,33 @@ def strip_anchored_calls(
     chat_history, so with no notice the model sees its call as accepted and
     never retries it. The error path passes None -- a status message has
     already gone out there.
+
+    ``empty_fallback`` is returned when the reply was NOTHING but tool calls
+    and stripping leaves it empty. Without one the original text is returned
+    (the historical behavior), which in that case hands the user the raw
+    call and its payload -- so the anchored tools pass a sentence instead.
     """
     text = response_text
     removed = 0
-    for _ in range(8):
+    while True:
         match = tool.detect(text)
         if not match:
             break
-        text = remove_anchored_call(text, match)
+        shortened = remove_anchored_call(text, match, tool)
+        if len(shortened) >= len(text):
+            logger.warning(
+                f"{tool.name}: tool-call removal made no progress; "
+                f"stopping with {len(text)} chars left"
+            )
+            break
+        text = shortened
         removed += 1
     text = text.strip()
     if removed and notice:
         text = f"{text}\n\n{notice}" if text else notice
-    return text or response_text
+    if text:
+        return text
+    return empty_fallback if empty_fallback is not None else response_text
 
 
 class BaseTool(ABC):

--- a/fighthealthinsurance/chat/tools/generate_appeal_letter_tool.py
+++ b/fighthealthinsurance/chat/tools/generate_appeal_letter_tool.py
@@ -21,8 +21,10 @@ from fighthealthinsurance.chat.appeal_letter_generator import (
     denial_has_letter_context,
     draft_letter_for_chat,
 )
+from fighthealthinsurance.denial_context import merge_qa
 
 from .appeal_tool import AppealTool
+from .base_tool import parse_anchored_json_payload
 from .patterns import GENERATE_APPEAL_LETTER_REGEX
 
 # Payload keys that are letter-generation context rather than Appeal/Denial
@@ -87,15 +89,21 @@ class GenerateAppealLetterTool(AppealTool):
             await self.send_error_message("Cannot draft a letter: no chat context")
             return response_text, context
 
-        json_data = match.group(1).strip()
         try:
-            appeal_data = json.loads(json_data)
+            # Precise payload + span (see parse_anchored_json_payload): replace
+            # call_span, not the greedy match.group(0), so a second tool call
+            # in the same reply survives for its own handler.
+            appeal_data, call_span = parse_anchored_json_payload(response_text, match)
         except json.JSONDecodeError as e:
+            # No payload content in the log or the error frame: the letter
+            # JSON carries medical/claim details (PHI) -- sizes only.
             logger.warning(
-                f"Invalid JSON data {e} in generate_appeal_letter token: {json_data}"
+                f"Invalid JSON in generate_appeal_letter token "
+                f"({len(match.group(1))} chars): {e.msg} at pos {e.pos}"
             )
             await self.send_error_message(
-                f"Error processing appeal data: Invalid JSON format {e} -- {json_data}"
+                "Error processing appeal data: the letter request was not "
+                "valid JSON. Please try again."
             )
             raise
 
@@ -104,18 +112,18 @@ class GenerateAppealLetterTool(AppealTool):
             # Peel off the letter-context keys BEFORE the field update so the
             # allowlist doesn't warn on them; they reach the models through
             # denial.qa_context below.
-            extra_context = []
+            extra_context = {}
             for key in _CONTEXT_ONLY_KEYS:
                 value = appeal_data.pop(key, None)
                 if value:
-                    extra_context.append(str(value).strip())
+                    extra_context[key] = str(value).strip()
 
             appeal, denial = await self._get_or_create_appeal(chat, appeal_data)
             if not appeal or not denial:
                 await self.send_status_message("Failed to create or update appeal.")
                 return (
                     response_text.replace(
-                        match.group(0),
+                        call_span,
                         "I couldn't set up the appeal record to draft a letter into.",
                     ),
                     context,
@@ -123,12 +131,10 @@ class GenerateAppealLetterTool(AppealTool):
 
             await self._update_appeal_fields(appeal, denial, appeal_data)
             if extra_context:
-                addition = "Context from the chat: " + " ".join(extra_context)
-                denial.qa_context = (
-                    f"{denial.qa_context}\n{addition}"
-                    if denial.qa_context
-                    else addition
-                )
+                # qa_context is a JSON dict grown via merge_qa ("merge, never
+                # overwrite" -- see denial_context); a plain-text append here
+                # would corrupt it to the {"misc": ...} fallback shape.
+                merge_qa(denial, extra_context, source="generate_appeal_letter")
             await appeal.asave()
             await denial.asave()
 
@@ -137,7 +143,7 @@ class GenerateAppealLetterTool(AppealTool):
                 # a letter of blanks.
                 return (
                     response_text.replace(
-                        match.group(0),
+                        call_span,
                         "Before I draft the letter I need at least one of: "
                         "the procedure or service that was denied, the "
                         "diagnosis, or the denial letter text (you can paste "
@@ -150,20 +156,29 @@ class GenerateAppealLetterTool(AppealTool):
                 "Drafting your appeal letter with our appeal-generation "
                 "pipeline -- this can take a minute..."
             )
-            letter = await draft_letter_for_chat(
+            drafted = await draft_letter_for_chat(
                 appeal=appeal,
                 denial=denial,
                 use_external=self.use_external,
             )
 
-            if letter:
+            if drafted and drafted.saved_to_appeal:
                 await self.send_status_message(
                     f"Appeal letter drafted and saved to Appeal #{appeal.id}."
                 )
                 replacement = (
                     f"I've drafted an appeal letter and saved it to "
                     f"{self._appeal_link(appeal)}. Here's the draft -- tell me "
-                    f"what you'd like to change:\n\n---\n\n{letter}"
+                    f"what you'd like to change:\n\n---\n\n{drafted.text}"
+                )
+            elif drafted:
+                # The letter exists but the appeal save failed: deliver it
+                # without claiming it was saved anywhere.
+                await self.send_status_message("Appeal letter drafted.")
+                replacement = (
+                    f"I've drafted an appeal letter, but couldn't attach it to "
+                    f"{self._appeal_link(appeal)} just now -- please copy it "
+                    f"from this chat. Here's the draft:\n\n---\n\n{drafted.text}"
                 )
             else:
                 await self.send_status_message("Letter generation did not succeed.")
@@ -174,7 +189,7 @@ class GenerateAppealLetterTool(AppealTool):
                     f"{self._appeal_link(appeal)}, where you can also generate "
                     f"the letter, or ask me to try again in a few minutes."
                 )
-            return response_text.replace(match.group(0), replacement), context
+            return response_text.replace(call_span, replacement), context
 
         except Exception as e:
             logger.opt(exception=True).warning(f"Error drafting appeal letter: {e}")

--- a/fighthealthinsurance/chat/tools/generate_appeal_letter_tool.py
+++ b/fighthealthinsurance/chat/tools/generate_appeal_letter_tool.py
@@ -1,0 +1,178 @@
+"""Generate-appeal-letter tool handler for the chat interface.
+
+Handles ``**generate_appeal_letter {...}**`` calls from the LLM. Instead of
+the chat model writing a full appeal letter inline (the longest and most
+failure-prone chat generation -- see the "Please go ahead and draft a
+letter." total-failure incidents), the model emits this small call with the
+denial details it knows and the dedicated appeal-generation pipeline
+(appeal-tuned models, curated specialized templates, the shed ladder) writes
+the letter. The tool creates/updates the chat-linked Appeal + Denial from
+the same payload, saves the drafted letter to the appeal, and replaces the
+call with the letter text plus a link.
+"""
+
+import json
+import re
+from typing import Any, Awaitable, Callable, Optional, Tuple
+
+from loguru import logger
+
+from fighthealthinsurance.chat.appeal_letter_generator import (
+    denial_has_letter_context,
+    draft_letter_for_chat,
+)
+
+from .appeal_tool import AppealTool
+from .patterns import GENERATE_APPEAL_LETTER_REGEX
+
+# Payload keys that are letter-generation context rather than Appeal/Denial
+# columns; folded into denial.qa_context (which the appeal prompt bakes in)
+# instead of going through the field allowlist, which would warn on them.
+_CONTEXT_ONLY_KEYS = ("medical_reason", "additional_context")
+
+
+class GenerateAppealLetterTool(AppealTool):
+    """
+    Tool handler that drafts the appeal letter via the appeal pipeline.
+
+    Subclasses AppealTool for its get-or-create / field-update plumbing;
+    only the detection pattern and the execute flow differ:
+    1. Extract the JSON parameters (denial/appeal fields + optional
+       medical_reason/additional_context).
+    2. Create or update the Appeal + Denial linked to the chat.
+    3. Draft the letter through the appeal-generation pipeline
+       (draft_letter_for_chat), which also persists it to the appeal.
+    4. Replace the tool call with the drafted letter and an appeal link.
+    """
+
+    pattern = GENERATE_APPEAL_LETTER_REGEX
+    detect_flags: int = re.DOTALL | re.MULTILINE | re.IGNORECASE
+    name = "Generate Appeal Letter"
+
+    def __init__(
+        self,
+        send_status_message: Callable[[str], Awaitable[None]],
+        send_error_message: Optional[Callable[[str], Awaitable[None]]] = None,
+        domain: str = "",
+        use_external: bool = True,
+    ):
+        """
+        Args:
+            send_status_message: Async function to send status updates
+            send_error_message: Async function to send error messages
+            domain: The domain URL for generating appeal links
+            use_external: This chat session's external-model consent,
+                forwarded to the letter pipeline's backup call list
+        """
+        super().__init__(send_status_message, send_error_message, domain)
+        self.use_external = use_external
+
+    def _appeal_link(self, appeal: Any) -> str:
+        return f"[Appeal #{appeal.id}]({self.domain}/appeals/{appeal.id})"
+
+    async def execute(
+        self,
+        match: re.Match[str],
+        response_text: str,
+        context: str,
+        chat: Any = None,
+        **kwargs,
+    ) -> Tuple[str, str]:
+        if not chat:
+            logger.warning("GenerateAppealLetterTool called without chat object")
+            await self.send_error_message("Cannot draft a letter: no chat context")
+            return response_text, context
+
+        json_data = match.group(1).strip()
+        try:
+            appeal_data = json.loads(json_data)
+        except json.JSONDecodeError as e:
+            logger.warning(
+                f"Invalid JSON data {e} in generate_appeal_letter token: {json_data}"
+            )
+            await self.send_error_message(
+                f"Error processing appeal data: Invalid JSON format {e} -- {json_data}"
+            )
+            raise
+
+        try:
+            await self.send_status_message("Setting up your appeal...")
+            # Peel off the letter-context keys BEFORE the field update so the
+            # allowlist doesn't warn on them; they reach the models through
+            # denial.qa_context below.
+            extra_context = []
+            for key in _CONTEXT_ONLY_KEYS:
+                value = appeal_data.pop(key, None)
+                if value:
+                    extra_context.append(str(value).strip())
+
+            appeal, denial = await self._get_or_create_appeal(chat, appeal_data)
+            if not appeal or not denial:
+                await self.send_status_message("Failed to create or update appeal.")
+                return (
+                    response_text.replace(
+                        match.group(0),
+                        "I couldn't set up the appeal record to draft a letter into.",
+                    ),
+                    context,
+                )
+
+            await self._update_appeal_fields(appeal, denial, appeal_data)
+            if extra_context:
+                addition = "Context from the chat: " + " ".join(extra_context)
+                denial.qa_context = (
+                    f"{denial.qa_context}\n{addition}"
+                    if denial.qa_context
+                    else addition
+                )
+            await appeal.asave()
+            await denial.asave()
+
+            if not denial_has_letter_context(denial):
+                # Nothing to write a letter ABOUT yet; asking beats generating
+                # a letter of blanks.
+                return (
+                    response_text.replace(
+                        match.group(0),
+                        "Before I draft the letter I need at least one of: "
+                        "the procedure or service that was denied, the "
+                        "diagnosis, or the denial letter text (you can paste "
+                        "it here). Which of those can you share?",
+                    ),
+                    context,
+                )
+
+            await self.send_status_message(
+                "Drafting your appeal letter with our appeal-generation "
+                "pipeline -- this can take a minute..."
+            )
+            letter = await draft_letter_for_chat(
+                appeal=appeal,
+                denial=denial,
+                use_external=self.use_external,
+            )
+
+            if letter:
+                await self.send_status_message(
+                    f"Appeal letter drafted and saved to Appeal #{appeal.id}."
+                )
+                replacement = (
+                    f"I've drafted an appeal letter and saved it to "
+                    f"{self._appeal_link(appeal)}. Here's the draft -- tell me "
+                    f"what you'd like to change:\n\n---\n\n{letter}"
+                )
+            else:
+                await self.send_status_message("Letter generation did not succeed.")
+                replacement = (
+                    f"I wasn't able to draft the letter just now -- the "
+                    f"letter-writing models didn't return a usable draft. "
+                    f"Your appeal details are saved to "
+                    f"{self._appeal_link(appeal)}, where you can also generate "
+                    f"the letter, or ask me to try again in a few minutes."
+                )
+            return response_text.replace(match.group(0), replacement), context
+
+        except Exception as e:
+            logger.opt(exception=True).warning(f"Error drafting appeal letter: {e}")
+            await self.send_error_message(f"Error drafting appeal letter: {str(e)}")
+            raise

--- a/fighthealthinsurance/chat/tools/generate_appeal_letter_tool.py
+++ b/fighthealthinsurance/chat/tools/generate_appeal_letter_tool.py
@@ -95,10 +95,20 @@ class GenerateAppealLetterTool(AppealTool):
         A reply should carry at most one generate_appeal_letter call; any
         further ones would each run another full generation, so they are
         removed (span-bounded) rather than executed or left to render raw.
+        The notice keeps the drop visible to the user and to the model,
+        which reads this text back as history.
         """
         updated = response_text.replace(call_span, replacement, 1)
         if self.detect(updated):
-            updated = strip_anchored_calls(self, updated)
+            updated = strip_anchored_calls(
+                self,
+                updated,
+                notice=(
+                    "(Note: I drafted one letter for this message. If you "
+                    "wanted another version -- a different procedure or a "
+                    "different angle -- just ask and I'll write it.)"
+                ),
+            )
         return updated
 
     async def execute(

--- a/fighthealthinsurance/chat/tools/generate_appeal_letter_tool.py
+++ b/fighthealthinsurance/chat/tools/generate_appeal_letter_tool.py
@@ -24,7 +24,7 @@ from fighthealthinsurance.chat.appeal_letter_generator import (
 from fighthealthinsurance.denial_context import merge_qa
 
 from .appeal_tool import AppealTool
-from .base_tool import parse_anchored_json_payload
+from .base_tool import parse_anchored_json_payload, strip_anchored_calls
 from .patterns import GENERATE_APPEAL_LETTER_REGEX
 
 # Payload keys that are letter-generation context rather than Appeal/Denial
@@ -54,6 +54,11 @@ class GenerateAppealLetterTool(AppealTool):
     # on-error tool-syntax strip in BaseTool.handle) stay side by side.
     detect_all_flags: int = re.DOTALL | re.MULTILINE | re.IGNORECASE
     name = "Generate Appeal Letter"
+    # ONE letter per turn, unlike AppealTool's 3: each execution runs a full
+    # (deadline-bounded) generation, so a duplicate call would double the
+    # model spend and blow the turn budget. Straggler calls past the first
+    # are stripped instead (see _replace_call).
+    max_calls_per_reply: int = 1
 
     def __init__(
         self,
@@ -61,6 +66,7 @@ class GenerateAppealLetterTool(AppealTool):
         send_error_message: Optional[Callable[[str], Awaitable[None]]] = None,
         domain: str = "",
         use_external: bool = True,
+        deadline_seconds: Optional[float] = None,
     ):
         """
         Args:
@@ -69,12 +75,31 @@ class GenerateAppealLetterTool(AppealTool):
             domain: The domain URL for generating appeal links
             use_external: This chat session's external-model consent,
                 forwarded to the letter pipeline's backup call list
+            deadline_seconds: Cap for the letter generation, typically the
+                turn budget's remaining time (see
+                ChatInterface._remaining_letter_deadline). None applies the
+                pipeline's env default.
         """
         super().__init__(send_status_message, send_error_message, domain)
         self.use_external = use_external
+        self.deadline_seconds = deadline_seconds
 
     def _appeal_link(self, appeal: Any) -> str:
         return f"[Appeal #{appeal.id}]({self.domain}/appeals/{appeal.id})"
+
+    def _replace_call(
+        self, response_text: str, call_span: str, replacement: str
+    ) -> str:
+        """Replace this call's exact span, then strip straggler calls.
+
+        A reply should carry at most one generate_appeal_letter call; any
+        further ones would each run another full generation, so they are
+        removed (span-bounded) rather than executed or left to render raw.
+        """
+        updated = response_text.replace(call_span, replacement, 1)
+        if self.detect(updated):
+            updated = strip_anchored_calls(self, updated)
+        return updated
 
     async def execute(
         self,
@@ -122,7 +147,8 @@ class GenerateAppealLetterTool(AppealTool):
             if not appeal or not denial:
                 await self.send_status_message("Failed to create or update appeal.")
                 return (
-                    response_text.replace(
+                    self._replace_call(
+                        response_text,
                         call_span,
                         "I couldn't set up the appeal record to draft a letter into.",
                     ),
@@ -142,7 +168,8 @@ class GenerateAppealLetterTool(AppealTool):
                 # Nothing to write a letter ABOUT yet; asking beats generating
                 # a letter of blanks.
                 return (
-                    response_text.replace(
+                    self._replace_call(
+                        response_text,
                         call_span,
                         "Before I draft the letter I need at least one of: "
                         "the procedure or service that was denied, the "
@@ -160,6 +187,7 @@ class GenerateAppealLetterTool(AppealTool):
                 appeal=appeal,
                 denial=denial,
                 use_external=self.use_external,
+                deadline_seconds=self.deadline_seconds,
             )
 
             if drafted and drafted.saved_to_appeal:
@@ -170,6 +198,17 @@ class GenerateAppealLetterTool(AppealTool):
                     f"I've drafted an appeal letter and saved it to "
                     f"{self._appeal_link(appeal)}. Here's the draft -- tell me "
                     f"what you'd like to change:\n\n---\n\n{drafted.text}"
+                )
+            elif drafted and drafted.preserved_existing:
+                # A reserve draft was served but the appeal already carries a
+                # letter (possibly user-edited); it was deliberately left
+                # untouched -- say so instead of claiming a save.
+                await self.send_status_message("Appeal letter drafted.")
+                replacement = (
+                    f"{self._appeal_link(appeal)} already has a saved letter, "
+                    f"so I've left that one untouched. Here's a draft you can "
+                    f"compare with it or copy from this chat:"
+                    f"\n\n---\n\n{drafted.text}"
                 )
             elif drafted:
                 # The letter exists but the appeal save failed: deliver it
@@ -189,7 +228,7 @@ class GenerateAppealLetterTool(AppealTool):
                     f"{self._appeal_link(appeal)}, where you can also generate "
                     f"the letter, or ask me to try again in a few minutes."
                 )
-            return response_text.replace(call_span, replacement), context
+            return self._replace_call(response_text, call_span, replacement), context
 
         except Exception as e:
             logger.opt(exception=True).warning(f"Error drafting appeal letter: {e}")

--- a/fighthealthinsurance/chat/tools/generate_appeal_letter_tool.py
+++ b/fighthealthinsurance/chat/tools/generate_appeal_letter_tool.py
@@ -47,6 +47,10 @@ class GenerateAppealLetterTool(AppealTool):
 
     pattern = GENERATE_APPEAL_LETTER_REGEX
     detect_flags: int = re.DOTALL | re.MULTILINE | re.IGNORECASE
+    # Inherited from AppealTool with the same value; declared explicitly so
+    # the ^...$-anchored pattern and the MULTILINE requirement (for the
+    # on-error tool-syntax strip in BaseTool.handle) stay side by side.
+    detect_all_flags: int = re.DOTALL | re.MULTILINE | re.IGNORECASE
     name = "Generate Appeal Letter"
 
     def __init__(

--- a/fighthealthinsurance/chat/tools/patterns.py
+++ b/fighthealthinsurance/chat/tools/patterns.py
@@ -51,6 +51,16 @@ CREATE_OR_UPDATE_PRIOR_AUTH_REGEX = (
     r"^\s*\*{0,4}create_or_update_prior_auth\*{0,4}\s*(\{.*\})\s*$"
 )
 
+# Generate appeal letter tool - captures JSON with denial/appeal fields.
+# Matches: generate_appeal_letter {JSON} with optional ** markers.
+# Routes letter drafting to the dedicated appeal-generation pipeline instead
+# of having the chat model write the whole letter inline (the longest, most
+# failure-prone chat generation); same anchored line format as
+# CREATE_OR_UPDATE_APPEAL_REGEX.
+GENERATE_APPEAL_LETTER_REGEX = (
+    r"^\s*\*{0,4}generate_appeal_letter\*{0,4}\s*(\{.*\})\s*$"
+)
+
 # Medicaid.gov page lookup - captures JSON parameters
 # Matches: medicaid_gov_lookup {JSON} or **medicaid_gov_lookup {JSON}**
 # Resolves a curated page, an allowlisted URL, or a free-text query to a
@@ -133,7 +143,8 @@ TOOL_DETECT_FLAGS = re.DOTALL | re.MULTILINE | re.IGNORECASE
 # Matches the bare name too -- the handlers tolerate 0-4 asterisks, so
 # requiring `**name**` adjacency missed the unadorned form.
 ACTION_TOKEN_MENTION_RE = re.compile(
-    r"\*{0,4}\b(?:create_or_update_appeal|create_or_update_prior_auth)\b\*{0,4}",
+    r"\*{0,4}\b(?:create_or_update_appeal|create_or_update_prior_auth"
+    r"|generate_appeal_letter)\b\*{0,4}",
     re.IGNORECASE,
 )
 
@@ -146,6 +157,7 @@ ALL_TOOL_PATTERNS = [
     MEDICAID_GOV_LOOKUP_REGEX,
     CREATE_OR_UPDATE_APPEAL_REGEX,
     CREATE_OR_UPDATE_PRIOR_AUTH_REGEX,
+    GENERATE_APPEAL_LETTER_REGEX,
     FETCH_DOC_REGEX,
     USPSTF_LOOKUP_REGEX,
     LOOKUP_PA_REQUIREMENT_REGEX,

--- a/fighthealthinsurance/chat/tools/prior_auth_tool.py
+++ b/fighthealthinsurance/chat/tools/prior_auth_tool.py
@@ -13,7 +13,12 @@ from loguru import logger
 
 from fighthealthinsurance.utils import aget_related
 
-from .base_tool import BaseTool, is_safe_tool_field, settable_model_fields
+from .base_tool import (
+    BaseTool,
+    is_safe_tool_field,
+    parse_anchored_json_payload,
+    settable_model_fields,
+)
 from .patterns import CREATE_OR_UPDATE_PRIOR_AUTH_REGEX
 
 
@@ -84,10 +89,13 @@ class PriorAuthTool(BaseTool):
             await self.send_error_message("Cannot create prior auth: no chat context")
             return response_text, context
 
-        json_data = match.group(1).strip()
-
         try:
-            prior_auth_data = json.loads(json_data)
+            # Precise payload + span (see parse_anchored_json_payload): replace
+            # call_span, not the greedy match.group(0), so a second tool call
+            # in the same reply survives for its own handler.
+            prior_auth_data, call_span = parse_anchored_json_payload(
+                response_text, match
+            )
             await self.send_status_message(
                 "Processing prior authorization update/create data..."
             )
@@ -99,7 +107,7 @@ class PriorAuthTool(BaseTool):
                 await prior_auth.asave()
 
                 cleaned_response = response_text.replace(
-                    match.group(0),
+                    call_span,
                     f"I've created/updated [Prior Auth Request #{prior_auth.id}]"
                     f"({self.domain}/prior-auths/view/{prior_auth.id}) for you.",
                 )
@@ -110,7 +118,7 @@ class PriorAuthTool(BaseTool):
                 return cleaned_response, context
             else:
                 cleaned_response = response_text.replace(
-                    match.group(0),
+                    call_span,
                     "I couldn't create or update the prior authorization request.",
                 )
                 await self.send_status_message(
@@ -118,9 +126,12 @@ class PriorAuthTool(BaseTool):
                 )
                 return cleaned_response, context
 
-        except json.JSONDecodeError:
+        except json.JSONDecodeError as e:
+            # No payload content in the log: prior-auth JSON carries
+            # medical/claim details (PHI) -- sizes only.
             logger.warning(
-                f"Invalid JSON data in create_or_update_prior_auth token: {json_data}"
+                f"Invalid JSON in create_or_update_prior_auth token "
+                f"({len(match.group(1))} chars): {e.msg} at pos {e.pos}"
             )
             await self.send_status_message(
                 "Error processing prior auth data: Invalid JSON format."

--- a/fighthealthinsurance/chat/tools/prior_auth_tool.py
+++ b/fighthealthinsurance/chat/tools/prior_auth_tool.py
@@ -29,6 +29,10 @@ class PriorAuthTool(BaseTool):
 
     pattern = CREATE_OR_UPDATE_PRIOR_AUTH_REGEX
     detect_flags: int = re.DOTALL | re.MULTILINE | re.IGNORECASE
+    # ^...$-anchored pattern: the on-error strip needs MULTILINE too, or a
+    # call after a line of prose leaks raw tool syntax when execute raises
+    # (see AppealTool).
+    detect_all_flags: int = re.DOTALL | re.MULTILINE | re.IGNORECASE
     name = "Prior Auth"
 
     # Field name mappings for normalization

--- a/fighthealthinsurance/chat/tools/prior_auth_tool.py
+++ b/fighthealthinsurance/chat/tools/prior_auth_tool.py
@@ -18,6 +18,7 @@ from .base_tool import (
     is_safe_tool_field,
     parse_anchored_json_payload,
     settable_model_fields,
+    strip_anchored_calls,
 )
 from .patterns import CREATE_OR_UPDATE_PRIOR_AUTH_REGEX
 
@@ -39,6 +40,9 @@ class PriorAuthTool(BaseTool):
     # (see AppealTool).
     detect_all_flags: int = re.DOTALL | re.MULTILINE | re.IGNORECASE
     name = "Prior Auth"
+    # See AppealTool: exact-span replacement means each call in a reply
+    # needs its own pass.
+    max_calls_per_reply: int = 3
 
     # Field name mappings for normalization
     FIELD_MAPPINGS = {
@@ -63,6 +67,10 @@ class PriorAuthTool(BaseTool):
         super().__init__(send_status_message)
         self.send_error_message = send_error_message or send_status_message
         self.domain = domain
+
+    def strip_calls_on_error(self, response_text: str) -> str:
+        """Span-bounded on-error strip (see AppealTool.strip_calls_on_error)."""
+        return strip_anchored_calls(self, response_text)
 
     async def execute(
         self,
@@ -106,10 +114,13 @@ class PriorAuthTool(BaseTool):
                 await self._update_prior_auth_fields(prior_auth, prior_auth_data)
                 await prior_auth.asave()
 
+                # count=1: byte-identical duplicate calls each get their own
+                # pass via max_calls_per_reply.
                 cleaned_response = response_text.replace(
                     call_span,
                     f"I've created/updated [Prior Auth Request #{prior_auth.id}]"
                     f"({self.domain}/prior-auths/view/{prior_auth.id}) for you.",
+                    1,
                 )
                 await self.send_status_message(
                     f"Prior Auth Request #{prior_auth.id} has been created/updated "
@@ -120,6 +131,7 @@ class PriorAuthTool(BaseTool):
                 cleaned_response = response_text.replace(
                     call_span,
                     "I couldn't create or update the prior authorization request.",
+                    1,
                 )
                 await self.send_status_message(
                     "Failed to create or update prior authorization request."

--- a/fighthealthinsurance/chat/tools/prior_auth_tool.py
+++ b/fighthealthinsurance/chat/tools/prior_auth_tool.py
@@ -70,7 +70,14 @@ class PriorAuthTool(BaseTool):
 
     def strip_calls_on_error(self, response_text: str) -> str:
         """Span-bounded on-error strip (see AppealTool.strip_calls_on_error)."""
-        return strip_anchored_calls(self, response_text)
+        return strip_anchored_calls(
+            self,
+            response_text,
+            empty_fallback=(
+                "Sorry -- I hit a problem saving that prior authorization. "
+                "Could you tell me again what you'd like recorded?"
+            ),
+        )
 
     async def execute(
         self,

--- a/fighthealthinsurance/chat_interface.py
+++ b/fighthealthinsurance/chat_interface.py
@@ -1611,7 +1611,12 @@ class ChatInterface:
                     f"(use_external_models={self.use_external_models}, "
                     f"turn_timed_out={turn_timed_out})"
                 )
-                record_chat_turn("letter_fallback")
+                # Keep the turn-outcome labels a partition: a timed-out turn
+                # was already counted as "timeout" above. Rescues (including
+                # timed-out ones) remain visible via the reliability event
+                # below.
+                if not turn_timed_out:
+                    record_chat_turn("letter_fallback")
                 capture_reliability_event(
                     "chat_turn_letter_fallback_rescue",
                     chat_id=str(chat.id),
@@ -1639,10 +1644,14 @@ class ChatInterface:
                     f"from [Appeal #{letter_appeal.id}]"
                     f"(/appeals/{letter_appeal.id})."
                 )
+            # Sizes only -- the user's message is PHI and must not be
+            # written to the logs (same rule as the debug_llm logging above).
             logger.error(
-                f"Failed to generate response for user_message: '{user_message}' in chat {chat.id} "
-                f"after trying all models. use_external_models={self.use_external_models} "
-                f"letter_request={letter_request}"
+                f"Failed to generate a response in chat {chat.id} after "
+                f"trying all models "
+                f"(message_chars={len(user_message or '')}, "
+                f"use_external_models={self.use_external_models}, "
+                f"letter_request={letter_request})"
             )
             if not turn_timed_out:
                 record_chat_turn("failed")

--- a/fighthealthinsurance/chat_interface.py
+++ b/fighthealthinsurance/chat_interface.py
@@ -211,6 +211,11 @@ class ChatInterface:
         # Per-session cap for medicaid_gov_lookup, kept out here because the
         # tool is rebuilt every turn (same shape as _doc_fetch_count).
         self._medicaid_gov_lookup_count: list[int] = [0]
+        # monotonic deadline of the turn in flight (set by handle_chat_message
+        # just before its wait_for). Lets the letter tool clamp its generation
+        # deadline to the time actually left in the turn -- see
+        # _remaining_letter_deadline. None outside a budgeted turn.
+        self._turn_deadline: Optional[float] = None
 
     @staticmethod
     def _append_to_history(chat, role: str, content: str):
@@ -680,6 +685,7 @@ class ChatInterface:
             self.send_status_message,
             self.send_error_message,
             use_external=self.use_external_models,
+            deadline_seconds=self._remaining_letter_deadline(),
         )
         response_text, context, _ = await generate_letter_tool.handle(
             response_text, context, chat=chat
@@ -1376,6 +1382,10 @@ class ChatInterface:
         # client showing a spinner forever.
         turn_budget = _env_float("FHI_CHAT_TURN_BUDGET", 150.0)
         turn_timed_out = False
+        # Recorded so the letter tool can clamp its generation deadline to
+        # what is actually left of this budget (see
+        # _remaining_letter_deadline).
+        self._turn_deadline = time.monotonic() + turn_budget
         heartbeat_task = asyncio.create_task(self._turn_heartbeat())
         try:
             response_text, context_part = await asyncio.wait_for(
@@ -1564,9 +1574,26 @@ class ChatInterface:
             # served straight from the DB -- so "every chat model failed"
             # does not mean the letter is out of reach.
             fallback_reply: Optional[str] = None
+            letter_appeal = None
             letter_request = looks_like_letter_request(user_message)
             if letter_request:
-                fallback_reply = await self._attempt_letter_fallback_reply()
+                # One lookup for both the fallback attempt and the
+                # appeal-page link in the error message below.
+                try:
+                    letter_appeal = await self._linked_appeal_for_letter_fallback()
+                except Exception:
+                    logger.opt(exception=True).warning(
+                        f"Could not look up linked appeal for chat {chat.id}"
+                    )
+                if letter_appeal:
+                    fallback_reply = await self._attempt_letter_fallback_reply(
+                        letter_appeal
+                    )
+                else:
+                    logger.info(
+                        f"Chat {chat.id}: no letter-capable linked appeal; "
+                        f"skipping letter fallback"
+                    )
             if fallback_reply:
                 try:
                     self.chat = chat = await apersist_chat_turn(
@@ -1606,13 +1633,12 @@ class ChatInterface:
                     "You can enable 'Use backup models' in settings to allow fallback to "
                     "additional model providers when our primary models are unavailable."
                 )
-            if letter_request:
-                appeal_link = await self._linked_appeal_link()
-                if appeal_link:
-                    err_msg += (
-                        f" You can also generate your appeal letter directly "
-                        f"from {appeal_link}."
-                    )
+            if letter_appeal:
+                err_msg += (
+                    f" You can also generate your appeal letter directly "
+                    f"from [Appeal #{letter_appeal.id}]"
+                    f"(/appeals/{letter_appeal.id})."
+                )
             logger.error(
                 f"Failed to generate response for user_message: '{user_message}' in chat {chat.id} "
                 f"after trying all models. use_external_models={self.use_external_models} "
@@ -1643,40 +1669,36 @@ class ChatInterface:
             return None
         return appeal
 
-    async def _linked_appeal_link(self) -> Optional[str]:
-        """Markdown link to the chat's letter-capable linked appeal, or None.
-        Used to point the user at the appeal page when even the letter
-        fallback couldn't deliver."""
-        try:
-            appeal = await self._linked_appeal_for_letter_fallback()
-        except Exception:
-            logger.opt(exception=True).debug(
-                f"Could not look up linked appeal for chat {self.chat.id}"
-            )
-            return None
-        if not appeal:
-            return None
-        return f"[Appeal #{appeal.id}](/appeals/{appeal.id})"
+    def _remaining_letter_deadline(self) -> Optional[float]:
+        """Letter-generation deadline clamped to the turn budget's remainder.
 
-    async def _attempt_letter_fallback_reply(self) -> Optional[str]:
+        Without the clamp, a letter drafted near the budget's end was
+        cancelled at the wait_for timeout -- the bridge thread kept burning
+        model quota on a drain nobody would read, the finished letter was
+        discarded unsaved, and the total-failure fallback then re-generated
+        it from scratch. The margin leaves room to persist and deliver the
+        reply; the floor keeps a near-exhausted turn's attempt cheap (the
+        pipeline degrades to its static templates almost immediately).
+        Returns None outside a budgeted turn (e.g. direct tool tests),
+        letting the pipeline's env default apply.
+        """
+        if self._turn_deadline is None:
+            return None
+        remaining = self._turn_deadline - time.monotonic() - 15.0
+        default = _env_float("FHI_CHAT_LETTER_DEADLINE", 75.0)
+        return max(10.0, min(default, remaining))
+
+    async def _attempt_letter_fallback_reply(self, appeal) -> Optional[str]:
         """Draft the requested appeal letter after a total chat-model failure.
 
-        Serves an existing ProposedAppeal first (a DB read is the one step
-        guaranteed to work while models are down), then runs a bounded
-        appeal-pipeline generation. Requires a chat-linked appeal whose
-        denial has substance -- with no context, generation would only hand
-        the user a letter of blanks. Never raises: the caller still owes the
-        user an error frame when this returns None.
+        ``appeal`` is the letter-capable linked appeal the caller already
+        looked up. Serves an existing ProposedAppeal first (a DB read is the
+        one step guaranteed to work while models are down), then runs a
+        bounded appeal-pipeline generation. Never raises: the caller still
+        owes the user an error frame when this returns None.
         """
         chat = self.chat
         try:
-            appeal = await self._linked_appeal_for_letter_fallback()
-            if not appeal:
-                logger.info(
-                    f"Chat {chat.id}: no letter-capable linked appeal; "
-                    f"skipping letter fallback"
-                )
-                return None
             await self.send_status_message(
                 "Our chat models are having trouble right now -- drafting "
                 "your appeal letter through the appeal generator instead..."
@@ -1699,14 +1721,22 @@ class ChatInterface:
                 heartbeat_task.cancel()
             if not drafted:
                 return None
-            # Only claim the letter is on the appeal when the save succeeded.
-            saved_note = (
-                f"It's saved to [Appeal #{appeal.id}](/appeals/{appeal.id})."
-                if drafted.saved_to_appeal
-                else f"I couldn't attach it to [Appeal #{appeal.id}]"
-                f"(/appeals/{appeal.id}) just now, so please copy it from "
-                f"this chat."
-            )
+            # Word the appeal-row relationship honestly: saved, deliberately
+            # left alone (it already had a real letter), or failed to save.
+            appeal_link = f"[Appeal #{appeal.id}](/appeals/{appeal.id})"
+            if drafted.saved_to_appeal:
+                saved_note = f"It's saved to {appeal_link}."
+            elif drafted.preserved_existing:
+                saved_note = (
+                    f"{appeal_link} already has a saved letter, so I've left "
+                    f"that one untouched -- copy this draft from the chat if "
+                    f"you prefer it."
+                )
+            else:
+                saved_note = (
+                    f"I couldn't attach it to {appeal_link} just now, so "
+                    f"please copy it from this chat."
+                )
             return (
                 f"Our chat models are having trouble right now, so I drafted "
                 f"your appeal letter with our dedicated appeal generator "

--- a/fighthealthinsurance/chat_interface.py
+++ b/fighthealthinsurance/chat_interface.py
@@ -1686,7 +1686,7 @@ class ChatInterface:
             # on the socket for the user (and any idle-reaping proxy).
             heartbeat_task = asyncio.create_task(self._turn_heartbeat())
             try:
-                letter = await draft_letter_for_chat(
+                drafted = await draft_letter_for_chat(
                     appeal=appeal,
                     denial=appeal.for_denial,
                     use_external=self.use_external_models,
@@ -1697,14 +1697,21 @@ class ChatInterface:
                 )
             finally:
                 heartbeat_task.cancel()
-            if not letter:
+            if not drafted:
                 return None
+            # Only claim the letter is on the appeal when the save succeeded.
+            saved_note = (
+                f"It's saved to [Appeal #{appeal.id}](/appeals/{appeal.id})."
+                if drafted.saved_to_appeal
+                else f"I couldn't attach it to [Appeal #{appeal.id}]"
+                f"(/appeals/{appeal.id}) just now, so please copy it from "
+                f"this chat."
+            )
             return (
                 f"Our chat models are having trouble right now, so I drafted "
                 f"your appeal letter with our dedicated appeal generator "
-                f"instead. It's saved to [Appeal #{appeal.id}]"
-                f"(/appeals/{appeal.id}). Here's the draft -- please review "
-                f"the details before sending:\n\n---\n\n{letter}"
+                f"instead. {saved_note} Here's the draft -- please review "
+                f"the details before sending:\n\n---\n\n{drafted.text}"
             )
         except Exception as e:
             logger.opt(exception=True).warning(

--- a/fighthealthinsurance/chat_interface.py
+++ b/fighthealthinsurance/chat_interface.py
@@ -61,6 +61,7 @@ from fighthealthinsurance.chat.tools import (
     ClinicalTrialsTool,
     DocFetcherTool,
     FinancialAssistanceTool,
+    GenerateAppealLetterTool,
     MedicaidEligibilityTool,
     MedicaidGovLookupTool,
     MedicaidInfoTool,
@@ -69,6 +70,11 @@ from fighthealthinsurance.chat.tools import (
     PubMedTool,
     RxNormLookupTool,
     USPSTFLookupTool,
+)
+from fighthealthinsurance.chat.appeal_letter_generator import (
+    denial_has_letter_context,
+    draft_letter_for_chat,
+    looks_like_letter_request,
 )
 from fighthealthinsurance.extralink_context_helper import ExtraLinkContextHelper
 from fighthealthinsurance.rag_client import get_rag_context_for_denial
@@ -661,9 +667,21 @@ class ChatInterface:
             user_message_for_scoring=scoring_message,
         )
 
-        # Non-recursive tools: appeal, prior auth
+        # Non-recursive tools: appeal, appeal letter, prior auth
         appeal_tool = AppealTool(self.send_status_message, self.send_error_message)
         response_text, context, _ = await appeal_tool.handle(
+            response_text, context, chat=chat
+        )
+
+        # After AppealTool on purpose: when a reply carries both calls, the
+        # field updates from create_or_update_appeal land first and the
+        # generated letter (which reads them) wins the appeal_text.
+        generate_letter_tool = GenerateAppealLetterTool(
+            self.send_status_message,
+            self.send_error_message,
+            use_external=self.use_external_models,
+        )
+        response_text, context, _ = await generate_letter_tool.handle(
             response_text, context, chat=chat
         )
 
@@ -1535,6 +1553,47 @@ class ChatInterface:
                 logger.opt(exception=True).error(
                     f"Could not persist user message for failed turn in chat {chat.id}"
                 )
+
+            # Letter-draft rescue: when the failed turn was asking us to
+            # draft the appeal letter and the chat is linked to an appeal
+            # with real denial context, route the request to the dedicated
+            # appeal-generation pipeline instead of erroring out. It fails
+            # differently from chat (no repeat-rejection scoring, its own
+            # backend ladder), its specialized static templates need no
+            # model at all, and a precomputed ProposedAppeal reserve is
+            # served straight from the DB -- so "every chat model failed"
+            # does not mean the letter is out of reach.
+            fallback_reply: Optional[str] = None
+            letter_request = looks_like_letter_request(user_message)
+            if letter_request:
+                fallback_reply = await self._attempt_letter_fallback_reply()
+            if fallback_reply:
+                try:
+                    self.chat = chat = await apersist_chat_turn(
+                        chat,
+                        new_messages=[{"role": "assistant", "content": fallback_reply}],
+                    )
+                except Exception:
+                    logger.opt(exception=True).warning(
+                        f"Could not persist letter-fallback reply for chat "
+                        f"{chat.id}; delivering it unpersisted"
+                    )
+                logger.warning(
+                    f"Chat {chat.id}: all chat models failed for a letter-draft "
+                    f"request but the appeal-generator fallback delivered "
+                    f"(use_external_models={self.use_external_models}, "
+                    f"turn_timed_out={turn_timed_out})"
+                )
+                record_chat_turn("letter_fallback")
+                capture_reliability_event(
+                    "chat_turn_letter_fallback_rescue",
+                    chat_id=str(chat.id),
+                    use_external_models=self.use_external_models,
+                    turn_timed_out=turn_timed_out,
+                )
+                await self.send_message_to_client(fallback_reply)
+                return
+
             # Provide more helpful error message based on context
             err_msg = (
                 "Sorry, all available models (including backup models) are currently "
@@ -1547,9 +1606,17 @@ class ChatInterface:
                     "You can enable 'Use backup models' in settings to allow fallback to "
                     "additional model providers when our primary models are unavailable."
                 )
+            if letter_request:
+                appeal_link = await self._linked_appeal_link()
+                if appeal_link:
+                    err_msg += (
+                        f" You can also generate your appeal letter directly "
+                        f"from {appeal_link}."
+                    )
             logger.error(
                 f"Failed to generate response for user_message: '{user_message}' in chat {chat.id} "
-                f"after trying all models. use_external_models={self.use_external_models}"
+                f"after trying all models. use_external_models={self.use_external_models} "
+                f"letter_request={letter_request}"
             )
             if not turn_timed_out:
                 record_chat_turn("failed")
@@ -1558,8 +1625,92 @@ class ChatInterface:
                 chat_id=str(chat.id),
                 use_external_models=self.use_external_models,
                 message_chars=len(user_message or ""),
+                letter_fallback_attempted=letter_request,
             )
             await self.send_error_message(err_msg)
+
+    async def _linked_appeal_for_letter_fallback(self):
+        """The chat's linked appeal (with denial preloaded) if its denial
+        carries enough context to draft a letter from, else None."""
+        appeal = (
+            await Appeal.objects.select_related("for_denial")
+            .filter(chat=self.chat)
+            .afirst()
+        )
+        if not appeal or not appeal.for_denial:
+            return None
+        if not denial_has_letter_context(appeal.for_denial):
+            return None
+        return appeal
+
+    async def _linked_appeal_link(self) -> Optional[str]:
+        """Markdown link to the chat's letter-capable linked appeal, or None.
+        Used to point the user at the appeal page when even the letter
+        fallback couldn't deliver."""
+        try:
+            appeal = await self._linked_appeal_for_letter_fallback()
+        except Exception:
+            logger.opt(exception=True).debug(
+                f"Could not look up linked appeal for chat {self.chat.id}"
+            )
+            return None
+        if not appeal:
+            return None
+        return f"[Appeal #{appeal.id}](/appeals/{appeal.id})"
+
+    async def _attempt_letter_fallback_reply(self) -> Optional[str]:
+        """Draft the requested appeal letter after a total chat-model failure.
+
+        Serves an existing ProposedAppeal first (a DB read is the one step
+        guaranteed to work while models are down), then runs a bounded
+        appeal-pipeline generation. Requires a chat-linked appeal whose
+        denial has substance -- with no context, generation would only hand
+        the user a letter of blanks. Never raises: the caller still owes the
+        user an error frame when this returns None.
+        """
+        chat = self.chat
+        try:
+            appeal = await self._linked_appeal_for_letter_fallback()
+            if not appeal:
+                logger.info(
+                    f"Chat {chat.id}: no letter-capable linked appeal; "
+                    f"skipping letter fallback"
+                )
+                return None
+            await self.send_status_message(
+                "Our chat models are having trouble right now -- drafting "
+                "your appeal letter through the appeal generator instead..."
+            )
+            # The turn's own heartbeat was cancelled when generation failed;
+            # the fallback can run for another minute, so keep frames moving
+            # on the socket for the user (and any idle-reaping proxy).
+            heartbeat_task = asyncio.create_task(self._turn_heartbeat())
+            try:
+                letter = await draft_letter_for_chat(
+                    appeal=appeal,
+                    denial=appeal.for_denial,
+                    use_external=self.use_external_models,
+                    prefer_existing=True,
+                    deadline_seconds=_env_float(
+                        "FHI_CHAT_LETTER_FALLBACK_DEADLINE", 60.0
+                    ),
+                )
+            finally:
+                heartbeat_task.cancel()
+            if not letter:
+                return None
+            return (
+                f"Our chat models are having trouble right now, so I drafted "
+                f"your appeal letter with our dedicated appeal generator "
+                f"instead. It's saved to [Appeal #{appeal.id}]"
+                f"(/appeals/{appeal.id}). Here's the draft -- please review "
+                f"the details before sending:\n\n---\n\n{letter}"
+            )
+        except Exception as e:
+            logger.opt(exception=True).warning(
+                f"Letter fallback failed for chat {chat.id}: {e}"
+            )
+            return None
 
     async def replay_chat_history(self):
         """Sends the existing chat history to the client, minus internal

--- a/fighthealthinsurance/exec.py
+++ b/fighthealthinsurance/exec.py
@@ -67,12 +67,17 @@ cleaner_executor = ThreadPoolExecutor(
 # Chat-driven appeal-letter drains (chat/appeal_letter_generator): each one
 # can hold a thread for up to its generation deadline (~75s), and a
 # degraded-model period -- exactly when the letter fallback fires -- can
-# start many at once. A small dedicated pool caps that concurrency so the
-# drains can't crowd the shared bridge_executor's short hops (websocket
-# consumers' DB bridges included). Same deadlock posture as bridge_executor:
-# these tasks block ON model futures, and nothing a model call depends on
-# runs here.
+# start many at once. A dedicated pool caps that concurrency so the drains
+# can't crowd the shared bridge_executor's short hops (websocket consumers'
+# DB bridges included), and doubles as backpressure on the ML backends.
+# Sized for burst headroom rather than the minimum, because the cap is also
+# a QUEUE: the callers' deadlines are absolute and include time spent
+# waiting here (see generate_letter_for_denial), so a queued drain that is
+# already past its deadline exits at once instead of holding a thread --
+# but a too-small pool would still make live requests wait behind
+# abandoned ones. Same deadlock posture as bridge_executor: these tasks
+# block ON model futures, and nothing a model call depends on runs here.
 letter_executor = ThreadPoolExecutor(
-    max_workers=_pool_size("FHI_LETTER_EXECUTOR_WORKERS", 4),
+    max_workers=_pool_size("FHI_LETTER_EXECUTOR_WORKERS", 8),
     thread_name_prefix="fhi-letter",
 )

--- a/fighthealthinsurance/exec.py
+++ b/fighthealthinsurance/exec.py
@@ -63,3 +63,16 @@ cleaner_executor = ThreadPoolExecutor(
     max_workers=_pool_size("FHI_CLEANER_EXECUTOR_WORKERS", 8),
     thread_name_prefix="fhi-cleaner",
 )
+
+# Chat-driven appeal-letter drains (chat/appeal_letter_generator): each one
+# can hold a thread for up to its generation deadline (~75s), and a
+# degraded-model period -- exactly when the letter fallback fires -- can
+# start many at once. A small dedicated pool caps that concurrency so the
+# drains can't crowd the shared bridge_executor's short hops (websocket
+# consumers' DB bridges included). Same deadlock posture as bridge_executor:
+# these tasks block ON model futures, and nothing a model call depends on
+# runs here.
+letter_executor = ThreadPoolExecutor(
+    max_workers=_pool_size("FHI_LETTER_EXECUTOR_WORKERS", 4),
+    thread_name_prefix="fhi-letter",
+)

--- a/fighthealthinsurance/ml/ml_metrics.py
+++ b/fighthealthinsurance/ml/ml_metrics.py
@@ -43,7 +43,9 @@ ML_CALL_SECONDS = Histogram(
 
 CHAT_TURNS_TOTAL = Counter(
     "fhi_chat_turns_total",
-    "Chat turns by outcome (ok, failed, timeout).",
+    "Chat turns by outcome (ok, failed, timeout, letter_fallback -- a "
+    "failed/timed-out turn rescued by the appeal-generator letter fallback; "
+    "a timed-out rescue counts under both timeout and letter_fallback).",
     labelnames=("outcome",),
 )
 
@@ -101,7 +103,8 @@ def record_ml_failure(model: object, reason: str) -> None:
 
 
 def record_chat_turn(outcome: str) -> None:
-    """Record a chat turn outcome (ok / failed / timeout). Never raises."""
+    """Record a chat turn outcome (ok / failed / timeout / letter_fallback).
+    Never raises."""
     try:
         CHAT_TURNS_TOTAL.labels(outcome=outcome).inc()
     except Exception:  # pragma: no cover

--- a/fighthealthinsurance/ml/ml_metrics.py
+++ b/fighthealthinsurance/ml/ml_metrics.py
@@ -44,8 +44,11 @@ ML_CALL_SECONDS = Histogram(
 CHAT_TURNS_TOTAL = Counter(
     "fhi_chat_turns_total",
     "Chat turns by outcome (ok, failed, timeout, letter_fallback -- a "
-    "failed/timed-out turn rescued by the appeal-generator letter fallback; "
-    "a timed-out rescue counts under both timeout and letter_fallback).",
+    "failed turn rescued by the appeal-generator letter fallback). The "
+    "labels partition turns: a timed-out turn counts only as timeout even "
+    "when the fallback then rescued it (rescues, timed-out ones included, "
+    "are reported via the chat_turn_letter_fallback_rescue reliability "
+    "event).",
     labelnames=("outcome",),
 )
 

--- a/fighthealthinsurance/ml/ml_metrics.py
+++ b/fighthealthinsurance/ml/ml_metrics.py
@@ -156,6 +156,10 @@ class ExecutorQueueCollector(Collector):
                 "interactive": fhi_exec.executor,
                 "background": fhi_exec.background_executor,
                 "pubmed": fhi_exec.pubmed_executor,
+                # Sampled because this pool exists to CAP concurrency: a
+                # standing queue here is the signal that chat letter drains
+                # are waiting on each other (see exec.letter_executor).
+                "letter": fhi_exec.letter_executor,
             }
             queued = GaugeMetricFamily(
                 "fhi_executor_queued_tasks",

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -1237,6 +1237,10 @@ And if we had the denial text in the previous case we would instead do: **create
 Or to create a prior auth for the same fake patient with the prior auth text "prior text auth goes here" you could write: **create_or_update_prior_auth**{"patient_name": "Not A Real Person", "text": "prior text auth goes here", "diagnosis": "high risk", "procedure": "prep"}
 (note those two are just examples, not the actual prior auth or appeal).
 IMPORTANT: Do NOT ask the user for the patient's name. The patient's name is provided automatically by the system when creating appeals or prior auth requests. You can use a placeholder like "Patient Name" in examples — the system will fill it in.
+
+**Drafting the appeal letter itself**: When the user asks you to actually draft/write/generate the appeal letter (e.g. "please draft the letter", "write my appeal"), do NOT write the whole letter yourself and do NOT put a letter you wrote into create_or_update_appeal. Instead emit, on its own line (same line-format rules as above):
+**generate_appeal_letter**{"procedure": "...", "diagnosis": "...", "denial_text": "...", "insurance_company": "...", "medical_reason": "..."}
+Include whichever fields you know from the conversation — all are optional, but include at least one of procedure, diagnosis, or denial_text (ask the user if you know none of them). "medical_reason" is a short summary of why the care is medically necessary, from what the user told you. The system routes this to our dedicated appeal-letter generator (appeal-tuned models plus curated legal/clinical templates), creates or updates the appeal record, and shows the user the drafted letter with a link. Use create_or_update_appeal only for setting/correcting fields or when the user hands you exact letter text to save; use generate_appeal_letter to produce the letter. Don't emit both in the same message unless the user asked for both.
 """
 
         # Conditionally include logged-in instructions

--- a/fighthealthinsurance/models.py
+++ b/fighthealthinsurance/models.py
@@ -3908,8 +3908,10 @@ class ModelCallAttempt(models.Model):
         max_length=64, blank=True, default="", db_index=True
     )
     # "live" for a user-facing generation, "speculative" for the background
-    # precompute. Without this the two interleave on the same denial and a
-    # failed live run can't be read apart from the precompute's attempts.
+    # precompute, "chat" for a letter drafted from the chat interface (the
+    # generate_appeal_letter tool / total-failure fallback). Without this the
+    # runs interleave on the same denial and a failed live run can't be read
+    # apart from the other flows' attempts.
     run_kind = models.CharField(
         max_length=32, blank=True, default="live", db_index=True
     )

--- a/fighthealthinsurance/settings.py
+++ b/fighthealthinsurance/settings.py
@@ -1014,11 +1014,13 @@ class Prod(Base):
             # single thread_sensitive sync lane (1) + exec.executor (24
             # interactive) + background_executor (8) + pubmed_executor (4)
             # + bridge_executor (32, runs ORM-touching generation bridges)
-            # = 69, PLUS one thread-sensitive lane per live WebSocket
+            # + letter_executor (8, chat-driven appeal-letter drains)
+            # = 77, PLUS one thread-sensitive lane per live WebSocket
             # (websockets.PerConnectionThreadSensitiveMixin). The historical
             # default of 40 therefore NO LONGER covers a fully busy worker:
             # before re-enabling pooling, set PG_POOL_MAX_SIZE with the
-            # bridge pool and expected concurrent sockets in the budget, or
+            # bridge/letter pools and expected concurrent sockets in the
+            # budget, or
             # accept pool-wait throttling under peak. (Keep in sync with
             # exec.py's pool sizes / their FHI_*_EXECUTOR_WORKERS overrides,
             # and remember cluster-wide max_connections must cover

--- a/tests/async/test_chat_failure_persistence.py
+++ b/tests/async/test_chat_failure_persistence.py
@@ -10,78 +10,20 @@ Also covers the transactional persistence helper directly: two interleaved
 writers over the same chat row must not lose each other's messages.
 """
 
-import contextlib
-import typing
-from unittest.mock import AsyncMock, patch
-
-from asgiref.sync import sync_to_async
-from django.contrib.auth import get_user_model
 from loguru import logger
 from rest_framework.test import APITestCase
 
 from fighthealthinsurance.chat.chat_persistence import apersist_chat_turn
 from fighthealthinsurance.chat_interface import ChatInterface
-from fighthealthinsurance.models import OngoingChat, ProfessionalUser
-from tests.sync.mock_chat_model import MockChatModel
+from fighthealthinsurance.models import OngoingChat
 
-if typing.TYPE_CHECKING:
-    from django.contrib.auth.models import User
-else:
-    User = get_user_model()
-
-
-@contextlib.contextmanager
-def _llm_call_fails(side_effect):
-    """Route model selection to a mock backend and make the LLM call fail."""
-    mock_model = MockChatModel()
-    with contextlib.ExitStack() as stack:
-        get_backends = stack.enter_context(
-            patch("fighthealthinsurance.ml.ml_router.MLRouter.get_chat_backends")
-        )
-        get_backends.return_value = [mock_model]
-        get_fallback = stack.enter_context(
-            patch(
-                "fighthealthinsurance.ml.ml_router.MLRouter.get_chat_backends_with_fallback"
-            )
-        )
-        get_fallback.return_value = ([mock_model], [])
-        stack.enter_context(
-            patch(
-                "fighthealthinsurance.chat_interface.fire_and_forget_in_new_threadpool",
-                new_callable=AsyncMock,
-            )
-        )
-        stack.enter_context(
-            patch.object(
-                ChatInterface,
-                "_call_llm_with_actions",
-                new=AsyncMock(side_effect=side_effect),
-            )
-        )
-        yield
-
-
-async def _make_professional_chat(username, npi):
-    user = await sync_to_async(User.objects.create_user)(
-        username=username, password="testpass", email=f"{username}@example.com"
-    )
-    professional = await sync_to_async(ProfessionalUser.objects.create)(
-        user=user, active=True, npi_number=npi
-    )
-    chat = await sync_to_async(OngoingChat.objects.create)(
-        professional_user=professional,
-        chat_history=[],
-        summary_for_next_call=[],
-    )
-    return user, chat
-
-
-class _FrameRecorder:
-    def __init__(self):
-        self.frames = []
-
-    async def __call__(self, frame):
-        self.frames.append(frame)
+# Shared with the letter-fallback tests via chat_fixtures (tests/async is not
+# an importable package name, so the helpers cannot live in this module).
+from tests.chat_fixtures import (
+    FrameRecorder as _FrameRecorder,
+    llm_call_fails as _llm_call_fails,
+    make_professional_chat as _make_professional_chat,
+)
 
 
 class ChatFailurePersistenceTest(APITestCase):

--- a/tests/async/test_chat_letter_fallback.py
+++ b/tests/async/test_chat_letter_fallback.py
@@ -14,11 +14,12 @@ from rest_framework.test import APITestCase
 
 from fighthealthinsurance import common_view_logic
 from fighthealthinsurance.chat.appeal_letter_generator import (
+    DraftedLetter,
     draft_letter_for_chat,
     find_reserve_letter,
     generate_letter_for_denial,
 )
-from fighthealthinsurance.chat.tools import GenerateAppealLetterTool
+from fighthealthinsurance.chat.tools import AppealTool, GenerateAppealLetterTool
 from fighthealthinsurance.chat_interface import ChatInterface
 from fighthealthinsurance.generate_appeal import GeneratedAppeal
 from fighthealthinsurance.models import (
@@ -90,7 +91,7 @@ class ChatLetterFallbackTest(APITestCase):
     async def test_letter_request_rescued_by_letter_fallback(self):
         with patch(
             "fighthealthinsurance.chat_interface.draft_letter_for_chat",
-            new=AsyncMock(return_value=GENERATED_LETTER),
+            new=AsyncMock(return_value=DraftedLetter(GENERATED_LETTER, True)),
         ) as mock_draft:
             chat, appeal, _, recorder = await self._run_failing_turn(
                 "letterfall1", "9999920001", "Please go ahead and draft a letter."
@@ -110,7 +111,7 @@ class ChatLetterFallbackTest(APITestCase):
     async def test_letter_fallback_reply_is_persisted(self):
         with patch(
             "fighthealthinsurance.chat_interface.draft_letter_for_chat",
-            new=AsyncMock(return_value=GENERATED_LETTER),
+            new=AsyncMock(return_value=DraftedLetter(GENERATED_LETTER, True)),
         ):
             chat, _, _, _ = await self._run_failing_turn(
                 "letterfall2", "9999920002", "Please go ahead and draft a letter."
@@ -152,7 +153,7 @@ class ChatLetterFallbackTest(APITestCase):
     async def test_no_fallback_without_linked_appeal(self):
         with patch(
             "fighthealthinsurance.chat_interface.draft_letter_for_chat",
-            new=AsyncMock(return_value=GENERATED_LETTER),
+            new=AsyncMock(return_value=DraftedLetter(GENERATED_LETTER, True)),
         ) as mock_draft:
             chat, _, _, recorder = await self._run_failing_turn(
                 "letterfall4",
@@ -171,7 +172,7 @@ class ChatLetterFallbackTest(APITestCase):
     async def test_non_letter_request_skips_fallback_and_errors(self):
         with patch(
             "fighthealthinsurance.chat_interface.draft_letter_for_chat",
-            new=AsyncMock(return_value=GENERATED_LETTER),
+            new=AsyncMock(return_value=DraftedLetter(GENERATED_LETTER, True)),
         ) as mock_draft:
             chat, _, _, recorder = await self._run_failing_turn(
                 "letterfall5", "9999920005", "Why was my MRI claim denied?"
@@ -215,7 +216,7 @@ class GenerateAppealLetterToolTest(APITestCase):
         with patch(
             "fighthealthinsurance.chat.tools.generate_appeal_letter_tool."
             "draft_letter_for_chat",
-            new=AsyncMock(return_value=GENERATED_LETTER),
+            new=AsyncMock(return_value=DraftedLetter(GENERATED_LETTER, True)),
         ) as mock_draft:
             response, context, handled = await tool.handle(
                 response_text, "", chat=chat
@@ -242,7 +243,7 @@ class GenerateAppealLetterToolTest(APITestCase):
         with patch(
             "fighthealthinsurance.chat.tools.generate_appeal_letter_tool."
             "draft_letter_for_chat",
-            new=AsyncMock(return_value=GENERATED_LETTER),
+            new=AsyncMock(return_value=DraftedLetter(GENERATED_LETTER, True)),
         ) as mock_draft:
             response, _, handled = await tool.handle(
                 "**generate_appeal_letter**{}", "", chat=chat
@@ -389,10 +390,10 @@ class DraftLetterForChatTest(APITestCase):
             "generate_letter_for_denial",
             new=AsyncMock(return_value=generated),
         ):
-            letter = await draft_letter_for_chat(
+            drafted = await draft_letter_for_chat(
                 appeal=appeal, denial=denial, use_external=False
             )
-        self.assertEqual(letter, GENERATED_LETTER)
+        self.assertEqual(drafted, DraftedLetter(GENERATED_LETTER, True))
         fresh_appeal = await Appeal.objects.aget(id=appeal.id)
         self.assertEqual(fresh_appeal.appeal_text, GENERATED_LETTER)
         row = await ProposedAppeal.objects.aget(for_denial=denial)
@@ -406,10 +407,89 @@ class DraftLetterForChatTest(APITestCase):
         await ProposedAppeal.objects.acreate(
             appeal_text=RESERVE_LETTER, for_denial=denial
         )
-        letter = await draft_letter_for_chat(
+        drafted = await draft_letter_for_chat(
             appeal=appeal, denial=denial, use_external=False, prefer_existing=True
         )
-        self.assertEqual(letter, RESERVE_LETTER)
+        self.assertEqual(drafted.text, RESERVE_LETTER)
         self.assertEqual(
             await ProposedAppeal.objects.filter(for_denial=denial).acount(), 1
         )
+
+    async def test_failed_appeal_save_reported_not_hidden(self):
+        """A letter whose appeal save failed is still delivered, but flagged
+        so callers don't claim it was saved to the appeal."""
+        user, chat = await _make_professional_chat("draftpersist3", "9999940003")
+        appeal, denial = await _link_letter_appeal(chat, user)
+        await ProposedAppeal.objects.acreate(
+            appeal_text=RESERVE_LETTER, for_denial=denial
+        )
+        with patch.object(
+            Appeal, "asave", new=AsyncMock(side_effect=RuntimeError("db down"))
+        ):
+            drafted = await draft_letter_for_chat(
+                appeal=appeal, denial=denial, use_external=False, prefer_existing=True
+            )
+        self.assertEqual(drafted, DraftedLetter(RESERVE_LETTER, False))
+
+
+class PairedToolCallsTest(APITestCase):
+    """Two anchored tool calls in one reply must not swallow each other.
+
+    The greedy anchored patterns run under DOTALL, so before precise payload
+    extraction (parse_anchored_json_payload) the first handler's capture ran
+    through the second call's closing brace -- json failed and BOTH calls
+    were stripped. Handlers run in chat_interface order: AppealTool first,
+    then GenerateAppealLetterTool.
+    """
+
+    async def _run_both_tools(self, chat, response_text):
+        appeal_tool = AppealTool(AsyncMock(), AsyncMock())
+        response_text, context, _ = await appeal_tool.handle(
+            response_text, "", chat=chat
+        )
+        letter_tool = GenerateAppealLetterTool(AsyncMock(), AsyncMock())
+        with patch(
+            "fighthealthinsurance.chat.tools.generate_appeal_letter_tool."
+            "draft_letter_for_chat",
+            new=AsyncMock(return_value=DraftedLetter(GENERATED_LETTER, True)),
+        ) as mock_draft:
+            response_text, context, _ = await letter_tool.handle(
+                response_text, context, chat=chat
+            )
+        return response_text, mock_draft
+
+    async def test_appeal_then_letter_calls_both_run(self):
+        _, chat = await _make_professional_chat("paired1", "9999950001")
+        response = (
+            "Setting up your appeal first.\n"
+            '**create_or_update_appeal**{"procedure": "MRI", '
+            '"diagnosis": "chronic back pain"}\n'
+            "Now drafting the letter.\n"
+            '**generate_appeal_letter**{"insurance_company": "Acme Health"}'
+        )
+        result, mock_draft = await self._run_both_tools(chat, response)
+        mock_draft.assert_awaited_once()
+        self.assertNotIn("create_or_update_appeal", result)
+        self.assertNotIn("generate_appeal_letter", result)
+        # The prose between the calls survives both replacements.
+        self.assertIn("Now drafting the letter.", result)
+        self.assertIn(GENERATED_LETTER, result)
+        appeal = await Appeal.objects.select_related("for_denial").aget(chat=chat)
+        self.assertEqual(appeal.for_denial.procedure, "MRI")
+        self.assertEqual(appeal.for_denial.insurance_company, "Acme Health")
+
+    async def test_letter_then_appeal_calls_both_run(self):
+        _, chat = await _make_professional_chat("paired2", "9999950002")
+        response = (
+            '**generate_appeal_letter**{"procedure": "MRI"}\n'
+            "Also recording the diagnosis.\n"
+            '**create_or_update_appeal**{"diagnosis": "chronic back pain"}'
+        )
+        result, mock_draft = await self._run_both_tools(chat, response)
+        mock_draft.assert_awaited_once()
+        self.assertNotIn("create_or_update_appeal", result)
+        self.assertNotIn("generate_appeal_letter", result)
+        self.assertIn("Also recording the diagnosis.", result)
+        appeal = await Appeal.objects.select_related("for_denial").aget(chat=chat)
+        self.assertEqual(appeal.for_denial.procedure, "MRI")
+        self.assertEqual(appeal.for_denial.diagnosis, "chronic back pain")

--- a/tests/async/test_chat_letter_fallback.py
+++ b/tests/async/test_chat_letter_fallback.py
@@ -366,6 +366,22 @@ class FindReserveLetterTest(APITestCase):
         # The live row wins even though the speculative one is longer.
         self.assertEqual(found, RESERVE_LETTER)
 
+    async def test_junk_rows_cannot_evict_reserve_from_the_window(self):
+        """A pile of runt live drafts (a degraded-model period) must not fill
+        the bounded lookup window and hide the one deliverable reserve --
+        the runt filter runs in SQL before the slice."""
+        denial = await Denial.objects.acreate(
+            denial_text="denied", hashed_email=Denial.get_hashed_email("e@f.com")
+        )
+        for _ in range(12):
+            await ProposedAppeal.objects.acreate(
+                appeal_text="junk", for_denial=denial, speculative=False
+            )
+        await ProposedAppeal.objects.acreate(
+            appeal_text=RESERVE_LETTER, for_denial=denial, speculative=True
+        )
+        self.assertEqual(await find_reserve_letter(denial), RESERVE_LETTER)
+
     async def test_returns_none_when_no_deliverable_rows(self):
         denial = await Denial.objects.acreate(
             denial_text="denied", hashed_email=Denial.get_hashed_email("c@d.com")
@@ -414,6 +430,27 @@ class DraftLetterForChatTest(APITestCase):
         self.assertEqual(
             await ProposedAppeal.objects.filter(for_denial=denial).acount(), 1
         )
+
+    async def test_reserve_does_not_overwrite_existing_letter(self):
+        """A reserve draft must never clobber a real (possibly user-edited)
+        letter already on the appeal; it is delivered without saving."""
+        user, chat = await _make_professional_chat("draftpersist4", "9999940004")
+        appeal, denial = await _link_letter_appeal(chat, user)
+        edited = (
+            "My carefully hand-edited appeal letter about the MRI denial, "
+            "which must not be replaced by a stale precomputed draft."
+        )
+        appeal.appeal_text = edited
+        await appeal.asave()
+        await ProposedAppeal.objects.acreate(
+            appeal_text=RESERVE_LETTER, for_denial=denial
+        )
+        drafted = await draft_letter_for_chat(
+            appeal=appeal, denial=denial, use_external=False, prefer_existing=True
+        )
+        self.assertEqual(drafted, DraftedLetter(RESERVE_LETTER, False, True))
+        fresh = await Appeal.objects.aget(id=appeal.id)
+        self.assertEqual(fresh.appeal_text, edited)
 
     async def test_failed_appeal_save_reported_not_hidden(self):
         """A letter whose appeal save failed is still delivered, but flagged
@@ -493,3 +530,105 @@ class PairedToolCallsTest(APITestCase):
         appeal = await Appeal.objects.select_related("for_denial").aget(chat=chat)
         self.assertEqual(appeal.for_denial.procedure, "MRI")
         self.assertEqual(appeal.for_denial.diagnosis, "chronic back pain")
+
+
+class MultiCallAndErrorStripTest(APITestCase):
+    """Same-tool duplicates execute per call; error strips stay span-bounded."""
+
+    async def test_two_appeal_calls_both_apply(self):
+        """Each call of the same anchored tool gets its own pass -- neither
+        renders as raw syntax nor silently loses its field updates."""
+        _, chat = await _make_professional_chat("multicall1", "9999960001")
+        response = (
+            '**create_or_update_appeal**{"procedure": "MRI"}\n'
+            "Also recording:\n"
+            '**create_or_update_appeal**{"diagnosis": "chronic back pain"}'
+        )
+        tool = AppealTool(AsyncMock(), AsyncMock())
+        result, _, handled = await tool.handle(response, "", chat=chat)
+        self.assertTrue(handled)
+        self.assertNotIn("create_or_update_appeal", result)
+        self.assertIn("Also recording:", result)
+        appeal = await Appeal.objects.select_related("for_denial").aget(chat=chat)
+        self.assertEqual(appeal.for_denial.procedure, "MRI")
+        self.assertEqual(appeal.for_denial.diagnosis, "chronic back pain")
+
+    async def test_duplicate_letter_calls_draft_once_and_strip_stragglers(self):
+        """One letter per turn: the second call is stripped, not re-drafted."""
+        _, chat = await _make_professional_chat("multicall2", "9999960002")
+        response = (
+            '**generate_appeal_letter**{"procedure": "MRI"}\n'
+            "And again for luck:\n"
+            '**generate_appeal_letter**{"procedure": "MRI scan"}'
+        )
+        tool = GenerateAppealLetterTool(AsyncMock(), AsyncMock())
+        with patch(
+            "fighthealthinsurance.chat.tools.generate_appeal_letter_tool."
+            "draft_letter_for_chat",
+            new=AsyncMock(return_value=DraftedLetter(GENERATED_LETTER, True)),
+        ) as mock_draft:
+            result, _, handled = await tool.handle(response, "", chat=chat)
+        self.assertTrue(handled)
+        mock_draft.assert_awaited_once()
+        self.assertNotIn("generate_appeal_letter", result)
+        self.assertEqual(result.count(GENERATED_LETTER), 1)
+
+    async def test_appeal_tool_error_leaves_letter_call_intact(self):
+        """When AppealTool's execute blows up, the on-error strip must not
+        swallow the prose or the pending generate_appeal_letter call (the
+        old greedy re.sub deleted everything between the two calls)."""
+        _, chat = await _make_professional_chat("multicall3", "9999960003")
+        response = (
+            '**create_or_update_appeal**{"procedure": "MRI"}\n'
+            "Now drafting the letter.\n"
+            '**generate_appeal_letter**{"procedure": "MRI"}'
+        )
+        tool = AppealTool(AsyncMock(), AsyncMock())
+        with patch.object(
+            AppealTool,
+            "_get_or_create_appeal",
+            new=AsyncMock(side_effect=RuntimeError("db down")),
+        ):
+            result, _, handled = await tool.handle(response, "", chat=chat)
+        self.assertTrue(handled)
+        self.assertNotIn("create_or_update_appeal", result)
+        self.assertIn("Now drafting the letter.", result)
+        self.assertIn("generate_appeal_letter", result)
+
+
+class LetterDeadlineClampTest(APITestCase):
+    """The letter tool's deadline is clamped to the turn budget's remainder."""
+
+    def _interface(self):
+        from unittest.mock import MagicMock
+
+        return ChatInterface(
+            send_json_message_func=AsyncMock(), chat=MagicMock(), user=None
+        )
+
+    def test_none_outside_a_budgeted_turn(self):
+        self.assertIsNone(self._interface()._remaining_letter_deadline())
+
+    def test_clamped_to_remaining_budget(self):
+        import time as time_mod
+
+        interface = self._interface()
+        interface._turn_deadline = time_mod.monotonic() + 40.0
+        deadline = interface._remaining_letter_deadline()
+        # ~40s left minus the 15s margin, well under the 75s env default.
+        self.assertLess(deadline, 30.0)
+        self.assertGreater(deadline, 20.0)
+
+    def test_floored_when_budget_nearly_exhausted(self):
+        import time as time_mod
+
+        interface = self._interface()
+        interface._turn_deadline = time_mod.monotonic() + 1.0
+        self.assertEqual(interface._remaining_letter_deadline(), 10.0)
+
+    def test_capped_at_env_default_when_budget_is_ample(self):
+        import time as time_mod
+
+        interface = self._interface()
+        interface._turn_deadline = time_mod.monotonic() + 10_000.0
+        self.assertEqual(interface._remaining_letter_deadline(), 75.0)

--- a/tests/async/test_chat_letter_fallback.py
+++ b/tests/async/test_chat_letter_fallback.py
@@ -572,6 +572,8 @@ class MultiCallAndErrorStripTest(APITestCase):
         mock_draft.assert_awaited_once()
         self.assertNotIn("generate_appeal_letter", result)
         self.assertEqual(result.count(GENERATED_LETTER), 1)
+        # The dropped duplicate is acknowledged rather than vanishing.
+        self.assertIn("drafted one letter", result)
 
     async def test_calls_past_the_cap_are_stripped_not_leaked(self):
         """A reply with more calls than max_calls_per_reply executes the
@@ -594,6 +596,10 @@ class MultiCallAndErrorStripTest(APITestCase):
         self.assertEqual(appeal.for_denial.diagnosis, "chronic back pain")
         self.assertEqual(appeal.for_denial.insurance_company, "Acme Health")
         self.assertIsNone(appeal.for_denial.employer_name)
+        # The drop is stated, not silent: this text is what the user reads
+        # AND what the model sees as history, so an unannounced drop would
+        # leave both believing the update landed.
+        self.assertIn("hasn't been saved", result)
 
     async def test_appeal_tool_error_leaves_letter_call_intact(self):
         """When AppealTool's execute blows up, the on-error strip must not

--- a/tests/async/test_chat_letter_fallback.py
+++ b/tests/async/test_chat_letter_fallback.py
@@ -1,0 +1,415 @@
+"""A failed chat turn asking for a letter should still deliver a letter.
+
+When every chat model fails on a "please draft the letter" turn (the
+handle_chat_message total-failure branch), the appeal-generation pipeline is
+tried before giving up: an existing ProposedAppeal reserve is served straight
+from the DB, and otherwise a bounded make_appeals run drafts one. Also covers
+the generate_appeal_letter chat tool, which routes letter drafting to the
+same pipeline instead of having the chat model write the letter inline.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+from rest_framework.test import APITestCase
+
+from fighthealthinsurance import common_view_logic
+from fighthealthinsurance.chat.appeal_letter_generator import (
+    draft_letter_for_chat,
+    find_reserve_letter,
+    generate_letter_for_denial,
+)
+from fighthealthinsurance.chat.tools import GenerateAppealLetterTool
+from fighthealthinsurance.chat_interface import ChatInterface
+from fighthealthinsurance.generate_appeal import GeneratedAppeal
+from fighthealthinsurance.models import (
+    Appeal,
+    Denial,
+    OngoingChat,
+    ProposedAppeal,
+)
+
+# Failure plumbing shared with the failed-turn persistence tests: routes model
+# selection to a mock backend and makes the chat LLM pass fail.
+from tests.chat_fixtures import (
+    FrameRecorder as _FrameRecorder,
+    llm_call_fails as _llm_call_fails,
+    make_professional_chat as _make_professional_chat,
+)
+
+# Long enough to pass is_real_appeal and the reserve length preference.
+RESERVE_LETTER = (
+    "Dear Insurance Company, I am writing to formally appeal the denial of "
+    "the MRI ordered for my chronic back pain. The imaging is medically "
+    "necessary to evaluate ongoing symptoms that have not improved with "
+    "conservative treatment. Please reverse the denial. Sincerely, Patient"
+)
+
+GENERATED_LETTER = (
+    "Dear Acme Health, I appeal the denial of claim 123. The requested "
+    "procedure is medically necessary for the diagnosis documented in the "
+    "attached records, and the denial should be overturned. Sincerely, Me"
+)
+
+
+async def _link_letter_appeal(chat, user, **denial_fields):
+    """Create a Denial with letter context and an Appeal linked to the chat."""
+    fields = {
+        "denial_text": "Your MRI claim was denied as not medically necessary.",
+        "procedure": "MRI",
+        "diagnosis": "chronic back pain",
+        "hashed_email": Denial.get_hashed_email(user.email),
+    }
+    fields.update(denial_fields)
+    denial = await Denial.objects.acreate(**fields)
+    appeal = await Appeal.objects.acreate(
+        chat=chat,
+        for_denial=denial,
+        hashed_email=fields["hashed_email"],
+    )
+    return appeal, denial
+
+
+class ChatLetterFallbackTest(APITestCase):
+    """The total-failure branch routes letter requests to the appeal pipeline."""
+
+    async def _run_failing_turn(self, username, npi, message, link_appeal=True):
+        user, chat = await _make_professional_chat(username, npi)
+        appeal = denial = None
+        if link_appeal:
+            appeal, denial = await _link_letter_appeal(chat, user)
+        recorder = _FrameRecorder()
+        interface = ChatInterface(
+            send_json_message_func=recorder,
+            chat=chat,
+            user=user,
+        )
+        with _llm_call_fails(lambda *a, **k: (None, None)):
+            await interface.handle_chat_message(message)
+        return chat, appeal, denial, recorder
+
+    async def test_letter_request_rescued_by_letter_fallback(self):
+        with patch(
+            "fighthealthinsurance.chat_interface.draft_letter_for_chat",
+            new=AsyncMock(return_value=GENERATED_LETTER),
+        ) as mock_draft:
+            chat, appeal, _, recorder = await self._run_failing_turn(
+                "letterfall1", "9999920001", "Please go ahead and draft a letter."
+            )
+        mock_draft.assert_awaited_once()
+        self.assertTrue(mock_draft.await_args.kwargs["prefer_existing"])
+        # The turn delivers the letter as an assistant reply, not an error.
+        error_frames = [f for f in recorder.frames if "error" in f]
+        self.assertEqual(error_frames, [])
+        assistant_frames = [
+            f for f in recorder.frames if f.get("role") == "assistant"
+        ]
+        self.assertEqual(len(assistant_frames), 1)
+        self.assertIn(GENERATED_LETTER, assistant_frames[0]["content"])
+        self.assertIn(f"/appeals/{appeal.id}", assistant_frames[0]["content"])
+
+    async def test_letter_fallback_reply_is_persisted(self):
+        with patch(
+            "fighthealthinsurance.chat_interface.draft_letter_for_chat",
+            new=AsyncMock(return_value=GENERATED_LETTER),
+        ):
+            chat, _, _, _ = await self._run_failing_turn(
+                "letterfall2", "9999920002", "Please go ahead and draft a letter."
+            )
+        fresh = await OngoingChat.objects.aget(id=chat.id)
+        assistant_msgs = [
+            m for m in (fresh.chat_history or []) if m.get("role") == "assistant"
+        ]
+        self.assertEqual(len(assistant_msgs), 1)
+        self.assertIn(GENERATED_LETTER, assistant_msgs[0]["content"])
+        # The user's message survived too (pre-persist).
+        user_msgs = [m for m in fresh.chat_history if m.get("role") == "user"]
+        self.assertEqual(len(user_msgs), 1)
+
+    async def test_letter_fallback_serves_existing_reserve_without_models(self):
+        """With a ProposedAppeal already in the DB the rescue needs zero
+        model calls: the reserve is served and saved onto the appeal."""
+        user, chat = await _make_professional_chat("letterfall3", "9999920003")
+        appeal, denial = await _link_letter_appeal(chat, user)
+        await ProposedAppeal.objects.acreate(
+            appeal_text=RESERVE_LETTER, for_denial=denial, speculative=True
+        )
+        recorder = _FrameRecorder()
+        interface = ChatInterface(
+            send_json_message_func=recorder,
+            chat=chat,
+            user=user,
+        )
+        with _llm_call_fails(lambda *a, **k: (None, None)):
+            await interface.handle_chat_message("Can you write the appeal letter?")
+        assistant_frames = [
+            f for f in recorder.frames if f.get("role") == "assistant"
+        ]
+        self.assertEqual(len(assistant_frames), 1)
+        self.assertIn(RESERVE_LETTER, assistant_frames[0]["content"])
+        fresh_appeal = await Appeal.objects.aget(id=appeal.id)
+        self.assertEqual(fresh_appeal.appeal_text, RESERVE_LETTER)
+
+    async def test_no_fallback_without_linked_appeal(self):
+        with patch(
+            "fighthealthinsurance.chat_interface.draft_letter_for_chat",
+            new=AsyncMock(return_value=GENERATED_LETTER),
+        ) as mock_draft:
+            chat, _, _, recorder = await self._run_failing_turn(
+                "letterfall4",
+                "9999920004",
+                "Please go ahead and draft a letter.",
+                link_appeal=False,
+            )
+        mock_draft.assert_not_awaited()
+        error_frames = [f for f in recorder.frames if "error" in f]
+        self.assertTrue(error_frames, f"expected an error frame: {recorder.frames}")
+        assistant_frames = [
+            f for f in recorder.frames if f.get("role") == "assistant"
+        ]
+        self.assertEqual(assistant_frames, [])
+
+    async def test_non_letter_request_skips_fallback_and_errors(self):
+        with patch(
+            "fighthealthinsurance.chat_interface.draft_letter_for_chat",
+            new=AsyncMock(return_value=GENERATED_LETTER),
+        ) as mock_draft:
+            chat, _, _, recorder = await self._run_failing_turn(
+                "letterfall5", "9999920005", "Why was my MRI claim denied?"
+            )
+        mock_draft.assert_not_awaited()
+        error_frames = [f for f in recorder.frames if "error" in f]
+        self.assertTrue(error_frames)
+
+    async def test_failed_fallback_error_links_to_appeal_page(self):
+        """When even the letter fallback can't deliver, the error message
+        points the user at the linked appeal's own generation page."""
+        with patch(
+            "fighthealthinsurance.chat_interface.draft_letter_for_chat",
+            new=AsyncMock(return_value=None),
+        ):
+            chat, appeal, _, recorder = await self._run_failing_turn(
+                "letterfall6", "9999920006", "Please go ahead and draft a letter."
+            )
+        error_frames = [f for f in recorder.frames if "error" in f]
+        self.assertEqual(len(error_frames), 1)
+        self.assertIn(f"/appeals/{appeal.id}", error_frames[0]["error"])
+
+
+class GenerateAppealLetterToolTest(APITestCase):
+    """The generate_appeal_letter tool: appeal setup + pipeline handoff."""
+
+    async def _make_chat(self, username, npi):
+        _, chat = await _make_professional_chat(username, npi)
+        return chat
+
+    async def test_tool_drafts_letter_and_links_appeal(self):
+        chat = await self._make_chat("lettertool1", "9999930001")
+        status = AsyncMock()
+        tool = GenerateAppealLetterTool(status, AsyncMock())
+        response_text = (
+            "On it!\n"
+            '**generate_appeal_letter**{"procedure": "MRI", '
+            '"diagnosis": "chronic back pain", '
+            '"medical_reason": "failed six weeks of conservative therapy"}'
+        )
+        with patch(
+            "fighthealthinsurance.chat.tools.generate_appeal_letter_tool."
+            "draft_letter_for_chat",
+            new=AsyncMock(return_value=GENERATED_LETTER),
+        ) as mock_draft:
+            response, context, handled = await tool.handle(
+                response_text, "", chat=chat
+            )
+        self.assertTrue(handled)
+        mock_draft.assert_awaited_once()
+        self.assertNotIn("generate_appeal_letter", response)
+        self.assertIn(GENERATED_LETTER, response)
+        self.assertIn("/appeals/", response)
+        # The surrounding prose the model wrote survives.
+        self.assertIn("On it!", response)
+        appeal = await Appeal.objects.select_related("for_denial").aget(chat=chat)
+        self.assertEqual(appeal.for_denial.procedure, "MRI")
+        self.assertEqual(appeal.for_denial.diagnosis, "chronic back pain")
+        # The letter-context key is folded into qa_context, not dropped.
+        self.assertIn(
+            "failed six weeks of conservative therapy",
+            appeal.for_denial.qa_context or "",
+        )
+
+    async def test_tool_asks_for_details_when_no_letter_context(self):
+        chat = await self._make_chat("lettertool2", "9999930002")
+        tool = GenerateAppealLetterTool(AsyncMock(), AsyncMock())
+        with patch(
+            "fighthealthinsurance.chat.tools.generate_appeal_letter_tool."
+            "draft_letter_for_chat",
+            new=AsyncMock(return_value=GENERATED_LETTER),
+        ) as mock_draft:
+            response, _, handled = await tool.handle(
+                "**generate_appeal_letter**{}", "", chat=chat
+            )
+        self.assertTrue(handled)
+        mock_draft.assert_not_awaited()
+        self.assertNotIn("generate_appeal_letter", response)
+        self.assertIn("procedure or service", response)
+
+    async def test_tool_failure_keeps_appeal_link(self):
+        chat = await self._make_chat("lettertool3", "9999930003")
+        tool = GenerateAppealLetterTool(AsyncMock(), AsyncMock())
+        with patch(
+            "fighthealthinsurance.chat.tools.generate_appeal_letter_tool."
+            "draft_letter_for_chat",
+            new=AsyncMock(return_value=None),
+        ):
+            response, _, handled = await tool.handle(
+                '**generate_appeal_letter**{"procedure": "MRI"}', "", chat=chat
+            )
+        self.assertTrue(handled)
+        self.assertNotIn("generate_appeal_letter", response)
+        self.assertIn("/appeals/", response)
+        appeal = await Appeal.objects.select_related("for_denial").aget(chat=chat)
+        self.assertEqual(appeal.for_denial.procedure, "MRI")
+
+    async def test_invalid_json_strips_tool_syntax(self):
+        chat = await self._make_chat("lettertool4", "9999930004")
+        error = AsyncMock()
+        tool = GenerateAppealLetterTool(AsyncMock(), error)
+        response, _, handled = await tool.handle(
+            "Here you go.\n**generate_appeal_letter**{not valid json}",
+            "",
+            chat=chat,
+        )
+        self.assertTrue(handled)
+        self.assertNotIn("generate_appeal_letter", response)
+        error.assert_awaited()
+
+
+class LetterSelectionPolicyTest(APITestCase):
+    """generate_letter_for_denial picks a letter, not just any model output."""
+
+    def _denial(self):
+        return Denial(
+            denial_text="Denied as not medically necessary.",
+            procedure="MRI",
+            diagnosis="back pain",
+        )
+
+    async def test_long_model_letter_wins_immediately(self):
+        long_letter = GeneratedAppeal(text="word " * 120, model_name="fhi-model")
+        never_reached = GeneratedAppeal(text="word " * 400, model_name="other")
+        with patch.object(
+            common_view_logic.appealGenerator,
+            "make_appeals",
+            return_value=iter([long_letter, never_reached]),
+        ):
+            item = await generate_letter_for_denial(self._denial())
+        self.assertIsNotNone(item)
+        self.assertEqual(item.model_name, "fhi-model")
+
+    async def test_short_model_output_loses_to_longer_static_template(self):
+        """A medically-necessary one-liner must not beat a full static
+        template letter just because it carries a model name."""
+        one_liner = GeneratedAppeal(
+            text="The MRI is medically necessary for diagnosis.",
+            model_name="fhi-model",
+        )
+        static_letter = GeneratedAppeal(text="word " * 300, model_name=None)
+        with patch.object(
+            common_view_logic.appealGenerator,
+            "make_appeals",
+            return_value=iter([one_liner, static_letter]),
+        ):
+            item = await generate_letter_for_denial(self._denial())
+        self.assertIsNotNone(item)
+        self.assertIsNone(item.model_name)
+        self.assertEqual(item.text, static_letter.text)
+
+    async def test_runt_only_output_returns_none(self):
+        runt = GeneratedAppeal(text="no", model_name="fhi-model")
+        with patch.object(
+            common_view_logic.appealGenerator,
+            "make_appeals",
+            return_value=iter([runt]),
+        ):
+            item = await generate_letter_for_denial(self._denial())
+        self.assertIsNone(item)
+
+    async def test_generation_failure_returns_none(self):
+        with patch.object(
+            common_view_logic.appealGenerator,
+            "make_appeals",
+            side_effect=RuntimeError("boom"),
+        ):
+            item = await generate_letter_for_denial(self._denial())
+        self.assertIsNone(item)
+
+
+class FindReserveLetterTest(APITestCase):
+    """Reserve lookup prefers live rows and skips runts."""
+
+    async def test_prefers_live_over_speculative_and_skips_runts(self):
+        denial = await Denial.objects.acreate(
+            denial_text="denied", hashed_email=Denial.get_hashed_email("a@b.com")
+        )
+        await ProposedAppeal.objects.acreate(
+            appeal_text=RESERVE_LETTER + " speculative extra text here",
+            for_denial=denial,
+            speculative=True,
+        )
+        await ProposedAppeal.objects.acreate(
+            appeal_text=RESERVE_LETTER, for_denial=denial, speculative=False
+        )
+        await ProposedAppeal.objects.acreate(
+            appeal_text="runt", for_denial=denial, speculative=False
+        )
+        found = await find_reserve_letter(denial)
+        # The live row wins even though the speculative one is longer.
+        self.assertEqual(found, RESERVE_LETTER)
+
+    async def test_returns_none_when_no_deliverable_rows(self):
+        denial = await Denial.objects.acreate(
+            denial_text="denied", hashed_email=Denial.get_hashed_email("c@d.com")
+        )
+        await ProposedAppeal.objects.acreate(
+            appeal_text="runt", for_denial=denial, speculative=False
+        )
+        self.assertIsNone(await find_reserve_letter(denial))
+
+
+class DraftLetterForChatTest(APITestCase):
+    """draft_letter_for_chat persistence behavior."""
+
+    async def test_generated_letter_persisted_with_provenance(self):
+        user, chat = await _make_professional_chat("draftpersist1", "9999940001")
+        appeal, denial = await _link_letter_appeal(chat, user)
+        generated = GeneratedAppeal(
+            text=GENERATED_LETTER, model_name="fhi-model", context_level="full"
+        )
+        with patch(
+            "fighthealthinsurance.chat.appeal_letter_generator."
+            "generate_letter_for_denial",
+            new=AsyncMock(return_value=generated),
+        ):
+            letter = await draft_letter_for_chat(
+                appeal=appeal, denial=denial, use_external=False
+            )
+        self.assertEqual(letter, GENERATED_LETTER)
+        fresh_appeal = await Appeal.objects.aget(id=appeal.id)
+        self.assertEqual(fresh_appeal.appeal_text, GENERATED_LETTER)
+        row = await ProposedAppeal.objects.aget(for_denial=denial)
+        self.assertEqual(row.model_name, "fhi-model")
+        self.assertEqual(row.context_level, "full")
+        self.assertFalse(row.speculative)
+
+    async def test_reserve_reuse_creates_no_duplicate_row(self):
+        user, chat = await _make_professional_chat("draftpersist2", "9999940002")
+        appeal, denial = await _link_letter_appeal(chat, user)
+        await ProposedAppeal.objects.acreate(
+            appeal_text=RESERVE_LETTER, for_denial=denial
+        )
+        letter = await draft_letter_for_chat(
+            appeal=appeal, denial=denial, use_external=False, prefer_existing=True
+        )
+        self.assertEqual(letter, RESERVE_LETTER)
+        self.assertEqual(
+            await ProposedAppeal.objects.filter(for_denial=denial).acount(), 1
+        )

--- a/tests/async/test_chat_letter_fallback.py
+++ b/tests/async/test_chat_letter_fallback.py
@@ -573,6 +573,28 @@ class MultiCallAndErrorStripTest(APITestCase):
         self.assertNotIn("generate_appeal_letter", result)
         self.assertEqual(result.count(GENERATED_LETTER), 1)
 
+    async def test_calls_past_the_cap_are_stripped_not_leaked(self):
+        """A reply with more calls than max_calls_per_reply executes the
+        first three and strips the rest -- raw tool syntax never renders."""
+        _, chat = await _make_professional_chat("multicall4", "9999960004")
+        response = (
+            '**create_or_update_appeal**{"procedure": "MRI"}\n'
+            '**create_or_update_appeal**{"diagnosis": "chronic back pain"}\n'
+            '**create_or_update_appeal**{"insurance_company": "Acme Health"}\n'
+            '**create_or_update_appeal**{"employer_name": "Overflow Corp"}'
+        )
+        tool = AppealTool(AsyncMock(), AsyncMock())
+        result, _, handled = await tool.handle(response, "", chat=chat)
+        self.assertTrue(handled)
+        self.assertNotIn("create_or_update_appeal", result)
+        self.assertNotIn("Overflow Corp", result)
+        appeal = await Appeal.objects.select_related("for_denial").aget(chat=chat)
+        # First three applied; the over-cap call was stripped, not executed.
+        self.assertEqual(appeal.for_denial.procedure, "MRI")
+        self.assertEqual(appeal.for_denial.diagnosis, "chronic back pain")
+        self.assertEqual(appeal.for_denial.insurance_company, "Acme Health")
+        self.assertIsNone(appeal.for_denial.employer_name)
+
     async def test_appeal_tool_error_leaves_letter_call_intact(self):
         """When AppealTool's execute blows up, the on-error strip must not
         swallow the prose or the pending generate_appeal_letter call (the
@@ -610,12 +632,16 @@ class LetterDeadlineClampTest(APITestCase):
         self.assertIsNone(self._interface()._remaining_letter_deadline())
 
     def test_clamped_to_remaining_budget(self):
+        import os
         import time as time_mod
 
         interface = self._interface()
         interface._turn_deadline = time_mod.monotonic() + 40.0
-        deadline = interface._remaining_letter_deadline()
-        # ~40s left minus the 15s margin, well under the 75s env default.
+        # Pin the env default so an FHI_CHAT_LETTER_DEADLINE set in the
+        # environment can't change what the clamp is compared against.
+        with patch.dict(os.environ, {"FHI_CHAT_LETTER_DEADLINE": "75"}):
+            deadline = interface._remaining_letter_deadline()
+        # ~40s left minus the 15s margin, well under the 75s default.
         self.assertLess(deadline, 30.0)
         self.assertGreater(deadline, 20.0)
 
@@ -627,8 +653,10 @@ class LetterDeadlineClampTest(APITestCase):
         self.assertEqual(interface._remaining_letter_deadline(), 10.0)
 
     def test_capped_at_env_default_when_budget_is_ample(self):
+        import os
         import time as time_mod
 
         interface = self._interface()
         interface._turn_deadline = time_mod.monotonic() + 10_000.0
-        self.assertEqual(interface._remaining_letter_deadline(), 75.0)
+        with patch.dict(os.environ, {"FHI_CHAT_LETTER_DEADLINE": "75"}):
+            self.assertEqual(interface._remaining_letter_deadline(), 75.0)

--- a/tests/chat_fixtures.py
+++ b/tests/chat_fixtures.py
@@ -1,4 +1,4 @@
-"""Shared fixtures for the chat loop-prevention tests.
+"""Shared fixtures for the chat tests.
 
 These constants and test doubles were previously copy-pasted across five
 test modules and had already drifted (one copy dropped a paragraph, so it
@@ -6,9 +6,16 @@ exercised the similarity thresholds against different text than the others).
 Defining them once keeps every suite testing the same shapes, and means a
 change to ``RemoteModelLike.generate_chat_response`` only has to be mirrored
 in one place -- the mock signature is what guards against real TypeErrors.
+
+Also home to the failed-turn plumbing (``llm_call_fails``,
+``make_professional_chat``, ``FrameRecorder``): ``tests/async`` is not an
+importable package name (``async`` is a keyword), so helpers shared between
+its modules have to live outside it.
 """
 
+import contextlib
 from typing import Optional
+from unittest.mock import AsyncMock, patch
 
 # The reply from the observed production loop: the assistant re-sent this
 # verbatim after the user answered "CA".
@@ -119,3 +126,74 @@ class RecordingChatModel:
         if self._anti_repeat_marker in (current_message_for_llm or ""):
             return (self._fresh_reply, "mock context summary")
         return (self._looped_reply, "mock context summary")
+
+
+@contextlib.contextmanager
+def llm_call_fails(side_effect):
+    """Route model selection to a mock backend and make the LLM call fail.
+
+    ``side_effect`` is handed to the ``_call_llm_with_actions`` AsyncMock:
+    an exception instance to raise, or a callable returning ``(None, None)``
+    for the models-returned-nothing shape.
+    """
+    from fighthealthinsurance.chat_interface import ChatInterface
+    from tests.sync.mock_chat_model import MockChatModel
+
+    mock_model = MockChatModel()
+    with contextlib.ExitStack() as stack:
+        get_backends = stack.enter_context(
+            patch("fighthealthinsurance.ml.ml_router.MLRouter.get_chat_backends")
+        )
+        get_backends.return_value = [mock_model]
+        get_fallback = stack.enter_context(
+            patch(
+                "fighthealthinsurance.ml.ml_router.MLRouter.get_chat_backends_with_fallback"
+            )
+        )
+        get_fallback.return_value = ([mock_model], [])
+        stack.enter_context(
+            patch(
+                "fighthealthinsurance.chat_interface.fire_and_forget_in_new_threadpool",
+                new_callable=AsyncMock,
+            )
+        )
+        stack.enter_context(
+            patch.object(
+                ChatInterface,
+                "_call_llm_with_actions",
+                new=AsyncMock(side_effect=side_effect),
+            )
+        )
+        yield
+
+
+async def make_professional_chat(username, npi):
+    """A professional user plus an empty OngoingChat bound to them."""
+    from asgiref.sync import sync_to_async
+    from django.contrib.auth import get_user_model
+
+    from fighthealthinsurance.models import OngoingChat, ProfessionalUser
+
+    User = get_user_model()
+    user = await sync_to_async(User.objects.create_user)(
+        username=username, password="testpass", email=f"{username}@example.com"
+    )
+    professional = await sync_to_async(ProfessionalUser.objects.create)(
+        user=user, active=True, npi_number=npi
+    )
+    chat = await sync_to_async(OngoingChat.objects.create)(
+        professional_user=professional,
+        chat_history=[],
+        summary_for_next_call=[],
+    )
+    return user, chat
+
+
+class FrameRecorder:
+    """Collects the JSON frames a ChatInterface sends to its client."""
+
+    def __init__(self):
+        self.frames = []
+
+    async def __call__(self, frame):
+        self.frames.append(frame)

--- a/tests/sync/test_chat_tools.py
+++ b/tests/sync/test_chat_tools.py
@@ -2051,3 +2051,74 @@ class TestClaimIdSubstitutionGuard(TestCase):
         self.assertIn("To Acme Health", result)
         self.assertIn("{claim_id}", result)
         self.assertIn("MRI", result)
+
+
+class TestAnchoredCallRemoval(TestCase):
+    """Span-bounded removal must leave no raw tool syntax behind.
+
+    The reply these produce is what the user reads AND what is persisted to
+    chat_history, so a leftover call means its JSON payload -- which can
+    carry medical detail -- is shown and stored.
+    """
+
+    def _tool(self):
+        from fighthealthinsurance.chat.tools import AppealTool
+
+        return AppealTool(AsyncMock(), AsyncMock())
+
+    def test_strips_more_calls_than_the_old_fixed_cap(self):
+        from fighthealthinsurance.chat.tools.base_tool import strip_anchored_calls
+
+        tool = self._tool()
+        text = "Here you go.\n" + "\n".join(
+            '**create_or_update_appeal**{"procedure": "MRI %d"}' % i
+            for i in range(12)
+        )
+        result = strip_anchored_calls(tool, text)
+        self.assertNotIn("create_or_update_appeal", result)
+        self.assertNotIn("MRI", result)
+        self.assertIn("Here you go.", result)
+
+    def test_malformed_multiline_payload_leaves_no_json_tail(self):
+        from fighthealthinsurance.chat.tools.base_tool import strip_anchored_calls
+
+        tool = self._tool()
+        text = (
+            "Saving that now.\n"
+            "**create_or_update_appeal**{\n"
+            '  "procedure": "MRI",\n'
+            '  "diagnosis": "chronic back pain",\n'
+            "  oops not valid json\n"
+            "}\n"
+            "Anything else?"
+        )
+        result = strip_anchored_calls(tool, text)
+        self.assertNotIn("create_or_update_appeal", result)
+        # None of the payload survives -- not the keys, not the values.
+        self.assertNotIn("chronic back pain", result)
+        self.assertNotIn("procedure", result)
+        self.assertIn("Saving that now.", result)
+        self.assertIn("Anything else?", result)
+
+    def test_malformed_call_does_not_swallow_the_next_call(self):
+        from fighthealthinsurance.chat.tools.base_tool import remove_anchored_call
+
+        tool = self._tool()
+        text = (
+            "**create_or_update_appeal**{\n  broken\n}\n"
+            '**create_or_update_appeal**{"procedure": "MRI"}'
+        )
+        result = remove_anchored_call(text, tool.detect(text), tool)
+        self.assertNotIn("broken", result)
+        # The following call survives for its own handler pass.
+        self.assertIn('**create_or_update_appeal**{"procedure": "MRI"}', result)
+
+    def test_tool_call_only_reply_never_returns_raw_payload(self):
+        """A reply that is nothing but a failed call must not fall back to
+        the original text -- that would show the user the raw JSON."""
+        tool = self._tool()
+        text = '**create_or_update_appeal**{"procedure": "MRI", "diagnosis": "back pain"}'
+        result = tool.strip_calls_on_error(text)
+        self.assertNotIn("create_or_update_appeal", result)
+        self.assertNotIn("back pain", result)
+        self.assertIn("problem saving", result)

--- a/tests/sync/test_chat_tools.py
+++ b/tests/sync/test_chat_tools.py
@@ -1975,3 +1975,57 @@ class TestSubstituteDenialFields(TestCase):
         self.assertFalse(denial_has_letter_context(None))
         self.assertFalse(denial_has_letter_context(Empty()))
         self.assertTrue(denial_has_letter_context(HasProcedure()))
+
+
+class TestParseAnchoredJsonPayload(TestCase):
+    """Precise payload extraction for the anchored **tool**{...} calls."""
+
+    def _match(self, text):
+        from fighthealthinsurance.chat.tools import GenerateAppealLetterTool
+
+        match = GenerateAppealLetterTool(AsyncMock()).detect(text)
+        self.assertIsNotNone(match)
+        return match
+
+    def test_payload_stops_at_own_call_despite_later_braces(self):
+        from fighthealthinsurance.chat.tools.base_tool import (
+            parse_anchored_json_payload,
+        )
+
+        text = (
+            '**generate_appeal_letter**{"procedure": "MRI"}\n'
+            "Some prose in between.\n"
+            '**create_or_update_prior_auth**{"treatment": "PT"}'
+        )
+        payload, span = parse_anchored_json_payload(text, self._match(text))
+        self.assertEqual(payload, {"procedure": "MRI"})
+        # The span covers only this call, so replacing it leaves the later
+        # tool call (and the prose) for its own handler.
+        self.assertEqual(span, '**generate_appeal_letter**{"procedure": "MRI"}')
+
+    def test_pretty_printed_multiline_payload_parses(self):
+        from fighthealthinsurance.chat.tools.base_tool import (
+            parse_anchored_json_payload,
+        )
+
+        text = '**generate_appeal_letter**{\n  "procedure": "MRI",\n  "diagnosis": "back pain"\n}'
+        payload, span = parse_anchored_json_payload(text, self._match(text))
+        self.assertEqual(
+            payload, {"procedure": "MRI", "diagnosis": "back pain"}
+        )
+        self.assertEqual(span, text)
+
+    def test_invalid_payload_raises_json_error(self):
+        import json as json_mod
+
+        from fighthealthinsurance.chat.tools.base_tool import (
+            parse_anchored_json_payload,
+        )
+
+        # A match whose captured region does not start a valid JSON object:
+        # the greedy pattern accepts it (there is a later } at end of line),
+        # but raw_decode must reject it so the handler's error path runs.
+        text = '**generate_appeal_letter**{invalid json}'
+        payload_match = self._match(text)
+        with self.assertRaises(json_mod.JSONDecodeError):
+            parse_anchored_json_payload(text, payload_match)

--- a/tests/sync/test_chat_tools.py
+++ b/tests/sync/test_chat_tools.py
@@ -1862,3 +1862,116 @@ class TestMedicaidIndeterminateWithQuestions(TestCase):
             determination_made=True,
         )
         self.assertNotIn("canNOT produce a Medicaid estimate", info)
+
+
+class TestGenerateAppealLetterPattern(TestCase):
+    """Detection and screening behavior for the generate_appeal_letter tool."""
+
+    def test_detects_anchored_call_with_markers(self):
+        from fighthealthinsurance.chat.tools import GenerateAppealLetterTool
+
+        tool = GenerateAppealLetterTool(AsyncMock())
+        text = '**generate_appeal_letter**{"procedure": "MRI", "diagnosis": "back pain"}'
+        match = tool.detect(text)
+        self.assertIsNotNone(match)
+        self.assertEqual(
+            match.group(1), '{"procedure": "MRI", "diagnosis": "back pain"}'
+        )
+
+    def test_detects_call_after_prose_line(self):
+        """The pattern is ^...$-anchored; MULTILINE detect flags must find a
+        call that follows a sentence of prose."""
+        from fighthealthinsurance.chat.tools import GenerateAppealLetterTool
+
+        tool = GenerateAppealLetterTool(AsyncMock())
+        text = 'On it -- drafting now.\ngenerate_appeal_letter {"procedure": "MRI"}\n'
+        self.assertIsNotNone(tool.detect(text))
+
+    def test_counts_as_tool_invocation(self):
+        text = 'Sure.\n**generate_appeal_letter**{"procedure": "MRI"}\n'
+        self.assertEqual(count_tool_invocations(text), 1)
+
+    def test_bare_mention_is_not_an_invocation_but_blocks_alternates(self):
+        from fighthealthinsurance.chat.tools import contains_tool_call
+
+        prose = "I can use generate_appeal_letter to draft this for you."
+        self.assertEqual(count_tool_invocations(prose), 0)
+        # Action-token mention: an alternate answer carrying it must be
+        # screened out (only the winning reply runs state-mutating flows).
+        self.assertTrue(contains_tool_call(prose))
+
+
+class TestLetterRequestDetector(TestCase):
+    """looks_like_letter_request gates the total-failure letter fallback."""
+
+    def test_matches_draft_requests(self):
+        from fighthealthinsurance.chat.appeal_letter_generator import (
+            looks_like_letter_request,
+        )
+
+        for message in [
+            "Please go ahead and draft a letter.",
+            "Can you write the appeal for me?",
+            "Generate an appeal letter to my insurer",
+            "please redo the letter with the new diagnosis",
+        ]:
+            with self.subTest(message=message):
+                self.assertTrue(looks_like_letter_request(message))
+
+    def test_ignores_non_draft_messages(self):
+        from fighthealthinsurance.chat.appeal_letter_generator import (
+            looks_like_letter_request,
+        )
+
+        for message in [
+            "Why was my MRI claim denied?",
+            "I got a letter from my insurer yesterday",
+            "What is an appeal?",
+            "",
+            None,
+        ]:
+            with self.subTest(message=message):
+                self.assertFalse(looks_like_letter_request(message))
+
+
+class TestSubstituteDenialFields(TestCase):
+    """Placeholder substitution for chat-served letters."""
+
+    class _Denial:
+        insurance_company = "Acme Health"
+        claim_id = "CLM-123"
+        diagnosis = None
+        procedure = "UNKNOWN"
+
+    def test_substitutes_known_fields_and_keeps_unknown_placeholders(self):
+        from fighthealthinsurance.chat.appeal_letter_generator import (
+            substitute_denial_fields,
+        )
+
+        letter = (
+            "Dear {insurance_company}, re claim {claim_id} for {procedure} "
+            "({diagnosis})."
+        )
+        result = substitute_denial_fields(letter, self._Denial())
+        self.assertIn("Acme Health", result)
+        self.assertIn("CLM-123", result)
+        # None and the extractor's UNKNOWN marker keep the fill-in blank.
+        self.assertIn("{procedure}", result)
+        self.assertIn("{diagnosis}", result)
+
+    def test_denial_context_gate(self):
+        from fighthealthinsurance.chat.appeal_letter_generator import (
+            denial_has_letter_context,
+        )
+
+        class Empty:
+            denial_text = "   "
+            procedure = ""
+            diagnosis = None
+
+        class HasProcedure(Empty):
+            procedure = "MRI"
+
+        self.assertFalse(denial_has_letter_context(None))
+        self.assertFalse(denial_has_letter_context(Empty()))
+        self.assertTrue(denial_has_letter_context(HasProcedure()))

--- a/tests/sync/test_chat_tools.py
+++ b/tests/sync/test_chat_tools.py
@@ -2029,3 +2029,25 @@ class TestParseAnchoredJsonPayload(TestCase):
         payload_match = self._match(text)
         with self.assertRaises(json_mod.JSONDecodeError):
             parse_anchored_json_payload(text, payload_match)
+
+
+class TestClaimIdSubstitutionGuard(TestCase):
+    """Mirror of sub_in_appeals' claim_id != insurance_company guard."""
+
+    def test_claim_id_matching_insurance_company_keeps_placeholder(self):
+        from fighthealthinsurance.chat.appeal_letter_generator import (
+            substitute_denial_fields,
+        )
+
+        class D:
+            insurance_company = "Acme Health"
+            claim_id = "Acme Health"  # known extractor failure mode
+            diagnosis = None
+            procedure = "MRI"
+
+        result = substitute_denial_fields(
+            "To {insurance_company} re claim {claim_id} for {procedure}.", D()
+        )
+        self.assertIn("To Acme Health", result)
+        self.assertIn("{claim_id}", result)
+        self.assertIn("MRI", result)


### PR DESCRIPTION
## Summary

When every chat model fails on a turn requesting an appeal letter, route the request to the dedicated appeal-generation pipeline instead of returning an error. This provides a graceful fallback that leverages specialized templates, precomputed reserves, and appeal-tuned models to still deliver a letter when chat models are unavailable.

## Key Changes

- **New module `fighthealthinsurance/chat/appeal_letter_generator.py`**: Core letter-drafting pipeline that:
  - Detects letter requests via regex pattern matching
  - Checks for sufficient denial context
  - Routes to `AppealGenerator.make_appeals` with deadline enforcement
  - Substitutes known denial fields into templates
  - Serves precomputed `ProposedAppeal` reserves from the database (zero model calls)
  - Returns the first deliverable letter, preferring longer model outputs over short ones

- **New tool `GenerateAppealLetterTool`**: Allows chat models to emit `**generate_appeal_letter {...}**` calls instead of writing full letters inline, keeping chat responses short while appeal-specialized models handle letter drafting

- **Total-failure fallback in `ChatInterface.handle_chat_message`**: When all chat models fail on a letter-draft request:
  - Attempts letter generation via the appeal pipeline
  - Persists successful fallback replies to chat history
  - Provides helpful error messages with appeal page links when fallback also fails
  - Records reliability metrics for monitoring

- **Test coverage**: Comprehensive async test suite (`tests/async/test_chat_letter_fallback.py`) covering:
  - Letter fallback rescue with generated letters
  - Serving precomputed reserves without model calls
  - Fallback only triggers with linked appeals and letter requests
  - Error messages link to appeal pages
  - Tool JSON parsing and field substitution

- **Supporting changes**:
  - Added `GENERATE_APPEAL_LETTER_REGEX` pattern to `chat/tools/patterns.py`
  - Exported `GenerateAppealLetterTool` from `chat/tools/__init__.py`
  - Updated `ChatInterface` to instantiate and run the new tool
  - Added helper methods `_attempt_letter_fallback_reply()` and `_linked_appeal_link()` to `ChatInterface`
  - Updated metrics to track `letter_fallback` outcomes
  - Refactored shared test fixtures to `tests/chat_fixtures.py` for reuse across async test modules

## Implementation Details

- **Deadline enforcement**: Letter generation respects a configurable timeout (default 75s) to avoid blocking chat indefinitely
- **Reserve preference**: Existing `ProposedAppeal` rows are checked first (live > speculative, longest wins) before running models
- **Field substitution**: Placeholders like `{insurance_company}` are filled from denial data; unknown fields keep their placeholders
- **Graceful degradation**: Specialized templates and static appeals serve as zero-model fallback when all models fail
- **Metrics**: New `letter_fallback` outcome tracked in `CHAT_TURNS_TOTAL` counter for reliability monitoring

https://claude.ai/code/session_01S6NyPG28jiTqhaKFfH8q7u

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added chat-based appeal letter drafting using denial details.
  * Generated letters are linked to the related appeal and accessible from chat.
  * Added fallback drafting when standard chat processing fails.
  * Reuses suitable existing drafts when available.

* **Bug Fixes**
  * Improved handling of failed or timed-out letter requests.
  * Added clearer responses when required denial information is missing.
  * Improved processing and cleanup of multiple chat actions in a single response.

* **Tests**
  * Added coverage for generation, fallback behavior, draft reuse, persistence, and request detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->