### PR TITLE
Staff dashboard: resend a fax whose vendor-send claim was stranded

### DIFF
--- a/fighthealthinsurance/staff_views.py
+++ b/fighthealthinsurance/staff_views.py
@@ -4,6 +4,7 @@ import json
 from collections import Counter
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
+from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.db.models import Count, F, QuerySet
 from django.db.models.functions import Lower
@@ -598,6 +599,70 @@ class AdminModelQueryView(View):
             "result": result,
             "error": error,
         }
+
+
+class ResendStuckFaxView(View):
+    """Release a stranded vendor-send claim and re-dispatch the fax.
+
+    A fax whose worker died mid-send (OOM, eviction, node loss) leaves
+    ``vendor_send_completed`` True with no in-process ``except`` alive to
+    release it. ``send_fax_via_vendor`` then short-circuits on that claim
+    forever, so the fax can never be retried by any normal path -- it just
+    sits in the status dashboard as "STUCK". Clearing it by hand meant a
+    shell on a prod pod; this is that operation, gated and audited.
+
+    POST only, and deliberately so: a GET would let a crawler, a prefetch or
+    a mis-pasted link re-fax a patient's appeal to an insurer.
+
+    The one thing this must never do is re-send a fax that actually went
+    through. A stranded claim means the send was CLAIMED, not that it
+    completed -- the claim is taken before the document is handed to the
+    vendor. So the guard is ``fax_success``: if the fax succeeded, refuse,
+    whatever the claim says. ``precheck_fax`` enforces the same rule
+    downstream, but refusing here keeps a dashboard mis-click from ever
+    reaching the send path.
+    """
+
+    def post(self, request):
+        from asgiref.sync import async_to_sync
+
+        from fighthealthinsurance import temporal_client
+        from fighthealthinsurance.models import FaxesToSend
+
+        fax_uuid = (request.POST.get("uuid") or "").strip()
+        if not fax_uuid:
+            return HttpResponse("Missing uuid", status=400)
+        try:
+            fax = FaxesToSend.objects.get(uuid=fax_uuid)
+        except (FaxesToSend.DoesNotExist, ValidationError, ValueError):
+            return HttpResponse("No such fax", status=404)
+
+        if fax.fax_success:
+            # Already delivered; re-sending would fax the insurer twice.
+            logger.warning(
+                f"Staff resend refused for fax uuid={fax.uuid}: already successful"
+            )
+            return HttpResponse("Fax already sent successfully; refusing", status=409)
+        if fax.destination is None:
+            return HttpResponse("Fax has no destination", status=400)
+
+        released = FaxesToSend.objects.filter(pk=fax.pk).update(
+            vendor_send_completed=False
+        )
+        logger.info(
+            f"Staff {request.user} resending fax uuid={fax.uuid} "
+            f"(claim released: {bool(released)})"
+        )
+        try:
+            workflow_id = async_to_sync(temporal_client.start_send_fax_workflow)(
+                fax.hashed_email, str(fax.uuid)
+            )
+        except Exception as e:
+            logger.opt(exception=True).error(
+                f"Staff resend failed to start workflow for fax uuid={fax.uuid}"
+            )
+            return HttpResponse(f"Could not start send: {e}", status=502)
+        return HttpResponse(f"Resend started: {workflow_id}")
 
 
 class ScheduleFollowUps(View):

--- a/fighthealthinsurance/staff_views.py
+++ b/fighthealthinsurance/staff_views.py
@@ -643,7 +643,10 @@ class ResendStuckFaxView(View):
                 f"Staff resend refused for fax uuid={fax.uuid}: already successful"
             )
             return HttpResponse("Fax already sent successfully; refusing", status=409)
-        if fax.destination is None:
+        if not fax.destination or not fax.destination.strip():
+            # Blank and whitespace-only pass an `is None` check but precheck_fax
+            # treats them as missing, so the endpoint would report a resend
+            # started that could never send (external review).
             return HttpResponse("Fax has no destination", status=400)
 
         released = FaxesToSend.objects.filter(pk=fax.pk).update(
@@ -654,8 +657,13 @@ class ResendStuckFaxView(View):
             f"(claim released: {bool(released)})"
         )
         try:
+            # force_restart because this IS the explicit resend that flag is
+            # for: the workflow id is deterministic per fax, so a failed send
+            # whose run is still open would raise WorkflowAlreadyStartedError
+            # and this recovery endpoint would answer 502 for the one case it
+            # exists to handle (external review).
             workflow_id = async_to_sync(temporal_client.start_send_fax_workflow)(
-                fax.hashed_email, str(fax.uuid)
+                fax.hashed_email, str(fax.uuid), force_restart=True
             )
         except Exception as e:
             logger.opt(exception=True).error(

--- a/fighthealthinsurance/templates/admin_status.html
+++ b/fighthealthinsurance/templates/admin_status.html
@@ -307,13 +307,27 @@
       </div>
       {% if fax_outcomes.recent_failures %}
       <table class="status">
-        <thead><tr><th>Fax</th><th>When</th><th>Claim</th></tr></thead>
+        <thead><tr><th>Fax</th><th>When</th><th>Claim</th><th>Action</th></tr></thead>
         <tbody>
         {% for f in fax_outcomes.recent_failures %}
           <tr>
             <td><code>{{ f.uuid }}</code></td>
             <td>{{ f.date|date:"Y-m-d H:i" }}</td>
             <td>{% if f.claim_stuck %}<span class="badge bad">STUCK</span>{% else %}<span class="badge ok">released</span>{% endif %}</td>
+            <td>
+              {# POST, never GET: a GET would let a crawler or prefetch re-fax
+                 a patient's appeal to an insurer. The view refuses any fax
+                 whose fax_success is True, so a mis-click cannot double-send
+                 one that already went through. #}
+              <form method="post" action="/timbit/help/resend_stuck_fax" style="margin:0">
+                {% csrf_token %}
+                <input type="hidden" name="uuid" value="{{ f.uuid }}">
+                <button type="submit"
+                        onclick="return confirm('Re-send this fax to the insurer? Only do this if it never went through.');">
+                  Resend
+                </button>
+              </form>
+            </td>
           </tr>
         {% endfor %}
         </tbody>

--- a/fighthealthinsurance/urls.py
+++ b/fighthealthinsurance/urls.py
@@ -93,6 +93,11 @@ urlpatterns: List[Union[URLPattern, URLResolver]] = [
         name="admin_model_query",
     ),
     path(
+        "timbit/help/resend_stuck_fax",
+        staff_member_required(staff_views.ResendStuckFaxView.as_view()),
+        name="resend_stuck_fax",
+    ),
+    path(
         "timbit/help/followup_sched",
         staff_member_required(staff_views.ScheduleFollowUps.as_view()),
     ),

--- a/tests/sync/test_staff_resend_stuck_fax.py
+++ b/tests/sync/test_staff_resend_stuck_fax.py
@@ -51,6 +51,10 @@ class ResendStuckFaxTest(TestCase):
         self.fax.refresh_from_db()
         assert self.fax.vendor_send_completed is False
         assert start.called
+        # An explicit resend must supersede any run still open for this fax,
+        # or the deterministic workflow id makes this endpoint 502 in exactly
+        # the case it exists for.
+        assert start.call_args.kwargs.get("force_restart") is True, start.call_args
 
     def test_refuses_a_fax_that_already_succeeded(self):
         """The stranded claim means the send was CLAIMED, not that it
@@ -66,6 +70,20 @@ class ResendStuckFaxTest(TestCase):
         assert not start.called
         self.fax.refresh_from_db()
         # ...and the claim is left exactly as it was.
+        assert self.fax.vendor_send_completed is True
+
+    def test_blank_destination_is_refused(self):
+        """Whitespace passes an `is None` check but precheck_fax treats it as
+        missing, so we would report a resend that could never send."""
+        FaxesToSend.objects.filter(pk=self.fax.pk).update(destination="   ")
+        self._login()
+        with patch(
+            "fighthealthinsurance.temporal_client.start_send_fax_workflow"
+        ) as start:
+            r = self.client.post(self.url, {"uuid": str(self.fax.uuid)})
+        assert r.status_code == 400
+        assert not start.called
+        self.fax.refresh_from_db()
         assert self.fax.vendor_send_completed is True
 
     def test_get_is_not_allowed(self):

--- a/tests/sync/test_staff_resend_stuck_fax.py
+++ b/tests/sync/test_staff_resend_stuck_fax.py
@@ -1,0 +1,97 @@
+"""Staff dashboard: re-send a fax whose vendor-send claim was stranded.
+
+A worker that dies mid-send (OOM, eviction) leaves vendor_send_completed
+True with no in-process handler alive to release it, and
+send_fax_via_vendor then short-circuits on that claim forever. These cover
+the two things that actually matter: staff can clear it, and nobody can use
+it to fax an insurer twice.
+"""
+
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.test import Client, TestCase
+
+from fighthealthinsurance.models import Denial, FaxesToSend
+
+
+class ResendStuckFaxTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+        User = get_user_model()
+        self.staff = User.objects.create_user(
+            username="staffer", password="pw", is_staff=True
+        )
+        self.denial = Denial.objects.create(
+            hashed_email="h", denial_text="denied", insurance_company="TestIns"
+        )
+        self.fax = FaxesToSend.objects.create(
+            hashed_email="h",
+            denial_id=self.denial,
+            destination="15551234567",
+            sent=True,
+            fax_success=False,
+            should_send=True,
+            paid=True,
+            vendor_send_completed=True,  # the stranded claim
+        )
+        self.url = "/timbit/help/resend_stuck_fax"
+
+    def _login(self):
+        self.client.force_login(self.staff)
+
+    def test_releases_the_claim_and_starts_a_send(self):
+        self._login()
+        with patch(
+            "fighthealthinsurance.temporal_client.start_send_fax_workflow"
+        ) as start:
+            start.return_value = "send-fax-abc"
+            r = self.client.post(self.url, {"uuid": str(self.fax.uuid)})
+        assert r.status_code == 200, r.content
+        self.fax.refresh_from_db()
+        assert self.fax.vendor_send_completed is False
+        assert start.called
+
+    def test_refuses_a_fax_that_already_succeeded(self):
+        """The stranded claim means the send was CLAIMED, not that it
+        completed. fax_success is the only field that says it went through --
+        so it, not the claim, is what guards against double-faxing."""
+        FaxesToSend.objects.filter(pk=self.fax.pk).update(fax_success=True)
+        self._login()
+        with patch(
+            "fighthealthinsurance.temporal_client.start_send_fax_workflow"
+        ) as start:
+            r = self.client.post(self.url, {"uuid": str(self.fax.uuid)})
+        assert r.status_code == 409
+        assert not start.called
+        self.fax.refresh_from_db()
+        # ...and the claim is left exactly as it was.
+        assert self.fax.vendor_send_completed is True
+
+    def test_get_is_not_allowed(self):
+        """A GET would let a crawler or a prefetch re-fax a patient's appeal."""
+        self._login()
+        with patch(
+            "fighthealthinsurance.temporal_client.start_send_fax_workflow"
+        ) as start:
+            r = self.client.get(self.url, {"uuid": str(self.fax.uuid)})
+        assert r.status_code in (405, 302), r.status_code
+        assert not start.called
+
+    def test_requires_staff(self):
+        User = get_user_model()
+        nonstaff = User.objects.create_user(username="rando", password="pw")
+        self.client.force_login(nonstaff)
+        with patch(
+            "fighthealthinsurance.temporal_client.start_send_fax_workflow"
+        ) as start:
+            r = self.client.post(self.url, {"uuid": str(self.fax.uuid)})
+        assert r.status_code in (302, 403), r.status_code
+        assert not start.called
+
+    def test_unknown_uuid_is_a_404_not_a_crash(self):
+        self._login()
+        r = self.client.post(
+            self.url, {"uuid": "00000000-0000-0000-0000-000000000000"}
+        )
+        assert r.status_code == 404


### PR DESCRIPTION
The status page already surfaces "Failed with claim stuck (cannot auto-resend)" but offered no way to act on it. A fax whose worker died mid-send leaves vendor_send_completed True with no in-process handler alive to release it, and send_fax_via_vendor short-circuits on that claim forever -- so the fax can never be retried by any normal path. Clearing it meant a shell on a production pod, which is how faxes 656 and 657 were recovered by hand today.

Adds a Resend button on each stuck row: release the claim, start SendFaxWorkflow, report the workflow id.

Two deliberate constraints.

POST only. A GET would let a crawler, a prefetch, or a mis-pasted link re-fax a patient's appeal to an insurer.

fax_success is the guard, not the claim. A stranded claim means the send was CLAIMED, not that it completed -- the claim is taken before the document is handed to the vendor, which is exactly why a mid-send death strands it. So the view refuses any fax whose fax_success is True whatever the claim says, and leaves its claim untouched. precheck_fax enforces the same rule downstream; refusing here keeps a dashboard mis-click from reaching the send path at all. The button also carries a confirm().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Staff can resend fax transmissions that became stuck during vendor delivery.
  * The fax failure dashboard now includes a confirmation-protected resend action.
  * Resend requests validate fax status and destination, with clear responses for invalid, missing, or already successful faxes.

* **Access Control**
  * The resend action is restricted to authorized staff and accepts POST requests only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->