### PR TITLE
Journey enablement hardening, round 1

### DIFF
--- a/fighthealthinsurance/activities/appeal_journey.py
+++ b/fighthealthinsurance/activities/appeal_journey.py
@@ -13,6 +13,11 @@ sanitized exceptions so no case content enters workflow history.
 
 import asyncio
 
+from channels.db import database_sync_to_async
+from django.core.exceptions import FieldError, ValidationError
+from django.db import close_old_connections
+from django.db.utils import DataError, ProgrammingError
+
 from loguru import logger
 
 from temporalio import activity
@@ -28,6 +33,31 @@ from fighthealthinsurance.appeal_journey_core import (
 
 HEARTBEAT_INTERVAL_S = 10.0
 
+# Activity-entry connection hygiene, mirroring the fax activities: a
+# long-lived worker's ORM lane can hold a server-closed connection between
+# attempts, and the first query of a new attempt would then fail as if it
+# were a real error. Django 5.2 has no native async variant, so bridge the
+# sync one; database_sync_to_async runs it on the same thread-sensitive
+# lane the native async ORM uses, which is exactly the connection to check.
+_aclose_old_connections = database_sync_to_async(close_old_connections)
+
+# Failures that no retry can fix: schema drift, bad field references,
+# invalid values. Retrying these forever (the precheck's retry policy is
+# unbounded by design) would keep a broken workflow open while classifying
+# a programming error as transient (external review). OperationalError and
+# InterfaceError stay retryable: those ARE the transient class.
+_NON_RETRYABLE_ERRORS = (ValidationError, FieldError, ProgrammingError, DataError)
+
+
+def _non_retryable(e: Exception, denial_uuid: str) -> ApplicationError:
+    # type name + opaque uuid only; detail stays in worker logs.
+    logger.opt(exception=True).error(
+        f"Non-retryable {type(e).__name__} in appeal journey for denial {denial_uuid}"
+    )
+    return ApplicationError(
+        f"{type(e).__name__} for denial {denial_uuid}", non_retryable=True
+    )
+
 
 async def _heartbeats():
     """Liveness-only heartbeat loop; cancelled when its attempt ends."""
@@ -42,10 +72,14 @@ async def _heartbeats():
 
 @activity.defn
 async def precheck_appeal_journey(hashed_email: str, denial_uuid: str) -> str:
-    denial = await aload_denial(hashed_email, denial_uuid)
-    if denial is None:
-        return STATUS_NOT_FOUND
-    return await aprecheck_appeal_journey(denial)
+    await _aclose_old_connections()
+    try:
+        denial = await aload_denial(hashed_email, denial_uuid)
+        if denial is None:
+            return STATUS_NOT_FOUND
+        return await aprecheck_appeal_journey(denial)
+    except _NON_RETRYABLE_ERRORS as e:
+        raise _non_retryable(e, denial_uuid) from None
 
 
 @activity.defn
@@ -53,11 +87,14 @@ async def generate_and_store_appeals(hashed_email: str, denial_uuid: str) -> int
     """Generate + persist drafts; returns the number stored this attempt."""
     beat = asyncio.create_task(_heartbeats())
     try:
+        await _aclose_old_connections()
         denial = await aload_denial(hashed_email, denial_uuid)
         if denial is None:
             return 0
         try:
             return int(await agenerate_and_store_appeals(denial))
+        except _NON_RETRYABLE_ERRORS as e:
+            raise _non_retryable(e, denial_uuid) from None
         except JourneyIncomplete as e:
             # Counts and uuid only -- safe for history, and retryable by
             # design: the durable postcondition was not met.

--- a/fighthealthinsurance/activities/appeal_journey.py
+++ b/fighthealthinsurance/activities/appeal_journey.py
@@ -111,5 +111,11 @@ async def generate_and_store_appeals(hashed_email: str, denial_uuid: str) -> int
             raise ApplicationError(
                 f"appeal generation failed for denial {denial_uuid}"
             ) from None
+    except _NON_RETRYABLE_ERRORS as e:
+        # The denial LOOKUP runs before the inner classifier, so a schema
+        # failure there needs the same non-retryable treatment -- otherwise
+        # this activity retries exactly the class of error the classifier
+        # exists to stop (PR review).
+        raise _non_retryable(e, denial_uuid) from None
     finally:
         beat.cancel()

--- a/fighthealthinsurance/activities/intake_journey.py
+++ b/fighthealthinsurance/activities/intake_journey.py
@@ -10,10 +10,12 @@ from temporalio import activity
 from temporalio.exceptions import ApplicationError
 
 from fighthealthinsurance import intake_journey_core
+from fighthealthinsurance.activities.appeal_journey import _aclose_old_connections
 
 
 @activity.defn
 async def send_abandonment_nudge(hashed_email: str, denial_uuid: str) -> bool:
+    await _aclose_old_connections()
     try:
         return await intake_journey_core.send_abandonment_nudge(
             hashed_email, denial_uuid

--- a/fighthealthinsurance/intake_journey_core.py
+++ b/fighthealthinsurance/intake_journey_core.py
@@ -12,11 +12,13 @@ from loguru import logger
 from fighthealthinsurance.appeal_journey_core import aload_denial
 
 NUDGE_SUBJECT = "Your appeal on Fight Health Insurance is waiting"
+# Copy makes no resume promise: the link is the plain homepage until a real
+# resume route (signed, expiring token) exists -- see send_abandonment_nudge.
 NUDGE_BODY = (
     "You started putting together an appeal on Fight Health Insurance and "
-    "didn't get to finish. Your progress is saved -- pick up where you left "
-    "off whenever you're ready:\n\n{url}\n\nIf you'd rather not continue, "
-    "you can ignore this email; we won't send another reminder."
+    "didn't get to finish. If you'd like to keep going, you can return "
+    "any time:\n\n{url}\n\nIf you'd rather not continue, you can ignore "
+    "this email; we won't send another reminder."
 )
 
 

--- a/fighthealthinsurance/intake_journey_core.py
+++ b/fighthealthinsurance/intake_journey_core.py
@@ -35,10 +35,14 @@ async def send_abandonment_nudge(hashed_email: str, denial_uuid: str) -> bool:
     base = getattr(
         settings, "FHI_PUBLIC_BASE_URL", "https://www.fighthealthinsurance.com"
     )
-    resume_url = f"{base}/?resume={denial_uuid}"
+    # Plain homepage link: no resume handler exists yet, so a ?resume=
+    # parameter would be an inert promise -- and a denial uuid does not
+    # belong in a URL (mail clients log and preview them). A real resume
+    # link needs a signed, expiring token and its own route (external
+    # review); that lands with the resume feature itself.
     await _asend_mail(
         NUDGE_SUBJECT,
-        NUDGE_BODY.format(url=resume_url),
+        NUDGE_BODY.format(url=base),
         denial.raw_email,
     )
     logger.info(f"Intake nudge sent for denial {denial_uuid}")

--- a/fighthealthinsurance/temporal_client.py
+++ b/fighthealthinsurance/temporal_client.py
@@ -320,9 +320,13 @@ async def start_intake_journey(
         ),
         id=f"intake-{denial_uuid}",
         task_queue=settings.TEMPORAL_APPEAL_TASK_QUEUE,
-        # One intake journey per denial EVER: re-running the form update
-        # after a completed journey must not start a fresh run (and a fresh
-        # 24h nudge timer) for a finished case.
+        # One intake journey per denial: re-running the form update after a
+        # completed journey must not start a fresh run (and a fresh 24h
+        # nudge timer) for a finished case. NOTE this guarantee is bounded
+        # by namespace history retention (720h) -- after the old run's
+        # history expires, the id becomes startable again. The durable
+        # backstop is the precheck: existing drafts end a journey at its
+        # first step, so a post-retention duplicate no-ops (external review).
         id_reuse_policy=WorkflowIDReusePolicy.REJECT_DUPLICATE,
     )
     logger.info(f"Started IntakeJourneyWorkflow {handle.id}")

--- a/fighthealthinsurance/workflows/intake_journey.py
+++ b/fighthealthinsurance/workflows/intake_journey.py
@@ -22,6 +22,7 @@ from datetime import timedelta
 
 from temporalio import workflow
 from temporalio.common import RetryPolicy
+from temporalio.exceptions import WorkflowAlreadyStartedError
 
 from fighthealthinsurance.workflows.types import GenerateAppealInput, IntakeJourneyInput
 
@@ -118,12 +119,22 @@ class IntakeJourneyWorkflow:
         # retry policy; the deterministic child id keeps duplicate journeys
         # idempotent, and precheck no-ops if drafts already exist (e.g. the
         # interactive flow delivered them first).
-        await workflow.execute_child_workflow(
-            "GenerateAppealWorkflow",
-            GenerateAppealInput(
-                hashed_email=journey.hashed_email,
-                denial_uuid=journey.denial_uuid,
-            ),
-            id=f"generate-appeal-{journey.denial_uuid}",
-        )
+        try:
+            await workflow.execute_child_workflow(
+                "GenerateAppealWorkflow",
+                GenerateAppealInput(
+                    hashed_email=journey.hashed_email,
+                    denial_uuid=journey.denial_uuid,
+                ),
+                id=f"generate-appeal-{journey.denial_uuid}",
+            )
+        except WorkflowAlreadyStartedError:
+            # A standalone generation with this id is already RUNNING (e.g. a
+            # management-command dispatch); a child cannot attach to it, and
+            # failing the whole intake journey over work that is underway
+            # would be wrong. Drafts are governed by the durable database
+            # postcondition either way (external review).
+            workflow.logger.info(
+                "generation already running for this denial; intake defers to it"
+            )
         return "completed"

--- a/tests/temporal/test_appeal_journey_activities.py
+++ b/tests/temporal/test_appeal_journey_activities.py
@@ -97,3 +97,52 @@ async def test_generate_sanitizes_exceptions(mock_load, mock_generate):
     assert "sensitive" not in str(exc_info.value)
     assert "u" in str(exc_info.value)
     assert exc_info.value.__cause__ is None
+
+
+@pytest.mark.asyncio
+@patch(f"{_MOD}.aprecheck_appeal_journey", new_callable=AsyncMock)
+@patch(f"{_MOD}.aload_denial", new_callable=AsyncMock)
+async def test_precheck_programming_error_is_non_retryable(mock_load, mock_precheck):
+    """The precheck's retry policy is unbounded, so a schema/programming
+    failure must be classified non-retryable instead of spinning forever
+    disguised as a transient error."""
+    from django.db.utils import ProgrammingError
+
+    mock_load.return_value = object()
+    mock_precheck.side_effect = ProgrammingError('column "nope" does not exist')
+    env = ActivityEnvironment()
+    with pytest.raises(ApplicationError) as exc_info:
+        await env.run(journey_activities.precheck_appeal_journey, "h", "u")
+    assert exc_info.value.non_retryable
+    # Sanitized: the failure names the error type and opaque uuid only.
+    assert "nope" not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+@patch(f"{_MOD}.agenerate_and_store_appeals", new_callable=AsyncMock)
+@patch(f"{_MOD}.aload_denial", new_callable=AsyncMock)
+async def test_generate_validation_error_is_non_retryable(mock_load, mock_generate):
+    from django.core.exceptions import ValidationError
+
+    mock_load.return_value = object()
+    mock_generate.side_effect = ValidationError("bad value")
+    env = ActivityEnvironment()
+    with pytest.raises(ApplicationError) as exc_info:
+        await env.run(journey_activities.generate_and_store_appeals, "h", "u")
+    assert exc_info.value.non_retryable
+
+
+@pytest.mark.asyncio
+@patch(f"{_MOD}.agenerate_and_store_appeals", new_callable=AsyncMock)
+@patch(f"{_MOD}.aload_denial", new_callable=AsyncMock)
+async def test_generate_operational_error_stays_retryable(mock_load, mock_generate):
+    """A dropped/refused database connection is exactly the transient class
+    the retry policy exists for -- it must NOT be marked non-retryable."""
+    from django.db.utils import OperationalError
+
+    mock_load.return_value = object()
+    mock_generate.side_effect = OperationalError("server closed the connection")
+    env = ActivityEnvironment()
+    with pytest.raises(ApplicationError) as exc_info:
+        await env.run(journey_activities.generate_and_store_appeals, "h", "u")
+    assert not exc_info.value.non_retryable

--- a/tests/temporal/test_appeal_journey_activities.py
+++ b/tests/temporal/test_appeal_journey_activities.py
@@ -146,3 +146,18 @@ async def test_generate_operational_error_stays_retryable(mock_load, mock_genera
     with pytest.raises(ApplicationError) as exc_info:
         await env.run(journey_activities.generate_and_store_appeals, "h", "u")
     assert not exc_info.value.non_retryable
+
+
+@pytest.mark.asyncio
+@patch(f"{_MOD}.aload_denial", new_callable=AsyncMock)
+async def test_generate_denial_lookup_schema_error_is_non_retryable(mock_load):
+    """The denial LOOKUP runs before the inner classifier; a schema failure
+    there must get the same non-retryable classification (PR review)."""
+    from django.db.utils import ProgrammingError
+
+    mock_load.side_effect = ProgrammingError('relation "nope" does not exist')
+    env = ActivityEnvironment()
+    with pytest.raises(ApplicationError) as exc_info:
+        await env.run(journey_activities.generate_and_store_appeals, "h", "u")
+    assert exc_info.value.non_retryable
+    assert "nope" not in str(exc_info.value)

--- a/tests/temporal/test_intake_journey_workflow.py
+++ b/tests/temporal/test_intake_journey_workflow.py
@@ -110,3 +110,60 @@ async def test_query_reports_progress_and_late_completion_generates():
             result = await handle.result()
     assert result == "completed"
     assert rec.calls == []
+
+
+@workflow.defn(name="GenerateAppealWorkflow")
+class _BlockingGenerateAppeal:
+    """Stands in for a standalone generation that is still RUNNING when the
+    intake journey tries to start its child under the same workflow id."""
+
+    def __init__(self) -> None:
+        self._release = False
+
+    @workflow.signal
+    def release(self) -> None:
+        self._release = True
+
+    @workflow.run
+    async def run(self, journey: GenerateAppealInput) -> int:
+        await workflow.wait_condition(lambda: self._release)
+        return 0
+
+
+@pytest.mark.asyncio
+async def test_running_standalone_generation_does_not_fail_the_journey():
+    """A management/manual generation workflow already holds
+    generate-appeal-{uuid}. The child start collides; the journey must
+    treat generation-in-progress as success, not die on the collision
+    (external review)."""
+    rec = _Recorder()
+    task_queue = str(uuid.uuid4())
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        worker = Worker(
+            env.client,
+            task_queue=task_queue,
+            workflows=[IntakeJourneyWorkflow, _BlockingGenerateAppeal],
+            activities=rec.activities(),
+        )
+        standalone = await env.client.start_workflow(
+            _BlockingGenerateAppeal.run,
+            GenerateAppealInput(hashed_email="h", denial_uuid="u"),
+            id="generate-appeal-u",
+            task_queue=task_queue,
+        )
+        handle = await env.client.start_workflow(
+            IntakeJourneyWorkflow.run,
+            IntakeJourneyInput(hashed_email="h", denial_uuid="u", contact_opt_in=True),
+            id=str(uuid.uuid4()),
+            task_queue=task_queue,
+        )
+        async with worker:
+            await handle.signal(IntakeJourneyWorkflow.form_completed)
+            # This completing AT ALL is the proof: were there no collision,
+            # the registered "GenerateAppealWorkflow" here is the blocking
+            # stub, so a successfully-started child would block forever and
+            # the journey could never return. (No cleanup of the standalone:
+            # the time-skipping server ages it out with the environment.)
+            result = await handle.result()
+    assert result == "completed"
+    assert standalone is not None


### PR DESCRIPTION
Dark-safe fixes from the external reviews, ahead of flag enablement:

- Connection hygiene at async activity entry: precheck, generation, and the nudge activity run close_old_connections (bridged onto the async ORM's thread-sensitive lane) before touching the database, mirroring the fax activities, so a server-closed connection between attempts can't masquerade as a real failure.
- Retry classification: ValidationError/FieldError/ProgrammingError/ DataError raise non-retryable ApplicationErrors (sanitized to type name + opaque uuid). The precheck's retry policy is unbounded by design, and without this a schema error would retry forever labeled transient. OperationalError stays retryable. Tests for all three.
- Child workflow-id collision: a standalone generation already running as generate-appeal-{uuid} no longer fails the intake journey; the journey logs and defers, since drafts are governed by the durable database postcondition. Workflow-environment test reproduces the collision against a blocking standalone.
- REJECT_DUPLICATE comment now states the retention-bounded truth and names the precheck as the durable idempotency backstop.
- The abandonment nudge links to the plain homepage: no inert ?resume= parameter and no denial uuid in a URL; a real resume link ships with a signed, expiring token alongside the resume feature itself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Intake journeys now complete successfully when standalone appeal generation is already running.
  - Stale database connections are closed before key journey and notification activities.
  - Schema and validation errors are reported as non-retryable, sanitized errors, preventing endless retries.
  - Operational failures remain retryable.

- **User Experience**
  - Abandonment reminder links now direct users to the public homepage rather than using an unsecured resume parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->