### PR TITLE
Handle long pastes and uploads with deferred summarization and fallback acks

### DIFF
--- a/fighthealthinsurance/chat/document_processor.py
+++ b/fighthealthinsurance/chat/document_processor.py
@@ -281,9 +281,30 @@ async def _claim_document_for_processing(
     A conditional UPDATE, so of any number of concurrent callers (the turn's
     deferred kickoff, the storage watchdog, a resubmission) exactly one wins
     and dispatches a worker; the in-memory status checks alone raced.
+
+    Claiming FROM ``PROCESSING`` (the dead-worker rescue) needs one extra
+    step to keep that guarantee: PROCESSING -> PROCESSING changes nothing but
+    still MATCHES, so the database reports a successful claim to every caller
+    at once -- several armed rescues would each dispatch a fan-out on the
+    same document. Such callers first demote the row out of PROCESSING, which
+    only one of them can match, and the winner then takes the ordinary claim.
+    Dying between the two leaves the row FAILED, which a resubmission retries
+    -- strictly better than the stuck PROCESSING it replaced.
     """
+    statuses = list(from_statuses)
+    if ChatDocument.Status.PROCESSING in statuses:
+        statuses = [s for s in statuses if s != ChatDocument.Status.PROCESSING]
+        demoted = await ChatDocument.objects.filter(
+            id=doc_id, processing_status=ChatDocument.Status.PROCESSING
+        ).aupdate(processing_status=ChatDocument.Status.FAILED)
+        if demoted and ChatDocument.Status.FAILED not in statuses:
+            statuses.append(ChatDocument.Status.FAILED)
+        if not statuses:
+            # Nothing else was requested and the demote lost the race: some
+            # other caller is rescuing this row.
+            return False
     updated = await ChatDocument.objects.filter(
-        id=doc_id, processing_status__in=from_statuses
+        id=doc_id, processing_status__in=statuses
     ).aupdate(processing_status=ChatDocument.Status.PROCESSING)
     return bool(updated)
 
@@ -376,10 +397,10 @@ async def _deferred_summarization_watchdog(
     if claim_statuses is None:
         claim_statuses = [ChatDocument.Status.PENDING]
     await asyncio.sleep(delay)
-    try:
-        doc = await ChatDocument.objects.aget(id=doc_id)
-    except ChatDocument.DoesNotExist:
-        return
+    # Straight to the claim: it is filtered by id, so a document deleted
+    # while this was parked matches nothing and simply loses the claim --
+    # no separate existence check (which would also drag the whole
+    # full_text back out of the database just to throw it away).
     if not await _claim_document_for_processing(doc_id, claim_statuses):
         return
     logger.warning(

--- a/fighthealthinsurance/chat/document_processor.py
+++ b/fighthealthinsurance/chat/document_processor.py
@@ -262,14 +262,30 @@ async def summarize_chunks(
 def summarization_needed(doc: ChatDocument) -> bool:
     """Whether ``doc`` still needs (re)summarization kicked off.
 
-    PENDING covers both a fresh document and one orphaned before its
-    deferred kickoff ran (e.g. the WebSocket turn was cancelled mid-flight);
-    FAILED documents get another try. PROCESSING/COMPLETED are left alone.
+    PENDING covers both a fresh document and one whose deferred kickoff never
+    ran (rescued by the watchdog below); FAILED documents get another try on
+    resubmission. PROCESSING/COMPLETED are left alone.
     """
     return doc.processing_status in (
         ChatDocument.Status.PENDING,
         ChatDocument.Status.FAILED,
     )
+
+
+async def _claim_document_for_processing(
+    doc_id: int,
+    from_statuses: List[str],
+) -> bool:
+    """Atomically claim ``doc_id`` for summarization (-> PROCESSING).
+
+    A conditional UPDATE, so of any number of concurrent callers (the turn's
+    deferred kickoff, the storage watchdog, a resubmission) exactly one wins
+    and dispatches a worker; the in-memory status checks alone raced.
+    """
+    updated = await ChatDocument.objects.filter(
+        id=doc_id, processing_status__in=from_statuses
+    ).aupdate(processing_status=ChatDocument.Status.PROCESSING)
+    return bool(updated)
 
 
 async def start_document_summarization(
@@ -278,15 +294,66 @@ async def start_document_summarization(
 ) -> bool:
     """Fire background summarization for ``doc`` if it still needs it.
 
-    Safe to call repeatedly -- see :func:`summarization_needed`. Returns True
-    when a background task was actually fired.
+    Safe to call repeatedly and concurrently: after the cheap in-memory
+    pre-filter, the document is claimed with an atomic conditional UPDATE, so
+    only one caller dispatches a worker per PENDING/FAILED state. Returns
+    True when this call dispatched the background task. If dispatch itself
+    fails, the claim is released back to FAILED so a later attempt can retry.
     """
     if not summarization_needed(doc):
         return False
-    await fire_and_forget_in_new_threadpool(
-        summarize_chunks(doc.id, denial_context=denial_context)
-    )
+    if not await _claim_document_for_processing(
+        doc.id,
+        [ChatDocument.Status.PENDING, ChatDocument.Status.FAILED],
+    ):
+        return False
+    doc.processing_status = ChatDocument.Status.PROCESSING
+    try:
+        await fire_and_forget_in_new_threadpool(
+            summarize_chunks(doc.id, denial_context=denial_context)
+        )
+    except Exception:
+        doc.processing_status = ChatDocument.Status.FAILED
+        await ChatDocument.objects.filter(
+            id=doc.id, processing_status=ChatDocument.Status.PROCESSING
+        ).aupdate(processing_status=ChatDocument.Status.FAILED)
+        raise
     return True
+
+
+# How long the watchdog waits before rescuing a still-PENDING deferred
+# document. Longer than the chat turn budget (FHI_CHAT_TURN_BUDGET, 150s
+# default) so the turn's own kickoff always gets to go first.
+DEFERRED_SUMMARY_WATCHDOG_SECONDS = 240.0
+
+
+async def _deferred_summarization_watchdog(
+    doc_id: int,
+    denial_context: Optional[str],
+    delay: float,
+) -> None:
+    """Backstop for deferred summarization: rescue a stranded PENDING doc.
+
+    The turn that stored the document is supposed to kick summarization off
+    after its LLM pass, but anything between storage and that kickoff -- a
+    raise in history prep, the WebSocket consumer being cancelled on
+    disconnect -- skips it. This runs in its own fire-and-forget thread, so
+    it survives the consumer coroutine, waits out the turn, and claims the
+    document only if it is STILL PENDING (a FAILED first attempt is not
+    retried here -- that stays a resubmission-time decision).
+    """
+    await asyncio.sleep(delay)
+    try:
+        doc = await ChatDocument.objects.aget(id=doc_id)
+    except ChatDocument.DoesNotExist:
+        return
+    if not await _claim_document_for_processing(doc_id, [ChatDocument.Status.PENDING]):
+        return
+    logger.warning(
+        f"ChatDocument {doc_id} was still PENDING {delay:.0f}s after deferred "
+        f"storage (its turn never started summarization); watchdog starting it"
+    )
+    await summarize_chunks(doc_id, denial_context=denial_context)
 
 
 async def process_uploaded_document(
@@ -304,10 +371,14 @@ async def process_uploaded_document(
     the existing document -- its original ``document_name`` wins -- instead of
     creating a duplicate row and a second summarization storm.
 
-    With ``defer_summarization=True`` no summarization is fired here; the
-    caller must call :func:`start_document_summarization` afterwards. The
-    chat turn uses this so the batch summarization work doesn't compete with
-    the interactive LLM calls for the same backends.
+    With ``defer_summarization=True`` no summarization worker is dispatched
+    here; the caller must call :func:`start_document_summarization` after its
+    own LLM pass. The chat turn uses this so the batch summarization work
+    doesn't compete with the interactive LLM calls for the same backends. A
+    watchdog thread is still armed at storage time so the document cannot be
+    stranded PENDING if the caller dies (disconnect, setup error) before its
+    deferred kickoff runs -- the atomic claim keeps the two from ever both
+    dispatching.
     """
     doc: Optional[ChatDocument] = None
     async for existing in (
@@ -339,5 +410,13 @@ async def process_uploaded_document(
 
     if not defer_summarization:
         await start_document_summarization(doc, denial_context=denial_context)
+    elif summarization_needed(doc):
+        await fire_and_forget_in_new_threadpool(
+            _deferred_summarization_watchdog(
+                doc.id,
+                denial_context,
+                DEFERRED_SUMMARY_WATCHDOG_SECONDS,
+            )
+        )
 
     return doc

--- a/fighthealthinsurance/chat/document_processor.py
+++ b/fighthealthinsurance/chat/document_processor.py
@@ -259,30 +259,85 @@ async def summarize_chunks(
             logger.debug(f"Could not persist failed status: {save_err}")
 
 
+def summarization_needed(doc: ChatDocument) -> bool:
+    """Whether ``doc`` still needs (re)summarization kicked off.
+
+    PENDING covers both a fresh document and one orphaned before its
+    deferred kickoff ran (e.g. the WebSocket turn was cancelled mid-flight);
+    FAILED documents get another try. PROCESSING/COMPLETED are left alone.
+    """
+    return doc.processing_status in (
+        ChatDocument.Status.PENDING,
+        ChatDocument.Status.FAILED,
+    )
+
+
+async def start_document_summarization(
+    doc: ChatDocument,
+    denial_context: Optional[str] = None,
+) -> bool:
+    """Fire background summarization for ``doc`` if it still needs it.
+
+    Safe to call repeatedly -- see :func:`summarization_needed`. Returns True
+    when a background task was actually fired.
+    """
+    if not summarization_needed(doc):
+        return False
+    await fire_and_forget_in_new_threadpool(
+        summarize_chunks(doc.id, denial_context=denial_context)
+    )
+    return True
+
+
 async def process_uploaded_document(
     chat,
     document_name: str,
     full_text: str,
     denial_context: Optional[str] = None,
+    defer_summarization: bool = False,
 ) -> ChatDocument:
-    """Create a ChatDocument and fire background summarization.
+    """Store ``full_text`` as a ChatDocument and (by default) fire background
+    summarization. Returns the ChatDocument so the caller can reference it.
 
-    Returns the ChatDocument so the caller can reference it.
+    Identical content re-submitted to the same chat (the user re-pasting a
+    long message after a failed turn, or re-uploading the same file) reuses
+    the existing document -- its original ``document_name`` wins -- instead of
+    creating a duplicate row and a second summarization storm.
+
+    With ``defer_summarization=True`` no summarization is fired here; the
+    caller must call :func:`start_document_summarization` afterwards. The
+    chat turn uses this so the batch summarization work doesn't compete with
+    the interactive LLM calls for the same backends.
     """
-    doc = await ChatDocument.objects.acreate(
-        chat=chat,
-        document_name=document_name or "uploaded_document",
-        full_text=full_text,
-        char_count=len(full_text),
-        processing_status=ChatDocument.Status.PENDING,
-    )
+    doc: Optional[ChatDocument] = None
+    async for existing in (
+        ChatDocument.objects.filter(chat=chat, char_count=len(full_text))
+        .order_by("-created_at")
+        .aiterator()
+    ):
+        if existing.full_text == full_text:
+            doc = existing
+            logger.info(
+                f"Reusing ChatDocument {doc.id} ({doc.document_name}) for chat "
+                f"{chat.id}: identical content re-submitted "
+                f"(status={doc.processing_status})"
+            )
+            break
 
-    logger.info(
-        f"Created ChatDocument {doc.id} for chat {chat.id} " f"({len(full_text)} chars)"
-    )
+    if doc is None:
+        doc = await ChatDocument.objects.acreate(
+            chat=chat,
+            document_name=document_name or "uploaded_document",
+            full_text=full_text,
+            char_count=len(full_text),
+            processing_status=ChatDocument.Status.PENDING,
+        )
+        logger.info(
+            f"Created ChatDocument {doc.id} for chat {chat.id} "
+            f"({len(full_text)} chars)"
+        )
 
-    await fire_and_forget_in_new_threadpool(
-        summarize_chunks(doc.id, denial_context=denial_context)
-    )
+    if not defer_summarization:
+        await start_document_summarization(doc, denial_context=denial_context)
 
     return doc

--- a/fighthealthinsurance/chat/document_processor.py
+++ b/fighthealthinsurance/chat/document_processor.py
@@ -288,20 +288,11 @@ async def _claim_document_for_processing(
     return bool(updated)
 
 
-async def start_document_summarization(
+async def _claim_and_dispatch_summarization(
     doc: ChatDocument,
-    denial_context: Optional[str] = None,
+    denial_context: Optional[str],
 ) -> bool:
-    """Fire background summarization for ``doc`` if it still needs it.
-
-    Safe to call repeatedly and concurrently: after the cheap in-memory
-    pre-filter, the document is claimed with an atomic conditional UPDATE, so
-    only one caller dispatches a worker per PENDING/FAILED state. Returns
-    True when this call dispatched the background task. If dispatch itself
-    fails, the claim is released back to FAILED so a later attempt can retry.
-    """
-    if not summarization_needed(doc):
-        return False
+    """Claim ``doc`` and dispatch its worker; release the claim on failure."""
     if not await _claim_document_for_processing(
         doc.id,
         [ChatDocument.Status.PENDING, ChatDocument.Status.FAILED],
@@ -321,10 +312,44 @@ async def start_document_summarization(
     return True
 
 
+async def start_document_summarization(
+    doc: ChatDocument,
+    denial_context: Optional[str] = None,
+) -> bool:
+    """Fire background summarization for ``doc`` if it still needs it.
+
+    Safe to call repeatedly and concurrently: after the cheap in-memory
+    pre-filter, the document is claimed with an atomic conditional UPDATE, so
+    only one caller dispatches a worker per PENDING/FAILED state. Returns
+    True when this call dispatched the background task. If dispatch itself
+    fails, the claim is released back to FAILED so a later attempt can retry.
+
+    Shielded against caller cancellation: the turn's finally-block kickoff
+    can be cancelled mid-await (consumer disconnect), and without the shield
+    the claim's UPDATE could commit in its worker thread while the awaiting
+    coroutine died between claim and dispatch -- stranding the row PROCESSING
+    with no worker and nothing left that may claim it. The shielded task runs
+    to completion detached; a cancelled caller still sees its CancelledError.
+    """
+    if not summarization_needed(doc):
+        return False
+    return await asyncio.shield(_claim_and_dispatch_summarization(doc, denial_context))
+
+
 # How long the watchdog waits before rescuing a still-PENDING deferred
 # document. Longer than the chat turn budget (FHI_CHAT_TURN_BUDGET, 150s
 # default) so the turn's own kickoff always gets to go first.
 DEFERRED_SUMMARY_WATCHDOG_SECONDS = 240.0
+
+# Rescue delay for a resubmission that hit a row already marked PROCESSING.
+# A healthy worker reaches a terminal status well within this; one that died
+# without persisting one (pod restart, OOM) leaves the row PROCESSING
+# forever, and dedupe would otherwise pin every future resubmission to that
+# dead row with nothing allowed to claim it. Deliberately generous so a
+# genuinely long-running job on a huge document is very unlikely to still be
+# mid-flight when the rescue claims it (a double-run wastes work but both
+# writers converge on the same summaries).
+STUCK_PROCESSING_RESCUE_SECONDS = 600.0
 
 
 async def _deferred_summarization_watchdog(
@@ -359,8 +384,8 @@ async def _deferred_summarization_watchdog(
         return
     logger.warning(
         f"ChatDocument {doc_id} was still {'/'.join(claim_statuses)} "
-        f"{delay:.0f}s after deferred storage (its turn never started "
-        f"summarization); watchdog starting it"
+        f"{delay:.0f}s after (re)submission -- no live worker got it to a "
+        f"terminal status; watchdog starting summarization"
     )
     await summarize_chunks(doc_id, denial_context=denial_context)
 
@@ -390,6 +415,7 @@ async def process_uploaded_document(
     dispatching.
     """
     doc: Optional[ChatDocument] = None
+    reused = False
     async for existing in (
         ChatDocument.objects.filter(chat=chat, char_count=len(full_text))
         .order_by("-created_at")
@@ -397,6 +423,7 @@ async def process_uploaded_document(
     ):
         if existing.full_text == full_text:
             doc = existing
+            reused = True
             logger.info(
                 f"Reusing ChatDocument {doc.id} ({doc.document_name}) for chat "
                 f"{chat.id}: identical content re-submitted "
@@ -417,8 +444,11 @@ async def process_uploaded_document(
             f"({len(full_text)} chars)"
         )
 
+    dispatched_here = False
     if not defer_summarization:
-        await start_document_summarization(doc, denial_context=denial_context)
+        dispatched_here = await start_document_summarization(
+            doc, denial_context=denial_context
+        )
     elif summarization_needed(doc):
         # The watchdog may only claim from the status observed NOW: a fresh
         # PENDING doc must not be re-touched once its fast path has run,
@@ -433,6 +463,25 @@ async def process_uploaded_document(
                 denial_context,
                 DEFERRED_SUMMARY_WATCHDOG_SECONDS,
                 claim_statuses=[doc.processing_status],
+            )
+        )
+
+    if (
+        reused
+        and not dispatched_here
+        and doc.processing_status == ChatDocument.Status.PROCESSING
+    ):
+        # The resubmission hit a row that claims a worker is in flight. If it
+        # truly is, it reaches a terminal status and this rescue's claim
+        # misses; if the worker died without persisting one, nothing else may
+        # ever claim the row and dedupe would pin every future resubmission
+        # to it -- so rescue it after a generous delay.
+        await fire_and_forget_in_new_threadpool(
+            _deferred_summarization_watchdog(
+                doc.id,
+                denial_context,
+                STUCK_PROCESSING_RESCUE_SECONDS,
+                claim_statuses=[ChatDocument.Status.PROCESSING],
             )
         )
 

--- a/fighthealthinsurance/chat/document_processor.py
+++ b/fighthealthinsurance/chat/document_processor.py
@@ -331,27 +331,36 @@ async def _deferred_summarization_watchdog(
     doc_id: int,
     denial_context: Optional[str],
     delay: float,
+    claim_statuses: Optional[List[str]] = None,
 ) -> None:
-    """Backstop for deferred summarization: rescue a stranded PENDING doc.
+    """Backstop for deferred summarization: rescue a stranded document.
 
     The turn that stored the document is supposed to kick summarization off
     after its LLM pass, but anything between storage and that kickoff -- a
     raise in history prep, the WebSocket consumer being cancelled on
     disconnect -- skips it. This runs in its own fire-and-forget thread, so
     it survives the consumer coroutine, waits out the turn, and claims the
-    document only if it is STILL PENDING (a FAILED first attempt is not
-    retried here -- that stays a resubmission-time decision).
+    document only if it still sits in ``claim_statuses`` -- the status it had
+    when the watchdog was armed (default PENDING). A fresh document whose
+    fast path already ran therefore is not re-touched, while a FAILED
+    document the user explicitly resubmitted still gets its retry even if
+    the resubmitting turn dies. (For that resubmitted-FAILED case, a turn
+    whose own retry ran and failed again may get one extra watchdog retry --
+    bounded to one per resubmission and accepted.)
     """
+    if claim_statuses is None:
+        claim_statuses = [ChatDocument.Status.PENDING]
     await asyncio.sleep(delay)
     try:
         doc = await ChatDocument.objects.aget(id=doc_id)
     except ChatDocument.DoesNotExist:
         return
-    if not await _claim_document_for_processing(doc_id, [ChatDocument.Status.PENDING]):
+    if not await _claim_document_for_processing(doc_id, claim_statuses):
         return
     logger.warning(
-        f"ChatDocument {doc_id} was still PENDING {delay:.0f}s after deferred "
-        f"storage (its turn never started summarization); watchdog starting it"
+        f"ChatDocument {doc_id} was still {'/'.join(claim_statuses)} "
+        f"{delay:.0f}s after deferred storage (its turn never started "
+        f"summarization); watchdog starting it"
     )
     await summarize_chunks(doc_id, denial_context=denial_context)
 
@@ -411,11 +420,19 @@ async def process_uploaded_document(
     if not defer_summarization:
         await start_document_summarization(doc, denial_context=denial_context)
     elif summarization_needed(doc):
+        # The watchdog may only claim from the status observed NOW: a fresh
+        # PENDING doc must not be re-touched once its fast path has run,
+        # while a resubmitted FAILED doc must still get its retry if this
+        # turn dies. A re-paste while an earlier watchdog is still parked
+        # arms a second one; that is deliberate -- the atomic claim lets at
+        # most one dispatch, so extras are harmless no-ops, and deduping the
+        # threads themselves would need persisted watchdog state.
         await fire_and_forget_in_new_threadpool(
             _deferred_summarization_watchdog(
                 doc.id,
                 denial_context,
                 DEFERRED_SUMMARY_WATCHDOG_SECONDS,
+                claim_statuses=[doc.processing_status],
             )
         )
 

--- a/fighthealthinsurance/chat/llm_client.py
+++ b/fighthealthinsurance/chat/llm_client.py
@@ -168,13 +168,15 @@ def find_repeated_reply(
     # user prose: a reply acknowledging the stored paste/document naturally
     # reuses their wording, so echoing them is not a loop. Without this
     # exemption a long-paste turn could have EVERY candidate hard-rejected,
-    # failing the whole turn.
-    if (
-        current_message
-        and not is_stored_message_marker(current_message)
-        and is_mostly_repeated(response_text, current_message)
-    ):
-        return "echoes_user_message"
+    # failing the whole turn. A reply that IS the bare marker adds nothing,
+    # though -- reject that one so it can't be delivered as the answer (when
+    # every candidate is a bare echo, the stored-content acknowledgment
+    # fallback takes over with something actually useful).
+    if current_message and is_mostly_repeated(response_text, current_message):
+        if not is_stored_message_marker(current_message):
+            return "echoes_user_message"
+        if normalize_text(response_text) == normalize_text(current_message):
+            return "echoes_user_message"
     if not chat_history:
         return None
     checked = 0

--- a/fighthealthinsurance/chat/llm_client.py
+++ b/fighthealthinsurance/chat/llm_client.py
@@ -10,7 +10,10 @@ from typing import Awaitable, Callable, Dict, List, Optional, Tuple
 
 from loguru import logger
 
-from fighthealthinsurance.chat.message_preprocessor import MessageVariant
+from fighthealthinsurance.chat.message_preprocessor import (
+    MessageVariant,
+    is_stored_message_marker,
+)
 from fighthealthinsurance.chat.safety_filters import (
     detect_eligibility_verdict,
     detect_false_promises,
@@ -160,7 +163,17 @@ def find_repeated_reply(
     # the requested output.
     if current_message and user_requested_transformation(current_message):
         return None
-    if current_message and is_mostly_repeated(response_text, current_message):
+    # The stored-content markers ("You pasted a long message (~N chars)...",
+    # "I've uploaded a document: ...") are system-generated stand-ins, not
+    # user prose: a reply acknowledging the stored paste/document naturally
+    # reuses their wording, so echoing them is not a loop. Without this
+    # exemption a long-paste turn could have EVERY candidate hard-rejected,
+    # failing the whole turn.
+    if (
+        current_message
+        and not is_stored_message_marker(current_message)
+        and is_mostly_repeated(response_text, current_message)
+    ):
         return "echoes_user_message"
     if not chat_history:
         return None
@@ -220,8 +233,10 @@ def compute_repetition_penalty(
     # check runs BEFORE bag-of-words equality so a long reply sharing the
     # exact word set (which IS a near-verbatim reorder) gets the stronger
     # penalty; short reorders never trip the similarity path and still land
-    # in the mild bag-of-words bucket.
-    if current_message:
+    # in the mild bag-of-words bucket. Stored-content markers are exempt for
+    # the same reason as in find_repeated_reply: they are system-written, so
+    # a reply that acknowledges them in similar words is not an echo.
+    if current_message and not is_stored_message_marker(current_message):
         normalized_current = normalize_text(current_message)
         if normalized_response == normalized_current:
             penalty += EXACT_REPEAT_PENALTY

--- a/fighthealthinsurance/chat/message_preprocessor.py
+++ b/fighthealthinsurance/chat/message_preprocessor.py
@@ -11,6 +11,7 @@ This module depends only on the stdlib plus loguru (the project's standard
 logger) and must never log full message contents (PHI).
 """
 
+import re
 import time
 import unicodedata
 from dataclasses import dataclass, field
@@ -84,6 +85,49 @@ _TRAILING_JOINERS = frozenset({chr(0x200D), chr(0x200C)})
 
 # Whitespace we always preserve, even when stripping control characters.
 _KEPT_WHITESPACE = "\t\n\r"
+
+
+def build_long_paste_marker(char_count: int, doc_name: str) -> str:
+    """The compact text stored in chat history in place of a long paste.
+
+    Kept in one place so ``is_stored_message_marker`` below can recognize it
+    reliably wherever it needs rebuilding (e.g. after document-storage dedupe
+    resolves to an earlier document name).
+    """
+    return (
+        f"You pasted a long message (~{char_count:,} chars). "
+        f"It has been stored for reference as {doc_name}."
+    )
+
+
+# The system-generated stand-ins that replace stored content in chat history:
+# the long-paste marker above and the document-upload marker built in
+# chat_interface.handle_chat_message. Matched in full so a user message that
+# merely quotes one is not mistaken for the marker itself.
+_STORED_MESSAGE_MARKER_RES = (
+    re.compile(
+        r"You pasted a long message \(~[\d,]+ chars\)\. "
+        r"It has been stored for reference as \S.*\."
+    ),
+    re.compile(
+        r"I've uploaded a document: .+ \([\d,]+ characters\)\. "
+        r"The document is being analyzed and its contents are available "
+        r"for reference\."
+    ),
+)
+
+
+def is_stored_message_marker(text: Optional[str]) -> bool:
+    """Whether ``text`` is one of the system-generated stored-content markers.
+
+    These markers are written by us, not the user, so a reply that reuses
+    their wording (acknowledging the stored paste/document by name) is
+    legitimate -- repeat-rejection layers use this to stand down on the
+    echoes-the-user-message rung for such turns.
+    """
+    if not text:
+        return False
+    return any(r.fullmatch(text.strip()) for r in _STORED_MESSAGE_MARKER_RES)
 
 
 @dataclass
@@ -211,10 +255,7 @@ def _build_long_variants(
     doc_name = document_name or f"pasted_message_{int(time.time())}.txt"
     head = safe_display_truncate(safe, DISPLAY_PREVIEW_CHARS)
     tail = _safe_tail(safe, TAIL_PREVIEW_CHARS)
-    marker = (
-        f"You pasted a long message (~{char_count:,} chars). "
-        f"It has been stored for reference as {doc_name}."
-    )
+    marker = build_long_paste_marker(char_count, doc_name)
     common_meta: Dict[str, Any] = {
         "document_name": doc_name,
         "char_count": char_count,

--- a/fighthealthinsurance/chat/message_preprocessor.py
+++ b/fighthealthinsurance/chat/message_preprocessor.py
@@ -87,6 +87,21 @@ _TRAILING_JOINERS = frozenset({chr(0x200D), chr(0x200C)})
 _KEPT_WHITESPACE = "\t\n\r"
 
 
+_WHITESPACE_RUN_RE = re.compile(r"\s+")
+
+
+def sanitize_document_name(name: Optional[str]) -> str:
+    """Collapse whitespace runs (newlines included) in a document name.
+
+    Upload names arrive from the client. The stored-content markers built
+    around a name are single-line by design, and ``is_stored_message_marker``
+    matches them as single lines -- a newline smuggled into a filename would
+    silently break that recognition and with it the marker-echo exemption.
+    Returns "" for None/blank input so callers can apply their own fallback.
+    """
+    return _WHITESPACE_RUN_RE.sub(" ", name or "").strip()
+
+
 def build_long_paste_marker(char_count: int, doc_name: str) -> str:
     """The compact text stored in chat history in place of a long paste.
 
@@ -252,7 +267,10 @@ def _build_long_variants(
     caller (in document storage); these variants stay compact -- a preferred
     head+tail reference and a truncated last resort.
     """
-    doc_name = document_name or f"pasted_message_{int(time.time())}.txt"
+    doc_name = (
+        sanitize_document_name(document_name)
+        or f"pasted_message_{int(time.time())}.txt"
+    )
     head = safe_display_truncate(safe, DISPLAY_PREVIEW_CHARS)
     tail = _safe_tail(safe, TAIL_PREVIEW_CHARS)
     marker = build_long_paste_marker(char_count, doc_name)

--- a/fighthealthinsurance/chat_interface.py
+++ b/fighthealthinsurance/chat_interface.py
@@ -1193,19 +1193,18 @@ class ChatInterface:
                 sanitize_document_name(raw_name) if isinstance(raw_name, str) else ""
             )
             if actual_name and actual_name != doc_name:
-                message_variants = [
-                    replace(
-                        v,
-                        text_for_llm=v.text_for_llm.replace(doc_name, actual_name),
-                        display_text=(
-                            v.display_text.replace(doc_name, actual_name)
-                            if v.display_text
-                            else v.display_text
-                        ),
-                        metadata={**v.metadata, "document_name": actual_name},
-                    )
-                    for v in message_variants
-                ]
+                # Rebuild the variants around the real name rather than
+                # string-replacing the old one through them: the truncated
+                # variant's text IS the user's raw paste, and document_name
+                # is client-supplied, so a name that happens to occur in
+                # their content (say "the") would have been rewritten inside
+                # the message we send to the model. user_message is still the
+                # raw paste here -- it becomes the marker below.
+                message_variants = prepare_user_message_variants(
+                    user_message,
+                    is_document=is_document,
+                    document_name=actual_name,
+                )
                 long_paste_variant = next(
                     v for v in message_variants if v.metadata.get("store_full_text")
                 )

--- a/fighthealthinsurance/chat_interface.py
+++ b/fighthealthinsurance/chat_interface.py
@@ -41,9 +41,13 @@ from fighthealthinsurance.chat.llm_client import (
 )
 from fighthealthinsurance.chat.message_preprocessor import (
     MessageVariant,
+    build_long_paste_marker,
     prepare_user_message_variants,
 )
-from fighthealthinsurance.chat.document_processor import process_uploaded_document
+from fighthealthinsurance.chat.document_processor import (
+    process_uploaded_document,
+    start_document_summarization,
+)
 from fighthealthinsurance.chat.document_search import get_document_context_for_message
 from fighthealthinsurance.chat.retry_handler import (
     retry_llm_with_fallback,
@@ -87,6 +91,7 @@ from fighthealthinsurance.reliability_events import capture_reliability_event
 from fighthealthinsurance.ml.ml_router import ml_router
 from fighthealthinsurance.models import (
     Appeal,
+    ChatDocument,
     ChatType,
     OngoingChat,
     PolicyDocument,
@@ -838,6 +843,17 @@ class ChatInterface:
             )
             return
 
+        # Set when this turn's full text was diverted to document storage (an
+        # explicit upload here, or a long paste further down). Used to (a)
+        # kick the long paste's deferred background summarization after the
+        # LLM pass and (b) fall back to a useful acknowledgment instead of an
+        # error frame when every model fails -- the content is stored and
+        # being analyzed, so "all models are experiencing issues, try again"
+        # would be both unhelpful and misleading.
+        stored_content_doc: Optional[ChatDocument] = None
+        stored_content_denial_context: Optional[str] = None
+        stored_content_ack: Optional[str] = None
+
         # Handle document uploads: store separately and replace with marker in chat
         if is_document and user_message:
             doc_name = document_name or "uploaded_document"
@@ -848,12 +864,20 @@ class ChatInterface:
 
             denial_context = await self._denial_context_for_chat(chat)
 
-            await process_uploaded_document(
+            # Summarization starts inside (not deferred): several paths below
+            # can return before the LLM pass, and the upload must get analyzed
+            # regardless of which one this turn takes.
+            uploaded_doc = await process_uploaded_document(
                 chat=chat,
                 document_name=doc_name,
                 full_text=user_message,
                 denial_context=denial_context,
             )
+            # Re-uploading identical content dedupes to the earlier document:
+            # adopt its name so the marker references a document that exists.
+            actual_name = getattr(uploaded_doc, "document_name", None)
+            if isinstance(actual_name, str) and actual_name:
+                doc_name = actual_name
 
             user_message = (
                 f"I've uploaded a document: {doc_name} ({char_count:,} characters). "
@@ -861,6 +885,13 @@ class ChatInterface:
             )
             await self.send_status_message(
                 f"Document received: {doc_name}. Analyzing content in background..."
+            )
+            stored_content_ack = (
+                f"I've received your document {doc_name} ({char_count:,} characters) "
+                f"and I'm reading through it in the background. I couldn't put "
+                f"together a full reply on this pass — ask me a question about the "
+                f"document, or tell me what you'd like to do next (for example "
+                f'"summarize it" or "help me draft an appeal from it").'
             )
 
         # Check if this is a new chat BEFORE any linking modifies chat_history
@@ -1132,18 +1163,59 @@ class ChatInterface:
                 f"as {doc_name} for reference"
             )
             denial_context = await self._denial_context_for_chat(chat)
-            await process_uploaded_document(
+            # Summarization is deferred to this turn's finally block (there is
+            # no early return between here and the LLM pass): fanning out the
+            # chunk summaries now would compete with the user's own turn for
+            # the same backends -- on internal-only deployments that
+            # self-inflicted contention helped time out exactly the turns that
+            # deliver a long paste.
+            stored_content_doc = await process_uploaded_document(
                 chat=chat,
                 document_name=doc_name,
                 full_text=user_message,
                 denial_context=denial_context,
+                defer_summarization=True,
             )
+            stored_content_denial_context = denial_context
+            # Re-pasting identical content (say, after a failed turn) dedupes
+            # to the earlier document: adopt its name in the marker and every
+            # variant so we reference a document that actually exists.
+            actual_name = getattr(stored_content_doc, "document_name", None)
+            if isinstance(actual_name, str) and actual_name and actual_name != doc_name:
+                message_variants = [
+                    replace(
+                        v,
+                        text_for_llm=v.text_for_llm.replace(doc_name, actual_name),
+                        display_text=(
+                            v.display_text.replace(doc_name, actual_name)
+                            if v.display_text
+                            else v.display_text
+                        ),
+                        metadata={**v.metadata, "document_name": actual_name},
+                    )
+                    for v in message_variants
+                ]
+                long_paste_variant = next(
+                    v for v in message_variants if v.metadata.get("store_full_text")
+                )
+                doc_name = actual_name
             await self.send_status_message(
                 f"Long message received ({char_count:,} chars). "
                 f"Stored for reference and analyzing in background..."
             )
             # From here on, history + scoring use the compact marker.
-            user_message = long_paste_variant.display_text or user_message
+            user_message = long_paste_variant.display_text or build_long_paste_marker(
+                char_count, doc_name
+            )
+            stored_content_ack = (
+                f"I've received your message — it's a long one (~{char_count:,} "
+                f"characters), so I saved the full text as {doc_name} and I'm "
+                f"reading through it in the background. I couldn't put together a "
+                f"full reply on this pass. You don't need to paste it again — just "
+                f"tell me what you'd like me to do with it (for example "
+                f'"summarize this denial letter" or "help me draft an appeal"), or '
+                f"ask about a specific part."
+            )
 
         # Determine how to wrap a variant's text for the LLM (intro template on
         # new chats, delete-data instruction on ongoing turns), then apply it to
@@ -1417,6 +1489,23 @@ class ChatInterface:
             logger.debug(f"Models tried for failed chat {chat.id}: {primary_models}")
         finally:
             heartbeat_task.cancel()
+            # Deferred long-paste summarization: started only now, after the
+            # interactive LLM pass, so the chunk-summary fan-out doesn't
+            # compete with the user's own turn for the same backends. Nothing
+            # here yields, so this still runs when the consumer coroutine is
+            # being cancelled (disconnect mid-turn) -- the document must not
+            # be stranded unanalyzed.
+            if stored_content_doc is not None:
+                try:
+                    await start_document_summarization(
+                        stored_content_doc,
+                        denial_context=stored_content_denial_context,
+                    )
+                except Exception:
+                    logger.opt(exception=True).warning(
+                        f"Could not start deferred document summarization for "
+                        f"chat {chat.id}"
+                    )
             # Backstop for the once-per-turn loop metric. The depth-0 exits
             # inside _call_llm_with_actions record it themselves, but a tool
             # handler raising -- or the turn budget above firing -- unwinds
@@ -1520,15 +1609,22 @@ class ChatInterface:
             # persist it anyway so a reconnect/replay doesn't erase what they
             # typed (previously the whole turn was dropped on failure). Only
             # resubmitted when the pre-persist failed -- see
-            # user_message_prepersisted above.
+            # user_message_prepersisted above. When the turn stored the user's
+            # content (long paste / upload), the acknowledgment below is
+            # persisted with it so a replay shows a coherent exchange.
+            failed_turn_messages: List[Dict[str, str]] = (
+                []
+                if user_message_prepersisted
+                else [{"role": "user", "content": user_message}]
+            )
+            if stored_content_ack:
+                failed_turn_messages.append(
+                    {"role": "assistant", "content": stored_content_ack}
+                )
             try:
                 self.chat = chat = await apersist_chat_turn(
                     chat,
-                    new_messages=(
-                        []
-                        if user_message_prepersisted
-                        else [{"role": "user", "content": user_message}]
-                    ),
+                    new_messages=failed_turn_messages,
                     new_summaries=turn_summaries,
                 )
             except Exception:
@@ -1558,8 +1654,21 @@ class ChatInterface:
                 chat_id=str(chat.id),
                 use_external_models=self.use_external_models,
                 message_chars=len(user_message or ""),
+                stored_content_ack_delivered=bool(stored_content_ack),
             )
-            await self.send_error_message(err_msg)
+            if stored_content_ack:
+                # The user's content IS safely stored and queued for analysis,
+                # so tell them that and how to proceed instead of erroring:
+                # "models are experiencing issues, try again" reads as "your
+                # paste was lost, send it again", which just duplicates the
+                # failure (and the storage).
+                logger.info(
+                    f"Delivering stored-content acknowledgment for failed turn "
+                    f"in chat {chat.id}"
+                )
+                await self.send_message_to_client(stored_content_ack)
+            else:
+                await self.send_error_message(err_msg)
 
     async def replay_chat_history(self):
         """Sends the existing chat history to the client, minus internal

--- a/fighthealthinsurance/chat_interface.py
+++ b/fighthealthinsurance/chat_interface.py
@@ -43,6 +43,7 @@ from fighthealthinsurance.chat.message_preprocessor import (
     MessageVariant,
     build_long_paste_marker,
     prepare_user_message_variants,
+    sanitize_document_name,
 )
 from fighthealthinsurance.chat.document_processor import (
     process_uploaded_document,
@@ -856,7 +857,10 @@ class ChatInterface:
 
         # Handle document uploads: store separately and replace with marker in chat
         if is_document and user_message:
-            doc_name = document_name or "uploaded_document"
+            # Client-supplied name: sanitize so a newline inside a filename
+            # can't break the single-line marker (or its recognition by
+            # is_stored_message_marker) built around it below.
+            doc_name = sanitize_document_name(document_name) or "uploaded_document"
             char_count = len(user_message)
             logger.info(
                 f"Document uploaded in chat {chat.id}: {doc_name} ({char_count} chars)"
@@ -874,10 +878,11 @@ class ChatInterface:
                 denial_context=denial_context,
             )
             # Re-uploading identical content dedupes to the earlier document:
-            # adopt its name so the marker references a document that exists.
-            actual_name = getattr(uploaded_doc, "document_name", None)
-            if isinstance(actual_name, str) and actual_name:
-                doc_name = actual_name
+            # adopt its name (sanitized -- legacy rows may predate the name
+            # sanitization) so the marker references a document that exists.
+            raw_name = getattr(uploaded_doc, "document_name", None)
+            if isinstance(raw_name, str):
+                doc_name = sanitize_document_name(raw_name) or doc_name
 
             user_message = (
                 f"I've uploaded a document: {doc_name} ({char_count:,} characters). "
@@ -1180,10 +1185,14 @@ class ChatInterface:
             )
             stored_content_denial_context = denial_context
             # Re-pasting identical content (say, after a failed turn) dedupes
-            # to the earlier document: adopt its name in the marker and every
+            # to the earlier document: adopt its name (sanitized -- legacy
+            # rows may predate the name sanitization) in the marker and every
             # variant so we reference a document that actually exists.
-            actual_name = getattr(stored_content_doc, "document_name", None)
-            if isinstance(actual_name, str) and actual_name and actual_name != doc_name:
+            raw_name = getattr(stored_content_doc, "document_name", None)
+            actual_name = (
+                sanitize_document_name(raw_name) if isinstance(raw_name, str) else ""
+            )
+            if actual_name and actual_name != doc_name:
                 message_variants = [
                     replace(
                         v,

--- a/fighthealthinsurance/chat_interface.py
+++ b/fighthealthinsurance/chat_interface.py
@@ -1163,12 +1163,14 @@ class ChatInterface:
                 f"as {doc_name} for reference"
             )
             denial_context = await self._denial_context_for_chat(chat)
-            # Summarization is deferred to this turn's finally block (there is
-            # no early return between here and the LLM pass): fanning out the
-            # chunk summaries now would compete with the user's own turn for
-            # the same backends -- on internal-only deployments that
+            # Summarization is deferred to this turn's finally block: fanning
+            # out the chunk summaries now would compete with the user's own
+            # turn for the same backends -- on internal-only deployments that
             # self-inflicted contention helped time out exactly the turns that
-            # deliver a long paste.
+            # deliver a long paste. If this turn dies before that finally runs
+            # (a raise in the setup below, the consumer cancelled on
+            # disconnect), the watchdog process_uploaded_document arms at
+            # storage time rescues the still-PENDING document.
             stored_content_doc = await process_uploaded_document(
                 chat=chat,
                 document_name=doc_name,
@@ -1491,10 +1493,12 @@ class ChatInterface:
             heartbeat_task.cancel()
             # Deferred long-paste summarization: started only now, after the
             # interactive LLM pass, so the chunk-summary fan-out doesn't
-            # compete with the user's own turn for the same backends. Nothing
-            # here yields, so this still runs when the consumer coroutine is
-            # being cancelled (disconnect mid-turn) -- the document must not
-            # be stranded unanalyzed.
+            # compete with the user's own turn for the same backends. This is
+            # the best-effort fast path -- the atomic claim inside means at
+            # most one dispatcher wins, and the watchdog armed at storage
+            # time rescues the document if this block never runs or is
+            # cancelled mid-await (its DB claim can yield), so the document
+            # cannot be stranded unanalyzed either way.
             if stored_content_doc is not None:
                 try:
                     await start_document_summarization(

--- a/tests/async/test_chat_long_message.py
+++ b/tests/async/test_chat_long_message.py
@@ -21,8 +21,9 @@ from asgiref.sync import sync_to_async
 
 from fighthealthinsurance.chat.message_preprocessor import (
     DIRECT_CHAT_HARD_LIMIT_CHARS,
+    DIRECT_CHAT_SOFT_LIMIT_CHARS,
 )
-from fighthealthinsurance.models import OngoingChat, ProfessionalUser
+from fighthealthinsurance.models import ChatDocument, OngoingChat, ProfessionalUser
 from fighthealthinsurance.websockets import OngoingChatConsumer
 from tests.sync.mock_chat_model import MockChatModel
 
@@ -46,6 +47,29 @@ class RecordingMockModel(MockChatModel):
     async def generate_chat_response(self, message, **kwargs):
         self.received_messages.append(message)
         return await super().generate_chat_response(message, **kwargs)
+
+
+class FailingMockModel(MockChatModel):
+    """Mock model whose every generation attempt fails (returns nothing)."""
+
+    async def generate_chat_response(self, message, **kwargs):
+        return (None, None)
+
+
+class VaryingMockModel(MockChatModel):
+    """Mock model that answers something different every call, so multi-turn
+    tests don't trip the repeated-reply rejection ladder."""
+
+    def __init__(self):
+        super().__init__()
+        self.calls = 0
+
+    async def generate_chat_response(self, message, **kwargs):
+        self.calls += 1
+        return (
+            f"Reply number {self.calls} with fresh guidance about the denial.",
+            f"Summary: turn {self.calls}.",
+        )
 
 
 async def _make_professional_chat(username, npi):
@@ -177,6 +201,128 @@ class LongPasteChatTest(APITestCase):
                 for prev, nxt in pairwise(roles):
                     self.assertNotEqual(prev, nxt)
                 self.assertEqual(roles[-1], "assistant")
+
+
+class LongPasteAllModelsFailTest(APITestCase):
+    """When every model fails on a long-paste turn, the user must get a
+    useful acknowledgment (content stored, how to proceed) instead of the
+    generic all-models-down error frame -- the paste IS stored and queued
+    for analysis, so 'try again' would only duplicate the failure."""
+
+    async def test_total_model_failure_yields_acknowledgment_not_error(self):
+        big = "Coverage denied: intensive outpatient program not authorized. " * 400
+        mock_model = FailingMockModel()
+        with _patched_backends(mock_model):
+            with patch(
+                "fighthealthinsurance.chat_interface.process_uploaded_document",
+                new_callable=AsyncMock,
+            ):
+                user, chat = await _make_professional_chat("longpaste3", "9999900004")
+                communicator = WebsocketCommunicator(
+                    OngoingChatConsumer.as_asgi(), "/ws/ongoing-chat/"
+                )
+                communicator.scope["user"] = user
+                connected, _ = await communicator.connect()
+                self.assertTrue(connected)
+                try:
+                    await communicator.send_json_to(
+                        {"chat_id": str(chat.id), "content": big}
+                    )
+                    response = await _drain_to_content(communicator)
+                finally:
+                    await communicator.disconnect()
+
+                # An assistant message, not an error frame.
+                self.assertNotIn("error", response)
+                self.assertIn("content", response)
+                ack = response["content"]
+                self.assertIn("pasted_message_", ack)
+                self.assertIn("paste it again", ack)
+
+                # History shows a coherent, alternating exchange: the compact
+                # marker followed by the acknowledgment.
+                await chat.arefresh_from_db()
+                roles = [m.get("role") for m in chat.chat_history]
+                self.assertEqual(roles, ["user", "assistant"])
+                self.assertIn("stored for reference", chat.chat_history[0]["content"])
+                self.assertEqual(chat.chat_history[1]["content"], ack)
+
+    async def test_total_model_failure_on_short_message_still_errors(self):
+        # The acknowledgment fallback is only for turns whose content was
+        # diverted to storage; an ordinary failed turn keeps the error frame.
+        mock_model = FailingMockModel()
+        with _patched_backends(mock_model):
+            user, chat = await _make_professional_chat("shortfail1", "9999900005")
+            communicator = WebsocketCommunicator(
+                OngoingChatConsumer.as_asgi(), "/ws/ongoing-chat/"
+            )
+            communicator.scope["user"] = user
+            connected, _ = await communicator.connect()
+            try:
+                await communicator.send_json_to(
+                    {"chat_id": str(chat.id), "content": "Why was my claim denied?"}
+                )
+                response = await _drain_to_content(communicator)
+            finally:
+                await communicator.disconnect()
+
+            self.assertIn("error", response)
+
+
+class LongPasteDedupTest(APITestCase):
+    """Re-pasting the same long message (say, after a failed turn) must not
+    create a second stored document, and the marker in history must keep
+    referencing the document that actually exists."""
+
+    async def test_repaste_reuses_document_and_marker_names_it(self):
+        # ~20k chars: over the soft limit that triggers long-paste storage
+        # (like the ~19k production failure) though under the hard cap.
+        big = "Denied for lack of prior authorization on imaging. " * 400
+        self.assertGreater(len(big), DIRECT_CHAT_SOFT_LIMIT_CHARS)
+
+        mock_model = VaryingMockModel()
+        with _patched_backends(mock_model):
+            # Real document storage; only the summarization fan-out is mocked
+            # (both the deferred kick in document_processor and any direct
+            # fire) so no ML work runs.
+            with patch(
+                "fighthealthinsurance.chat.document_processor.fire_and_forget_in_new_threadpool",
+                new_callable=AsyncMock,
+            ) as mock_fire:
+                user, chat = await _make_professional_chat("longpaste4", "9999900006")
+                communicator = WebsocketCommunicator(
+                    OngoingChatConsumer.as_asgi(), "/ws/ongoing-chat/"
+                )
+                communicator.scope["user"] = user
+                connected, _ = await communicator.connect()
+                try:
+                    for _ in range(2):
+                        await communicator.send_json_to(
+                            {"chat_id": str(chat.id), "content": big}
+                        )
+                        await _drain_to_content(communicator)
+                finally:
+                    await communicator.disconnect()
+
+                # One stored document, summarization kicked off (deferred to
+                # after the turn, but still kicked).
+                docs = [
+                    d
+                    async for d in ChatDocument.objects.filter(chat_id=chat.id).all()
+                ]
+                self.assertEqual(len(docs), 1)
+                self.assertTrue(mock_fire.called)
+
+                # Every marker in history references the document that exists.
+                await chat.arefresh_from_db()
+                user_msgs = [
+                    m["content"]
+                    for m in chat.chat_history
+                    if m.get("role") == "user"
+                ]
+                self.assertEqual(len(user_msgs), 2)
+                for msg in user_msgs:
+                    self.assertIn(docs[0].document_name, msg)
 
 
 class NormalMessagePrimaryPathTest(APITestCase):

--- a/tests/async/test_chat_long_message.py
+++ b/tests/async/test_chat_long_message.py
@@ -285,6 +285,7 @@ class LongPasteAllModelsFailTest(APITestCase):
                     )
                     communicator.scope["user"] = user
                     connected, _ = await communicator.connect()
+                    self.assertTrue(connected)
                     try:
                         await communicator.send_json_to(
                             {"chat_id": str(chat.id), "content": big}
@@ -302,9 +303,7 @@ class LongPasteAllModelsFailTest(APITestCase):
                     d async for d in ChatDocument.objects.filter(chat_id=chat.id).all()
                 ]
                 self.assertEqual(len(docs), 1)
-                self.assertEqual(
-                    docs[0].processing_status, ChatDocument.Status.PENDING
-                )
+                self.assertEqual(docs[0].processing_status, ChatDocument.Status.PENDING)
                 fired_names = [
                     call.args[0].__name__ for call in mock_fire.call_args_list
                 ]
@@ -323,6 +322,7 @@ class LongPasteAllModelsFailTest(APITestCase):
             )
             communicator.scope["user"] = user
             connected, _ = await communicator.connect()
+            self.assertTrue(connected)
             try:
                 await communicator.send_json_to(
                     {"chat_id": str(chat.id), "content": "Why was my claim denied?"}
@@ -360,6 +360,7 @@ class LongPasteDedupTest(APITestCase):
                 )
                 communicator.scope["user"] = user
                 connected, _ = await communicator.connect()
+                self.assertTrue(connected)
                 try:
                     for _ in range(2):
                         await communicator.send_json_to(
@@ -372,8 +373,7 @@ class LongPasteDedupTest(APITestCase):
                 # One stored document, summarization kicked off (deferred to
                 # after the turn, but still kicked).
                 docs = [
-                    d
-                    async for d in ChatDocument.objects.filter(chat_id=chat.id).all()
+                    d async for d in ChatDocument.objects.filter(chat_id=chat.id).all()
                 ]
                 self.assertEqual(len(docs), 1)
                 self.assertTrue(mock_fire.called)
@@ -381,9 +381,7 @@ class LongPasteDedupTest(APITestCase):
                 # Every marker in history references the document that exists.
                 await chat.arefresh_from_db()
                 user_msgs = [
-                    m["content"]
-                    for m in chat.chat_history
-                    if m.get("role") == "user"
+                    m["content"] for m in chat.chat_history if m.get("role") == "user"
                 ]
                 self.assertEqual(len(user_msgs), 2)
                 for msg in user_msgs:

--- a/tests/async/test_chat_long_message.py
+++ b/tests/async/test_chat_long_message.py
@@ -213,8 +213,11 @@ class LongPasteAllModelsFailTest(APITestCase):
         big = "Coverage denied: intensive outpatient program not authorized. " * 400
         mock_model = FailingMockModel()
         with _patched_backends(mock_model):
+            # Real document storage (the acknowledgment must only ever claim
+            # "stored" when content truly is); only the summarization fan-out
+            # is mocked so no background ML work runs.
             with patch(
-                "fighthealthinsurance.chat_interface.process_uploaded_document",
+                "fighthealthinsurance.chat.document_processor.fire_and_forget_in_new_threadpool",
                 new_callable=AsyncMock,
             ):
                 user, chat = await _make_professional_chat("longpaste3", "9999900004")
@@ -236,8 +239,16 @@ class LongPasteAllModelsFailTest(APITestCase):
                 self.assertNotIn("error", response)
                 self.assertIn("content", response)
                 ack = response["content"]
-                self.assertIn("pasted_message_", ack)
                 self.assertIn("paste it again", ack)
+
+                # The content really was stored, and the acknowledgment names
+                # the document that actually exists.
+                docs = [
+                    d async for d in ChatDocument.objects.filter(chat_id=chat.id).all()
+                ]
+                self.assertEqual(len(docs), 1)
+                self.assertEqual(docs[0].full_text, big)
+                self.assertIn(docs[0].document_name, ack)
 
                 # History shows a coherent, alternating exchange: the compact
                 # marker followed by the acknowledgment.
@@ -246,6 +257,57 @@ class LongPasteAllModelsFailTest(APITestCase):
                 self.assertEqual(roles, ["user", "assistant"])
                 self.assertIn("stored for reference", chat.chat_history[0]["content"])
                 self.assertEqual(chat.chat_history[1]["content"], ack)
+
+    async def test_setup_failure_after_storage_still_arms_summarization(self):
+        # A raise between storage and the LLM pass (here: history prep) exits
+        # the turn before the deferred kickoff in its finally block. The
+        # document must survive as PENDING with the storage-time watchdog
+        # armed to rescue it -- not be stranded unanalyzed.
+        big = "Denial letter contents pasted just before a setup crash. " * 400
+        mock_model = RecordingMockModel()
+        with _patched_backends(mock_model):
+            with patch(
+                "fighthealthinsurance.chat.document_processor.fire_and_forget_in_new_threadpool",
+                new_callable=AsyncMock,
+            ) as mock_fire:
+                with patch(
+                    "fighthealthinsurance.chat_interface.prepare_history_for_llm",
+                    side_effect=RuntimeError("boom after storage"),
+                ):
+                    user, chat = await _make_professional_chat(
+                        "longpaste5", "9999900007"
+                    )
+                    communicator = WebsocketCommunicator(
+                        OngoingChatConsumer.as_asgi(), "/ws/ongoing-chat/"
+                    )
+                    communicator.scope["user"] = user
+                    connected, _ = await communicator.connect()
+                    try:
+                        await communicator.send_json_to(
+                            {"chat_id": str(chat.id), "content": big}
+                        )
+                        response = await _drain_to_content(communicator)
+                    finally:
+                        await communicator.disconnect()
+
+                # The turn itself failed (consumer-level error frame)...
+                self.assertIn("error", response)
+
+                # ...but the document was stored, is still PENDING, and the
+                # watchdog was armed at storage time to start summarization.
+                docs = [
+                    d async for d in ChatDocument.objects.filter(chat_id=chat.id).all()
+                ]
+                self.assertEqual(len(docs), 1)
+                self.assertEqual(
+                    docs[0].processing_status, ChatDocument.Status.PENDING
+                )
+                fired_names = [
+                    call.args[0].__name__ for call in mock_fire.call_args_list
+                ]
+                self.assertIn("_deferred_summarization_watchdog", fired_names)
+                # No summarization worker was dispatched mid-crash.
+                self.assertNotIn("summarize_chunks", fired_names)
 
     async def test_total_model_failure_on_short_message_still_errors(self):
         # The acknowledgment fallback is only for turns whose content was

--- a/tests/async/test_chat_long_message.py
+++ b/tests/async/test_chat_long_message.py
@@ -58,14 +58,17 @@ class FailingMockModel(MockChatModel):
 
 class VaryingMockModel(MockChatModel):
     """Mock model that answers something different every call, so multi-turn
-    tests don't trip the repeated-reply rejection ladder."""
+    tests don't trip the repeated-reply rejection ladder. Records every
+    message it was asked to generate against."""
 
     def __init__(self):
         super().__init__()
         self.calls = 0
+        self.received_messages: list[str] = []
 
     async def generate_chat_response(self, message, **kwargs):
         self.calls += 1
+        self.received_messages.append(message)
         return (
             f"Reply number {self.calls} with fresh guidance about the denial.",
             f"Summary: turn {self.calls}.",
@@ -385,6 +388,69 @@ class LongPasteDedupTest(APITestCase):
                 self.assertEqual(len(user_msgs), 2)
                 for msg in user_msgs:
                     self.assertIn(docs[0].document_name, msg)
+
+
+class LongPasteNameAdoptionDoesNotCorruptContentTest(APITestCase):
+    """Adopting a deduped document's name must not rewrite the user's own
+    words. document_name is client-supplied and the truncated variant's text
+    IS the raw paste, so a name that occurs in the pasted content (here the
+    word "denied") must never be substituted inside the message we send to
+    the model."""
+
+    async def test_repaste_with_content_word_as_document_name(self):
+        big = "The claim was denied because it was denied again. " * 500
+        self.assertGreater(len(big), DIRECT_CHAT_SOFT_LIMIT_CHARS)
+
+        mock_model = VaryingMockModel()
+        with _patched_backends(mock_model):
+            with patch(
+                "fighthealthinsurance.chat.document_processor.fire_and_forget_in_new_threadpool",
+                new_callable=AsyncMock,
+            ):
+                user, chat = await _make_professional_chat("longpaste6", "9999900008")
+                communicator = WebsocketCommunicator(
+                    OngoingChatConsumer.as_asgi(), "/ws/ongoing-chat/"
+                )
+                communicator.scope["user"] = user
+                connected, _ = await communicator.connect()
+                self.assertTrue(connected)
+                try:
+                    # First paste stores the document under its own name.
+                    await communicator.send_json_to(
+                        {
+                            "chat_id": str(chat.id),
+                            "content": big,
+                            "document_name": "first_doc.txt",
+                        }
+                    )
+                    await _drain_to_content(communicator)
+
+                    # Re-paste of the SAME content, this time naming it with a
+                    # word that appears throughout that content. It dedupes
+                    # onto "first_doc.txt", triggering name adoption.
+                    await communicator.send_json_to(
+                        {
+                            "chat_id": str(chat.id),
+                            "content": big,
+                            "document_name": "denied",
+                        }
+                    )
+                    await _drain_to_content(communicator)
+                finally:
+                    await communicator.disconnect()
+
+                docs = [
+                    d async for d in ChatDocument.objects.filter(chat_id=chat.id).all()
+                ]
+                self.assertEqual(len(docs), 1)
+                self.assertEqual(docs[0].document_name, "first_doc.txt")
+
+                # The user's words survived intact: no message sent to the
+                # model contains the substitution "first_doc.txt" where the
+                # user wrote "denied".
+                self.assertTrue(mock_model.received_messages)
+                for msg in mock_model.received_messages:
+                    self.assertNotIn("was first_doc.txt because", msg)
 
 
 class NormalMessagePrimaryPathTest(APITestCase):

--- a/tests/async/test_document_processing.py
+++ b/tests/async/test_document_processing.py
@@ -20,6 +20,7 @@ from fighthealthinsurance.chat.document_processor import (
     DEFAULT_CHUNK_SIZE,
     DEFERRED_SUMMARY_WATCHDOG_SECONDS,
     STUCK_PROCESSING_RESCUE_SECONDS,
+    _claim_document_for_processing,
     _deferred_summarization_watchdog,
     chunk_document,
     process_uploaded_document,
@@ -508,6 +509,57 @@ class TestProcessUploadedDocument(APITestCase):
                 )
         # The fresh doc dispatched its own worker; no rescue is needed.
         mock_watchdog.assert_not_called()
+
+    async def test_stuck_processing_claim_is_exclusive(self):
+        # A PROCESSING -> PROCESSING conditional UPDATE changes nothing but
+        # still matches, so the database would report a successful claim to
+        # every caller: N resubmissions onto one stuck row would each start a
+        # full summarization fan-out. Exactly one caller may win.
+        chat = await OngoingChat.objects.acreate()
+        doc = await ChatDocument.objects.acreate(
+            chat=chat,
+            document_name="stuck_exclusive.txt",
+            full_text="text whose worker died",
+            char_count=22,
+            processing_status=ChatDocument.Status.PROCESSING,
+        )
+
+        results = await asyncio.gather(
+            _claim_document_for_processing(doc.id, [ChatDocument.Status.PROCESSING]),
+            _claim_document_for_processing(doc.id, [ChatDocument.Status.PROCESSING]),
+            _claim_document_for_processing(doc.id, [ChatDocument.Status.PROCESSING]),
+        )
+        assert sorted(results) == [False, False, True]
+        await doc.arefresh_from_db()
+        assert doc.processing_status == ChatDocument.Status.PROCESSING
+
+    async def test_concurrent_stuck_rescues_dispatch_one_worker(self):
+        chat = await OngoingChat.objects.acreate()
+        doc = await ChatDocument.objects.acreate(
+            chat=chat,
+            document_name="stuck_race.txt",
+            full_text="text whose worker died",
+            char_count=22,
+            processing_status=ChatDocument.Status.PROCESSING,
+        )
+
+        with patch(
+            "fighthealthinsurance.chat.document_processor.summarize_chunks",
+            new_callable=AsyncMock,
+        ) as mock_summarize:
+            await asyncio.gather(
+                *(
+                    _deferred_summarization_watchdog(
+                        doc.id,
+                        None,
+                        delay=0.01,
+                        claim_statuses=[ChatDocument.Status.PROCESSING],
+                    )
+                    for _ in range(3)
+                )
+            )
+
+        assert mock_summarize.await_count == 1
 
     async def test_watchdog_can_rescue_stuck_processing_when_told_to(self):
         chat = await OngoingChat.objects.acreate()

--- a/tests/async/test_document_processing.py
+++ b/tests/async/test_document_processing.py
@@ -19,6 +19,7 @@ from fighthealthinsurance.chat.document_processor import (
     DEFAULT_CHUNK_SIZE,
     chunk_document,
     process_uploaded_document,
+    start_document_summarization,
 )
 from fighthealthinsurance.chat.document_search import (
     _extract_search_terms,
@@ -286,3 +287,130 @@ class TestProcessUploadedDocument(APITestCase):
                 full_text="Some text",
             )
             mock_fire.assert_called_once()
+
+    async def test_defer_summarization_skips_the_fire(self):
+        chat = await OngoingChat.objects.acreate()
+
+        with patch(
+            "fighthealthinsurance.chat.document_processor.fire_and_forget_in_new_threadpool",
+            new_callable=AsyncMock,
+        ) as mock_fire:
+            doc = await process_uploaded_document(
+                chat=chat,
+                document_name="test.pdf",
+                full_text="Some text",
+                defer_summarization=True,
+            )
+            mock_fire.assert_not_called()
+
+            # The caller kicks it off later; a PENDING doc fires.
+            fired = await start_document_summarization(doc)
+            assert fired
+            mock_fire.assert_called_once()
+
+    async def test_start_summarization_skips_docs_already_processed(self):
+        chat = await OngoingChat.objects.acreate()
+        for status in (
+            ChatDocument.Status.PROCESSING,
+            ChatDocument.Status.COMPLETED,
+        ):
+            doc = await ChatDocument.objects.acreate(
+                chat=chat,
+                document_name=f"{status}.pdf",
+                full_text="Text",
+                char_count=4,
+                processing_status=status,
+            )
+            with patch(
+                "fighthealthinsurance.chat.document_processor.fire_and_forget_in_new_threadpool",
+                new_callable=AsyncMock,
+            ) as mock_fire:
+                fired = await start_document_summarization(doc)
+                assert not fired
+                mock_fire.assert_not_called()
+
+    async def test_identical_resubmission_reuses_existing_document(self):
+        chat = await OngoingChat.objects.acreate()
+        full_text = "The same long pasted denial letter, resubmitted after a failure."
+
+        with patch(
+            "fighthealthinsurance.chat.document_processor.fire_and_forget_in_new_threadpool",
+            new_callable=AsyncMock,
+        ):
+            first = await process_uploaded_document(
+                chat=chat,
+                document_name="pasted_message_100.txt",
+                full_text=full_text,
+            )
+            second = await process_uploaded_document(
+                chat=chat,
+                document_name="pasted_message_200.txt",
+                full_text=full_text,
+            )
+
+        assert second.id == first.id
+        # The original name wins so history references a real document.
+        assert second.document_name == "pasted_message_100.txt"
+        count = await ChatDocument.objects.filter(chat=chat).acount()
+        assert count == 1
+
+    async def test_different_content_is_not_deduped(self):
+        chat = await OngoingChat.objects.acreate()
+
+        with patch(
+            "fighthealthinsurance.chat.document_processor.fire_and_forget_in_new_threadpool",
+            new_callable=AsyncMock,
+        ):
+            first = await process_uploaded_document(
+                chat=chat,
+                document_name="a.txt",
+                full_text="first document text",
+            )
+            second = await process_uploaded_document(
+                chat=chat,
+                document_name="b.txt",
+                full_text="second, different text",
+            )
+
+        assert second.id != first.id
+        count = await ChatDocument.objects.filter(chat=chat).acount()
+        assert count == 2
+
+    async def test_same_content_in_a_different_chat_is_not_deduped(self):
+        chat_a = await OngoingChat.objects.acreate()
+        chat_b = await OngoingChat.objects.acreate()
+        full_text = "shared text pasted into two unrelated chats"
+
+        with patch(
+            "fighthealthinsurance.chat.document_processor.fire_and_forget_in_new_threadpool",
+            new_callable=AsyncMock,
+        ):
+            doc_a = await process_uploaded_document(
+                chat=chat_a, document_name="a.txt", full_text=full_text
+            )
+            doc_b = await process_uploaded_document(
+                chat=chat_b, document_name="b.txt", full_text=full_text
+            )
+
+        assert doc_a.id != doc_b.id
+
+    async def test_resubmission_of_failed_document_refires_summarization(self):
+        chat = await OngoingChat.objects.acreate()
+        full_text = "content whose first summarization attempt failed"
+
+        with patch(
+            "fighthealthinsurance.chat.document_processor.fire_and_forget_in_new_threadpool",
+            new_callable=AsyncMock,
+        ) as mock_fire:
+            first = await process_uploaded_document(
+                chat=chat, document_name="a.txt", full_text=full_text
+            )
+            first.processing_status = ChatDocument.Status.FAILED
+            await first.asave(update_fields=["processing_status"])
+
+            second = await process_uploaded_document(
+                chat=chat, document_name="b.txt", full_text=full_text
+            )
+            assert second.id == first.id
+            # Once for the initial store, once for the FAILED retry.
+            assert mock_fire.call_count == 2

--- a/tests/async/test_document_processing.py
+++ b/tests/async/test_document_processing.py
@@ -19,17 +19,12 @@ from rest_framework.test import APITestCase
 from fighthealthinsurance.chat.document_processor import (
     DEFAULT_CHUNK_SIZE,
     DEFERRED_SUMMARY_WATCHDOG_SECONDS,
+    STUCK_PROCESSING_RESCUE_SECONDS,
     _deferred_summarization_watchdog,
     chunk_document,
     process_uploaded_document,
     start_document_summarization,
 )
-
-
-def _fired_coroutine_names(mock_fire) -> list[str]:
-    """Names of the coroutines handed to the mocked fire-and-forget helper."""
-    names = [call.args[0].__name__ for call in mock_fire.call_args_list]
-    return names
 from fighthealthinsurance.chat.document_search import (
     _extract_search_terms,
     _score_chunk,
@@ -41,6 +36,11 @@ if typing.TYPE_CHECKING:
     from django.contrib.auth.models import User
 else:
     User = get_user_model()
+
+
+def _fired_coroutine_names(mock_fire) -> list[str]:
+    """Names of the coroutines handed to the mocked fire-and-forget helper."""
+    return [call.args[0].__name__ for call in mock_fire.call_args_list]
 
 
 class TestChunkDocument(TestCase):
@@ -460,6 +460,77 @@ class TestProcessUploadedDocument(APITestCase):
             DEFERRED_SUMMARY_WATCHDOG_SECONDS,
             claim_statuses=[ChatDocument.Status.FAILED],
         )
+
+    async def test_resubmission_onto_processing_row_arms_stuck_rescue(self):
+        # A worker can die without persisting a terminal status (pod restart,
+        # OOM), leaving the row PROCESSING forever. Dedupe pins every future
+        # resubmission to that row, so the resubmission must arm a rescue
+        # watchdog that may claim PROCESSING after a generous delay.
+        chat = await OngoingChat.objects.acreate()
+        full_text = "content whose worker died mid-run without a terminal status"
+        await ChatDocument.objects.acreate(
+            chat=chat,
+            document_name="stuck.txt",
+            full_text=full_text,
+            char_count=len(full_text),
+            processing_status=ChatDocument.Status.PROCESSING,
+        )
+
+        with patch(
+            "fighthealthinsurance.chat.document_processor.fire_and_forget_in_new_threadpool",
+            new_callable=AsyncMock,
+        ):
+            with patch(
+                "fighthealthinsurance.chat.document_processor._deferred_summarization_watchdog"
+            ) as mock_watchdog:
+                doc = await process_uploaded_document(
+                    chat=chat, document_name="retry.txt", full_text=full_text
+                )
+
+        mock_watchdog.assert_called_once_with(
+            doc.id,
+            None,
+            STUCK_PROCESSING_RESCUE_SECONDS,
+            claim_statuses=[ChatDocument.Status.PROCESSING],
+        )
+
+    async def test_fresh_document_does_not_arm_stuck_rescue(self):
+        chat = await OngoingChat.objects.acreate()
+        with patch(
+            "fighthealthinsurance.chat.document_processor.fire_and_forget_in_new_threadpool",
+            new_callable=AsyncMock,
+        ):
+            with patch(
+                "fighthealthinsurance.chat.document_processor._deferred_summarization_watchdog"
+            ) as mock_watchdog:
+                await process_uploaded_document(
+                    chat=chat, document_name="fresh.txt", full_text="brand new"
+                )
+        # The fresh doc dispatched its own worker; no rescue is needed.
+        mock_watchdog.assert_not_called()
+
+    async def test_watchdog_can_rescue_stuck_processing_when_told_to(self):
+        chat = await OngoingChat.objects.acreate()
+        doc = await ChatDocument.objects.acreate(
+            chat=chat,
+            document_name="stuck2.txt",
+            full_text="text from a dead worker",
+            char_count=23,
+            processing_status=ChatDocument.Status.PROCESSING,
+        )
+
+        with patch(
+            "fighthealthinsurance.chat.document_processor.summarize_chunks",
+            new_callable=AsyncMock,
+        ) as mock_summarize:
+            await _deferred_summarization_watchdog(
+                doc.id,
+                None,
+                delay=0.01,
+                claim_statuses=[ChatDocument.Status.PROCESSING],
+            )
+
+        mock_summarize.assert_awaited_once_with(doc.id, denial_context=None)
 
     async def test_watchdog_handles_deleted_document(self):
         with patch(

--- a/tests/async/test_document_processing.py
+++ b/tests/async/test_document_processing.py
@@ -18,6 +18,7 @@ from rest_framework.test import APITestCase
 
 from fighthealthinsurance.chat.document_processor import (
     DEFAULT_CHUNK_SIZE,
+    DEFERRED_SUMMARY_WATCHDOG_SECONDS,
     _deferred_summarization_watchdog,
     chunk_document,
     process_uploaded_document,
@@ -398,6 +399,67 @@ class TestProcessUploadedDocument(APITestCase):
             mock_summarize.assert_not_awaited()
             await doc.arefresh_from_db()
             assert doc.processing_status == status
+
+    async def test_watchdog_rescues_resubmitted_failed_document(self):
+        # A FAILED doc the user resubmitted arms a watchdog claiming FAILED,
+        # so the retry still happens even if the resubmitting turn dies.
+        chat = await OngoingChat.objects.acreate()
+        doc = await ChatDocument.objects.acreate(
+            chat=chat,
+            document_name="failed_retry.txt",
+            full_text="content whose first analysis failed",
+            char_count=35,
+            processing_status=ChatDocument.Status.FAILED,
+        )
+
+        with patch(
+            "fighthealthinsurance.chat.document_processor.summarize_chunks",
+            new_callable=AsyncMock,
+        ) as mock_summarize:
+            await _deferred_summarization_watchdog(
+                doc.id,
+                None,
+                delay=0.01,
+                claim_statuses=[ChatDocument.Status.FAILED],
+            )
+
+        mock_summarize.assert_awaited_once_with(doc.id, denial_context=None)
+        await doc.arefresh_from_db()
+        assert doc.processing_status == ChatDocument.Status.PROCESSING
+
+    async def test_deferred_resubmission_arms_watchdog_for_failed_status(self):
+        chat = await OngoingChat.objects.acreate()
+        full_text = "identical content resubmitted after a failed analysis"
+
+        with patch(
+            "fighthealthinsurance.chat.document_processor.fire_and_forget_in_new_threadpool",
+            new_callable=AsyncMock,
+        ):
+            first = await process_uploaded_document(
+                chat=chat, document_name="a.txt", full_text=full_text
+            )
+            first.processing_status = ChatDocument.Status.FAILED
+            await first.asave(update_fields=["processing_status"])
+
+            with patch(
+                "fighthealthinsurance.chat.document_processor._deferred_summarization_watchdog"
+            ) as mock_watchdog:
+                second = await process_uploaded_document(
+                    chat=chat,
+                    document_name="b.txt",
+                    full_text=full_text,
+                    defer_summarization=True,
+                )
+
+        assert second.id == first.id
+        # The watchdog is armed to claim from the status observed at arming
+        # time, so it can rescue this FAILED doc (not just PENDING ones).
+        mock_watchdog.assert_called_once_with(
+            first.id,
+            None,
+            DEFERRED_SUMMARY_WATCHDOG_SECONDS,
+            claim_statuses=[ChatDocument.Status.FAILED],
+        )
 
     async def test_watchdog_handles_deleted_document(self):
         with patch(

--- a/tests/async/test_document_processing.py
+++ b/tests/async/test_document_processing.py
@@ -8,6 +8,7 @@ Tests cover:
 4. ChatDocument model creation and processing
 """
 
+import asyncio
 import typing
 from unittest.mock import patch, AsyncMock
 
@@ -17,10 +18,17 @@ from rest_framework.test import APITestCase
 
 from fighthealthinsurance.chat.document_processor import (
     DEFAULT_CHUNK_SIZE,
+    _deferred_summarization_watchdog,
     chunk_document,
     process_uploaded_document,
     start_document_summarization,
 )
+
+
+def _fired_coroutine_names(mock_fire) -> list[str]:
+    """Names of the coroutines handed to the mocked fire-and-forget helper."""
+    names = [call.args[0].__name__ for call in mock_fire.call_args_list]
+    return names
 from fighthealthinsurance.chat.document_search import (
     _extract_search_terms,
     _score_chunk,
@@ -268,7 +276,9 @@ class TestProcessUploadedDocument(APITestCase):
         assert doc.id is not None
         assert doc.document_name == "test.pdf"
         assert doc.char_count == len(full_text)
-        assert doc.processing_status == ChatDocument.Status.PENDING
+        # The immediate (non-deferred) path dispatches a worker, which claims
+        # the row atomically -- so it leaves storage already PROCESSING.
+        assert doc.processing_status == ChatDocument.Status.PROCESSING
         assert doc.full_text == full_text
 
         exists = await ChatDocument.objects.filter(id=doc.id).aexists()
@@ -288,7 +298,7 @@ class TestProcessUploadedDocument(APITestCase):
             )
             mock_fire.assert_called_once()
 
-    async def test_defer_summarization_skips_the_fire(self):
+    async def test_defer_summarization_arms_watchdog_but_no_worker(self):
         chat = await OngoingChat.objects.acreate()
 
         with patch(
@@ -301,12 +311,101 @@ class TestProcessUploadedDocument(APITestCase):
                 full_text="Some text",
                 defer_summarization=True,
             )
-            mock_fire.assert_not_called()
+            # Deferred: no summarization worker yet -- only the stranded-doc
+            # watchdog is armed at storage time.
+            assert _fired_coroutine_names(mock_fire) == [
+                "_deferred_summarization_watchdog"
+            ]
+            assert doc.processing_status == ChatDocument.Status.PENDING
 
-            # The caller kicks it off later; a PENDING doc fires.
+            # The caller kicks the worker off later; a PENDING doc fires.
             fired = await start_document_summarization(doc)
             assert fired
-            mock_fire.assert_called_once()
+            assert _fired_coroutine_names(mock_fire) == [
+                "_deferred_summarization_watchdog",
+                "summarize_chunks",
+            ]
+
+            # A second kickoff loses the (already-spent) claim: no double fire.
+            fired_again = await start_document_summarization(doc)
+            assert not fired_again
+            assert len(mock_fire.call_args_list) == 2
+
+    async def test_start_summarization_claims_atomically_under_concurrency(self):
+        chat = await OngoingChat.objects.acreate()
+
+        with patch(
+            "fighthealthinsurance.chat.document_processor.fire_and_forget_in_new_threadpool",
+            new_callable=AsyncMock,
+        ) as mock_fire:
+            doc = await process_uploaded_document(
+                chat=chat,
+                document_name="test.pdf",
+                full_text="Some text",
+                defer_summarization=True,
+            )
+            # Two concurrent kickoffs (the turn's deferred start racing a
+            # resubmission): the conditional-UPDATE claim lets exactly one
+            # dispatch a worker.
+            results = await asyncio.gather(
+                start_document_summarization(doc),
+                start_document_summarization(doc),
+            )
+            assert sorted(results) == [False, True]
+            assert _fired_coroutine_names(mock_fire).count("summarize_chunks") == 1
+
+    async def test_watchdog_rescues_stranded_pending_document(self):
+        chat = await OngoingChat.objects.acreate()
+        doc = await ChatDocument.objects.acreate(
+            chat=chat,
+            document_name="stranded.txt",
+            full_text="Text stored by a turn that died before its kickoff.",
+            char_count=51,
+            processing_status=ChatDocument.Status.PENDING,
+        )
+
+        with patch(
+            "fighthealthinsurance.chat.document_processor.summarize_chunks",
+            new_callable=AsyncMock,
+        ) as mock_summarize:
+            await _deferred_summarization_watchdog(doc.id, None, delay=0.01)
+
+        mock_summarize.assert_awaited_once_with(doc.id, denial_context=None)
+        await doc.arefresh_from_db()
+        assert doc.processing_status == ChatDocument.Status.PROCESSING
+
+    async def test_watchdog_leaves_started_and_failed_documents_alone(self):
+        chat = await OngoingChat.objects.acreate()
+        # PROCESSING/COMPLETED were started normally; FAILED is deliberately
+        # not retried by the watchdog (retries stay a resubmission decision).
+        for status in (
+            ChatDocument.Status.PROCESSING,
+            ChatDocument.Status.COMPLETED,
+            ChatDocument.Status.FAILED,
+        ):
+            doc = await ChatDocument.objects.acreate(
+                chat=chat,
+                document_name=f"{status}.txt",
+                full_text=f"text in state {status}",
+                char_count=10,
+                processing_status=status,
+            )
+            with patch(
+                "fighthealthinsurance.chat.document_processor.summarize_chunks",
+                new_callable=AsyncMock,
+            ) as mock_summarize:
+                await _deferred_summarization_watchdog(doc.id, None, delay=0.01)
+            mock_summarize.assert_not_awaited()
+            await doc.arefresh_from_db()
+            assert doc.processing_status == status
+
+    async def test_watchdog_handles_deleted_document(self):
+        with patch(
+            "fighthealthinsurance.chat.document_processor.summarize_chunks",
+            new_callable=AsyncMock,
+        ) as mock_summarize:
+            await _deferred_summarization_watchdog(999999999, None, delay=0.01)
+        mock_summarize.assert_not_awaited()
 
     async def test_start_summarization_skips_docs_already_processed(self):
         chat = await OngoingChat.objects.acreate()

--- a/tests/sync/test_llm_client.py
+++ b/tests/sync/test_llm_client.py
@@ -24,6 +24,7 @@ from fighthealthinsurance.chat.llm_client import (
     BAD_CONTEXT_PATTERNS,
     INVENTED_ELIGIBILITY_VERDICT_PENALTY,
 )
+from fighthealthinsurance.chat.message_preprocessor import build_long_paste_marker
 from tests.chat_fixtures import CANNED_MEDICAID_REPLY, FRESH_REPLY, LOOPED_REPLY
 
 
@@ -588,6 +589,54 @@ class TestFindRepeatedReply(TestCase):
                 "Now reformat it into three paragraphs",
             )
         )
+
+
+class TestStoredMarkerEchoExemption(TestCase):
+    """A long-paste/upload turn replaces the user message with a
+    system-written marker; a reply acknowledging the stored content by name
+    legitimately reuses that wording, so the echoes-the-user rung must stand
+    down for markers -- otherwise every candidate on such a turn could be
+    hard-rejected, failing the whole turn."""
+
+    MARKER = build_long_paste_marker(18949, "pasted_message_1787951051.txt")
+
+    def test_reply_echoing_the_marker_is_not_hard_rejected(self):
+        # Verbatim echo -- the strongest possible match, which the
+        # echoes-the-user rung would otherwise reject outright.
+        self.assertIsNone(find_repeated_reply(self.MARKER, [], self.MARKER))
+
+    def test_reply_echoing_real_user_text_is_still_rejected(self):
+        msg = "Help me figure out how to navigate the new medicaid requirements."
+        self.assertEqual(find_repeated_reply(msg, [], msg), "echoes_user_message")
+
+    def test_assistant_repeat_still_rejected_on_marker_turns(self):
+        history = [
+            {"role": "user", "content": "Help me with this denial."},
+            {"role": "assistant", "content": LOOPED_REPLY},
+        ]
+        self.assertEqual(
+            find_repeated_reply(LOOPED_REPLY, history, self.MARKER),
+            "repeats_recent_assistant_reply",
+        )
+
+    def test_no_soft_penalty_for_marker_similarity(self):
+        self.assertEqual(
+            compute_repetition_penalty(self.MARKER, [], current_message=self.MARKER),
+            0.0,
+        )
+
+    def test_marker_echo_not_scored_negative_infinity(self):
+        reply = (
+            f"{self.MARKER} I'm reading through it now — tell me what you'd "
+            f"like me to do with it."
+        )
+        score = score_llm_response(
+            (reply, "Context: long pasted denial letter stored."),
+            100,
+            chat_history=[],
+            current_message=self.MARKER,
+        )
+        self.assertGreater(score, 0)
 
 
 class TestTransformRequestSoftPenalty(TestCase):

--- a/tests/sync/test_llm_client.py
+++ b/tests/sync/test_llm_client.py
@@ -600,10 +600,19 @@ class TestStoredMarkerEchoExemption(TestCase):
 
     MARKER = build_long_paste_marker(18949, "pasted_message_1787951051.txt")
 
-    def test_reply_echoing_the_marker_is_not_hard_rejected(self):
-        # Verbatim echo -- the strongest possible match, which the
-        # echoes-the-user rung would otherwise reject outright.
-        self.assertIsNone(find_repeated_reply(self.MARKER, [], self.MARKER))
+    def test_reply_reusing_marker_wording_is_not_hard_rejected(self):
+        # Near-verbatim reuse with actual content on top: legitimate
+        # acknowledgment, must survive the echoes-the-user rung.
+        reply = f"{self.MARKER} I'm reading it now."
+        self.assertIsNone(find_repeated_reply(reply, [], self.MARKER))
+
+    def test_bare_marker_echo_is_still_rejected(self):
+        # A reply that IS the marker adds nothing -- rejecting it lets the
+        # stored-content acknowledgment fallback deliver something useful.
+        self.assertEqual(
+            find_repeated_reply(self.MARKER, [], self.MARKER),
+            "echoes_user_message",
+        )
 
     def test_reply_echoing_real_user_text_is_still_rejected(self):
         msg = "Help me figure out how to navigate the new medicaid requirements."

--- a/tests/sync/test_message_preprocessor.py
+++ b/tests/sync/test_message_preprocessor.py
@@ -33,6 +33,7 @@ from fighthealthinsurance.chat.message_preprocessor import (
     is_stored_message_marker,
     prepare_user_message_variants,
     safe_display_truncate,
+    sanitize_document_name,
     strip_control_chars,
 )
 
@@ -272,6 +273,31 @@ class StoredMessageMarkerTest(SimpleTestCase):
     def test_text_merely_containing_the_marker_is_not_a_marker(self):
         marker = build_long_paste_marker(9000, "pasted_message_1.txt")
         self.assertFalse(is_stored_message_marker(f"The system said: {marker} Weird!"))
+
+    def test_sanitize_document_name_collapses_newlines(self):
+        self.assertEqual(
+            sanitize_document_name("denial\nletter\r\n final.pdf"),
+            "denial letter final.pdf",
+        )
+        self.assertEqual(sanitize_document_name("  plain.txt  "), "plain.txt")
+        self.assertEqual(sanitize_document_name(None), "")
+        self.assertEqual(sanitize_document_name("\n \t"), "")
+
+    def test_marker_with_sanitized_client_name_is_recognized(self):
+        # A client filename with a newline would break the single-line marker
+        # patterns; after sanitization the marker round-trips.
+        name = sanitize_document_name("my\ndenial.pdf")
+        marker = build_long_paste_marker(12000, name)
+        self.assertTrue(is_stored_message_marker(marker))
+
+    def test_long_paste_variants_sanitize_provided_document_name(self):
+        big = "Denied as not medically necessary. " * 600
+        variants = prepare_user_message_variants(
+            big, is_document=False, document_name="weird\nname.txt"
+        )
+        ref = next(v for v in variants if v.kind == "long_message_document_reference")
+        self.assertEqual(ref.metadata.get("document_name"), "weird name.txt")
+        self.assertTrue(is_stored_message_marker(ref.display_text))
 
 
 class VariantScoringTest(SimpleTestCase):

--- a/tests/sync/test_message_preprocessor.py
+++ b/tests/sync/test_message_preprocessor.py
@@ -28,7 +28,9 @@ from fighthealthinsurance.chat.message_preprocessor import (
     DIRECT_CHAT_SOFT_LIMIT_CHARS,
     LONG_DOC_REFERENCE_DELTA,
     MessageVariant,
+    build_long_paste_marker,
     has_suspicious_unicode,
+    is_stored_message_marker,
     prepare_user_message_variants,
     safe_display_truncate,
     strip_control_chars,
@@ -229,6 +231,47 @@ class UnicodeHelperTest(SimpleTestCase):
     def test_strip_control_chars_keeps_tabs_and_newlines(self):
         self.assertEqual(strip_control_chars("a\tb\nc"), "a\tb\nc")
         self.assertEqual(strip_control_chars("a" + ZERO_WIDTH_SPACE + "b"), "ab")
+
+
+class StoredMessageMarkerTest(SimpleTestCase):
+    """is_stored_message_marker recognizes exactly the system-written markers
+    that replace stored content in chat history -- and nothing else."""
+
+    def test_built_long_paste_marker_is_recognized(self):
+        marker = build_long_paste_marker(18949, "pasted_message_1787951051.txt")
+        self.assertTrue(is_stored_message_marker(marker))
+
+    def test_variant_display_text_is_recognized(self):
+        big = "Denied as not medically necessary. " * 600
+        variants = prepare_user_message_variants(big, is_document=False)
+        ref = next(v for v in variants if v.kind == "long_message_document_reference")
+        self.assertTrue(is_stored_message_marker(ref.display_text))
+
+    def test_document_upload_marker_is_recognized(self):
+        # Mirrors the marker built in chat_interface.handle_chat_message.
+        marker = (
+            "I've uploaded a document: denial_letter.pdf (12,345 characters). "
+            "The document is being analyzed and its contents are available "
+            "for reference."
+        )
+        self.assertTrue(is_stored_message_marker(marker))
+
+    def test_marker_with_surrounding_whitespace_is_recognized(self):
+        marker = build_long_paste_marker(9000, "pasted_message_1.txt")
+        self.assertTrue(is_stored_message_marker(f"  {marker}\n"))
+
+    def test_normal_user_text_is_not_a_marker(self):
+        for text in (
+            "Why was my physical therapy claim denied?",
+            "You pasted a long message the other day, what was in it?",
+            "",
+            None,
+        ):
+            self.assertFalse(is_stored_message_marker(text))
+
+    def test_text_merely_containing_the_marker_is_not_a_marker(self):
+        marker = build_long_paste_marker(9000, "pasted_message_1.txt")
+        self.assertFalse(is_stored_message_marker(f"The system said: {marker} Weird!"))
 
 
 class VariantScoringTest(SimpleTestCase):

--- a/tests/sync/test_message_preprocessor.py
+++ b/tests/sync/test_message_preprocessor.py
@@ -274,13 +274,19 @@ class StoredMessageMarkerTest(SimpleTestCase):
         marker = build_long_paste_marker(9000, "pasted_message_1.txt")
         self.assertFalse(is_stored_message_marker(f"The system said: {marker} Weird!"))
 
-    def test_sanitize_document_name_collapses_newlines(self):
+    def test_sanitize_document_name_collapses_newline_runs(self):
         self.assertEqual(
             sanitize_document_name("denial\nletter\r\n final.pdf"),
             "denial letter final.pdf",
         )
+
+    def test_sanitize_document_name_trims_surrounding_whitespace(self):
         self.assertEqual(sanitize_document_name("  plain.txt  "), "plain.txt")
+
+    def test_sanitize_document_name_of_none_is_empty(self):
         self.assertEqual(sanitize_document_name(None), "")
+
+    def test_sanitize_document_name_of_whitespace_only_is_empty(self):
         self.assertEqual(sanitize_document_name("\n \t"), "")
 
     def test_marker_with_sanitized_client_name_is_recognized(self):
@@ -290,13 +296,19 @@ class StoredMessageMarkerTest(SimpleTestCase):
         marker = build_long_paste_marker(12000, name)
         self.assertTrue(is_stored_message_marker(marker))
 
-    def test_long_paste_variants_sanitize_provided_document_name(self):
+    def _long_paste_reference_variant(self, document_name):
         big = "Denied as not medically necessary. " * 600
         variants = prepare_user_message_variants(
-            big, is_document=False, document_name="weird\nname.txt"
+            big, is_document=False, document_name=document_name
         )
-        ref = next(v for v in variants if v.kind == "long_message_document_reference")
+        return next(v for v in variants if v.kind == "long_message_document_reference")
+
+    def test_long_paste_variants_sanitize_provided_document_name(self):
+        ref = self._long_paste_reference_variant("weird\nname.txt")
         self.assertEqual(ref.metadata.get("document_name"), "weird name.txt")
+
+    def test_long_paste_marker_stays_recognizable_after_sanitization(self):
+        ref = self._long_paste_reference_variant("weird\nname.txt")
         self.assertTrue(is_stored_message_marker(ref.display_text))
 
 


### PR DESCRIPTION
## Summary

Improves handling of long-paste messages and document uploads by deferring background summarization to avoid competing with interactive LLM calls, and providing useful acknowledgments when all models fail on stored-content turns instead of generic error frames.

## Key Changes

- **Deferred summarization for long pastes**: When a message exceeds the soft limit and is stored as a document, summarization is now deferred to after the LLM pass (in a finally block) rather than fired immediately. This prevents the batch summarization work from competing with the user's own turn for the same ML backends, which was causing timeouts on internal deployments.

- **Document deduplication**: Identical content re-submitted to the same chat (e.g., after a failed turn) now reuses the existing document instead of creating duplicates. The original document name is preserved so history references a document that actually exists.

- **Fallback acknowledgments for total model failure**: When every model fails on a turn where content was stored (long paste or upload), the system now returns a useful acknowledgment message instead of a generic "all models are experiencing issues" error frame. The content is already stored and being analyzed, so the acknowledgment explains this and guides the user on next steps.

- **Stored-content marker exemption from repeat detection**: Long-paste and upload markers are system-generated stand-ins, not user prose. Replies that acknowledge the stored content by name now bypass the "echoes user message" rejection layer, preventing legitimate responses from being hard-rejected on stored-content turns.

- **New helper functions**:
  - `build_long_paste_marker()`: Centralizes the compact marker text for consistency
  - `is_stored_message_marker()`: Recognizes system-generated markers via regex matching
  - `start_document_summarization()`: Safely fires summarization with idempotency checks
  - `summarization_needed()`: Determines if a document still needs summarization (PENDING or FAILED status)

## Implementation Details

- Document deduplication uses content hash matching (char count + full text equality) within a single chat to detect re-submissions
- Deferred summarization is kicked in the finally block of `handle_chat_message`, ensuring it runs even if the consumer coroutine is cancelled mid-turn
- Failed documents (status=FAILED) are eligible for re-summarization on re-submission, allowing retry of failed analysis
- The `defer_summarization` parameter in `process_uploaded_document` controls whether summarization fires immediately (uploads) or is deferred (long pastes)
- Marker recognition uses full-match regex patterns to avoid false positives from user text that merely quotes the markers

## Tests Added

- `LongPasteAllModelsFailTest`: Verifies acknowledgment on total model failure for long pastes, and that short messages still get error frames
- `LongPasteDedupTest`: Confirms re-pasting identical content reuses the document and preserves marker names
- Document processor tests for deduplication, deferred summarization, and re-summarization of failed documents
- LLM client tests for marker echo exemption from repeat detection and scoring
- Message preprocessor tests for marker recognition

https://claude.ai/code/session_01J3ujsTLWUCtuiMjKB7224n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Duplicate document uploads and long pastes are reused instead of creating duplicate records.
  * Document summarization can be deferred and started reliably after chat responses.
  * Stored-content acknowledgments are shown when processing succeeds but the assistant response fails.
  * References to uploaded or pasted content are no longer incorrectly flagged as duplicate responses.

* **Bug Fixes**
  * Improved document naming and history references for resubmitted content.
  * Failed or interrupted summaries can be recovered and retried automatically.
  * Concurrent processing no longer creates duplicate summarization work.

* **Tests**
  * Added coverage for deduplication, recovery, failure handling, and marker recognition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->