### PR TITLE
Build the JS bundles in the source tree, then collectstatic

### DIFF
--- a/scripts/setup_templates.sh
+++ b/scripts/setup_templates.sh
@@ -46,12 +46,20 @@ else
 fi
 
 ./manage.py makemigrations --check || (./manage.py makemigrations && ./manage.py migrate)
-./manage.py validate_templates &
-./manage.py collectstatic --no-input "${COLLECTSTATIC_IGNORES[@]}" &
-wait
 
-pushd ./static/js
+# Build the JS bundles in the SOURCE tree before collectstatic, so the fresh
+# dist/ gets collected. Building inside the collected static/js used to work
+# only because collectstatic copied package.json and the .ts sources there;
+# since collectstatic_ignores.sh stopped publishing those (no node_modules in
+# the image), a fresh checkout has nothing to build in static/js. Same layout
+# as scripts/ci_npm_build.sh and scripts/build_static.sh.
+JS_PATH=fighthealthinsurance/static/js
+pushd "${JS_PATH}"
 npm i
 npm run build
 popd
+
+./manage.py validate_templates &
+./manage.py collectstatic --no-input "${COLLECTSTATIC_IGNORES[@]}" &
+wait
 


### PR DESCRIPTION
`scripts/setup_templates.sh` (the pre-build step of `build.sh`) ran `npm i &&
  npm run build` inside the *collected* `static/js`. That only ever worked because
  collectstatic used to copy `package.json` and the `.ts` sources there. Since
  #936 stopped publishing those (no `node_modules` in the image), a fresh checkout
  has nothing to build in `static/js`:

  - `npm i` fails: no `package.json` (npm walks up and errors at the repo root)
  - with `package.json` copied in, webpack finds no entry points and fails on
  `./src`

  Machines that had built before #936 kept stale copies in `static/js` and never
  noticed. A fresh machine can't deploy (hit this deploying v0.23.2a).

  **Fix:** build in `fighthealthinsurance/static/js` first, the same layout
  `scripts/ci_npm_build.sh` and `scripts/build_static.sh` already use, and run
  collectstatic afterwards so the fresh `dist/` is what gets collected and shipped
  in the image. No change to `build.sh` or the Dockerfile.

  **Tested:** ran `scripts/setup_templates.sh` end to end on a checkout without
  stale copies: mypy clean, webpack compiled from the source dir, collectstatic
  picked up `dist/`. shellcheck clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the setup process to build JavaScript assets before template validation and static file collection.
  * Improved setup reliability by ensuring the latest source bundles are included in collected static files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->