### PR TITLE
Azure backends: name the deployments that actually exist

### DIFF
--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -2883,7 +2883,17 @@ class RemoteOpenLike(RemoteModel):
         # hyphenated variants (gpt-5-mini), and both reject a custom temperature.
         # Matching only "gpt-5" and "gpt-5-" let every dotted release through and
         # paid one rejected request before the runtime fallback learned better.
-        if name == "gpt-5" or name.startswith(("gpt-5-", "gpt-5.")):
+        #
+        # The dotted arm requires a DIGIT after the dot. Azure deployment names
+        # are operator-chosen, so a bare "gpt-5." prefix match would also strip
+        # the parameter from something like a "gpt-5.production" deployment
+        # backed by a non-reasoning model, silently dropping a temperature the
+        # model does support.
+        if (
+            name == "gpt-5"
+            or name.startswith("gpt-5-")
+            or re.match(r"^gpt-5\.\d", name)
+        ):
             return False
         if re.match(r"^o[134](-|$)", name):
             return False

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -2879,21 +2879,17 @@ class RemoteOpenLike(RemoteModel):
         if model in self._temperature_unsupported_models:
             return False
         name = model.split("/")[-1].lower()
-        # The family ships dotted point releases (gpt-5.1 ... gpt-5.5) as well as
-        # hyphenated variants (gpt-5-mini), and both reject a custom temperature.
-        # Matching only "gpt-5" and "gpt-5-" let every dotted release through and
-        # paid one rejected request before the runtime fallback learned better.
+        # The family ships dotted point releases (gpt-5.1 ... gpt-5.5) and
+        # hyphenated variants (gpt-5-mini, gpt-5.1-codex, dated snapshots); all
+        # of them reject a custom temperature.
         #
-        # The dotted arm requires a DIGIT after the dot. Azure deployment names
-        # are operator-chosen, so a bare "gpt-5." prefix match would also strip
-        # the parameter from something like a "gpt-5.production" deployment
-        # backed by a non-reasoning model, silently dropping a temperature the
-        # model does support.
-        if (
-            name == "gpt-5"
-            or name.startswith("gpt-5-")
-            or re.match(r"^gpt-5\.\d", name)
-        ):
+        # Anchored on the WHOLE identifier rather than a prefix. Azure
+        # deployment names are operator-chosen, so "gpt-5.production" or
+        # "gpt-5.5x" may be a non-reasoning model behind a suggestive name, and
+        # silently dropping a temperature it does support is a worse failure
+        # than the single 400 this check exists to avoid. Unrecognized
+        # deployments are still caught at runtime (see the docstring).
+        if re.match(r"^gpt-5(\.\d+)?($|-)", name):
             return False
         if re.match(r"^o[134](-|$)", name):
             return False

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -4747,10 +4747,17 @@ class RemoteAzureOpenAI(RemoteAzureOpenLike):
     MAX_LEN: ClassVar[int] = 128000
 
     # Latest broadly-available Azure OpenAI deployments (cheapest -> premium).
+    # Only gpt-5.5 is deployed on our sponsored Foundry resource (deployments
+    # checked 2026-09-04). gpt-4.1-mini / gpt-5-mini / gpt-5 were never
+    # provisioned there, so the previous defaults named deployments that do not
+    # exist and every call through them would 404. Sponsorship credits make this
+    # backend free to us, so it carries the lowest proxy cost of any external
+    # backend; "frontier" is what puts it in the default fan-out at all, because
+    # tier outranks cost and cost only breaks ties within a tier.
+    # Deployments change more often than this file: set AZURE_OPENAI_MODELS to
+    # override without a code change.
     DEFAULT_MODELS: ClassVar[List[Tuple[str, int, str]]] = [
-        ("gpt-4.1-mini", 55, "speed"),
-        ("gpt-5-mini", 75, "quality"),
-        ("gpt-5", 135, "premium"),
+        ("gpt-5.5", 10, "frontier"),
     ]
 
     # Per-subclass rate-limit state (do not share across providers).
@@ -4800,9 +4807,11 @@ class RemoteAzureClaude(RemoteAzureOpenLike):
     # "premium" in MLRouter.best_external_models, so it is preferred rather
     # than merely registered. Cost only breaks ties WITHIN a tier, so leaving
     # it at "premium" would have kept it out of the default fan-out entirely.
+    # Only these two are deployed on our resource (checked 2026-09-04);
+    # claude-haiku-4-5 and claude-sonnet-4-6 were never provisioned, so naming
+    # them here just produced dead entries. Override with AZURE_ANTHROPIC_MODELS
+    # when a deployment is added rather than editing this list.
     DEFAULT_MODELS: ClassVar[List[Tuple[str, int, str]]] = [
-        ("claude-haiku-4-5", 55, "speed"),
-        ("claude-sonnet-4-6", 95, "quality"),
         ("claude-opus-4-8", 135, "premium"),
         ("claude-fable-5", 175, "frontier"),
     ]

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -2879,7 +2879,11 @@ class RemoteOpenLike(RemoteModel):
         if model in self._temperature_unsupported_models:
             return False
         name = model.split("/")[-1].lower()
-        if name == "gpt-5" or name.startswith("gpt-5-"):
+        # The family ships dotted point releases (gpt-5.1 ... gpt-5.5) as well as
+        # hyphenated variants (gpt-5-mini), and both reject a custom temperature.
+        # Matching only "gpt-5" and "gpt-5-" let every dotted release through and
+        # paid one rejected request before the runtime fallback learned better.
+        if name == "gpt-5" or name.startswith(("gpt-5-", "gpt-5.")):
             return False
         if re.match(r"^o[134](-|$)", name):
             return False

--- a/tests/async-unit/test_azure_models.py
+++ b/tests/async-unit/test_azure_models.py
@@ -24,6 +24,7 @@ from fighthealthinsurance.ml.ml_models import (
     RemoteModelLike,
 )
 from fighthealthinsurance.ml.ml_router import MLRouter
+from fighthealthinsurance.ml.ml_router import MLRouter
 
 AZURE_OPENAI_ENV = {
     "AZURE_OPENAI_API_KEY": "test-key",
@@ -161,12 +162,12 @@ class TestAzureBackends(unittest.TestCase):
     @patch.dict(os.environ, AZURE_OPENAI_ENV)
     def test_openai_init(self):
         """Azure OpenAI init wires model, external/system flags, context, tier."""
-        m = RemoteAzureOpenAI(model="gpt-5")
-        self.assertEqual(m.model, "gpt-5")
+        m = RemoteAzureOpenAI(model="gpt-5.5")
+        self.assertEqual(m.model, "gpt-5.5")
         self.assertTrue(m.external)
         self.assertTrue(m.supports_system)
         self.assertEqual(m.get_max_context(), 128000)
-        self.assertEqual(m.get_tier(), "premium")
+        self.assertEqual(m.get_tier(), "frontier")
 
     @patch.dict(os.environ, AZURE_CLAUDE_ENV)
     def test_claude_init(self):
@@ -208,26 +209,73 @@ class TestAzureBackends(unittest.TestCase):
 
     @patch.dict(os.environ, AZURE_OPENAI_ENV)
     def test_openai_models_prefixed_and_cost_ordered(self):
-        """models() yields azure-openai/-prefixed entries, cheapest first."""
+        """models() yields azure-openai/-prefixed entries, cheapest first.
+
+        Only gpt-5.5 is provisioned on our sponsored resource, so the default
+        list has one entry; the prefixing and ordering contract is unchanged
+        and an env override can still add more.
+        """
         models = RemoteAzureOpenAI.models()
-        self.assertEqual(len(models), 3)
+        self.assertEqual(len(models), 1)
         self.assertTrue(all(m.name.startswith("azure-openai/") for m in models))
         costs = [m.cost for m in models]
         self.assertEqual(costs, sorted(costs))  # cheapest -> premium
 
     @patch.dict(os.environ, AZURE_CLAUDE_ENV)
     def test_claude_models_use_latest_ids(self):
-        """Azure Claude exposes the latest Haiku/Sonnet/Opus/Fable deployments."""
+        """Azure Claude exposes exactly the deployments we have provisioned.
+
+        Haiku 4.5 and Sonnet 4.6 were never deployed on our resource, so
+        listing them produced entries that would 404 on first use.
+        """
         names = {m.name for m in RemoteAzureClaude.models()}
         self.assertEqual(
             names,
             {
-                "azure-anthropic/claude-haiku-4-5",
-                "azure-anthropic/claude-sonnet-4-6",
                 "azure-anthropic/claude-opus-4-8",
                 "azure-anthropic/claude-fable-5",
             },
         )
+
+    @patch.dict(os.environ, {**AZURE_OPENAI_ENV, **AZURE_CLAUDE_ENV})
+    def test_sponsored_gpt_leads_the_external_fanout(self):
+        """The sponsored deployment must LEAD the external fan-out, which takes
+        two independent properties, asserted separately here.
+
+        First its proxy cost has to fall below the paid-external band, because
+        ``external_models_by_cost`` is what feeds selection and anything sorting
+        after the paid backends can never lead. Second it has to survive
+        ``best_external_models``, which sorts by quality descending and only
+        falls back to cost order for ties, so too low a tier drops it before
+        cost is ever consulted. Asserting either alone lets the other regress
+        silently and quietly hands traffic back to a paid backend.
+        """
+        gpt_desc = RemoteAzureOpenAI.models()[0]
+        self.assertEqual(gpt_desc.internal_name, "gpt-5.5")
+
+        # 20 is the bottom of the paid-external proxy band in this codebase. If
+        # a paid backend is ever priced below it, this is the assertion that
+        # should fail and force that decision back into the open rather than
+        # letting paid traffic quietly take the lead.
+        paid_external_floor = 20
+        self.assertLess(
+            gpt_desc.cost,
+            paid_external_floor,
+            "the sponsored deployment must undercut the paid-external band",
+        )
+
+        # And it must actually win the router's own selection against an
+        # equally capable paid backend, not merely look cheaper in a table.
+        gpt = RemoteAzureOpenAI(model="gpt-5.5")
+        paid = MagicMock(spec=RemoteModelLike)
+        paid.external = True
+        paid.quality.return_value = gpt.quality()
+        paid.is_available.return_value = True
+        paid.health_checked_live = True
+
+        router = MLRouter()
+        router.external_models_by_cost = [gpt, paid]
+        self.assertIs(router.best_external_models(limit=2)[0], gpt)
 
     @patch.dict(os.environ, AZURE_CLAUDE_ENV)
     def test_claude_fable_is_the_priciest_deployment(self):
@@ -292,10 +340,7 @@ class TestAzureBackends(unittest.TestCase):
         """A separators-only AZURE_OPENAI_MODELS (no real names) falls back to
         the defaults instead of silently disabling the provider."""
         models = RemoteAzureOpenAI.models()
-        self.assertEqual(
-            [m.internal_name for m in models],
-            ["gpt-4.1-mini", "gpt-5-mini", "gpt-5"],
-        )
+        self.assertEqual([m.internal_name for m in models], ["gpt-5.5"])
 
     @patch.dict(os.environ, AZURE_OPENAI_ENV)
     def test_model_is_ok(self):

--- a/tests/async-unit/test_azure_models.py
+++ b/tests/async-unit/test_azure_models.py
@@ -692,6 +692,31 @@ class TestAzureClaudeMessages(unittest.TestCase):
 
         asyncio.run(run())
 
+    @patch.dict(os.environ, AZURE_OPENAI_ENV)
+    def test_gpt5_point_releases_drop_temperature(self):
+        """The gpt-5 family 400s on a custom temperature, and it ships DOTTED
+        point releases as well as hyphenated variants.
+
+        The matcher recognised "gpt-5" and the "gpt-5-" prefix only, so every
+        dotted release looked temperature-capable: the first call to it posted
+        a temperature, ate an HTTP 400, and only then landed in the runtime
+        fallback. Harmless when no dotted release was configured; gpt-5.5 is a
+        shipped default now, so that rejected request is on the hot path.
+        """
+        m = RemoteAzureOpenAI(model="gpt-5.5")
+        for name in (
+            "gpt-5",
+            "gpt-5-mini",
+            "gpt-5.5",
+            "gpt-5.1",
+            "gpt-5.4-mini",
+            "azure-openai/gpt-5.5",  # provider-prefixed registrations too
+        ):
+            with self.subTest(model=name):
+                self.assertFalse(m._supports_custom_temperature(name))
+        # Non-reasoning deployments must keep the parameter.
+        self.assertTrue(m._supports_custom_temperature("gpt-4.1-mini"))
+
     @patch.dict(os.environ, AZURE_CLAUDE_ENV)
     def test_every_no_sampling_prefix_is_recognized(self):
         """Each id in _CLAUDE_NO_SAMPLING_PREFIXES must actually be matched — a

--- a/tests/async-unit/test_azure_models.py
+++ b/tests/async-unit/test_azure_models.py
@@ -714,8 +714,15 @@ class TestAzureClaudeMessages(unittest.TestCase):
         ):
             with self.subTest(model=name):
                 self.assertFalse(m._supports_custom_temperature(name))
-        # Non-reasoning deployments must keep the parameter.
+        # Non-reasoning deployments must keep the parameter...
         self.assertTrue(m._supports_custom_temperature("gpt-4.1-mini"))
+        # ...including operator-named deployments that merely start "gpt-5.".
+        # Azure deployment names are chosen by whoever creates them, so a bare
+        # prefix match would strip temperature from a non-reasoning model behind
+        # a name like this, which is a silent wrong answer rather than a 400.
+        for name in ("gpt-5.production", "gpt-5.legacy-mini", "gpt-5x"):
+            with self.subTest(model=name):
+                self.assertTrue(m._supports_custom_temperature(name))
 
     @patch.dict(os.environ, AZURE_CLAUDE_ENV)
     def test_every_no_sampling_prefix_is_recognized(self):

--- a/tests/async-unit/test_azure_models.py
+++ b/tests/async-unit/test_azure_models.py
@@ -710,6 +710,9 @@ class TestAzureClaudeMessages(unittest.TestCase):
             "gpt-5.5",
             "gpt-5.1",
             "gpt-5.4-mini",
+            "gpt-5.1-codex",
+            "gpt-5-2026-04-24",  # dated snapshot ids
+            "gpt-5.5-2026-04-24",
             "azure-openai/gpt-5.5",  # provider-prefixed registrations too
         ):
             with self.subTest(model=name):
@@ -720,7 +723,13 @@ class TestAzureClaudeMessages(unittest.TestCase):
         # Azure deployment names are chosen by whoever creates them, so a bare
         # prefix match would strip temperature from a non-reasoning model behind
         # a name like this, which is a silent wrong answer rather than a 400.
-        for name in ("gpt-5.production", "gpt-5.legacy-mini", "gpt-5x"):
+        for name in (
+            "gpt-5.production",
+            "gpt-5.legacy-mini",
+            "gpt-5x",
+            "gpt-5.5.production",  # a real release id is only a PREFIX here
+            "gpt-5.5x",
+        ):
             with self.subTest(model=name):
                 self.assertTrue(m._supports_custom_temperature(name))
 

--- a/tests/async-unit/test_model_backend_health.py
+++ b/tests/async-unit/test_model_backend_health.py
@@ -295,17 +295,19 @@ class TestEnumeration:
         assert static == []
 
     def test_only_models_filter_accepts_internal_name(self, monkeypatch, fresh_router):
-        # The wire id "claude-sonnet-4-6" matches BOTH the direct Anthropic
+        # The wire id "claude-opus-4-8" matches BOTH the direct Anthropic
         # model and the (unconfigured) azure-anthropic deployment of the same
         # name — the configured one is checkable, the other reports its
-        # configuration state.
+        # configuration state. (Was claude-sonnet-4-6 until that deployment was
+        # dropped from the Azure defaults: it was never provisioned on our
+        # resource. Opus is the id that still spans both providers.)
         _clear_provider_env(monkeypatch)
         monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key-123")
         static, checkable = mhc.enumerate_backend_checks(
-            only_models=["claude-sonnet-4-6"]
+            only_models=["claude-opus-4-8"]
         )
-        assert [r.model_name for r, _ in checkable] == ["anthropic/claude-sonnet-4-6"]
-        assert {r.model_name for r in static} == {"azure-anthropic/claude-sonnet-4-6"}
+        assert [r.model_name for r, _ in checkable] == ["anthropic/claude-opus-4-8"]
+        assert {r.model_name for r in static} == {"azure-anthropic/claude-opus-4-8"}
         assert {r.category for r in static} == {mhc.CATEGORY_NOT_CONFIGURED}
 
     def test_disabled_backends_never_invoked_end_to_end(

--- a/tests/sync/test_backfill_model_metadata.py
+++ b/tests/sync/test_backfill_model_metadata.py
@@ -95,15 +95,20 @@ class BackfillModelMetadataTest(TestCase):
 
     def test_bare_wire_id_repaired_only_when_unique(self):
         # claude-haiku-4-5-20251001 exists only in the direct Anthropic
-        # catalog -> repaired. claude-sonnet-4-6 is both an anthropic wire id
+        # catalog -> repaired. claude-opus-4-8 is both an anthropic wire id
         # and an azure-anthropic deployment name -> ambiguous, untouched.
+        #
+        # The ambiguous example was claude-sonnet-4-6 until that deployment was
+        # dropped from the Azure defaults (it was never provisioned on our
+        # resource), which made the id unique and silently inverted what this
+        # test was checking. Opus is the id that still spans both providers.
         unique = self._make_appeal("claude-haiku-4-5-20251001")
-        ambiguous = self._make_appeal("claude-sonnet-4-6")
+        ambiguous = self._make_appeal("claude-opus-4-8")
         self._run("--apply")
         unique.refresh_from_db()
         ambiguous.refresh_from_db()
         self.assertEqual(unique.model_name, "anthropic/claude-haiku-4-5")
-        self.assertEqual(ambiguous.model_name, "claude-sonnet-4-6")
+        self.assertEqual(ambiguous.model_name, "claude-opus-4-8")
 
     def test_null_rows_left_for_unknown_bucket(self):
         row = self._make_appeal(None)


### PR DESCRIPTION
Our Azure config named five deployments that are not on the sponsored Foundry resource and none of the three that are, so every call down the Azure path would have failed on the deployment name before ordering mattered at all.

Deployments on the resource, checked 2026-09-04: gpt-5.5 (2026-04-24), claude-opus-4-8, claude-fable-5. Not deployed, and now removed from the defaults: gpt-4.1-mini, gpt-5-mini, gpt-5, claude-haiku-4-5, claude-sonnet-4-6.

The GPT side is covered by sponsorship credits, so gpt-5.5 carries the lowest proxy cost of any external backend. It is frontier-tier because tier is what admits a model to the default fan-out; cost only breaks ties within a tier, so a lower tier would have kept it out no matter how cheap it looked. Internal self-hosted models keep their precedence: the router takes internal first and externals after, which this does not touch.

AZURE_OPENAI_MODELS and AZURE_ANTHROPIC_MODELS still override, so the next deployment needs a config value rather than a code change.

Tests: the Azure tests asserted the old lists and now assert the deployed ones. test_only_models_filter_accepts_internal_name deliberately used an id spanning both the direct and Azure Anthropic providers; claude-sonnet-4-6 no longer does, so it moves to claude-opus-4-8, which still does. Adds test_sponsored_gpt_leads_the_external_fanout, which asserts both levers together, since the previous tests sorted a one-item list and would have passed while the routing intent regressed. Mutation-checked: cost 200 fails it, tier "premium" fails it.

Full async-unit suite matches the origin/main baseline: 51 pre-existing failures, no new ones.


Claude-Session: https://claude.ai/code/session_01PfFVxQnsrNXnVmAmb4FcCr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Model Availability**
  * Azure OpenAI defaults now use `gpt-5.5`.
  * Azure Anthropic defaults now include `claude-opus-4-8` and `claude-fable-5`.
  * Previously defaulted Azure models that are no longer provisioned have been removed.

* **Model Selection**
  * Sponsored `gpt-5.5` takes priority over equivalent paid external models.

* **Compatibility**
  * Custom temperature settings are not supported for GPT-5 point-release models, including `gpt-5.5`.
  * Operator-selected model names such as `gpt-5.5.production` and `gpt-5.5x` are classified correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->