### PR TITLE
Fix the intake outbox relay OOM, and the alert that stayed silent thr…

### DIFF
--- a/k8s/temporal/intake-outbox-alerts.yaml
+++ b/k8s/temporal/intake-outbox-alerts.yaml
@@ -56,12 +56,35 @@ spec:
         # app's own metrics -- a suspended schedule or a Job that never
         # completes produces no series at all. kube-state-metrics is the only
         # producer that can see it.
-        # VERIFY-LIVE: metric and label shape vary across kube-state-metrics
-        # versions (kube_cronjob_status_last_successful_time is v2.x); confirm
-        # against the live Prometheus before relying on this alert.
+        #
+        # VERIFIED LIVE 2026-09-06 against this cluster's Prometheus, and the
+        # check found a hole: kube-state-metrics emits NO
+        # kube_cronjob_status_last_successful_time series at all for a CronJob
+        # that has never once succeeded. `time() - <absent>` is an empty
+        # vector, so the single-armed expression could not fire for the one
+        # failure mode it most needed to catch -- a relay broken from birth.
+        # That is exactly what happened: the relay OOMKilled on every run for
+        # six hours and this alert stayed silent throughout.
+        #
+        # So the second arm covers never-succeeded explicitly. Notes on it:
+        #  * `and on()` is required. absent() yields ONLY the labels named in
+        #    its matcher, while kube_cronjob_created carries namespace/job/
+        #    instance, so a bare `and` matches no label set and is silently
+        #    empty -- the same class of bug as the original expression.
+        #  * The kube_cronjob_created guard keeps this from firing for a
+        #    CronJob that does not exist (a rename, or this rule copied to a
+        #    cluster without the relay): absent() is 1 there too, but
+        #    kube_cronjob_created is empty, so `and on()` drops it.
+        #  * Both selectors pin namespace as well as cronjob. absent() over an
+        #    unpinned matcher would be satisfied by a same-named CronJob in any
+        #    other namespace, which is the one way this arm could fail open.
         - alert: FHIIntakeOutboxRelayNotSucceeding
           expr: >-
-            time() - kube_cronjob_status_last_successful_time{cronjob="fhi-intake-outbox-relay"} > 600
+            (time() - kube_cronjob_status_last_successful_time{cronjob="fhi-intake-outbox-relay",namespace="totallylegitco"} > 600)
+            or
+            ((absent(kube_cronjob_status_last_successful_time{cronjob="fhi-intake-outbox-relay",namespace="totallylegitco"}) == 1)
+             and on()
+             ((time() - kube_cronjob_created{cronjob="fhi-intake-outbox-relay",namespace="totallylegitco"}) > 600))
           for: 10m
           labels:
             severity: warning
@@ -70,4 +93,14 @@ spec:
             description: >-
               The relay CronJob runs every minute. No successful completion in
               over ten minutes means the schedule is suspended, the Job is
-              failing, or one run is hung past its activeDeadlineSeconds.
+              failing, or one run is hung past its activeDeadlineSeconds --
+              or it has never succeeded at all since being created, which is
+              what the second arm of this expression catches. Read the success
+              time explicitly -- the default `kubectl get cronjob` columns show
+              LAST SCHEDULE, which keeps advancing every minute even while
+              every single run dies, so it looks healthy during exactly this
+              failure:
+                kubectl -n totallylegitco get cronjob fhi-intake-outbox-relay \
+                  -o jsonpath='{.status.lastSuccessfulTime}'
+              An empty result means it has never succeeded. Then check the most
+              recent Job pod for an OOMKilled (exit 137) termination.

--- a/k8s/temporal/intake-outbox-cronjob.yaml
+++ b/k8s/temporal/intake-outbox-cronjob.yaml
@@ -56,11 +56,23 @@ spec:
                   drop: ["ALL"]
                 seccompProfile:
                   type: RuntimeDefault
+              # Sized from a measurement, not a guess. Peak RSS of
+              # `manage.py deliver_intake_events` measured in a live web pod
+              # was ~1072 MiB. That run was on the inert path (the intake flag
+              # was off, so it delivered nothing), which makes it a floor, not
+              # a ceiling: it is the Django/ML import footprint every pod on
+              # this image pays before doing any work at all. That floor alone
+              # was already double the old 512Mi limit, which is why the relay
+              # was OOMKilled ~4s in, during import, before ever reaching
+              # deliver_intake_events. Matched to fhi-fax-worker and
+              # fhi-appeal-worker (1536Mi / 3Gi), the two workloads that run
+              # this same image as a long-lived process, so the limit carries
+              # real headroom over the import floor once delivery does work.
               resources:
                 requests:
                   cpu: "100m"
-                  memory: 256Mi
+                  memory: 1536Mi
                 limits:
                   cpu: "500m"
-                  memory: 512Mi
+                  memory: 3Gi
           restartPolicy: Never

--- a/tests/async-unit/test_intake_outbox.py
+++ b/tests/async-unit/test_intake_outbox.py
@@ -725,8 +725,12 @@ class TestClaimExpiry(TransactionTestCase):
     never produce a duplicate ack."""
 
     def test_claim_ttl_outlives_the_relay_run(self):
-        assert intake_outbox.CLAIM_TTL_SECONDS > intake_outbox.DEFAULT_TIME_BUDGET_SECONDS
-        assert intake_outbox.CLAIM_TTL_SECONDS >= 600  # Job activeDeadlineSeconds 300 + margin
+        assert (
+            intake_outbox.CLAIM_TTL_SECONDS > intake_outbox.DEFAULT_TIME_BUDGET_SECONDS
+        )
+        assert (
+            intake_outbox.CLAIM_TTL_SECONDS >= 600
+        )  # Job activeDeadlineSeconds 300 + margin
 
     def test_expired_claim_with_the_right_token_neither_delivers_nor_acks(self):
         from asgiref.sync import async_to_sync
@@ -753,7 +757,7 @@ class TestClaimExpiry(TransactionTestCase):
         denial = _make_denial(8142)
         row = _pending(denial, intake_outbox.INTAKE_STARTED)
         claims = intake_outbox.claim_batch()
-        (pk, token) = claims[0]
+        pk, token = claims[0]
         short = timezone.now() + datetime.timedelta(seconds=30)
         IntakeJourneyEvent.objects.filter(pk=pk).update(claimed_until=short)
         seen = {}
@@ -765,8 +769,9 @@ class TestClaimExpiry(TransactionTestCase):
                 .afirst()
             )
 
-        with patch(_CLIENT, AsyncMock(return_value=_client())), patch.object(
-            intake_outbox, "_acall", observe
+        with (
+            patch(_CLIENT, AsyncMock(return_value=_client())),
+            patch.object(intake_outbox, "_acall", observe),
         ):
             counts = async_to_sync(intake_outbox.adeliver_claimed)(claims)
         assert counts["delivered"] == 1
@@ -794,7 +799,10 @@ class TestClaimExpiry(TransactionTestCase):
         assert stale_counts["lost_claim"] == 1 and stale_counts["delivered"] == 0
         assert fresh_counts["delivered"] == 1
         assert client.start_workflow.await_count == 1
-        assert IntakeJourneyEvent.objects.filter(pk=row.pk, acked_at__isnull=False).count() == 1
+        assert (
+            IntakeJourneyEvent.objects.filter(pk=row.pk, acked_at__isnull=False).count()
+            == 1
+        )
 
 
 @override_settings(**_INTAKE_ON)
@@ -827,7 +835,10 @@ class TestInlineDeliveryRespectsClaims(TransactionTestCase):
         acall = AsyncMock(return_value=None)
         with patch.object(intake_outbox, "_acall", acall):
             assert async_to_sync(intake_outbox.adeliver)(row) is True
-        assert acall.await_args.kwargs["timeout"] == intake_outbox.INLINE_RPC_TIMEOUT_SECONDS
+        assert (
+            acall.await_args.kwargs["timeout"]
+            == intake_outbox.INLINE_RPC_TIMEOUT_SECONDS
+        )
 
 
 class TestRelayDeployment:
@@ -871,7 +882,23 @@ class TestRelayDeployment:
         # that stopped running produces no series at all.
         assert "kube_cronjob_status_last_successful_time" in alerts
         assert 'cronjob="fhi-intake-outbox-relay"' in alerts
-        assert "VERIFY-LIVE" in alerts
+        # This used to require an unresolved VERIFY-LIVE marker, because the
+        # kube-state-metrics shape had never been confirmed against a real
+        # Prometheus. It has been now, and the check found a hole: KSM emits
+        # NO last_successful_time series at all for a CronJob that has never
+        # succeeded, so the original single-armed expression evaluated to an
+        # empty vector and could not fire for a relay broken from birth --
+        # which is exactly what happened, silently, for six hours.
+        #
+        # So the reminder is discharged and these assert the fix instead: the
+        # never-succeeded arm, the created-guard that stops it firing for a
+        # CronJob that does not exist, the `on()` without which the two
+        # vectors share no labels and the arm is silently empty, and the
+        # namespace pin that stops absent() being satisfied elsewhere.
+        assert "absent(kube_cronjob_status_last_successful_time" in alerts
+        assert "kube_cronjob_created" in alerts
+        assert "and on()" in alerts
+        assert 'namespace="totallylegitco"' in alerts
 
     def test_non_positive_time_budget_does_no_relay_work(self):
         """A zero/negative budget defers every claimed row, and each keeps

--- a/tests/async-unit/test_intake_outbox.py
+++ b/tests/async-unit/test_intake_outbox.py
@@ -757,7 +757,7 @@ class TestClaimExpiry(TransactionTestCase):
         denial = _make_denial(8142)
         row = _pending(denial, intake_outbox.INTAKE_STARTED)
         claims = intake_outbox.claim_batch()
-        pk, token = claims[0]
+        pk, _token = claims[0]
         short = timezone.now() + datetime.timedelta(seconds=30)
         IntakeJourneyEvent.objects.filter(pk=pk).update(claimed_until=short)
         seen = {}
@@ -864,6 +864,22 @@ class TestRelayDeployment:
         )
         assert alerts_at - guard < 400
 
+    @staticmethod
+    def _alert_expr(manifest_text: str, alert_name: str) -> str:
+        """The `expr` of one named alert, parsed out of the PrometheusRule.
+
+        Scoped on purpose: asserting against the whole manifest lets the
+        surrounding comments satisfy the check.
+        """
+        import yaml
+
+        doc = yaml.safe_load(manifest_text)
+        for group in doc["spec"]["groups"]:
+            for rule in group.get("rules", []):
+                if rule.get("alert") == alert_name:
+                    return rule["expr"]
+        raise AssertionError(f"no alert named {alert_name} in the manifest")
+
     def test_cronjob_cannot_hang_forever(self):
         cronjob = (
             self._repo() / "k8s" / "temporal" / "intake-outbox-cronjob.yaml"
@@ -890,15 +906,27 @@ class TestRelayDeployment:
         # empty vector and could not fire for a relay broken from birth --
         # which is exactly what happened, silently, for six hours.
         #
-        # So the reminder is discharged and these assert the fix instead: the
-        # never-succeeded arm, the created-guard that stops it firing for a
-        # CronJob that does not exist, the `on()` without which the two
-        # vectors share no labels and the arm is silently empty, and the
-        # namespace pin that stops absent() being satisfied elsewhere.
-        assert "absent(kube_cronjob_status_last_successful_time" in alerts
-        assert "kube_cronjob_created" in alerts
-        assert "and on()" in alerts
-        assert 'namespace="totallylegitco"' in alerts
+        # So the reminder is discharged and these assert the fix instead.
+        # Parsed and scoped to the one alert, NOT grepped against the file:
+        # the prose above these rules necessarily discusses absent(), on() and
+        # kube_cronjob_created, so a substring check against the whole manifest
+        # is satisfied by the commentary and would keep passing with the
+        # expression gutted back to its broken single-armed form (verified --
+        # two of four such checks did exactly that).
+        expr = self._alert_expr(alerts, "FHIIntakeOutboxRelayNotSucceeding")
+        # The never-succeeded arm.
+        assert "absent(kube_cronjob_status_last_successful_time" in expr
+        # The guard that stops it firing for a CronJob that does not exist.
+        assert "kube_cronjob_created" in expr
+        # Without on() the two vectors share no label set and the arm is
+        # silently empty -- the same class of bug as the original expression.
+        assert "and on()" in expr
+        # Pins the namespace so absent() cannot be satisfied by a same-named
+        # CronJob elsewhere in the cluster.
+        assert expr.count('namespace="totallylegitco"') >= 2
+        # ...and the original arm is still there for the has-succeeded-then-
+        # stopped case, so the fix added coverage rather than replacing it.
+        assert "time() - kube_cronjob_status_last_successful_time" in expr
 
     def test_non_positive_time_budget_does_no_relay_work(self):
         """A zero/negative budget defers every claimed row, and each keeps


### PR DESCRIPTION
…ough it

The relay CronJob has been OOMKilled on every run since it was created, never once reaching deliver_intake_events. Peak RSS of the command, measured in a live web pod, is ~1072 MiB against a 512Mi limit -- and that measurement is a floor, taken on the inert path with the intake flag off, so it is the Django/ML import footprint alone before any delivery work. It is the only workload on this image still carrying the old small numbers; web, fhi-fax-worker and fhi-appeal-worker were all raised to 1536Mi earlier for exactly this reason. Matched to the two workers.

This was harmless only by accident: with TEMPORAL_INTAKE_JOURNEY_ENABLED off, record_intent() returns None, so no rows are queued and the relay has nothing to deliver. It is a hard blocker for turning that flag on -- an outbox whose relay cannot start is an outbox that silently drops journeys, which is the precise failure the outbox exists to prevent.

FHIIntakeOutboxRelayNotSucceeding should have caught this and did not, for six hours. kube-state-metrics emits no
kube_cronjob_status_last_successful_time series at all for a CronJob that has never succeeded, so `time() - <absent>` is an empty vector and the single-armed expression could not fire for the one failure mode it most needed to catch. Verified against this cluster's Prometheus: three CronJobs known, only two carry the series, and the old expression returns an empty vector while kube_cronjob_spec_suspend for the same CronJob does return a series -- so Prometheus sees the object fine.

The added arm covers never-succeeded explicitly. `and on()` is required: absent() yields only the labels named in its matcher, while kube_cronjob_created carries namespace/job/instance, so a bare `and` matches no label set and is silently empty -- the same class of bug as the original expression. The kube_cronjob_created guard keeps the arm from firing for a CronJob that does not exist, and both selectors pin namespace so absent() cannot be satisfied by a same-named CronJob elsewhere. All four behaviours were checked against live Prometheus, including a control that correctly returns empty.

The runbook line was also wrong and is corrected: the default `kubectl get cronjob` columns show LAST SCHEDULE, which keeps advancing every minute even while every run dies, so it reads healthy during exactly this failure. The description now says to read
.status.lastSuccessfulTime explicitly.

Both manifests pass kubectl apply --dry-run=server.


Claude-Session: https://claude.ai/code/session_019SPqa4FZ43ahAjoD53Uj81

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved intake-outbox relay alerting to detect both stalled relays and CronJobs that have never completed successfully.
  - Scoped relay monitoring to the correct namespace for more accurate alert results.
  - Added clearer troubleshooting guidance, including checks for completion timestamps and out-of-memory termination.

- **Chores**
  - Increased the intake-outbox CronJob’s memory request and limit to better support its observed peak usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->