### PR TITLE
Temporal worker observability and redundancy

### DIFF
--- a/fighthealthinsurance/management/commands/run_temporal_worker.py
+++ b/fighthealthinsurance/management/commands/run_temporal_worker.py
@@ -28,6 +28,33 @@ from django.core.management.base import BaseCommand, CommandError
 
 QUEUE_ROLES = ("fax", "appeal", "all")
 
+# Prometheus scrape endpoint for the SDK's worker metrics. Temporal accepts
+# work for a task queue with no healthy poller and queues it silently, so
+# worker health must be OBSERVED: schedule-to-start latency, task-slot
+# availability, activity failures, RPC failures (external review). Set by
+# the worker manifests; unset (dev, tests) means no endpoint.
+METRICS_BIND_ENV = "TEMPORAL_METRICS_BIND"
+
+
+def metrics_runtime() -> Any:
+    """The SDK ``Runtime`` carrying the Prometheus config, or None when
+    ``TEMPORAL_METRICS_BIND`` is unset/blank."""
+    bind = (os.environ.get(METRICS_BIND_ENV) or "").strip()
+    if not bind:
+        return None
+    from temporalio.runtime import PrometheusConfig, Runtime, TelemetryConfig
+
+    return Runtime(
+        telemetry=TelemetryConfig(
+            metrics=PrometheusConfig(
+                bind_address=bind,
+                # Seconds, not the SDK's millisecond default, so alert
+                # thresholds in k8s/temporal/worker-alerts.yaml read plainly.
+                durations_as_seconds=True,
+            )
+        )
+    )
+
 
 class Command(BaseCommand):
     help = "Run the Temporal worker for FHI workflows and activities."
@@ -106,11 +133,13 @@ class Command(BaseCommand):
             settings, "TEMPORAL_APPEAL_JOURNEY_ENABLED", False
         )
 
-        client = await get_temporal_client()
+        runtime = metrics_runtime()
+        client = await get_temporal_client(runtime=runtime)
         self.stdout.write(
             f"Connected to Temporal at {settings.TEMPORAL_HOST} "
             f"(namespace={settings.TEMPORAL_NAMESPACE}); role={role}; appeal "
-            f"journey {'ENABLED' if journey_enabled else 'disabled'}"
+            f"journey {'ENABLED' if journey_enabled else 'disabled'}; metrics "
+            f"{os.environ.get(METRICS_BIND_ENV) if runtime else 'off'}"
         )
 
         with ThreadPoolExecutor(max_workers=max_workers) as activity_executor:

--- a/fighthealthinsurance/management/commands/run_temporal_worker.py
+++ b/fighthealthinsurance/management/commands/run_temporal_worker.py
@@ -104,7 +104,6 @@ class Command(BaseCommand):
         )
         from fighthealthinsurance.workflows.send_fax import SendFaxWorkflow
 
-        task_queue = options.get("task_queue") or settings.TEMPORAL_TASK_QUEUE
         max_workers = options.get("max_workers") or getattr(
             settings, "TEMPORAL_MAX_ACTIVITY_WORKERS", 20
         )
@@ -115,6 +114,17 @@ class Command(BaseCommand):
             raise CommandError(
                 f"TEMPORAL_WORKER_QUEUES={role!r}: expected one of {QUEUE_ROLES}"
             )
+        # --task-queue overrides the queue of the SELECTED role: for the fax
+        # role (or 'all') it replaces the fax queue as before; for the appeal
+        # role it replaces the appeal queue, instead of silently setting a fax
+        # queue that role never polls (review).
+        queue_override = options.get("task_queue")
+        task_queue = (
+            queue_override if role != "appeal" and queue_override else None
+        ) or settings.TEMPORAL_TASK_QUEUE
+        appeal_queue = (
+            queue_override if role == "appeal" and queue_override else None
+        ) or settings.TEMPORAL_APPEAL_TASK_QUEUE
 
         from typing import Any as _Any, Callable, List
 
@@ -152,6 +162,10 @@ class Command(BaseCommand):
                     workflows=fax_workflows,
                     activities=fax_activity_fns,
                     activity_executor=activity_executor,
+                    # Match the slot count to the thread executor: with more
+                    # slots than threads, accepted activities queue locally
+                    # while their start-to-close clock runs (review).
+                    max_concurrent_activities=max_workers,
                     # Kubernetes sends SIGTERM at pod shutdown; a running
                     # send_fax_via_vendor attempt may legitimately spend up
                     # to its 30-minute start_to_close in vendor backends
@@ -175,7 +189,6 @@ class Command(BaseCommand):
                 # thread executor and its concurrency is bounded separately
                 # (low and explicit: current letter volume is small, and a
                 # small bound is most of the blast-radius story).
-                appeal_queue = settings.TEMPORAL_APPEAL_TASK_QUEUE
                 appeal_workflows: List[type] = [GenerateAppealWorkflow]
                 appeal_activity_fns = [
                     journey_activities.precheck_appeal_journey,

--- a/fighthealthinsurance/temporal_client.py
+++ b/fighthealthinsurance/temporal_client.py
@@ -22,11 +22,15 @@ from loguru import logger
 _RESULT_WAIT_SECONDS = 15 * 60
 
 
-async def get_temporal_client() -> Any:
+async def get_temporal_client(runtime: Any = None) -> Any:
     """Connect a Temporal client using Django settings.
 
     Supports a plain connection (local dev server), server-side TLS, and mTLS
     with client cert/key files for a self-hosted cluster.
+
+    ``runtime`` is the SDK ``temporalio.runtime.Runtime`` carrying telemetry
+    config; only the worker process passes one (it hosts the Prometheus
+    metrics endpoint). Web/Ray callers leave it None and get the default.
     """
     from temporalio.client import Client
     from temporalio.service import TLSConfig
@@ -56,6 +60,8 @@ async def get_temporal_client() -> Any:
     payload_key = getattr(settings, "TEMPORAL_PAYLOAD_KEY", "")
     if payload_key:
         connect_kwargs["data_converter"] = _encrypting_data_converter(payload_key)
+    if runtime is not None:
+        connect_kwargs["runtime"] = runtime
 
     return await Client.connect(
         settings.TEMPORAL_HOST,

--- a/k8s/temporal/README.md
+++ b/k8s/temporal/README.md
@@ -77,6 +77,9 @@ fits comfortably next to the Ray heads (which already request 6 GiB each).
    # ${FHI_BASE}/${FHI_VERSION} are substituted the same way as the other k8s/ manifests.
    envsubst < worker.yaml | kubectl apply -f -
    envsubst < appeal-worker.yaml | kubectl apply -f -
+   kubectl apply -f worker-pdb.yaml
+   kubectl apply -f worker-podmonitor.yaml   # needs the Prometheus operator CRDs
+   kubectl apply -f worker-alerts.yaml
    ```
 
 ## Turning it on
@@ -205,6 +208,9 @@ required.
   the install command pins): Postgres-backed, no Cassandra/Elasticsearch.
 - `worker.yaml` — the `fhi-fax-worker` Deployment.
 - `appeal-worker.yaml` — the `fhi-appeal-worker` Deployment (dark-safe; idles until the journey flags flip).
+- `worker-pdb.yaml` — PodDisruptionBudgets (minAvailable: 1) for both worker Deployments.
+- `worker-podmonitor.yaml` — scrapes the SDK's Prometheus endpoint (`TEMPORAL_METRICS_BIND`, port 9464) on both workers.
+- `worker-alerts.yaml` — PrometheusRule: schedule-to-start latency, slot exhaustion, activity failures, frontend RPC failures.
 
 ## What runs here today vs. next
 

--- a/k8s/temporal/README.md
+++ b/k8s/temporal/README.md
@@ -78,8 +78,15 @@ fits comfortably next to the Ray heads (which already request 6 GiB each).
    envsubst < worker.yaml | kubectl apply -f -
    envsubst < appeal-worker.yaml | kubectl apply -f -
    kubectl apply -f worker-pdb.yaml
-   kubectl apply -f worker-podmonitor.yaml   # needs the Prometheus operator CRDs
-   kubectl apply -f worker-alerts.yaml
+   # The PodMonitor and PrometheusRule need the Prometheus operator's CRDs.
+   # scripts/build.sh skips each when its CRD is absent; do the same by hand
+   # so these commands work on a cluster without the operator.
+   kubectl get crd podmonitors.monitoring.coreos.com >/dev/null 2>&1 \
+     && kubectl apply -f worker-podmonitor.yaml \
+     || echo "no PodMonitor CRD -- worker metrics will not be scraped"
+   kubectl get crd prometheusrules.monitoring.coreos.com >/dev/null 2>&1 \
+     && kubectl apply -f worker-alerts.yaml \
+     || echo "no PrometheusRule CRD -- worker alerts not installed"
    ```
 
 ## Turning it on

--- a/k8s/temporal/README.md
+++ b/k8s/temporal/README.md
@@ -157,6 +157,19 @@ back to plain TLS.
    (`launch_polling_actors --force` relaunch excludes it under Temporal, but
    does not kill a live one).
 
+5. **Worker observability (review-9)** — before relying on the alert
+   rules in `worker-alerts.yaml`, verify against the LIVE Prometheus:
+   the PodMonitor selector actually produces `up{pod=~"fhi-(fax|appeal)-worker-.*"}`
+   targets (operator `podMonitorSelector` caveat), kube-state-metrics is
+   scraped (`kube_deployment_status_replicas_available`), the SDK series
+   carry `namespace="default"` (the Temporal namespace, not the Kubernetes
+   one), and every SERVER-side metric name in the `fhi-temporal-server-side`
+   group exists on the deployed Temporal server version (`approximate_backlog_count`,
+   `task_schedule_to_start_latency`, `activity_timeout`) with the units the
+   thresholds assume. Worker-side series vanish when the last worker dies,
+   so only the worker-loss and server-side rules can page on "zero workers";
+   promote their severity once verified.
+
 ## Applying a values.yaml change
 
 Editing `values.yaml` does **not** change anything by itself, and neither does

--- a/k8s/temporal/appeal-worker.yaml
+++ b/k8s/temporal/appeal-worker.yaml
@@ -12,10 +12,12 @@ metadata:
     app: fight-health-insurance-prod
     group: fight-health-insurance-prod-temporal-appeal-worker
 spec:
-  # One replica while volume is low. Raise to 2 before relying on the
-  # journey in production so a deploy or node failure doesn't remove every
-  # appeal poller at once.
-  replicas: 1
+  # Two pollers on the queue so a deploy or node failure doesn't remove every
+  # appeal poller at once (external review). Volume is low; this is
+  # redundancy, not capacity -- concurrency stays bounded per pod by
+  # max_concurrent_activities. Paired with worker-pdb.yaml and the spread
+  # constraint below.
+  replicas: 2
   selector:
     matchLabels:
       group: fight-health-insurance-prod-temporal-appeal-worker
@@ -30,6 +32,15 @@ spec:
       # SIGTERM'd pod finishes or cleanly cancels its attempt instead of
       # orphaning it into a costly retry.
       terminationGracePeriodSeconds: 360
+      # Spread the two replicas across nodes; ScheduleAnyway so a one-node
+      # cluster still schedules the second replica.
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              group: fight-health-insurance-prod-temporal-appeal-worker
       containers:
         - image: ${FHI_BASE}:${FHI_VERSION}
           name: totallylegitco
@@ -37,7 +48,14 @@ spec:
           # TEMPORAL_WORKER is set; TEMPORAL_WORKER_QUEUES picks the role.
           # No fax SSH identity or key mount here: appeal activities touch
           # only the database and model backends.
+          ports:
+            # Temporal SDK Prometheus metrics (scraped by worker-podmonitor.yaml).
+            - name: metrics
+              containerPort: 9464
+              protocol: TCP
           env:
+            - name: TEMPORAL_METRICS_BIND
+              value: "0.0.0.0:9464"
             - name: TEMPORAL_WORKER
               value: "1"
             - name: TEMPORAL_WORKER_QUEUES

--- a/k8s/temporal/worker-alerts.yaml
+++ b/k8s/temporal/worker-alerts.yaml
@@ -1,0 +1,106 @@
+# =============================================================================
+# PrometheusRule for the Temporal workers (fhi-fax-worker, fhi-appeal-worker).
+#
+# Temporal accepts work for a task queue with no healthy poller and queues it
+# silently -- no error anywhere -- so worker health has to be OBSERVED, not
+# assumed (external review). These rules cover the four failure shapes the
+# review named: work waiting because nobody polls or slots are exhausted,
+# activities failing, heartbeat-timeout-shaped failures, and the client's own
+# RPC failures against the Temporal frontend. Scraped via
+# worker-podmonitor.yaml; the SDK is configured with durations_as_seconds, so
+# the latency thresholds below are in seconds.
+#
+# ==> VERIFY-LIVE (metric names/labels): these are the Temporal Python SDK
+#     (sdk-core 1.32) Prometheus names as shipped in the installed package;
+#     confirm labels on your build before relying on them:
+#       kubectl -n totallylegitco exec deploy/fhi-fax-worker -- \
+#         curl -s localhost:9464/metrics | grep -E 'temporal_(activity|worker|request)'
+#     Note: sdk-core exposes no distinct heartbeat-timeout counter; a
+#     heartbeat-timed-out attempt surfaces as an activity failure/cancellation
+#     on the worker and as an activity timeout on the SERVER's metrics. The
+#     activity-failure rule below is the worker-side signal for it.
+# =============================================================================
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: fhi-temporal-workers
+  namespace: totallylegitco
+  labels:
+    app: fight-health-insurance
+    role: alert-rules
+spec:
+  groups:
+    - name: fhi-temporal-workers
+      rules:
+        # ---- WORK WAITING: schedule-to-start latency ---------------------------
+        # p95 time an activity task sat on the queue before a worker picked it
+        # up. Sustained high values mean too few pollers/slots -- or NO poller,
+        # the silent-queue failure mode.
+        - alert: FhiTemporalActivityScheduleToStartSlow
+          expr: >-
+            histogram_quantile(0.95,
+              sum by (le, task_queue) (
+                rate(temporal_activity_schedule_to_start_latency_bucket{namespace="totallylegitco"}[10m])
+              )
+            ) > 60
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Temporal activities waiting >60s to start on {{ $labels.task_queue }}"
+            description: >-
+              p95 schedule-to-start latency on task queue {{ $labels.task_queue }}
+              is {{ $value }}s. Either the worker Deployment for that queue is
+              down/undersized or its activity slots are exhausted
+              (FhiTemporalWorkerSlotsExhausted). A queue with no poller shows
+              here first -- Temporal never errors on it.
+
+        # ---- SLOT EXHAUSTION ---------------------------------------------------
+        # max_concurrent_activities is deliberately small on the appeal worker;
+        # zero available slots for 5 minutes means work is queueing behind it.
+        - alert: FhiTemporalWorkerSlotsExhausted
+          expr: >-
+            min_over_time(temporal_worker_task_slots_available{namespace="totallylegitco"}[5m]) == 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Temporal worker {{ $labels.pod }} has had 0 free task slots for 5m"
+            description: >-
+              {{ $labels.pod }} ({{ $labels.task_queue }}, {{ $labels.worker_type }})
+              has reported zero available task slots for 5 minutes. Work is
+              queueing behind it; raise replicas or the slot bound after checking
+              the activities are actually progressing (not stuck model calls).
+
+        # ---- ACTIVITY FAILURES (includes heartbeat-timeout-shaped failures) -----
+        - alert: FhiTemporalActivityFailures
+          expr: >-
+            sum by (task_queue, activity_type) (
+              increase(temporal_activity_execution_failed{namespace="totallylegitco"}[15m])
+            ) > 3
+          for: 0m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Temporal activity {{ $labels.activity_type }} failing on {{ $labels.task_queue }}"
+            description: >-
+              More than 3 failed executions of {{ $labels.activity_type }} in 15m
+              ({{ $value }}). For the fax queue this can mean vendor trouble; for
+              the appeal queue, model-backend or database trouble. Heartbeat
+              timeouts (dead worker mid-attempt) land here too.
+
+        # ---- CLIENT RPC FAILURES against the Temporal frontend ------------------
+        - alert: FhiTemporalRequestFailures
+          expr: >-
+            sum by (pod) (increase(temporal_request_failure{namespace="totallylegitco"}[10m])) > 10
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Temporal worker {{ $labels.pod }} cannot talk to the frontend"
+            description: >-
+              {{ $value }} failed RPCs from {{ $labels.pod }} to temporal-frontend
+              in 10m. If every worker pod fires at once the frontend or its
+              database is the problem; if one pod fires, check that pod's
+              network/TLS config. Workflows keep queueing meanwhile -- nothing
+              is lost, but nothing progresses.

--- a/k8s/temporal/worker-alerts.yaml
+++ b/k8s/temporal/worker-alerts.yaml
@@ -130,8 +130,7 @@ spec:
         # ---- SLOT EXHAUSTION -------------------------------------------------
         - alert: FhiTemporalWorkerSlotsExhausted
           expr: >-
-            min_over_time(temporal_worker_task_slots_available{namespace="default"}[5m]) == 0
-          for: 5m
+            max_over_time(temporal_worker_task_slots_available{namespace="default"}[5m]) == 0
           labels:
             severity: warning
           annotations:

--- a/k8s/temporal/worker-alerts.yaml
+++ b/k8s/temporal/worker-alerts.yaml
@@ -3,22 +3,39 @@
 #
 # Temporal accepts work for a task queue with no healthy poller and queues it
 # silently -- no error anywhere -- so worker health has to be OBSERVED, not
-# assumed (external review). These rules cover the four failure shapes the
-# review named: work waiting because nobody polls or slots are exhausted,
-# activities failing, heartbeat-timeout-shaped failures, and the client's own
-# RPC failures against the Temporal frontend. Scraped via
-# worker-podmonitor.yaml; the SDK is configured with durations_as_seconds, so
-# the latency thresholds below are in seconds.
+# assumed (external review). Three families of rules, because no single
+# source can see every failure:
 #
-# ==> VERIFY-LIVE (metric names/labels): these are the Temporal Python SDK
-#     (sdk-core 1.32) Prometheus names as shipped in the installed package;
-#     confirm labels on your build before relying on them:
+#   1. WORKER-SIDE (SDK metrics scraped from the worker pods): slot
+#      exhaustion, activity failures, RPC failures, schedule-to-start as the
+#      worker measures it. These series come from the worker process itself,
+#      so they VANISH when the last worker dies -- they can never fire on
+#      "zero workers" (external review).
+#   2. WORKER-LOSS (Kubernetes + scrape targets): absent(up) per Deployment
+#      and kube-state available-replica counts. These are the only rules that
+#      can fire when no worker exists to emit anything.
+#   3. SERVER-SIDE (the Temporal server's own metrics): backlog, timeouts and
+#      schedule-to-start as the MATCHING/HISTORY services measure them, which
+#      keep counting when every worker is gone.
+#
+# The Temporal NAMESPACE the workers use is `default` (TEMPORAL_NAMESPACE in
+# worker.yaml / appeal-worker.yaml); the Kubernetes namespace is
+# `totallylegitco`. SDK series carry the Temporal namespace as `namespace`,
+# so worker-side rules match namespace="default" -- NOT the Kubernetes one
+# (external review found the previous rules filtered on totallylegitco and
+# could never match). The manifest test pins this.
+#
+# ==> VERIFY-LIVE before enablement (README checklist):
+#   - SDK metric names/labels (sdk-core 1.32):
 #       kubectl -n totallylegitco exec deploy/fhi-fax-worker -- \
 #         curl -s localhost:9464/metrics | grep -E 'temporal_(activity|worker|request)'
-#     Note: sdk-core exposes no distinct heartbeat-timeout counter; a
-#     heartbeat-timed-out attempt surfaces as an activity failure/cancellation
-#     on the worker and as an activity timeout on the SERVER's metrics. The
-#     activity-failure rule below is the worker-side signal for it.
+#   - `up{...}` label shape for PodMonitor targets (pod / container labels).
+#   - kube-state-metrics present (kube_deployment_status_replicas_available).
+#   - Server metric names: scrape the temporal-frontend/matching/history
+#     services' /metrics (Helm release "temporal") and confirm the names in
+#     family 3 exist on the deployed server version; adjust before relying on
+#     them. They are shipped here with long `for:` and low severity on
+#     purpose until verified.
 # =============================================================================
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
@@ -30,17 +47,73 @@ metadata:
     role: alert-rules
 spec:
   groups:
+    # ------------------------------------------------------------------------
+    # Family 2: WORKER LOSS. Fires when a worker Deployment has no scrape
+    # target or no available replica -- the case worker-side metrics are
+    # blind to, because a dead worker emits nothing.
+    # ------------------------------------------------------------------------
+    - name: fhi-temporal-worker-loss
+      rules:
+        - alert: FhiTemporalFaxWorkerAbsent
+          expr: absent(up{pod=~"fhi-fax-worker-.*", container="totallylegitco"} == 1)
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "No scraped, healthy fhi-fax-worker pod for 5m"
+            description: >-
+              Prometheus has no live scrape target for the fax worker. Fax
+              workflows keep queueing on the fhi-fax task queue with nobody
+              polling -- Temporal will not raise an error about this.
+        - alert: FhiTemporalAppealWorkerAbsent
+          expr: absent(up{pod=~"fhi-appeal-worker-.*", container="totallylegitco"} == 1)
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "No scraped, healthy fhi-appeal-worker pod for 5m"
+            description: >-
+              Prometheus has no live scrape target for the appeal worker. Any
+              appeal/intake journey work queues silently until a poller
+              returns.
+        # kube-state-metrics view of the same condition; independent of the
+        # PodMonitor working at all. VERIFY-LIVE: kube-state-metrics installed.
+        - alert: FhiTemporalWorkerNoAvailableReplicas
+          expr: >-
+            kube_deployment_status_replicas_available{namespace="totallylegitco", deployment=~"fhi-(fax|appeal)-worker"} < 1
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "{{ $labels.deployment }} has no available replicas"
+            description: >-
+              Deployment {{ $labels.deployment }} reports zero available
+              replicas for 5 minutes (rollout stuck, node loss, crash loop).
+              Its task queue has no poller.
+        - alert: FhiTemporalWorkerBelowRedundancy
+          expr: >-
+            kube_deployment_status_replicas_available{namespace="totallylegitco", deployment=~"fhi-(fax|appeal)-worker"} < 2
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "{{ $labels.deployment }} running below 2 replicas for 30m"
+            description: >-
+              One poller left on {{ $labels.deployment }}; the next node
+              drain or deploy removes the queue's last poller.
+
+    # ------------------------------------------------------------------------
+    # Family 1: WORKER-SIDE SDK metrics. Temporal namespace label is
+    # "default" here (see header).
+    # ------------------------------------------------------------------------
     - name: fhi-temporal-workers
       rules:
-        # ---- WORK WAITING: schedule-to-start latency ---------------------------
-        # p95 time an activity task sat on the queue before a worker picked it
-        # up. Sustained high values mean too few pollers/slots -- or NO poller,
-        # the silent-queue failure mode.
+        # ---- WORK WAITING: schedule-to-start latency as the worker sees it ----
         - alert: FhiTemporalActivityScheduleToStartSlow
           expr: >-
             histogram_quantile(0.95,
               sum by (le, task_queue) (
-                rate(temporal_activity_schedule_to_start_latency_bucket{namespace="totallylegitco"}[10m])
+                rate(temporal_activity_schedule_to_start_latency_bucket{namespace="default"}[10m])
               )
             ) > 60
           for: 10m
@@ -50,17 +123,14 @@ spec:
             summary: "Temporal activities waiting >60s to start on {{ $labels.task_queue }}"
             description: >-
               p95 schedule-to-start latency on task queue {{ $labels.task_queue }}
-              is {{ $value }}s. Either the worker Deployment for that queue is
-              down/undersized or its activity slots are exhausted
-              (FhiTemporalWorkerSlotsExhausted). A queue with no poller shows
-              here first -- Temporal never errors on it.
+              is {{ $value }}s: too few pollers/slots. NOTE this rule needs a
+              live worker to report it; a queue with NO poller is caught by
+              the worker-loss and server-side rules, not this one.
 
-        # ---- SLOT EXHAUSTION ---------------------------------------------------
-        # max_concurrent_activities is deliberately small on the appeal worker;
-        # zero available slots for 5 minutes means work is queueing behind it.
+        # ---- SLOT EXHAUSTION -------------------------------------------------
         - alert: FhiTemporalWorkerSlotsExhausted
           expr: >-
-            min_over_time(temporal_worker_task_slots_available{namespace="totallylegitco"}[5m]) == 0
+            min_over_time(temporal_worker_task_slots_available{namespace="default"}[5m]) == 0
           for: 5m
           labels:
             severity: warning
@@ -72,11 +142,14 @@ spec:
               queueing behind it; raise replicas or the slot bound after checking
               the activities are actually progressing (not stuck model calls).
 
-        # ---- ACTIVITY FAILURES (includes heartbeat-timeout-shaped failures) -----
+        # ---- ACTIVITY FAILURES (includes heartbeat-timeout-shaped failures) ---
+        # sdk-core exposes no distinct heartbeat-timeout counter; a heartbeat-
+        # timed-out attempt surfaces as an activity failure here and as an
+        # activity timeout on the SERVER (family 3).
         - alert: FhiTemporalActivityFailures
           expr: >-
             sum by (task_queue, activity_type) (
-              increase(temporal_activity_execution_failed{namespace="totallylegitco"}[15m])
+              increase(temporal_activity_execution_failed{namespace="default"}[15m])
             ) > 3
           for: 0m
           labels:
@@ -86,13 +159,12 @@ spec:
             description: >-
               More than 3 failed executions of {{ $labels.activity_type }} in 15m
               ({{ $value }}). For the fax queue this can mean vendor trouble; for
-              the appeal queue, model-backend or database trouble. Heartbeat
-              timeouts (dead worker mid-attempt) land here too.
+              the appeal queue, model-backend or database trouble.
 
-        # ---- CLIENT RPC FAILURES against the Temporal frontend ------------------
+        # ---- CLIENT RPC FAILURES against the Temporal frontend ----------------
         - alert: FhiTemporalRequestFailures
           expr: >-
-            sum by (pod) (increase(temporal_request_failure{namespace="totallylegitco"}[10m])) > 10
+            sum by (pod) (increase(temporal_request_failure{namespace="default"}[10m])) > 10
           for: 5m
           labels:
             severity: critical
@@ -102,5 +174,60 @@ spec:
               {{ $value }} failed RPCs from {{ $labels.pod }} to temporal-frontend
               in 10m. If every worker pod fires at once the frontend or its
               database is the problem; if one pod fires, check that pod's
-              network/TLS config. Workflows keep queueing meanwhile -- nothing
-              is lost, but nothing progresses.
+              network/TLS config.
+
+    # ------------------------------------------------------------------------
+    # Family 3: SERVER-SIDE. Measured by the Temporal server's matching and
+    # history services, so they keep counting with zero workers alive.
+    # ==> VERIFY-LIVE: metric names below follow the Temporal server's
+    #     Prometheus naming (no temporal_ prefix on server series; labels
+    #     namespace / taskqueue / task_type per the server's metric
+    #     definitions) but are NOT confirmed against this cluster's server
+    #     version. Long `for:` and low severity until verified; promote after.
+    # ------------------------------------------------------------------------
+    - name: fhi-temporal-server-side
+      rules:
+        - alert: FhiTemporalTaskQueueBacklog
+          expr: >-
+            max by (taskqueue, task_type) (approximate_backlog_count{namespace="default", taskqueue=~"fhi-.*"}) > 25
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Temporal backlog >25 tasks on {{ $labels.taskqueue }} ({{ $labels.task_type }}) for 30m"
+            description: >-
+              Server-side backlog on {{ $labels.taskqueue }} is {{ $value }}
+              tasks. This is the authoritative "nobody is polling / pollers
+              can't keep up" signal: it is measured by the matching service
+              and survives every worker dying. VERIFY-LIVE: metric name.
+        - alert: FhiTemporalServerScheduleToStartSlow
+          expr: >-
+            histogram_quantile(0.95,
+              sum by (le, taskqueue) (
+                rate(task_schedule_to_start_latency_bucket{namespace="default", taskqueue=~"fhi-.*"}[10m])
+              )
+            ) > 60
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Server-side p95 schedule-to-start >60s on {{ $labels.taskqueue }}"
+            description: >-
+              The matching service measured tasks waiting >60s (p95) before a
+              worker picked them up on {{ $labels.taskqueue }}. Unlike the
+              worker-side latency rule, this fires with zero workers. Units:
+              VERIFY-LIVE (server histograms may be milliseconds; adjust the
+              threshold if so).
+        - alert: FhiTemporalActivityTimeouts
+          expr: >-
+            sum by (namespace) (increase(activity_timeout{namespace="default"}[30m])) > 3
+          for: 0m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Temporal server recorded >3 activity timeouts in 30m"
+            description: >-
+              Heartbeat / start-to-close / schedule-to-start activity timeouts
+              as counted by the history service -- the server-side face of a
+              worker dying mid-attempt. VERIFY-LIVE: metric name and the
+              timeout_type label on the deployed server version.

--- a/k8s/temporal/worker-pdb.yaml
+++ b/k8s/temporal/worker-pdb.yaml
@@ -1,0 +1,32 @@
+# =============================================================================
+# PodDisruptionBudgets for the Temporal worker Deployments. With replicas: 2
+# and a hostname spread constraint on each Deployment, minAvailable: 1 keeps
+# at least one poller on every task queue through node drains and voluntary
+# evictions -- a queue with zero pollers is the silent-failure mode Temporal
+# never errors on (external review).
+# =============================================================================
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: fhi-fax-worker
+  namespace: totallylegitco
+  labels:
+    app: fight-health-insurance-prod
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      group: fight-health-insurance-prod-temporal-worker
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: fhi-appeal-worker
+  namespace: totallylegitco
+  labels:
+    app: fight-health-insurance-prod
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      group: fight-health-insurance-prod-temporal-appeal-worker

--- a/k8s/temporal/worker-podmonitor.yaml
+++ b/k8s/temporal/worker-podmonitor.yaml
@@ -1,0 +1,32 @@
+# =============================================================================
+# PodMonitor for BOTH Temporal worker Deployments (fhi-fax-worker and
+# fhi-appeal-worker). The Temporal Python SDK exposes Prometheus metrics from
+# the worker process itself (TEMPORAL_METRICS_BIND, default 0.0.0.0:9464 --
+# see run_temporal_worker.py); scraping per pod gives complete series labelled
+# by pod, same reasoning as fhi-web-podmonitor.yaml.
+#
+# ==> VERIFY-LIVE: same operator-selector caveat as fhi-web-podmonitor.yaml --
+#     the operator only picks this up if its podMonitorSelector /
+#     podMonitorNamespaceSelector match; mirror any required label here.
+# =============================================================================
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: fhi-temporal-workers
+  namespace: totallylegitco
+  labels:
+    app: fight-health-insurance
+spec:
+  selector:
+    matchExpressions:
+      - key: group
+        operator: In
+        values:
+          - fight-health-insurance-prod-temporal-worker
+          - fight-health-insurance-prod-temporal-appeal-worker
+  podMetricsEndpoints:
+    # "metrics" is the named containerPort (9464) on both worker Deployments.
+    - port: metrics
+      path: /metrics
+      scheme: http
+      interval: 30s

--- a/k8s/temporal/worker.yaml
+++ b/k8s/temporal/worker.yaml
@@ -9,9 +9,11 @@ metadata:
     app: fight-health-insurance-prod
     group: fight-health-insurance-prod-temporal-worker
 spec:
-  # Faxes are low volume; start with one worker and scale out by raising
-  # replicas (Temporal load-balances tasks across all workers on the queue).
-  replicas: 1
+  # Two pollers on the queue: a deploy or node failure must never remove
+  # every fax poller at once (Temporal queues work for a pollerless queue
+  # silently -- external review). Volume is low; two is redundancy, not
+  # capacity. Paired with worker-pdb.yaml and the spread constraint below.
+  replicas: 2
   selector:
     matchLabels:
       group: fight-health-insurance-prod-temporal-worker
@@ -28,11 +30,28 @@ spec:
       # fax is genuinely mid-send, which is exactly when killing the pod
       # would risk a double-send.
       terminationGracePeriodSeconds: 1860
+      # Spread the two replicas across nodes so one node failure cannot take
+      # both fax pollers. ScheduleAnyway (not DoNotSchedule): on a one-node
+      # cluster the second replica must still schedule.
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              group: fight-health-insurance-prod-temporal-worker
       containers:
         - image: ${FHI_BASE}:${FHI_VERSION}
           name: totallylegitco
           # start-server.sh runs `manage.py run_temporal_worker` when this is set.
+          ports:
+            # Temporal SDK Prometheus metrics (scraped by worker-podmonitor.yaml).
+            - name: metrics
+              containerPort: 9464
+              protocol: TCP
           env:
+            - name: TEMPORAL_METRICS_BIND
+              value: "0.0.0.0:9464"
             # SSH to FaxyMcFaxFace must go as user "ray" (the account the fax
             # host trusts). asyncssh/paramiko take the default username from
             # getpass.getuser(), which reads USER/LOGNAME before /etc/passwd,

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -181,6 +181,22 @@ envsubst < k8s/temporal/backfill-fingerprints-job.yaml | kubectl apply -f -
 # problems to look at, not background noise to leave retrying unattended.
 kubectl -n totallylegitco wait --for=condition=complete job/fhi-backfill-appeal-fingerprints --timeout=30m \
   || { echo "Fingerprint backfill Job did not complete within 30m; inspect it: kubectl -n totallylegitco logs job/fhi-backfill-appeal-fingerprints"; exit 1; }
+# Worker redundancy + observability (external review): PDBs keep one poller
+# per queue through drains; the PodMonitor scrapes the SDK's Prometheus
+# endpoint and the PrometheusRule alerts on the silent failure modes (work
+# waiting, slots exhausted, activity/RPC failures). Same CRD-gating as the
+# web PodMonitor below: skipped only where the operator is absent.
+kubectl apply -f k8s/temporal/worker-pdb.yaml
+if kubectl get crd podmonitors.monitoring.coreos.com >/dev/null 2>&1; then
+    kubectl apply -f k8s/temporal/worker-podmonitor.yaml
+else
+    echo "WARNING: no PodMonitor CRD in this cluster -- Temporal worker metrics will not be scraped"
+fi
+if kubectl get crd prometheusrules.monitoring.coreos.com >/dev/null 2>&1; then
+    kubectl apply -f k8s/temporal/worker-alerts.yaml
+else
+    echo "WARNING: no PrometheusRule CRD in this cluster -- Temporal worker alerts not installed"
+fi
 
 # In-cluster scraping of the app's /metrics (which is no longer reachable from
 # the internet -- see docs/metrics-endpoint-access.md). The apply is skipped

--- a/tests/temporal/test_run_temporal_worker.py
+++ b/tests/temporal/test_run_temporal_worker.py
@@ -115,3 +115,102 @@ def test_deploy_script_applies_both_worker_manifests():
         assert m, f"{name} must pin TEMPORAL_WORKER_QUEUES"
         roles[name] = m.group(1)
     assert roles == {"worker.yaml": "fax", "appeal-worker.yaml": "appeal"}
+
+
+def _free_bind() -> str:
+    """A loopback address with an OS-assigned free port: building a real
+    SDK Runtime binds the Prometheus exporter immediately, so each test
+    needs its own port."""
+    import socket
+
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return f"127.0.0.1:{sock.getsockname()[1]}"
+
+
+def test_metrics_runtime_is_off_when_unset():
+    from fighthealthinsurance.management.commands.run_temporal_worker import (
+        metrics_runtime,
+    )
+
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("TEMPORAL_METRICS_BIND", None)
+        assert metrics_runtime() is None
+
+
+def test_metrics_runtime_builds_prometheus_config_when_set():
+    """Runtime exposes no config introspection (and binds the port on
+    construction), so capture what it was built WITH."""
+    from unittest.mock import Mock
+
+    from temporalio.runtime import PrometheusConfig
+
+    from fighthealthinsurance.management.commands.run_temporal_worker import (
+        metrics_runtime,
+    )
+
+    runtime_cls = Mock()
+    with (
+        patch.dict(os.environ, {"TEMPORAL_METRICS_BIND": "0.0.0.0:9464"}),
+        patch("temporalio.runtime.Runtime", runtime_cls),
+    ):
+        metrics_runtime()
+    cfg = runtime_cls.call_args.kwargs["telemetry"].metrics
+    assert isinstance(cfg, PrometheusConfig)
+    assert cfg.bind_address == "0.0.0.0:9464"
+    assert cfg.durations_as_seconds is True
+
+
+def test_worker_passes_metrics_runtime_to_the_client():
+    """The runtime reaches Client.connect only through get_temporal_client's
+    runtime kwarg; web/Ray callers never pass one."""
+    from django.test import override_settings
+    from unittest.mock import AsyncMock, Mock
+
+    connect = AsyncMock(return_value=Mock())
+    with (
+        patch.dict(os.environ, {"TEMPORAL_METRICS_BIND": _free_bind()}),
+        patch("temporalio.worker.Worker", _recording_worker_cls()),
+        patch("fighthealthinsurance.temporal_client.get_temporal_client", connect),
+        override_settings(
+            TEMPORAL_ENABLED=True,
+            TEMPORAL_APPEAL_JOURNEY_ENABLED=False,
+            TEMPORAL_TASK_QUEUE="q-fax",
+            TEMPORAL_HOST="test-host",
+            TEMPORAL_NAMESPACE="test-ns",
+        ),
+    ):
+        asyncio.run(asyncio.wait_for(Command()._run({"queues": "fax"}), timeout=2))
+    from temporalio.runtime import Runtime
+
+    assert isinstance(connect.call_args.kwargs.get("runtime"), Runtime)
+
+
+def test_worker_manifests_are_redundant_and_scraped():
+    """Review-5 finding 8: two pollers per queue, a PDB per Deployment, a
+    hostname spread constraint, and a metrics port on both workers."""
+    import pathlib
+    import re
+
+    root = pathlib.Path(__file__).resolve().parents[2]
+    tdir = root / "k8s" / "temporal"
+    for name in ("worker.yaml", "appeal-worker.yaml"):
+        text = (tdir / name).read_text()
+        replicas = int(re.search(r"^\s*replicas:\s*(\d+)", text, re.M).group(1))
+        assert replicas >= 2, f"{name} must run >=2 replicas"
+        assert "topologySpreadConstraints:" in text, f"{name} needs a spread constraint"
+        assert "kubernetes.io/hostname" in text
+        assert re.search(r"name: metrics\s*\n\s*containerPort: 9464", text), (
+            f"{name} must expose the metrics port"
+        )
+        assert 'name: TEMPORAL_METRICS_BIND' in text
+    pdb = (tdir / "worker-pdb.yaml").read_text()
+    assert pdb.count("kind: PodDisruptionBudget") == 2
+    for group in (
+        "fight-health-insurance-prod-temporal-worker",
+        "fight-health-insurance-prod-temporal-appeal-worker",
+    ):
+        assert group in pdb, f"PDB missing for {group}"
+    build = (root / "scripts" / "build.sh").read_text()
+    for manifest in ("worker-pdb.yaml", "worker-podmonitor.yaml", "worker-alerts.yaml"):
+        assert f"k8s/temporal/{manifest}" in build, f"build.sh must apply {manifest}"

--- a/tests/temporal/test_run_temporal_worker.py
+++ b/tests/temporal/test_run_temporal_worker.py
@@ -117,17 +117,6 @@ def test_deploy_script_applies_both_worker_manifests():
     assert roles == {"worker.yaml": "fax", "appeal-worker.yaml": "appeal"}
 
 
-def _free_bind() -> str:
-    """A loopback address with an OS-assigned free port: building a real
-    SDK Runtime binds the Prometheus exporter immediately, so each test
-    needs its own port."""
-    import socket
-
-    with socket.socket() as sock:
-        sock.bind(("127.0.0.1", 0))
-        return f"127.0.0.1:{sock.getsockname()[1]}"
-
-
 def test_metrics_runtime_is_off_when_unset():
     from fighthealthinsurance.management.commands.run_temporal_worker import (
         metrics_runtime,
@@ -168,8 +157,14 @@ def test_worker_passes_metrics_runtime_to_the_client():
     from unittest.mock import AsyncMock, Mock
 
     connect = AsyncMock(return_value=Mock())
+    sentinel_runtime = Mock(name="sentinel-runtime")
     with (
-        patch.dict(os.environ, {"TEMPORAL_METRICS_BIND": _free_bind()}),
+        patch.dict(os.environ, {"TEMPORAL_METRICS_BIND": "127.0.0.1:9464"}),
+        patch(
+            "fighthealthinsurance.management.commands.run_temporal_worker."
+            "metrics_runtime",
+            return_value=sentinel_runtime,
+        ),
         patch("temporalio.worker.Worker", _recording_worker_cls()),
         patch("fighthealthinsurance.temporal_client.get_temporal_client", connect),
         override_settings(
@@ -181,9 +176,7 @@ def test_worker_passes_metrics_runtime_to_the_client():
         ),
     ):
         asyncio.run(asyncio.wait_for(Command()._run({"queues": "fax"}), timeout=2))
-    from temporalio.runtime import Runtime
-
-    assert isinstance(connect.call_args.kwargs.get("runtime"), Runtime)
+    assert connect.call_args.kwargs.get("runtime") is sentinel_runtime
 
 
 def test_worker_manifests_are_redundant_and_scraped():

--- a/tests/temporal/test_run_temporal_worker.py
+++ b/tests/temporal/test_run_temporal_worker.py
@@ -214,3 +214,90 @@ def test_worker_manifests_are_redundant_and_scraped():
     build = (root / "scripts" / "build.sh").read_text()
     for manifest in ("worker-pdb.yaml", "worker-podmonitor.yaml", "worker-alerts.yaml"):
         assert f"k8s/temporal/{manifest}" in build, f"build.sh must apply {manifest}"
+
+
+def _run_with_options(options, **flags):
+    """Like _run_with but with arbitrary command options (task_queue etc.)."""
+    from django.test import override_settings
+    from unittest.mock import AsyncMock, Mock
+
+    worker_cls = _recording_worker_cls()
+    settings = dict(
+        TEMPORAL_ENABLED=True,
+        TEMPORAL_APPEAL_JOURNEY_ENABLED=True,
+        TEMPORAL_INTAKE_JOURNEY_ENABLED=False,
+        TEMPORAL_TASK_QUEUE="q-fax",
+        TEMPORAL_APPEAL_TASK_QUEUE="q-appeal",
+        TEMPORAL_HOST="test-host",
+        TEMPORAL_NAMESPACE="test-ns",
+    )
+    settings.update(flags)
+    with (
+        patch("temporalio.worker.Worker", worker_cls),
+        patch(
+            "fighthealthinsurance.temporal_client.get_temporal_client",
+            AsyncMock(return_value=Mock()),
+        ),
+        override_settings(**settings),
+    ):
+        asyncio.run(asyncio.wait_for(Command()._run(options), timeout=2))
+    return [c.kwargs for c in worker_cls.call_args_list]
+
+
+def test_task_queue_override_applies_to_the_selected_role():
+    """--task-queue must override the queue the selected role actually
+    polls; for the appeal role it previously set a fax queue that role
+    never used (review)."""
+    fax = _run_with_options({"queues": "fax", "task_queue": "custom"})
+    assert [k["task_queue"] for k in fax] == ["custom"]
+    appeal = _run_with_options({"queues": "appeal", "task_queue": "custom"})
+    assert [k["task_queue"] for k in appeal] == ["custom"]
+    both = _run_with_options({"queues": "all", "task_queue": "custom"})
+    assert [k["task_queue"] for k in both] == ["custom", "q-appeal"]
+
+
+def test_fax_worker_slots_match_the_thread_executor():
+    """More activity slots than executor threads would let accepted
+    activities queue locally while their start-to-close clock runs."""
+    kwargs = _run_with_options({"queues": "fax", "max_workers": 7})
+    assert kwargs[0]["max_concurrent_activities"] == 7
+
+
+def test_alert_rules_use_the_workers_temporal_namespace_and_cover_worker_loss():
+    """Review-9: rules filtered on the Kubernetes namespace could never match
+    SDK series (which carry the Temporal namespace, 'default'); and worker-
+    side series vanish with the last worker, so worker-loss must be alerted
+    from scrape/kube-state data and server-side metrics."""
+    import pathlib
+    import re
+
+    root = pathlib.Path(__file__).resolve().parents[2]
+    tdir = root / "k8s" / "temporal"
+    configured = set()
+    for name in ("worker.yaml", "appeal-worker.yaml"):
+        text = (tdir / name).read_text()
+        m = re.search(r'name: TEMPORAL_NAMESPACE\s*\n\s*value: "([^"]+)"', text)
+        assert m, f"{name} must pin TEMPORAL_NAMESPACE"
+        configured.add(m.group(1))
+    assert len(configured) == 1
+    (ns,) = configured
+
+    rules = (tdir / "worker-alerts.yaml").read_text()
+    # Every Temporal-namespace matcher in a PromQL expr must be the configured
+    # one; the Kubernetes namespace may only appear as a kube_* label or in
+    # the manifest's own metadata.
+    exprs = re.findall(r"expr:\s*>-\s*\n((?:\s{12}.*\n)+)", rules)
+    assert exprs, "no rule expressions parsed"
+    for expr in exprs:
+        for label_ns in re.findall(r'(?<!kube_)\bnamespace="([^"]+)"', expr):
+            if "kube_deployment" in expr:
+                continue  # kube-state label: Kubernetes namespace is correct
+            assert label_ns == ns, f"rule filters on Temporal namespace {label_ns!r}, workers use {ns!r}"
+    for needle in (
+        "absent(up{",
+        "kube_deployment_status_replicas_available",
+        "approximate_backlog_count",
+        "FhiTemporalFaxWorkerAbsent",
+        "FhiTemporalAppealWorkerAbsent",
+    ):
+        assert needle in rules, f"worker-loss/server-side coverage missing: {needle}"


### PR DESCRIPTION
Temporal accepts work for a task queue with no healthy poller and queues it silently, so worker health has to be observed rather than assumed (external review, finding 8). This makes the workers redundant and watchable, all dark-safe:

- Metrics: the worker process serves the SDK's Prometheus endpoint when TEMPORAL_METRICS_BIND is set (both manifests set 0.0.0.0:9464; unset in dev/tests means off). Built via temporalio.runtime.Runtime with durations_as_seconds so alert thresholds read plainly; passed into Client.connect through a new get_temporal_client(runtime=) kwarg that only the worker uses.
- Redundancy: both worker Deployments run 2 replicas, spread across nodes by hostname (ScheduleAnyway so a one-node cluster still schedules), with a PodDisruptionBudget (minAvailable: 1) each so a drain never removes every poller from a queue.
- Scraping + alerts: a PodMonitor for both workers and a PrometheusRule covering schedule-to-start latency, task-slot exhaustion, activity failures (the worker-side face of heartbeat timeouts), and frontend RPC failures -- metric names verified against the installed SDK, with VERIFY-LIVE notes for labels. build.sh applies the PDB always and the operator objects behind the same CRD guard the web PodMonitor uses.
- Tests: metrics runtime built/omitted from the env var, the runtime reaching the client, and a manifest check for replicas, spread, the metrics port, both PDBs, and the deploy script applying every new manifest.


Claude-Session: https://claude.ai/code/session_019SPqa4FZ43ahAjoD53Uj81

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics exposure for Temporal workers, including configurable runtime binding and second-based duration reporting.
  * Added monitoring collection, alerting, and deployment guidance for worker health and performance.
  * Increased fax and appeal worker redundancy to two replicas with improved distribution and disruption protection.
  * Added role-specific task queue overrides and aligned fax activity concurrency with configured thread counts.

* **Documentation**
  * Added deployment instructions and observability verification steps for the new worker monitoring resources.

* **Tests**
  * Added coverage for metrics configuration, queue assignment, worker concurrency, redundancy, and monitoring manifests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->