### PR TITLE
mypy: stop charts/ bokeh stub gaps from failing the build on some mac…

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -12,3 +12,18 @@ check_untyped_defs = True
 django_settings_module = "fighthealthinsurance.settings"
 django_configuration = "Dev"
 strict_settings = False
+
+# charts/ is not a mypy target. The check runs `-p fighthealthinsurance -p
+# fhi_users`; this package is only reached by following an import from one of
+# them. Its errors are bokeh STUB gaps, not real defects -- figure(
+# x_axis_type=..., tools=..., tooltips=...) and Range.start are all valid at
+# runtime, but bokeh 3.10's type stubs do not declare them.
+#
+# Worse, whether they surface at all depended on whether bokeh happened to be
+# installed in the checking environment: with it absent, ignore_missing_imports
+# makes figure() Any and the file is silently clean (this is why CI passed),
+# while any machine that had bokeh installed failed the identical command. That
+# non-determinism blocked a production deploy, since scripts/setup_templates.sh
+# runs mypy as a build gate. Pin the outcome instead of leaving it to chance.
+[mypy-charts.*]
+ignore_errors = True


### PR DESCRIPTION
…hines

Running scripts/build.sh from a developer machine aborted before building anything: setup_templates.sh runs mypy as a build gate, and mypy reported 24 errors in charts/views.py. The identical command passes in CI.

The errors are bokeh STUB gaps, not defects. figure(x_axis_type=..., tools=..., tooltips=...) and Range.start are all valid bokeh at runtime; bokeh 3.10's type stubs simply do not declare them. charts/ is also not a mypy target -- the check runs `-p fighthealthinsurance -p fhi_users` and only reaches this package by following an import.

What made it a build gate rather than a nuisance is that the outcome was not deterministic. mypy.ini sets ignore_missing_imports, so where bokeh is NOT installed in the checking environment figure() is Any and the file is silently clean -- which is why CI has always passed. Any environment that does have bokeh installed fails the same command on the same commit. So whether a production deploy could proceed depended on an unrelated package being present.

Ignore errors for charts.* and pin the result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated static type-checking configuration to suppress errors from the charts package.
  * Added documentation explaining the configuration and known type-stub limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->