### PR TITLE
Generation lease: a renewal error is not proof the lease was lost

### DIFF
--- a/fighthealthinsurance/appeal_journey_core.py
+++ b/fighthealthinsurance/appeal_journey_core.py
@@ -27,6 +27,7 @@ from asgiref.sync import async_to_sync
 from loguru import logger
 
 from fighthealthinsurance import generation_lease
+from fighthealthinsurance.ml import ml_models
 from fighthealthinsurance.utils import is_real_appeal
 
 STATUS_OK = "ok"
@@ -61,10 +62,9 @@ class LeaseHeld(Exception):
     """
 
 
-# How often a running journey pushes its lease expiry out; well inside the
-# lease TTL so a live attempt never expires mid-run while a dead one frees
-# the denial within one TTL.
-LEASE_EXTEND_INTERVAL_S = 10.0
+# The renewal interval and the give-up policy now live with the lease itself
+# (generation_lease.EXTEND_INTERVAL_SECONDS and keep_renewed), so the journey
+# and the interactive flow cannot drift apart on either one.
 
 
 async def acheck_generation_postcondition(denial) -> bool:
@@ -205,13 +205,33 @@ async def agenerate_and_store_appeals(denial) -> int:
             f"generation lease held for denial {denial.uuid} (epoch {lease.epoch})"
         )
 
+    # The same shared renewal policy the interactive flow uses
+    # (generation_lease.keep_renewed). This loop previously had NO error
+    # handling at all: a single transient aextend exception killed the task,
+    # after which the lease expired within one TTL while the attempt kept
+    # generating -- and every draft insert then failed the assert_holds fence
+    # inside its own transaction, so the journey burned model calls and
+    # persisted nothing. The dead task's exception was never retrieved
+    # either, surfacing only as an asyncio warning (external review).
+    lease_clock = generation_lease.RenewalClock()
+
     async def _keep_lease() -> None:
         # Owned by this attempt: cancelled in the finally below, so a dead
         # attempt stops extending and the lease expires within one TTL.
-        while True:
-            await asyncio.sleep(LEASE_EXTEND_INTERVAL_S)
-            if not await generation_lease.aextend(denial, lease.epoch):
-                return  # stolen: the per-frame check ends the run
+        # Returns when ownership is provably lost; the per-frame check ends
+        # the run.
+        def _lost(reason: str) -> None:
+            # A STOLEN lease moves the epoch and the per-frame check sees it;
+            # an EXPIRED one does not, so without this the only symptom is a
+            # fenced insert failing later (external review).
+            logger.warning(
+                f"Appeal journey: lease no longer held for denial "
+                f"{denial.uuid}: {reason}"
+            )
+
+        await generation_lease.keep_renewed(
+            denial, lease.epoch, lease_clock, on_lost=_lost
+        )
 
     extender = asyncio.create_task(_keep_lease())
     frames = 0
@@ -228,25 +248,34 @@ async def agenerate_and_store_appeals(denial) -> int:
         ),
     )
     try:
-        async with asyncio.timeout(GENERATION_BUDGET_SECONDS):
-            async for chunk in agen:
-                if _appeal_text_from_chunk(chunk) is None:
-                    continue
-                # Early stop on DURABLE progress: appeal frames are few, so a
-                # count query per frame is cheap, and only rows that actually
-                # persisted can end the consumption early.
-                frames += 1
-                if await generation_lease.acurrent_epoch(denial) != lease.epoch:
-                    # Fencing token moved: an interactive run stole the
-                    # lease. Stop quietly with what is stored; the user is
-                    # being served live and the retry's baseline check will
-                    # see their drafts.
-                    stolen = True
-                    break
-                # Distinct fingerprints, not row ids: duplicate rows are one
-                # deliverable draft (the fingerprint work now on main).
-                if len(await _stored_fingerprints()) >= TARGET_APPEALS:
-                    break
+        # Bound the PROVIDER calls to the same budget, not just this loop.
+        # asyncio.timeout stops awaiting the generator, but a model call
+        # already submitted to a thread keeps its socket open and keeps
+        # spending -- start_to_close does not kill threads. The appeal task
+        # timeout defaults to 300s against a 240s budget, so a single call
+        # could outlive the whole attempt, three times per workflow (enable
+        # gate 3). Inside this block ml_task_timeout() clamps every provider
+        # call to whatever is left.
+        with ml_models.attempt_deadline(GENERATION_BUDGET_SECONDS):
+            async with asyncio.timeout(GENERATION_BUDGET_SECONDS):
+                async for chunk in agen:
+                    if _appeal_text_from_chunk(chunk) is None:
+                        continue
+                    # Early stop on DURABLE progress: appeal frames are few, so a
+                    # count query per frame is cheap, and only rows that actually
+                    # persisted can end the consumption early.
+                    frames += 1
+                    if await generation_lease.acurrent_epoch(denial) != lease.epoch:
+                        # Fencing token moved: an interactive run stole the
+                        # lease. Stop quietly with what is stored; the user is
+                        # being served live and the retry's baseline check will
+                        # see their drafts.
+                        stolen = True
+                        break
+                    # Distinct fingerprints, not row ids: duplicate rows are one
+                    # deliverable draft (the fingerprint work now on main).
+                    if len(await _stored_fingerprints()) >= TARGET_APPEALS:
+                        break
     except TimeoutError:
         logger.info(
             f"Appeal journey: generation budget reached after {frames} "

--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -3117,37 +3117,28 @@ class AppealsBackendHelper:
             # the epoch move and stops quietly, and one arriving inside the
             # TTL backs off. One UPDATE; expiry is the release. Never let a
             # lease hiccup break the interactive flow (external review).
-            async def _keep_interactive_lease(epoch: int) -> None:
-                # Renew from the moment of acquisition, not the first
-                # insert: make_appeals can run past the TTL before its
-                # first draft, and an expired lease would let a journey
-                # supersede a live human (review). A renewal matching
-                # zero rows means we were superseded; persistent DB
-                # failure is treated the same way rather than writing
-                # under a lease we cannot prove we hold.
+            # One shared renewal policy for the interactive flow and the
+            # appeal journey (generation_lease.keep_renewed), so the two
+            # cannot drift apart, and one shared clock so a renewal
+            # confirmed by EITHER path counts for both -- save_appeal below
+            # renews this same lease after each draft, and crediting only
+            # the background loop meant a run whose background calls kept
+            # raising declared the lease lost after a TTL while per-save
+            # renewals were succeeding throughout (external review).
+            lease_clock = generation_lease.RenewalClock()
+
+            def _lease_lost(reason: str) -> None:
                 nonlocal superseded
-                failures = 0
-                while True:
-                    await asyncio.sleep(generation_lease.EXTEND_INTERVAL_SECONDS)
-                    try:
-                        renewed = await generation_lease.aextend(denial, epoch)
-                    except Exception:
-                        failures += 1
-                        logger.opt(exception=True).warning(
-                            f"[gen_id={generation_id}] lease renewal failed "
-                            f"({failures}) for denial {denial_id}"
-                        )
-                        if failures < 3:
-                            continue
-                        renewed = False
-                    if not renewed:
-                        superseded = True
-                        logger.info(
-                            f"[gen_id={generation_id}] interactive lease no "
-                            f"longer held for denial {denial_id}; stopping"
-                        )
-                        return
-                    failures = 0
+                superseded = True
+                logger.info(
+                    f"[gen_id={generation_id}] interactive lease no longer "
+                    f"held for denial {denial_id}: {reason}"
+                )
+
+            async def _keep_interactive_lease(epoch: int) -> None:
+                await generation_lease.keep_renewed(
+                    denial, epoch, lease_clock, on_lost=_lease_lost
+                )
 
             try:
                 stolen = await generation_lease.aacquire(
@@ -4399,12 +4390,25 @@ class AppealsBackendHelper:
                 # stored (it passed the fence when it was inserted), but the
                 # run is superseded and stops after this frame.
                 try:
-                    if not await generation_lease.aextend(denial, lease_epoch):
+                    _renew_started = time.monotonic()
+                    # Bounded like the background loop: a hung renewal here
+                    # would park the interactive flow AFTER the draft was
+                    # already durable (external review). The timeout is
+                    # caught by the except below and treated as transient.
+                    if not await asyncio.wait_for(
+                        generation_lease.aextend(denial, lease_epoch),
+                        timeout=generation_lease.EXTEND_INTERVAL_SECONDS,
+                    ):
                         superseded = True
                         logger.info(
                             f"[gen_id={generation_id}] lease no longer held after "
                             f"saving a draft for denial {denial_id}"
                         )
+                    else:
+                        # A renewal confirmed HERE is still a renewal: tell the
+                        # shared clock, or the background loop's expiry check
+                        # counts from a staleness this path already disproved.
+                        lease_clock.confirm(_renew_started)
                 except Exception:
                     logger.opt(exception=True).warning(
                         f"[gen_id={generation_id}] lease renewal failed after a "

--- a/fighthealthinsurance/generation_lease.py
+++ b/fighthealthinsurance/generation_lease.py
@@ -22,7 +22,10 @@ bridge through channels' ``database_sync_to_async`` per the repo rule for
 ORM-touching app code.
 """
 
+import asyncio
+import time
 import uuid
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Optional
@@ -37,6 +40,90 @@ DEFAULT_TTL_SECONDS = 300  # generation budget (240s) + drain margin
 # acquisition (a model call can run several minutes before its first draft,
 # longer than the TTL, so renewal cannot wait for the first insert).
 EXTEND_INTERVAL_SECONDS = 10.0
+
+
+class RenewalClock:
+    """The last CONFIRMED renewal of one held lease, shared by every path
+    that extends it.
+
+    A lease can be renewed from more than one place: a background task on a
+    timer, and (interactively) once more after each draft is saved. Whether
+    the holder still owns the lease is a property of the LEASE, not of any
+    one renewal loop, so a renewal confirmed anywhere has to count
+    everywhere. Tracking it per-loop meant a background loop whose calls kept
+    raising declared the lease lost after one TTL while per-save renewals
+    were succeeding the whole time -- stopping a generation that provably
+    still held it (external review).
+
+    Stamps are taken BEFORE the call that they describe, never after: the
+    database anchors ``expires_at`` on a clock read taken before its own
+    UPDATE, so crediting the round trip to ourselves would put our local
+    deadline later than the real one -- exactly wrong when the database is
+    slow, which is the only time any of this matters.
+    """
+
+    __slots__ = ("_last_confirmed",)
+
+    def __init__(self, started: Optional[float] = None) -> None:
+        self._last_confirmed = time.monotonic() if started is None else started
+
+    def confirm(self, at: Optional[float] = None) -> None:
+        """Record a renewal that the database acknowledged."""
+        stamp = time.monotonic() if at is None else at
+        if stamp > self._last_confirmed:
+            self._last_confirmed = stamp
+
+    def stale_for(self) -> float:
+        """Seconds since the last renewal we can actually vouch for."""
+        return time.monotonic() - self._last_confirmed
+
+
+async def keep_renewed(
+    denial,
+    epoch: int,
+    clock: "RenewalClock",
+    *,
+    on_lost: Optional[Callable[[str], None]] = None,
+) -> None:
+    """Renew a held lease until ownership is provably lost, then return.
+
+    One policy, shared by the interactive flow and the appeal journey, so the
+    two cannot drift apart.
+
+    A renewal that RETURNS False is proof of loss: the row's epoch moved or
+    the lease expired, so someone else owns it -- stop immediately. An
+    EXCEPTION proves nothing of the kind; it says the database was briefly
+    unreachable, not that ownership changed, and the lease stays valid until
+    its TTL. Give up on errors only once more than a TTL has passed since the
+    last confirmed renewal, at which point it really has expired.
+
+    Each call is bounded by the extend interval so a HANGING renewal cannot
+    park the loop forever without the deadline ever being evaluated -- a hang
+    surfaces as a timeout the elapsed check can see.
+    """
+    interval = EXTEND_INTERVAL_SECONDS
+    while True:
+        await asyncio.sleep(interval)
+        started = time.monotonic()
+        try:
+            renewed = await asyncio.wait_for(aextend(denial, epoch), timeout=interval)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            stale = clock.stale_for()
+            if stale < DEFAULT_TTL_SECONDS:
+                continue
+            if on_lost is not None:
+                on_lost(
+                    f"no confirmed renewal for {stale:.0f}s (TTL "
+                    f"{DEFAULT_TTL_SECONDS}s); lease has expired"
+                )
+            return
+        if not renewed:
+            if on_lost is not None:
+                on_lost("renewal reported the lease is no longer held")
+            return
+        clock.confirm(started)
 
 
 def _now():

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -1,4 +1,6 @@
 import asyncio
+import contextlib
+import contextvars
 import itertools
 import os
 import random
@@ -774,10 +776,73 @@ _ML_TASK_TIMEOUT_ENVS: dict[str, tuple[str, float]] = {
 }
 
 
+# The deadline of the attempt currently in flight, as a time.monotonic()
+# stamp, or None outside one. A ContextVar (not a global) so concurrent
+# generations on the same worker cannot read each other's budget; asgiref's
+# sync_to_async and channels' database_sync_to_async both copy the calling
+# context into the worker thread, so a clamp set here reaches the blocking
+# provider call that actually holds the socket.
+_ATTEMPT_DEADLINE: contextvars.ContextVar[Optional[float]] = contextvars.ContextVar(
+    "fhi_ml_attempt_deadline", default=None
+)
+
+# Never hand a client a zero or negative timeout. requests treats 0 as
+# "fail immediately" and None as "wait forever" -- passing either by
+# accident at the moment the budget runs out would be worse than the
+# unclamped behaviour this exists to fix.
+MIN_TASK_TIMEOUT_SECONDS = 1.0
+
+
+@contextlib.contextmanager
+def attempt_deadline(seconds: float):
+    """Bound every provider call made inside this block to ``seconds``.
+
+    The appeal task timeout defaults to 300s while the journey's generation
+    budget is 240s, so one provider call could outlive the whole attempt and
+    keep spending after Temporal had already moved on -- three attempts of
+    that per workflow. start_to_close does not kill the thread holding the
+    socket, so the only way to stop the spend is to not let the call outlive
+    the budget in the first place (enable gate 3).
+
+    Nested blocks keep the EARLIER deadline when it is tighter: an inner
+    stage may not award itself more time than the attempt has left.
+    """
+    proposed = time.monotonic() + max(0.0, seconds)
+    current = _ATTEMPT_DEADLINE.get()
+    token = _ATTEMPT_DEADLINE.set(
+        proposed if current is None else min(current, proposed)
+    )
+    try:
+        yield
+    finally:
+        _ATTEMPT_DEADLINE.reset(token)
+
+
+def remaining_attempt_budget() -> Optional[float]:
+    """Seconds left in the current attempt, or None when unbounded."""
+    deadline = _ATTEMPT_DEADLINE.get()
+    if deadline is None:
+        return None
+    return deadline - time.monotonic()
+
+
 def ml_task_timeout(task: str) -> float:
-    """Effective inference timeout (seconds) for a named task type."""
+    """Effective inference timeout (seconds) for a named task type.
+
+    Clamped to whatever is left of the enclosing attempt budget, when there
+    is one. Outside an attempt_deadline block this is exactly the configured
+    value, so the interactive and chat paths are unchanged.
+    """
     env_name, default = _ML_TASK_TIMEOUT_ENVS.get(task, _ML_TASK_TIMEOUT_ENVS["appeal"])
-    return _env_float(env_name, default)
+    configured = _env_float(env_name, default)
+    remaining = remaining_attempt_budget()
+    if remaining is None:
+        return configured
+    # The floor is a guard against handing a client 0 or a negative value, not
+    # a licence to LENGTHEN a deliberately short timeout: max(1.0, ...) turned
+    # a configured 0.5s into 1.0s (external review). Never exceed either bound.
+    floor = min(MIN_TASK_TIMEOUT_SECONDS, configured)
+    return max(floor, min(configured, remaining))
 
 
 class RemoteModelLike(DenialBase):

--- a/tests/async-unit/test_generation_lease.py
+++ b/tests/async-unit/test_generation_lease.py
@@ -278,6 +278,177 @@ class TestInteractiveLease(_JourneyTestBase):
         )
 
     @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_transient_renewal_errors_do_not_abort_a_run_that_still_holds(
+        self, mock_gen
+    ):
+        """A renewal EXCEPTION says the database was briefly unreachable --
+        it says nothing about ownership. The old loop treated three of them
+        (30 seconds) as 'superseded' and killed the stream, while the lease's
+        expires_at was still ~270s away: the run aborted a lease it provably
+        still held, costing the user drafts and synthesis (external review).
+        Errors well inside the TTL must not stop the run."""
+        import threading
+        import time as _time
+
+        from fighthealthinsurance.common_view_logic import AppealsBackendHelper
+
+        denial = _make_denial(9220)
+        email = "lease_9220@example.com"
+        attempts = {"n": 0}
+        enough_failures = threading.Event()
+
+        async def always_raises(denial_, epoch, ttl_seconds=None):
+            attempts["n"] += 1
+            # Far more than the three that used to be fatal.
+            if attempts["n"] >= 6:
+                enough_failures.set()
+            raise RuntimeError("transient connection error")
+
+        def three_drafts(*args, **kwargs):
+            # Hold the generator open until well past the old 3-failure
+            # threshold, so the renewal loop provably keeps running.
+            assert enough_failures.wait(timeout=30), "renewal task never retried"
+            for d in _drafts(LETTERS):
+                yield d
+
+        mock_gen.make_appeals.side_effect = three_drafts
+
+        async def drive():
+            async for _chunk in AppealsBackendHelper.generate_appeals(
+                {"denial_id": denial.denial_id, "email": email, "semi_sekret": "sekret"}
+            ):
+                pass
+
+        with patch.object(generation_lease, "EXTEND_INTERVAL_SECONDS", 0.02), patch.object(
+            generation_lease, "DEFAULT_TTL_SECONDS", 30
+        ), patch.object(generation_lease, "aextend", always_raises):
+            async_to_sync(drive)()
+
+        assert attempts["n"] >= 6, f"only {attempts['n']} renewal attempts"
+        # The run kept its lease and persisted every draft. Under the old
+        # loop it would have broken out after the third failure.
+        assert (
+            ProposedAppeal.objects.filter(for_denial=denial, speculative=False).count()
+            == len(LETTERS)
+        )
+
+    def test_expiry_is_decided_by_the_clock_not_by_an_attempt_count(self):
+        """The give-up rule, tested directly on the shared helper.
+
+        The previous version of this test drove the whole generator with a
+        shrunken TTL and asserted "fewer drafts than LETTERS". That passed for
+        the wrong reason: the loop gives up on about the third exception, but
+        the test waited for an eighth that never came, timed out inside the
+        generator, and the swallowed error produced zero drafts -- so it would
+        have passed identically with the expiry rule deleted (external
+        review). Assert the mechanism instead.
+        """
+        calls: list = []
+
+        async def always_raises(denial_, epoch, ttl_seconds=None):
+            calls.append(1)
+            raise RuntimeError("transient connection error")
+
+        lost: list = []
+        clock = generation_lease.RenewalClock()
+
+        async def drive():
+            with patch.object(generation_lease, "EXTEND_INTERVAL_SECONDS", 0.01), patch.object(
+                generation_lease, "DEFAULT_TTL_SECONDS", 0.25
+            ), patch.object(generation_lease, "aextend", always_raises):
+                await generation_lease.keep_renewed(
+                    object(), 1, clock, on_lost=lambda why: lost.append(why)
+                )
+
+        async_to_sync(drive)()
+
+        # It kept retrying well past the old three-strikes rule...
+        assert len(calls) > 3, calls
+        # ...and gave up only once the clock said a full TTL had elapsed
+        # without a confirmed renewal.
+        assert lost, "never reported the lease lost"
+        assert "has expired" in lost[0]
+        assert clock.stale_for() >= 0.25
+
+    def test_a_renewal_confirmed_anywhere_keeps_the_run_alive(self):
+        """CodeRabbit's finding: the lease is renewed from TWO places -- the
+        background loop and once more after each draft is saved. Ownership is
+        a property of the LEASE, not of one loop, so a renewal confirmed by
+        the save path has to stop the background loop declaring expiry."""
+        clock = generation_lease.RenewalClock()
+        lost: list = []
+        ticks = {"n": 0}
+
+        async def always_raises(denial_, epoch, ttl_seconds=None):
+            ticks["n"] += 1
+            # Stand in for save_appeal confirming the same lease out-of-band.
+            if ticks["n"] % 3 == 0:
+                clock.confirm()
+            raise RuntimeError("background renewal is failing")
+
+        async def drive():
+            with patch.object(generation_lease, "EXTEND_INTERVAL_SECONDS", 0.01), patch.object(
+                generation_lease, "DEFAULT_TTL_SECONDS", 0.15
+            ), patch.object(generation_lease, "aextend", always_raises):
+                await asyncio.wait_for(
+                    generation_lease.keep_renewed(
+                        object(), 1, clock, on_lost=lambda why: lost.append(why)
+                    ),
+                    timeout=2.0,
+                )
+
+        # Every background call raises, but the out-of-band confirmations keep
+        # resetting staleness, so the run is never declared expired.
+        with pytest.raises(asyncio.TimeoutError):
+            async_to_sync(drive)()
+        assert not lost, lost
+        assert ticks["n"] > 10, ticks
+
+    def test_a_renewal_that_returns_false_stops_immediately(self):
+        """Returning False IS proof of loss -- unchanged behaviour, and the
+        thing the error handling must not accidentally swallow."""
+        lost: list = []
+
+        async def says_lost(denial_, epoch, ttl_seconds=None):
+            return False
+
+        async def drive():
+            with patch.object(generation_lease, "EXTEND_INTERVAL_SECONDS", 0.01), patch.object(
+                generation_lease, "aextend", says_lost
+            ):
+                await generation_lease.keep_renewed(
+                    object(), 1, generation_lease.RenewalClock(),
+                    on_lost=lambda why: lost.append(why),
+                )
+
+        async_to_sync(drive)()
+        assert lost and "no longer held" in lost[0]
+
+    def test_a_hanging_renewal_is_bounded_and_still_expires(self):
+        """A renewal that never returns used to park the loop forever, so the
+        deadline was never evaluated at all (external review). Each call is
+        bounded by the extend interval."""
+        lost: list = []
+
+        async def hangs(denial_, epoch, ttl_seconds=None):
+            await asyncio.sleep(60)
+
+        async def drive():
+            with patch.object(generation_lease, "EXTEND_INTERVAL_SECONDS", 0.01), patch.object(
+                generation_lease, "DEFAULT_TTL_SECONDS", 0.2
+            ), patch.object(generation_lease, "aextend", hangs):
+                await asyncio.wait_for(
+                    generation_lease.keep_renewed(
+                        object(), 1, generation_lease.RenewalClock(),
+                        on_lost=lambda why: lost.append(why),
+                    ),
+                    timeout=5.0,
+                )
+
+        async_to_sync(drive)()
+        assert lost and "has expired" in lost[0]
+
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
     def test_slow_first_draft_is_kept_alive_by_renewal_from_acquisition(
         self, mock_gen
     ):

--- a/tests/async-unit/test_ml_attempt_deadline.py
+++ b/tests/async-unit/test_ml_attempt_deadline.py
@@ -1,0 +1,105 @@
+"""Provider transport timeouts clamped to the attempt budget (enable gate 3).
+
+The appeal task timeout defaults to 300s while the journey's generation
+budget is 240s, so one provider call could outlive the whole attempt and keep
+spending after Temporal moved on -- three attempts of that per workflow.
+start_to_close does not kill the thread holding the socket, so the call must
+not be allowed to outlive the budget in the first place.
+"""
+
+import asyncio
+import time
+
+import pytest
+from asgiref.sync import sync_to_async
+
+from fighthealthinsurance.ml import ml_models
+
+
+def test_unclamped_outside_an_attempt():
+    """Interactive and chat paths must be untouched."""
+    assert ml_models.remaining_attempt_budget() is None
+    assert ml_models.ml_task_timeout("appeal") == 300.0
+    assert ml_models.ml_task_timeout("chat") == 90.0
+
+
+def test_clamped_to_whats_left_of_the_budget():
+    with ml_models.attempt_deadline(30.0):
+        t = ml_models.ml_task_timeout("appeal")
+    # 300s configured, 30s left -> 30s.
+    assert 29.0 < t <= 30.0, t
+
+
+def test_configured_value_wins_when_it_is_the_tighter_bound():
+    """The clamp is a ceiling, never a floor: a short task timeout is not
+    stretched to fill the budget."""
+    with ml_models.attempt_deadline(600.0):
+        assert ml_models.ml_task_timeout("entity") == 45.0
+
+
+def test_never_returns_a_zero_or_negative_timeout():
+    """requests treats 0 as fail-immediately and None as wait-forever, so a
+    budget that has already run out must still yield a small positive value
+    rather than either of those."""
+    with ml_models.attempt_deadline(0.0):
+        t = ml_models.ml_task_timeout("appeal")
+    assert t == ml_models.MIN_TASK_TIMEOUT_SECONDS
+    assert t > 0
+
+
+def test_the_floor_never_lengthens_a_short_configured_timeout(monkeypatch):
+    """The floor guards against handing a client 0 or a negative value; it is
+    not a licence to make a deliberately short timeout longer. max(1.0, ...)
+    turned a configured 0.5s into 1.0s (external review)."""
+    monkeypatch.setenv("FHI_ML_TIMEOUT_ENTITY", "0.5")
+    with ml_models.attempt_deadline(0.0):
+        t = ml_models.ml_task_timeout("entity")
+    assert t == 0.5, t
+    assert t > 0
+
+
+def test_nested_blocks_keep_the_tighter_deadline():
+    """An inner stage may not award itself more time than the attempt has."""
+    with ml_models.attempt_deadline(20.0):
+        with ml_models.attempt_deadline(600.0):
+            assert ml_models.ml_task_timeout("appeal") <= 20.0
+        assert ml_models.ml_task_timeout("appeal") <= 20.0
+    assert ml_models.remaining_attempt_budget() is None
+
+
+def test_the_deadline_is_restored_even_when_the_block_raises():
+    with pytest.raises(RuntimeError):
+        with ml_models.attempt_deadline(10.0):
+            raise RuntimeError("boom")
+    assert ml_models.remaining_attempt_budget() is None
+
+
+@pytest.mark.asyncio
+async def test_the_clamp_reaches_a_threaded_provider_call():
+    """The load-bearing assumption: provider calls run in worker THREADS via
+    asgiref, and a ContextVar set on the event loop must reach them. If
+    asgiref did not copy the context, the clamp would silently do nothing
+    where it matters most."""
+
+    def in_a_worker_thread() -> float:
+        # Exactly what a blocking backend does before opening its socket.
+        return ml_models.ml_task_timeout("appeal")
+
+    with ml_models.attempt_deadline(25.0):
+        seen = await sync_to_async(in_a_worker_thread, thread_sensitive=False)()
+    assert 24.0 < seen <= 25.0, seen
+
+
+@pytest.mark.asyncio
+async def test_concurrent_attempts_do_not_see_each_others_budget():
+    """A ContextVar, not a global: two generations on one worker must not
+    clamp each other."""
+
+    async def run(budget: float, hold: float) -> float:
+        with ml_models.attempt_deadline(budget):
+            await asyncio.sleep(hold)
+            return ml_models.ml_task_timeout("appeal")
+
+    tight, loose = await asyncio.gather(run(5.0, 0.05), run(120.0, 0.05))
+    assert tight <= 5.0, tight
+    assert 100.0 < loose <= 120.0, loose


### PR DESCRIPTION
The interactive renewal loop treated three consecutive renewal EXCEPTIONS the same as a renewal that returned False, and stopped the run. Those are not the same thing. A renewal returning False is proof of loss: the row's epoch moved or the lease expired, so someone else owns it. An exception only says the database was briefly unreachable -- it says nothing about ownership, and the lease we already hold stays valid until its TTL runs out.

Three failures at a 10s interval is 30 seconds, while DEFAULT_TTL_SECONDS is 300: expires_at was still roughly 270 seconds away, and assert_holds would have passed. So a live user's generation aborted a lease it provably still held. The cost lands on the user twice: the streaming loop breaks, and the synthesis step is skipped because it is guarded on `not superseded`, so they get a short set of drafts and no synthesized letter. Nothing gates this -- it runs on every interactive generation.

Now an exception only retries, and the run gives up solely once more than a full TTL has passed since the last renewal we can actually vouch for, at which point the lease genuinely has expired and writing under it would mean writing under a lease we cannot prove we hold. A renewal that RETURNS False still stops the run immediately, unchanged.

Found by a pre-deploy audit of the merged tranche. Holding for after the current deploy rather than adding it to that batch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Interactive generation runs now continue through temporary lease-renewal errors when the lease remains within its valid time-to-live.
  - Renewal failures stop a run only after the lease has gone unconfirmed beyond its full validity period.
  - Successful renewals reset the validity window, helping prevent interruptions during longer-running generation tasks.

- **Tests**
  - Added coverage for both transient renewal failures and failures that persist beyond the lease’s validity period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->