### PR TITLE
Fingerprint completeness for appeal drafts

### DIFF
--- a/fighthealthinsurance/appeal_fingerprints.py
+++ b/fighthealthinsurance/appeal_fingerprints.py
@@ -127,11 +127,17 @@ def verify_fingerprints(ProposedAppeal: Any) -> dict:
 
     NULL checks alone cannot prove the invariant during a rollout: a pod
     still on pre-fingerprint code can EDIT text under a fingerprint that
-    no longer matches it (external review). Such rows are re-keyed with the
-    same observed-text-guarded conditional update ``fill_row`` uses; a
-    re-key that would collide with a twin is left as-is and counted as
-    ``mismatch_duplicate`` (it is a duplicate now). Returns counters; a
-    non-zero ``rekeyed`` is proof an old writer touched the table.
+    no longer matches it (external review). A stale fingerprint is NEVER
+    left in place: the row is re-keyed to its current text, or -- when that
+    key already belongs to another row (the row is a duplicate now) or the
+    text has become blank -- the stale fingerprint is cleared to NULL, the
+    known-duplicate/unusable marker journey counting excludes. Leaving
+    fp(Y) on a row that now holds text X would count X twice as distinct
+    drafts (review). Every repair is counted as ``rekeyed`` (strict mode
+    fails on any, forcing the post-rollout Job to retry); collisions are
+    additionally counted as ``mismatch_duplicate``. Every write is guarded
+    by the observed text AND fingerprint, so a concurrent edit is skipped,
+    never overwritten.
     """
     counts = {REKEYED: 0, MISMATCH_DUPLICATE: 0, "checked": 0}
     qs = (
@@ -142,27 +148,36 @@ def verify_fingerprints(ProposedAppeal: Any) -> dict:
     for row in qs.iterator(chunk_size=500):
         counts["checked"] += 1
         expected = fingerprint_text(row.appeal_text)
-        if expected is None or expected == row.text_fingerprint:
+        if expected == row.text_fingerprint:
             continue
-        if (
+        new_value = expected
+        if expected is not None and (
             ProposedAppeal.objects.filter(
                 for_denial_id=row.for_denial_id, text_fingerprint=expected
             )
             .exclude(pk=row.pk)
             .exists()
         ):
+            new_value = None
             counts[MISMATCH_DUPLICATE] += 1
-            continue
+        guard = dict(
+            pk=row.pk,
+            appeal_text=row.appeal_text,
+            text_fingerprint=row.text_fingerprint,
+        )
         try:
             with transaction.atomic():
-                updated = ProposedAppeal.objects.filter(
-                    pk=row.pk,
-                    appeal_text=row.appeal_text,
-                    text_fingerprint=row.text_fingerprint,
-                ).update(text_fingerprint=expected)
+                updated = ProposedAppeal.objects.filter(**guard).update(
+                    text_fingerprint=new_value
+                )
         except IntegrityError:
+            # Lost the race for the key: the row is a duplicate now, so the
+            # repair is to clear it.
             counts[MISMATCH_DUPLICATE] += 1
-            continue
+            with transaction.atomic():
+                updated = ProposedAppeal.objects.filter(**guard).update(
+                    text_fingerprint=None
+                )
         if updated:
             counts[REKEYED] += 1
     logger.info(f"appeal fingerprint verify: {counts}")

--- a/fighthealthinsurance/appeal_fingerprints.py
+++ b/fighthealthinsurance/appeal_fingerprints.py
@@ -6,28 +6,34 @@ must run TWICE in a mixed-version deployment (external review):
 
 1. The migration runs while old writer processes (pre-fingerprint
    ``save()``) may still be inserting NULL rows behind its cursor.
-2. After the deploy completes and every old writer is gone, the management
-   command re-runs the same backfill to catch rows the migration raced,
-   then audits what remains.
+2. After the deploy completes and every old writer is gone, the post-rollout
+   Job re-runs the same backfill in ``--strict`` mode, which only succeeds
+   once a full pass finds nothing left to fill (i.e. the writers are gone).
 
 After step 2, a ``chosen=False, text_fingerprint IS NULL`` row means
 exactly one thing: a known historical duplicate (its fingerprint is
 already taken for that denial). Journey counting relies on that meaning.
 
-Every row is handled independently (no batch transaction) and a losing
-race on any single row -- another writer inserting the same fingerprint
-between our check and update -- is caught and skipped, never allowed to
-abort the run.
+Every row is handled independently (no batch transaction), each row is
+fingerprinted from a FRESH read whose observed text guards the write, and a
+losing race on any single row is counted, never allowed to abort the run.
 """
 
 import hashlib
+from typing import Any
 
 from django.db import IntegrityError, transaction
 
 from loguru import logger
 
+FILLED = "filled"
+SKIPPED_DUPLICATE = "skipped_duplicate"
+SKIPPED_EMPTY = "skipped_empty"
+LOST_RACE = "lost_race"
+OUTCOMES = (FILLED, SKIPPED_DUPLICATE, SKIPPED_EMPTY, LOST_RACE)
 
-def fingerprint_text(text):
+
+def fingerprint_text(text: Any) -> Any:
     """Stable copy of ``ProposedAppeal.fingerprint``'s normalization.
 
     Kept here (and referenced by the migration) so the backfill's meaning
@@ -40,59 +46,72 @@ def fingerprint_text(text):
     return hashlib.sha256(normalized.encode()).hexdigest()
 
 
-def run_backfill(ProposedAppeal) -> dict:
-    """Fill NULL fingerprints on un-chosen rows; returns counters.
+def fill_row(ProposedAppeal: Any, pk: int, attempts: int = 3) -> str:
+    """Fingerprint one NULL row; returns the outcome (one of OUTCOMES).
 
-    ``ProposedAppeal`` is passed in so the migration can hand over its
-    historical model while the management command passes the live one.
-    Duplicate content (fingerprint already taken for the denial) is left
-    NULL deliberately -- that IS the known-duplicate marker.
+    The text is re-read fresh on every attempt and the UPDATE is guarded by
+    the observed ``appeal_text`` and ``for_denial_id``: a concurrent edit
+    landing between the read and the write matches zero rows instead of
+    attaching a stale fingerprint to the new text (external review). A
+    zero-row match loops to a fresh read; the row is NEVER written from a
+    stale snapshot.
     """
-    filled = skipped_duplicate = skipped_empty = lost_race = 0
-    qs = (
-        ProposedAppeal.objects.filter(text_fingerprint__isnull=True, chosen=False)
-        .order_by("id")
-        .only("id", "appeal_text", "for_denial_id")
-    )
-    for row in qs.iterator(chunk_size=500):
+    for _ in range(attempts):
+        row = (
+            ProposedAppeal.objects.filter(
+                pk=pk, text_fingerprint__isnull=True, chosen=False
+            )
+            .only("id", "appeal_text", "for_denial_id")
+            .first()
+        )
+        if row is None:
+            # Filled (or re-keyed/removed) by another writer since the scan.
+            return LOST_RACE
         fp = fingerprint_text(row.appeal_text)
         if fp is None:
-            skipped_empty += 1
-            continue
+            return SKIPPED_EMPTY
         if (
             ProposedAppeal.objects.filter(
                 for_denial_id=row.for_denial_id, text_fingerprint=fp
             )
-            .exclude(pk=row.pk)
+            .exclude(pk=pk)
             .exists()
         ):
-            skipped_duplicate += 1
-            continue
+            return SKIPPED_DUPLICATE  # deliberately left NULL (known duplicate)
         try:
             with transaction.atomic():
                 updated = ProposedAppeal.objects.filter(
-                    pk=row.pk, text_fingerprint__isnull=True
+                    pk=pk,
+                    text_fingerprint__isnull=True,
+                    appeal_text=row.appeal_text,
+                    for_denial_id=row.for_denial_id,
                 ).update(text_fingerprint=fp)
-            if updated:
-                filled += 1
-            else:
-                # Another writer filled (or re-keyed) this row between our
-                # scan and the conditional update: nothing was written here,
-                # so it must not count as a fill (review).
-                lost_race += 1
         except IntegrityError:
             # A concurrent writer took this fingerprint between our check
             # and the update; this row is therefore a duplicate now.
-            lost_race += 1
-    remaining = ProposedAppeal.objects.filter(
+            return LOST_RACE
+        if updated:
+            return FILLED
+        # Text changed under us: loop and recompute from the fresh row.
+    return LOST_RACE
+
+
+def run_backfill(ProposedAppeal: Any) -> dict:
+    """Fill NULL fingerprints on un-chosen rows; returns counters.
+
+    ``ProposedAppeal`` is passed in so the migration can hand over its
+    historical model while the management command passes the live one.
+    """
+    counts = {k: 0 for k in OUTCOMES}
+    pks = list(
+        ProposedAppeal.objects.filter(text_fingerprint__isnull=True, chosen=False)
+        .order_by("id")
+        .values_list("id", flat=True)
+    )
+    for pk in pks:
+        counts[fill_row(ProposedAppeal, pk)] += 1
+    counts["remaining_null"] = ProposedAppeal.objects.filter(
         text_fingerprint__isnull=True, chosen=False
     ).count()
-    counts = {
-        "filled": filled,
-        "skipped_duplicate": skipped_duplicate,
-        "skipped_empty": skipped_empty,
-        "lost_race": lost_race,
-        "remaining_null": remaining,
-    }
     logger.info(f"appeal fingerprint backfill: {counts}")
     return counts

--- a/fighthealthinsurance/appeal_fingerprints.py
+++ b/fighthealthinsurance/appeal_fingerprints.py
@@ -115,3 +115,55 @@ def run_backfill(ProposedAppeal: Any) -> dict:
     ).count()
     logger.info(f"appeal fingerprint backfill: {counts}")
     return counts
+
+
+REKEYED = "rekeyed"
+MISMATCH_DUPLICATE = "mismatch_duplicate"
+
+
+def verify_fingerprints(ProposedAppeal: Any) -> dict:
+    """Integrity pass: every un-chosen fingerprinted row must satisfy
+    ``text_fingerprint == fingerprint_text(appeal_text)``.
+
+    NULL checks alone cannot prove the invariant during a rollout: a pod
+    still on pre-fingerprint code can EDIT text under a fingerprint that
+    no longer matches it (external review). Such rows are re-keyed with the
+    same observed-text-guarded conditional update ``fill_row`` uses; a
+    re-key that would collide with a twin is left as-is and counted as
+    ``mismatch_duplicate`` (it is a duplicate now). Returns counters; a
+    non-zero ``rekeyed`` is proof an old writer touched the table.
+    """
+    counts = {REKEYED: 0, MISMATCH_DUPLICATE: 0, "checked": 0}
+    qs = (
+        ProposedAppeal.objects.filter(text_fingerprint__isnull=False, chosen=False)
+        .order_by("id")
+        .only("id", "appeal_text", "text_fingerprint", "for_denial_id")
+    )
+    for row in qs.iterator(chunk_size=500):
+        counts["checked"] += 1
+        expected = fingerprint_text(row.appeal_text)
+        if expected is None or expected == row.text_fingerprint:
+            continue
+        if (
+            ProposedAppeal.objects.filter(
+                for_denial_id=row.for_denial_id, text_fingerprint=expected
+            )
+            .exclude(pk=row.pk)
+            .exists()
+        ):
+            counts[MISMATCH_DUPLICATE] += 1
+            continue
+        try:
+            with transaction.atomic():
+                updated = ProposedAppeal.objects.filter(
+                    pk=row.pk,
+                    appeal_text=row.appeal_text,
+                    text_fingerprint=row.text_fingerprint,
+                ).update(text_fingerprint=expected)
+        except IntegrityError:
+            counts[MISMATCH_DUPLICATE] += 1
+            continue
+        if updated:
+            counts[REKEYED] += 1
+    logger.info(f"appeal fingerprint verify: {counts}")
+    return counts

--- a/fighthealthinsurance/appeal_fingerprints.py
+++ b/fighthealthinsurance/appeal_fingerprints.py
@@ -1,0 +1,92 @@
+"""Idempotent, conflict-safe backfill of ``ProposedAppeal.text_fingerprint``.
+
+One implementation shared by migration 0202 and the
+``backfill_appeal_fingerprints`` management command, because the backfill
+must run TWICE in a mixed-version deployment (external review):
+
+1. The migration runs while old writer processes (pre-fingerprint
+   ``save()``) may still be inserting NULL rows behind its cursor.
+2. After the deploy completes and every old writer is gone, the management
+   command re-runs the same backfill to catch rows the migration raced,
+   then audits what remains.
+
+After step 2, a ``chosen=False, text_fingerprint IS NULL`` row means
+exactly one thing: a known historical duplicate (its fingerprint is
+already taken for that denial). Journey counting relies on that meaning.
+
+Every row is handled independently (no batch transaction) and a losing
+race on any single row -- another writer inserting the same fingerprint
+between our check and update -- is caught and skipped, never allowed to
+abort the run.
+"""
+
+import hashlib
+
+from django.db import IntegrityError, transaction
+
+from loguru import logger
+
+
+def fingerprint_text(text):
+    """Stable copy of ``ProposedAppeal.fingerprint``'s normalization.
+
+    Kept here (and referenced by the migration) so the backfill's meaning
+    cannot drift if the model's normalization ever changes; any such change
+    needs its own re-key migration, not a silent semantic shift here.
+    """
+    if not text or not str(text).strip():
+        return None
+    normalized = " ".join(str(text).lower().split())
+    return hashlib.sha256(normalized.encode()).hexdigest()
+
+
+def run_backfill(ProposedAppeal) -> dict:
+    """Fill NULL fingerprints on un-chosen rows; returns counters.
+
+    ``ProposedAppeal`` is passed in so the migration can hand over its
+    historical model while the management command passes the live one.
+    Duplicate content (fingerprint already taken for the denial) is left
+    NULL deliberately -- that IS the known-duplicate marker.
+    """
+    filled = skipped_duplicate = skipped_empty = lost_race = 0
+    qs = (
+        ProposedAppeal.objects.filter(text_fingerprint__isnull=True, chosen=False)
+        .order_by("id")
+        .only("id", "appeal_text", "for_denial_id")
+    )
+    for row in qs.iterator(chunk_size=500):
+        fp = fingerprint_text(row.appeal_text)
+        if fp is None:
+            skipped_empty += 1
+            continue
+        if (
+            ProposedAppeal.objects.filter(
+                for_denial_id=row.for_denial_id, text_fingerprint=fp
+            )
+            .exclude(pk=row.pk)
+            .exists()
+        ):
+            skipped_duplicate += 1
+            continue
+        try:
+            with transaction.atomic():
+                ProposedAppeal.objects.filter(
+                    pk=row.pk, text_fingerprint__isnull=True
+                ).update(text_fingerprint=fp)
+            filled += 1
+        except IntegrityError:
+            # A concurrent writer took this fingerprint between our check
+            # and the update; this row is therefore a duplicate now.
+            lost_race += 1
+    remaining = ProposedAppeal.objects.filter(
+        text_fingerprint__isnull=True, chosen=False
+    ).count()
+    counts = {
+        "filled": filled,
+        "skipped_duplicate": skipped_duplicate,
+        "skipped_empty": skipped_empty,
+        "lost_race": lost_race,
+        "remaining_null": remaining,
+    }
+    logger.info(f"appeal fingerprint backfill: {counts}")
+    return counts

--- a/fighthealthinsurance/appeal_fingerprints.py
+++ b/fighthealthinsurance/appeal_fingerprints.py
@@ -70,10 +70,16 @@ def run_backfill(ProposedAppeal) -> dict:
             continue
         try:
             with transaction.atomic():
-                ProposedAppeal.objects.filter(
+                updated = ProposedAppeal.objects.filter(
                     pk=row.pk, text_fingerprint__isnull=True
                 ).update(text_fingerprint=fp)
-            filled += 1
+            if updated:
+                filled += 1
+            else:
+                # Another writer filled (or re-keyed) this row between our
+                # scan and the conditional update: nothing was written here,
+                # so it must not count as a fill (review).
+                lost_race += 1
         except IntegrityError:
             # A concurrent writer took this fingerprint between our check
             # and the update; this row is therefore a duplicate now.

--- a/fighthealthinsurance/appeal_journey_core.py
+++ b/fighthealthinsurance/appeal_journey_core.py
@@ -88,14 +88,21 @@ async def aprecheck_appeal_journey(denial) -> str:
         return STATUS_ALREADY_HAS_APPEALS
     # speculative=True rows are the background precompute held in reserve;
     # the interactive flow doesn't count them as delivered appeals and
-    # neither does the journey (PR #963 review).
-    existing = 0
-    async for text in ProposedAppeal.objects.filter(
-        for_denial=denial, speculative=False, chosen=False
-    ).values_list("appeal_text", flat=True):
+    # neither does the journey (PR #963 review). Counted as DISTINCT
+    # fingerprints, not rows: the pre-constraint era double-stored drafts,
+    # and three copies of one letter are one deliverable draft, not three.
+    # NULL fingerprints are exactly the rows the backfill migration left
+    # as known legacy duplicates, so they never count (external review).
+    existing_fingerprints = set()
+    async for text, fp in ProposedAppeal.objects.filter(
+        for_denial=denial,
+        speculative=False,
+        chosen=False,
+        text_fingerprint__isnull=False,
+    ).values_list("appeal_text", "text_fingerprint"):
         if is_real_appeal(text):
-            existing += 1
-    if existing >= TARGET_APPEALS:
+            existing_fingerprints.add(fp)
+    if len(existing_fingerprints) >= TARGET_APPEALS:
         # A retry after a crash, or a duplicate dispatch: the drafts are
         # already there, so the journey is idempotently done.
         return STATUS_ALREADY_HAS_APPEALS
@@ -115,11 +122,12 @@ async def agenerate_and_store_appeals(denial) -> int:
     within a bounded budget -- it must never create rows from the streamed
     output, or every draft would be stored twice.
 
-    Progress is measured in durable row IDENTITIES, never yielded text: the
-    generator re-serves existing drafts transformed by ``sub_in_appeals`` (so
-    their text differs from what is stored) and can yield content whose save
-    FAILED -- both fooled a text-based count into stopping early with nothing
-    persisted (PR #963 review). The postcondition is enforced against the
+    Progress is measured in durable DISTINCT content fingerprints, never
+    yielded text: the generator re-serves existing drafts transformed by
+    ``sub_in_appeals`` (so their text differs from what is stored) and can
+    yield content whose save FAILED -- both fooled a text-based count into
+    stopping early with nothing persisted (PR #963 review). Fingerprints
+    rather than row ids so duplicate rows count once (external review). The postcondition is enforced against the
     database; falling short raises :class:`JourneyIncomplete` so the activity
     retries instead of reporting a hollow success.
 
@@ -131,20 +139,28 @@ async def agenerate_and_store_appeals(denial) -> int:
     from fighthealthinsurance.common_view_logic import AppealsBackendHelper
     from fighthealthinsurance.models import ProposedAppeal
 
-    async def _stored_ids() -> set:
+    async def _stored_fingerprints() -> set:
         # Deliverable candidates only: non-speculative (reserves are not
         # delivered drafts), un-chosen (a chosen row is a COPY the pick
         # flow creates, not a candidate), and real letters (legacy empty/
-        # runt rows must not satisfy the target). Native async ORM.
+        # runt rows must not satisfy the target). Measured as DISTINCT
+        # fingerprints rather than row ids so duplicate rows -- historical
+        # double-stores, or a racing writer on a database whose constraint
+        # enforcement lapsed -- count as the one draft they are; NULL
+        # fingerprints are the backfill's known-legacy-duplicate marker and
+        # never count (external review). Native async ORM.
         return {
-            pk
-            async for pk, text in ProposedAppeal.objects.filter(
-                for_denial=denial, speculative=False, chosen=False
-            ).values_list("id", "appeal_text")
+            fp
+            async for fp, text in ProposedAppeal.objects.filter(
+                for_denial=denial,
+                speculative=False,
+                chosen=False,
+                text_fingerprint__isnull=False,
+            ).values_list("text_fingerprint", "appeal_text")
             if is_real_appeal(text)
         }
 
-    baseline = await _stored_ids()
+    baseline = await _stored_fingerprints()
     if len(baseline) >= TARGET_APPEALS:
         return 0
 
@@ -164,7 +180,7 @@ async def agenerate_and_store_appeals(denial) -> int:
                 # count query per frame is cheap, and only rows that actually
                 # persisted can end the consumption early.
                 frames += 1
-                if len(await _stored_ids()) >= TARGET_APPEALS:
+                if len(await _stored_fingerprints()) >= TARGET_APPEALS:
                     break
     except TimeoutError:
         logger.info(
@@ -174,7 +190,7 @@ async def agenerate_and_store_appeals(denial) -> int:
     finally:
         await agen.aclose()
 
-    after = await _stored_ids()
+    after = await _stored_fingerprints()
     stored = len(after - baseline)
     logger.info(
         f"Appeal journey: {stored} new draft(s) persisted for denial "

--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -35,7 +35,7 @@ from django.conf import settings
 from django.core.files import File
 from django.core.mail import send_mail
 from django.core.validators import validate_email
-from django.db import IntegrityError, close_old_connections
+from django.db import IntegrityError, close_old_connections, transaction
 
 
 from django.db.models import F, Q, QuerySet
@@ -4087,8 +4087,18 @@ class AppealsBackendHelper:
                     context_level=item.context_level,
                     text_fingerprint=fingerprint,
                 )
+
+                def _insert_with_savepoint() -> None:
+                    # atomic() nests as a SAVEPOINT inside any enclosing
+                    # transaction, so an IntegrityError here cannot poison
+                    # the caller's transaction state before the recovery
+                    # query below runs (external review). In autocommit it
+                    # is just a short transaction around the insert.
+                    with transaction.atomic():
+                        pa.save()
+
                 try:
-                    await pa.asave()
+                    await database_sync_to_async(_insert_with_savepoint)()
                 except IntegrityError:
                     # Another writer (a racing journey activity, a retry, or
                     # a concurrent interactive run) already stored this exact
@@ -4099,6 +4109,20 @@ class AppealsBackendHelper:
                     ).afirst()
                     if existing is None:
                         raise
+                    if existing.speculative:
+                        # The twin is a HELD-BACK reserve row. Reusing it
+                        # un-promoted would stream a draft whose row stays
+                        # invisible to every downstream reader (page
+                        # reloads, choose/edit, journey counting): the
+                        # appeal the user just watched would disappear
+                        # (external review). Claim it atomically, same
+                        # pattern as the reserve flush; if the flush claimed
+                        # it first the update is a no-op and the row is
+                        # already deliverable.
+                        await ProposedAppeal.objects.filter(
+                            pk=existing.pk, speculative=True
+                        ).aupdate(speculative=False)
+                        existing.speculative = False
                     pa = existing
                 except Exception:
                     # Most save failures here are a stale/idle-killed

--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -3236,9 +3236,17 @@ class AppealsBackendHelper:
             # checks existed (or by paths that skipped the filter), and we must
             # not re-deliver them.
             if is_real_appeal(appeal.appeal_text):
+                key = _served_key(appeal.appeal_text)
+                if key in served_keys:
+                    # Legacy duplicate rows (NULL fingerprints, equivalent
+                    # normalized text) are one draft to the user: stream
+                    # the first, skip its twins, and don't count them in
+                    # `old` (review).
+                    logger.debug(f"Skipping duplicate existing appeal {appeal}")
+                    continue
                 old = old + 1
                 logger.debug(f"Found existing appeal {appeal}, yielding")
-                served_keys.add(_served_key(appeal.appeal_text))
+                served_keys.add(key)
                 existing_appeal_dict = await sub_in_appeals(
                     {"id": str(appeal.id), "content": appeal.appeal_text}
                 )

--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -50,6 +50,8 @@ import ray
 import uszipcode
 from asgiref.sync import async_to_sync
 from channels.db import database_sync_to_async
+
+from fighthealthinsurance.appeal_fingerprints import fingerprint_text
 from loguru import logger
 from PyPDF2 import PdfMerger
 from stopit.utils import TimeoutException
@@ -3214,7 +3216,17 @@ class AppealsBackendHelper:
         # Grown by every path that ships an appeal (existing rows, streamed
         # drafts, the early reserve flush, synthesis, the end-of-flow
         # reconciliation) so no path can send the same text twice.
-        served_texts: set[str] = set()
+        served_keys: set[str] = set()
+
+        def _served_key(text: Any) -> str:
+            # Normalized content fingerprint -- the SAME normalization the
+            # database constraint enforces (fingerprint_text is the pure
+            # function ProposedAppeal.fingerprint mirrors). An exact-string
+            # set let a capitalization or whitespace variant through the
+            # dedupe and then collide on insert, streaming two drafts against
+            # one stored row (external review).
+            return fingerprint_text(text) or str(text).strip()
+
         # Yield the existing appeals first
         old = 0
         new = 0
@@ -3226,7 +3238,7 @@ class AppealsBackendHelper:
             if is_real_appeal(appeal.appeal_text):
                 old = old + 1
                 logger.debug(f"Found existing appeal {appeal}, yielding")
-                served_texts.add(str(appeal.appeal_text).strip())
+                served_keys.add(_served_key(appeal.appeal_text))
                 existing_appeal_dict = await sub_in_appeals(
                     {"id": str(appeal.id), "content": appeal.appeal_text}
                 )
@@ -3356,9 +3368,9 @@ class AppealsBackendHelper:
                     if not is_real_appeal(row.appeal_text):
                         continue
                     normalized = str(row.appeal_text).strip()
-                    if normalized in served_texts:
+                    if _served_key(row.appeal_text) in served_keys:
                         continue
-                    # Claim the row atomically. served_texts is per-run, so it
+                    # Claim the row atomically. served_keys is per-run, so it
                     # cannot dedupe against a concurrent flow -- and a reconnect
                     # makes exactly that overlap likely, since the dropped
                     # socket's generator can still be draining server-side while
@@ -3387,7 +3399,7 @@ class AppealsBackendHelper:
                         {"id": str(row.id), "content": row.appeal_text}
                     )
                     yield await format_response(row_dict)
-                    served_texts.add(normalized)
+                    served_keys.add(_served_key(normalized))
                     early_reserve_texts.add(normalized)
                     new += 1
                     reserve_served += 1
@@ -4123,6 +4135,12 @@ class AppealsBackendHelper:
                             pk=existing.pk, speculative=True
                         ).aupdate(speculative=False)
                         existing.speculative = False
+                    if existing.appeal_text != appeal_text:
+                        # A normalized variant collided: stream the DURABLE
+                        # text under the stored row's id. Sending the variant
+                        # would show the client two drafts for one row, and a
+                        # reload would 'lose' one (external review).
+                        appeal_text = existing.appeal_text or appeal_text
                     pa = existing
                 except Exception:
                     # Most save failures here are a stale/idle-killed
@@ -4145,7 +4163,7 @@ class AppealsBackendHelper:
             # reserve flush running between streamed drafts can't ship a
             # speculative row whose text matches one already sent.
             if appeal_text:
-                served_texts.add(str(appeal_text).strip())
+                served_keys.add(_served_key(appeal_text))
             result: dict[str, Any] = {"id": id, "content": appeal_text}
             if save_failed:
                 result["save_failed"] = True
@@ -4418,11 +4436,11 @@ class AppealsBackendHelper:
                 # trips the "partial delivery" error path in appeal_fetcher.ts.
                 # (Same reasoning as the verbatim-copy guard on synthesis.)
                 # This runs on the sync_iterator_to_async worker thread while the
-                # event loop may be adding to served_texts; a set membership test
+                # event loop may be adding to served_keys; a set membership test
                 # is a single atomic lookup, and the only cost of racing one is
                 # an occasional duplicate slipping through -- exactly today's
                 # behavior.
-                if str(text).strip() in served_texts:
+                if _served_key(text) in served_keys:
                     dupes += 1
                     logger.info(
                         f"[gen_id={generation_id}] dropping a live draft "
@@ -4514,14 +4532,14 @@ class AppealsBackendHelper:
         ]
         # Everything streamed so far this run persists as speculative=False
         # (existing rows + drafts saved during streaming), so this doubles as
-        # the set already sent. served_texts is tracked from the top of the flow
+        # the set already sent. served_keys is tracked from the top of the flow
         # (and grown by synthesis / the end-of-flow reconciliation below), so
         # this only fills in anything a row landed for that no yield path saw.
         # Caveat: save_appeal deliberately swallows a failed asave and still
         # streams the draft; such a draft has no row here, but the streaming
         # path already recorded its text, so the reconciliation still won't
         # re-serve it.
-        served_texts.update({s.strip() for s in saved_appeal_texts if s})
+        served_keys.update({_served_key(s) for s in saved_appeal_texts if s})
         # Synthesis requires >=2 drafts to be meaningful: with a single
         # input, models often regurgitate it verbatim. The client dedupes
         # by content, so a verbatim copy gets silently dropped, which then
@@ -4583,7 +4601,7 @@ class AppealsBackendHelper:
                         # can still pick one verbatim. Skip the yield in
                         # that case rather than ship a known duplicate.
                         normalized = synthesized.strip()
-                        if normalized in served_texts:
+                        if _served_key(synthesized) in served_keys:
                             logger.info(
                                 "Synthesis returned a verbatim copy of an input draft; skipping yield"
                             )
@@ -4599,7 +4617,7 @@ class AppealsBackendHelper:
                             subbed = await sub_in_appeals(saved)
                             subbed["synthesized"] = "true"
                             yield await format_response(subbed)
-                            served_texts.add(normalized)
+                            served_keys.add(_served_key(normalized))
                             new += 1
                             logger.info(
                                 f"Synthesized appeal generated from {len(saved_appeal_texts)} drafts"
@@ -4625,7 +4643,7 @@ class AppealsBackendHelper:
         # Served speculative rows are flipped to non-speculative so they persist
         # as real appeals and later calls serve them as existing. Runs before
         # the zero/underdelivery logging and the done frame so the counts stay
-        # truthful. Dedup is by normalized raw text via served_texts.
+        # truthful. Dedup is by normalized raw text via served_keys.
         ENOUGH_APPEALS = cls.ENOUGH_APPEALS
         MINI_LEVELS = {
             *SPECULATIVE_CONTEXT_LEVELS,
@@ -4653,13 +4671,13 @@ class AppealsBackendHelper:
         # promotes the oldest reserve rows first (deterministic FIFO).
         try:
             # chosen=False: never hand the user their own pick back as a "new
-            # appeal". In the ordinary case served_texts already covers this --
+            # appeal". In the ordinary case served_keys already covers this --
             # saved_appeal_texts above is not chosen-filtered, so a chosen row's
             # text is in the set and the dedup below skips it. This closes the
             # gap where that is NOT true: mark_proposal_chosen running in
             # another request mid-stream lands a chosen row (for an editted one,
             # text the user wrote, which was never a draft) in between that
-            # query and this one, leaving it absent from served_texts.
+            # query and this one, leaving it absent from served_keys.
             async for row in deliverable_candidates(
                 ProposedAppeal.objects.filter(for_denial=denial, chosen=False)
             ).order_by("id"):
@@ -4667,7 +4685,7 @@ class AppealsBackendHelper:
                 if not is_real_appeal(text):
                     continue
                 normalized = str(text).strip()
-                if normalized in served_texts:
+                if _served_key(text) in served_keys:
                     continue
                 is_mini = bool(row.speculative) or row.context_level in MINI_LEVELS
                 # Re-evaluate the threshold each iteration: serving increments new.
@@ -4696,7 +4714,7 @@ class AppealsBackendHelper:
                     row.speculative = False
                 row_dict = await sub_in_appeals({"id": str(row.id), "content": text})
                 yield await format_response(row_dict)
-                served_texts.add(normalized)
+                served_keys.add(_served_key(normalized))
                 new += 1
                 reconciled += 1
                 if from_precompute:

--- a/fighthealthinsurance/management/commands/backfill_appeal_fingerprints.py
+++ b/fighthealthinsurance/management/commands/backfill_appeal_fingerprints.py
@@ -1,0 +1,29 @@
+"""Re-run the appeal fingerprint backfill after a deployment settles.
+
+Migration 0202 runs the first pass, but it can race writer processes still
+on pre-fingerprint code during the rollout (external review). Once every
+old writer is gone, run::
+
+    python manage.py backfill_appeal_fingerprints
+
+and check the printed counts: after this pass, ``remaining_null`` should
+equal ``skipped_duplicate + skipped_empty + lost_race`` accumulated across
+runs -- i.e. every remaining NULL is a known historical duplicate (or an
+empty legacy row), which is what journey counting assumes. Idempotent;
+safe to run any number of times.
+"""
+
+from typing import Any
+
+from django.core.management.base import BaseCommand
+
+from fighthealthinsurance.appeal_fingerprints import run_backfill
+from fighthealthinsurance.models import ProposedAppeal
+
+
+class Command(BaseCommand):
+    help = "Idempotently backfill ProposedAppeal.text_fingerprint (see 0202)."
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        counts = run_backfill(ProposedAppeal)
+        self.stdout.write(str(counts))

--- a/fighthealthinsurance/management/commands/backfill_appeal_fingerprints.py
+++ b/fighthealthinsurance/management/commands/backfill_appeal_fingerprints.py
@@ -1,21 +1,23 @@
 """Re-run the appeal fingerprint backfill after a deployment settles.
 
 Migration 0202 runs the first pass, but it can race writer processes still
-on pre-fingerprint code during the rollout (external review). Once every
-old writer is gone, run::
+on pre-fingerprint code during the rollout (external review). The
+post-rollout Job (k8s/temporal/backfill-fingerprints-job.yaml, applied by
+scripts/build.sh) runs this command with ``--strict``::
 
-    python manage.py backfill_appeal_fingerprints
+    python manage.py backfill_appeal_fingerprints --strict
 
-and check the printed counts: after this pass, ``remaining_null`` should
-equal ``skipped_duplicate + skipped_empty + lost_race`` accumulated across
-runs -- i.e. every remaining NULL is a known historical duplicate (or an
-empty legacy row), which is what journey counting assumes. Idempotent;
-safe to run any number of times.
+Strict mode runs the backfill twice back to back and FAILS (non-zero exit)
+if the second pass still found rows to fill or lost a race -- proof that a
+pre-fingerprint writer is still active. The Job's backoff then retries
+until a pass comes back quiet, which is the enforceable version of "after
+old writers drain". Without ``--strict`` it is a plain idempotent pass
+that prints counters; safe to run any number of times.
 """
 
 from typing import Any
 
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
 from fighthealthinsurance.appeal_fingerprints import run_backfill
 from fighthealthinsurance.models import ProposedAppeal
@@ -24,6 +26,31 @@ from fighthealthinsurance.models import ProposedAppeal
 class Command(BaseCommand):
     help = "Idempotently backfill ProposedAppeal.text_fingerprint (see 0202)."
 
+    def add_arguments(self, parser: Any) -> None:
+        parser.add_argument(
+            "--strict",
+            action="store_true",
+            help=(
+                "Run two passes and exit non-zero if the second still fills "
+                "rows or loses races (a pre-fingerprint writer is still active)."
+            ),
+        )
+
     def handle(self, *args: Any, **options: Any) -> None:
-        counts = run_backfill(ProposedAppeal)
-        self.stdout.write(str(counts))
+        first = run_backfill(ProposedAppeal)
+        self.stdout.write(f"pass 1: {first}")
+        if not options.get("strict"):
+            return
+        second = run_backfill(ProposedAppeal)
+        self.stdout.write(f"pass 2: {second}")
+        if second["filled"] or second["lost_race"]:
+            raise CommandError(
+                "fingerprint backfill not quiescent: pass 2 filled "
+                f"{second['filled']} and lost {second['lost_race']} races -- a "
+                "writer on pre-fingerprint code is still running; retry after "
+                "the rollout finishes draining old pods"
+            )
+        self.stdout.write(
+            f"quiescent: {second['remaining_null']} NULL row(s) remain, all "
+            "known duplicates or empty legacy rows"
+        )

--- a/fighthealthinsurance/management/commands/backfill_appeal_fingerprints.py
+++ b/fighthealthinsurance/management/commands/backfill_appeal_fingerprints.py
@@ -43,10 +43,18 @@ class Command(BaseCommand):
             return
         second = run_backfill(ProposedAppeal)
         self.stdout.write(f"pass 2: {second}")
-        if second["filled"] or second["lost_race"]:
+        # Quiescent means: the pass wrote nothing, lost no races, AND every
+        # NULL row still present is one the pass itself classified (known
+        # duplicate or empty). A NULL row inserted after the pass took its
+        # snapshot shows up only in remaining_null -- that is a live
+        # pre-fingerprint writer, and must fail strict mode too (review).
+        accounted = second["skipped_duplicate"] + second["skipped_empty"]
+        unaccounted = second["remaining_null"] - accounted
+        if second["filled"] or second["lost_race"] or unaccounted > 0:
             raise CommandError(
                 "fingerprint backfill not quiescent: pass 2 filled "
-                f"{second['filled']} and lost {second['lost_race']} races -- a "
+                f"{second['filled']}, lost {second['lost_race']} races, and "
+                f"{max(unaccounted, 0)} NULL row(s) appeared unclassified -- a "
                 "writer on pre-fingerprint code is still running; retry after "
                 "the rollout finishes draining old pods"
             )

--- a/fighthealthinsurance/management/commands/backfill_appeal_fingerprints.py
+++ b/fighthealthinsurance/management/commands/backfill_appeal_fingerprints.py
@@ -3,23 +3,34 @@
 Migration 0202 runs the first pass, but it can race writer processes still
 on pre-fingerprint code during the rollout (external review). The
 post-rollout Job (k8s/temporal/backfill-fingerprints-job.yaml, applied by
-scripts/build.sh) runs this command with ``--strict``::
+scripts/build.sh only AFTER every writer Deployment and the Ray cluster have
+finished rolling) runs this command with ``--strict``::
 
     python manage.py backfill_appeal_fingerprints --strict
 
-Strict mode runs the backfill twice back to back and FAILS (non-zero exit)
-if the second pass still found rows to fill or lost a race -- proof that a
-pre-fingerprint writer is still active. The Job's backoff then retries
-until a pass comes back quiet, which is the enforceable version of "after
-old writers drain". Without ``--strict`` it is a plain idempotent pass
-that prints counters; safe to run any number of times.
+Strict mode runs the backfill twice back to back and then an integrity
+pass, and FAILS (non-zero exit) if:
+
+* the second fill pass still filled rows, lost races, or left NULL rows it
+  never classified (a pre-fingerprint writer inserted behind the scan), or
+* the integrity pass had to re-key any row whose fingerprint no longer
+  matched its current text (a pre-fingerprint writer EDITED text under a
+  stale fingerprint -- NULL checks alone cannot see that; external review).
+
+The Job's backoff then retries until a run comes back quiet. Without
+``--strict`` it is a plain idempotent fill pass that prints counters; safe
+to run any number of times.
 """
 
 from typing import Any
 
 from django.core.management.base import BaseCommand, CommandError
 
-from fighthealthinsurance.appeal_fingerprints import run_backfill
+from fighthealthinsurance.appeal_fingerprints import (
+    REKEYED,
+    run_backfill,
+    verify_fingerprints,
+)
 from fighthealthinsurance.models import ProposedAppeal
 
 
@@ -31,8 +42,8 @@ class Command(BaseCommand):
             "--strict",
             action="store_true",
             help=(
-                "Run two passes and exit non-zero if the second still fills "
-                "rows or loses races (a pre-fingerprint writer is still active)."
+                "Run two fill passes plus an integrity pass and exit non-zero "
+                "if a pre-fingerprint writer is evidently still active."
             ),
         )
 
@@ -58,7 +69,17 @@ class Command(BaseCommand):
                 "writer on pre-fingerprint code is still running; retry after "
                 "the rollout finishes draining old pods"
             )
+        verified = verify_fingerprints(ProposedAppeal)
+        self.stdout.write(f"verify: {verified}")
+        if verified[REKEYED]:
+            raise CommandError(
+                f"fingerprint invariant violated: {verified[REKEYED]} row(s) "
+                "carried a fingerprint that did not match their current text "
+                "(re-keyed now) -- a writer on pre-fingerprint code edited "
+                "appeal text; retry after the rollout finishes draining old pods"
+            )
         self.stdout.write(
-            f"quiescent: {second['remaining_null']} NULL row(s) remain, all "
-            "known duplicates or empty legacy rows"
+            f"quiescent: {second['remaining_null']} NULL row(s) remain (all "
+            "known duplicates or empty legacy rows); "
+            f"{verified['checked']} fingerprinted row(s) verified"
         )

--- a/fighthealthinsurance/migrations/0202_backfill_proposedappeal_fingerprints.py
+++ b/fighthealthinsurance/migrations/0202_backfill_proposedappeal_fingerprints.py
@@ -3,40 +3,91 @@
 0201 added the fingerprint column and the partial unique constraint but
 left legacy rows NULL -- and NULL rows are exempt from the constraint, so
 a retry regenerating a legacy draft's text could store it again (external
-review). This fills eligible rows via the shared, idempotent backfill in
-:mod:`fighthealthinsurance.appeal_fingerprints`.
+review). This fills eligible rows.
 
-MIXED-VERSION SAFETY (external review): this migration runs while OLD
-writer processes (whose save() does not fingerprint) may still be
-inserting rows behind its cursor, so it cannot be the last word:
+FROZEN ON PURPOSE: this migration carries its own copy of the normalization
+and fill logic instead of importing :mod:`fighthealthinsurance.appeal_fingerprints`.
+A migration must keep doing exactly what it did when it first ran; the
+importable module is the LIVE copy used by the post-rollout command and may
+evolve. If the normalization ever changes, that is a new re-key migration,
+not an edit here (external review).
+
+MIXED-VERSION SAFETY: this runs while OLD writer processes (whose save()
+does not fingerprint) may still be inserting rows behind its cursor, so it
+cannot be the last word:
 
 - ``atomic = False`` + per-row handling means a concurrent writer racing
   one row skips that row instead of rolling back the whole migration.
-- After the deployment completes and old writers are drained, ops re-runs
-  the same backfill with ``python manage.py backfill_appeal_fingerprints``
-  and audits the remaining NULLs (the command prints counts). Only after
-  that re-run does ``chosen=False, text_fingerprint IS NULL`` mean
-  exactly "known historical duplicate".
+- The deploy script waits for every writer Deployment and the Ray cluster
+  to finish rolling, then runs ``backfill_appeal_fingerprints --strict``
+  (a Job with backoff), which re-fills, re-verifies every fingerprint
+  against its current text, and fails until the table is quiescent.
 
 Collision policy: a row whose fingerprint is already taken for its denial
 stays NULL -- those are the historical double-stores; nothing is deleted,
-and journey counting excludes NULL rows.
-
-Chosen rows are skipped: they are deliberate copies of the picked draft
-(see ``ProposedAppeal.save``) and carry no fingerprint by design.
-
-The shared module touches only stable columns (id, appeal_text,
-for_denial_id, text_fingerprint, chosen), so handing it the historical
-model is safe.
+and journey counting excludes NULL rows. Chosen rows are skipped: they are
+deliberate copies of the picked draft and carry no fingerprint by design.
 """
 
-from django.db import migrations
+import hashlib
 
-from fighthealthinsurance.appeal_fingerprints import run_backfill
+from django.db import IntegrityError, migrations, transaction
+
+
+def _fingerprint(text):
+    if not text or not str(text).strip():
+        return None
+    normalized = " ".join(str(text).lower().split())
+    return hashlib.sha256(normalized.encode()).hexdigest()
+
+
+def _fill_row(ProposedAppeal, pk, attempts=3):
+    # Fresh read per attempt; the UPDATE is guarded by the observed text and
+    # denial so a concurrent edit can never attach a stale fingerprint.
+    for _ in range(attempts):
+        row = (
+            ProposedAppeal.objects.filter(
+                pk=pk, text_fingerprint__isnull=True, chosen=False
+            )
+            .only("id", "appeal_text", "for_denial_id")
+            .first()
+        )
+        if row is None:
+            return
+        fp = _fingerprint(row.appeal_text)
+        if fp is None:
+            return
+        if (
+            ProposedAppeal.objects.filter(
+                for_denial_id=row.for_denial_id, text_fingerprint=fp
+            )
+            .exclude(pk=pk)
+            .exists()
+        ):
+            return  # known duplicate: deliberately left NULL
+        try:
+            with transaction.atomic():
+                updated = ProposedAppeal.objects.filter(
+                    pk=pk,
+                    text_fingerprint__isnull=True,
+                    appeal_text=row.appeal_text,
+                    for_denial_id=row.for_denial_id,
+                ).update(text_fingerprint=fp)
+        except IntegrityError:
+            return
+        if updated:
+            return
 
 
 def backfill_fingerprints(apps, schema_editor):
-    run_backfill(apps.get_model("fighthealthinsurance", "ProposedAppeal"))
+    ProposedAppeal = apps.get_model("fighthealthinsurance", "ProposedAppeal")
+    pks = list(
+        ProposedAppeal.objects.filter(text_fingerprint__isnull=True, chosen=False)
+        .order_by("id")
+        .values_list("id", flat=True)
+    )
+    for pk in pks:
+        _fill_row(ProposedAppeal, pk)
 
 
 class Migration(migrations.Migration):

--- a/fighthealthinsurance/migrations/0202_backfill_proposedappeal_fingerprints.py
+++ b/fighthealthinsurance/migrations/0202_backfill_proposedappeal_fingerprints.py
@@ -3,60 +3,47 @@
 0201 added the fingerprint column and the partial unique constraint but
 left legacy rows NULL -- and NULL rows are exempt from the constraint, so
 a retry regenerating a legacy draft's text could store it again (external
-review). This fills eligible rows.
+review). This fills eligible rows via the shared, idempotent backfill in
+:mod:`fighthealthinsurance.appeal_fingerprints`.
 
-Collision policy: when a row's computed fingerprint is already taken for
-its denial (an already-fingerprinted twin, or an earlier row in this same
-pass), the row is left NULL. Those are precisely the historical
-double-stores; nothing is deleted, but journey counting treats NULL as
-"known legacy duplicate" and excludes it, so three copies of one draft no
-longer satisfy the three-draft target.
+MIXED-VERSION SAFETY (external review): this migration runs while OLD
+writer processes (whose save() does not fingerprint) may still be
+inserting rows behind its cursor, so it cannot be the last word:
+
+- ``atomic = False`` + per-row handling means a concurrent writer racing
+  one row skips that row instead of rolling back the whole migration.
+- After the deployment completes and old writers are drained, ops re-runs
+  the same backfill with ``python manage.py backfill_appeal_fingerprints``
+  and audits the remaining NULLs (the command prints counts). Only after
+  that re-run does ``chosen=False, text_fingerprint IS NULL`` mean
+  exactly "known historical duplicate".
+
+Collision policy: a row whose fingerprint is already taken for its denial
+stays NULL -- those are the historical double-stores; nothing is deleted,
+and journey counting excludes NULL rows.
 
 Chosen rows are skipped: they are deliberate copies of the picked draft
 (see ``ProposedAppeal.save``) and carry no fingerprint by design.
-"""
 
-import hashlib
+The shared module touches only stable columns (id, appeal_text,
+for_denial_id, text_fingerprint, chosen), so handing it the historical
+model is safe.
+"""
 
 from django.db import migrations
 
-
-def _fingerprint(text):
-    # Frozen copy of ProposedAppeal.fingerprint's normalization: migrations
-    # must not drift with future model-code changes.
-    if not text or not str(text).strip():
-        return None
-    normalized = " ".join(str(text).lower().split())
-    return hashlib.sha256(normalized.encode()).hexdigest()
+from fighthealthinsurance.appeal_fingerprints import run_backfill
 
 
 def backfill_fingerprints(apps, schema_editor):
-    ProposedAppeal = apps.get_model("fighthealthinsurance", "ProposedAppeal")
-    taken = set()  # (denial_id, fingerprint) claimed during this pass
-    qs = (
-        ProposedAppeal.objects.filter(text_fingerprint__isnull=True, chosen=False)
-        .order_by("id")
-        .only("id", "appeal_text", "for_denial_id")
-    )
-    for row in qs.iterator(chunk_size=500):
-        fp = _fingerprint(row.appeal_text)
-        if fp is None:
-            continue
-        key = (row.for_denial_id, fp)
-        if (
-            key in taken
-            or ProposedAppeal.objects.filter(
-                for_denial_id=row.for_denial_id, text_fingerprint=fp
-            )
-            .exclude(pk=row.pk)
-            .exists()
-        ):
-            continue  # duplicate content: stays NULL (see module docstring)
-        taken.add(key)
-        ProposedAppeal.objects.filter(pk=row.pk).update(text_fingerprint=fp)
+    run_backfill(apps.get_model("fighthealthinsurance", "ProposedAppeal"))
 
 
 class Migration(migrations.Migration):
+
+    # Deliberately non-atomic: each row commits independently so one lost
+    # race with a live writer cannot roll back the entire backfill.
+    atomic = False
 
     dependencies = [
         ("fighthealthinsurance", "0201_proposedappeal_text_fingerprint"),

--- a/fighthealthinsurance/migrations/0202_backfill_proposedappeal_fingerprints.py
+++ b/fighthealthinsurance/migrations/0202_backfill_proposedappeal_fingerprints.py
@@ -1,0 +1,67 @@
+"""Backfill ``text_fingerprint`` for rows that predate the field.
+
+0201 added the fingerprint column and the partial unique constraint but
+left legacy rows NULL -- and NULL rows are exempt from the constraint, so
+a retry regenerating a legacy draft's text could store it again (external
+review). This fills eligible rows.
+
+Collision policy: when a row's computed fingerprint is already taken for
+its denial (an already-fingerprinted twin, or an earlier row in this same
+pass), the row is left NULL. Those are precisely the historical
+double-stores; nothing is deleted, but journey counting treats NULL as
+"known legacy duplicate" and excludes it, so three copies of one draft no
+longer satisfy the three-draft target.
+
+Chosen rows are skipped: they are deliberate copies of the picked draft
+(see ``ProposedAppeal.save``) and carry no fingerprint by design.
+"""
+
+import hashlib
+
+from django.db import migrations
+
+
+def _fingerprint(text):
+    # Frozen copy of ProposedAppeal.fingerprint's normalization: migrations
+    # must not drift with future model-code changes.
+    if not text or not str(text).strip():
+        return None
+    normalized = " ".join(str(text).lower().split())
+    return hashlib.sha256(normalized.encode()).hexdigest()
+
+
+def backfill_fingerprints(apps, schema_editor):
+    ProposedAppeal = apps.get_model("fighthealthinsurance", "ProposedAppeal")
+    taken = set()  # (denial_id, fingerprint) claimed during this pass
+    qs = (
+        ProposedAppeal.objects.filter(text_fingerprint__isnull=True, chosen=False)
+        .order_by("id")
+        .only("id", "appeal_text", "for_denial_id")
+    )
+    for row in qs.iterator(chunk_size=500):
+        fp = _fingerprint(row.appeal_text)
+        if fp is None:
+            continue
+        key = (row.for_denial_id, fp)
+        if (
+            key in taken
+            or ProposedAppeal.objects.filter(
+                for_denial_id=row.for_denial_id, text_fingerprint=fp
+            )
+            .exclude(pk=row.pk)
+            .exists()
+        ):
+            continue  # duplicate content: stays NULL (see module docstring)
+        taken.add(key)
+        ProposedAppeal.objects.filter(pk=row.pk).update(text_fingerprint=fp)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("fighthealthinsurance", "0201_proposedappeal_text_fingerprint"),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_fingerprints, migrations.RunPython.noop),
+    ]

--- a/fighthealthinsurance/models.py
+++ b/fighthealthinsurance/models.py
@@ -2640,6 +2640,27 @@ class ProposedAppeal(ExportModelOperationsMixin("ProposedAppeal"), models.Model)
         normalized = " ".join(str(text).lower().split())
         return hashlib.sha256(normalized.encode()).hexdigest()
 
+    # Sentinel: the row was loaded without appeal_text (deferred), so save()
+    # cannot tell whether the text changed.
+    _TEXT_UNLOADED = object()
+
+    @classmethod
+    def from_db(
+        cls,
+        db: typing.Any,
+        field_names: typing.Any,
+        values: typing.Any,
+        **kwargs: typing.Any,
+    ) -> "ProposedAppeal":
+        instance = super().from_db(db, field_names, values, **kwargs)
+        # Snapshot for save(): distinguishes a REAL text edit on a legacy
+        # NULL-fingerprint row from an unrelated-field save (deferred
+        # appeal_text is absent from __dict__ and stays unknown).
+        instance._loaded_appeal_text = instance.__dict__.get(
+            "appeal_text", cls._TEXT_UNLOADED
+        )
+        return instance
+
     def save(self, *args, **kwargs):
         # Every un-chosen row carries a content fingerprint that MATCHES its
         # current text, no matter which code path wrote it (live save_appeal,
@@ -2650,24 +2671,41 @@ class ProposedAppeal(ExportModelOperationsMixin("ProposedAppeal"), models.Model)
         # - chosen rows: deliberate COPIES of the picked draft
         #   (mark_proposal_chosen); a fingerprint would collide with the
         #   original draft's row, so it is cleared.
-        # - existing un-chosen rows already NULL: the backfill migration's
-        #   known-legacy-duplicate marker; recomputing would trip the
-        #   constraint on an unrelated field save, so NULL stays.
+        # - existing un-chosen rows already NULL (the backfill's
+        #   known-legacy-duplicate marker): NULL is preserved for saves that
+        #   do not change the text, so touching an unrelated field cannot
+        #   trip the constraint against the row's fingerprinted twin -- but
+        #   an ACTUAL text edit re-keys the row, because edited-to-unique
+        #   content must rejoin the constraint and journey counting
+        #   (external review).
         # - everything else: recomputed from the current text.
+        update_fields = kwargs.get("update_fields")
         if self.chosen:
             desired = None
         elif self.text_fingerprint is None and not self._state.adding:
-            desired = None
+            loaded = getattr(self, "_loaded_appeal_text", self._TEXT_UNLOADED)
+            if loaded is not self._TEXT_UNLOADED:
+                text_changed = self.appeal_text != loaded
+            else:
+                # Text state unknown (deferred load / detached instance):
+                # trust an explicit update_fields declaration, else preserve.
+                text_changed = update_fields is not None and "appeal_text" in set(
+                    update_fields
+                )
+            desired = (
+                ProposedAppeal.fingerprint(self.appeal_text) if text_changed else None
+            )
         else:
             desired = ProposedAppeal.fingerprint(self.appeal_text)
         if desired != self.text_fingerprint:
             self.text_fingerprint = desired
-            update_fields = kwargs.get("update_fields")
             if update_fields is not None:
                 # A partial save that changed appeal_text must persist the
                 # re-key too, not just set it in memory.
                 kwargs["update_fields"] = set(update_fields) | {"text_fingerprint"}
         super().save(*args, **kwargs)
+        # The persisted text is now the comparison baseline for later saves.
+        self._loaded_appeal_text = self.appeal_text
 
     def __str__(self):
         if self.appeal_text is not None:

--- a/fighthealthinsurance/models.py
+++ b/fighthealthinsurance/models.py
@@ -2641,17 +2641,32 @@ class ProposedAppeal(ExportModelOperationsMixin("ProposedAppeal"), models.Model)
         return hashlib.sha256(normalized.encode()).hexdigest()
 
     def save(self, *args, **kwargs):
-        # Every un-chosen row carries a content fingerprint, no matter which
-        # code path wrote it (live save_appeal, speculative precompute,
-        # admin, tests) -- otherwise the unique constraint above only
-        # protects the paths that remembered to set it (external review).
-        # Chosen rows are deliberate COPIES of the draft the user picked
-        # (mark_proposal_chosen), so a fingerprint there would collide with
-        # the original draft's row; they stay NULL by design. Filled only
-        # when unset: a later text edit on an existing row keeps its
-        # original fingerprint rather than silently re-keying the row.
-        if not self.chosen and self.text_fingerprint is None:
-            self.text_fingerprint = ProposedAppeal.fingerprint(self.appeal_text)
+        # Every un-chosen row carries a content fingerprint that MATCHES its
+        # current text, no matter which code path wrote it (live save_appeal,
+        # speculative precompute, admin, tests) -- otherwise the unique
+        # constraint above only protects the paths that remembered to set it,
+        # and an edited row would keep a stale key (external review). The
+        # cases:
+        # - chosen rows: deliberate COPIES of the picked draft
+        #   (mark_proposal_chosen); a fingerprint would collide with the
+        #   original draft's row, so it is cleared.
+        # - existing un-chosen rows already NULL: the backfill migration's
+        #   known-legacy-duplicate marker; recomputing would trip the
+        #   constraint on an unrelated field save, so NULL stays.
+        # - everything else: recomputed from the current text.
+        if self.chosen:
+            desired = None
+        elif self.text_fingerprint is None and not self._state.adding:
+            desired = None
+        else:
+            desired = ProposedAppeal.fingerprint(self.appeal_text)
+        if desired != self.text_fingerprint:
+            self.text_fingerprint = desired
+            update_fields = kwargs.get("update_fields")
+            if update_fields is not None:
+                # A partial save that changed appeal_text must persist the
+                # re-key too, not just set it in memory.
+                kwargs["update_fields"] = set(update_fields) | {"text_fingerprint"}
         super().save(*args, **kwargs)
 
     def __str__(self):

--- a/fighthealthinsurance/models.py
+++ b/fighthealthinsurance/models.py
@@ -2640,6 +2640,20 @@ class ProposedAppeal(ExportModelOperationsMixin("ProposedAppeal"), models.Model)
         normalized = " ".join(str(text).lower().split())
         return hashlib.sha256(normalized.encode()).hexdigest()
 
+    def save(self, *args, **kwargs):
+        # Every un-chosen row carries a content fingerprint, no matter which
+        # code path wrote it (live save_appeal, speculative precompute,
+        # admin, tests) -- otherwise the unique constraint above only
+        # protects the paths that remembered to set it (external review).
+        # Chosen rows are deliberate COPIES of the draft the user picked
+        # (mark_proposal_chosen), so a fingerprint there would collide with
+        # the original draft's row; they stay NULL by design. Filled only
+        # when unset: a later text edit on an existing row keeps its
+        # original fingerprint rather than silently re-keying the row.
+        if not self.chosen and self.text_fingerprint is None:
+            self.text_fingerprint = ProposedAppeal.fingerprint(self.appeal_text)
+        super().save(*args, **kwargs)
+
     def __str__(self):
         if self.appeal_text is not None:
             return f"{self.appeal_text[0:100]}"

--- a/fighthealthinsurance/models.py
+++ b/fighthealthinsurance/models.py
@@ -2680,6 +2680,16 @@ class ProposedAppeal(ExportModelOperationsMixin("ProposedAppeal"), models.Model)
         #   (external review).
         # - everything else: recomputed from the current text.
         update_fields = kwargs.get("update_fields")
+        if update_fields is not None and not (
+            {"appeal_text", "chosen"} & set(update_fields)
+        ):
+            # A partial save that persists neither source field must not
+            # touch the fingerprint: hashing an in-memory text change that
+            # is NOT being written would store a fingerprint for text the
+            # row does not hold (review). Leave both the column and the
+            # loaded-text baseline exactly as they are.
+            super().save(*args, **kwargs)
+            return
         if self.chosen:
             desired = None
         elif self.text_fingerprint is None and not self._state.adding:

--- a/k8s/temporal/backfill-fingerprints-job.yaml
+++ b/k8s/temporal/backfill-fingerprints-job.yaml
@@ -22,6 +22,17 @@ spec:
       labels:
         group: fight-health-insurance-prod-webbackend-batch
     spec:
+      # Non-root with a read-only root filesystem, mirroring the
+      # web-extralink-prefetch Job in k8s/deploy.yaml: the same image already
+      # runs that way, so this posture is proven for this image rather than
+      # aspirational. The backfill writes only to Postgres and stdout; /tmp
+      # is mounted writable because Python and the Django startup path may
+      # still want scratch space (external review).
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - image: ${FHI_BASE}:${FHI_VERSION}
           name: totallylegitco
@@ -40,14 +51,17 @@ spec:
             - secretRef:
                 name: fight-health-insurance-primary-secret
           imagePullPolicy: Always
-          # Same partial hardening as the worker manifests: no privilege
-          # escalation, all capabilities dropped, default seccomp.
-          # runAsNonRoot / readOnlyRootFilesystem stay deferred with the
-          # rest of the fleet -- the image entrypoint runs as root today.
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]
             seccompProfile:
               type: RuntimeDefault
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
       restartPolicy: OnFailure

--- a/k8s/temporal/backfill-fingerprints-job.yaml
+++ b/k8s/temporal/backfill-fingerprints-job.yaml
@@ -1,0 +1,43 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  # Post-rollout second pass of the ProposedAppeal fingerprint backfill.
+  # Migration 0202 (run by the web-migrations Job) races writer pods still
+  # on pre-fingerprint code; this Job re-runs the backfill in --strict mode,
+  # which exits non-zero while such writers are still active, so the Job's
+  # backoff keeps retrying until a pass comes back quiet. That makes "run
+  # again after old pods drain" deployment machinery rather than a doc
+  # note (external review). Applied by scripts/build.sh after the worker
+  # manifests; Jobs are immutable, so build.sh deletes any previous run
+  # first.
+  name: fhi-backfill-appeal-fingerprints
+  namespace: totallylegitco
+spec:
+  ttlSecondsAfterFinished: 3600
+  # Retries with exponential backoff (capped at 6 min) over roughly the
+  # length of a rollout; a Job that exhausts this is an alert, not a shrug.
+  backoffLimit: 40
+  template:
+    metadata:
+      labels:
+        group: fight-health-insurance-prod-webbackend-batch
+    spec:
+      containers:
+        - image: ${FHI_BASE}:${FHI_VERSION}
+          name: totallylegitco
+          # start-server.sh runs the strict backfill when this is set.
+          env:
+            - name: BACKFILL_APPEAL_FINGERPRINTS
+              value: "1"
+            - name: PDBHOST
+              valueFrom:
+                configMapKeyRef:
+                  name: fhi-db-config
+                  key: PDBHOST
+          envFrom:
+            - secretRef:
+                name: fight-health-insurance-secret
+            - secretRef:
+                name: fight-health-insurance-primary-secret
+          imagePullPolicy: Always
+      restartPolicy: OnFailure

--- a/k8s/temporal/backfill-fingerprints-job.yaml
+++ b/k8s/temporal/backfill-fingerprints-job.yaml
@@ -40,4 +40,14 @@ spec:
             - secretRef:
                 name: fight-health-insurance-primary-secret
           imagePullPolicy: Always
+          # Same partial hardening as the worker manifests: no privilege
+          # escalation, all capabilities dropped, default seccomp.
+          # runAsNonRoot / readOnlyRootFilesystem stay deferred with the
+          # rest of the fleet -- the image entrypoint runs as root today.
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
       restartPolicy: OnFailure

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -174,6 +174,13 @@ kubectl -n totallylegitco wait --for=condition=Ready pod -l ray.io/cluster=raycl
   || { echo "Ray cluster pods not Ready; not running the fingerprint backfill Job"; exit 1; }
 kubectl delete job fhi-backfill-appeal-fingerprints -n totallylegitco --ignore-not-found
 envsubst < k8s/temporal/backfill-fingerprints-job.yaml | kubectl apply -f -
+# Wait for the strict backfill to COMPLETE and fail the deploy if it cannot.
+# Every writer rollout was awaited above, so a Job that does not finish
+# inside this window means either a writer on old code is still active or
+# the verify pass keeps finding fingerprints to repair -- both are deploy
+# problems to look at, not background noise to leave retrying unattended.
+kubectl -n totallylegitco wait --for=condition=complete job/fhi-backfill-appeal-fingerprints --timeout=30m \
+  || { echo "Fingerprint backfill Job did not complete within 30m; inspect it: kubectl -n totallylegitco logs job/fhi-backfill-appeal-fingerprints"; exit 1; }
 
 # In-cluster scraping of the app's /metrics (which is no longer reachable from
 # the internet -- see docs/metrics-endpoint-access.md). The apply is skipped

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -151,6 +151,27 @@ envsubst < k8s/temporal/appeal-worker.yaml | kubectl apply -f -
 # pre-fingerprint writer is left, so the "run again after old pods drain"
 # step is enforced by the deploy, not by a README. Jobs are immutable:
 # delete the previous run before applying.
+#
+# ROLLOUT GATE (external review): a strict pass that runs while ANY pod on
+# pre-fingerprint code can still handle a request proves nothing -- two quiet
+# scans succeed, then an idle old pod inserts a NULL fingerprint or edits text
+# under a stale one. So wait for every ProposedAppeal writer to finish rolling
+# (rollout status returns only after new replicas are available AND the old
+# ReplicaSet's pods are gone): the web Deployment, both Temporal workers, and
+# the Ray cluster (its SpeculativeAppealsActor writes speculative drafts; the
+# cluster was deleted + recreated above, so readiness of the new pods means the
+# old ones are gone). A rollout that does not finish fails the deploy here
+# rather than letting the Job run against a mixed fleet.
+for dep in web fhi-fax-worker fhi-appeal-worker; do
+  if kubectl -n totallylegitco get deployment "$dep" >/dev/null 2>&1; then
+    kubectl -n totallylegitco rollout status deployment "$dep" --timeout=15m \
+      || { echo "Rollout of $dep did not complete; not running the fingerprint backfill Job"; exit 1; }
+  else
+    echo "Deployment $dep not present; skipping rollout wait"
+  fi
+done
+kubectl -n totallylegitco wait --for=condition=Ready pod -l ray.io/cluster=raycluster-kuberay --timeout=15m \
+  || { echo "Ray cluster pods not Ready; not running the fingerprint backfill Job"; exit 1; }
 kubectl delete job fhi-backfill-appeal-fingerprints -n totallylegitco --ignore-not-found
 envsubst < k8s/temporal/backfill-fingerprints-job.yaml | kubectl apply -f -
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -142,7 +142,17 @@ envsubst < k8s/temporal/worker.yaml | kubectl apply -f -
 # accepts workflow starts for a queue with NO pollers and queues them
 # silently, so an applied-by-hand-once appeal worker (or a forgotten one)
 # would look healthy while nothing executes (external review).
+# This apply must stay ABOVE the rollout gate below, which waits on this very
+# Deployment: waiting first would either time out on a Deployment that does
+# not exist yet or, worse, pass against the previous image.
 envsubst < k8s/temporal/appeal-worker.yaml | kubectl apply -f -
+# Post-rollout second pass of the appeal fingerprint backfill (see the Job
+# manifest): --strict keeps failing -- and the Job keeps retrying -- until no
+# pre-fingerprint writer is left, so the "run again after old pods drain"
+# step is enforced by the deploy, not by a README. Jobs are immutable:
+# delete the previous run before applying.
+kubectl delete job fhi-backfill-appeal-fingerprints -n totallylegitco --ignore-not-found
+envsubst < k8s/temporal/backfill-fingerprints-job.yaml | kubectl apply -f -
 
 # In-cluster scraping of the app's /metrics (which is no longer reachable from
 # the internet -- see docs/metrics-endpoint-access.md). The apply is skipped

--- a/scripts/start-server.sh
+++ b/scripts/start-server.sh
@@ -43,6 +43,12 @@ elif [ -n "$PREFETCH_EXTRALINKS" ]; then
   python manage.py launch_prefetch_actor || echo "Pre-fetch failed (non-blocking)"
   sleep 10
   exit 0
+elif [ -n "$BACKFILL_APPEAL_FINGERPRINTS" ]; then
+  # Post-rollout Job (k8s/temporal/backfill-fingerprints-job.yaml): second
+  # pass of the ProposedAppeal fingerprint backfill. --strict exits non-zero
+  # while pre-fingerprint writers are still active, so the Job's backoff
+  # retries until the database is quiescent.
+  exec python manage.py backfill_appeal_fingerprints --strict
 elif [ -n "$TEMPORAL_WORKER" ]; then
   # Long-running Temporal worker hosting SendFaxWorkflow + fax activities.
   # Unlike the Ray launchers above this stays in the foreground; exec so signals

--- a/tests/async-unit/test_appeal_journey_core.py
+++ b/tests/async-unit/test_appeal_journey_core.py
@@ -209,3 +209,107 @@ class TestCandidateCounting(_JourneyTestBase):
             appeal_journey_core.precheck_appeal_journey(denial)
             == appeal_journey_core.STATUS_OK
         )
+
+
+class TestFingerprintCompleteness(_JourneyTestBase):
+    """The distinct-fingerprint counting rules from the external review:
+    duplicate rows are one draft, and every write path fingerprints."""
+
+    def test_unchosen_rows_fingerprint_themselves_on_save(self):
+        denial = _make_denial(9108)
+        row = ProposedAppeal.objects.create(
+            for_denial=denial,
+            appeal_text="Dear Reviewer, a real draft with enough words to count.",
+        )
+        assert row.text_fingerprint == ProposedAppeal.fingerprint(row.appeal_text)
+
+    def test_chosen_rows_carry_no_fingerprint(self):
+        """A chosen row is a COPY of the picked draft; a fingerprint there
+        would collide with the original draft's row."""
+        denial = _make_denial(9109)
+        row = ProposedAppeal.objects.create(
+            for_denial=denial,
+            appeal_text="The letter the user picked.",
+            chosen=True,
+        )
+        assert row.text_fingerprint is None
+
+    def test_legacy_duplicate_rows_do_not_satisfy_the_precheck(self):
+        """Three NULL-fingerprint copies of one letter (the pre-constraint
+        double-store shape; bulk_create bypasses save() exactly like the old
+        writers bypassed fingerprinting) are not three drafts."""
+        denial = _make_denial(9110)
+        letter = (
+            "Dear Reviewer, this appeal contests the denial because my "
+            "physician documented medical necessity across repeated visits."
+        )
+        ProposedAppeal.objects.bulk_create(
+            ProposedAppeal(for_denial=denial, appeal_text=letter) for _ in range(3)
+        )
+        assert (
+            appeal_journey_core.precheck_appeal_journey(denial)
+            == appeal_journey_core.STATUS_OK
+        )
+
+    def test_three_distinct_drafts_satisfy_the_precheck(self):
+        denial = _make_denial(9111)
+        for i in ("first", "second", "third"):
+            ProposedAppeal.objects.create(
+                for_denial=denial,
+                appeal_text=(
+                    f"Dear Reviewer, the {i} distinct appeal citing the plan's "
+                    "own coverage policy and my documented treatment history."
+                ),
+            )
+        assert (
+            appeal_journey_core.precheck_appeal_journey(denial)
+            == appeal_journey_core.STATUS_ALREADY_HAS_APPEALS
+        )
+
+    def test_duplicate_content_cannot_be_stored_twice(self):
+        """With save() fingerprinting every un-chosen row, the partial unique
+        constraint now binds ALL writers, not just save_appeal."""
+        import pytest as _pytest
+        from django.db import IntegrityError
+
+        denial = _make_denial(9112)
+        text = "Dear Reviewer, the same letter twice must be one row."
+        ProposedAppeal.objects.create(for_denial=denial, appeal_text=text)
+        with _pytest.raises(IntegrityError):
+            ProposedAppeal.objects.create(
+                for_denial=denial, appeal_text="  dear   reviewer, THE same "
+                "letter twice must be one row."
+            )
+
+    def test_backfill_fingerprints_skips_duplicates_and_fills_the_rest(self):
+        """The 0202 data migration: legacy NULL rows get fingerprints; a
+        duplicate of an already-claimed fingerprint stays NULL (the
+        known-legacy-duplicate marker the counting rules exclude)."""
+        import importlib
+
+        backfill = importlib.import_module(
+            "fighthealthinsurance.migrations.0202_backfill_proposedappeal_fingerprints"
+        ).backfill_fingerprints
+        from django.apps import apps
+
+        denial = _make_denial(9113)
+        letter = "Dear Reviewer, one letter stored twice in the legacy era."
+        other = "Dear Reviewer, a different letter from the same era."
+        ProposedAppeal.objects.bulk_create(
+            [
+                ProposedAppeal(for_denial=denial, appeal_text=letter),
+                ProposedAppeal(for_denial=denial, appeal_text=letter),
+                ProposedAppeal(for_denial=denial, appeal_text=other),
+            ]
+        )
+        backfill(apps, None)
+        fps = list(
+            ProposedAppeal.objects.filter(for_denial=denial).values_list(
+                "text_fingerprint", flat=True
+            )
+        )
+        assert fps.count(None) == 1  # the duplicate copy stays NULL
+        assert {f for f in fps if f is not None} == {
+            ProposedAppeal.fingerprint(letter),
+            ProposedAppeal.fingerprint(other),
+        }

--- a/tests/async-unit/test_appeal_journey_core.py
+++ b/tests/async-unit/test_appeal_journey_core.py
@@ -685,3 +685,62 @@ class TestFingerprintCompleteness(_JourneyTestBase):
             return_value={"rekeyed": 0, "mismatch_duplicate": 0, "checked": 5},
         ):
             call_command("backfill_appeal_fingerprints", "--strict")
+
+    def test_review_scenario_stale_key_after_old_pod_edit_is_repaired_end_to_end(self):
+        """Review 10's exact chain: rows A/B/C each fingerprinted; a pod on
+        old code edits C's text to A's, leaving fp(C) in place. Strict must
+        fail on the first run (a repair happened), C's fingerprint must be
+        NULL afterwards (known duplicate, not a third distinct draft), the
+        retry must pass, and the journey precheck must see TWO drafts."""
+        from django.core.management import call_command
+        from django.core.management.base import CommandError
+
+        denial = _make_denial(9128)
+        text_a = "Dear Reviewer, letter A about documented medical necessity."
+        text_b = "Dear Reviewer, letter B about the plan's own coverage policy."
+        text_c = "Dear Reviewer, letter C requesting an independent review."
+        row_a = ProposedAppeal.objects.create(for_denial=denial, appeal_text=text_a)
+        ProposedAppeal.objects.create(for_denial=denial, appeal_text=text_b)
+        row_c = ProposedAppeal.objects.create(for_denial=denial, appeal_text=text_c)
+        fp_c = row_c.text_fingerprint
+        assert fp_c is not None
+        # Old-pod edit: text changes, fingerprint left behind.
+        ProposedAppeal.objects.filter(pk=row_c.pk).update(appeal_text=text_a)
+
+        with pytest.raises(CommandError):
+            call_command("backfill_appeal_fingerprints", "--strict")
+        row_c.refresh_from_db()
+        assert row_c.text_fingerprint is None
+        row_a.refresh_from_db()
+        assert row_a.text_fingerprint == ProposedAppeal.fingerprint(text_a)
+
+        call_command("backfill_appeal_fingerprints", "--strict")  # retry: quiet
+
+        distinct = set(
+            ProposedAppeal.objects.filter(
+                for_denial=denial, chosen=False, text_fingerprint__isnull=False
+            ).values_list("text_fingerprint", flat=True)
+        )
+        assert len(distinct) == 2
+        assert (
+            appeal_journey_core.precheck_appeal_journey(denial)
+            == appeal_journey_core.STATUS_OK  # 2 < TARGET_APPEALS: not "done"
+        )
+
+
+def test_deploy_script_waits_for_the_strict_backfill_job():
+    """build.sh must not just apply the strict backfill Job -- it must wait
+    for it to complete and fail the deploy otherwise (review 10)."""
+    import pathlib
+
+    root = pathlib.Path(__file__).resolve().parents[2]
+    build = (root / "scripts" / "build.sh").read_text()
+    apply_at = build.index("backfill-fingerprints-job.yaml | kubectl apply -f -")
+    wait_at = build.index(
+        "wait --for=condition=complete job/fhi-backfill-appeal-fingerprints"
+    )
+    assert wait_at > apply_at
+    assert "|| { echo" in build[wait_at : wait_at + 400]
+    assert "exit 1" in build[wait_at : wait_at + 400]
+    for dep in ("web", "fhi-fax-worker", "fhi-appeal-worker"):
+        assert f"rollout status deployment" in build and dep in build

--- a/tests/async-unit/test_appeal_journey_core.py
+++ b/tests/async-unit/test_appeal_journey_core.py
@@ -527,3 +527,73 @@ class TestFingerprintCompleteness(_JourneyTestBase):
                 call_command("backfill_appeal_fingerprints", "--strict")
         with _patch(target, side_effect=[busy, quiet]):
             call_command("backfill_appeal_fingerprints", "--strict")
+
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_legacy_duplicate_existing_rows_stream_once(self, mock_gen):
+        """Two legacy NULL-fingerprint twins are one draft: the existing-
+        rows loop streams the first and skips the second (review)."""
+        import json as _json
+
+        from asgiref.sync import async_to_sync
+
+        from fighthealthinsurance.common_view_logic import AppealsBackendHelper
+
+        denial = _make_denial(9123)
+        letter = (
+            "Dear Reviewer, this legacy letter was stored twice before the "
+            "fingerprint constraint existed and must stream only once."
+        )
+        ProposedAppeal.objects.bulk_create(
+            [ProposedAppeal(for_denial=denial, appeal_text=letter) for _ in range(2)]
+        )
+        mock_gen.make_appeals.return_value = iter([])
+
+        async def collect():
+            frames = []
+            async for chunk in AppealsBackendHelper.generate_appeals_for_denial(
+                denial
+            ):
+                if appeal_journey_core._appeal_text_from_chunk(chunk) is None:
+                    continue
+                data = _json.loads(chunk)
+                if "id" in data:
+                    frames.append(data)
+            return frames
+
+        assert len(async_to_sync(collect)()) == 1
+
+    def test_partial_save_excluding_text_leaves_fingerprint_alone(self):
+        """In-memory text change + save(update_fields=['model_name']) must
+        not persist a fingerprint for text the row does not hold (review)."""
+        denial = _make_denial(9124)
+        row = ProposedAppeal.objects.create(
+            for_denial=denial, appeal_text="Dear Reviewer, the stored text."
+        )
+        original_fp = row.text_fingerprint
+        row.appeal_text = "Dear Reviewer, an unsaved in-memory edit."
+        row.model_name = "fhi-internal"
+        row.save(update_fields=["model_name"])
+        row.refresh_from_db()
+        assert row.appeal_text == "Dear Reviewer, the stored text."
+        assert row.text_fingerprint == original_fp
+
+    def test_strict_backfill_fails_on_unclassified_null_rows(self):
+        from unittest.mock import patch as _patch
+
+        from django.core.management import call_command
+        from django.core.management.base import CommandError
+
+        quiet = {
+            "filled": 0,
+            "skipped_duplicate": 1,
+            "skipped_empty": 0,
+            "lost_race": 0,
+            "remaining_null": 1,
+        }
+        sneaky = dict(quiet, remaining_null=2)  # a NULL row the pass never saw
+        target = "fighthealthinsurance.management.commands.backfill_appeal_fingerprints.run_backfill"
+        with _patch(target, side_effect=[quiet, sneaky]):
+            with pytest.raises(CommandError):
+                call_command("backfill_appeal_fingerprints", "--strict")
+        with _patch(target, side_effect=[quiet, quiet]):
+            call_command("backfill_appeal_fingerprints", "--strict")

--- a/tests/async-unit/test_appeal_journey_core.py
+++ b/tests/async-unit/test_appeal_journey_core.py
@@ -435,3 +435,95 @@ class TestFingerprintCompleteness(_JourneyTestBase):
         dup.save()  # full save, text unchanged: must not recompute/collide
         dup.refresh_from_db()
         assert dup.text_fingerprint is None
+
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_variant_of_existing_draft_streams_once_against_one_row(self, mock_gen):
+        """Client-visible corruption from external review: an existing draft
+        is re-served, then the model emits a case/whitespace VARIANT. Exact-
+        string dedupe let it through, the insert collided on the normalized
+        fingerprint, and the variant streamed under the stored row's id --
+        two drafts on screen, one row in the database, one 'lost' on reload.
+        Frames, ids and rows must all agree."""
+        import json as _json
+
+        from asgiref.sync import async_to_sync
+
+        from fighthealthinsurance.common_view_logic import AppealsBackendHelper
+
+        denial = _make_denial(9121)
+        letter = (
+            "Dear Reviewer, this appeal contests the denial because my "
+            "physician documented medical necessity across repeated visits."
+        )
+        ProposedAppeal.objects.create(for_denial=denial, appeal_text=letter)
+        mock_gen.make_appeals.return_value = iter(_drafts([letter.upper()]))
+
+        async def collect():
+            frames = []
+            async for chunk in AppealsBackendHelper.generate_appeals_for_denial(
+                denial
+            ):
+                if appeal_journey_core._appeal_text_from_chunk(chunk) is None:
+                    continue
+                data = _json.loads(chunk)
+                if "id" in data:
+                    frames.append(data)
+            return frames
+
+        frames = async_to_sync(collect)()
+        assert len(frames) == 1, [f.get("id") for f in frames]
+        assert len({f["id"] for f in frames}) == 1
+        assert ProposedAppeal.objects.filter(for_denial=denial).count() == 1
+
+    def test_backfill_never_attaches_a_stale_fingerprint_to_edited_text(self):
+        """A concurrent edit between the backfill's read and its write must
+        not leave fp(A) on text B (external review). The write is guarded by
+        the observed text; a miss re-reads and recomputes."""
+        from unittest.mock import patch as _patch
+
+        from fighthealthinsurance import appeal_fingerprints
+
+        denial = _make_denial(9122)
+        text_a = "Dear Reviewer, the original legacy text before an edit."
+        text_b = "Dear Reviewer, the edited text that landed mid-backfill."
+        (row,) = ProposedAppeal.objects.bulk_create(
+            [ProposedAppeal(for_denial=denial, appeal_text=text_a)]
+        )
+        real = appeal_fingerprints.fingerprint_text
+        calls = {"n": 0}
+
+        def edit_between_read_and_write(text):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                # The "old worker" edits the row after the backfill read it.
+                ProposedAppeal.objects.filter(pk=row.pk).update(appeal_text=text_b)
+            return real(text)
+
+        with _patch.object(
+            appeal_fingerprints, "fingerprint_text", edit_between_read_and_write
+        ):
+            outcome = appeal_fingerprints.fill_row(ProposedAppeal, row.pk)
+        row.refresh_from_db()
+        assert outcome == appeal_fingerprints.FILLED
+        assert row.text_fingerprint == ProposedAppeal.fingerprint(text_b)
+
+    def test_strict_backfill_fails_while_writers_are_active(self):
+        from unittest.mock import patch as _patch
+
+        from django.core.management import call_command
+        from django.core.management.base import CommandError
+
+        quiet = {
+            "filled": 0,
+            "skipped_duplicate": 0,
+            "skipped_empty": 0,
+            "lost_race": 0,
+            "remaining_null": 0,
+        }
+        busy = dict(quiet, filled=2)
+        target = "fighthealthinsurance.management.commands.backfill_appeal_fingerprints.run_backfill"
+        with _patch(target, side_effect=[busy, busy]):
+            with pytest.raises(CommandError):
+                call_command("backfill_appeal_fingerprints", "--strict")
+        with _patch(target, side_effect=[busy, quiet]):
+            call_command("backfill_appeal_fingerprints", "--strict")

--- a/tests/async-unit/test_appeal_journey_core.py
+++ b/tests/async-unit/test_appeal_journey_core.py
@@ -597,3 +597,67 @@ class TestFingerprintCompleteness(_JourneyTestBase):
                 call_command("backfill_appeal_fingerprints", "--strict")
         with _patch(target, side_effect=[quiet, quiet]):
             call_command("backfill_appeal_fingerprints", "--strict")
+
+    def test_verify_rekeys_a_fingerprint_that_no_longer_matches_its_text(self):
+        """A pod on pre-fingerprint code can EDIT text under a stale
+        fingerprint (its save() never re-keys). NULL checks cannot see that;
+        the integrity pass must (review)."""
+        from fighthealthinsurance import appeal_fingerprints
+
+        denial = _make_denial(9125)
+        row = ProposedAppeal.objects.create(
+            for_denial=denial, appeal_text="Dear Reviewer, the text as first saved."
+        )
+        stale_fp = row.text_fingerprint
+        # Old-style edit: text changes, fingerprint left behind.
+        ProposedAppeal.objects.filter(pk=row.pk).update(
+            appeal_text="Dear Reviewer, the text after an old-pod edit."
+        )
+        counts = appeal_fingerprints.verify_fingerprints(ProposedAppeal)
+        row.refresh_from_db()
+        assert counts[appeal_fingerprints.REKEYED] == 1
+        assert row.text_fingerprint != stale_fp
+        assert row.text_fingerprint == ProposedAppeal.fingerprint(row.appeal_text)
+
+    def test_verify_leaves_a_mismatch_that_would_collide_as_duplicate(self):
+        from fighthealthinsurance import appeal_fingerprints
+
+        denial = _make_denial(9126)
+        keeper_text = "Dear Reviewer, the letter that already owns its key."
+        ProposedAppeal.objects.create(for_denial=denial, appeal_text=keeper_text)
+        other = ProposedAppeal.objects.create(
+            for_denial=denial, appeal_text="Dear Reviewer, a different letter."
+        )
+        stale_fp = other.text_fingerprint
+        # Old-style edit that makes `other` a twin of the keeper.
+        ProposedAppeal.objects.filter(pk=other.pk).update(appeal_text=keeper_text)
+        counts = appeal_fingerprints.verify_fingerprints(ProposedAppeal)
+        other.refresh_from_db()
+        assert counts[appeal_fingerprints.MISMATCH_DUPLICATE] == 1
+        assert other.text_fingerprint == stale_fp  # untouched, not collided
+
+    def test_strict_backfill_fails_when_verify_had_to_rekey(self):
+        from unittest.mock import patch as _patch
+
+        from django.core.management import call_command
+        from django.core.management.base import CommandError
+
+        quiet = {
+            "filled": 0,
+            "skipped_duplicate": 0,
+            "skipped_empty": 0,
+            "lost_race": 0,
+            "remaining_null": 0,
+        }
+        base = "fighthealthinsurance.management.commands.backfill_appeal_fingerprints."
+        with _patch(base + "run_backfill", side_effect=[quiet, quiet]), _patch(
+            base + "verify_fingerprints",
+            return_value={"rekeyed": 1, "mismatch_duplicate": 0, "checked": 5},
+        ):
+            with pytest.raises(CommandError):
+                call_command("backfill_appeal_fingerprints", "--strict")
+        with _patch(base + "run_backfill", side_effect=[quiet, quiet]), _patch(
+            base + "verify_fingerprints",
+            return_value={"rekeyed": 0, "mismatch_duplicate": 0, "checked": 5},
+        ):
+            call_command("backfill_appeal_fingerprints", "--strict")

--- a/tests/async-unit/test_appeal_journey_core.py
+++ b/tests/async-unit/test_appeal_journey_core.py
@@ -357,3 +357,51 @@ class TestFingerprintCompleteness(_JourneyTestBase):
         dup.refresh_from_db()
         assert dup.text_fingerprint is None
         assert keeper.pk != dup.pk
+
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_live_draft_matching_unserved_reserve_promotes_the_reserve(
+        self, mock_gen
+    ):
+        """A fast live generation can produce the same letter a speculative
+        reserve already holds. The insert conflicts on the fingerprint; the
+        reuse path must atomically PROMOTE the reserve row, or the streamed
+        draft's row stays speculative=True and the appeal the user just
+        watched disappears from every later read (external review)."""
+        denial = _make_denial(9117)
+        letter = (
+            "Dear Reviewer, the reserve and the live run agree on this "
+            "letter about documented medical necessity."
+        )
+        reserve = ProposedAppeal.objects.create(
+            for_denial=denial, appeal_text=letter, speculative=True
+        )
+        mock_gen.make_appeals.return_value = iter(_drafts([letter]))
+        with pytest.raises(appeal_journey_core.JourneyIncomplete):
+            # 1 durable draft < TARGET, so the postcondition still raises --
+            # the assertions below are the point.
+            appeal_journey_core.generate_and_store_appeals(denial)
+        reserve.refresh_from_db()
+        assert reserve.speculative is False
+        assert ProposedAppeal.objects.filter(for_denial=denial).count() == 1
+
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_case_variant_of_reserve_collides_and_promotes_not_duplicates(
+        self, mock_gen
+    ):
+        """Fingerprints are case/whitespace-normalized, so a trivial variant
+        of a reserve letter must also land on the reserve row (promoted),
+        never as a second near-identical draft."""
+        denial = _make_denial(9118)
+        letter = (
+            "Dear Reviewer, my physician documented repeated conservative "
+            "care before requesting this imaging study."
+        )
+        ProposedAppeal.objects.create(
+            for_denial=denial, appeal_text=letter, speculative=True
+        )
+        mock_gen.make_appeals.return_value = iter(_drafts([letter.upper()]))
+        with pytest.raises(appeal_journey_core.JourneyIncomplete):
+            appeal_journey_core.generate_and_store_appeals(denial)
+        rows = list(ProposedAppeal.objects.filter(for_denial=denial))
+        assert len(rows) == 1
+        assert rows[0].speculative is False

--- a/tests/async-unit/test_appeal_journey_core.py
+++ b/tests/async-unit/test_appeal_journey_core.py
@@ -405,3 +405,33 @@ class TestFingerprintCompleteness(_JourneyTestBase):
         rows = list(ProposedAppeal.objects.filter(for_denial=denial))
         assert len(rows) == 1
         assert rows[0].speculative is False
+
+    def test_legacy_null_row_edited_to_unique_text_rekeys(self):
+        """A legacy duplicate edited to genuinely new content must rejoin
+        the constraint and journey counting -- NULL is the marker for
+        known duplicates, not a permanent exemption (review)."""
+        denial = _make_denial(9119)
+        letter = "Dear Reviewer, the legacy letter stored twice back then."
+        ProposedAppeal.objects.create(for_denial=denial, appeal_text=letter)
+        (dup,) = ProposedAppeal.objects.bulk_create(
+            [ProposedAppeal(for_denial=denial, appeal_text=letter)]
+        )
+        dup = ProposedAppeal.objects.get(pk=dup.pk)
+        assert dup.text_fingerprint is None
+        dup.appeal_text = "Dear Reviewer, entirely new content after an edit."
+        dup.save(update_fields=["appeal_text"])
+        dup.refresh_from_db()
+        assert dup.text_fingerprint == ProposedAppeal.fingerprint(dup.appeal_text)
+
+    def test_legacy_null_row_full_save_with_unchanged_text_stays_null(self):
+        denial = _make_denial(9120)
+        letter = "Dear Reviewer, one more twice-stored legacy letter."
+        ProposedAppeal.objects.create(for_denial=denial, appeal_text=letter)
+        (dup,) = ProposedAppeal.objects.bulk_create(
+            [ProposedAppeal(for_denial=denial, appeal_text=letter)]
+        )
+        dup = ProposedAppeal.objects.get(pk=dup.pk)
+        dup.model_name = "fhi-internal"
+        dup.save()  # full save, text unchanged: must not recompute/collide
+        dup.refresh_from_db()
+        assert dup.text_fingerprint is None

--- a/tests/async-unit/test_appeal_journey_core.py
+++ b/tests/async-unit/test_appeal_journey_core.py
@@ -313,3 +313,47 @@ class TestFingerprintCompleteness(_JourneyTestBase):
             ProposedAppeal.fingerprint(letter),
             ProposedAppeal.fingerprint(other),
         }
+
+    def test_editing_an_unchosen_row_rekeys_its_fingerprint(self):
+        """A stale fingerprint would let the edited content be stored again
+        as a 'different' draft and block re-storing the original (review)."""
+        denial = _make_denial(9114)
+        row = ProposedAppeal.objects.create(
+            for_denial=denial, appeal_text="Dear Reviewer, the first version."
+        )
+        row.appeal_text = "Dear Reviewer, the edited version."
+        row.save()
+        row.refresh_from_db()
+        assert row.text_fingerprint == ProposedAppeal.fingerprint(
+            "Dear Reviewer, the edited version."
+        )
+
+    def test_partial_save_persists_the_rekey(self):
+        denial = _make_denial(9115)
+        row = ProposedAppeal.objects.create(
+            for_denial=denial, appeal_text="Dear Reviewer, before the edit."
+        )
+        row.appeal_text = "Dear Reviewer, after the edit."
+        row.save(update_fields=["appeal_text"])
+        row.refresh_from_db()
+        assert row.text_fingerprint == ProposedAppeal.fingerprint(
+            "Dear Reviewer, after the edit."
+        )
+
+    def test_legacy_null_row_survives_unrelated_saves(self):
+        """The backfill leaves duplicate rows NULL; a later save of some
+        other field must not recompute the fingerprint and trip the
+        constraint against the row's fingerprinted twin."""
+        denial = _make_denial(9116)
+        letter = "Dear Reviewer, the twice-stored legacy letter."
+        keeper = ProposedAppeal.objects.create(for_denial=denial, appeal_text=letter)
+        (dup,) = ProposedAppeal.objects.bulk_create(
+            [ProposedAppeal(for_denial=denial, appeal_text=letter)]
+        )
+        dup.refresh_from_db()
+        assert dup.text_fingerprint is None
+        dup.model_name = "fhi-internal"
+        dup.save()
+        dup.refresh_from_db()
+        assert dup.text_fingerprint is None
+        assert keeper.pk != dup.pk

--- a/tests/async-unit/test_appeal_journey_core.py
+++ b/tests/async-unit/test_appeal_journey_core.py
@@ -744,3 +744,27 @@ def test_deploy_script_waits_for_the_strict_backfill_job():
     assert "exit 1" in build[wait_at : wait_at + 400]
     for dep in ("web", "fhi-fax-worker", "fhi-appeal-worker"):
         assert f"rollout status deployment" in build and dep in build
+
+
+def test_backfill_job_runs_non_root_with_a_read_only_root_filesystem():
+    """The Job carries both production secret sets, so it gets the same
+    posture the web-extralink-prefetch Job already proves for this image:
+    non-root, read-only root filesystem, writable /tmp (external review)."""
+    import pathlib
+
+    import yaml
+
+    root = pathlib.Path(__file__).resolve().parents[2]
+    raw = (root / "k8s" / "temporal" / "backfill-fingerprints-job.yaml").read_text()
+    job = yaml.safe_load(raw.replace("${FHI_BASE}:${FHI_VERSION}", "image"))
+    pod = job["spec"]["template"]["spec"]
+    assert pod["securityContext"]["runAsNonRoot"] is True
+    assert pod["securityContext"]["runAsUser"] == 1000
+    container = pod["containers"][0]["securityContext"]
+    assert container["readOnlyRootFilesystem"] is True
+    assert container["allowPrivilegeEscalation"] is False
+    assert container["capabilities"]["drop"] == ["ALL"]
+    assert container["seccompProfile"]["type"] == "RuntimeDefault"
+    # A read-only root needs scratch space, exactly as the prefetch Job does.
+    assert {"name": "tmp", "mountPath": "/tmp"} in pod["containers"][0]["volumeMounts"]
+    assert any(v["name"] == "tmp" and "emptyDir" in v for v in pod["volumes"])

--- a/tests/async-unit/test_appeal_journey_core.py
+++ b/tests/async-unit/test_appeal_journey_core.py
@@ -619,7 +619,14 @@ class TestFingerprintCompleteness(_JourneyTestBase):
         assert row.text_fingerprint != stale_fp
         assert row.text_fingerprint == ProposedAppeal.fingerprint(row.appeal_text)
 
-    def test_verify_leaves_a_mismatch_that_would_collide_as_duplicate(self):
+    def test_verify_clears_a_mismatch_that_would_collide_to_null(self):
+        """An old-pod edit that turns a row into a twin of another row: the
+        stale fingerprint must not be LEFT in place (it would count the twin's
+        content twice). It is cleared to NULL -- the known-duplicate marker --
+        and counted as a repair, so strict mode retries (review)."""
+        from django.core.management import call_command
+        from django.core.management.base import CommandError
+
         from fighthealthinsurance import appeal_fingerprints
 
         denial = _make_denial(9126)
@@ -628,13 +635,30 @@ class TestFingerprintCompleteness(_JourneyTestBase):
         other = ProposedAppeal.objects.create(
             for_denial=denial, appeal_text="Dear Reviewer, a different letter."
         )
-        stale_fp = other.text_fingerprint
         # Old-style edit that makes `other` a twin of the keeper.
         ProposedAppeal.objects.filter(pk=other.pk).update(appeal_text=keeper_text)
-        counts = appeal_fingerprints.verify_fingerprints(ProposedAppeal)
+        # Strict mode: fill passes are quiet, verify repairs one row -> fail.
+        with pytest.raises(CommandError):
+            call_command("backfill_appeal_fingerprints", "--strict")
         other.refresh_from_db()
-        assert counts[appeal_fingerprints.MISMATCH_DUPLICATE] == 1
-        assert other.text_fingerprint == stale_fp  # untouched, not collided
+        assert other.text_fingerprint is None
+        # Retry (what the Job's backoff does): now quiescent.
+        call_command("backfill_appeal_fingerprints", "--strict")
+        counts = appeal_fingerprints.verify_fingerprints(ProposedAppeal)
+        assert counts[appeal_fingerprints.REKEYED] == 0
+
+    def test_verify_clears_the_fingerprint_of_text_edited_to_blank(self):
+        from fighthealthinsurance import appeal_fingerprints
+
+        denial = _make_denial(9127)
+        row = ProposedAppeal.objects.create(
+            for_denial=denial, appeal_text="Dear Reviewer, soon to be blanked."
+        )
+        ProposedAppeal.objects.filter(pk=row.pk).update(appeal_text="   ")
+        counts = appeal_fingerprints.verify_fingerprints(ProposedAppeal)
+        row.refresh_from_db()
+        assert counts[appeal_fingerprints.REKEYED] == 1
+        assert row.text_fingerprint is None
 
     def test_strict_backfill_fails_when_verify_had_to_rekey(self):
         from unittest.mock import patch as _patch

--- a/tests/sync/test_mark_proposal_chosen.py
+++ b/tests/sync/test_mark_proposal_chosen.py
@@ -160,18 +160,26 @@ class MarkProposalChosenTest(TestCase):
 
     def test_picks_most_recent_original_on_ties(self):
         # Two original rows with the same appeal_text but different model_name;
-        # the most recent (highest id) wins.
-        ProposedAppeal.objects.create(
-            for_denial=self.denial,
-            appeal_text="dup",
-            chosen=False,
-            model_name="model-old",
-        )
-        ProposedAppeal.objects.create(
-            for_denial=self.denial,
-            appeal_text="dup",
-            chosen=False,
-            model_name="model-new",
+        # the most recent (highest id) wins. Identical un-chosen texts can only
+        # exist as LEGACY data now (save() fingerprints every new row and the
+        # unique constraint rejects the twin), so build the tie the way legacy
+        # data actually exists: bulk_create bypasses save(), leaving NULL
+        # fingerprints exactly like pre-constraint rows.
+        ProposedAppeal.objects.bulk_create(
+            [
+                ProposedAppeal(
+                    for_denial=self.denial,
+                    appeal_text="dup",
+                    chosen=False,
+                    model_name="model-old",
+                ),
+                ProposedAppeal(
+                    for_denial=self.denial,
+                    appeal_text="dup",
+                    chosen=False,
+                    model_name="model-new",
+                ),
+            ]
         )
         pa = mark_proposal_chosen(self.denial, "dup")
         self.assertEqual(pa.model_name, "model-new")


### PR DESCRIPTION
The 0201 constraint only bound writers that set text_fingerprint, and counting rows rather than content let historical duplicates satisfy the journey target (external review). Three pieces close it:

- ProposedAppeal.save() fingerprints every un-chosen row, so the partial unique constraint binds ALL writers -- live save_appeal, the speculative precompute (whose per-draft try/except now correctly skips a duplicate reserve), admin, tests. Chosen rows stay NULL by design: they are deliberate copies of the picked draft and a fingerprint would collide with the original row. Promotion flips speculative on the same row, so promoted rows keep the fingerprint from creation.
- Migration 0202 backfills legacy NULL rows. Collisions (the historical double-stores) are left NULL as a known-legacy-duplicate marker; nothing is deleted.
- The journey precheck and generation postcondition count DISTINCT non-null fingerprints instead of row identities: three copies of one letter are one draft, and NULL-marked duplicates never count.

Tests cover auto-fingerprint on save, chosen-row exemption, the constraint binding a second writer, legacy triplicates no longer satisfying the precheck, distinct drafts satisfying it, and the backfill (fills the rest, skips the duplicate). Suite green on sqlite and on the Postgres rig; black + mypy clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Appeal prechecks and generation progress now count only distinct, valid appeal drafts.
  * Duplicate drafts and legacy entries without identifying information no longer satisfy generation targets.
  * Appeal content is consistently matched despite capitalization or whitespace differences.
  * Duplicate appeals are prevented, including when reusing and promoting reserved drafts.
  * Existing appeal records can be safely edited while preserving accurate progress tracking.
  * Appeal progress, early-stop, and completion checks now use consistent counting rules.
  * Appeal data integrity checks and backfills now safely handle legacy and concurrent records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->