### PR TITLE
Bump to v0.23.2a

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -40,7 +40,7 @@ else
 fi
 
 # BUILDKIT_NO_CLIENT_TOKEN=true
-FHI_VERSION=v0.23.1a
+FHI_VERSION=v0.23.2a
 
 
 MYORG=${MYORG:-totallylegitco}


### PR DESCRIPTION
Picks up #948, #949, #950, #951 and #954 (staff Temporal status page, Temporal UI proxy, pro-connector address edit, async test fix, agent directives). #949 also needs the Temporal helm upgrade after deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default FHI version used during builds to v0.23.2a.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->