### PR TITLE
Serve pdf.js and tesseract workers from dist, not node_modules

### DIFF
--- a/fighthealthinsurance/static/js/package-lock.json
+++ b/fighthealthinsurance/static/js/package-lock.json
@@ -55,6 +55,7 @@
         "@types/qs": "^6.9.17",
         "@types/uuid": "^10.0.0",
         "babel-loader": "^10.0.0",
+        "copy-webpack-plugin": "^13.0.1",
         "css-loader": "^7.1.4",
         "prettier": "3.5.3",
         "style-loader": "^4.0.0",
@@ -3602,6 +3603,43 @@
       "peer": true,
       "dependencies": {
         "toggle-selection": "^1.0.6"
+      }
+    },
+    "node_modules/copy-webpack-plugin": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-13.0.1.tgz",
+      "integrity": "sha512-J+YV3WfhY6W/Xf9h+J1znYuqTye2xkBUIGyTPWuBAT27qajBa5mR4f8WBmfDY3YjRftT2kqZZiLi1qf0H+UOFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob-parent": "^6.0.1",
+        "normalize-path": "^3.0.0",
+        "schema-utils": "^4.2.0",
+        "serialize-javascript": "^6.0.2",
+        "tinyglobby": "^0.2.12"
+      },
+      "engines": {
+        "node": ">= 18.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      }
+    },
+    "node_modules/copy-webpack-plugin/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/core-js": {
@@ -9359,6 +9397,54 @@
       "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",

--- a/fighthealthinsurance/static/js/package.json
+++ b/fighthealthinsurance/static/js/package.json
@@ -67,6 +67,7 @@
     "@types/qs": "^6.9.17",
     "@types/uuid": "^10.0.0",
     "babel-loader": "^10.0.0",
+    "copy-webpack-plugin": "^13.0.1",
     "css-loader": "^7.1.4",
     "prettier": "3.5.3",
     "style-loader": "^4.0.0",

--- a/fighthealthinsurance/static/js/scrub_ocr.ts
+++ b/fighthealthinsurance/static/js/scrub_ocr.ts
@@ -1,4 +1,4 @@
-import { pdfjsLib, node_module_path } from "./shared";
+import { pdfjsLib, workers_path } from "./shared";
 import {
   PDFDocumentProxy,
   TextContent,
@@ -64,7 +64,9 @@ async function runDualOCRWithGrace(
     if (isUsableOCRState(tesseractState)) {
       const qwenResult = await Promise.race([
         trackedQwen
-          .catch((reason): SettledState<string> => ({ status: "rejected", reason }))
+          .catch(
+            (reason): SettledState<string> => ({ status: "rejected", reason }),
+          )
           .then((state) => ({ timedOut: false as const, state })),
         sleep(OCR_GRACE_PERIOD_MS).then(() => ({ timedOut: true as const })),
       ]);
@@ -83,12 +85,17 @@ async function runDualOCRWithGrace(
     if (isUsableOCRState(qwenState)) {
       const tesseractResult = await Promise.race([
         trackedTesseract
-          .catch((reason): SettledState<string> => ({ status: "rejected", reason }))
+          .catch(
+            (reason): SettledState<string> => ({ status: "rejected", reason }),
+          )
           .then((state) => ({ timedOut: false as const, state })),
         sleep(OCR_GRACE_PERIOD_MS).then(() => ({ timedOut: true as const })),
       ]);
 
-      if (!tesseractResult.timedOut && isUsableOCRState(tesseractResult.state)) {
+      if (
+        !tesseractResult.timedOut &&
+        isUsableOCRState(tesseractResult.state)
+      ) {
         tesseractState = tesseractResult.state;
       }
     } else {
@@ -100,11 +107,17 @@ async function runDualOCRWithGrace(
   }
 
   if (tesseractState?.status === "rejected") {
-    console.warn("[TesseractOCR] Primary OCR path failed", tesseractState.reason);
+    console.warn(
+      "[TesseractOCR] Primary OCR path failed",
+      tesseractState.reason,
+    );
   }
 
   if (qwenState?.status === "rejected") {
-    console.warn("[QwenOCR] Parallel OCR path failed; using Tesseract result", qwenState.reason);
+    console.warn(
+      "[QwenOCR] Parallel OCR path failed; using Tesseract result",
+      qwenState.reason,
+    );
   }
 
   if (qwenState === null) {
@@ -113,7 +126,8 @@ async function runDualOCRWithGrace(
     );
   }
 
-  const tesseractText = tesseractState?.status === "fulfilled" ? tesseractState.value : "";
+  const tesseractText =
+    tesseractState?.status === "fulfilled" ? tesseractState.value : "";
   const qwenText = qwenState?.status === "fulfilled" ? qwenState.value : "";
 
   if (!tesseractText && !qwenText) {
@@ -130,8 +144,8 @@ async function runDualOCRWithGrace(
 async function getTesseractWorkerRaw(): Promise<Tesseract.Worker> {
   console.log("Loading tesseract worker.");
   const worker = await Tesseract.createWorker("eng", 1, {
-    corePath: node_module_path + "/tesseract.js-core",
-    workerPath: node_module_path + "/tesseract.js/dist/worker.min.js",
+    corePath: workers_path + "tesseract.js-core",
+    workerPath: workers_path + "tesseract.js/worker.min.js",
     logger: function (m) {
       console.log(m);
     },
@@ -147,7 +161,9 @@ const memoizeOne = require("async-memoize-one");
 const getTesseractWorker = memoizeOne(getTesseractWorkerRaw);
 
 function isPDF(file: File): boolean {
-  return file.type === "application/pdf" || file.name.toLowerCase().endsWith(".pdf");
+  return (
+    file.type === "application/pdf" || file.name.toLowerCase().endsWith(".pdf")
+  );
 }
 
 async function getFileAsArrayBuffer(file: File): Promise<Uint8Array> {
@@ -194,21 +210,29 @@ function mergeOCRTexts({ tesseractText, qwenText }: OCRResults): string {
 }
 
 function isAdvancedOCREnabled(): boolean {
-  const checkbox = document.getElementById("advanced_ocr_enabled") as HTMLInputElement | null;
+  const checkbox = document.getElementById(
+    "advanced_ocr_enabled",
+  ) as HTMLInputElement | null;
   // Default to true when the checkbox is absent (non-scrub pages).
   return checkbox ? checkbox.checked : true;
 }
 
-async function recognizeImageText(file: Blob | File | string): Promise<OCRResults> {
+async function recognizeImageText(
+  file: Blob | File | string,
+): Promise<OCRResults> {
   const worker = await getTesseractWorker();
   const tesseractPromise = worker
     .recognize(file)
     .then((result: Tesseract.RecognizeResult) => result.data.text);
-  const qwenPromise = isAdvancedOCREnabled() ? recognizeWithQwenWebGPU(file) : Promise.resolve("");
+  const qwenPromise = isAdvancedOCREnabled()
+    ? recognizeWithQwenWebGPU(file)
+    : Promise.resolve("");
   const result = await runDualOCRWithGrace(tesseractPromise, qwenPromise);
 
   if (result.usedFallback) {
-    console.warn("[TesseractOCR] Falling back to Qwen OCR text because Tesseract output was unavailable");
+    console.warn(
+      "[TesseractOCR] Falling back to Qwen OCR text because Tesseract output was unavailable",
+    );
   }
 
   return {
@@ -282,7 +306,10 @@ export const recognize = async function (
   }
 };
 
-async function getPDFPageText(pdf: PDFDocumentProxy, pageNo: number): Promise<string> {
+async function getPDFPageText(
+  pdf: PDFDocumentProxy,
+  pageNo: number,
+): Promise<string> {
   const page = await pdf.getPage(pageNo);
   const tokenizedText: TextContent = await page.getTextContent();
   const items: TextItem[] = [];

--- a/fighthealthinsurance/static/js/shared.ts
+++ b/fighthealthinsurance/static/js/shared.ts
@@ -33,21 +33,23 @@ function clearFormData(): void {
   const keysToRemove: string[] = [];
   for (let i = 0; i < window.localStorage.length; i++) {
     const key = window.localStorage.key(i);
-    if (key && (key.startsWith("store_") || key === "email" || key === "denial_text")) {
+    if (
+      key &&
+      (key.startsWith("store_") || key === "email" || key === "denial_text")
+    ) {
       keysToRemove.push(key);
     }
   }
-  keysToRemove.forEach(key => window.localStorage.removeItem(key));
+  keysToRemove.forEach((key) => window.localStorage.removeItem(key));
 }
 
 // Get item with TTL check
 function getLocalStorageItemWithTTL(key: string): string | null {
-
   // If someones disabled persistence remove items if found.
   const stored = window.localStorage.getItem(key);
   if (!isPersistenceEnabled()) {
-      window.localStorage.removeItem(key);
-      return null;
+    window.localStorage.removeItem(key);
+    return null;
   }
   if (!stored) {
     return null;
@@ -122,11 +124,15 @@ const storeTextareaLocal = async function (event: Event) {
   setLocalStorageItemWithTTL(name, value);
 };
 
-const node_module_path = "/static/js/node_modules/";
+// Runtime worker assets (pdf.js, tesseract.js) are copied into dist/workers/
+// by the webpack build (see webpack.config.js). They must never be loaded
+// from the third-party package tree under static/js: it is no longer
+// collected and nginx denies it outright, which is what broke PDF loading
+// and OCR in production. tests/async-unit/test_worker_assets.py pins this.
+const workers_path = "/static/js/dist/workers/";
 
 // pdf.js
-pdfjsLib.GlobalWorkerOptions.workerSrc =
-  node_module_path + "pdfjs-dist/build/pdf.worker.min.mjs";
+pdfjsLib.GlobalWorkerOptions.workerSrc = workers_path + "pdf.worker.min.mjs";
 
 /**
  * Get CSRF token from cookies for Django requests.
@@ -152,7 +158,7 @@ export {
   storeLocal,
   storeTextareaLocal,
   pdfjsLib,
-  node_module_path,
+  workers_path,
   getLocalStorageItemOrDefault,
   getLocalStorageItemOrDefaultEQ,
   getLocalStorageItemWithTTL,

--- a/fighthealthinsurance/static/js/webpack.config.js
+++ b/fighthealthinsurance/static/js/webpack.config.js
@@ -1,7 +1,20 @@
 const path = require('path');
 const glob = require('glob');
 const TerserPlugin = require('terser-webpack-plugin');
+const CopyPlugin = require('copy-webpack-plugin');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
+
+// Runtime worker assets that pdf.js and tesseract.js load by URL at runtime
+// (they cannot be bundled). They used to be served straight out of
+// /static/js/node_modules/, which stopped being published (collectstatic
+// ignore + nginx deny, PR #936) -- so they are copied into dist/workers/,
+// which ships with the bundles. Nothing at runtime may reference a
+// node_modules URL; tests/async-unit/test_worker_assets.py pins that.
+const workerAssets = [
+  { from: 'node_modules/pdfjs-dist/build/pdf.worker.min.mjs', to: 'workers/pdf.worker.min.mjs' },
+  { from: 'node_modules/tesseract.js/dist/worker.min.js', to: 'workers/tesseract.js/worker.min.js' },
+  { from: 'node_modules/tesseract.js-core/*.{js,wasm}', to: 'workers/tesseract.js-core/[name][ext]' },
+];
 
 // Check if bundle analysis is requested
 const shouldAnalyze = process.env.ANALYZE === 'true';
@@ -130,13 +143,16 @@ module.exports = async (env, argv) => {
   },
   // Generate source maps in both development and production (OSS project, helpful for debugging)
   devtool: 'source-map',
-  // Plugins - conditionally add bundle analyzer
-  plugins: shouldAnalyze ? [
-    new BundleAnalyzerPlugin({
-      analyzerMode: 'static',
-      reportFilename: 'bundle-report.html',
-      openAnalyzer: true,
-    }),
-  ] : [],
+  // Plugins - the worker asset copy always; the bundle analyzer on request
+  plugins: [
+    new CopyPlugin({ patterns: workerAssets }),
+    ...(shouldAnalyze ? [
+      new BundleAnalyzerPlugin({
+        analyzerMode: 'static',
+        reportFilename: 'bundle-report.html',
+        openAnalyzer: true,
+      }),
+    ] : []),
+  ],
 };
 }

--- a/tests/async-unit/test_worker_assets.py
+++ b/tests/async-unit/test_worker_assets.py
@@ -1,0 +1,50 @@
+"""Runtime worker assets must never be loaded from a node_modules URL.
+
+pdf.js and tesseract.js load their workers by URL at runtime. They used to
+point at /static/js/node_modules/..., which PR #936 correctly stopped
+publishing (collectstatic ignore + nginx `deny all`) -- and that silently
+broke PDF loading and OCR in production. The webpack build now copies the
+assets into dist/workers/; these tests pin both halves so the regression
+cannot recur unnoticed.
+"""
+
+import re
+from pathlib import Path
+
+JS_DIR = Path(__file__).resolve().parent.parent.parent / "fighthealthinsurance" / "static" / "js"
+WEBPACK = JS_DIR / "webpack.config.js"
+SOURCES = [
+    p
+    for p in list(JS_DIR.glob("*.ts")) + list(JS_DIR.glob("*.tsx"))
+    if "node_modules" not in p.parts
+]
+
+
+def test_no_runtime_source_references_a_node_modules_url():
+    offenders = [
+        p.name
+        for p in SOURCES
+        if re.search(r"static/js/node_modules|node_module_path", p.read_text())
+    ]
+    assert offenders == [], f"node_modules URLs in: {offenders}"
+
+
+def test_webpack_copies_every_runtime_worker_asset_into_dist_workers():
+    text = WEBPACK.read_text()
+    assert "copy-webpack-plugin" in text
+    for src, dest in (
+        ("pdfjs-dist/build/pdf.worker.min.mjs", "workers/pdf.worker.min.mjs"),
+        ("tesseract.js/dist/worker.min.js", "workers/tesseract.js/worker.min.js"),
+        ("tesseract.js-core/", "workers/tesseract.js-core/"),
+    ):
+        assert src in text, f"missing copy source {src}"
+        assert dest in text, f"missing copy destination {dest}"
+
+
+def test_sources_point_at_the_copied_workers():
+    shared = (JS_DIR / "shared.ts").read_text()
+    ocr = (JS_DIR / "scrub_ocr.ts").read_text()
+    assert '"/static/js/dist/workers/"' in shared
+    assert 'workers_path + "pdf.worker.min.mjs"' in shared
+    assert 'workers_path + "tesseract.js-core"' in ocr
+    assert 'workers_path + "tesseract.js/worker.min.js"' in ocr


### PR DESCRIPTION
PDF loading and image OCR broke in production after #936 correctly stopped publishing static/js/node_modules (collectstatic ignore + nginx deny all): the pdf.js worker and the tesseract.js worker/core were still loaded by URL from that tree, so every PDF upload and OCR pass now hit a 403.

The webpack build copies those runtime-loaded assets into dist/workers/ (copy-webpack-plugin), which ships alongside the bundles and is never ignored; shared.ts and scrub_ocr.ts point at /static/js/dist/workers/. Tests pin both halves: no runtime source may reference a node_modules URL, and the build config must copy every worker asset.


Claude-Session: https://claude.ai/code/session_019SPqa4FZ43ahAjoD53Uj81