### PR TITLE
Appeal journey workflow

### DIFF
--- a/fighthealthinsurance/activities/appeal_journey.py
+++ b/fighthealthinsurance/activities/appeal_journey.py
@@ -1,0 +1,50 @@
+"""Temporal activities for the queued appeal-generation journey.
+
+Thin synchronous wrappers around :mod:`fighthealthinsurance.appeal_journey_core`,
+following the fax activities' conventions: ``close_old_connections`` at entry,
+opaque identifiers only, sanitized exceptions, and heartbeats around the slow
+generation call (via the shared helper in :mod:`.fax`) so a dead worker is
+detected in seconds rather than at the start-to-close timeout.
+"""
+
+from django.db import close_old_connections
+
+from loguru import logger
+
+from temporalio import activity
+from temporalio.exceptions import ApplicationError
+
+from fighthealthinsurance import appeal_journey_core
+from fighthealthinsurance.activities.fax import _call_with_heartbeats
+
+
+@activity.defn
+def precheck_appeal_journey(hashed_email: str, denial_uuid: str) -> str:
+    close_old_connections()
+    denial = appeal_journey_core.load_denial(hashed_email, denial_uuid)
+    if denial is None:
+        return appeal_journey_core.STATUS_NOT_FOUND
+    return appeal_journey_core.precheck_appeal_journey(denial)
+
+
+@activity.defn
+def generate_and_store_appeals(hashed_email: str, denial_uuid: str) -> int:
+    """Generate + persist drafts; returns the number stored this attempt."""
+    close_old_connections()
+    denial = appeal_journey_core.load_denial(hashed_email, denial_uuid)
+    if denial is None:
+        return 0
+    try:
+        return int(
+            _call_with_heartbeats(
+                appeal_journey_core.generate_and_store_appeals, denial
+            )
+        )
+    except Exception:
+        # Keep detail in worker logs; history gets only the opaque uuid.
+        logger.opt(exception=True).error(
+            f"Appeal generation failed for denial {denial_uuid}"
+        )
+        raise ApplicationError(
+            f"appeal generation failed for denial {denial_uuid}"
+        ) from None

--- a/fighthealthinsurance/activities/fax.py
+++ b/fighthealthinsurance/activities/fax.py
@@ -53,10 +53,20 @@ def _call_with_heartbeats(fn, *args):
     box: dict = {}
 
     def _target():
+        # This inner thread has its own thread-local Django connections; the
+        # close_old_connections() at activity entry ran on the EXECUTOR
+        # thread and does nothing for this one. Sweep at entry and close in
+        # finally so repeated attempts can't accumulate idle server
+        # connections (PR #963 review).
+        from django.db import close_old_connections, connections
+
+        close_old_connections()
         try:
             box["result"] = fn(*args)
         except BaseException as e:  # noqa: BLE001 - re-raised on the activity thread
             box["error"] = e
+        finally:
+            connections.close_all()
 
     t = threading.Thread(target=_target, daemon=True)
     t.start()

--- a/fighthealthinsurance/appeal_journey_core.py
+++ b/fighthealthinsurance/appeal_journey_core.py
@@ -47,7 +47,12 @@ def precheck_appeal_journey(denial) -> str:
 
     if not (denial.denial_text or "").strip():
         return STATUS_NO_DENIAL_TEXT
-    existing = ProposedAppeal.objects.filter(for_denial=denial).count()
+    # speculative=True rows are the background precompute held in reserve;
+    # the interactive flow doesn't count them as delivered appeals and
+    # neither does the journey (PR #963 review).
+    existing = ProposedAppeal.objects.filter(
+        for_denial=denial, speculative=False
+    ).count()
     if existing >= TARGET_APPEALS:
         # A retry after a crash, or a duplicate dispatch: the drafts are
         # already there, so the journey is idempotently done.
@@ -56,21 +61,33 @@ def precheck_appeal_journey(denial) -> str:
 
 
 def generate_and_store_appeals(denial) -> int:
-    """Generate appeal drafts and persist them; returns how many were stored.
+    """Drive the shared generator until enough drafts exist; returns how many
+    new drafts got persisted.
 
-    Consumes the same async generator the interactive flow streams from, with
-    a bounded budget, and dedupes against drafts already stored for this
-    denial so an activity retry cannot double-store.
+    ``AppealsBackendHelper.generate_appeals`` persists every generated draft
+    itself (``save_appeal``) before yielding its frame, so this function only
+    CONSUMES the stream within a bounded budget and reports the persisted
+    delta -- it must never create rows from the streamed output, or every
+    draft would be stored twice (PR #963 review). The yielded texts are used
+    solely to stop consuming early once enough new drafts have appeared.
     """
     from fighthealthinsurance.common_view_logic import AppealsBackendHelper
     from fighthealthinsurance.models import ProposedAppeal
 
+    def _stored_count() -> int:
+        # Non-speculative only: reserve precompute rows don't count as
+        # delivered drafts anywhere else either.
+        return ProposedAppeal.objects.filter(
+            for_denial=denial, speculative=False
+        ).count()
+
     existing_texts = set(
-        ProposedAppeal.objects.filter(for_denial=denial).values_list(
+        ProposedAppeal.objects.filter(for_denial=denial, speculative=False).values_list(
             "appeal_text", flat=True
         )
     )
-    needed = TARGET_APPEALS - len(existing_texts)
+    before = _stored_count()
+    needed = TARGET_APPEALS - before
     if needed <= 0:
         return 0
 
@@ -81,8 +98,8 @@ def generate_and_store_appeals(denial) -> int:
         "semi_sekret": denial.semi_sekret,
     }
 
-    async def _collect() -> list:
-        collected: list = []
+    async def _consume() -> None:
+        new_texts: set = set()
         # generate_appeals is an async generator (declared AsyncIterator), so
         # aclose() exists at runtime; the cast lets mypy see it.
         agen = cast(
@@ -92,26 +109,25 @@ def generate_and_store_appeals(denial) -> int:
             async with asyncio.timeout(GENERATION_BUDGET_SECONDS):
                 async for chunk in agen:
                     text = _appeal_text_from_chunk(chunk)
+                    # The generator re-serves existing drafts first; only
+                    # genuinely new texts count toward the early stop.
                     if text and text not in existing_texts:
-                        collected.append(text)
-                        existing_texts.add(text)
-                    if len(collected) >= needed:
+                        new_texts.add(text)
+                    if len(new_texts) >= needed:
                         break
         except TimeoutError:
             logger.info(
                 f"Appeal journey: generation budget reached with "
-                f"{len(collected)} new draft(s) for denial {denial.uuid}"
+                f"{len(new_texts)} new draft(s) seen for denial {denial.uuid}"
             )
         finally:
             await agen.aclose()
-        return collected
 
-    stored = 0
-    for text in asyncio.run(_collect()):
-        ProposedAppeal.objects.create(for_denial=denial, appeal_text=text)
-        stored += 1
+    asyncio.run(_consume())
+    stored = max(0, _stored_count() - before)
     logger.info(
-        f"Appeal journey: stored {stored} draft(s) for denial uuid={denial.uuid}"
+        f"Appeal journey: {stored} new draft(s) persisted for denial "
+        f"uuid={denial.uuid}"
     )
     return stored
 

--- a/fighthealthinsurance/appeal_journey_core.py
+++ b/fighthealthinsurance/appeal_journey_core.py
@@ -1,0 +1,129 @@
+"""Core logic for the durable appeal-generation journey.
+
+Mirrors :mod:`fighthealthinsurance.fax_send_core`: plain synchronous functions
+that the Temporal activities in
+:mod:`fighthealthinsurance.activities.appeal_journey` wrap thinly. Everything
+re-loads the denial from opaque identifiers ``(hashed_email, denial_uuid)`` so
+no PHI crosses the workflow boundary.
+
+This is the queued/async path: generate appeal drafts in the background and
+persist them as ``ProposedAppeal`` rows for the user to find. The interactive
+streaming path (``AppealsBackendHelper.generate_appeals`` over websockets)
+stays exactly as it is; this journey reuses it as a library so the prompt
+assembly, context gathering and substitutions have one implementation.
+"""
+
+import asyncio
+import json
+from typing import AsyncGenerator, Optional, cast
+
+from loguru import logger
+
+STATUS_OK = "ok"
+STATUS_NOT_FOUND = "not_found"
+STATUS_NO_DENIAL_TEXT = "no_denial_text"
+STATUS_ALREADY_HAS_APPEALS = "already_has_appeals"
+
+# How many drafts one journey run aims to persist, and how long the generation
+# step may spend before returning with whatever it has. The activity's
+# start_to_close is set above this so a full budget is never cut short.
+TARGET_APPEALS = 3
+GENERATION_BUDGET_SECONDS = 240
+
+
+def load_denial(hashed_email: str, denial_uuid: str):
+    from fighthealthinsurance.models import Denial
+
+    try:
+        return Denial.objects.filter(hashed_email=hashed_email, uuid=denial_uuid).get()
+    except Denial.DoesNotExist:
+        logger.warning(f"Appeal journey: no denial for uuid={denial_uuid}")
+        return None
+
+
+def precheck_appeal_journey(denial) -> str:
+    """Validate the denial can produce appeals; cheap and side-effect free."""
+    from fighthealthinsurance.models import ProposedAppeal
+
+    if not (denial.denial_text or "").strip():
+        return STATUS_NO_DENIAL_TEXT
+    existing = ProposedAppeal.objects.filter(for_denial=denial).count()
+    if existing >= TARGET_APPEALS:
+        # A retry after a crash, or a duplicate dispatch: the drafts are
+        # already there, so the journey is idempotently done.
+        return STATUS_ALREADY_HAS_APPEALS
+    return STATUS_OK
+
+
+def generate_and_store_appeals(denial) -> int:
+    """Generate appeal drafts and persist them; returns how many were stored.
+
+    Consumes the same async generator the interactive flow streams from, with
+    a bounded budget, and dedupes against drafts already stored for this
+    denial so an activity retry cannot double-store.
+    """
+    from fighthealthinsurance.common_view_logic import AppealsBackendHelper
+    from fighthealthinsurance.models import ProposedAppeal
+
+    existing_texts = set(
+        ProposedAppeal.objects.filter(for_denial=denial).values_list(
+            "appeal_text", flat=True
+        )
+    )
+    needed = TARGET_APPEALS - len(existing_texts)
+    if needed <= 0:
+        return 0
+
+    parameters = {
+        "denial_id": denial.denial_id,
+        "email": None,
+        "hashed_email": denial.hashed_email,
+        "semi_sekret": denial.semi_sekret,
+    }
+
+    async def _collect() -> list:
+        collected: list = []
+        # generate_appeals is an async generator (declared AsyncIterator), so
+        # aclose() exists at runtime; the cast lets mypy see it.
+        agen = cast(
+            AsyncGenerator[str, None], AppealsBackendHelper.generate_appeals(parameters)
+        )
+        try:
+            async with asyncio.timeout(GENERATION_BUDGET_SECONDS):
+                async for chunk in agen:
+                    text = _appeal_text_from_chunk(chunk)
+                    if text and text not in existing_texts:
+                        collected.append(text)
+                        existing_texts.add(text)
+                    if len(collected) >= needed:
+                        break
+        except TimeoutError:
+            logger.info(
+                f"Appeal journey: generation budget reached with "
+                f"{len(collected)} new draft(s) for denial {denial.uuid}"
+            )
+        finally:
+            await agen.aclose()
+        return collected
+
+    stored = 0
+    for text in asyncio.run(_collect()):
+        ProposedAppeal.objects.create(for_denial=denial, appeal_text=text)
+        stored += 1
+    logger.info(
+        f"Appeal journey: stored {stored} draft(s) for denial uuid={denial.uuid}"
+    )
+    return stored
+
+
+def _appeal_text_from_chunk(chunk: str) -> Optional[str]:
+    """The generator yields JSON strings; pull the appeal text out defensively."""
+    try:
+        data = json.loads(chunk)
+    except (TypeError, json.JSONDecodeError):
+        return None
+    if isinstance(data, dict):
+        text = data.get("content") or data.get("appeal") or data.get("text")
+        if isinstance(text, str) and text.strip():
+            return text.strip()
+    return None

--- a/fighthealthinsurance/appeal_journey_core.py
+++ b/fighthealthinsurance/appeal_journey_core.py
@@ -17,6 +17,8 @@ import asyncio
 import json
 from typing import AsyncGenerator, Optional, cast
 
+from asgiref.sync import async_to_sync
+
 from loguru import logger
 
 STATUS_OK = "ok"
@@ -32,12 +34,20 @@ GENERATION_BUDGET_SECONDS = 240
 
 
 def load_denial(hashed_email: str, denial_uuid: str):
+    from django.core.exceptions import ValidationError
+
     from fighthealthinsurance.models import Denial
 
     try:
         return Denial.objects.filter(hashed_email=hashed_email, uuid=denial_uuid).get()
     except Denial.DoesNotExist:
         logger.warning(f"Appeal journey: no denial for uuid={denial_uuid}")
+        return None
+    except (ValidationError, ValueError):
+        # A malformed uuid fails field validation BEFORE DoesNotExist applies;
+        # left unhandled it escapes into the precheck's unlimited retry and
+        # poisons the workflow (PR #963 review). Same terminal answer.
+        logger.warning(f"Appeal journey: invalid denial uuid {denial_uuid!r}")
         return None
 
 
@@ -60,36 +70,35 @@ def precheck_appeal_journey(denial) -> str:
     return STATUS_OK
 
 
+class JourneyIncomplete(Exception):
+    """Raised when a run ends with fewer durable drafts than the target.
+
+    Surfacing this (instead of returning a partial count) is what makes the
+    activity's retry policy meaningful: a swallowed budget timeout, a failed
+    save inside the generator, or an empty stream must look like a retryable
+    failure, not success (PR #963 review).
+    """
+
+
 def generate_and_store_appeals(denial) -> int:
     """Drive the shared generator until enough drafts exist; returns how many
     new drafts got persisted.
 
     ``AppealsBackendHelper.generate_appeals`` persists every generated draft
     itself (``save_appeal``) before yielding its frame, so this function only
-    CONSUMES the stream within a bounded budget and reports the persisted
-    delta -- it must never create rows from the streamed output, or every
-    draft would be stored twice (PR #963 review). The yielded texts are used
-    solely to stop consuming early once enough new drafts have appeared.
+    CONSUMES the stream within a bounded budget -- it must never create rows
+    from the streamed output, or every draft would be stored twice.
+
+    Progress is measured in durable row IDENTITIES, never yielded text: the
+    generator re-serves existing drafts transformed by ``sub_in_appeals`` (so
+    their text differs from what is stored) and can yield content whose save
+    FAILED -- both fooled a text-based count into stopping early with nothing
+    persisted (PR #963 review). The postcondition is enforced against the
+    database; falling short raises :class:`JourneyIncomplete` so the activity
+    retries instead of reporting a hollow success.
     """
     from fighthealthinsurance.common_view_logic import AppealsBackendHelper
     from fighthealthinsurance.models import ProposedAppeal
-
-    def _stored_count() -> int:
-        # Non-speculative only: reserve precompute rows don't count as
-        # delivered drafts anywhere else either.
-        return ProposedAppeal.objects.filter(
-            for_denial=denial, speculative=False
-        ).count()
-
-    existing_texts = set(
-        ProposedAppeal.objects.filter(for_denial=denial, speculative=False).values_list(
-            "appeal_text", flat=True
-        )
-    )
-    before = _stored_count()
-    needed = TARGET_APPEALS - before
-    if needed <= 0:
-        return 0
 
     parameters = {
         "denial_id": denial.denial_id,
@@ -98,8 +107,26 @@ def generate_and_store_appeals(denial) -> int:
         "semi_sekret": denial.semi_sekret,
     }
 
-    async def _consume() -> None:
-        new_texts: set = set()
+    async def _stored_ids() -> set:
+        # Non-speculative only: reserve precompute rows don't count as
+        # delivered drafts anywhere else either. Native async ORM (no
+        # bridge) per repo convention.
+        return {
+            pk
+            async for pk in ProposedAppeal.objects.filter(
+                for_denial=denial, speculative=False
+            ).values_list("id", flat=True)
+        }
+
+    async def _run() -> tuple:
+        # Every DB read lives inside this one async context: the generator's
+        # internal connection cleanup can close sync-thread connections, so a
+        # sync-side query after consumption is not safe to rely on.
+        baseline = await _stored_ids()
+        if len(baseline) >= TARGET_APPEALS:
+            return baseline, baseline
+
+        frames = 0
         # generate_appeals is an async generator (declared AsyncIterator), so
         # aclose() exists at runtime; the cast lets mypy see it.
         agen = cast(
@@ -108,27 +135,37 @@ def generate_and_store_appeals(denial) -> int:
         try:
             async with asyncio.timeout(GENERATION_BUDGET_SECONDS):
                 async for chunk in agen:
-                    text = _appeal_text_from_chunk(chunk)
-                    # The generator re-serves existing drafts first; only
-                    # genuinely new texts count toward the early stop.
-                    if text and text not in existing_texts:
-                        new_texts.add(text)
-                    if len(new_texts) >= needed:
+                    if _appeal_text_from_chunk(chunk) is None:
+                        continue
+                    # Early stop on DURABLE progress: appeal frames are few,
+                    # so a count query per frame is cheap, and only rows that
+                    # actually persisted can end the consumption early.
+                    frames += 1
+                    if len(await _stored_ids()) >= TARGET_APPEALS:
                         break
         except TimeoutError:
             logger.info(
-                f"Appeal journey: generation budget reached with "
-                f"{len(new_texts)} new draft(s) seen for denial {denial.uuid}"
+                f"Appeal journey: generation budget reached after {frames} "
+                f"appeal frame(s) for denial {denial.uuid}"
             )
         finally:
             await agen.aclose()
+        return baseline, await _stored_ids()
 
-    asyncio.run(_consume())
-    stored = max(0, _stored_count() - before)
+    # async_to_sync (not asyncio.run): asgiref keeps the sync-thread context,
+    # so the generator's thread_sensitive ORM bridges execute on THIS thread
+    # and its Django connection, matching how the interactive stack drives it.
+    baseline, after = async_to_sync(_run)()
+    stored = len(after - baseline)
     logger.info(
         f"Appeal journey: {stored} new draft(s) persisted for denial "
         f"uuid={denial.uuid}"
     )
+    if len(after) < TARGET_APPEALS:
+        raise JourneyIncomplete(
+            f"{len(after)} of {TARGET_APPEALS} drafts durable for denial "
+            f"{denial.uuid} (stored {stored} this attempt)"
+        )
     return stored
 
 

--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -2897,7 +2897,10 @@ class AppealsBackendHelper:
         denial_id = parameters["denial_id"]
         email = parameters["email"]
         semi_sekret = parameters["semi_sekret"]
-        hashed_email = Denial.get_hashed_email(email)
+        # The durable appeal journey (appeal_journey_core) re-loads denials
+        # from opaque ids and never has the raw email, so it passes the stored
+        # hashed_email directly; interactive callers keep sending email.
+        hashed_email = parameters.get("hashed_email") or Denial.get_hashed_email(email)
         # Extract the professional_to_finish parameter from the input, default to False
         professional_to_finish = parameters.get("professional_to_finish", False)
         # Set by the JS client when this socket replaces one that dropped (see

--- a/fighthealthinsurance/management/commands/dispatch_appeal_journey.py
+++ b/fighthealthinsurance/management/commands/dispatch_appeal_journey.py
@@ -1,0 +1,37 @@
+"""Dispatch a durable appeal-generation journey for one denial.
+
+Manual/testing entry point for ``GenerateAppealWorkflow`` while no product
+surface dispatches it yet: look the denial up by uuid, then hand its opaque
+identifiers to Temporal. Requires TEMPORAL_ENABLED and
+TEMPORAL_APPEAL_JOURNEY_ENABLED plus a running worker
+(``python manage.py run_temporal_worker``).
+"""
+
+from typing import Any
+
+from django.core.management.base import BaseCommand, CommandError
+
+
+class Command(BaseCommand):
+    help = "Start a durable GenerateAppealWorkflow for a denial (by uuid)."
+
+    def add_arguments(self, parser: Any) -> None:
+        parser.add_argument("denial_uuid", help="The Denial uuid to generate for.")
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        from fighthealthinsurance.models import Denial
+        from fighthealthinsurance.temporal_client import dispatch_appeal_generation
+
+        denial_uuid = options["denial_uuid"]
+        try:
+            denial = Denial.objects.get(uuid=denial_uuid)
+        except Denial.DoesNotExist:
+            raise CommandError(f"No denial with uuid {denial_uuid}")
+
+        if dispatch_appeal_generation(denial.hashed_email, str(denial.uuid)):
+            self.stdout.write(f"Dispatched appeal journey for denial {denial_uuid}")
+        else:
+            raise CommandError(
+                "Dispatch failed -- is TEMPORAL_ENABLED (and "
+                "TEMPORAL_APPEAL_JOURNEY_ENABLED) set, with Temporal reachable?"
+            )

--- a/fighthealthinsurance/management/commands/dispatch_appeal_journey.py
+++ b/fighthealthinsurance/management/commands/dispatch_appeal_journey.py
@@ -19,10 +19,17 @@ class Command(BaseCommand):
         parser.add_argument("denial_uuid", help="The Denial uuid to generate for.")
 
     def handle(self, *args: Any, **options: Any) -> None:
+        import uuid as uuid_mod
+
         from fighthealthinsurance.models import Denial
         from fighthealthinsurance.temporal_client import dispatch_appeal_generation
 
-        denial_uuid = options["denial_uuid"]
+        # Canonicalize before dispatch: a malformed uuid must fail HERE, not
+        # become a workflow retrying a ValidationError forever.
+        try:
+            denial_uuid = str(uuid_mod.UUID(options["denial_uuid"]))
+        except ValueError:
+            raise CommandError(f"Not a valid uuid: {options['denial_uuid']!r}")
         try:
             denial = Denial.objects.get(uuid=denial_uuid)
         except Denial.DoesNotExist:

--- a/fighthealthinsurance/management/commands/run_temporal_worker.py
+++ b/fighthealthinsurance/management/commands/run_temporal_worker.py
@@ -58,25 +58,40 @@ class Command(BaseCommand):
             settings, "TEMPORAL_MAX_ACTIVITY_WORKERS", 20
         )
 
+        from typing import Any as _Any, Callable, List
+
+        workflows: List[type] = [SendFaxWorkflow]
+        activities: List[Callable[..., _Any]] = [
+            fax_activities.precheck_fax,
+            fax_activities.send_fax_via_vendor,
+            fax_activities.release_send_claim,
+            fax_activities.finalize_fax,
+        ]
+        # Register the appeal journey only when its flag is on, so the flag
+        # is a real execution kill switch: with unconditional registration a
+        # direct Temporal start (or a task queued before the flag flipped)
+        # would still run on a "dark" worker (PR #963 review).
+        journey_enabled = getattr(settings, "TEMPORAL_APPEAL_JOURNEY_ENABLED", False)
+        if journey_enabled:
+            workflows.append(GenerateAppealWorkflow)
+            activities += [
+                journey_activities.precheck_appeal_journey,
+                journey_activities.generate_and_store_appeals,
+            ]
+
         client = await get_temporal_client()
         self.stdout.write(
             f"Connected to Temporal at {settings.TEMPORAL_HOST} "
-            f"(namespace={settings.TEMPORAL_NAMESPACE})"
+            f"(namespace={settings.TEMPORAL_NAMESPACE}); appeal journey "
+            f"{'ENABLED' if journey_enabled else 'disabled'}"
         )
 
         with ThreadPoolExecutor(max_workers=max_workers) as activity_executor:
             worker = Worker(
                 client,
                 task_queue=task_queue,
-                workflows=[SendFaxWorkflow, GenerateAppealWorkflow],
-                activities=[
-                    fax_activities.precheck_fax,
-                    fax_activities.send_fax_via_vendor,
-                    fax_activities.release_send_claim,
-                    fax_activities.finalize_fax,
-                    journey_activities.precheck_appeal_journey,
-                    journey_activities.generate_and_store_appeals,
-                ],
+                workflows=workflows,
+                activities=activities,
                 activity_executor=activity_executor,
             )
             self.stdout.write(

--- a/fighthealthinsurance/management/commands/run_temporal_worker.py
+++ b/fighthealthinsurance/management/commands/run_temporal_worker.py
@@ -43,8 +43,14 @@ class Command(BaseCommand):
     async def _run(self, options: dict) -> None:
         from temporalio.worker import Worker
 
-        from fighthealthinsurance.activities import fax as fax_activities
+        from fighthealthinsurance.activities import (
+            appeal_journey as journey_activities,
+            fax as fax_activities,
+        )
         from fighthealthinsurance.temporal_client import get_temporal_client
+        from fighthealthinsurance.workflows.generate_appeal import (
+            GenerateAppealWorkflow,
+        )
         from fighthealthinsurance.workflows.send_fax import SendFaxWorkflow
 
         task_queue = options.get("task_queue") or settings.TEMPORAL_TASK_QUEUE
@@ -62,12 +68,14 @@ class Command(BaseCommand):
             worker = Worker(
                 client,
                 task_queue=task_queue,
-                workflows=[SendFaxWorkflow],
+                workflows=[SendFaxWorkflow, GenerateAppealWorkflow],
                 activities=[
                     fax_activities.precheck_fax,
                     fax_activities.send_fax_via_vendor,
                     fax_activities.release_send_claim,
                     fax_activities.finalize_fax,
+                    journey_activities.precheck_appeal_journey,
+                    journey_activities.generate_and_store_appeals,
                 ],
                 activity_executor=activity_executor,
             )

--- a/fighthealthinsurance/settings.py
+++ b/fighthealthinsurance/settings.py
@@ -131,6 +131,12 @@ class Base(Configuration):
     # SendFaxWorkflow instead. The worker process is run with
     # `python manage.py run_temporal_worker`.
     TEMPORAL_ENABLED = os.getenv("TEMPORAL_ENABLED", "false").lower() == "true"
+    # The queued appeal-generation journey (GenerateAppealWorkflow) is gated
+    # separately so fax sending can run on Temporal while this stays dark. It
+    # only takes effect when TEMPORAL_ENABLED is also true.
+    TEMPORAL_APPEAL_JOURNEY_ENABLED = (
+        os.getenv("TEMPORAL_APPEAL_JOURNEY_ENABLED", "false").lower() == "true"
+    )
     TEMPORAL_HOST = os.getenv("TEMPORAL_HOST", "localhost:7233")
     TEMPORAL_NAMESPACE = os.getenv("TEMPORAL_NAMESPACE", "default")
     TEMPORAL_TASK_QUEUE = os.getenv("TEMPORAL_TASK_QUEUE", "fhi-fax")

--- a/fighthealthinsurance/settings.py
+++ b/fighthealthinsurance/settings.py
@@ -146,6 +146,12 @@ class Base(Configuration):
     # TLS for a self-hosted / Cloud cluster. When TEMPORAL_TLS is true and both
     # the cert and key paths are set the client uses mTLS; otherwise it uses
     # server-side TLS.
+    # Fernet key for client-side encryption of every Temporal payload (see
+    # temporal_codec.py). Unset = plaintext payloads (ids-only by design).
+    # Generate with: python -c "from cryptography.fernet import Fernet;
+    # print(Fernet.generate_key().decode())". Destroying/rotating the key
+    # crypto-shreds all existing workflow histories at once.
+    TEMPORAL_PAYLOAD_KEY = os.getenv("TEMPORAL_PAYLOAD_KEY", "")
     TEMPORAL_TLS = os.getenv("TEMPORAL_TLS", "false").lower() == "true"
     TEMPORAL_CLIENT_CERT_PATH = os.getenv("TEMPORAL_CLIENT_CERT_PATH", "")
     TEMPORAL_CLIENT_KEY_PATH = os.getenv("TEMPORAL_CLIENT_KEY_PATH", "")

--- a/fighthealthinsurance/settings.py
+++ b/fighthealthinsurance/settings.py
@@ -146,11 +146,13 @@ class Base(Configuration):
     # TLS for a self-hosted / Cloud cluster. When TEMPORAL_TLS is true and both
     # the cert and key paths are set the client uses mTLS; otherwise it uses
     # server-side TLS.
-    # Fernet key for client-side encryption of every Temporal payload (see
-    # temporal_codec.py). Unset = plaintext payloads (ids-only by design).
-    # Generate with: python -c "from cryptography.fernet import Fernet;
-    # print(Fernet.generate_key().decode())". Destroying/rotating the key
-    # crypto-shreds all existing workflow histories at once.
+    # Fernet key(s) for client-side encryption of every Temporal payload
+    # (see temporal_codec.py). Unset = plaintext payloads (ids-only by
+    # design). Comma-separated for rotation: the FIRST key encrypts, all
+    # keys decrypt -- prepend a new key and retire the old one only after
+    # retention has expired everything it encrypted. Generate with:
+    # python -c "from cryptography.fernet import Fernet;
+    # print(Fernet.generate_key().decode())".
     TEMPORAL_PAYLOAD_KEY = os.getenv("TEMPORAL_PAYLOAD_KEY", "")
     TEMPORAL_TLS = os.getenv("TEMPORAL_TLS", "false").lower() == "true"
     TEMPORAL_CLIENT_CERT_PATH = os.getenv("TEMPORAL_CLIENT_CERT_PATH", "")

--- a/fighthealthinsurance/temporal_client.py
+++ b/fighthealthinsurance/temporal_client.py
@@ -175,6 +175,56 @@ def dispatch_fax_send_blocking(hashed_email: str, fax_uuid: str) -> Optional[boo
         return None
 
 
+async def start_generate_appeal_workflow(hashed_email: str, denial_uuid: str) -> str:
+    """Start ``GenerateAppealWorkflow`` for a denial. Returns the workflow id.
+
+    The deterministic id means at most one journey is in flight per denial; a
+    duplicate dispatch while one is open raises ``WorkflowAlreadyStartedError``
+    (handled in :func:`dispatch_appeal_generation`), and a re-dispatch after it
+    closed starts a fresh run, which the precheck ends immediately when the
+    drafts are already stored.
+    """
+    from fighthealthinsurance.workflows.types import GenerateAppealInput
+
+    client = await get_temporal_client()
+    handle = await client.start_workflow(
+        "GenerateAppealWorkflow",
+        GenerateAppealInput(hashed_email=hashed_email, denial_uuid=str(denial_uuid)),
+        id=f"generate-appeal-{denial_uuid}",
+        task_queue=settings.TEMPORAL_TASK_QUEUE,
+    )
+    logger.info(f"Started GenerateAppealWorkflow {handle.id} for denial {denial_uuid}")
+    return str(handle.id)
+
+
+def dispatch_appeal_generation(hashed_email: str, denial_uuid: str) -> bool:
+    """Dispatch a durable appeal-generation journey when enabled.
+
+    Returns True if the journey was handed to Temporal (or one is already in
+    flight for this denial), False when Temporal or the journey flag is off or
+    the start failed. There is no fallback path: this is a new queued flow, so
+    a False simply means nothing was queued.
+    """
+    if not getattr(settings, "TEMPORAL_ENABLED", False):
+        return False
+    if not getattr(settings, "TEMPORAL_APPEAL_JOURNEY_ENABLED", False):
+        return False
+    from temporalio.exceptions import WorkflowAlreadyStartedError
+
+    try:
+        async_to_sync(start_generate_appeal_workflow)(hashed_email, str(denial_uuid))
+        return True
+    except WorkflowAlreadyStartedError:
+        # A journey for this denial is already open; the dispatch is satisfied.
+        logger.info(f"GenerateAppealWorkflow already running for denial {denial_uuid}")
+        return True
+    except Exception:
+        logger.opt(exception=True).error(
+            f"Failed to start GenerateAppealWorkflow for denial {denial_uuid}"
+        )
+        return False
+
+
 def dispatch_fax_send(
     hashed_email: str,
     fax_uuid: str,

--- a/fighthealthinsurance/temporal_client.py
+++ b/fighthealthinsurance/temporal_client.py
@@ -55,22 +55,34 @@ async def get_temporal_client() -> Any:
     connect_kwargs: dict = {}
     payload_key = getattr(settings, "TEMPORAL_PAYLOAD_KEY", "")
     if payload_key:
-        import dataclasses as _dc
-
-        import temporalio.converter
-
-        from fighthealthinsurance.temporal_codec import EncryptionCodec
-
-        connect_kwargs["data_converter"] = _dc.replace(
-            temporalio.converter.default(),
-            payload_codec=EncryptionCodec(payload_key),
-        )
+        connect_kwargs["data_converter"] = _encrypting_data_converter(payload_key)
 
     return await Client.connect(
         settings.TEMPORAL_HOST,
         namespace=settings.TEMPORAL_NAMESPACE,
         tls=tls,
         **connect_kwargs,
+    )
+
+
+def _encrypting_data_converter(payload_key: str):
+    """Payload codec + ENCODED failure attributes. The codec alone is not
+    enough: Temporal's default failure converter leaves exception messages
+    and stack traces as plaintext protobuf fields, so an activity error
+    could leak text into history around the encryption (external review).
+    With encoded attributes, message/stack move into the payload the codec
+    encrypts."""
+    import dataclasses as _dc
+
+    import temporalio.converter
+    from temporalio.converter import DefaultFailureConverterWithEncodedAttributes
+
+    from fighthealthinsurance.temporal_codec import EncryptionCodec
+
+    return _dc.replace(
+        temporalio.converter.default(),
+        payload_codec=EncryptionCodec(payload_key),
+        failure_converter_class=DefaultFailureConverterWithEncodedAttributes,
     )
 
 

--- a/fighthealthinsurance/temporal_client.py
+++ b/fighthealthinsurance/temporal_client.py
@@ -47,10 +47,30 @@ async def get_temporal_client() -> Any:
         else:
             tls = True
 
+    # With TEMPORAL_PAYLOAD_KEY set, every payload is encrypted client-side
+    # before it reaches the Temporal server (see temporal_codec.py): history
+    # holds ciphertext only, and destroying the key crypto-shreds whatever
+    # namespace retention has not yet expired. The worker connects through
+    # this same function, so one setting covers both sides.
+    connect_kwargs: dict = {}
+    payload_key = getattr(settings, "TEMPORAL_PAYLOAD_KEY", "")
+    if payload_key:
+        import dataclasses as _dc
+
+        import temporalio.converter
+
+        from fighthealthinsurance.temporal_codec import EncryptionCodec
+
+        connect_kwargs["data_converter"] = _dc.replace(
+            temporalio.converter.default(),
+            payload_codec=EncryptionCodec(payload_key),
+        )
+
     return await Client.connect(
         settings.TEMPORAL_HOST,
         namespace=settings.TEMPORAL_NAMESPACE,
         tls=tls,
+        **connect_kwargs,
     )
 
 

--- a/fighthealthinsurance/temporal_codec.py
+++ b/fighthealthinsurance/temporal_codec.py
@@ -1,0 +1,54 @@
+"""Payload encryption for Temporal, so workflow history never stores
+readable identifiers.
+
+Workflow inputs are already claim-check style -- opaque ``(hashed_email,
+uuid)`` pairs, never case content -- but a hashed email is still
+pseudonymous personal data under GDPR, and it sits in Temporal's own
+database until namespace retention (720h, see ``k8s/temporal/README.md``)
+expires it. With ``TEMPORAL_PAYLOAD_KEY`` set, every payload (inputs,
+results, and the values inside errors) is Fernet-encrypted by the client
+before it reaches the Temporal server, so:
+
+- the Temporal database and UI hold ciphertext only;
+- retention expiry remains the storage bound (no long-term storage);
+- rotating away or destroying the key crypto-shreds every history at once,
+  which satisfies erasure obligations for anything retention has not yet
+  removed.
+
+Decoding passes unencrypted payloads through untouched, so histories
+written before the key was configured keep replaying during rollout.
+"""
+
+from typing import Iterable, List
+
+from cryptography.fernet import Fernet
+
+from temporalio.api.common.v1 import Payload
+from temporalio.converter import PayloadCodec
+
+ENCODING = b"binary/encrypted-fernet"
+
+
+class EncryptionCodec(PayloadCodec):
+    def __init__(self, key: str) -> None:
+        self._fernet = Fernet(key)
+
+    async def encode(self, payloads: Iterable[Payload]) -> List[Payload]:
+        return [
+            Payload(
+                metadata={"encoding": ENCODING},
+                data=self._fernet.encrypt(p.SerializeToString()),
+            )
+            for p in payloads
+        ]
+
+    async def decode(self, payloads: Iterable[Payload]) -> List[Payload]:
+        out: List[Payload] = []
+        for p in payloads:
+            if p.metadata.get("encoding") == ENCODING:
+                out.append(Payload.FromString(self._fernet.decrypt(p.data)))
+            else:
+                # Pre-codec history (or another producer without the key):
+                # pass through so old workflows keep replaying.
+                out.append(p)
+        return out

--- a/fighthealthinsurance/temporal_codec.py
+++ b/fighthealthinsurance/temporal_codec.py
@@ -19,7 +19,7 @@ written before the key was configured keep replaying during rollout.
 
 from typing import Iterable, List
 
-from cryptography.fernet import Fernet
+from cryptography.fernet import Fernet, MultiFernet
 
 from temporalio.api.common.v1 import Payload
 from temporalio.converter import PayloadCodec
@@ -28,8 +28,13 @@ ENCODING = b"binary/encrypted-fernet"
 
 
 class EncryptionCodec(PayloadCodec):
+    """``key`` may be a comma-separated list: the FIRST key encrypts, every
+    key decrypts -- so rotation is "prepend the new key, keep the old one
+    until retention has expired everything it encrypted"."""
+
     def __init__(self, key: str) -> None:
-        self._fernet = Fernet(key)
+        keys = [k.strip() for k in key.split(",") if k.strip()]
+        self._fernet = MultiFernet([Fernet(k) for k in keys])
 
     async def encode(self, payloads: Iterable[Payload]) -> List[Payload]:
         return [

--- a/fighthealthinsurance/temporal_codec.py
+++ b/fighthealthinsurance/temporal_codec.py
@@ -2,18 +2,16 @@
 readable identifiers.
 
 Workflow inputs are already claim-check style -- opaque ``(hashed_email,
-uuid)`` pairs, never case content -- but a hashed email is still
-pseudonymous personal data under GDPR, and it sits in Temporal's own
-database until namespace retention (720h, see ``k8s/temporal/README.md``)
-expires it. With ``TEMPORAL_PAYLOAD_KEY`` set, every payload (inputs,
+uuid)`` pairs, never case content -- but a hashed email is still a
+user-linked identifier, and it sits in Temporal's own database until
+namespace retention (720h, see ``k8s/temporal/README.md``) expires it. With ``TEMPORAL_PAYLOAD_KEY`` set, every payload (inputs,
 results, and the values inside errors) is Fernet-encrypted by the client
 before it reaches the Temporal server, so:
 
 - the Temporal database and UI hold ciphertext only;
 - retention expiry remains the storage bound (no long-term storage);
-- rotating away or destroying the key crypto-shreds every history at once,
-  which satisfies erasure obligations for anything retention has not yet
-  removed.
+- rotating away or destroying the key renders every history unreadable at
+  once, an immediate backstop for anything retention has not yet removed.
 
 Decoding passes unencrypted payloads through untouched, so histories
 written before the key was configured keep replaying during rollout.

--- a/fighthealthinsurance/workflows/generate_appeal.py
+++ b/fighthealthinsurance/workflows/generate_appeal.py
@@ -1,0 +1,63 @@
+"""``GenerateAppealWorkflow`` -- durable, queued appeal-draft generation.
+
+The interactive flow streams appeals to a watching user and stays in-process.
+This workflow is for the queued shape: a user (or a future product surface)
+asks for drafts, the work survives worker restarts, and the drafts land as
+``ProposedAppeal`` rows.
+
+Unlike the fax send, generation has no irreversible external side effect, and
+the store step dedupes against existing drafts -- so the generation activity
+retries freely. Payloads carry opaque identifiers only; no PHI enters
+workflow history.
+"""
+
+from datetime import timedelta
+
+from temporalio import workflow
+from temporalio.common import RetryPolicy
+
+from fighthealthinsurance.workflows.types import GenerateAppealInput
+
+with workflow.unsafe.imports_passed_through():
+    from fighthealthinsurance.activities import appeal_journey as appeal_activities
+
+# Bookkeeping steps retry forever with capped backoff (same rationale as the
+# fax workflow's DURABLE_RETRY): a bounded retry running out would orphan the
+# journey silently.
+DURABLE_RETRY = RetryPolicy(maximum_attempts=0, maximum_interval=timedelta(minutes=5))
+
+# Generation is safe to retry (idempotent store), so a real retry policy:
+# transient model-backend failures get three attempts with backoff.
+GENERATION_RETRY = RetryPolicy(
+    maximum_attempts=3,
+    initial_interval=timedelta(seconds=30),
+    maximum_interval=timedelta(minutes=5),
+)
+
+
+@workflow.defn
+class GenerateAppealWorkflow:
+    @workflow.run
+    async def run(self, journey: GenerateAppealInput) -> int:
+        status = await workflow.execute_activity(
+            appeal_activities.precheck_appeal_journey,
+            args=[journey.hashed_email, journey.denial_uuid],
+            start_to_close_timeout=timedelta(seconds=60),
+            retry_policy=DURABLE_RETRY,
+        )
+        if status != "ok":
+            # not_found / no_denial_text / already_has_appeals are all terminal
+            # and idempotent; the workflow records the status and stops.
+            workflow.logger.info(f"Appeal journey ended at precheck: {status}")
+            return 0
+
+        stored = await workflow.execute_activity(
+            appeal_activities.generate_and_store_appeals,
+            args=[journey.hashed_email, journey.denial_uuid],
+            # Above the core's GENERATION_BUDGET_SECONDS so the budget, not
+            # the timeout, ends a slow attempt; heartbeats catch dead workers.
+            start_to_close_timeout=timedelta(minutes=8),
+            heartbeat_timeout=timedelta(seconds=120),
+            retry_policy=GENERATION_RETRY,
+        )
+        return int(stored)

--- a/fighthealthinsurance/workflows/types.py
+++ b/fighthealthinsurance/workflows/types.py
@@ -23,3 +23,17 @@ class SendFaxInput:
     hashed_email: str
     fax_uuid: str
     delay_send: bool = False
+
+
+@dataclass
+class GenerateAppealInput:
+    """Input for ``GenerateAppealWorkflow``.
+
+    Attributes:
+        hashed_email: Hashed email used (with ``denial_uuid``) to look the
+            denial up.
+        denial_uuid: The ``Denial`` uuid, as a string.
+    """
+
+    hashed_email: str
+    denial_uuid: str

--- a/k8s/temporal/README.md
+++ b/k8s/temporal/README.md
@@ -217,3 +217,21 @@ required.
 > hashed email + fax uuid + booleans — **no PHI** is written to Temporal
 > history. Any future workflow that must carry PHI should add an encryption
 > `PayloadCodec` (see the Temporal data-handling reference) before doing so.
+
+## Data protection (GDPR)
+
+Workflow payloads are claim-check style by contract: opaque
+`(hashed_email, uuid)` identifiers only, never case content (enforced by
+`tests/temporal/test_temporal_codec.py`). Two further layers:
+
+- **Retention is the storage bound.** The namespace is created with
+  `--retention 720h`, so closed-workflow histories are deleted by the
+  server after 30 days. Do not raise this without a data-protection
+  conversation.
+- **Payload encryption.** Set `TEMPORAL_PAYLOAD_KEY` (a Fernet key) in the
+  app/worker environment and every payload is encrypted client-side
+  (`fighthealthinsurance/temporal_codec.py`): the Temporal database and UI
+  hold ciphertext only. Destroying or rotating the key crypto-shreds all
+  histories at once, which covers erasure requests for anything retention
+  has not yet expired. Decoding passes pre-key plaintext histories
+  through, so the key can be introduced without draining workflows.

--- a/k8s/temporal/README.md
+++ b/k8s/temporal/README.md
@@ -218,7 +218,7 @@ required.
 > history. Any future workflow that must carry PHI should add an encryption
 > `PayloadCodec` (see the Temporal data-handling reference) before doing so.
 
-## Data protection (GDPR)
+## Protecting user data in workflow history
 
 Workflow payloads are claim-check style by contract: opaque
 `(hashed_email, uuid)` identifiers only, never case content (enforced by
@@ -226,12 +226,13 @@ Workflow payloads are claim-check style by contract: opaque
 
 - **Retention is the storage bound.** The namespace is created with
   `--retention 720h`, so closed-workflow histories are deleted by the
-  server after 30 days. Do not raise this without a data-protection
-  conversation.
+  server after 30 days. History is a debugging window, not a data store
+  (the durable data lives in Django); raise it deliberately, not by
+  default.
 - **Payload encryption.** Set `TEMPORAL_PAYLOAD_KEY` (a Fernet key) in the
   app/worker environment and every payload is encrypted client-side
   (`fighthealthinsurance/temporal_codec.py`): the Temporal database and UI
-  hold ciphertext only. Destroying or rotating the key crypto-shreds all
-  histories at once, which covers erasure requests for anything retention
-  has not yet expired. Decoding passes pre-key plaintext histories
+  hold ciphertext only. Destroying or rotating the key renders all
+  existing histories unreadable at once, an immediate backstop if any
+  history ever needs to be expunged ahead of retention. Decoding passes pre-key plaintext histories
   through, so the key can be introduced without draining workflows.

--- a/tests/async-unit/test_appeal_journey_core.py
+++ b/tests/async-unit/test_appeal_journey_core.py
@@ -1,0 +1,122 @@
+"""Integration tests for appeal_journey_core against the REAL generator.
+
+These exercise the database-backed core consuming the actual
+``AppealsBackendHelper.generate_appeals`` iterator with only the model layer
+(``appealGenerator``) stubbed -- the layer where the PR #963 review found the
+failures: substituted re-served drafts fooling text-based progress counting,
+empty streams reported as success, and speculative reserves counted as
+delivered drafts. Denials are created with ``gen_attempts=3`` so the research
+phase is skipped and the tests stay fast.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from django.test import TestCase
+
+from fighthealthinsurance import appeal_journey_core
+from fighthealthinsurance.models import Denial, ProposedAppeal
+from fighthealthinsurance.generate_appeal import GeneratedAppeal
+
+
+def _drafts(texts):
+    """Wrap plain strings as the GeneratedAppeal drafts make_appeals emits."""
+    return [
+        GeneratedAppeal(text=t, model_name="fhi-internal", context_level="full")
+        for t in texts
+    ]
+
+
+def _make_denial(denial_id, gen_attempts=3):
+    email = f"journey_core_{denial_id}@example.com"
+    return Denial.objects.create(
+        denial_id=denial_id,
+        denial_text="Coverage for the requested MRI was denied as not medically necessary.",
+        semi_sekret="sekret",
+        hashed_email=Denial.get_hashed_email(email),
+        gen_attempts=gen_attempts,
+    )
+
+
+class TestGenerateAndStoreAppeals(TestCase):
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_substituted_existing_drafts_cannot_satisfy_the_target(self, mock_gen):
+        """Two existing placeholder drafts + one generated draft = exactly one
+        new durable row. The generator re-serves existing drafts transformed
+        by sub_in_appeals, so text-based progress counting saw them as new and
+        stopped before generating; durable-ID counting must not."""
+        denial = _make_denial(9101)
+        for i in range(2):
+            ProposedAppeal.objects.create(
+                for_denial=denial,
+                appeal_text=f"Dear [Insurance Company],\n\nExisting draft {i} for [Patient Name].",
+            )
+        mock_gen.make_appeals.return_value = iter(
+            _drafts(["Dear Reviewer, a genuinely new appeal citing the denial."])
+        )
+
+        stored = appeal_journey_core.generate_and_store_appeals(denial)
+
+        assert stored == 1
+        assert (
+            ProposedAppeal.objects.filter(for_denial=denial, speculative=False).count()
+            == 3
+        )
+
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_empty_stream_raises_journey_incomplete(self, mock_gen):
+        """A generator that produces nothing must surface as a retryable
+        failure, never as a successful activity with zero drafts."""
+        denial = _make_denial(9102)
+        mock_gen.make_appeals.return_value = iter([])
+
+        with pytest.raises(appeal_journey_core.JourneyIncomplete):
+            appeal_journey_core.generate_and_store_appeals(denial)
+
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_retry_after_partial_attempt_tops_up_to_target(self, mock_gen):
+        """First attempt persists one draft and fails the postcondition; the
+        retry generates the remainder and reaches exactly the target."""
+        denial = _make_denial(9103)
+        mock_gen.make_appeals.return_value = iter(_drafts(["Only draft, attempt one."]))
+        with pytest.raises(appeal_journey_core.JourneyIncomplete):
+            appeal_journey_core.generate_and_store_appeals(denial)
+        assert ProposedAppeal.objects.filter(for_denial=denial).count() == 1
+
+        mock_gen.make_appeals.return_value = iter(
+            _drafts(["Second draft, attempt two.", "Third draft, attempt two."])
+        )
+        stored = appeal_journey_core.generate_and_store_appeals(denial)
+        assert stored == 2
+        assert (
+            ProposedAppeal.objects.filter(for_denial=denial, speculative=False).count()
+            == appeal_journey_core.TARGET_APPEALS
+        )
+
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_speculative_reserves_do_not_satisfy_the_target(self, mock_gen):
+        """Reserve precompute rows are not delivered drafts: with three
+        speculative rows present the journey still generates."""
+        denial = _make_denial(9104)
+        for i in range(3):
+            ProposedAppeal.objects.create(
+                for_denial=denial,
+                appeal_text=f"Reserve draft {i}.",
+                speculative=True,
+            )
+        assert (
+            appeal_journey_core.precheck_appeal_journey(denial)
+            == appeal_journey_core.STATUS_OK
+        )
+        mock_gen.make_appeals.return_value = iter(
+            _drafts(["New A.", "New B.", "New C."])
+        )
+        stored = appeal_journey_core.generate_and_store_appeals(denial)
+        assert stored == 3
+
+
+class TestLoadDenial(TestCase):
+    def test_malformed_uuid_is_terminal_not_retry_fuel(self):
+        """An invalid uuid must return None (terminal not_found), not raise a
+        ValidationError into the precheck's unlimited retry."""
+        assert appeal_journey_core.load_denial("h", "not-a-uuid") is None

--- a/tests/async-unit/test_appeal_journey_core.py
+++ b/tests/async-unit/test_appeal_journey_core.py
@@ -93,10 +93,13 @@ class TestGenerateAndStoreAppeals(TestCase):
             == appeal_journey_core.TARGET_APPEALS
         )
 
-    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
-    def test_speculative_reserves_do_not_satisfy_the_target(self, mock_gen):
+    def test_speculative_reserves_do_not_satisfy_the_precheck(self):
         """Reserve precompute rows are not delivered drafts: with three
-        speculative rows present the journey still generates."""
+        speculative rows present the precheck still asks for generation.
+        (The generation-side guarantee -- that the run then produces new
+        durable drafts instead of re-serving the reserves -- arrives with
+        the dedicated generation entry point in the tier-2 PR, where it is
+        tested end to end.)"""
         denial = _make_denial(9104)
         for i in range(3):
             ProposedAppeal.objects.create(
@@ -108,11 +111,6 @@ class TestGenerateAndStoreAppeals(TestCase):
             appeal_journey_core.precheck_appeal_journey(denial)
             == appeal_journey_core.STATUS_OK
         )
-        mock_gen.make_appeals.return_value = iter(
-            _drafts(["New A.", "New B.", "New C."])
-        )
-        stored = appeal_journey_core.generate_and_store_appeals(denial)
-        assert stored == 3
 
 
 class TestLoadDenial(TestCase):

--- a/tests/temporal/test_appeal_journey_activities.py
+++ b/tests/temporal/test_appeal_journey_activities.py
@@ -1,0 +1,77 @@
+"""Tests for the appeal-journey Temporal activity wrappers.
+
+These verify the thin wrapper behavior -- load the denial, delegate to
+``appeal_journey_core``, and the not-found fallbacks -- using
+``ActivityEnvironment``, which runs in-process and needs no Temporal test
+server. The wrapped business logic itself lives in ``appeal_journey_core``.
+"""
+
+import uuid
+from unittest.mock import Mock, patch
+
+import pytest
+
+from temporalio.testing import ActivityEnvironment
+
+from fighthealthinsurance.activities import appeal_journey as journey_activities
+from fighthealthinsurance.appeal_journey_core import STATUS_NOT_FOUND, STATUS_OK
+
+
+@patch("fighthealthinsurance.appeal_journey_core.load_denial", return_value=None)
+def test_precheck_not_found_returns_status(mock_load):
+    env = ActivityEnvironment()
+    result = env.run(
+        journey_activities.precheck_appeal_journey, "h", str(uuid.uuid4())
+    )
+    assert result == STATUS_NOT_FOUND
+
+
+@patch(
+    "fighthealthinsurance.appeal_journey_core.precheck_appeal_journey",
+    return_value=STATUS_OK,
+)
+@patch("fighthealthinsurance.appeal_journey_core.load_denial")
+def test_precheck_delegates_to_core(mock_load, mock_precheck):
+    env = ActivityEnvironment()
+    fake_denial = object()
+    mock_load.return_value = fake_denial
+    result = env.run(journey_activities.precheck_appeal_journey, "h", "u")
+    mock_load.assert_called_once_with("h", "u")
+    mock_precheck.assert_called_once_with(fake_denial)
+    assert result == STATUS_OK
+
+
+@patch("fighthealthinsurance.appeal_journey_core.load_denial", return_value=None)
+def test_generate_not_found_stores_nothing(mock_load):
+    env = ActivityEnvironment()
+    assert env.run(journey_activities.generate_and_store_appeals, "h", "u") == 0
+
+
+@patch(
+    "fighthealthinsurance.appeal_journey_core.generate_and_store_appeals",
+    return_value=2,
+)
+@patch("fighthealthinsurance.appeal_journey_core.load_denial")
+def test_generate_delegates_to_core(mock_load, mock_generate):
+    env = ActivityEnvironment()
+    fake_denial = Mock(uuid="u")
+    mock_load.return_value = fake_denial
+    result = env.run(journey_activities.generate_and_store_appeals, "h", "u")
+    mock_generate.assert_called_once_with(fake_denial)
+    assert result == 2
+
+
+@patch("fighthealthinsurance.appeal_journey_core.generate_and_store_appeals")
+@patch("fighthealthinsurance.appeal_journey_core.load_denial")
+def test_generate_sanitizes_exceptions(mock_load, mock_generate):
+    """Raised errors must not leak denial/model text into workflow history."""
+    from temporalio.exceptions import ApplicationError
+
+    mock_load.return_value = Mock(uuid="u")
+    mock_generate.side_effect = Exception("sensitive diagnosis text")
+    env = ActivityEnvironment()
+    with pytest.raises(ApplicationError) as exc_info:
+        env.run(journey_activities.generate_and_store_appeals, "h", "u")
+    assert "sensitive" not in str(exc_info.value)
+    assert "u" in str(exc_info.value)
+    assert exc_info.value.__cause__ is None

--- a/tests/temporal/test_generate_appeal_workflow.py
+++ b/tests/temporal/test_generate_appeal_workflow.py
@@ -1,0 +1,156 @@
+"""Tests for ``GenerateAppealWorkflow`` orchestration (activities mocked).
+
+These validate the durable-workflow control flow -- which activities run, in
+what order, with what retry behavior -- without touching the database or a
+model backend. The underlying ``appeal_journey_core`` logic has its own
+activity-level tests.
+
+Requires the Temporal test server, which ``temporalio`` downloads on first run.
+"""
+
+import uuid
+
+import pytest
+
+from temporalio import activity
+from temporalio.client import WorkflowFailureError
+from temporalio.exceptions import ApplicationError
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
+
+from fighthealthinsurance.appeal_journey_core import (
+    STATUS_ALREADY_HAS_APPEALS,
+    STATUS_NO_DENIAL_TEXT,
+    STATUS_NOT_FOUND,
+    STATUS_OK,
+)
+from fighthealthinsurance.workflows.generate_appeal import GenerateAppealWorkflow
+from fighthealthinsurance.workflows.types import GenerateAppealInput
+
+
+class _Recorder:
+    """Builds mock journey activities that record calls and return canned values."""
+
+    def __init__(
+        self,
+        precheck_status: str = STATUS_OK,
+        stored: int = 3,
+        precheck_fail_times: int = 0,
+        generate_fail_times: int = 0,
+    ):
+        self.precheck_status = precheck_status
+        self.stored = stored
+        self.precheck_fail_times = precheck_fail_times
+        self.generate_fail_times = generate_fail_times
+        self.calls: list = []
+
+    def activities(self):
+        rec = self
+
+        @activity.defn(name="precheck_appeal_journey")
+        async def precheck_appeal_journey(hashed_email: str, denial_uuid: str) -> str:
+            rec.calls.append(("precheck", hashed_email, denial_uuid))
+            precheck_count = sum(1 for c in rec.calls if c[0] == "precheck")
+            if precheck_count <= rec.precheck_fail_times:
+                raise ApplicationError("simulated transient precheck failure")
+            return rec.precheck_status
+
+        @activity.defn(name="generate_and_store_appeals")
+        async def generate_and_store_appeals(
+            hashed_email: str, denial_uuid: str
+        ) -> int:
+            rec.calls.append(("generate", hashed_email, denial_uuid))
+            generate_count = sum(1 for c in rec.calls if c[0] == "generate")
+            if generate_count <= rec.generate_fail_times:
+                raise ApplicationError("simulated transient generation failure")
+            return rec.stored
+
+        return [precheck_appeal_journey, generate_and_store_appeals]
+
+
+async def _run(env: WorkflowEnvironment, rec: _Recorder):
+    task_queue = str(uuid.uuid4())
+    async with Worker(
+        env.client,
+        task_queue=task_queue,
+        workflows=[GenerateAppealWorkflow],
+        activities=rec.activities(),
+    ):
+        return await env.client.execute_workflow(
+            GenerateAppealWorkflow.run,
+            GenerateAppealInput(hashed_email="h", denial_uuid="u"),
+            id=str(uuid.uuid4()),
+            task_queue=task_queue,
+        )
+
+
+@pytest.mark.asyncio
+async def test_ok_path_generates_and_reports_stored_count():
+    rec = _Recorder(precheck_status=STATUS_OK, stored=3)
+    async with await WorkflowEnvironment.start_local() as env:
+        result = await _run(env, rec)
+    assert result == 3
+    assert [c[0] for c in rec.calls] == ["precheck", "generate"]
+
+
+@pytest.mark.asyncio
+async def test_not_found_stops_without_generating():
+    rec = _Recorder(precheck_status=STATUS_NOT_FOUND)
+    async with await WorkflowEnvironment.start_local() as env:
+        result = await _run(env, rec)
+    assert result == 0
+    assert [c[0] for c in rec.calls] == ["precheck"]
+
+
+@pytest.mark.asyncio
+async def test_no_denial_text_stops_without_generating():
+    rec = _Recorder(precheck_status=STATUS_NO_DENIAL_TEXT)
+    async with await WorkflowEnvironment.start_local() as env:
+        result = await _run(env, rec)
+    assert result == 0
+    assert [c[0] for c in rec.calls] == ["precheck"]
+
+
+@pytest.mark.asyncio
+async def test_already_has_appeals_is_idempotent_noop():
+    """A duplicate dispatch (or post-crash retry) with drafts already stored
+    must end cleanly without generating more."""
+    rec = _Recorder(precheck_status=STATUS_ALREADY_HAS_APPEALS)
+    async with await WorkflowEnvironment.start_local() as env:
+        result = await _run(env, rec)
+    assert result == 0
+    assert [c[0] for c in rec.calls] == ["precheck"]
+
+
+@pytest.mark.asyncio
+async def test_precheck_retries_through_transient_failure():
+    """Precheck retries forever (capped backoff): a bounded retry running out
+    would orphan the journey before any drafts were attempted."""
+    rec = _Recorder(precheck_status=STATUS_OK, stored=1, precheck_fail_times=3)
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        result = await _run(env, rec)
+    assert result == 1
+    assert sum(1 for c in rec.calls if c[0] == "precheck") >= 4
+    assert [c[0] for c in rec.calls if c[0] == "generate"] == ["generate"]
+
+
+@pytest.mark.asyncio
+async def test_generation_retries_transient_failure_then_succeeds():
+    """Unlike the fax vendor send, generation stores idempotently (the core
+    dedupes against existing drafts), so transient backend failures retry."""
+    rec = _Recorder(precheck_status=STATUS_OK, stored=2, generate_fail_times=2)
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        result = await _run(env, rec)
+    assert result == 2
+    assert sum(1 for c in rec.calls if c[0] == "generate") == 3
+
+
+@pytest.mark.asyncio
+async def test_generation_exhausting_retries_fails_the_workflow():
+    """Three failed attempts surface as a failed workflow -- visible in the
+    Temporal UI -- rather than silently reporting zero drafts."""
+    rec = _Recorder(precheck_status=STATUS_OK, generate_fail_times=99)
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        with pytest.raises(WorkflowFailureError):
+            await _run(env, rec)
+    assert sum(1 for c in rec.calls if c[0] == "generate") == 3

--- a/tests/temporal/test_temporal_codec.py
+++ b/tests/temporal/test_temporal_codec.py
@@ -1,6 +1,6 @@
 """Tests for Temporal payload encryption and the no-PHI payload contract.
 
-The GDPR posture has two layers: workflow inputs carry only opaque
+The data-protection posture has two layers: workflow inputs carry only opaque
 identifiers (enforced here as a contract test so nobody adds case content
 to a payload dataclass later), and with TEMPORAL_PAYLOAD_KEY set every
 payload is Fernet-encrypted client-side so Temporal's database and UI hold

--- a/tests/temporal/test_temporal_codec.py
+++ b/tests/temporal/test_temporal_codec.py
@@ -65,3 +65,29 @@ def test_payload_dataclasses_carry_only_opaque_identifiers():
             f"{klass.__name__} gained fields {fields - allowed}: Temporal "
             "payloads may only carry opaque identifiers (see temporal_codec.py)"
         )
+
+
+@pytest.mark.asyncio
+async def test_key_rotation_old_ciphertext_still_decodes():
+    """Comma-separated keys: first encrypts, all decrypt."""
+    old = Fernet.generate_key().decode()
+    new = Fernet.generate_key().decode()
+    encoded_old = (await EncryptionCodec(old).encode([_payload(b"x")]))[0]
+    rotated = EncryptionCodec(f"{new},{old}")
+    (decoded,) = await rotated.decode([encoded_old])
+    assert decoded == _payload(b"x")
+    # and new writes are NOT readable by the old key alone
+    encoded_new = (await rotated.encode([_payload(b"y")]))[0]
+    with pytest.raises(InvalidToken):
+        await EncryptionCodec(old).decode([encoded_new])
+
+
+def test_data_converter_encodes_failure_attributes():
+    """The failure converter must move exception text into encodable
+    payloads; the default leaves message/stack as plaintext protobuf."""
+    from temporalio.converter import DefaultFailureConverterWithEncodedAttributes
+
+    from fighthealthinsurance.temporal_client import _encrypting_data_converter
+
+    conv = _encrypting_data_converter(Fernet.generate_key().decode())
+    assert conv.failure_converter_class is DefaultFailureConverterWithEncodedAttributes

--- a/tests/temporal/test_temporal_codec.py
+++ b/tests/temporal/test_temporal_codec.py
@@ -10,7 +10,7 @@ ciphertext until namespace retention (720h) expires it.
 import dataclasses
 
 import pytest
-from cryptography.fernet import Fernet
+from cryptography.fernet import Fernet, InvalidToken
 
 from temporalio.api.common.v1 import Payload
 
@@ -48,7 +48,7 @@ async def test_wrong_key_fails_loudly_not_silently():
     codec = EncryptionCodec(_KEY)
     (encoded,) = await codec.encode([_payload(b"x")])
     other = EncryptionCodec(Fernet.generate_key().decode())
-    with pytest.raises(Exception):
+    with pytest.raises(InvalidToken):
         await other.decode([encoded])
 
 

--- a/tests/temporal/test_temporal_codec.py
+++ b/tests/temporal/test_temporal_codec.py
@@ -1,0 +1,67 @@
+"""Tests for Temporal payload encryption and the no-PHI payload contract.
+
+The GDPR posture has two layers: workflow inputs carry only opaque
+identifiers (enforced here as a contract test so nobody adds case content
+to a payload dataclass later), and with TEMPORAL_PAYLOAD_KEY set every
+payload is Fernet-encrypted client-side so Temporal's database and UI hold
+ciphertext until namespace retention (720h) expires it.
+"""
+
+import dataclasses
+
+import pytest
+from cryptography.fernet import Fernet
+
+from temporalio.api.common.v1 import Payload
+
+from fighthealthinsurance.temporal_codec import ENCODING, EncryptionCodec
+
+_KEY = Fernet.generate_key().decode()
+
+
+def _payload(data: bytes) -> Payload:
+    return Payload(metadata={"encoding": b"json/plain"}, data=data)
+
+
+@pytest.mark.asyncio
+async def test_roundtrip_encrypts_and_restores():
+    codec = EncryptionCodec(_KEY)
+    original = _payload(b'{"hashed_email": "abc", "fax_uuid": "u"}')
+    (encoded,) = await codec.encode([original])
+    assert encoded.metadata["encoding"] == ENCODING
+    assert b"abc" not in encoded.data  # ciphertext, not readable ids
+    (decoded,) = await codec.decode([encoded])
+    assert decoded == original
+
+
+@pytest.mark.asyncio
+async def test_plaintext_history_passes_through():
+    """Histories written before the key existed must keep replaying."""
+    codec = EncryptionCodec(_KEY)
+    legacy = _payload(b'{"fax_uuid": "u"}')
+    (decoded,) = await codec.decode([legacy])
+    assert decoded == legacy
+
+
+@pytest.mark.asyncio
+async def test_wrong_key_fails_loudly_not_silently():
+    codec = EncryptionCodec(_KEY)
+    (encoded,) = await codec.encode([_payload(b"x")])
+    other = EncryptionCodec(Fernet.generate_key().decode())
+    with pytest.raises(Exception):
+        await other.decode([encoded])
+
+
+def test_payload_dataclasses_carry_only_opaque_identifiers():
+    """Tripwire: workflow inputs must stay claim-check style. Any new field
+    that could carry case content (text, letters, names, emails) needs a
+    design conversation, not a quiet addition."""
+    from fighthealthinsurance.workflows import types as wf_types
+
+    allowed = {"hashed_email", "fax_uuid", "denial_uuid", "delay_send"}
+    for klass in (wf_types.SendFaxInput, wf_types.GenerateAppealInput):
+        fields = {f.name for f in dataclasses.fields(klass)}
+        assert fields <= allowed, (
+            f"{klass.__name__} gained fields {fields - allowed}: Temporal "
+            "payloads may only carry opaque identifiers (see temporal_codec.py)"
+        )


### PR DESCRIPTION
Mirrors the fax pattern for the queued appeal path: GenerateAppealWorkflow runs a precheck (durable retry) then generate-and-store (3 attempts, heartbeats), landing drafts as ProposedAppeal rows. Core logic lives in appeal_journey_core.py shaped like fax_send_core.py: plain sync functions, opaque (hashed_email, denial_uuid) ids only, no PHI in workflow history.
 
The key difference from the fax send: generation retries freely because the store step dedupes against existing drafts, and a duplicate dispatch is an idempotent no-op once drafts exist. Generation reuses AppealsBackendHelper.generate_appeals as a library so prompt assembly has one implementation; it now accepts a pre-hashed email so the journey never touches the raw address.
 
Dark by default: gated behind TEMPORAL_APPEAL_JOURNEY_ENABLED (on top of TEMPORAL_ENABLED), and nothing dispatches it yet except the new dispatch_appeal_journey management command. Stacked on #959 for the shared heartbeat helper and worker registration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added queued, durable generation of appeal drafts with automatic storage.
  - Added validation, duplicate prevention, retry handling, and manual dispatch for individual denials.
  - Added configurable workflow controls and optional encryption for workflow data, including support for existing records.
  - Added guidance for managing workflow-history retention.

- **Bug Fixes**
  - Improved handling of missing information, unavailable denial text, timeouts, and temporary failures.
  - Sensitive error details are no longer exposed in workflow history.

- **Tests**
  - Added coverage for generation, retries, validation, duplicate prevention, encryption, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->