### PR TITLE
Backfill Job: give it a writable HOME so it can start at all

### DIFF
--- a/k8s/temporal/backfill-fingerprints-job.yaml
+++ b/k8s/temporal/backfill-fingerprints-job.yaml
@@ -40,6 +40,19 @@ spec:
           env:
             - name: BACKFILL_APPEAL_FINGERPRINTS
               value: "1"
+            # Importing the app pulls fighthealthinsurance.urls -> fax_views ->
+            # common_view_logic, whose DenialCreatorHelper builds a
+            # uszipcode SearchEngine AT CLASS-BODY SCOPE. That constructor
+            # mkdir's ~/.uszipcode on first use. This pod runs as UID 1000
+            # with readOnlyRootFilesystem and no home directory, so HOME is
+            # "/" and the mkdir dies with
+            #   OSError: [Errno 30] Read-only file system: '/.uszipcode'
+            # crash-looping the Job before the backfill runs a single query.
+            # Point HOME at the writable /tmp emptyDir this pod already
+            # mounts. (web-extralink-prefetch shares the hardening but never
+            # reaches this import, which is why it was not a warning sign.)
+            - name: HOME
+              value: "/tmp"
             - name: PDBHOST
               valueFrom:
                 configMapKeyRef:

--- a/tests/async-unit/test_appeal_journey_core.py
+++ b/tests/async-unit/test_appeal_journey_core.py
@@ -1190,6 +1190,31 @@ def test_temporal_workers_get_enough_memory_for_this_image():
         assert lim == "3Gi", f"{path} limit {lim}"
 
 
+def test_backfill_job_has_a_writable_home():
+    """readOnlyRootFilesystem + runAsUser 1000 leaves HOME="/" . Importing the
+    app pulls fighthealthinsurance.urls -> fax_views -> common_view_logic,
+    whose DenialCreatorHelper constructs a uszipcode SearchEngine at CLASS-BODY
+    scope; that constructor mkdir's ~/.uszipcode. With HOME unset the Job
+    crash-looped on `OSError: [Errno 30] Read-only file system: '/.uszipcode'`
+    before running a single query, and the deploy sat on the backfill gate
+    until it timed out. HOME must point at the writable /tmp emptyDir."""
+    import pathlib
+
+    import yaml
+
+    root = pathlib.Path(__file__).resolve().parents[2]
+    raw = (root / "k8s" / "temporal" / "backfill-fingerprints-job.yaml").read_text()
+    job = yaml.safe_load(raw.replace("${FHI_BASE}:${FHI_VERSION}", "image"))
+    pod = job["spec"]["template"]["spec"]
+    container = pod["containers"][0]
+    env = {e["name"]: e.get("value") for e in container["env"]}
+    assert env.get("HOME") == "/tmp", env
+    # ...and that path is actually writable in this pod.
+    assert {"name": "tmp", "mountPath": "/tmp"} in container["volumeMounts"]
+    assert any(v["name"] == "tmp" and "emptyDir" in v for v in pod["volumes"])
+    assert container["securityContext"]["readOnlyRootFilesystem"] is True
+
+
 def test_backfill_job_runs_non_root_with_a_read_only_root_filesystem():
     """The Job carries both production secret sets, so it gets the same
     posture the web-extralink-prefetch Job already proves for this image:


### PR DESCRIPTION
Caught in production during the v0.23.3a deploy: the strict fingerprint backfill Job went straight into CrashLoopBackOff and never ran a query.

    OSError: [Errno 30] Read-only file system: '/.uszipcode'

Importing the app pulls fighthealthinsurance.urls -> fax_views -> common_view_logic, and DenialCreatorHelper builds a uszipcode SearchEngine at CLASS-BODY scope, so the constructor runs at import time. It mkdir's ~/.uszipcode on first use. This pod runs as UID 1000 with readOnlyRootFilesystem and no home directory, so HOME is "/" and the mkdir cannot succeed.

The Job already mounts a writable /tmp emptyDir; HOME just never pointed at it. Setting HOME=/tmp fixes it, and the Job then completes in 14 seconds:

    pass 1: filled=0 skipped_duplicate=597 skipped_empty=29 remaining_null=626
    pass 2: filled=0 skipped_duplicate=597 skipped_empty=29 remaining_null=626
    verify: rekeyed=0 mismatch_duplicate=0 checked=23174
    quiescent: 626 NULL row(s) remain (all known duplicates or empty legacy
    rows); 23174 fingerprinted row(s) verified

This is my regression from the tranche: I gave this Job the same hardening web-extralink-prefetch carries, without noticing that the prefetch Job never reaches this import path, so its clean run was not the evidence I took it for.

Note the blast radius, because it argues for the migration gate the audit already recommended: the Job is the deploy's only detector for a failed migration, and a Job that cannot START looks exactly like one whose data pass is still running. The deploy correctly refused to pass the gate, but it would have sat there for the full 30 minutes before saying so.