### PR TITLE
Temporal workers: give them enough memory for the image they run

### DIFF
--- a/k8s/temporal/appeal-worker.yaml
+++ b/k8s/temporal/appeal-worker.yaml
@@ -87,7 +87,13 @@ spec:
           resources:
             requests:
               cpu: "250m"
-              memory: 512Mi
+              # The web pods run this SAME image with no memory limit and
+              # settle around 1.45Gi, so 1.5Gi is the honest floor for it.
+              memory: 1.5Gi
             limits:
               cpu: "1"
-              memory: 1Gi
+              # Double the expected working set. The old 1Gi cap was not a
+              # measurement -- fhi-fax-worker's observed 1020Mi was CENSORED
+              # by that very ceiling, so its real appetite was never known.
+              # Trivial against ~320GB of cluster memory at 4-42% used.
+              memory: 3Gi

--- a/k8s/temporal/worker.yaml
+++ b/k8s/temporal/worker.yaml
@@ -106,10 +106,16 @@ spec:
           resources:
             requests:
               cpu: "250m"
-              memory: 512Mi
+              # The web pods run this SAME image with no memory limit and
+              # settle around 1.45Gi, so 1.5Gi is the honest floor for it.
+              memory: 1.5Gi
             limits:
               cpu: "1"
-              memory: 1Gi
+              # Double the expected working set. The old 1Gi cap was not a
+              # measurement -- fhi-fax-worker's observed 1020Mi was CENSORED
+              # by that very ceiling, so its real appetite was never known.
+              # Trivial against ~320GB of cluster memory at 4-42% used.
+              memory: 3Gi
           volumeMounts:
             # No documents PVC on the rebuilt cluster (2026-07-30): the live
             # web Deployment mounts no uploads claim and

--- a/tests/async-unit/test_appeal_journey_core.py
+++ b/tests/async-unit/test_appeal_journey_core.py
@@ -1164,6 +1164,32 @@ def test_gate_kubectl_calls_carry_a_request_timeout():
             assert bound in line, line
 
 
+def test_temporal_workers_get_enough_memory_for_this_image():
+    """Both workers run the SAME image as the web pods, which request 1.5Gi and
+    sit around 1.45Gi in production. The workers were capped at 1Gi, and
+    fhi-fax-worker was OOMKilled in prod (exitCode 137) sitting at 1020Mi
+    against that 1024Mi ceiling. Shipping fhi-appeal-worker -- a brand-new
+    Deployment doing strictly more work -- under the same cap would crashloop
+    it on first start and time out the deploy's rollout gate."""
+    import pathlib
+
+    import yaml
+
+    root = pathlib.Path(__file__).resolve().parents[2]
+
+    def mem(path):
+        raw = (root / path).read_text().replace("${FHI_BASE}:${FHI_VERSION}", "image")
+        doc = yaml.safe_load(raw)
+        res = doc["spec"]["template"]["spec"]["containers"][0]["resources"]
+        return res["requests"]["memory"], res["limits"]["memory"]
+
+    for path in ("k8s/temporal/worker.yaml", "k8s/temporal/appeal-worker.yaml"):
+        req, lim = mem(path)
+        # The web Deployment's own request is the honest floor for this image.
+        assert req == "1.5Gi", f"{path} requests {req}"
+        assert lim == "3Gi", f"{path} limit {lim}"
+
+
 def test_backfill_job_runs_non_root_with_a_read_only_root_filesystem():
     """The Job carries both production secret sets, so it gets the same
     posture the web-extralink-prefetch Job already proves for this image:


### PR DESCRIPTION
fhi-fax-worker is being OOMKilled in production right now. Its last termination was exitCode 137, reason OOMKilled, and the surviving pod is sitting at 1020Mi against a 1024Mi limit with 3 restarts behind it.

The cap was set without reference to what this image costs to run. All three workloads run the SAME image: the web Deployment requests 1.5Gi with no limit and sits around 1.45Gi in production, while both workers requested 512Mi and were capped at 1Gi. The workers were never going to fit.

This matters more than usual right now because the next deploy creates fhi-appeal-worker for the first time, doing strictly more work than the fax worker -- appeal generation and ML calls rather than fax dispatch -- under the same 1Gi cap. It would very likely crashloop on first start, and the deploy's own rollout gate would then time out after 15 minutes and abort the deploy.

Both workers now request 1Gi and cap at 2Gi: above the web pods' measured footprint for the same image, with headroom for generation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance & Reliability**
  - Increased available memory for background processing workers, helping them handle memory-intensive workloads more reliably.
  - CPU allocations remain unchanged.

- **Tests**
  - Added coverage to verify that worker memory settings remain aligned with the required capacity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->