### PR TITLE
Fax send hardening: fast worker-death detection, safe retry, no stuck claims

### DIFF
--- a/fighthealthinsurance/activities/fax.py
+++ b/fighthealthinsurance/activities/fax.py
@@ -74,14 +74,14 @@ def _call_with_heartbeats(fn, *args):
 
 
 @activity.defn
-def send_fax_via_vendor(hashed_email: str, fax_uuid: str) -> bool:
-    """Send the fax through the vendor; returns whether it succeeded."""
+def send_fax_via_vendor(hashed_email: str, fax_uuid: str) -> str:
+    """Send the fax through the vendor; returns SEND_OK / SEND_FAILED / SEND_NOT_OWNER."""
     close_old_connections()
     fax = fax_send_core.load_fax(hashed_email, fax_uuid)
     if fax is None:
-        return False
+        return fax_send_core.SEND_FAILED
     try:
-        return bool(_call_with_heartbeats(fax_send_core.send_fax_via_vendor, fax))
+        return str(_call_with_heartbeats(fax_send_core.send_fax_via_vendor, fax))
     except Exception:
         # Temporal records raised exception messages + tracebacks verbatim in
         # durable workflow history. Keep the full detail in the worker logs,

--- a/fighthealthinsurance/activities/fax.py
+++ b/fighthealthinsurance/activities/fax.py
@@ -12,6 +12,8 @@ activities run on pooled worker threads and Django connections are
 thread-local; this drops any connection left stale/closed by a prior task.
 """
 
+import threading
+
 from django.db import close_old_connections
 
 from loguru import logger
@@ -33,6 +35,44 @@ def precheck_fax(hashed_email: str, fax_uuid: str) -> str:
     return fax_send_core.precheck_fax(fax)
 
 
+# How often the send activity heartbeats while the vendor call runs. The
+# workflow pairs this with ``heartbeat_timeout`` so a worker killed mid-send
+# (OOM, eviction) is detected in ~1-2 minutes instead of sitting silent until
+# the 30-minute start-to-close timeout (observed 2026-08-30).
+HEARTBEAT_INTERVAL_S = 10.0
+
+
+def _call_with_heartbeats(fn, *args):
+    """Run blocking ``fn`` in an inner thread, heartbeating while it works.
+
+    The heartbeats are a liveness signal only (no progress details). If this
+    worker process dies, the heartbeats stop and the server fails the attempt
+    with a HEARTBEAT timeout -- which the workflow treats as "the thread is
+    gone", the one failure mode where an automatic re-send cannot double-fax.
+    """
+    box: dict = {}
+
+    def _target():
+        try:
+            box["result"] = fn(*args)
+        except BaseException as e:  # noqa: BLE001 - re-raised on the activity thread
+            box["error"] = e
+
+    t = threading.Thread(target=_target, daemon=True)
+    t.start()
+    while t.is_alive():
+        t.join(timeout=HEARTBEAT_INTERVAL_S)
+        try:
+            activity.heartbeat()
+        except RuntimeError:
+            # Not inside an activity (direct call in tests): just wait it out.
+            t.join()
+            break
+    if "error" in box:
+        raise box["error"]
+    return box.get("result")
+
+
 @activity.defn
 def send_fax_via_vendor(hashed_email: str, fax_uuid: str) -> bool:
     """Send the fax through the vendor; returns whether it succeeded."""
@@ -41,7 +81,7 @@ def send_fax_via_vendor(hashed_email: str, fax_uuid: str) -> bool:
     if fax is None:
         return False
     try:
-        return fax_send_core.send_fax_via_vendor(fax)
+        return bool(_call_with_heartbeats(fax_send_core.send_fax_via_vendor, fax))
     except Exception:
         # Temporal records raised exception messages + tracebacks verbatim in
         # durable workflow history. Keep the full detail in the worker logs,
@@ -50,6 +90,22 @@ def send_fax_via_vendor(hashed_email: str, fax_uuid: str) -> bool:
         # sensitive strings into history.
         logger.opt(exception=True).error(f"Vendor send failed for fax {fax_uuid}")
         raise ApplicationError(f"vendor send failed for fax {fax_uuid}") from None
+
+
+@activity.defn
+def release_send_claim(hashed_email: str, fax_uuid: str) -> bool:
+    """Release the vendor-send claim after a failed attempt so resends work.
+
+    Idempotent; returns whether the fax was found. Run by the workflow after
+    any failed send, because an in-process release cannot happen when the
+    worker died holding the claim.
+    """
+    close_old_connections()
+    fax = fax_send_core.load_fax(hashed_email, fax_uuid)
+    if fax is None:
+        return False
+    fax_send_core.release_send_claim(fax)
+    return True
 
 
 @activity.defn

--- a/fighthealthinsurance/fax_send_core.py
+++ b/fighthealthinsurance/fax_send_core.py
@@ -88,8 +88,14 @@ def load_fax(hashed_email: str, fax_uuid: Union[str, UUID]) -> Optional["FaxesTo
         return None
 
 
-def _release_send_claim(fax: "FaxesToSend") -> None:
-    """Undo a vendor-send claim after a failed send so it can be retried."""
+def release_send_claim(fax: "FaxesToSend") -> None:
+    """Undo a vendor-send claim after a failed send so it can be retried.
+
+    Also called as its own Temporal activity after a failed workflow send: a
+    worker killed mid-send (OOM, eviction) dies with the claim still True and
+    no in-process ``except`` left alive to release it, which blocked every
+    later resend until a human cleared the flag (observed 2026-08-30).
+    """
     from fighthealthinsurance.models import FaxesToSend
 
     try:
@@ -166,11 +172,25 @@ def send_fax_via_vendor(fax: "FaxesToSend") -> bool:
     # without re-transmitting. A plain in-memory read of the flag was a TOCTOU
     # race -- the multi-minute vendor call sits between check and write, so two
     # senders both saw False and both faxed the insurer.
+    # Assemble the document BEFORE taking the claim. Assembly (PubMed PDF
+    # fetches + pandoc) is the memory-hungry phase -- it OOM-killed the worker
+    # on 2026-08-30 -- and a death here used to strand the claim without a fax
+    # ever reaching the vendor. Assembling first means a crash in this phase
+    # leaves the claim untouched and a retry can proceed. Worst case two
+    # concurrent senders both assemble (wasted work); the claim below still
+    # guarantees only one transmits.
+    # get_temporary_document_path leaves cleanup to the caller (delete=False),
+    # so remove the temp file on both success and failure paths.
+    document_path = fax.get_temporary_document_path()
     claimed = FaxesToSend.objects.filter(pk=fax.pk, vendor_send_completed=False).update(
         vendor_send_completed=True
     )
     if not claimed:
         logger.info(f"Fax uuid={fax.uuid} already claimed/sent; not re-sending")
+        try:
+            os.unlink(document_path)
+        except OSError:
+            pass
         return True
     fax.vendor_send_completed = True
     denial = fax.denial_id
@@ -180,9 +200,6 @@ def send_fax_via_vendor(fax: "FaxesToSend") -> bool:
     if fax.name is not None and len(fax.name) > 2:
         extra += f"This fax is sent on behalf of {fax.name}."
     logger.debug(f"Kicking off fax sending for uuid={fax.uuid}")
-    # get_temporary_document_path leaves cleanup to the caller (delete=False),
-    # so remove the temp file on both success and failure paths.
-    document_path = fax.get_temporary_document_path()
     try:
         result = asyncio.run(
             flexible_fax_magic.send_fax(
@@ -198,7 +215,7 @@ def send_fax_via_vendor(fax: "FaxesToSend") -> bool:
         # legitimate retry (the Temporal retry policy, or a Ray re-send) can send
         # again instead of short-circuiting on a marker for a fax that never
         # went out.
-        _release_send_claim(fax)
+        release_send_claim(fax)
         raise
     finally:
         try:
@@ -208,7 +225,7 @@ def send_fax_via_vendor(fax: "FaxesToSend") -> bool:
     if not result:
         # Vendor reported failure without raising -- release the claim too so the
         # failed send can be retried.
-        _release_send_claim(fax)
+        release_send_claim(fax)
     return result
 
 

--- a/fighthealthinsurance/fax_send_core.py
+++ b/fighthealthinsurance/fax_send_core.py
@@ -134,8 +134,17 @@ def precheck_fax(fax: "FaxesToSend") -> str:
     return STATUS_OK
 
 
-def send_fax_via_vendor(fax: "FaxesToSend") -> bool:
-    """Send the fax document through the fax vendor. Returns success.
+# send_fax_via_vendor outcomes. NOT_OWNER means another sender holds the
+# vendor-send claim: the caller must not finalize the fax or release the claim
+# (the owner's flow does both) -- reporting it as success recorded phantom
+# deliveries when the owner later failed (PR #959 review).
+SEND_OK = "sent"
+SEND_FAILED = "failed"
+SEND_NOT_OWNER = "not_owner"
+
+
+def send_fax_via_vendor(fax: "FaxesToSend") -> str:
+    """Send the fax document through the vendor; returns SEND_OK / SEND_FAILED / SEND_NOT_OWNER.
 
     Concurrency-safe via an atomic claim: a single conditional UPDATE flips
     ``vendor_send_completed`` False->True, and only the caller that wins the flip
@@ -158,13 +167,13 @@ def send_fax_via_vendor(fax: "FaxesToSend") -> bool:
         # is the authoritative guard against a concurrent sender; this in-memory
         # check just avoids a needless DB round-trip on a sequential retry.
         logger.info(f"Fax uuid={fax.uuid} already handed to vendor; not re-sending")
-        return True
+        return SEND_OK if (fax.sent and fax.fax_success) else SEND_NOT_OWNER
     destination = fax.destination
     if destination is None:
         # precheck_fax already screens this out; guard here too so a direct
         # caller can't crash the vendor send on a missing fax number.
         logger.warning(f"Fax uuid={fax.uuid} has no destination at send time")
-        return False
+        return SEND_FAILED
     # Atomically claim the right to send. The conditional UPDATE flips
     # vendor_send_completed False->True for exactly one caller; any concurrent
     # sender (a Ray delayed sweep racing the Temporal timer, or a Ray fallback
@@ -182,16 +191,24 @@ def send_fax_via_vendor(fax: "FaxesToSend") -> bool:
     # get_temporary_document_path leaves cleanup to the caller (delete=False),
     # so remove the temp file on both success and failure paths.
     document_path = fax.get_temporary_document_path()
-    claimed = FaxesToSend.objects.filter(pk=fax.pk, vendor_send_completed=False).update(
-        vendor_send_completed=True
-    )
+    try:
+        claimed = FaxesToSend.objects.filter(
+            pk=fax.pk, vendor_send_completed=False
+        ).update(vendor_send_completed=True)
+    except Exception:
+        # The document must not outlive a failed claim attempt (PR #959 review).
+        try:
+            os.unlink(document_path)
+        except OSError:
+            pass
+        raise
     if not claimed:
         logger.info(f"Fax uuid={fax.uuid} already claimed/sent; not re-sending")
         try:
             os.unlink(document_path)
         except OSError:
             pass
-        return True
+        return SEND_OK if (fax.sent and fax.fax_success) else SEND_NOT_OWNER
     fax.vendor_send_completed = True
     denial = fax.denial_id
     extra = ""
@@ -226,7 +243,7 @@ def send_fax_via_vendor(fax: "FaxesToSend") -> bool:
         # Vendor reported failure without raising -- release the claim too so the
         # failed send can be retried.
         release_send_claim(fax)
-    return result
+    return SEND_OK if result else SEND_FAILED
 
 
 def finalize_fax(
@@ -324,11 +341,15 @@ def do_send_fax_object(fax: "FaxesToSend") -> bool:
     if status in (STATUS_ALREADY_SENT, STATUS_NOT_FOUND):
         return False
     try:
-        success = send_fax_via_vendor(fax)
+        send_status = send_fax_via_vendor(fax)
     except Exception:
-        # The Temporal workflow retries the send activity via its retry policy;
-        # the Ray path records a failed send and notifies, as it did before.
         logger.opt(exception=True).error(f"Error sending fax uuid={fax.uuid}")
-        success = False
+        send_status = SEND_FAILED
+    if send_status == SEND_NOT_OWNER:
+        # Another sender owns the claim; its flow will finalize and notify.
+        # Finalizing here would record an outcome for a send we did not make.
+        logger.info(f"Fax uuid={fax.uuid}: claim held elsewhere; not finalizing")
+        return False
+    success = send_status == SEND_OK
     finalize_fax(fax, success, missing_destination=False)
     return success

--- a/fighthealthinsurance/management/commands/run_temporal_worker.py
+++ b/fighthealthinsurance/management/commands/run_temporal_worker.py
@@ -66,6 +66,7 @@ class Command(BaseCommand):
                 activities=[
                     fax_activities.precheck_fax,
                     fax_activities.send_fax_via_vendor,
+                    fax_activities.release_send_claim,
                     fax_activities.finalize_fax,
                 ],
                 activity_executor=activity_executor,

--- a/fighthealthinsurance/staff_views.py
+++ b/fighthealthinsurance/staff_views.py
@@ -9,6 +9,7 @@ from django.db.models import Count, QuerySet
 from django.db.models.functions import Lower
 from django.http import HttpResponse, HttpResponseBase, StreamingHttpResponse
 from django.shortcuts import redirect, render
+from django.db.models import Q
 from django.utils import timezone
 from django.views import View, generic
 
@@ -288,7 +289,12 @@ class AdminStatusView(generic.TemplateView):
 
         try:
             since = timezone.now() - datetime.timedelta(days=7)
-            recent = FaxesToSend.objects.filter(date__gte=since, sent=True)
+            # Filter on the last send attempt, not creation time: a fax created
+            # weeks ago that failed today must show here (PR #959 review).
+            recent = FaxesToSend.objects.filter(
+                Q(attempting_to_send_as_of__gte=since) | Q(date__gte=since),
+                sent=True,
+            )
             failed_qs = recent.filter(fax_success=False).order_by("-date")
             failed = [
                 {

--- a/fighthealthinsurance/staff_views.py
+++ b/fighthealthinsurance/staff_views.py
@@ -156,6 +156,7 @@ class AdminStatusView(generic.TemplateView):
         ctx["fax"] = self._fax_backend_status()
         ctx["fax_queue"] = self._fax_queue_status()
         ctx["temporal"] = self._temporal_status()
+        ctx["fax_outcomes"] = self._fax_outcome_status()
         ctx["storage"] = self._storage_status()
         return ctx
 
@@ -271,6 +272,43 @@ class AdminStatusView(generic.TemplateView):
             out["ok"] = False
             out["error"] = str(e)
         return out
+
+    @staticmethod
+    def _fax_outcome_status() -> Dict[str, Any]:
+        """Fax delivery outcomes (last 7 days) from the database.
+
+        The Temporal panel above shows workflow *status*, where "Completed"
+        only means the workflow finished -- a failed send still completes after
+        notifying the user (its Result is false). This panel answers the
+        question staff actually have: did the faxes get delivered? A row that
+        failed with ``vendor_send_completed`` still True cannot be re-sent by
+        the normal paths until the claim is released, so it is called out.
+        """
+        from fighthealthinsurance.models import FaxesToSend
+
+        try:
+            since = timezone.now() - datetime.timedelta(days=7)
+            recent = FaxesToSend.objects.filter(date__gte=since, sent=True)
+            failed_qs = recent.filter(fax_success=False).order_by("-date")
+            failed = [
+                {
+                    "uuid": str(f.uuid),
+                    "date": f.date,
+                    "claim_stuck": f.vendor_send_completed,
+                }
+                for f in failed_qs[:10]
+            ]
+            return {
+                "sent": recent.count(),
+                "delivered": recent.filter(fax_success=True).count(),
+                "failed": failed_qs.count(),
+                "stuck_claims": failed_qs.filter(vendor_send_completed=True).count(),
+                "recent_failures": failed,
+                "error": None,
+            }
+        except Exception as e:
+            logger.opt(exception=True).warning("Fax outcome status failed")
+            return {"error": str(e)}
 
     @staticmethod
     def _temporal_status() -> Dict[str, Any]:

--- a/fighthealthinsurance/staff_views.py
+++ b/fighthealthinsurance/staff_views.py
@@ -5,7 +5,7 @@ from collections import Counter
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from django.db import transaction
-from django.db.models import Count, QuerySet
+from django.db.models import Count, F, QuerySet
 from django.db.models.functions import Lower
 from django.http import HttpResponse, HttpResponseBase, StreamingHttpResponse
 from django.shortcuts import redirect, render
@@ -295,7 +295,12 @@ class AdminStatusView(generic.TemplateView):
                 Q(attempting_to_send_as_of__gte=since) | Q(date__gte=since),
                 sent=True,
             )
-            failed_qs = recent.filter(fax_success=False).order_by("-date")
+            # Order by attempt recency too, or an old-created fax admitted by
+            # the attempt filter gets displaced from the 10-row slice below by
+            # newer-created rows whose failures are actually older.
+            failed_qs = recent.filter(fax_success=False).order_by(
+                F("attempting_to_send_as_of").desc(nulls_last=True), "-date"
+            )
             failed = [
                 {
                     "uuid": str(f.uuid),

--- a/fighthealthinsurance/templates/admin_status.html
+++ b/fighthealthinsurance/templates/admin_status.html
@@ -252,6 +252,48 @@
     {% endif %}
   </div>
 
+  {# ---------------- Fax delivery outcomes ---------------- #}
+  <div class="status-section">
+    <h2>📠 Fax delivery (last 7 days)</h2>
+    {% if fax_outcomes.error %}
+      <p class="summary-line"><span class="badge bad">ERROR</span> <span class="error-text">{{ fax_outcomes.error }}</span></p>
+    {% else %}
+      <p class="summary-line"><span class="pill">A "Completed" workflow above only means it finished; this is whether faxes were delivered.</span></p>
+      <div class="stat-grid">
+        <div class="stat-card">
+          <div class="value">{{ fax_outcomes.sent|default:0 }}</div>
+          <div class="label">Sent</div>
+        </div>
+        <div class="stat-card">
+          <div class="value">{{ fax_outcomes.delivered|default:0 }}</div>
+          <div class="label">Delivered</div>
+        </div>
+        <div class="stat-card {% if fax_outcomes.failed %}alert{% endif %}">
+          <div class="value">{{ fax_outcomes.failed|default:0 }}</div>
+          <div class="label">Failed</div>
+        </div>
+        <div class="stat-card {% if fax_outcomes.stuck_claims %}alert{% endif %}">
+          <div class="value">{{ fax_outcomes.stuck_claims|default:0 }}</div>
+          <div class="label">Failed with claim stuck (cannot auto-resend)</div>
+        </div>
+      </div>
+      {% if fax_outcomes.recent_failures %}
+      <table class="status">
+        <thead><tr><th>Fax</th><th>When</th><th>Claim</th></tr></thead>
+        <tbody>
+        {% for f in fax_outcomes.recent_failures %}
+          <tr>
+            <td><code>{{ f.uuid }}</code></td>
+            <td>{{ f.date|date:"Y-m-d H:i" }}</td>
+            <td>{% if f.claim_stuck %}<span class="badge bad">STUCK</span>{% else %}<span class="badge ok">released</span>{% endif %}</td>
+          </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+      {% endif %}
+    {% endif %}
+  </div>
+
   {# ---------------- Storage ---------------- #}
   <div class="status-section">
     <h2>💾 External Storage</h2>

--- a/fighthealthinsurance/workflows/send_fax.py
+++ b/fighthealthinsurance/workflows/send_fax.py
@@ -14,9 +14,16 @@ boundary, so no PHI lands in workflow history.
 
 from datetime import timedelta
 
+from typing import Optional
+
 from temporalio import workflow
 from temporalio.common import RetryPolicy
-from temporalio.exceptions import ActivityError, is_cancelled_exception
+from temporalio.exceptions import (
+    ActivityError,
+    TimeoutError as TemporalTimeoutError,
+    TimeoutType,
+    is_cancelled_exception,
+)
 
 from fighthealthinsurance.fax_status import (
     STATUS_ALREADY_SENT,
@@ -32,6 +39,35 @@ with workflow.unsafe.imports_passed_through():
 # How long to wait before sending when ``delay_send`` is set. Mirrors the old
 # fax-polling actor's "older than 1 hour" threshold.
 DELAYED_SEND_WAIT = timedelta(hours=1)
+
+# Liveness for the vendor send: the activity heartbeats every ~10s while the
+# blocking vendor call runs (see activities.fax._call_with_heartbeats). If the
+# worker dies mid-send (OOM-killed at its memory limit on 2026-08-30), the
+# heartbeats stop and the attempt fails in ~2 minutes instead of sitting
+# silent until the 30-minute start-to-close.
+SEND_HEARTBEAT_TIMEOUT = timedelta(seconds=120)
+
+# A HEARTBEAT-timed-out attempt means the worker process is gone, so no vendor
+# call can still be running -- the one failure where an automatic second
+# attempt cannot double-fax. Anything else gets no automatic retry: the vendor
+# layer (HylaFax/Sonic) already re-dials internally, and re-sending on a
+# vendor-reported failure would burn paid submissions into the same problem.
+MAX_SEND_ATTEMPTS = 2
+
+# After a START_TO_CLOSE timeout the abandoned send thread may still be alive
+# inside a living worker (Temporal cannot cancel it). Wait out the vendor
+# layer's own internal timeouts before releasing the claim, so an explicit
+# resend cannot overlap a zombie transmission.
+ZOMBIE_DRAIN = timedelta(minutes=35)
+
+
+def _timeout_type(error: BaseException) -> Optional[TimeoutType]:
+    """The TimeoutType of an ActivityError's cause, or None if not a timeout."""
+    cause = getattr(error, "cause", None)
+    if isinstance(cause, TemporalTimeoutError):
+        return cause.type
+    return None
+
 
 # Activities that must not give up partway through a transient outage retry
 # forever with capped backoff, staying visibly running/retrying in the Temporal
@@ -81,35 +117,75 @@ class SendFaxWorkflow:
             )
             return False
 
-        # status == STATUS_OK: send (with retries), then record the outcome.
-        # The send is idempotent (vendor_send_completed marker), so retrying is
-        # safe -- a re-run after a crash short-circuits instead of re-faxing.
-        try:
-            success = await workflow.execute_activity(
-                fax_activities.send_fax_via_vendor,
-                args=[fax_input.hashed_email, fax_input.fax_uuid],
-                # The vendor layer has its own long internal timeouts (up to
-                # ~1300s per backend, across multiple backends), so give the
-                # activity a wide window. It is a synchronous, non-heartbeating
-                # thread Temporal cannot cancel, so a start_to_close timeout
-                # mid-send must NOT spawn a concurrent retry -> maximum_attempts=1.
-                # Cross-orchestrator dedupe is handled by the atomic
-                # vendor_send_completed claim in fax_send_core, not by retries.
-                start_to_close_timeout=timedelta(minutes=30),
-                retry_policy=RetryPolicy(maximum_attempts=1),
-            )
-        except ActivityError as e:
-            # Let cancellation cancel the workflow; otherwise record a failed
-            # send and still run finalize so the user is notified.
-            if is_cancelled_exception(e):
-                raise
-            workflow.logger.warning("Vendor fax send failed after retries")
-            success = False
+        # status == STATUS_OK: send, then record the outcome. The atomic
+        # vendor_send_completed claim in fax_send_core is the cross-orchestrator
+        # dedupe; Temporal-level retries stay at maximum_attempts=1 because the
+        # send is a synchronous thread Temporal cannot cancel -- a timed-out
+        # attempt may still be transmitting, so blind retries could double-fax.
+        # The one exception is a HEARTBEAT timeout (worker process died, thread
+        # provably gone): release the leaked claim and try once more.
+        success = False
+        send_hung = False
+        for attempt in range(1, MAX_SEND_ATTEMPTS + 1):
+            try:
+                success = await workflow.execute_activity(
+                    fax_activities.send_fax_via_vendor,
+                    args=[fax_input.hashed_email, fax_input.fax_uuid],
+                    # The vendor layer has its own long internal timeouts (up
+                    # to ~1300s per backend, across multiple backends), so the
+                    # start_to_close window stays wide; the heartbeat timeout
+                    # is what catches a dead worker quickly.
+                    start_to_close_timeout=timedelta(minutes=30),
+                    heartbeat_timeout=SEND_HEARTBEAT_TIMEOUT,
+                    retry_policy=RetryPolicy(maximum_attempts=1),
+                )
+                break
+            except ActivityError as e:
+                # Let cancellation cancel the workflow; otherwise classify.
+                if is_cancelled_exception(e):
+                    raise
+                timeout_type = _timeout_type(e)
+                if (
+                    timeout_type == TimeoutType.HEARTBEAT
+                    and attempt < MAX_SEND_ATTEMPTS
+                ):
+                    workflow.logger.warning(
+                        "Vendor fax send worker died mid-attempt; releasing claim and retrying"
+                    )
+                    await workflow.execute_activity(
+                        fax_activities.release_send_claim,
+                        args=[fax_input.hashed_email, fax_input.fax_uuid],
+                        start_to_close_timeout=timedelta(seconds=60),
+                        retry_policy=DURABLE_RETRY,
+                    )
+                    continue
+                send_hung = timeout_type == TimeoutType.START_TO_CLOSE
+                workflow.logger.warning("Vendor fax send failed after retries")
+                success = False
+                break
 
+        # Finalize first so the user hears about a failure promptly; claim
+        # cleanup below can afford to wait.
         await workflow.execute_activity(
             fax_activities.finalize_fax,
             args=[fax_input.hashed_email, fax_input.fax_uuid, success, False],
             start_to_close_timeout=timedelta(minutes=2),
             retry_policy=DURABLE_RETRY,
         )
+
+        if not success:
+            # A failed send must never leave the claim stuck (that blocked all
+            # resends until a human cleared it, 2026-08-30). In-process release
+            # covers vendor-reported failures; this durable release covers the
+            # paths where the process died holding the claim. After a
+            # START_TO_CLOSE timeout the send thread may still be alive, so
+            # wait out the vendor layer's internal timeouts first.
+            if send_hung:
+                await workflow.sleep(ZOMBIE_DRAIN)
+            await workflow.execute_activity(
+                fax_activities.release_send_claim,
+                args=[fax_input.hashed_email, fax_input.fax_uuid],
+                start_to_close_timeout=timedelta(seconds=60),
+                retry_policy=DURABLE_RETRY,
+            )
         return success

--- a/fighthealthinsurance/workflows/send_fax.py
+++ b/fighthealthinsurance/workflows/send_fax.py
@@ -45,16 +45,16 @@ DELAYED_SEND_WAIT = timedelta(hours=1)
 # worker dies mid-send (OOM-killed at its memory limit on 2026-08-30), the
 # heartbeats stop and the attempt fails in ~2 minutes instead of sitting
 # silent until the 30-minute start-to-close.
+#
+# NO automatic re-send on any failure, heartbeat timeouts included: lost
+# heartbeats prove the server stopped hearing from the worker, not that the
+# send thread died (a network partition leaves it dialing), so a second
+# attempt could double-fax (PR #959 review). Automatic retry needs a vendor
+# idempotency key first. The vendor layer (HylaFax/Sonic) already re-dials
+# internally; humans re-send explicitly via SendFaxHelper.resend().
 SEND_HEARTBEAT_TIMEOUT = timedelta(seconds=120)
 
-# A HEARTBEAT-timed-out attempt means the worker process is gone, so no vendor
-# call can still be running -- the one failure where an automatic second
-# attempt cannot double-fax. Anything else gets no automatic retry: the vendor
-# layer (HylaFax/Sonic) already re-dials internally, and re-sending on a
-# vendor-reported failure would burn paid submissions into the same problem.
-MAX_SEND_ATTEMPTS = 2
-
-# After a START_TO_CLOSE timeout the abandoned send thread may still be alive
+# After a timeout of either kind the abandoned send thread may still be alive
 # inside a living worker (Temporal cannot cancel it). Wait out the vendor
 # layer's own internal timeouts before releasing the claim, so an explicit
 # resend cannot overlap a zombie transmission.
@@ -124,45 +124,42 @@ class SendFaxWorkflow:
         # attempt may still be transmitting, so blind retries could double-fax.
         # The one exception is a HEARTBEAT timeout (worker process died, thread
         # provably gone): release the leaked claim and try once more.
-        success = False
+        send_status = "failed"
         send_hung = False
-        for attempt in range(1, MAX_SEND_ATTEMPTS + 1):
-            try:
-                success = await workflow.execute_activity(
-                    fax_activities.send_fax_via_vendor,
-                    args=[fax_input.hashed_email, fax_input.fax_uuid],
-                    # The vendor layer has its own long internal timeouts (up
-                    # to ~1300s per backend, across multiple backends), so the
-                    # start_to_close window stays wide; the heartbeat timeout
-                    # is what catches a dead worker quickly.
-                    start_to_close_timeout=timedelta(minutes=30),
-                    heartbeat_timeout=SEND_HEARTBEAT_TIMEOUT,
-                    retry_policy=RetryPolicy(maximum_attempts=1),
-                )
-                break
-            except ActivityError as e:
-                # Let cancellation cancel the workflow; otherwise classify.
-                if is_cancelled_exception(e):
-                    raise
-                timeout_type = _timeout_type(e)
-                if (
-                    timeout_type == TimeoutType.HEARTBEAT
-                    and attempt < MAX_SEND_ATTEMPTS
-                ):
-                    workflow.logger.warning(
-                        "Vendor fax send worker died mid-attempt; releasing claim and retrying"
-                    )
-                    await workflow.execute_activity(
-                        fax_activities.release_send_claim,
-                        args=[fax_input.hashed_email, fax_input.fax_uuid],
-                        start_to_close_timeout=timedelta(seconds=60),
-                        retry_policy=DURABLE_RETRY,
-                    )
-                    continue
-                send_hung = timeout_type == TimeoutType.START_TO_CLOSE
-                workflow.logger.warning("Vendor fax send failed after retries")
-                success = False
-                break
+        try:
+            send_status = await workflow.execute_activity(
+                fax_activities.send_fax_via_vendor,
+                args=[fax_input.hashed_email, fax_input.fax_uuid],
+                # The vendor layer has its own long internal timeouts (up
+                # to ~1300s per backend, across multiple backends), so the
+                # start_to_close window stays wide; the heartbeat timeout
+                # is what catches a dead worker quickly. maximum_attempts=1
+                # and no workflow-level retry: see the constants comment.
+                start_to_close_timeout=timedelta(minutes=30),
+                heartbeat_timeout=SEND_HEARTBEAT_TIMEOUT,
+                retry_policy=RetryPolicy(maximum_attempts=1),
+            )
+        except ActivityError as e:
+            # Let cancellation cancel the workflow; otherwise classify.
+            if is_cancelled_exception(e):
+                raise
+            send_hung = _timeout_type(e) in (
+                TimeoutType.START_TO_CLOSE,
+                TimeoutType.HEARTBEAT,
+            )
+            workflow.logger.warning("Vendor fax send failed")
+            send_status = "failed"
+
+        if workflow.patched("send-status-not-owner") and send_status == "not_owner":
+            # Another sender holds the vendor-send claim: its flow finalizes
+            # and notifies. Finalizing here would record an outcome for a send
+            # this workflow did not make (PR #959 review).
+            workflow.logger.info("Vendor send claim held elsewhere; not finalizing")
+            return False
+
+        # Old histories recorded booleans from the send activity; new ones
+        # record status strings. Both resolve here.
+        success = send_status == "sent" or send_status is True
 
         # Finalize first so the user hears about a failure promptly; claim
         # cleanup below can afford to wait.
@@ -177,9 +174,9 @@ class SendFaxWorkflow:
             # A failed send must never leave the claim stuck (that blocked all
             # resends until a human cleared it, 2026-08-30). In-process release
             # covers vendor-reported failures; this durable release covers the
-            # paths where the process died holding the claim. After a
-            # START_TO_CLOSE timeout the send thread may still be alive, so
-            # wait out the vendor layer's internal timeouts first.
+            # paths where the process died holding the claim. After a timeout
+            # of either kind the send thread may still be alive, so wait out
+            # the vendor layer's internal timeouts first.
             if send_hung:
                 await workflow.sleep(ZOMBIE_DRAIN)
             await workflow.execute_activity(

--- a/tests/async-unit/test_fax_send_core.py
+++ b/tests/async-unit/test_fax_send_core.py
@@ -102,18 +102,23 @@ class TestVendorSendAtomicClaim:
         with patch.object(
             fax, "get_temporary_document_path", return_value="/tmp/does-not-exist.pdf"
         ):
-            assert fax_send_core.send_fax_via_vendor(fax) is True
+            assert fax_send_core.send_fax_via_vendor(fax) == fax_send_core.SEND_OK
         fax.refresh_from_db()
         assert fax.vendor_send_completed is True
 
         # A racing sender that still holds a stale (False) in-memory marker must
-        # lose the atomic claim and NOT call the vendor a second time.
+        # lose the atomic claim and NOT call the vendor a second time. It gets
+        # SEND_NOT_OWNER (the delivery isn't finalized yet) so it neither
+        # finalizes nor releases the claim it does not hold.
         racer = FaxesToSend.objects.get(pk=fax.pk)
         racer.vendor_send_completed = False
         with patch.object(
             racer, "get_temporary_document_path", return_value="/tmp/does-not-exist.pdf"
         ):
-            assert fax_send_core.send_fax_via_vendor(racer) is True
+            assert (
+                fax_send_core.send_fax_via_vendor(racer)
+                == fax_send_core.SEND_NOT_OWNER
+            )
         assert mock_send.call_count == 1
 
     @patch("fighthealthinsurance.fax_send_core.flexible_fax_magic.send_fax")
@@ -123,7 +128,7 @@ class TestVendorSendAtomicClaim:
         with patch.object(
             fax, "get_temporary_document_path", return_value="/tmp/does-not-exist.pdf"
         ):
-            assert fax_send_core.send_fax_via_vendor(fax) is False
+            assert fax_send_core.send_fax_via_vendor(fax) == fax_send_core.SEND_FAILED
         fax.refresh_from_db()
         # Claim released so a genuine retry can send.
         assert fax.vendor_send_completed is False

--- a/tests/sync/test_admin_status.py
+++ b/tests/sync/test_admin_status.py
@@ -158,6 +158,51 @@ class AdminStatusFaxQueueTest(TestCase):
         self.assertEqual(q["failures_recent"], 1)  # E
 
 
+class FaxOutcomeStatusOrderingTest(TestCase):
+    """The failure list must surface the most recent send *attempts*, not the
+    most recently *created* faxes (PR #959 review)."""
+
+    def _make_fax(self, date=None, **kwargs):
+        defaults = dict(
+            hashed_email="h", paid=True, email="a@b.com", appeal_text="x", name="Test"
+        )
+        defaults.update(kwargs)
+        fax = FaxesToSend.objects.create(**defaults)
+        if date is not None:
+            # date is auto_now_add, so backdate via update() to bypass it.
+            FaxesToSend.objects.filter(pk=fax.pk).update(date=date)
+        return fax
+
+    def test_old_fax_with_recent_attempt_not_displaced_from_failures(self):
+        from fighthealthinsurance.staff_views import AdminStatusView
+
+        now = timezone.now()
+        # An old fax whose send was attempted (and failed) just now: admitted
+        # by the attempt-date filter, and must survive the 10-row slice.
+        old_but_fresh_failure = self._make_fax(
+            sent=True,
+            fax_success=False,
+            attempting_to_send_as_of=now,
+            date=now - datetime.timedelta(days=30),
+        )
+        # Eleven newer-created failures with older (or no) attempt timestamps.
+        for i in range(11):
+            self._make_fax(
+                sent=True,
+                fax_success=False,
+                attempting_to_send_as_of=now - datetime.timedelta(hours=i + 1),
+            )
+
+        outcomes = AdminStatusView._fax_outcome_status()
+        assert outcomes["error"] is None
+        assert outcomes["failed"] == 12
+        listed = [f["uuid"] for f in outcomes["recent_failures"]]
+        assert len(listed) == 10
+        # Ordered by attempt recency, the just-attempted old fax is first;
+        # ordering by creation date would have dropped it entirely.
+        assert listed[0] == str(old_but_fresh_failure.uuid)
+
+
 _TEMPORAL_CLIENT = "fighthealthinsurance.temporal_client.get_temporal_client"
 
 

--- a/tests/temporal/test_fax_activities.py
+++ b/tests/temporal/test_fax_activities.py
@@ -40,19 +40,26 @@ def test_precheck_fax_delegates_to_core(mock_load, mock_precheck):
 
 
 @patch("fighthealthinsurance.fax_send_core.load_fax", return_value=None)
-def test_send_fax_via_vendor_not_found_returns_false(mock_load):
+def test_send_fax_via_vendor_not_found_returns_failed(mock_load):
     env = ActivityEnvironment()
     result = env.run(fax_activities.send_fax_via_vendor, "h", "u")
-    assert result is False
+    assert result == "failed"
 
 
 @patch("fighthealthinsurance.fax_send_core.load_fax")
 def test_send_fax_via_vendor_skips_when_already_completed(mock_load):
-    """Idempotency guard: an already-handed-off fax is not re-sent on retry."""
-    mock_load.return_value = Mock(vendor_send_completed=True, uuid="u")
+    """Idempotency guard: an already-handed-off fax is not re-sent on retry.
+    Delivered -> sent (idempotent confirm); still in flight -> not_owner, so
+    the caller neither finalizes nor releases a claim it does not hold."""
+    mock_load.return_value = Mock(
+        vendor_send_completed=True, uuid="u", sent=True, fax_success=True
+    )
     env = ActivityEnvironment()
-    result = env.run(fax_activities.send_fax_via_vendor, "h", "u")
-    assert result is True
+    assert env.run(fax_activities.send_fax_via_vendor, "h", "u") == "sent"
+    mock_load.return_value = Mock(
+        vendor_send_completed=True, uuid="u", sent=False, fax_success=False
+    )
+    assert env.run(fax_activities.send_fax_via_vendor, "h", "u") == "not_owner"
 
 
 @patch("fighthealthinsurance.fax_send_core.send_fax_via_vendor")
@@ -102,7 +109,7 @@ def test_send_fax_via_vendor_heartbeats_while_sending(mock_load, mock_send):
 
     def slow_send(fax):
         time.sleep(0.15)
-        return True
+        return "sent"
 
     mock_send.side_effect = slow_send
     beats: list = []
@@ -110,7 +117,7 @@ def test_send_fax_via_vendor_heartbeats_while_sending(mock_load, mock_send):
     env.on_heartbeat = lambda *args: beats.append(args)
     with patch.object(fax_module, "HEARTBEAT_INTERVAL_S", 0.02):
         result = env.run(fax_activities.send_fax_via_vendor, "h", "u")
-    assert result is True
+    assert result == "sent"
     assert len(beats) >= 2
 
 

--- a/tests/temporal/test_fax_activities.py
+++ b/tests/temporal/test_fax_activities.py
@@ -87,3 +87,62 @@ def test_finalize_fax_delegates_to_core(mock_load, mock_finalize):
     result = env.run(fax_activities.finalize_fax, "h", "u", True, False)
     mock_finalize.assert_called_once_with(fake_fax, True, False)
     assert result is True
+
+
+@patch("fighthealthinsurance.fax_send_core.send_fax_via_vendor")
+@patch("fighthealthinsurance.fax_send_core.load_fax")
+def test_send_fax_via_vendor_heartbeats_while_sending(mock_load, mock_send):
+    """The activity heartbeats while the blocking vendor call runs, so a dead
+    worker is detected by heartbeat timeout instead of start-to-close."""
+    import time
+
+    from fighthealthinsurance.activities import fax as fax_module
+
+    mock_load.return_value = Mock(vendor_send_completed=False, uuid="u")
+
+    def slow_send(fax):
+        time.sleep(0.15)
+        return True
+
+    mock_send.side_effect = slow_send
+    beats: list = []
+    env = ActivityEnvironment()
+    env.on_heartbeat = lambda *args: beats.append(args)
+    with patch.object(fax_module, "HEARTBEAT_INTERVAL_S", 0.02):
+        result = env.run(fax_activities.send_fax_via_vendor, "h", "u")
+    assert result is True
+    assert len(beats) >= 2
+
+
+@patch("fighthealthinsurance.fax_send_core.load_fax", return_value=None)
+def test_release_send_claim_not_found_returns_false(mock_load):
+    env = ActivityEnvironment()
+    assert env.run(fax_activities.release_send_claim, "h", "u") is False
+
+
+@patch("fighthealthinsurance.fax_send_core.release_send_claim")
+@patch("fighthealthinsurance.fax_send_core.load_fax")
+def test_release_send_claim_delegates_to_core(mock_load, mock_release):
+    fake_fax = object()
+    mock_load.return_value = fake_fax
+    env = ActivityEnvironment()
+    assert env.run(fax_activities.release_send_claim, "h", "u") is True
+    mock_release.assert_called_once_with(fake_fax)
+
+
+def test_claim_is_taken_only_after_document_assembly():
+    """Document assembly is the memory-hungry phase (it OOM-killed the worker
+    2026-08-30); a crash there must not leave the vendor-send claim stuck."""
+    from unittest.mock import MagicMock
+
+    from fighthealthinsurance import fax_send_core
+
+    fax = Mock()
+    fax.vendor_send_completed = False
+    fax.destination = "000"
+    fax.uuid = "u"
+    fax.get_temporary_document_path.side_effect = RuntimeError("simulated OOM")
+    with patch("fighthealthinsurance.models.FaxesToSend", MagicMock()) as mock_model:
+        with pytest.raises(RuntimeError):
+            fax_send_core.send_fax_via_vendor(fax)
+        mock_model.objects.filter.assert_not_called()

--- a/tests/temporal/test_send_fax_workflow.py
+++ b/tests/temporal/test_send_fax_workflow.py
@@ -34,7 +34,7 @@ class _Recorder:
     def __init__(
         self,
         precheck_status: str = STATUS_OK,
-        send_result: bool = True,
+        send_result: str = "sent",
         send_raises: bool = False,
         finalize_fail_times: int = 0,
         precheck_fail_times: int = 0,
@@ -58,7 +58,7 @@ class _Recorder:
             return rec.precheck_status
 
         @activity.defn(name="send_fax_via_vendor")
-        async def send_fax_via_vendor(hashed_email: str, fax_uuid: str) -> bool:
+        async def send_fax_via_vendor(hashed_email: str, fax_uuid: str) -> str:
             rec.calls.append(("send", hashed_email, fax_uuid))
             if rec.send_raises:
                 raise ApplicationError("simulated vendor failure")
@@ -103,7 +103,7 @@ async def _run(env: WorkflowEnvironment, rec: _Recorder, *, delay_send: bool = F
 
 @pytest.mark.asyncio
 async def test_ok_path_sends_and_finalizes():
-    rec = _Recorder(precheck_status=STATUS_OK, send_result=True)
+    rec = _Recorder(precheck_status=STATUS_OK, send_result="sent")
     async with await WorkflowEnvironment.start_local() as env:
         result = await _run(env, rec)
     assert result is True
@@ -113,7 +113,7 @@ async def test_ok_path_sends_and_finalizes():
 
 @pytest.mark.asyncio
 async def test_send_failure_is_finalized_then_claim_released():
-    rec = _Recorder(precheck_status=STATUS_OK, send_result=False)
+    rec = _Recorder(precheck_status=STATUS_OK, send_result="failed")
     async with await WorkflowEnvironment.start_local() as env:
         result = await _run(env, rec)
     assert result is False
@@ -121,6 +121,17 @@ async def test_send_failure_is_finalized_then_claim_released():
     # after, so a failed send can always be explicitly re-sent.
     assert [c[0] for c in rec.calls] == ["precheck", "send", "finalize", "release"]
     assert rec.calls[2] == ("finalize", False, False)
+
+
+@pytest.mark.asyncio
+async def test_not_owner_send_finalizes_nothing():
+    """When another sender holds the vendor-send claim, this workflow must not
+    finalize the fax or release the claim -- the owner's flow does both."""
+    rec = _Recorder(precheck_status=STATUS_OK, send_result="not_owner")
+    async with await WorkflowEnvironment.start_local() as env:
+        result = await _run(env, rec)
+    assert result is False
+    assert [c[0] for c in rec.calls] == ["precheck", "send"]
 
 
 def test_timeout_type_classification():
@@ -182,7 +193,7 @@ async def test_not_found_stops_without_send_or_finalize():
 @pytest.mark.asyncio
 async def test_delay_send_waits_then_sends():
     """The 1h delay timer is auto-skipped by the time-skipping environment."""
-    rec = _Recorder(precheck_status=STATUS_OK, send_result=True)
+    rec = _Recorder(precheck_status=STATUS_OK, send_result="sent")
     async with await WorkflowEnvironment.start_time_skipping() as env:
         result = await _run(env, rec, delay_send=True)
     assert result is True

--- a/tests/temporal/test_send_fax_workflow.py
+++ b/tests/temporal/test_send_fax_workflow.py
@@ -64,6 +64,11 @@ class _Recorder:
                 raise ApplicationError("simulated vendor failure")
             return rec.send_result
 
+        @activity.defn(name="release_send_claim")
+        async def release_send_claim(hashed_email: str, fax_uuid: str) -> bool:
+            rec.calls.append(("release", hashed_email, fax_uuid))
+            return True
+
         @activity.defn(name="finalize_fax")
         async def finalize_fax(
             hashed_email: str,
@@ -77,7 +82,7 @@ class _Recorder:
                 raise ApplicationError("simulated transient finalize failure")
             return True
 
-        return [precheck_fax, send_fax_via_vendor, finalize_fax]
+        return [precheck_fax, send_fax_via_vendor, release_send_claim, finalize_fax]
 
 
 async def _run(env: WorkflowEnvironment, rec: _Recorder, *, delay_send: bool = False):
@@ -107,12 +112,34 @@ async def test_ok_path_sends_and_finalizes():
 
 
 @pytest.mark.asyncio
-async def test_send_failure_is_finalized_as_failure():
+async def test_send_failure_is_finalized_then_claim_released():
     rec = _Recorder(precheck_status=STATUS_OK, send_result=False)
     async with await WorkflowEnvironment.start_local() as env:
         result = await _run(env, rec)
     assert result is False
-    assert rec.calls[-1] == ("finalize", False, False)
+    # User notification (finalize) comes first; the durable claim release runs
+    # after, so a failed send can always be explicitly re-sent.
+    assert [c[0] for c in rec.calls] == ["precheck", "send", "finalize", "release"]
+    assert rec.calls[2] == ("finalize", False, False)
+
+
+def test_timeout_type_classification():
+    from unittest.mock import Mock as _Mock
+
+    from temporalio.exceptions import TimeoutError as TemporalTimeoutError, TimeoutType
+
+    from fighthealthinsurance.workflows.send_fax import _timeout_type
+
+    hb = TemporalTimeoutError(
+        "t", type=TimeoutType.HEARTBEAT, last_heartbeat_details=[]
+    )
+    assert _timeout_type(_Mock(cause=hb)) == TimeoutType.HEARTBEAT
+    stc = TemporalTimeoutError(
+        "t", type=TimeoutType.START_TO_CLOSE, last_heartbeat_details=[]
+    )
+    assert _timeout_type(_Mock(cause=stc)) == TimeoutType.START_TO_CLOSE
+    assert _timeout_type(_Mock(cause=RuntimeError("x"))) is None
+    assert _timeout_type(RuntimeError("no cause attr")) is None
 
 
 @pytest.mark.asyncio
@@ -166,18 +193,21 @@ async def test_delay_send_waits_then_sends():
 async def test_send_raising_is_finalized_as_failure_without_concurrent_retry():
     """A raising send is NOT retried, then recorded as a failed send.
 
-    The vendor activity is a synchronous, non-heartbeating thread Temporal
-    cannot cancel, so retrying it after a start_to_close timeout would run a
-    second attempt *concurrently* with the still-running first one and double-fax.
-    It therefore runs at most once (maximum_attempts=1); a failure is finalized
-    as a failed send so the user is still notified.
+    The vendor activity is a thread Temporal cannot cancel, so retrying after
+    a timeout could run a second attempt *concurrently* with the still-running
+    first one and double-fax. It runs at most once per attempt
+    (maximum_attempts=1), and the workflow only re-attempts on a HEARTBEAT
+    timeout (worker process dead, thread provably gone). A vendor error gets
+    no retry; it is finalized as a failed send (user notified) and the claim
+    is then released so an explicit resend can transmit.
     """
     rec = _Recorder(precheck_status=STATUS_OK, send_raises=True)
     async with await WorkflowEnvironment.start_time_skipping() as env:
         result = await _run(env, rec)
     assert result is False
     assert rec.calls.count(("send", "h", "u")) == 1
-    assert rec.calls[-1] == ("finalize", False, False)
+    assert [c[0] for c in rec.calls] == ["precheck", "send", "finalize", "release"]
+    assert rec.calls[2] == ("finalize", False, False)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
A fax on 2026-08-30 failed invisibly: the worker was OOM-killed (1Gi limit) six seconds into the send, while assembling the fax document (PubMed PDFs + pandoc). No heartbeat meant Temporal waited the full 30-minute start-to-close to notice, the in-process claim release never ran, so vendor_send_completed stayed True and every resend path short-circuited, while the workflow completed with Result=false.
 
 Four changes, one per link in that chain:
  - Claim after assembly — the vendor_send_completed claim is taken after get_temporary_document_path(), so a crash in the memory-hungry phase can't strand a claim. Worst case two senders both assemble; the atomic claim still ensures one transmits.
- Heartbeats — the send activity heartbeats every ~10s around the blocking vendor call; heartbeat_timeout=120s. A dead worker is caught in ~2 minutes, not 30.
- Safe retry taxonomy — one automatic re-attempt only on HEARTBEAT timeout (worker died, thread provably gone, cannot double-fax). No retry on vendor-reported failure (HylaFax already re-dials) or START_TO_CLOSE (the abandoned thread may still be transmitting; claim release waits a 35-min drain). Finalize (user email) always runs before claim cleanup.
 - Status page — "Fax delivery (last 7 days)": sent / delivered / failed / failed-with-stuck-claim, because the Temporal panel's "Completed" only means "finished".
 
Separate follow-ups worth discussing: the fax worker's 1Gi memory limit (the actual root cause), and resending fax 08c9f658 — nothing was dialed, so an explicit resend is safe.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a fax delivery outcomes section to the admin status page with seven-day sent, delivered, failed, and stuck counts.
  - Added recent fax failure details, timestamps, and claim-release status.

- **Bug Fixes**
  - Improved handling of interrupted or timed-out fax sends.
  - Added progress monitoring and recovery for stuck sends, enabling eligible faxes to be resent.
  - Prevented incomplete document preparation from blocking fax delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->