### PR TITLE
Make the async-unit suite hermetic to ambient ML provider config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# Agent instructions
+
+Repo-wide instructions for AI coding agents (Codex, Copilot, Cursor, Claude,
+and anything else that reads this file). The full guidance — build commands,
+architecture map, async/ORM bridge rules, test organization, code style —
+lives in [CLAUDE.md](CLAUDE.md). Read that first and follow all of it; the
+rules below are the ones agents most often get wrong, repeated here so they
+are never missed.
+
+## Non-negotiables
+
+- **Run tests only via tox** (`tox -e py313-django52-async-unit`, etc.).
+  Never invoke pytest directly or through `.tox/` virtualenv paths.
+- **Tests must be hermetic to credentials and live backends.** Never read
+  real API keys, endpoints, or backend hosts from the surrounding
+  environment, and never hardcode one into a test. A test needing a
+  credential uses `patch.dict(os.environ, ...)` scoped to that test — never
+  a module-level `os.environ[...]` write or `setdefault`, which leaks into
+  every later test in the process. The async-unit conftest scrubs the ML
+  provider env vars at collection start, and
+  `test_ml_router.py::TestRouterHermeticity` fails if a backend registers
+  from the environment anyway; when adding a new env-configured backend to
+  `ml_models.py`, add its env vars to `_AMBIENT_BACKEND_ENV_VARS` in
+  `tests/async-unit/conftest.py`. A unit test that makes a real network
+  call to a provider is a bug, even when it passes.
+- **No secrets anywhere in the repo** — not in code, tests, fixtures,
+  migrations, or docs, and not as "temporary" values written process-wide
+  via `os.environ`.
+- **Format and type-check via tox**: `tox -e py313-black` to check
+  formatting (fix with `black fighthealthinsurance fhi_users`),
+  `tox -e mypy` for types.
+- **Match the file you are editing** — naming, import style, comment
+  density, and the async/ORM bridge conventions described in CLAUDE.md.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,6 +195,18 @@ collectstatic build. What to know:
 - Prefer fixtures and factories over manual object setup. Reuse existing test helpers and fixtures before creating new ones.
 - Test edge cases and error paths, not just the happy path.
 - Mocking: mock external services and ML backends, but avoid mocking the code under test.
+- **Tests must be hermetic to credentials and live backends.** Never read real
+  API keys, endpoints, or backend hosts from the surrounding environment, and
+  never hardcode one into a test. A test needing a credential uses
+  `patch.dict(os.environ, ...)` scoped to that test — never a module-level
+  `os.environ[...]` write or `setdefault`, which leaks into every later test
+  in the process (xdist workers included). The async-unit conftest scrubs the
+  ML provider env vars at collection start and
+  `test_ml_router.py::TestRouterHermeticity` fails if a backend registers from
+  the environment anyway; when adding a new env-configured backend to
+  `ml_models.py`, add its env vars to `_AMBIENT_BACKEND_ENV_VARS` there. A
+  unit test that makes a real network call to a provider is a bug, even when
+  it passes.
 
 ### DRY (Don't Repeat Yourself)
 - Before writing new utility functions, helpers, or constants, check if similar functionality already exists in the codebase.

--- a/tests/async-unit/conftest.py
+++ b/tests/async-unit/conftest.py
@@ -1,7 +1,46 @@
 """Shared fixtures for async-unit tests of the ML backend transport layer."""
 
+import os
+
 import aiohttp
 import pytest
+
+# Unit tests must compose the same MLRouter everywhere. The ML backend
+# classes read provider credentials and backend hosts from the environment,
+# so on a machine where any of these are set a unit-suite MLRouter() picks
+# up live backends -- routing tests then assert against a different model
+# pool than CI sees, and a selected live backend means a unit test making
+# real network calls to a provider. Scrub them before any test module
+# imports app code (this runs at collection start, ahead of both the lazy
+# router singleton and routers built in setUp). Keep the list in sync with
+# the os.getenv / *_ENV usage in fighthealthinsurance/ml/ml_models.py;
+# test_ml_router.py::TestRouterHermeticity fails if a new one slips in.
+_AMBIENT_BACKEND_ENV_VARS = (
+    "ALPHA_HEALTH_BACKEND_HOST",
+    "ALPHA_HEALTH_BACKEND_PORT",
+    "ALPHA_HEALTH_BACKUP_BACKEND_HOST",
+    "ALPHA_HEALTH_BACKUP_BACKEND_PORT",
+    "ANTHROPIC_API_KEY",
+    "AZURE_ANTHROPIC_API_KEY",
+    "AZURE_ANTHROPIC_ENDPOINT",
+    "AZURE_ANTHROPIC_MODELS",
+    "AZURE_OPENAI_API_KEY",
+    "AZURE_OPENAI_ENDPOINT",
+    "AZURE_OPENAI_MODELS",
+    "DEEPINFRA_API",
+    "HEALTH_BACKEND_HOST",
+    "HEALTH_BACKEND_PORT",
+    "HEALTH_BACKUP_BACKEND_HOST",
+    "HEALTH_BACKUP_BACKEND_MODEL",
+    "HEALTH_BACKUP_BACKEND_PORT",
+    "NEW_HEALTH_BACKEND_HOST",
+    "NEW_HEALTH_BACKEND_PORT",
+    "PERPLEXITY_API",
+    "SECONDARY_NEW_HEALTH_BACKEND_HOST",
+    "SECONDARY_NEW_HEALTH_BACKEND_PORT",
+)
+for _name in _AMBIENT_BACKEND_ENV_VARS:
+    os.environ.pop(_name, None)
 from loguru import logger
 from multidict import CIMultiDict, CIMultiDictProxy
 from yarl import URL

--- a/tests/async-unit/test_anthropic_models.py
+++ b/tests/async-unit/test_anthropic_models.py
@@ -16,9 +16,6 @@ from unittest.mock import patch, MagicMock, AsyncMock
 
 import aiohttp
 
-# Set up environment before importing RemoteAnthropic
-os.environ.setdefault("ANTHROPIC_API_KEY", "test-api-key")
-
 from fighthealthinsurance.ml.ml_models import RemoteAnthropic, RemoteFullOpenLike
 from fighthealthinsurance.utils import RateLimiter
 
@@ -352,16 +349,15 @@ class TestRemoteAnthropicModelIsOk(unittest.TestCase):
 
         self.assertFalse(model.model_is_ok())
 
+    @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"})
     def test_model_is_ok_false_without_api_key(self):
         """Test model_is_ok returns False without API key."""
-        os.environ["ANTHROPIC_API_KEY"] = "test-key"
         model = RemoteAnthropic(model="claude-sonnet-4-6")
 
+        # patch.dict restores the pre-test environment on exit, so deleting
+        # inside the patched scope leaks nothing to later tests.
         del os.environ["ANTHROPIC_API_KEY"]
-        try:
-            self.assertFalse(model.model_is_ok())
-        finally:
-            os.environ["ANTHROPIC_API_KEY"] = "test-api-key"
+        self.assertFalse(model.model_is_ok())
 
 
 class TestRemoteAnthropicIntegration(unittest.TestCase):

--- a/tests/async-unit/test_ml_router.py
+++ b/tests/async-unit/test_ml_router.py
@@ -45,9 +45,24 @@ class TestRouterHermeticity(unittest.TestCase):
 
     def test_fresh_router_loads_no_models_from_the_environment(self):
         router = MLRouter()
+        # Check every pool the router builds: context-only models live in
+        # their own list (not all_models_by_cost), so asserting one pool
+        # could pass while an environment-backed context-only model stayed
+        # registered (PR review).
+        leaked = {
+            "all_models_by_cost": [str(m) for m in router.all_models_by_cost],
+            "context_only_models_by_cost": [
+                str(m) for m in router.context_only_models_by_cost
+            ],
+            "models_by_name": sorted(router.models_by_name),
+        }
         self.assertEqual(
-            [str(m) for m in router.all_models_by_cost],
-            [],
+            leaked,
+            {
+                "all_models_by_cost": [],
+                "context_only_models_by_cost": [],
+                "models_by_name": [],
+            },
             "MLRouter picked up backends from the environment inside the "
             "unit suite; extend _AMBIENT_BACKEND_ENV_VARS in "
             "tests/async-unit/conftest.py to cover the env var(s) involved.",

--- a/tests/async-unit/test_ml_router.py
+++ b/tests/async-unit/test_ml_router.py
@@ -31,6 +31,29 @@ def make_external_mock(
     return model
 
 
+class TestRouterHermeticity(unittest.TestCase):
+    """The unit suite's router must not see ambient backends.
+
+    conftest.py scrubs the provider credential / backend host environment
+    variables so a unit-suite ``MLRouter()`` composes identically on every
+    machine. If this fails, a backend was registered from the surrounding
+    environment: some env var read in ml_models.py is missing from
+    ``_AMBIENT_BACKEND_ENV_VARS`` in tests/async-unit/conftest.py. Left
+    unfixed, routing tests assert against a machine-dependent model pool
+    and a selected live backend turns unit tests into real provider calls.
+    """
+
+    def test_fresh_router_loads_no_models_from_the_environment(self):
+        router = MLRouter()
+        self.assertEqual(
+            [str(m) for m in router.all_models_by_cost],
+            [],
+            "MLRouter picked up backends from the environment inside the "
+            "unit suite; extend _AMBIENT_BACKEND_ENV_VARS in "
+            "tests/async-unit/conftest.py to cover the env var(s) involved.",
+        )
+
+
 class TestMLRouterGenerateTextBackendNames(unittest.TestCase):
     """Tests for MLRouter.generate_text_backend_names method."""
 
@@ -655,6 +678,12 @@ class TestMLRouterSummarize(unittest.TestCase):
 
     def setUp(self):
         self.router = MLRouter()
+        # Start every test from an explicitly empty model pool: each test
+        # installs exactly the mocks it asserts on, so selection can never
+        # fall through to a model the test didn't declare.
+        self.router.models_by_name = {}
+        self.router.internal_models_by_cost = []
+        self.router.external_models_by_cost = []
 
     async def async_test_use_external_false_never_selects_gemma(self):
         gemma = AsyncMock(spec=RemoteModelLike)
@@ -776,6 +805,10 @@ class TestMLRouterSummarizeChatHistory(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures."""
         self.router = MLRouter()
+        # Explicitly empty pool; see TestMLRouterSummarize.setUp.
+        self.router.models_by_name = {}
+        self.router.internal_models_by_cost = []
+        self.router.external_models_by_cost = []
 
     async def async_test_summarize_chat_history_short_history(self):
         """Test that short history returns None without summarization."""


### PR DESCRIPTION
The ML backend classes read provider credentials and backend hosts from the environment, so on a developer machine with any of those exported, a unit test that builds MLRouter() got live backends in its model pool. Routing assertions then diverged from CI (TestMLRouterSummarize's no-contentless-retry test fails on such machines), and a selected live backend meant a unit test making real network calls to a provider.

- tests/async-unit/conftest.py scrubs the provider env vars at collection start, before the lazy router singleton or any router built in setUp can see them.
- TestRouterHermeticity fails loudly if a backend still registers from the environment (e.g. a new env var missing from the scrub list). It caught its first leak immediately: test_anthropic_models.py set ANTHROPIC_API_KEY process-wide at module import, and one test re-set it in a finally, so phantom anthropic backends registered for every later test in the same worker -- on CI too. Both now use patch.dict.
- The summarize test classes start from an explicitly empty model pool so each test asserts only against the mocks it installed.

Test-only change; no production code touched.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved test isolation so ambient ML backend settings and credentials do not affect execution.
  - Added coverage confirming routers start without automatically detected backends.
  - Hardened summarization tests to use only explicitly configured models.
  - Simplified environment handling in Anthropic model tests.
  - Prevented unintended calls to live model providers.

- **Documentation**
  - Added guidance for maintaining isolated credentials and backend configuration in future tests.
  - Documented required testing, formatting, and type-checking practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->