### PR TITLE
Split fax and appeal workers into separate Deployments

### DIFF
--- a/fighthealthinsurance/management/commands/run_temporal_worker.py
+++ b/fighthealthinsurance/management/commands/run_temporal_worker.py
@@ -8,14 +8,25 @@ Activities are synchronous (blocking ORM + vendor I/O), so they run in a
 Run it as its own process / Kubernetes Deployment::
 
     python manage.py run_temporal_worker
+
+``--queues`` (or ``TEMPORAL_WORKER_QUEUES``) selects which queue(s) this
+process hosts, so fax and appeal work can run as SEPARATE Deployments and
+share no failure domain: appeal-generation memory/CPU pressure or an appeal
+crash-loop must never take fax sending down with it (external review).
+``all`` (the default) keeps the single-process shape for dev and small
+installs.
 """
 
 import asyncio
+import os
 from concurrent.futures import ThreadPoolExecutor
+from datetime import timedelta
 from typing import Any
 
 from django.conf import settings
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
+
+QUEUE_ROLES = ("fax", "appeal", "all")
 
 
 class Command(BaseCommand):
@@ -34,6 +45,15 @@ class Command(BaseCommand):
             help=(
                 "Max activity threads (defaults to "
                 "settings.TEMPORAL_MAX_ACTIVITY_WORKERS)."
+            ),
+        )
+        parser.add_argument(
+            "--queues",
+            choices=QUEUE_ROLES,
+            default=None,
+            help=(
+                "Which queue(s) this process hosts: 'fax', 'appeal', or "
+                "'all'. Defaults to TEMPORAL_WORKER_QUEUES, else 'all'."
             ),
         )
 
@@ -61,6 +81,13 @@ class Command(BaseCommand):
         max_workers = options.get("max_workers") or getattr(
             settings, "TEMPORAL_MAX_ACTIVITY_WORKERS", 20
         )
+        role = (
+            options.get("queues") or os.environ.get("TEMPORAL_WORKER_QUEUES") or "all"
+        ).lower()
+        if role not in QUEUE_ROLES:
+            raise CommandError(
+                f"TEMPORAL_WORKER_QUEUES={role!r}: expected one of {QUEUE_ROLES}"
+            )
 
         from typing import Any as _Any, Callable, List
 
@@ -82,26 +109,36 @@ class Command(BaseCommand):
         client = await get_temporal_client()
         self.stdout.write(
             f"Connected to Temporal at {settings.TEMPORAL_HOST} "
-            f"(namespace={settings.TEMPORAL_NAMESPACE}); appeal journey "
-            f"{'ENABLED' if journey_enabled else 'disabled'}"
+            f"(namespace={settings.TEMPORAL_NAMESPACE}); role={role}; appeal "
+            f"journey {'ENABLED' if journey_enabled else 'disabled'}"
         )
 
         with ThreadPoolExecutor(max_workers=max_workers) as activity_executor:
-            fax_worker = Worker(
-                client,
-                task_queue=task_queue,
-                workflows=fax_workflows,
-                activities=fax_activity_fns,
-                activity_executor=activity_executor,
-            )
-            runs = [fax_worker.run()]
-            queues = [task_queue]
-            if journey_enabled:
+            runs = []
+            queues = []
+            if role in ("fax", "all"):
+                fax_worker = Worker(
+                    client,
+                    task_queue=task_queue,
+                    workflows=fax_workflows,
+                    activities=fax_activity_fns,
+                    activity_executor=activity_executor,
+                    # Kubernetes sends SIGTERM at pod shutdown; give running
+                    # fax activities time to finish instead of orphaning a
+                    # vendor call mid-send. terminationGracePeriodSeconds in
+                    # the manifest must exceed this (external review).
+                    graceful_shutdown_timeout=timedelta(seconds=90),
+                )
+                runs.append(fax_worker.run())
+                queues.append(task_queue)
+            if role in ("appeal", "all") and journey_enabled:
                 # The journey runs on its OWN task queue and worker: several
                 # slow appeal generations must never occupy the fax worker's
                 # activity slots (separate failure domain; PR #963 review).
                 # Its activities are asyncio activities, so it needs no
-                # thread executor and its concurrency is bounded separately.
+                # thread executor and its concurrency is bounded separately
+                # (low and explicit: current letter volume is small, and a
+                # small bound is most of the blast-radius story).
                 appeal_queue = settings.TEMPORAL_APPEAL_TASK_QUEUE
                 appeal_workflows: List[type] = [GenerateAppealWorkflow]
                 appeal_activity_fns = [
@@ -120,9 +157,26 @@ class Command(BaseCommand):
                     workflows=appeal_workflows,
                     activities=appeal_activity_fns,
                     max_concurrent_activities=4,
+                    # Longer than the fax worker's: a generation attempt owns
+                    # a GENERATION_BUDGET_SECONDS (240s) model-call window and
+                    # cancelling it cooperatively takes time to drain.
+                    graceful_shutdown_timeout=timedelta(seconds=300),
                 )
                 runs.append(appeal_worker.run())
                 queues.append(appeal_queue)
+            if not runs:
+                # role=appeal with the journey flags dark. Idle instead of
+                # exiting: an exit would crash-loop the Deployment, but this
+                # pod being inert IS the kill switch working -- flipping the
+                # flags and restarting the Deployment brings it live.
+                self.stdout.write(
+                    "Appeal worker role selected but the appeal journey flags "
+                    "are OFF; idling (this process will host nothing until "
+                    "TEMPORAL_ENABLED and TEMPORAL_APPEAL_JOURNEY_ENABLED are "
+                    "set and the process restarts)."
+                )
+                await asyncio.Event().wait()
+                return
             self.stdout.write(
                 f"Starting Temporal worker(s) on task queue(s) "
                 f"{', '.join(repr(q) for q in queues)} "

--- a/fighthealthinsurance/management/commands/run_temporal_worker.py
+++ b/fighthealthinsurance/management/commands/run_temporal_worker.py
@@ -123,11 +123,18 @@ class Command(BaseCommand):
                     workflows=fax_workflows,
                     activities=fax_activity_fns,
                     activity_executor=activity_executor,
-                    # Kubernetes sends SIGTERM at pod shutdown; give running
-                    # fax activities time to finish instead of orphaning a
-                    # vendor call mid-send. terminationGracePeriodSeconds in
-                    # the manifest must exceed this (external review).
-                    graceful_shutdown_timeout=timedelta(seconds=90),
+                    # Kubernetes sends SIGTERM at pod shutdown; a running
+                    # send_fax_via_vendor attempt may legitimately spend up
+                    # to its 30-minute start_to_close in vendor backends
+                    # (~1300s each), and killing it mid-send risks the
+                    # vendor delivering a fax whose result we lost -- the
+                    # exact double-send the fax rule forbids. Drain covers
+                    # the full activity bound; when nothing is running,
+                    # shutdown is immediate, so rollouts only wait when a
+                    # fax is actually in flight (review).
+                    # terminationGracePeriodSeconds in the manifest must
+                    # exceed this.
+                    graceful_shutdown_timeout=timedelta(minutes=30),
                 )
                 runs.append(fax_worker.run())
                 queues.append(task_queue)

--- a/k8s/temporal/README.md
+++ b/k8s/temporal/README.md
@@ -13,7 +13,7 @@ The footprint is modest because we reuse infrastructure we already run:
 | A SQL datastore | **The existing PostgreSQL** | Add two databases: `temporal` and `temporal_visibility`. |
 | Advanced visibility (search/list workflows) | **PostgreSQL 12+** | No Elasticsearch needed — Postgres ≥ 12 provides advanced visibility natively. This is the big saving on a small cluster. |
 | Server services (frontend/history/matching/worker) | One combined Deployment via Helm | Start at `replicaCount: 1`; split/scale later. |
-| Workers (our code) | `fhi-fax-worker` Deployment (`worker.yaml`) | Runs `manage.py run_temporal_worker` on the existing app image. (Named `fhi-fax-worker` because the Helm chart itself owns a Deployment called `temporal-worker` — Temporal's internal worker service.) |
+| Workers (our code) | `fhi-fax-worker` (`worker.yaml`) + `fhi-appeal-worker` (`appeal-worker.yaml`) Deployments | Both run `manage.py run_temporal_worker` on the existing app image; `TEMPORAL_WORKER_QUEUES` picks the role (`fax` / `appeal`), so the two queues share no failure domain. The appeal Deployment is safe to apply dark: with the journey flags off it idles and hosts nothing. (Named `fhi-*-worker` because the Helm chart itself owns a Deployment called `temporal-worker` — Temporal's internal worker service.) |
 | Web UI | Temporal Web (chart `web.enabled`) | Optional; expose through the existing nginx ingress. |
 
 Rough resource ask for the server at our scale: ~0.5–1 vCPU and ~1–2 GiB. That

--- a/k8s/temporal/README.md
+++ b/k8s/temporal/README.md
@@ -76,6 +76,7 @@ fits comfortably next to the Ray heads (which already request 6 GiB each).
    ```sh
    # ${FHI_BASE}/${FHI_VERSION} are substituted the same way as the other k8s/ manifests.
    envsubst < worker.yaml | kubectl apply -f -
+   envsubst < appeal-worker.yaml | kubectl apply -f -
    ```
 
 ## Turning it on
@@ -203,6 +204,7 @@ required.
 - `values.yaml` — Helm values (validated against chart `temporal-1.6.0`, which
   the install command pins): Postgres-backed, no Cassandra/Elasticsearch.
 - `worker.yaml` — the `fhi-fax-worker` Deployment.
+- `appeal-worker.yaml` — the `fhi-appeal-worker` Deployment (dark-safe; idles until the journey flags flip).
 
 ## What runs here today vs. next
 

--- a/k8s/temporal/appeal-worker.yaml
+++ b/k8s/temporal/appeal-worker.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  # Appeal-journey worker, SEPARATE from fhi-fax-worker: appeal generation's
+  # memory/CPU pressure or a crash-loop must never remove fax pollers
+  # (external review). Safe to apply dark -- with the journey flags off the
+  # process logs that it is idling and hosts nothing (the kill switch), so
+  # it costs one small idle pod until enablement.
+  name: fhi-appeal-worker
+  namespace: totallylegitco
+  labels:
+    app: fight-health-insurance-prod
+    group: fight-health-insurance-prod-temporal-appeal-worker
+spec:
+  # One replica while volume is low. Raise to 2 before relying on the
+  # journey in production so a deploy or node failure doesn't remove every
+  # appeal poller at once.
+  replicas: 1
+  selector:
+    matchLabels:
+      group: fight-health-insurance-prod-temporal-appeal-worker
+  template:
+    metadata:
+      labels:
+        app: fight-health-insurance-prod
+        group: fight-health-insurance-prod-temporal-appeal-worker
+    spec:
+      # Above the worker's 300s graceful_shutdown_timeout, which itself
+      # covers the 240s generation budget plus cooperative-cancel drain: a
+      # SIGTERM'd pod finishes or cleanly cancels its attempt instead of
+      # orphaning it into a costly retry.
+      terminationGracePeriodSeconds: 360
+      containers:
+        - image: ${FHI_BASE}:${FHI_VERSION}
+          name: totallylegitco
+          # start-server.sh runs `manage.py run_temporal_worker` when
+          # TEMPORAL_WORKER is set; TEMPORAL_WORKER_QUEUES picks the role.
+          # No fax SSH identity or key mount here: appeal activities touch
+          # only the database and model backends.
+          env:
+            - name: TEMPORAL_WORKER
+              value: "1"
+            - name: TEMPORAL_WORKER_QUEUES
+              value: "appeal"
+            - name: TEMPORAL_ENABLED
+              value: "true"
+            # TEMPORAL_APPEAL_JOURNEY_ENABLED / TEMPORAL_INTAKE_JOURNEY_ENABLED
+            # intentionally NOT set here: they come from the app secrets and
+            # default OFF, so applying this manifest does not enable anything.
+            - name: TEMPORAL_HOST
+              value: "temporal-frontend:7233"
+            - name: TEMPORAL_NAMESPACE
+              value: "default"
+            - name: PDBHOST
+              valueFrom:
+                configMapKeyRef:
+                  name: fhi-db-config
+                  key: PDBHOST
+          envFrom:
+            - secretRef:
+                name: fight-health-insurance-secret
+            - secretRef:
+                name: fight-health-insurance-primary-secret
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: "250m"
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi

--- a/k8s/temporal/worker.yaml
+++ b/k8s/temporal/worker.yaml
@@ -21,6 +21,9 @@ spec:
         app: fight-health-insurance-prod
         group: fight-health-insurance-prod-temporal-worker
     spec:
+      # Above the worker's 90s graceful_shutdown_timeout so a SIGTERM'd pod
+      # can finish an in-flight vendor send before the kubelet kills it.
+      terminationGracePeriodSeconds: 120
       containers:
         - image: ${FHI_BASE}:${FHI_VERSION}
           name: totallylegitco
@@ -36,6 +39,11 @@ spec:
               value: "ray"
             - name: TEMPORAL_WORKER
               value: "1"
+            # This Deployment hosts ONLY the fax queue; appeal work runs in
+            # its own Deployment (appeal-worker.yaml) so appeal pressure or a
+            # crash-loop cannot take fax sending down (external review).
+            - name: TEMPORAL_WORKER_QUEUES
+              value: "fax"
             - name: TEMPORAL_ENABLED
               value: "true"
             # In-cluster Temporal frontend (Helm release "temporal" in this ns).

--- a/k8s/temporal/worker.yaml
+++ b/k8s/temporal/worker.yaml
@@ -21,9 +21,13 @@ spec:
         app: fight-health-insurance-prod
         group: fight-health-insurance-prod-temporal-worker
     spec:
-      # Above the worker's 90s graceful_shutdown_timeout so a SIGTERM'd pod
-      # can finish an in-flight vendor send before the kubelet kills it.
-      terminationGracePeriodSeconds: 120
+      # Above the worker's 30-minute graceful_shutdown_timeout so a
+      # SIGTERM'd pod can finish an in-flight vendor send (bounded by the
+      # activity's 30m start_to_close) before the kubelet kills it. Idle
+      # pods shut down immediately -- this only delays a rollout while a
+      # fax is genuinely mid-send, which is exactly when killing the pod
+      # would risk a double-send.
+      terminationGracePeriodSeconds: 1860
       containers:
         - image: ${FHI_BASE}:${FHI_VERSION}
           name: totallylegitco

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -138,6 +138,11 @@ envsubst < k8s/deploy.yaml | kubectl apply -f -
 # versions behind prod (v0.22.4a-dev vs v0.23.1a-dev). Same ${FHI_BASE}/${FHI_VERSION}
 # substitution as the manifests above.
 envsubst < k8s/temporal/worker.yaml | kubectl apply -f -
+# The appeal worker Deployment must roll with every deploy too -- Temporal
+# accepts workflow starts for a queue with NO pollers and queues them
+# silently, so an applied-by-hand-once appeal worker (or a forgotten one)
+# would look healthy while nothing executes (external review).
+envsubst < k8s/temporal/appeal-worker.yaml | kubectl apply -f -
 
 # In-cluster scraping of the app's /metrics (which is no longer reachable from
 # the internet -- see docs/metrics-endpoint-access.md). The apply is skipped

--- a/tests/temporal/test_run_temporal_worker.py
+++ b/tests/temporal/test_run_temporal_worker.py
@@ -25,3 +25,69 @@ def test_bad_env_role_fails_before_connecting():
     hosting every queue."""
     with pytest.raises(CommandError):
         asyncio.run(Command()._run({}))
+
+
+def _recording_worker_cls():
+    """Stand-in for temporalio.worker.Worker capturing construction kwargs;
+    run() completes immediately so _run's gather returns."""
+    from unittest.mock import AsyncMock, Mock
+
+    cls = Mock()
+
+    def _make(*args, **kwargs):
+        inst = Mock()
+        inst.run = AsyncMock()
+        return inst
+
+    cls.side_effect = _make
+    return cls
+
+
+def _run_with(role, **flags):
+    from django.test import override_settings
+    from unittest.mock import AsyncMock, Mock
+
+    worker_cls = _recording_worker_cls()
+    settings = dict(
+        TEMPORAL_ENABLED=True,
+        TEMPORAL_APPEAL_JOURNEY_ENABLED=True,
+        TEMPORAL_INTAKE_JOURNEY_ENABLED=False,
+        TEMPORAL_TASK_QUEUE="q-fax",
+        TEMPORAL_APPEAL_TASK_QUEUE="q-appeal",
+        TEMPORAL_HOST="test-host",
+        TEMPORAL_NAMESPACE="test-ns",
+    )
+    settings.update(flags)
+    with (
+        patch("temporalio.worker.Worker", worker_cls),
+        patch(
+            "fighthealthinsurance.temporal_client.get_temporal_client",
+            AsyncMock(return_value=Mock()),
+        ),
+        override_settings(**settings),
+    ):
+        asyncio.run(asyncio.wait_for(Command()._run({"queues": role}), timeout=2))
+    return [c.kwargs.get("task_queue") for c in worker_cls.call_args_list]
+
+
+def test_fax_role_hosts_only_the_fax_queue():
+    assert _run_with("fax") == ["q-fax"]
+
+
+def test_appeal_role_hosts_only_the_appeal_queue():
+    assert _run_with("appeal") == ["q-appeal"]
+
+
+def test_all_role_hosts_both_queues():
+    assert _run_with("all") == ["q-fax", "q-appeal"]
+
+
+def test_all_role_with_journey_dark_hosts_fax_only():
+    assert _run_with("all", TEMPORAL_APPEAL_JOURNEY_ENABLED=False) == ["q-fax"]
+
+
+def test_appeal_role_with_journey_dark_idles_hosting_nothing():
+    """The kill switch: role=appeal + dark flags must construct NO worker
+    and block (idle) rather than exit into a Deployment crash-loop."""
+    with pytest.raises(asyncio.TimeoutError):
+        _run_with("appeal", TEMPORAL_APPEAL_JOURNEY_ENABLED=False)

--- a/tests/temporal/test_run_temporal_worker.py
+++ b/tests/temporal/test_run_temporal_worker.py
@@ -91,3 +91,27 @@ def test_appeal_role_with_journey_dark_idles_hosting_nothing():
     and block (idle) rather than exit into a Deployment crash-loop."""
     with pytest.raises(asyncio.TimeoutError):
         _run_with("appeal", TEMPORAL_APPEAL_JOURNEY_ENABLED=False)
+
+
+def test_deploy_script_applies_both_worker_manifests():
+    """Temporal queues work for a pollerless task queue silently, so a
+    deploy that forgets the appeal worker looks healthy while nothing
+    executes. The deploy script must apply BOTH worker manifests, and the
+    manifests must pin complementary queue roles (external review)."""
+    import pathlib
+    import re
+
+    root = pathlib.Path(__file__).resolve().parents[2]
+    build = (root / "scripts" / "build.sh").read_text()
+    assert "k8s/temporal/worker.yaml" in build
+    assert "k8s/temporal/appeal-worker.yaml" in build
+
+    roles = {}
+    for name in ("worker.yaml", "appeal-worker.yaml"):
+        text = (root / "k8s" / "temporal" / name).read_text()
+        m = re.search(
+            r'name: TEMPORAL_WORKER_QUEUES\s*\n\s*value: "(\w+)"', text
+        )
+        assert m, f"{name} must pin TEMPORAL_WORKER_QUEUES"
+        roles[name] = m.group(1)
+    assert roles == {"worker.yaml": "fax", "appeal-worker.yaml": "appeal"}

--- a/tests/temporal/test_run_temporal_worker.py
+++ b/tests/temporal/test_run_temporal_worker.py
@@ -1,0 +1,27 @@
+"""Role selection for ``run_temporal_worker``: the queue split must fail
+loudly on a bad role and never silently host the wrong queues."""
+
+import asyncio
+import os
+from unittest.mock import patch
+
+import pytest
+from django.core.management.base import CommandError
+
+from fighthealthinsurance.management.commands.run_temporal_worker import (
+    QUEUE_ROLES,
+    Command,
+)
+
+
+def test_known_roles_are_exactly_fax_appeal_all():
+    assert QUEUE_ROLES == ("fax", "appeal", "all")
+
+
+@patch.dict(os.environ, {"TEMPORAL_WORKER_QUEUES": "bogus"})
+def test_bad_env_role_fails_before_connecting():
+    """argparse validates --queues, but the env var path must be checked
+    too -- a typo'd Deployment env must crash loudly, not default to
+    hosting every queue."""
+    with pytest.raises(CommandError):
+        asyncio.run(Command()._run({}))


### PR DESCRIPTION
run_temporal_worker gains a queue role (--queues / TEMPORAL_WORKER_QUEUES: fax, appeal, or all) so the two queues run as separate processes with no shared failure domain: appeal-generation pressure or a crash-loop cannot remove fax pollers (external review). 'all' stays the default for dev.

- worker.yaml pins the existing fhi-fax-worker to the fax role.
- appeal-worker.yaml adds fhi-appeal-worker: no fax SSH identity/mount, journey flags deliberately not set (safe to apply dark -- the process idles as the kill switch until flags flip).
- Graceful shutdown wired through: Worker graceful_shutdown_timeout (90s fax / 300s appeal, covering the 240s generation budget) with terminationGracePeriodSeconds above each (120s / 360s), so SIGTERM'd pods drain instead of orphaning work into retries.
- A typo'd role from the env crashes loudly rather than defaulting to hosting every queue; tests cover the role contract.


Claude-Session: https://claude.ai/code/session_019SPqa4FZ43ahAjoD53Uj81

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added separate Temporal worker roles for fax and appeal processing.
  - Added a dedicated appeal worker deployment that remains idle until enabled.
  - Added configuration to isolate fax and appeal processing queues.

- **Bug Fixes**
  - Invalid worker queue selections are now rejected before startup.
  - Extended shutdown time to allow in-progress fax delivery attempts to finish safely.

- **Documentation**
  - Updated Temporal deployment guidance for separate fax and appeal workers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->