### PR TITLE
Deploy: bump the version pin, guard the Ray wait, apply observability…

### DIFF
--- a/k8s/temporal/README.md
+++ b/k8s/temporal/README.md
@@ -97,37 +97,49 @@ PrometheusRules, `intake-outbox-cronjob.yaml` and
 `backfill-fingerprints-job.yaml` — so the hand commands above are for a
 first bring-up or a one-off repair, not for every release.
 
-Two things to know before you run it:
+Three things to know before you run it:
 
-- **It can wait up to ~90 minutes.** After applying, it blocks on the `web`,
-  `fhi-fax-worker` and `fhi-appeal-worker` rollouts (15m each) and on the Ray
-  pods going Ready (5m to appear, then 15m), then runs the strict fingerprint
-  backfill Job and polls up to 30m for it to finish. That is the mixed-version
-  guard: a strict pass that runs while any pre-fingerprint pod can still take
-  a request proves nothing, so the deploy makes sure the old writers are gone
-  first.
-- **A rollout that stalls or a backfill Job that fails ends the deploy
-  non-zero, on purpose.** The Job failing means it found rows a
-  pre-fingerprint writer produced; look at it before rerunning:
+- **It can wait a long time.** Worst case is about two hours: 15m per
+  Deployment rollout (`web`, `fhi-fax-worker`, `fhi-appeal-worker`), then up
+  to 10m each waiting for the old `web` and `fhi-appeal-worker` pods to
+  actually exit, up to 25m for the Ray cluster (old pods gone, new pods
+  appear, new pods Ready), then up to 30m for the strict fingerprint backfill
+  Job. In practice it is far shorter — the drains are mostly done by the time
+  the rollouts report, and the backfill on an already-clean table takes a
+  couple of minutes.
+- **Rolling out is not the same as draining, and the script waits for both.**
+  `kubectl rollout status` returns as soon as the new replicas are available
+  and the old ones stop being *counted* — a pod stops counting the moment it
+  is marked for deletion, while its process keeps running preStop and
+  finishing in-flight work. `web` allows 420s plus a 15s preStop and
+  `fhi-appeal-worker` 360s, and both write `ProposedAppeal` rows, so the
+  script additionally waits for those pods to be gone before the strict
+  backfill runs. `fhi-fax-worker` is rolled but deliberately not drained: it
+  polls the fax queue only, writes no `ProposedAppeal`, and its 1860s grace
+  period would add half an hour to every deploy for nothing.
+- **A stalled rollout or a failed backfill Job ends the deploy non-zero, on
+  purpose.** The Job failing means it found rows a pre-fingerprint writer
+  produced; look at it before rerunning:
 
   ```sh
   kubectl -n totallylegitco logs job/fhi-backfill-appeal-fingerprints
   ```
 
-  The applies all happen before the waits, so a failure here still leaves the
-  new image, the PDBs, the monitors, the alerts and the relay CronJob in place.
+  Every apply happens before every wait, so a failure here still leaves the
+  new image, the PDBs, the monitors, the alerts and the relay CronJob in
+  place.
 
-Two escape hatches when you need the deploy without the waits:
+Two escape hatches when the waiting is not what you want:
 
 | Flag | Effect |
 | --- | --- |
-| `--skip-journey-gates` | Applies everything including the backfill Job, but does not block on the rollouts or the Job. You check the Job yourself. |
-| `--skip-backfill` | Does not apply or wait for the backfill Job at all. For a cluster where it has already run clean. |
+| `--skip-journey-gates` | Applies everything including the backfill Job, but blocks on nothing — no rollout wait, no drain, no Job wait. You check the Job yourself. |
+| `--skip-backfill` | Does not apply or wait for the backfill Job, nor for the writer drain that only that Job needs. Rollout waits still run, because a Deployment that never finishes rolling is a broken deploy either way. |
 
-Both skip only the *waiting* (and, for `--skip-backfill`, the Job). Neither
-changes what image ships. Use them knowing what the gate buys you: without it,
-`ProposedAppeal.text_fingerprint` can carry NULLs or stale values from a pod
-that had not rolled yet, which only matters once the journey flags are on.
+Neither changes what image ships. What the gate buys you, if you skip it:
+`ProposedAppeal.text_fingerprint` can carry NULLs or stale values written by a
+pod that had not finished draining, which only matters once the journey flags
+are on.
 
 ## Turning it on
 

--- a/k8s/temporal/README.md
+++ b/k8s/temporal/README.md
@@ -103,8 +103,9 @@ Three things to know before you run it:
   Deployment rollout (`web`, `fhi-fax-worker`, `fhi-appeal-worker`), then up
   to 10m each waiting for the old `web` and `fhi-appeal-worker` pods to
   actually exit, up to 25m for the Ray cluster (old pods gone, new pods
-  appear, new pods Ready), then up to 30m for the strict fingerprint backfill
-  Job. In practice it is far shorter — the drains are mostly done by the time
+  appear, and as many pods Ready as the RayCluster spec calls for — head plus
+  each worker group's `replicas` clamped up to its `minReplicas`, which is how
+  KubeRay sizes it), then up to 30m for the strict fingerprint backfill Job. In practice it is far shorter — the drains are mostly done by the time
   the rollouts report, and the backfill on an already-clean table takes a
   couple of minutes.
 - **Rolling out is not the same as draining, and the script waits for both.**

--- a/k8s/temporal/README.md
+++ b/k8s/temporal/README.md
@@ -89,6 +89,46 @@ fits comfortably next to the Ray heads (which already request 6 GiB each).
      || echo "no PrometheusRule CRD -- worker alerts not installed"
    ```
 
+## What `scripts/build.sh` does with these manifests
+
+A normal prod deploy applies all of the above for you — `worker.yaml`,
+`appeal-worker.yaml`, `worker-pdb.yaml`, both PodMonitors, both
+PrometheusRules, `intake-outbox-cronjob.yaml` and
+`backfill-fingerprints-job.yaml` — so the hand commands above are for a
+first bring-up or a one-off repair, not for every release.
+
+Two things to know before you run it:
+
+- **It can wait up to ~90 minutes.** After applying, it blocks on the `web`,
+  `fhi-fax-worker` and `fhi-appeal-worker` rollouts (15m each) and on the Ray
+  pods going Ready (5m to appear, then 15m), then runs the strict fingerprint
+  backfill Job and polls up to 30m for it to finish. That is the mixed-version
+  guard: a strict pass that runs while any pre-fingerprint pod can still take
+  a request proves nothing, so the deploy makes sure the old writers are gone
+  first.
+- **A rollout that stalls or a backfill Job that fails ends the deploy
+  non-zero, on purpose.** The Job failing means it found rows a
+  pre-fingerprint writer produced; look at it before rerunning:
+
+  ```sh
+  kubectl -n totallylegitco logs job/fhi-backfill-appeal-fingerprints
+  ```
+
+  The applies all happen before the waits, so a failure here still leaves the
+  new image, the PDBs, the monitors, the alerts and the relay CronJob in place.
+
+Two escape hatches when you need the deploy without the waits:
+
+| Flag | Effect |
+| --- | --- |
+| `--skip-journey-gates` | Applies everything including the backfill Job, but does not block on the rollouts or the Job. You check the Job yourself. |
+| `--skip-backfill` | Does not apply or wait for the backfill Job at all. For a cluster where it has already run clean. |
+
+Both skip only the *waiting* (and, for `--skip-backfill`, the Job). Neither
+changes what image ships. Use them knowing what the gate buys you: without it,
+`ProposedAppeal.text_fingerprint` can carry NULLs or stale values from a pod
+that had not rolled yet, which only matters once the journey flags are on.
+
 ## Turning it on
 
 Fax sending only routes through Temporal when `TEMPORAL_ENABLED=true`. Until

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -191,6 +191,23 @@ deployment_present() {
     exit 1
 }
 
+# Same rule as deployment_present, for the optional Prometheus operator CRDs:
+# `kubectl get crd X >/dev/null 2>&1` reads a 403 or an API blip as "not
+# installed", silently skipping the PodMonitors and alert rules and printing a
+# message that says the cluster does not have the operator. That is the same
+# no-metrics gap the apply ordering above exists to close (external review).
+crd_present() {
+    local out
+    if out=$(kubectl --request-timeout=30s get crd "$1" -o name 2>&1); then
+        return 0
+    fi
+    if printf '%s' "$out" | grep -qi "not found"; then
+        return 1
+    fi
+    echo "kubectl get crd $1 failed, refusing to guess whether it exists: $out" >&2
+    exit 1
+}
+
 # Pods under a selector that are marked for deletion but whose processes are
 # still running.
 terminating_pods() {
@@ -237,6 +254,40 @@ ray_pods_exist() {
     [ -n "$out" ]
 }
 
+# KubeRay clamps a worker group's desired size UP to minReplicas, so
+# k8s/ray/cluster.yaml asking for `replicas: 1` under `minReplicas: 2` really
+# schedules TWO worker pods. "Some pod under this label is Ready" would let
+# the head satisfy the gate on its own while both workers were still being
+# created -- and the head is not the pod running SpeculativeAppealsActor
+# (external review). Work out the size this cluster should reach, and require
+# that many Ready.
+ray_expected_pods() {
+    local reps_raw mins_raw total=1 i
+    local -a reps mins
+    reps_raw="$("${KGET[@]}" get raycluster raycluster-kuberay \
+        -o jsonpath='{.spec.workerGroupSpecs[*].replicas}')" || return 1
+    mins_raw="$("${KGET[@]}" get raycluster raycluster-kuberay \
+        -o jsonpath='{.spec.workerGroupSpecs[*].minReplicas}')" || return 1
+    read -r -a reps <<< "$reps_raw"
+    read -r -a mins <<< "$mins_raw"
+    for i in "${!reps[@]}"; do
+        if [ "${mins[i]:-0}" -gt "${reps[i]:-0}" ]; then
+            total=$((total + ${mins[i]:-0}))
+        else
+            total=$((total + ${reps[i]:-0}))
+        fi
+    done
+    printf '%s' "$total"
+}
+
+ray_ready_pods() {
+    local out
+    out="$("${KGET[@]}" get pods -l ray.io/cluster=raycluster-kuberay \
+        --field-selector=status.phase!=Succeeded,status.phase!=Failed \
+        -o go-template='{{range .items}}{{range .status.conditions}}{{if and (eq .type "Ready") (eq .status "True")}}R{{end}}{{end}}{{end}}')" || return 1
+    printf '%s' "${#out}"
+}
+
 ray_pod_uids() {
     "${KGET[@]}" get pods -l ray.io/cluster=raycluster-kuberay \
         -o jsonpath='{.items[*].metadata.uid}'
@@ -263,6 +314,9 @@ ray_old_pods_remaining() {
         exit 1
     fi
     now=" $now "
+    # Split on spaces regardless of any ambient IFS: with a changed IFS the
+    # whole UID list becomes one token and every old pod would read as gone.
+    local IFS=' '
     for uid in $RAY_PODS_BEFORE; do
         case "$now" in *" $uid "*) return 0 ;; esac
     done
@@ -301,12 +355,12 @@ envsubst < k8s/temporal/appeal-worker.yaml | kubectl apply -f -
 # to close. They are cheap, idempotent applies with nothing to wait for, so
 # they belong above the waits.
 kubectl apply -f k8s/temporal/worker-pdb.yaml
-if kubectl get crd podmonitors.monitoring.coreos.com >/dev/null 2>&1; then
+if crd_present podmonitors.monitoring.coreos.com; then
     kubectl apply -f k8s/temporal/worker-podmonitor.yaml
 else
     echo "WARNING: no PodMonitor CRD in this cluster -- Temporal worker metrics will not be scraped"
 fi
-if kubectl get crd prometheusrules.monitoring.coreos.com >/dev/null 2>&1; then
+if crd_present prometheusrules.monitoring.coreos.com; then
     kubectl apply -f k8s/temporal/worker-alerts.yaml
 else
     echo "WARNING: no PrometheusRule CRD in this cluster -- Temporal worker alerts not installed"
@@ -319,7 +373,7 @@ envsubst < k8s/temporal/intake-outbox-cronjob.yaml | kubectl apply -f -
 # Alerts for the relay itself: a stalled outbox is invisible in worker and
 # web metrics (the events simply stop moving), so backlog age and CronJob
 # success age are the only signals that catch it (external review).
-if kubectl get crd prometheusrules.monitoring.coreos.com >/dev/null 2>&1; then
+if crd_present prometheusrules.monitoring.coreos.com; then
     kubectl apply -f k8s/temporal/intake-outbox-alerts.yaml
 else
     echo "WARNING: no PrometheusRule CRD in this cluster -- intake outbox alerts not installed"
@@ -373,7 +427,7 @@ else
     # Ray: the pods that existed before the delete must be gone before their
     # replacements can vouch for anything.
     ray_deadline=$((SECONDS + 300))
-    while ray_old_pods_remaining; do
+    while ray_old_pods_remaining || [ -n "$(terminating_pods ray.io/cluster=raycluster-kuberay)" ]; do
       if [ "$SECONDS" -ge "$ray_deadline" ]; then
         echo "Ray pods from before the cluster delete are still running after 5m; not running the fingerprint backfill Job" >&2
         exit 1
@@ -395,30 +449,30 @@ else
       sleep 10
     done
     if [ "$ray_pods_present" = true ]; then
-      # `kubectl wait` resolves its selector ONCE per invocation, so a single
-      # long wait started when only the head pod existed would never look at
-      # the worker pods created after it (external review). Call it
-      # repeatedly with a short timeout -- each call re-lists -- and require
-      # two consecutive clean passes so a lone head cannot satisfy the gate
-      # in the window before its workers are scheduled.
+      # Not `kubectl wait`: it resolves its selector ONCE per invocation, so a
+      # wait begun when only the head pod existed would never look at the
+      # worker pods created after it (external review). Re-count every tick
+      # against the size the cluster is supposed to reach.
+      if ! ray_expected="$(ray_expected_pods)"; then
+        echo "Could not read the RayCluster spec; refusing to guess how many pods to wait for" >&2
+        exit 1
+      fi
       ray_ready_deadline=$((SECONDS + 900))
-      ray_stable=0
-      while [ "$SECONDS" -lt "$ray_ready_deadline" ]; do
-        if kubectl --request-timeout=60s -n totallylegitco wait --for=condition=Ready pod \
-             -l ray.io/cluster=raycluster-kuberay \
-             --field-selector=status.phase!=Succeeded,status.phase!=Failed \
-             --timeout=30s >/dev/null 2>&1; then
-          ray_stable=$((ray_stable + 1))
-          [ "$ray_stable" -ge 2 ] && break
-        else
-          ray_stable=0
+      while :; do
+        if ! ray_ready="$(ray_ready_pods)"; then
+          echo "Could not count Ready Ray pods; refusing to treat that as ready" >&2
+          exit 1
+        fi
+        [ "$ray_ready" -ge "$ray_expected" ] && break
+        # Deadline checked AFTER a count, so a cluster that finishes in the
+        # last few seconds is not reported as a timeout.
+        if [ "$SECONDS" -ge "$ray_ready_deadline" ]; then
+          echo "Ray cluster: only $ray_ready of $ray_expected pods Ready after 15m; not running the fingerprint backfill Job" >&2
+          exit 1
         fi
         sleep 10
       done
-      if [ "$ray_stable" -lt 2 ]; then
-        echo "Ray cluster pods not consistently Ready within 15m; not running the fingerprint backfill Job" >&2
-        exit 1
-      fi
+      echo "Ray cluster: $ray_ready of $ray_expected pods Ready"
     else
       echo "No Ray cluster pods after 5m; skipping the Ray readiness wait (no Ray writers to drain)"
     fi
@@ -471,7 +525,7 @@ fi
 # only where the Prometheus operator's CRD is absent; every other failure (bad
 # manifest, RBAC, API error) is fatal, because a deploy that "succeeded" with no
 # metrics targets is exactly the silent gap this endpoint lockdown could create.
-if kubectl get crd podmonitors.monitoring.coreos.com >/dev/null 2>&1; then
+if crd_present podmonitors.monitoring.coreos.com; then
     kubectl apply -f k8s/fhi-web-podmonitor.yaml
 else
     echo "WARNING: no PodMonitor CRD in this cluster -- app metrics will not be scraped"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -168,10 +168,12 @@ echo "PDBHOST now set to: $(kubectl -n totallylegitco get configmap fhi-db-confi
 kubectl apply -f k8s/fhi-pg-main-9-scheduledbackup.yaml
 
 # --- deploy gate helpers ---------------------------------------------------
-# Every gate call below carries an explicit --request-timeout. kubectl's
+# Every POLLING call below carries an explicit --request-timeout. kubectl's
 # default is 0, i.e. wait forever, so one stuck API request would hang the
 # deploy straight through whatever budget the loops claim to enforce
-# (external review).
+# (external review). Blocking commands -- `rollout status`, `delete` -- are
+# deliberately left alone: they already take their own --timeout, and a
+# per-request bound there aborts operations that are progressing normally.
 KGET=(kubectl --request-timeout=30s -n totallylegitco)
 
 # `if kubectl get deployment X >/dev/null 2>&1` is NOT a safe presence test.
@@ -328,7 +330,7 @@ ray_old_pods_remaining() {
 # swallowed every failure -- 403, API error, timeout -- and reported a missing
 # cluster, after which the apply would merely update the CR still standing
 # (external review).
-kubectl --request-timeout=60s delete raycluster -n totallylegitco raycluster-kuberay --ignore-not-found
+kubectl delete raycluster -n totallylegitco raycluster-kuberay --ignore-not-found
 envsubst < k8s/ray/cluster.yaml | kubectl apply -f -
 
 # Deploy a staging env
@@ -387,7 +389,11 @@ if [ "$SKIP_JOURNEY_GATES" = true ]; then
 else
     for dep in web fhi-fax-worker fhi-appeal-worker; do
       if deployment_present "$dep"; then
-        kubectl --request-timeout=60s -n totallylegitco rollout status deployment "$dep" --timeout=15m \
+        # No --request-timeout here: --timeout=15m already bounds the wait,
+        # and a per-request bound makes older kubectl clients exit when the
+        # watch request expires instead of re-establishing it (external
+        # review).
+        kubectl -n totallylegitco rollout status deployment "$dep" --timeout=15m \
           || { echo "Rollout of $dep did not complete"; exit 1; }
       else
         echo "Deployment $dep not present; skipping rollout wait"
@@ -414,7 +420,7 @@ if [ "$SKIP_BACKFILL" = true ]; then
     echo "--skip-backfill: not applying or waiting for the fingerprint backfill Job"
 elif [ "$SKIP_JOURNEY_GATES" = true ]; then
     echo "--skip-journey-gates: applying the backfill Job WITHOUT gating on the writers"
-    kubectl --request-timeout=60s delete job fhi-backfill-appeal-fingerprints -n totallylegitco --ignore-not-found
+    kubectl delete job fhi-backfill-appeal-fingerprints -n totallylegitco --ignore-not-found
     envsubst < k8s/temporal/backfill-fingerprints-job.yaml | kubectl apply -f -
     echo "NOTE: check it yourself -- kubectl -n totallylegitco get job/fhi-backfill-appeal-fingerprints"
 else
@@ -427,7 +433,16 @@ else
     # Ray: the pods that existed before the delete must be gone before their
     # replacements can vouch for anything.
     ray_deadline=$((SECONDS + 300))
-    while ray_old_pods_remaining || [ -n "$(terminating_pods ray.io/cluster=raycluster-kuberay)" ]; do
+    while :; do
+      # `[ -n "$(terminating_pods ...)" ]` would discard kubectl's exit
+      # status: a failed list is an empty string, which reads as "nothing is
+      # terminating" and opens the gate (external review). Check it the way
+      # wait_for_drain does.
+      if ! ray_terminating="$(terminating_pods ray.io/cluster=raycluster-kuberay)"; then
+        echo "Could not list terminating Ray pods; refusing to guess that they are gone" >&2
+        exit 1
+      fi
+      ray_old_pods_remaining || [ -n "$ray_terminating" ] || break
       if [ "$SECONDS" -ge "$ray_deadline" ]; then
         echo "Ray pods from before the cluster delete are still running after 5m; not running the fingerprint backfill Job" >&2
         exit 1
@@ -477,7 +492,7 @@ else
       echo "No Ray cluster pods after 5m; skipping the Ray readiness wait (no Ray writers to drain)"
     fi
 
-    kubectl --request-timeout=60s delete job fhi-backfill-appeal-fingerprints -n totallylegitco --ignore-not-found
+    kubectl delete job fhi-backfill-appeal-fingerprints -n totallylegitco --ignore-not-found
     envsubst < k8s/temporal/backfill-fingerprints-job.yaml | kubectl apply -f -
     # Wait for the strict backfill, and FAIL FAST on a failed Job (external
     # review): `kubectl wait --for=condition=complete` ignores condition=Failed,

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,21 +10,48 @@ BUILDX_CMD=${BUILDX_CMD:-push}
 # setup (mypy, migrations, collectstatic, npm build) and the image builds -- so
 # the script can run on a deploy-only host or CI job that has just kubectl and
 # envsubst (no Python/Node build toolchain).
+#
+# --skip-journey-gates: apply everything, but do not BLOCK the deploy on the
+# writer rollouts or the fingerprint backfill Job. The Job is still applied and
+# still runs (with its own backoff); you just stop waiting for it here. Use it
+# when you want the deploy to land promptly and intend to check the Job
+# yourself -- and note the invariant it guards: until that strict pass is
+# quiet, a `chosen=False, text_fingerprint IS NULL` row does not yet reliably
+# mean "known duplicate", so journey counting should not be trusted (which
+# matters only once the journey flags are on).
+#
+# --skip-backfill: do not apply or wait for the backfill Job at all. For
+# clusters where it has already run clean, or a deploy that must not touch it.
 NO_BUILD=false
+SKIP_JOURNEY_GATES=false
+SKIP_BACKFILL=false
+usage() {
+    echo "Usage: $0 [--no-build] [--skip-journey-gates] [--skip-backfill]"
+    echo "  --no-build             Skip all build steps (template/static setup and image"
+    echo "                         builds); assume images are already built and pushed."
+    echo "  --skip-journey-gates   Apply everything but do not block on the writer"
+    echo "                         rollouts or the fingerprint backfill Job (~90m of"
+    echo "                         waits). The Job still runs; you check it yourself."
+    echo "  --skip-backfill        Do not apply or wait for the fingerprint backfill Job."
+}
 for arg in "$@"; do
     case "$arg" in
         --no-build)
             NO_BUILD=true
             ;;
+        --skip-journey-gates)
+            SKIP_JOURNEY_GATES=true
+            ;;
+        --skip-backfill)
+            SKIP_BACKFILL=true
+            ;;
         -h|--help)
-            echo "Usage: $0 [--no-build]"
-            echo "  --no-build  Skip all build steps (template/static setup and image builds);"
-            echo "              assume images are already built and pushed, and only deploy."
+            usage
             exit 0
             ;;
         *)
             echo "Unknown argument: $arg" >&2
-            echo "Usage: $0 [--no-build]" >&2
+            usage >&2
             exit 1
             ;;
     esac
@@ -40,7 +67,7 @@ else
 fi
 
 # BUILDKIT_NO_CLIENT_TOKEN=true
-FHI_VERSION=v0.23.2a
+FHI_VERSION=v0.23.3a
 
 
 MYORG=${MYORG:-totallylegitco}
@@ -146,46 +173,12 @@ envsubst < k8s/temporal/worker.yaml | kubectl apply -f -
 # Deployment: waiting first would either time out on a Deployment that does
 # not exist yet or, worse, pass against the previous image.
 envsubst < k8s/temporal/appeal-worker.yaml | kubectl apply -f -
-# Post-rollout second pass of the appeal fingerprint backfill (see the Job
-# manifest): --strict keeps failing -- and the Job keeps retrying -- until no
-# pre-fingerprint writer is left, so the "run again after old pods drain"
-# step is enforced by the deploy, not by a README. Jobs are immutable:
-# delete the previous run before applying.
-#
-# ROLLOUT GATE (external review): a strict pass that runs while ANY pod on
-# pre-fingerprint code can still handle a request proves nothing -- two quiet
-# scans succeed, then an idle old pod inserts a NULL fingerprint or edits text
-# under a stale one. So wait for every ProposedAppeal writer to finish rolling
-# (rollout status returns only after new replicas are available AND the old
-# ReplicaSet's pods are gone): the web Deployment, both Temporal workers, and
-# the Ray cluster (its SpeculativeAppealsActor writes speculative drafts; the
-# cluster was deleted + recreated above, so readiness of the new pods means the
-# old ones are gone). A rollout that does not finish fails the deploy here
-# rather than letting the Job run against a mixed fleet.
-for dep in web fhi-fax-worker fhi-appeal-worker; do
-  if kubectl -n totallylegitco get deployment "$dep" >/dev/null 2>&1; then
-    kubectl -n totallylegitco rollout status deployment "$dep" --timeout=15m \
-      || { echo "Rollout of $dep did not complete; not running the fingerprint backfill Job"; exit 1; }
-  else
-    echo "Deployment $dep not present; skipping rollout wait"
-  fi
-done
-kubectl -n totallylegitco wait --for=condition=Ready pod -l ray.io/cluster=raycluster-kuberay --timeout=15m \
-  || { echo "Ray cluster pods not Ready; not running the fingerprint backfill Job"; exit 1; }
-kubectl delete job fhi-backfill-appeal-fingerprints -n totallylegitco --ignore-not-found
-envsubst < k8s/temporal/backfill-fingerprints-job.yaml | kubectl apply -f -
-# Wait for the strict backfill to COMPLETE and fail the deploy if it cannot.
-# Every writer rollout was awaited above, so a Job that does not finish
-# inside this window means either a writer on old code is still active or
-# the verify pass keeps finding fingerprints to repair -- both are deploy
-# problems to look at, not background noise to leave retrying unattended.
-kubectl -n totallylegitco wait --for=condition=complete job/fhi-backfill-appeal-fingerprints --timeout=30m \
-  || { echo "Fingerprint backfill Job did not complete within 30m; inspect it: kubectl -n totallylegitco logs job/fhi-backfill-appeal-fingerprints"; exit 1; }
-# Worker redundancy + observability (external review): PDBs keep one poller
-# per queue through drains; the PodMonitor scrapes the SDK's Prometheus
-# endpoint and the PrometheusRule alerts on the silent failure modes (work
-# waiting, slots exhausted, activity/RPC failures). Same CRD-gating as the
-# web PodMonitor below: skipped only where the operator is absent.
+# Observability FIRST, before any gate that can exit (external review): a
+# backfill or rollout problem below used to skip the PDBs, both PodMonitors,
+# both PrometheusRules and the relay CronJob -- shipping the new image with no
+# metrics and no alerts, which is the exact silent gap these manifests exist
+# to close. They are cheap, idempotent applies with nothing to wait for, so
+# they belong above the waits.
 kubectl apply -f k8s/temporal/worker-pdb.yaml
 if kubectl get crd podmonitors.monitoring.coreos.com >/dev/null 2>&1; then
     kubectl apply -f k8s/temporal/worker-podmonitor.yaml
@@ -209,6 +202,87 @@ if kubectl get crd prometheusrules.monitoring.coreos.com >/dev/null 2>&1; then
     kubectl apply -f k8s/temporal/intake-outbox-alerts.yaml
 else
     echo "WARNING: no PrometheusRule CRD in this cluster -- intake outbox alerts not installed"
+fi
+
+# Post-rollout second pass of the appeal fingerprint backfill (see the Job
+# manifest): --strict keeps failing -- and the Job keeps retrying -- until no
+# pre-fingerprint writer is left, so the "run again after old pods drain"
+# step is enforced by the deploy, not by a README. Jobs are immutable:
+# delete the previous run before applying.
+#
+# ROLLOUT GATE (external review): a strict pass that runs while ANY pod on
+# pre-fingerprint code can still handle a request proves nothing -- two quiet
+# scans succeed, then an idle old pod inserts a NULL fingerprint or edits text
+# under a stale one. So wait for every ProposedAppeal writer to finish rolling
+# (rollout status returns only after new replicas are available AND the old
+# ReplicaSet's pods are gone): the web Deployment, both Temporal workers, and
+# the Ray cluster (its SpeculativeAppealsActor writes speculative drafts).
+# A rollout that does not finish fails the deploy rather than letting the Job
+# run against a mixed fleet. --skip-journey-gates skips the waiting only.
+if [ "$SKIP_BACKFILL" = true ]; then
+    echo "--skip-backfill: not applying or waiting for the fingerprint backfill Job"
+elif [ "$SKIP_JOURNEY_GATES" = true ]; then
+    echo "--skip-journey-gates: applying the backfill Job WITHOUT waiting for writer rollouts"
+    kubectl delete job fhi-backfill-appeal-fingerprints -n totallylegitco --ignore-not-found
+    envsubst < k8s/temporal/backfill-fingerprints-job.yaml | kubectl apply -f -
+    echo "NOTE: check it yourself -- kubectl -n totallylegitco get job/fhi-backfill-appeal-fingerprints"
+else
+    for dep in web fhi-fax-worker fhi-appeal-worker; do
+      if kubectl -n totallylegitco get deployment "$dep" >/dev/null 2>&1; then
+        kubectl -n totallylegitco rollout status deployment "$dep" --timeout=15m \
+          || { echo "Rollout of $dep did not complete; not running the fingerprint backfill Job"; exit 1; }
+      else
+        echo "Deployment $dep not present; skipping rollout wait"
+      fi
+    done
+    # Ray gets the same existence guard the Deployments have (external review):
+    # the cluster was deleted and re-applied above, so `kubectl wait` on a
+    # selector the operator has not populated yet errors out immediately with
+    # "no matching resources found" and would fail an otherwise fine deploy.
+    # Give the operator a chance to create pods, then wait on readiness.
+    ray_pods_present=false
+    for _ in $(seq 1 30); do
+      if [ -n "$(kubectl -n totallylegitco get pods -l ray.io/cluster=raycluster-kuberay \
+                   --field-selector=status.phase!=Succeeded,status.phase!=Failed \
+                   -o name 2>/dev/null)" ]; then
+        ray_pods_present=true
+        break
+      fi
+      sleep 10
+    done
+    if [ "$ray_pods_present" = true ]; then
+      # Same field selector as the presence check: a Succeeded/Failed pod left
+      # over from a previous cluster never goes Ready and would hang the wait.
+      kubectl -n totallylegitco wait --for=condition=Ready pod -l ray.io/cluster=raycluster-kuberay \
+        --field-selector=status.phase!=Succeeded,status.phase!=Failed --timeout=15m \
+        || { echo "Ray cluster pods not Ready; not running the fingerprint backfill Job"; exit 1; }
+    else
+      echo "No Ray cluster pods after 5m; skipping the Ray readiness wait (no Ray writers to drain)"
+    fi
+    kubectl delete job fhi-backfill-appeal-fingerprints -n totallylegitco --ignore-not-found
+    envsubst < k8s/temporal/backfill-fingerprints-job.yaml | kubectl apply -f -
+    # Wait for the strict backfill, and FAIL FAST on a failed Job (external
+    # review): `kubectl wait --for=condition=complete` ignores condition=Failed,
+    # so a Job that gives up would still cost the full 30 minutes before the
+    # deploy heard about it. Poll both conditions instead.
+    backfill_done=false
+    for _ in $(seq 1 180); do
+      if [ "$(kubectl -n totallylegitco get job fhi-backfill-appeal-fingerprints \
+                -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}' 2>/dev/null)" = "True" ]; then
+        backfill_done=true
+        break
+      fi
+      if [ "$(kubectl -n totallylegitco get job fhi-backfill-appeal-fingerprints \
+                -o jsonpath='{.status.conditions[?(@.type=="Failed")].status}' 2>/dev/null)" = "True" ]; then
+        echo "Fingerprint backfill Job FAILED; inspect it: kubectl -n totallylegitco logs job/fhi-backfill-appeal-fingerprints"
+        exit 1
+      fi
+      sleep 10
+    done
+    if [ "$backfill_done" != true ]; then
+      echo "Fingerprint backfill Job did not complete within 30m; inspect it: kubectl -n totallylegitco logs job/fhi-backfill-appeal-fingerprints"
+      exit 1
+    fi
 fi
 
 # In-cluster scraping of the app's /metrics (which is no longer reachable from

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 set -ex
+# Every pipe in this script is `envsubst < manifest | kubectl apply -f -`.
+# Without pipefail only kubectl's status counts, so an envsubst that died
+# partway through a multi-document manifest would apply the prefix it had
+# already emitted and report success (external review).
+set -o pipefail
 
 SCRIPT_DIR="$(dirname "$0")"
 
@@ -11,17 +16,25 @@ BUILDX_CMD=${BUILDX_CMD:-push}
 # the script can run on a deploy-only host or CI job that has just kubectl and
 # envsubst (no Python/Node build toolchain).
 #
-# --skip-journey-gates: apply everything, but do not BLOCK the deploy on the
-# writer rollouts or the fingerprint backfill Job. The Job is still applied and
-# still runs (with its own backoff); you just stop waiting for it here. Use it
-# when you want the deploy to land promptly and intend to check the Job
-# yourself -- and note the invariant it guards: until that strict pass is
-# quiet, a `chosen=False, text_fingerprint IS NULL` row does not yet reliably
-# mean "known duplicate", so journey counting should not be trusted (which
-# matters only once the journey flags are on).
+# --skip-journey-gates: apply everything, but do not BLOCK the deploy on
+# anything -- not the rollouts, not the writer drain, not the fingerprint
+# backfill Job. The Job is still applied and still runs (with its own
+# backoff); you just stop waiting for it here. Use it when you want the deploy
+# to land promptly and intend to check the Job yourself -- and note the
+# invariant it guards: until that strict pass is quiet, a
+# `chosen=False, text_fingerprint IS NULL` row does not yet reliably mean
+# "known duplicate", so journey counting should not be trusted (which matters
+# only once the journey flags are on).
 #
-# --skip-backfill: do not apply or wait for the backfill Job at all. For
-# clusters where it has already run clean, or a deploy that must not touch it.
+# --skip-backfill: do not apply or wait for the backfill Job, or for the
+# writer drain that exists only to make that Job meaningful. The rollout waits
+# still run -- a Deployment that never finishes rolling is a broken deploy
+# whether or not we are fingerprinting anything.
+#
+# Worst-case waiting with no flags: 45m of rollouts + 20m of writer drain +
+# 25m of Ray + 30m of backfill = about two hours. In practice the drains are
+# already most-done by the time the rollouts report, and the backfill on a
+# quiet table takes a couple of minutes.
 NO_BUILD=false
 SKIP_JOURNEY_GATES=false
 SKIP_BACKFILL=false
@@ -29,10 +42,12 @@ usage() {
     echo "Usage: $0 [--no-build] [--skip-journey-gates] [--skip-backfill]"
     echo "  --no-build             Skip all build steps (template/static setup and image"
     echo "                         builds); assume images are already built and pushed."
-    echo "  --skip-journey-gates   Apply everything but do not block on the writer"
-    echo "                         rollouts or the fingerprint backfill Job (~90m of"
-    echo "                         waits). The Job still runs; you check it yourself."
-    echo "  --skip-backfill        Do not apply or wait for the fingerprint backfill Job."
+    echo "  --skip-journey-gates   Apply everything but block on nothing: no rollout"
+    echo "                         waits, no writer drain, no backfill wait (up to ~2h"
+    echo "                         of waiting). The Job still runs; you check it yourself."
+    echo "  --skip-backfill        Do not apply or wait for the fingerprint backfill Job,"
+    echo "                         or for the writer drain that only that Job needs."
+    echo "                         Rollout waits still run."
 }
 for arg in "$@"; do
     case "$arg" in
@@ -101,7 +116,7 @@ read -rp "Have you checked dev and are ready to deploy to staging? (y/n) " yn
 case $yn in
     [Yy]* ) echo "Proceeding...";;
     [Nn]* ) echo "Exiting..."; exit;;
-    * ) echo "Invalid response. Please enter y or n.";;
+    * ) echo "Invalid response; treating as no. Exiting..."; exit 1;;
 esac
 
 # Reset to non-dev
@@ -126,7 +141,7 @@ read -rp "Have you checked staging and are ready to deploy to prod? (y/n) " yn
 case $yn in
     [Yy]* ) echo "Proceeding...";;
     [Nn]* ) echo "Exiting..."; exit;;
-    * ) echo "Invalid response. Please enter y or n.";;
+    * ) echo "Invalid response; treating as no. Exiting..."; exit 1;;
 esac
 
 # DB-host config (the pg8->pg9 cutover switch). This ConfigMap is the single,
@@ -152,8 +167,114 @@ echo "PDBHOST now set to: $(kubectl -n totallylegitco get configmap fhi-db-confi
 # incident: two plugin installs deadlocked reconciliation for 12 days).
 kubectl apply -f k8s/fhi-pg-main-9-scheduledbackup.yaml
 
+# --- deploy gate helpers ---------------------------------------------------
+# Every gate call below carries an explicit --request-timeout. kubectl's
+# default is 0, i.e. wait forever, so one stuck API request would hang the
+# deploy straight through whatever budget the loops claim to enforce
+# (external review).
+KGET=(kubectl --request-timeout=30s -n totallylegitco)
+
+# `if kubectl get deployment X >/dev/null 2>&1` is NOT a safe presence test.
+# A command used as an `if` condition does not trip errexit, so a transient
+# API error reads as "this Deployment does not exist" and silently skips its
+# gate. Only a confirmed NotFound counts as absent; anything else aborts
+# (external review).
+deployment_present() {
+    local dep="$1" out
+    if out=$("${KGET[@]}" get deployment "$dep" -o name 2>&1); then
+        return 0
+    fi
+    if printf '%s' "$out" | grep -qi "not found"; then
+        return 1
+    fi
+    echo "kubectl get deployment $dep failed, refusing to guess: $out" >&2
+    exit 1
+}
+
+# Pods under a selector that are marked for deletion but whose processes are
+# still running.
+terminating_pods() {
+    "${KGET[@]}" get pods -l "$1" \
+        -o go-template='{{range .items}}{{if .metadata.deletionTimestamp}}{{.metadata.name}}{{"\n"}}{{end}}{{end}}'
+}
+
+# `kubectl rollout status` is NOT a drain gate (external review). A pod stops
+# counting as an active replica the moment it is marked for deletion, so
+# rollout status returns while the old pods are still inside their grace
+# period -- running preStop, finishing in-flight work, and still able to
+# INSERT a ProposedAppeal. web allows 420s plus a 15s preStop and the appeal
+# worker 360s, so that window is minutes wide, which is long enough for an
+# old pod to write a NULL fingerprint just after the strict backfill observed
+# a quiet table. Wait for those pods to actually be gone.
+wait_for_drain() {
+    local selector="$1" name="$2" deadline=$((SECONDS + 600)) left
+    while [ "$SECONDS" -lt "$deadline" ]; do
+        if ! left="$(terminating_pods "$selector")"; then
+            echo "$name: could not list pods, refusing to guess that the drain finished" >&2
+            exit 1
+        fi
+        if [ -z "$left" ]; then
+            echo "$name: no pods still terminating"
+            return 0
+        fi
+        sleep 10
+    done
+    echo "$name: pods still terminating after 10m ($(terminating_pods "$selector" | tr '\n' ' ')); not running the fingerprint backfill Job" >&2
+    exit 1
+}
+
+# Same rule as deployment_present: a `[ -n "$(kubectl get ...)" ]` test turns
+# any API error into "no pods here", which silently drops the Ray half of the
+# writer gate. An empty LIST is absence; a failed call is not.
+ray_pods_exist() {
+    local out
+    if ! out=$("${KGET[@]}" get pods -l ray.io/cluster=raycluster-kuberay \
+                 --field-selector=status.phase!=Succeeded,status.phase!=Failed \
+                 -o name 2>&1); then
+        echo "kubectl get pods (ray) failed, refusing to guess: $out" >&2
+        exit 1
+    fi
+    [ -n "$out" ]
+}
+
+ray_pod_uids() {
+    "${KGET[@]}" get pods -l ray.io/cluster=raycluster-kuberay \
+        -o jsonpath='{.items[*].metadata.uid}'
+}
+
+# Snapshot the Ray pods BEFORE the delete below. `kubectl delete` defaults to
+# background cascading deletion, so the RayCluster object disappears before
+# its pods do, and old and new generations share the ray.io/cluster label --
+# an old Ready pod, still running SpeculativeAppealsActor and still able to
+# write, would otherwise satisfy the readiness gate on its own (external
+# review).
+if ! RAY_PODS_BEFORE="$(ray_pod_uids)"; then
+    echo "Could not list the current Ray pods; aborting before touching the cluster" >&2
+    exit 1
+fi
+
+ray_old_pods_remaining() {
+    local now uid
+    # Called as a `while` condition, where errexit is suppressed -- so check
+    # the call explicitly. `exit` here is a real exit: the function body runs
+    # in the current shell, unlike a command substitution.
+    if ! now="$(ray_pod_uids)"; then
+        echo "kubectl get pods (ray uids) failed, refusing to guess" >&2
+        exit 1
+    fi
+    now=" $now "
+    for uid in $RAY_PODS_BEFORE; do
+        case "$now" in *" $uid "*) return 0 ;; esac
+    done
+    return 1
+}
+
 # The raycluster operator doesn't handle upgrades well so delete + recreate instead.
-kubectl delete raycluster -n totallylegitco raycluster-kuberay || echo "No raycluster present"
+# --ignore-not-found rather than `|| echo "No raycluster present"`: that
+# swallowed every failure -- 403, API error, timeout -- and reported a missing
+# cluster, after which the apply would merely update the CR still standing
+# (external review).
+kubectl --request-timeout=60s delete raycluster -n totallylegitco raycluster-kuberay --ignore-not-found
 envsubst < k8s/ray/cluster.yaml | kubectl apply -f -
 
 # Deploy a staging env
@@ -204,83 +325,143 @@ else
     echo "WARNING: no PrometheusRule CRD in this cluster -- intake outbox alerts not installed"
 fi
 
+# ROLLOUT GATE. Independent of the backfill: a Deployment that never finishes
+# rolling is a broken deploy whether or not we are about to fingerprint
+# anything. Skipped only by --skip-journey-gates.
+if [ "$SKIP_JOURNEY_GATES" = true ]; then
+    echo "--skip-journey-gates: not waiting for any rollout"
+else
+    for dep in web fhi-fax-worker fhi-appeal-worker; do
+      if deployment_present "$dep"; then
+        kubectl --request-timeout=60s -n totallylegitco rollout status deployment "$dep" --timeout=15m \
+          || { echo "Rollout of $dep did not complete"; exit 1; }
+      else
+        echo "Deployment $dep not present; skipping rollout wait"
+      fi
+    done
+fi
+
 # Post-rollout second pass of the appeal fingerprint backfill (see the Job
 # manifest): --strict keeps failing -- and the Job keeps retrying -- until no
 # pre-fingerprint writer is left, so the "run again after old pods drain"
 # step is enforced by the deploy, not by a README. Jobs are immutable:
 # delete the previous run before applying.
 #
-# ROLLOUT GATE (external review): a strict pass that runs while ANY pod on
-# pre-fingerprint code can still handle a request proves nothing -- two quiet
-# scans succeed, then an idle old pod inserts a NULL fingerprint or edits text
-# under a stale one. So wait for every ProposedAppeal writer to finish rolling
-# (rollout status returns only after new replicas are available AND the old
-# ReplicaSet's pods are gone): the web Deployment, both Temporal workers, and
-# the Ray cluster (its SpeculativeAppealsActor writes speculative drafts).
-# A rollout that does not finish fails the deploy rather than letting the Job
-# run against a mixed fleet. --skip-journey-gates skips the waiting only.
+# WRITER GATE: a strict pass that runs while ANY pod on pre-fingerprint code
+# can still handle a request proves nothing -- two quiet scans succeed, then
+# an idle old pod inserts a NULL fingerprint or edits text under a stale one.
+# The ProposedAppeal writers are the web pods (save_appeal), the appeal
+# worker (the generation workflow) and the Ray cluster (its
+# SpeculativeAppealsActor). fhi-fax-worker polls the fax queue only and
+# writes no ProposedAppeal, so it is rolled above but deliberately NOT
+# drained here -- its 1860s grace period would add half an hour to every
+# deploy for nothing.
 if [ "$SKIP_BACKFILL" = true ]; then
     echo "--skip-backfill: not applying or waiting for the fingerprint backfill Job"
 elif [ "$SKIP_JOURNEY_GATES" = true ]; then
-    echo "--skip-journey-gates: applying the backfill Job WITHOUT waiting for writer rollouts"
-    kubectl delete job fhi-backfill-appeal-fingerprints -n totallylegitco --ignore-not-found
+    echo "--skip-journey-gates: applying the backfill Job WITHOUT gating on the writers"
+    kubectl --request-timeout=60s delete job fhi-backfill-appeal-fingerprints -n totallylegitco --ignore-not-found
     envsubst < k8s/temporal/backfill-fingerprints-job.yaml | kubectl apply -f -
     echo "NOTE: check it yourself -- kubectl -n totallylegitco get job/fhi-backfill-appeal-fingerprints"
 else
-    for dep in web fhi-fax-worker fhi-appeal-worker; do
-      if kubectl -n totallylegitco get deployment "$dep" >/dev/null 2>&1; then
-        kubectl -n totallylegitco rollout status deployment "$dep" --timeout=15m \
-          || { echo "Rollout of $dep did not complete; not running the fingerprint backfill Job"; exit 1; }
-      else
-        echo "Deployment $dep not present; skipping rollout wait"
+    # Old web / appeal-worker processes gone, not merely uncounted.
+    deployment_present web \
+      && wait_for_drain group=fight-health-insurance-prod-webbackend web
+    deployment_present fhi-appeal-worker \
+      && wait_for_drain group=fight-health-insurance-prod-temporal-appeal-worker fhi-appeal-worker
+
+    # Ray: the pods that existed before the delete must be gone before their
+    # replacements can vouch for anything.
+    ray_deadline=$((SECONDS + 300))
+    while ray_old_pods_remaining; do
+      if [ "$SECONDS" -ge "$ray_deadline" ]; then
+        echo "Ray pods from before the cluster delete are still running after 5m; not running the fingerprint backfill Job" >&2
+        exit 1
       fi
+      sleep 10
     done
-    # Ray gets the same existence guard the Deployments have (external review):
-    # the cluster was deleted and re-applied above, so `kubectl wait` on a
-    # selector the operator has not populated yet errors out immediately with
-    # "no matching resources found" and would fail an otherwise fine deploy.
-    # Give the operator a chance to create pods, then wait on readiness.
+
+    # Then wait for the new cluster. Existence guard first (external review):
+    # the cluster was just deleted and re-applied, so waiting on a selector
+    # the operator has not populated yet fails instantly with "no matching
+    # resources found" and would kill an otherwise healthy deploy.
     ray_pods_present=false
-    for _ in $(seq 1 30); do
-      if [ -n "$(kubectl -n totallylegitco get pods -l ray.io/cluster=raycluster-kuberay \
-                   --field-selector=status.phase!=Succeeded,status.phase!=Failed \
-                   -o name 2>/dev/null)" ]; then
+    ray_deadline=$((SECONDS + 300))
+    while [ "$SECONDS" -lt "$ray_deadline" ]; do
+      if ray_pods_exist; then
         ray_pods_present=true
         break
       fi
       sleep 10
     done
     if [ "$ray_pods_present" = true ]; then
-      # Same field selector as the presence check: a Succeeded/Failed pod left
-      # over from a previous cluster never goes Ready and would hang the wait.
-      kubectl -n totallylegitco wait --for=condition=Ready pod -l ray.io/cluster=raycluster-kuberay \
-        --field-selector=status.phase!=Succeeded,status.phase!=Failed --timeout=15m \
-        || { echo "Ray cluster pods not Ready; not running the fingerprint backfill Job"; exit 1; }
+      # `kubectl wait` resolves its selector ONCE per invocation, so a single
+      # long wait started when only the head pod existed would never look at
+      # the worker pods created after it (external review). Call it
+      # repeatedly with a short timeout -- each call re-lists -- and require
+      # two consecutive clean passes so a lone head cannot satisfy the gate
+      # in the window before its workers are scheduled.
+      ray_ready_deadline=$((SECONDS + 900))
+      ray_stable=0
+      while [ "$SECONDS" -lt "$ray_ready_deadline" ]; do
+        if kubectl --request-timeout=60s -n totallylegitco wait --for=condition=Ready pod \
+             -l ray.io/cluster=raycluster-kuberay \
+             --field-selector=status.phase!=Succeeded,status.phase!=Failed \
+             --timeout=30s >/dev/null 2>&1; then
+          ray_stable=$((ray_stable + 1))
+          [ "$ray_stable" -ge 2 ] && break
+        else
+          ray_stable=0
+        fi
+        sleep 10
+      done
+      if [ "$ray_stable" -lt 2 ]; then
+        echo "Ray cluster pods not consistently Ready within 15m; not running the fingerprint backfill Job" >&2
+        exit 1
+      fi
     else
       echo "No Ray cluster pods after 5m; skipping the Ray readiness wait (no Ray writers to drain)"
     fi
-    kubectl delete job fhi-backfill-appeal-fingerprints -n totallylegitco --ignore-not-found
+
+    kubectl --request-timeout=60s delete job fhi-backfill-appeal-fingerprints -n totallylegitco --ignore-not-found
     envsubst < k8s/temporal/backfill-fingerprints-job.yaml | kubectl apply -f -
     # Wait for the strict backfill, and FAIL FAST on a failed Job (external
     # review): `kubectl wait --for=condition=complete` ignores condition=Failed,
     # so a Job that gives up would still cost the full 30 minutes before the
-    # deploy heard about it. Poll both conditions instead.
+    # deploy heard about it. Poll both conditions instead, against a wall-clock
+    # deadline rather than a loop count (a loop count is not a time bound once
+    # each API call takes a moment of its own).
+    # Read once per tick and split the two conditions out of the same object,
+    # so a Job that flips Complete between two separate reads cannot be missed.
+    # This runs inside $( ), where `exit` would only kill the subshell -- hence
+    # `return 1` here and an explicit check at the call site.
+    job_conditions() {
+        "${KGET[@]}" get job fhi-backfill-appeal-fingerprints \
+            -o go-template='{{range .status.conditions}}{{.type}}={{.status}}{{"\n"}}{{end}}' \
+            || return 1
+    }
     backfill_done=false
-    for _ in $(seq 1 180); do
-      if [ "$(kubectl -n totallylegitco get job fhi-backfill-appeal-fingerprints \
-                -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}' 2>/dev/null)" = "True" ]; then
-        backfill_done=true
-        break
-      fi
-      if [ "$(kubectl -n totallylegitco get job fhi-backfill-appeal-fingerprints \
-                -o jsonpath='{.status.conditions[?(@.type=="Failed")].status}' 2>/dev/null)" = "True" ]; then
-        echo "Fingerprint backfill Job FAILED; inspect it: kubectl -n totallylegitco logs job/fhi-backfill-appeal-fingerprints"
+    backfill_deadline=$((SECONDS + 1800))
+    while :; do
+      if ! conds="$(job_conditions)"; then
+        echo "Could not read the backfill Job status; refusing to treat that as 'still running'" >&2
         exit 1
       fi
+      case "$conds" in *"Complete=True"*)
+        backfill_done=true
+        break ;;
+      esac
+      case "$conds" in *"Failed=True"*)
+        echo "Fingerprint backfill Job FAILED; inspect it: kubectl -n totallylegitco logs job/fhi-backfill-appeal-fingerprints" >&2
+        exit 1 ;;
+      esac
+      # Deadline checked AFTER a status read, so a Job that completes in the
+      # last few seconds is not reported as a timeout.
+      [ "$SECONDS" -lt "$backfill_deadline" ] || break
       sleep 10
     done
     if [ "$backfill_done" != true ]; then
-      echo "Fingerprint backfill Job did not complete within 30m; inspect it: kubectl -n totallylegitco logs job/fhi-backfill-appeal-fingerprints"
+      echo "Fingerprint backfill Job did not complete within 30m; inspect it: kubectl -n totallylegitco logs job/fhi-backfill-appeal-fingerprints" >&2
       exit 1
     fi
 fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -330,7 +330,13 @@ ray_old_pods_remaining() {
 # swallowed every failure -- 403, API error, timeout -- and reported a missing
 # cluster, after which the apply would merely update the CR still standing
 # (external review).
-kubectl delete raycluster -n totallylegitco raycluster-kuberay --ignore-not-found
+# --timeout because `kubectl delete` waits for finalizers by default and
+# --timeout=0 means "work it out from the object", which for a waited delete
+# is effectively forever (external review). 5m matches the budget the gate
+# below gives these same pods to disappear: if the delete cannot finish in
+# that time, the gate would fail anyway, so fail here where the message is
+# about the actual problem.
+kubectl delete raycluster -n totallylegitco raycluster-kuberay --ignore-not-found --timeout=5m
 envsubst < k8s/ray/cluster.yaml | kubectl apply -f -
 
 # Deploy a staging env
@@ -420,7 +426,7 @@ if [ "$SKIP_BACKFILL" = true ]; then
     echo "--skip-backfill: not applying or waiting for the fingerprint backfill Job"
 elif [ "$SKIP_JOURNEY_GATES" = true ]; then
     echo "--skip-journey-gates: applying the backfill Job WITHOUT gating on the writers"
-    kubectl delete job fhi-backfill-appeal-fingerprints -n totallylegitco --ignore-not-found
+    kubectl delete job fhi-backfill-appeal-fingerprints -n totallylegitco --ignore-not-found --timeout=2m
     envsubst < k8s/temporal/backfill-fingerprints-job.yaml | kubectl apply -f -
     echo "NOTE: check it yourself -- kubectl -n totallylegitco get job/fhi-backfill-appeal-fingerprints"
 else
@@ -492,7 +498,7 @@ else
       echo "No Ray cluster pods after 5m; skipping the Ray readiness wait (no Ray writers to drain)"
     fi
 
-    kubectl delete job fhi-backfill-appeal-fingerprints -n totallylegitco --ignore-not-found
+    kubectl delete job fhi-backfill-appeal-fingerprints -n totallylegitco --ignore-not-found --timeout=2m
     envsubst < k8s/temporal/backfill-fingerprints-job.yaml | kubectl apply -f -
     # Wait for the strict backfill, and FAIL FAST on a failed Job (external
     # review): `kubectl wait --for=condition=complete` ignores condition=Failed,

--- a/tests/async-unit/test_appeal_journey_core.py
+++ b/tests/async-unit/test_appeal_journey_core.py
@@ -799,7 +799,7 @@ def test_deploy_script_guards_the_ray_wait_on_pods_existing():
     otherwise fine. The Deployments already have an existence guard; Ray needs
     the same one (external review)."""
     build = _build_script()
-    wait_at = build.index("wait --for=condition=Ready pod")
+    wait_at = build.index("ray_expected_pods)")
     guard = build[:wait_at]
     assert "ray_pods_present=false" in guard
     assert 'if [ "$ray_pods_present" = true ]' in guard
@@ -950,6 +950,44 @@ def test_gate_waits_for_the_writer_pods_to_drain_not_just_to_roll():
     assert "exit 1" in fn
 
 
+def test_drained_deployments_actually_carry_the_labels_the_drain_selects_on():
+    """The drain keys on `group=` labels, which are NARROWER than the web
+    Deployment's own selector (`app: fight-health-insurance-prod`, which also
+    matches the worker pods and so cannot be used here). That is only sound
+    while every pod of those Deployments carries the group label -- if one
+    ever stopped, `rollout status` could finish and the drain would see an
+    empty list while an old pod was still inside its grace period (external
+    review). Pin the labels so that becomes a CI failure, not a silent hole."""
+    import pathlib
+
+    import yaml
+
+    root = pathlib.Path(__file__).resolve().parents[2]
+    build = _build_script()
+
+    def pod_template_labels(path, deployment_name):
+        raw = (root / path).read_text().replace("${FHI_BASE}:${FHI_VERSION}", "image")
+        for doc in yaml.safe_load_all(raw):
+            if (
+                doc
+                and doc.get("kind") == "Deployment"
+                and doc["metadata"]["name"] == deployment_name
+            ):
+                return doc["spec"]["template"]["metadata"]["labels"]
+        raise AssertionError(f"{deployment_name} not found in {path}")
+
+    for path, name, label in (
+        ("k8s/deploy.yaml", "web", "fight-health-insurance-prod-webbackend"),
+        (
+            "k8s/temporal/appeal-worker.yaml",
+            "fhi-appeal-worker",
+            "fight-health-insurance-prod-temporal-appeal-worker",
+        ),
+    ):
+        assert pod_template_labels(path, name).get("group") == label, name
+        assert f"wait_for_drain group={label} " in build
+
+
 def test_ray_gate_requires_the_pre_delete_pods_to_be_gone():
     """`kubectl delete` is background-cascading: the RayCluster object goes
     before its pods do, and both generations carry the same ray.io/cluster
@@ -966,15 +1004,60 @@ def test_ray_gate_requires_the_pre_delete_pods_to_be_gone():
     assert 'raycluster-kuberay || echo' not in build
 
 
-def test_ray_readiness_is_rechecked_against_a_relisted_pod_set():
-    """`kubectl wait` resolves its selector once per invocation, so a single
-    long wait begun when only the head pod existed would never look at the
-    worker pods created after it (external review)."""
+def test_ray_readiness_counts_pods_against_the_size_the_cluster_should_reach():
+    """`kubectl wait` resolves its selector once per invocation, so a wait
+    begun when only the head pod existed would never look at the worker pods
+    created after it -- and the head is not what runs SpeculativeAppealsActor.
+    KubeRay also clamps a worker group UP to minReplicas, so k8s/ray/cluster.yaml
+    (`replicas: 1`, `minReplicas: 2`) really means head + 2 workers
+    (external review)."""
+    import os
+    import pathlib
+    import subprocess
+    import tempfile
+
     build = _build_script()
-    assert "ray_stable=$((ray_stable + 1))" in build
-    assert 'if [ "$ray_stable" -lt 2 ]' in build
-    at = build.index('if [ "$ray_stable" -lt 2 ]')
-    assert "exit 1" in build[at : at + 300]
+    fns = "\n".join(
+        _extract_shell_function(build, name)
+        for name in ("ray_expected_pods", "ray_ready_pods")
+    )
+
+    def expected_for(replicas: str, min_replicas: str) -> str:
+        with tempfile.TemporaryDirectory() as tmp:
+            shim = pathlib.Path(tmp) / "kubectl"
+            shim.write_text(
+                "#!/bin/bash\n"
+                'for a in "$@"; do case "$a" in\n'
+                f'  *minReplicas*) echo -n "{min_replicas}"; exit 0 ;;\n'
+                f'  *workerGroupSpecs*replicas*) echo -n "{replicas}"; exit 0 ;;\n'
+                "esac; done\n"
+                "exit 0\n"
+            )
+            shim.chmod(0o755)
+            env = {**os.environ, "PATH": f"{tmp}:{os.environ['PATH']}"}
+            r = subprocess.run(
+                ["bash", "-c", "set -e\nKGET=(kubectl)\n" + fns + "\nray_expected_pods\n"],
+                capture_output=True,
+                text=True,
+                env=env,
+                timeout=60,
+            )
+            assert r.returncode == 0, r.stderr
+            return r.stdout
+
+    # The real manifest: one head plus a group clamped from 1 up to 2.
+    assert expected_for("1", "2") == "3"
+    # No clamp needed.
+    assert expected_for("3", "1") == "4"
+    # Several worker groups, each clamped independently.
+    assert expected_for("1 5", "2 2") == "8"
+    # No worker groups at all: the head alone.
+    assert expected_for("", "") == "1"
+
+    # And the gate compares the two rather than accepting any Ready pod.
+    assert '[ "$ray_ready" -ge "$ray_expected" ] && break' in build
+    at = build.index("only $ray_ready of $ray_expected pods Ready")
+    assert "exit 1" in build[at : at + 200]
 
 
 def test_skip_backfill_still_gates_the_rollouts():
@@ -1003,6 +1086,21 @@ def test_skip_backfill_still_gates_the_rollouts():
     assert "Rollout waits still run" in helped.stdout
 
 
+def test_crd_probes_do_not_read_an_api_error_as_a_missing_operator():
+    """`kubectl get crd X >/dev/null 2>&1` reads a 403 or an API blip as "not
+    installed", silently skipping the PodMonitors and alert rules while
+    printing a message blaming the cluster -- the same no-metrics gap the
+    apply ordering exists to close (external review)."""
+    build = _build_script()
+    code = [ln for ln in build.splitlines() if not ln.lstrip().startswith("#")]
+    assert not any("get crd" in ln and "2>&1; then" in ln for ln in code), (
+        "a CRD probe is still swallowing errors"
+    )
+    assert build.count("if crd_present ") == 4
+    fn = _extract_shell_function(build, "crd_present")
+    assert "not found" in fn and "exit 1" in fn
+
+
 def test_deploy_script_enables_pipefail():
     """Every pipe here is `envsubst < manifest | kubectl apply -f -`. Without
     pipefail only kubectl's status counts, so an envsubst that died partway
@@ -1018,11 +1116,18 @@ def test_gate_kubectl_calls_carry_a_request_timeout():
     claim to enforce (external review)."""
     build = _build_script()
     assert "KGET=(kubectl --request-timeout=" in build
-    # The long-running gate calls are not routed through KGET, so check them
-    # individually.
-    for call in ("rollout status deployment", "wait --for=condition=Ready pod"):
-        line = next(ln for ln in build.splitlines() if call in ln and "#" not in ln)
-        assert "--request-timeout=" in line, line
+    # The blocking gate calls are not routed through KGET, so they carry
+    # their own. Plain `kubectl apply` is deliberately not in this list: an
+    # apply is not a poll and should not be cut off at 30s.
+    for call in ("rollout status deployment", "delete raycluster", "delete job"):
+        lines = [
+            ln.strip()
+            for ln in build.splitlines()
+            if call in ln and not ln.lstrip().startswith("#")
+        ]
+        assert lines, call
+        for line in lines:
+            assert "--request-timeout=" in line, line
 
 
 def test_backfill_job_runs_non_root_with_a_read_only_root_filesystem():

--- a/tests/async-unit/test_appeal_journey_core.py
+++ b/tests/async-unit/test_appeal_journey_core.py
@@ -1145,11 +1145,23 @@ def test_gate_kubectl_calls_carry_a_request_timeout():
         assert lines, call
         for line in lines:
             assert "--request-timeout=" not in line, line
-    # The one bound that has to stay on the rollout is its own.
-    rollout = next(
-        ln for ln in build.splitlines() if "rollout status deployment" in ln
-    )
-    assert "--timeout=15m" in rollout
+    # Each of them still needs its OWN bound, or there is none at all:
+    # `kubectl delete` waits for finalizers by default and --timeout=0 means
+    # "work it out from the object", which for a waited delete is effectively
+    # forever (external review).
+    for call, bound in (
+        ("rollout status deployment", "--timeout=15m"),
+        ("delete raycluster", "--timeout=5m"),
+        ("delete job", "--timeout=2m"),
+    ):
+        lines = [
+            ln
+            for ln in build.splitlines()
+            if call in ln and not ln.lstrip().startswith("#")
+        ]
+        assert lines, call
+        for line in lines:
+            assert bound in line, line
 
 
 def test_backfill_job_runs_non_root_with_a_read_only_root_filesystem():

--- a/tests/async-unit/test_appeal_journey_core.py
+++ b/tests/async-unit/test_appeal_journey_core.py
@@ -728,22 +728,119 @@ class TestFingerprintCompleteness(_JourneyTestBase):
         )
 
 
-def test_deploy_script_waits_for_the_strict_backfill_job():
-    """build.sh must not just apply the strict backfill Job -- it must wait
-    for it to complete and fail the deploy otherwise (review 10)."""
+def _build_script() -> str:
     import pathlib
 
     root = pathlib.Path(__file__).resolve().parents[2]
-    build = (root / "scripts" / "build.sh").read_text()
+    return (root / "scripts" / "build.sh").read_text()
+
+
+def test_deploy_script_waits_for_the_strict_backfill_job():
+    """build.sh must not just apply the strict backfill Job -- it must wait
+    for it to complete and fail the deploy otherwise (review 10)."""
+    build = _build_script()
     apply_at = build.index("backfill-fingerprints-job.yaml | kubectl apply -f -")
-    wait_at = build.index(
-        "wait --for=condition=complete job/fhi-backfill-appeal-fingerprints"
-    )
+    wait_at = build.index("backfill_done=true")
     assert wait_at > apply_at
-    assert "|| { echo" in build[wait_at : wait_at + 400]
-    assert "exit 1" in build[wait_at : wait_at + 400]
+    tail = build[wait_at:]
+    assert 'if [ "$backfill_done" != true ]' in tail
+    assert "exit 1" in tail
     for dep in ("web", "fhi-fax-worker", "fhi-appeal-worker"):
-        assert f"rollout status deployment" in build and dep in build
+        assert "rollout status deployment" in build and dep in build
+
+
+def test_deploy_script_fails_fast_on_a_failed_backfill_job():
+    """`kubectl wait --for=condition=complete` ignores condition=Failed, so a
+    Job that gives up would burn the full 30m before the deploy noticed. The
+    poll has to look at both conditions (external review)."""
+    build = _build_script()
+    assert '@.type=="Complete"' in build
+    failed_at = build.index('@.type=="Failed"')
+    # ...and act on it: the Failed branch exits rather than continuing to poll.
+    assert "exit 1" in build[failed_at : failed_at + 500]
+    # ...and the blind wait is gone from the executed script (the comment
+    # explaining why it is gone naturally still names it).
+    code = [ln for ln in build.splitlines() if not ln.lstrip().startswith("#")]
+    assert not any("wait --for=condition=complete" in ln for ln in code)
+
+
+def test_deploy_script_applies_observability_before_any_gate_that_can_exit():
+    """A stalled rollout or a failed backfill used to skip the PDB, the
+    PodMonitors, the alert rules and the relay CronJob -- shipping a new image
+    with no metrics and no alerts. Every one of those applies belongs above
+    the first gate that can exit (external review)."""
+    build = _build_script()
+    gate_at = build.index('if [ "$SKIP_BACKFILL" = true ]')
+    for manifest in (
+        "worker-pdb.yaml",
+        "worker-podmonitor.yaml",
+        "worker-alerts.yaml",
+        "intake-outbox-cronjob.yaml",
+        "intake-outbox-alerts.yaml",
+        "appeal-worker.yaml",
+    ):
+        assert build.index(manifest) < gate_at, manifest
+
+
+def test_deploy_script_guards_the_ray_wait_on_pods_existing():
+    """The Ray cluster is deleted and recreated earlier in the same script, so
+    `kubectl wait` against a selector the operator has not populated yet fails
+    immediately with "no matching resources found" -- killing a deploy that is
+    otherwise fine. The Deployments already have an existence guard; Ray needs
+    the same one (external review)."""
+    build = _build_script()
+    wait_at = build.index("wait --for=condition=Ready pod -l ray.io/cluster")
+    guard = build[:wait_at]
+    assert "ray_pods_present=false" in guard
+    assert 'if [ "$ray_pods_present" = true ]' in guard
+    # A cluster with no Ray pods at all is a skip, not a deploy failure.
+    assert "skipping the Ray readiness wait" in build
+
+
+def test_deploy_script_version_is_bumped_past_the_last_deployed_image():
+    """build_django.sh short-circuits when the tag already exists in the
+    registry, so a deploy on an unbumped FHI_VERSION silently ships the old
+    image. v0.23.2a is what prod ran before this tranche."""
+    import re
+
+    build = _build_script()
+    version = re.search(r"^FHI_VERSION=(\S+)", build, re.MULTILINE).group(1)
+    assert version != "v0.23.2a"
+
+
+def test_deploy_script_rejects_unknown_flags_and_documents_the_real_ones():
+    """The flags are the escape hatch from ~90m of waits, so a typo has to be
+    a fast, loud failure rather than a silently ignored argument."""
+    import pathlib
+    import subprocess
+
+    root = pathlib.Path(__file__).resolve().parents[2]
+    script = str(root / "scripts" / "build.sh")
+
+    typo = subprocess.run(
+        ["bash", script, "--skip-backfil"], capture_output=True, text=True, timeout=60
+    )
+    assert typo.returncode != 0
+    assert "Unknown argument" in typo.stderr
+
+    helped = subprocess.run(
+        ["bash", script, "--help"], capture_output=True, text=True, timeout=60
+    )
+    assert helped.returncode == 0
+    for flag in ("--no-build", "--skip-journey-gates", "--skip-backfill"):
+        assert flag in helped.stdout
+
+
+def test_skip_flags_only_skip_waiting_not_the_applies():
+    """--skip-journey-gates must still apply the Job (you check it yourself);
+    only --skip-backfill opts out of the Job entirely. Neither may sit above
+    an apply of the image or the observability manifests."""
+    build = _build_script()
+    skip_gates_at = build.index('elif [ "$SKIP_JOURNEY_GATES" = true ]')
+    end_at = build.index("\nelse\n", skip_gates_at)
+    branch = build[skip_gates_at:end_at]
+    assert "backfill-fingerprints-job.yaml | kubectl apply -f -" in branch
+    assert "rollout status" not in branch
 
 
 def test_backfill_job_runs_non_root_with_a_read_only_root_filesystem():

--- a/tests/async-unit/test_appeal_journey_core.py
+++ b/tests/async-unit/test_appeal_journey_core.py
@@ -754,8 +754,8 @@ def test_deploy_script_fails_fast_on_a_failed_backfill_job():
     Job that gives up would burn the full 30m before the deploy noticed. The
     poll has to look at both conditions (external review)."""
     build = _build_script()
-    assert '@.type=="Complete"' in build
-    failed_at = build.index('@.type=="Failed"')
+    assert "Complete=True" in build
+    failed_at = build.index('*"Failed=True"*')
     # ...and act on it: the Failed branch exits rather than continuing to poll.
     assert "exit 1" in build[failed_at : failed_at + 500]
     # ...and the blind wait is gone from the executed script (the comment
@@ -764,13 +764,23 @@ def test_deploy_script_fails_fast_on_a_failed_backfill_job():
     assert not any("wait --for=condition=complete" in ln for ln in code)
 
 
+def test_backfill_poll_treats_an_unreadable_job_status_as_fatal():
+    """A failed `kubectl get job` must not read as 'not complete yet' -- that
+    turns an API outage into a silent 30m stall and then a bogus timeout
+    message (external review)."""
+    build = _build_script()
+    assert 'if ! conds="$(job_conditions)"; then' in build
+    at = build.index('if ! conds="$(job_conditions)"; then')
+    assert "exit 1" in build[at : at + 400]
+
+
 def test_deploy_script_applies_observability_before_any_gate_that_can_exit():
     """A stalled rollout or a failed backfill used to skip the PDB, the
     PodMonitors, the alert rules and the relay CronJob -- shipping a new image
     with no metrics and no alerts. Every one of those applies belongs above
     the first gate that can exit (external review)."""
     build = _build_script()
-    gate_at = build.index('if [ "$SKIP_BACKFILL" = true ]')
+    gate_at = build.index("# ROLLOUT GATE")
     for manifest in (
         "worker-pdb.yaml",
         "worker-podmonitor.yaml",
@@ -789,7 +799,7 @@ def test_deploy_script_guards_the_ray_wait_on_pods_existing():
     otherwise fine. The Deployments already have an existence guard; Ray needs
     the same one (external review)."""
     build = _build_script()
-    wait_at = build.index("wait --for=condition=Ready pod -l ray.io/cluster")
+    wait_at = build.index("wait --for=condition=Ready pod")
     guard = build[:wait_at]
     assert "ray_pods_present=false" in guard
     assert 'if [ "$ray_pods_present" = true ]' in guard
@@ -841,6 +851,178 @@ def test_skip_flags_only_skip_waiting_not_the_applies():
     branch = build[skip_gates_at:end_at]
     assert "backfill-fingerprints-job.yaml | kubectl apply -f -" in branch
     assert "rollout status" not in branch
+
+
+def _extract_shell_function(build: str, name: str) -> str:
+    """Pull one `name() { ... }` block out of the deploy script, so it can be
+    executed in isolation against a stub kubectl."""
+    start = build.index(f"{name}() {{")
+    end = build.index("\n}\n", start) + len("\n}\n")
+    return build[start:end]
+
+
+def test_confirmation_prompts_never_fall_through_to_the_next_environment():
+    """Both prompts used to print "Invalid response" on anything but y/n and
+    then keep going. At the staging prompt that walked a typo straight into
+    the production applies (external review)."""
+    import re
+    import subprocess
+
+    build = _build_script()
+    blocks = re.findall(r"case \$yn in.*?esac", build, re.S)
+    assert len(blocks) == 2, blocks
+    for block in blocks:
+        result = subprocess.run(
+            ["bash", "-c", "set -e\nyn=maybe\n" + block + '\necho "KEPT_GOING"'],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert result.returncode != 0, block
+        assert "KEPT_GOING" not in result.stdout, block
+
+
+def test_deployment_presence_check_distinguishes_notfound_from_an_api_error():
+    """A command used as an `if` condition does not trip errexit, so the old
+    `if kubectl get deployment X >/dev/null 2>&1` read a transient API error
+    as "this Deployment does not exist" and silently skipped its gate
+    (external review). Only a real NotFound may count as absent."""
+    import os
+    import pathlib
+    import subprocess
+    import tempfile
+
+    fn = _extract_shell_function(_build_script(), "deployment_present")
+
+    def run_against(kubectl_body: str):
+        with tempfile.TemporaryDirectory() as tmp:
+            shim = pathlib.Path(tmp) / "kubectl"
+            shim.write_text("#!/bin/bash\n" + kubectl_body + "\n")
+            shim.chmod(0o755)
+            env = {**os.environ, "PATH": f"{tmp}:{os.environ['PATH']}"}
+            script = (
+                "set -e\n"
+                "KGET=(kubectl -n totallylegitco)\n"
+                + fn
+                + '\nif deployment_present web; then echo PRESENT; else echo ABSENT; fi\n'
+            )
+            return subprocess.run(
+                ["bash", "-c", script],
+                capture_output=True,
+                text=True,
+                env=env,
+                timeout=60,
+            )
+
+    found = run_against('echo "deployment.apps/web"; exit 0')
+    assert found.returncode == 0 and "PRESENT" in found.stdout
+
+    missing = run_against(
+        'echo \'Error from server (NotFound): deployments.apps "web" not found\' >&2; exit 1'
+    )
+    assert missing.returncode == 0 and "ABSENT" in missing.stdout
+
+    # The one that used to be indistinguishable from "absent".
+    broken = run_against(
+        "echo 'Error from server (InternalError): an error on the server' >&2; exit 1"
+    )
+    assert broken.returncode != 0, broken.stdout
+    assert "ABSENT" not in broken.stdout
+    assert "refusing to guess" in broken.stderr
+
+
+def test_gate_waits_for_the_writer_pods_to_drain_not_just_to_roll():
+    """`rollout status` returns while old pods are still inside their grace
+    period, running preStop and finishing in-flight work -- and still able to
+    INSERT a ProposedAppeal. The two ProposedAppeal-writing Deployments must
+    additionally be drained; the fax worker must not be, since it writes none
+    and its 1860s grace would cost half an hour per deploy (external review)."""
+    build = _build_script()
+    drain_lines = [ln for ln in build.splitlines() if "wait_for_drain " in ln]
+    # One helper definition plus the two call sites.
+    calls = [ln for ln in drain_lines if "wait_for_drain group=" in ln]
+    assert len(calls) == 2, drain_lines
+    assert any("prod-webbackend" in ln for ln in calls)
+    assert any("temporal-appeal-worker" in ln for ln in calls)
+    assert not any("fax" in ln for ln in calls)
+    # And it is a real gate: failing to drain stops the deploy.
+    fn = _extract_shell_function(build, "wait_for_drain")
+    assert "exit 1" in fn
+
+
+def test_ray_gate_requires_the_pre_delete_pods_to_be_gone():
+    """`kubectl delete` is background-cascading: the RayCluster object goes
+    before its pods do, and both generations carry the same ray.io/cluster
+    label -- so an old Ready pod could satisfy the readiness gate while still
+    running SpeculativeAppealsActor (external review)."""
+    build = _build_script()
+    snapshot_at = build.index("RAY_PODS_BEFORE=")
+    delete_at = build.index("delete raycluster")
+    assert snapshot_at < delete_at, "the snapshot has to precede the delete"
+    assert "ray_old_pods_remaining" in build
+    # The old delete masked every failure -- 403, timeout, API error -- as an
+    # absent cluster.
+    assert 'delete raycluster -n totallylegitco raycluster-kuberay --ignore-not-found' in build
+    assert 'raycluster-kuberay || echo' not in build
+
+
+def test_ray_readiness_is_rechecked_against_a_relisted_pod_set():
+    """`kubectl wait` resolves its selector once per invocation, so a single
+    long wait begun when only the head pod existed would never look at the
+    worker pods created after it (external review)."""
+    build = _build_script()
+    assert "ray_stable=$((ray_stable + 1))" in build
+    assert 'if [ "$ray_stable" -lt 2 ]' in build
+    at = build.index('if [ "$ray_stable" -lt 2 ]')
+    assert "exit 1" in build[at : at + 300]
+
+
+def test_skip_backfill_still_gates_the_rollouts():
+    """--skip-backfill drops the Job and the drain that only the Job needs; a
+    Deployment that never finishes rolling is a broken deploy either way, so
+    the rollout waits stay. The help text has to say so."""
+    import pathlib
+    import subprocess
+
+    build = _build_script()
+    rollout_at = build.index("# ROLLOUT GATE")
+    backfill_at = build.index('if [ "$SKIP_BACKFILL" = true ]')
+    assert rollout_at < backfill_at
+    # The rollout gate answers only to --skip-journey-gates.
+    rollout_block = build[rollout_at:backfill_at]
+    assert "SKIP_JOURNEY_GATES" in rollout_block
+    assert "SKIP_BACKFILL" not in rollout_block
+
+    root = pathlib.Path(__file__).resolve().parents[2]
+    helped = subprocess.run(
+        ["bash", str(root / "scripts" / "build.sh"), "--help"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert "Rollout waits still run" in helped.stdout
+
+
+def test_deploy_script_enables_pipefail():
+    """Every pipe here is `envsubst < manifest | kubectl apply -f -`. Without
+    pipefail only kubectl's status counts, so an envsubst that died partway
+    through a multi-document manifest would apply the prefix it had already
+    emitted and report success (external review)."""
+    build = _build_script()
+    assert "set -o pipefail" in build
+
+
+def test_gate_kubectl_calls_carry_a_request_timeout():
+    """kubectl's default --request-timeout is 0, i.e. wait forever, so one
+    stuck API request would hang the deploy past whatever budget the polls
+    claim to enforce (external review)."""
+    build = _build_script()
+    assert "KGET=(kubectl --request-timeout=" in build
+    # The long-running gate calls are not routed through KGET, so check them
+    # individually.
+    for call in ("rollout status deployment", "wait --for=condition=Ready pod"):
+        line = next(ln for ln in build.splitlines() if call in ln and "#" not in ln)
+        assert "--request-timeout=" in line, line
 
 
 def test_backfill_job_runs_non_root_with_a_read_only_root_filesystem():

--- a/tests/async-unit/test_appeal_journey_core.py
+++ b/tests/async-unit/test_appeal_journey_core.py
@@ -1004,6 +1004,20 @@ def test_ray_gate_requires_the_pre_delete_pods_to_be_gone():
     assert 'raycluster-kuberay || echo' not in build
 
 
+def test_ray_terminating_check_does_not_discard_kubectls_exit_status():
+    """`[ -n "$(terminating_pods ...)" ]` throws away the exit status: a failed
+    list is an empty string, which reads as "nothing is terminating" and opens
+    the gate while old Ray pods can still write (external review)."""
+    build = _build_script()
+    code = [ln for ln in build.splitlines() if not ln.lstrip().startswith("#")]
+    assert not any(
+        'terminating_pods' in ln and '-n "$(' in ln for ln in code
+    ), "a terminating_pods read is still inside a bare test substitution"
+    assert 'if ! ray_terminating="$(terminating_pods' in build
+    at = build.index('if ! ray_terminating="$(terminating_pods')
+    assert "exit 1" in build[at : at + 300]
+
+
 def test_ray_readiness_counts_pods_against_the_size_the_cluster_should_reach():
     """`kubectl wait` resolves its selector once per invocation, so a wait
     begun when only the head pod existed would never look at the worker pods
@@ -1083,6 +1097,7 @@ def test_skip_backfill_still_gates_the_rollouts():
         text=True,
         timeout=60,
     )
+    assert helped.returncode == 0, helped.stderr
     assert "Rollout waits still run" in helped.stdout
 
 
@@ -1116,9 +1131,11 @@ def test_gate_kubectl_calls_carry_a_request_timeout():
     claim to enforce (external review)."""
     build = _build_script()
     assert "KGET=(kubectl --request-timeout=" in build
-    # The blocking gate calls are not routed through KGET, so they carry
-    # their own. Plain `kubectl apply` is deliberately not in this list: an
-    # apply is not a poll and should not be cut off at 30s.
+    # ...and the blocking commands deliberately do NOT carry one. They take
+    # their own --timeout, and a per-request bound aborts an operation that is
+    # progressing normally -- on older kubectl clients `rollout status` exits
+    # when its watch request expires rather than re-establishing it
+    # (external review). `kubectl apply` is in the same category.
     for call in ("rollout status deployment", "delete raycluster", "delete job"):
         lines = [
             ln.strip()
@@ -1127,7 +1144,12 @@ def test_gate_kubectl_calls_carry_a_request_timeout():
         ]
         assert lines, call
         for line in lines:
-            assert "--request-timeout=" in line, line
+            assert "--request-timeout=" not in line, line
+    # The one bound that has to stay on the rollout is its own.
+    rollout = next(
+        ln for ln in build.splitlines() if "rollout status deployment" in ln
+    )
+    assert "--timeout=15m" in rollout
 
 
 def test_backfill_job_runs_non_root_with_a_read_only_root_filesystem():

--- a/tests/async-unit/test_intake_outbox.py
+++ b/tests/async-unit/test_intake_outbox.py
@@ -845,9 +845,11 @@ class TestRelayDeployment:
         assert "k8s/temporal/intake-outbox-cronjob.yaml" in build
         assert "k8s/temporal/intake-outbox-alerts.yaml" in build
         # The alerts need the operator CRD; guarded like every other rule.
+        # crd_present() replaced the bare `kubectl get crd ... 2>&1` probe so
+        # an API error can no longer masquerade as a missing operator.
         alerts_at = build.index("k8s/temporal/intake-outbox-alerts.yaml")
         guard = build.rindex(
-            "kubectl get crd prometheusrules.monitoring.coreos.com", 0, alerts_at
+            "crd_present prometheusrules.monitoring.coreos.com", 0, alerts_at
         )
         assert alerts_at - guard < 400
 


### PR DESCRIPTION
… before the gates

The journey tranche (#968-#974) is merged but not deployed, and a review of the deploy path against what actually ships found three ways running build.sh as-is would go wrong.

FHI_VERSION was still v0.23.2a, the tag prod is already running. build_django.sh short-circuits when the tag exists in the registry, so the deploy would find it, skip the build, and re-apply the pre-tranche image -- including leaving the broken PDF upload and image OCR (#974) broken. Bumped to v0.23.3a.

The Ray readiness wait had no existence check, unlike the Deployment loop right above it. The script deletes and recreates the raycluster earlier in the same run, so `kubectl wait` against a selector the operator has not populated yet exits immediately with "no matching resources found" and fails an otherwise healthy deploy. It now waits up to 5m for pods to appear, skips the readiness wait when there are none, and applies the same phase filter to the wait so a leftover Succeeded/Failed pod cannot hang it.

The observability applies -- worker PDB, both PodMonitors, both PrometheusRules and the intake outbox CronJob -- sat below the backfill gate's `exit 1`. A stalled rollout or a failed Job therefore shipped the new image with no metrics and no alerts, which is exactly the silent gap those manifests exist to close. They are cheap idempotent applies with nothing to wait for, so they now run before any gate that can exit.

Also replaces `kubectl wait --for=condition=complete` on the backfill Job with a poll of both conditions. `wait` ignores condition=Failed, so a Job that gave up still cost the full 30 minutes before the deploy heard about it.

Two flags for when the ~90 minutes of waiting is not what you want: --skip-journey-gates still applies everything (Job included) but does not block on the rollouts or the Job; --skip-backfill leaves the Job alone entirely. Neither changes what image ships. The k8s/temporal README now documents the waits, the deliberate non-zero exits, and both flags.


Claude-Session: https://claude.ai/code/session_019SPqa4FZ43ahAjoD53Uj81

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deployment controls for skipping journey rollout waits or fingerprint backfill waits when necessary.
  * Deployments now wait for relevant services to drain before backfilling fingerprints.
  * Added readiness checks for Ray workloads and improved handling of rollout, resource, and terminating-pod status.
  * Deployments now fail promptly when job status is unavailable or a job reports failure.
  * Observability resources are applied before deployment readiness checks.

* **Documentation**
  * Expanded Temporal self-hosting guidance on deployment timing, draining, skip options, and data integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->