### PR TITLE
Harden generation entry points and Temporal key config

### DIFF
--- a/fighthealthinsurance/rest_views.py
+++ b/fighthealthinsurance/rest_views.py
@@ -68,6 +68,7 @@ from fighthealthinsurance.models import (
     SecondaryAppealProfessionalRelation,
 )
 from fighthealthinsurance.pubmed_tools import PubMedTools
+from fighthealthinsurance.utils import strip_internal_keys
 from fighthealthinsurance.rest_mixins import (
     CreateMixin,
     DeleteMixin,
@@ -794,7 +795,11 @@ def streaming_appeals_rest_fallback(request: Request):
         # make_appeals task + keepalive loops) to non-deterministic asyncgen
         # GC finalization -- on the transport chosen by users whose WebSocket
         # already failed.
-        aitr = common_view_logic.AppealsBackendHelper.generate_appeals(data)
+        # Request payloads never reach the generator with internal-only
+        # (underscore-prefixed) keys; those belong to internal dispatchers.
+        aitr = common_view_logic.AppealsBackendHelper.generate_appeals(
+            strip_internal_keys(data)
+        )
         try:
             # Flush a leading newline before awaiting generate_appeals
             # so anti-buffering headers and intermediary heuristics

--- a/fighthealthinsurance/temporal_codec.py
+++ b/fighthealthinsurance/temporal_codec.py
@@ -34,6 +34,14 @@ class EncryptionCodec(PayloadCodec):
 
     def __init__(self, key: str) -> None:
         keys = [k.strip() for k in key.split(",") if k.strip()]
+        if not keys:
+            # A set-but-unusable key (e.g. only commas/whitespace) would
+            # otherwise surface as MultiFernet's bare ValueError long after
+            # the config mistake was made.
+            raise ValueError(
+                "TEMPORAL_PAYLOAD_KEY is set but contains no usable key "
+                "after splitting on commas; provide at least one Fernet key"
+            )
         self._fernet = MultiFernet([Fernet(k) for k in keys])
 
     async def encode(self, payloads: Iterable[Payload]) -> List[Payload]:

--- a/fighthealthinsurance/utils.py
+++ b/fighthealthinsurance/utils.py
@@ -1783,3 +1783,16 @@ def medicaid_eligibility_page_enabled() -> bool:
     either hide a live page from crawlers or advertise a 404 to them.
     """
     return bool(getattr(settings, "MEDICAID_ELIGIBILITY_PAGE_ENABLED", False))
+
+
+def strip_internal_keys(parameters: dict) -> dict:
+    """Return a copy of ``parameters`` without underscore-prefixed keys.
+
+    Underscore-prefixed keys (``_internal_hashed_email``, and any added
+    later) are the private channel for internal callers that already hold
+    an authorized object and build the parameter dict themselves. Public
+    entry points must pass decoded request payloads through this before
+    handing them to ``AppealsBackendHelper.generate_appeals``, so a request
+    body can never smuggle internal flags into the generator.
+    """
+    return {k: v for k, v in parameters.items() if not k.startswith("_")}

--- a/fighthealthinsurance/websockets.py
+++ b/fighthealthinsurance/websockets.py
@@ -37,6 +37,7 @@ from fighthealthinsurance import common_view_logic
 from fighthealthinsurance.ml.bad_output_utils import strip_boilerplate_service
 from fighthealthinsurance.generate_prior_auth import prior_auth_generator
 from fighthealthinsurance.ml.ml_router import ml_router
+from fighthealthinsurance.utils import strip_internal_keys
 from fighthealthinsurance.models import (
     ChatLeads,
     ChatType,
@@ -695,8 +696,12 @@ class StreamingAppealsBackend(
             await self.close()
             return
         logger.debug(f"appeals ws: starting generation for denial {denial_id}")
+        # Request payloads never reach the generator with internal-only
+        # (underscore-prefixed) keys; those belong to internal dispatchers.
         aitr: AsyncIterator[str] = (
-            common_view_logic.AppealsBackendHelper.generate_appeals(data)
+            common_view_logic.AppealsBackendHelper.generate_appeals(
+                strip_internal_keys(data)
+            )
         )
         # We do a try/except here to log since the WS framework swallow exceptions sometimes
         appeal_count = 0

--- a/tests/async-unit/test_strip_internal_keys.py
+++ b/tests/async-unit/test_strip_internal_keys.py
@@ -1,0 +1,24 @@
+"""The underscore-prefix contract: request payloads cannot smuggle
+internal-only keys into the appeal generator (see
+``fighthealthinsurance.utils.strip_internal_keys`` and its call sites in
+rest_views/websockets)."""
+
+from fighthealthinsurance.utils import strip_internal_keys
+
+
+def test_underscore_keys_are_removed():
+    cleaned = strip_internal_keys(
+        {"denial_id": 1, "_internal_hashed_email": "h", "_background": True}
+    )
+    assert cleaned == {"denial_id": 1}
+
+
+def test_public_keys_pass_through_unchanged():
+    params = {"denial_id": 1, "email": "a@b.c", "semi_sekret": "s"}
+    assert strip_internal_keys(params) == params
+
+
+def test_original_dict_is_not_mutated():
+    params = {"_internal_hashed_email": "h"}
+    strip_internal_keys(params)
+    assert "_internal_hashed_email" in params

--- a/tests/temporal/test_temporal_codec.py
+++ b/tests/temporal/test_temporal_codec.py
@@ -43,6 +43,14 @@ async def test_plaintext_history_passes_through():
     assert decoded == legacy
 
 
+def test_key_of_only_separators_is_a_clear_config_error():
+    """A set-but-unusable TEMPORAL_PAYLOAD_KEY (only commas/whitespace) must
+    fail at construction with a message naming the setting, not surface as
+    MultiFernet's bare ValueError."""
+    with pytest.raises(ValueError, match="TEMPORAL_PAYLOAD_KEY"):
+        EncryptionCodec(",,,")
+
+
 @pytest.mark.asyncio
 async def test_wrong_key_fails_loudly_not_silently():
     codec = EncryptionCodec(_KEY)


### PR DESCRIPTION
Two small review follow-ups to the appeal-journey work:

- Public entry points (REST stream, websocket) now strip underscore-prefixed keys from decoded request payloads before handing them to AppealsBackendHelper.generate_appeals. Those keys are the private channel for internal dispatchers; honoring them from request data let a caller flip internal behavior (e.g. skip the gen_attempts budget accounting) from the outside. New strip_internal_keys helper in utils with tests.

- EncryptionCodec now rejects a TEMPORAL_PAYLOAD_KEY that contains no usable key after comma-splitting (e.g. only separators) with an error naming the setting, instead of surfacing MultiFernet's bare ValueError at first use. Test added.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Internal-only fields are now excluded from appeal-generation requests, preventing unintended request data from being processed.
  - Invalid encryption-key configuration now produces a clearer validation error.

- **Tests**
  - Added coverage confirming internal fields are filtered without modifying submitted data.
  - Added regression coverage for clearer errors when encryption keys contain no usable values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->