### PR TITLE
mypy: narrow the charts suppression to charts.views

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -13,8 +13,8 @@ django_settings_module = "fighthealthinsurance.settings"
 django_configuration = "Dev"
 strict_settings = False
 
-# charts/ is not a mypy target. The check runs `-p fighthealthinsurance -p
-# fhi_users`; this package is only reached by following an import from one of
+# charts.views is not a mypy target. The check runs `-p fighthealthinsurance -p
+# fhi_users`; this module is only reached by following an import from one of
 # them. Its errors are bokeh STUB gaps, not real defects -- figure(
 # x_axis_type=..., tools=..., tooltips=...) and Range.start are all valid at
 # runtime, but bokeh 3.10's type stubs do not declare them.
@@ -25,5 +25,11 @@ strict_settings = False
 # while any machine that had bokeh installed failed the identical command. That
 # non-determinism blocked a production deploy, since scripts/setup_templates.sh
 # runs mypy as a build gate. Pin the outcome instead of leaving it to chance.
-[mypy-charts.*]
+#
+# Scoped to charts.views deliberately, NOT charts.*: bokeh is imported here and
+# nowhere else in the package, so a wildcard would also silence charts.admin,
+# charts.apps, charts.models, charts.urls and anything added later -- hiding
+# real errors that have nothing to do with the stub gap this exists for
+# (external review).
+[mypy-charts.views]
 ignore_errors = True


### PR DESCRIPTION
#979 used [mypy-charts.*], which matches charts.admin, charts.apps, charts.models, charts.urls and anything added to the package later. The stub gap it exists for is bokeh's, and bokeh is imported in exactly one module -- charts/views.py, confirmed by grep across the package. So the wildcard was broader than its own stated cause and would have silently swallowed real errors in files that have nothing to do with bokeh.

Scoped to [mypy-charts.views]. mypy still reports Success across the tree with bokeh installed, which is the condition that was failing.