### PR TITLE
Model health check: report what the provider actually said

### DIFF
--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -402,12 +402,33 @@ def _attach_error_body(exc: aiohttp.ClientResponseError, body: str) -> None:
     classify on it.
 
     A dedicated attribute rather than ``exc.message``: that field is the HTTP
-    reason phrase every log site, ``describe_model_error``, the persisted
-    attempt record, and ``model_health_check._categorize_http_error`` read, and
-    overwriting it with a body would both bloat those and flip the health
-    check's "400 mentioning model" heuristic to MODEL_NOT_FOUND.
+    reason phrase every log site, ``describe_model_error`` and the persisted
+    attempt record read, and overwriting it with a body would bloat all of
+    them.
+
+    ``model_health_check._categorize_http_error`` reads BOTH -- the reason
+    phrase for the status line and this body for what the provider actually
+    said. It used to classify a "400 mentioning model" off ``exc.message``,
+    which could never match (that field is only ever the reason phrase); it now
+    matches on this body via ``_error_text_indicates_missing_model``.
     """
     setattr(exc, "fhi_response_body", body)
+
+
+# Attributes a probe reads to tell "no endpoint answered" from "an endpoint
+# answered with nothing". Both are set on the backend INSTANCE and are only
+# meaningful to a caller that armed (cleared) them first -- normal inference
+# never reads them.
+#
+# Two are needed, not one. A single _infer can try several endpoints (dual-mode
+# races primary against backup, then falls back sequentially), so a note left
+# by ONE failing leg does not mean nothing answered: the other leg may have
+# returned a 200 with an empty completion, which is a malformed response, not a
+# network failure. ENDPOINT_ANSWERED_ATTR records that some leg got an HTTP
+# response, and it wins -- so the verdict does not depend on which leg finished
+# last.
+LAST_TRANSPORT_ERROR_ATTR = "fhi_last_transport_error"
+ENDPOINT_ANSWERED_ATTR = "fhi_endpoint_answered"
 
 
 def _error_body_of(exc: aiohttp.ClientResponseError) -> str:
@@ -3285,12 +3306,28 @@ class RemoteOpenLike(RemoteModel):
                         headers={"Authorization": f"Bearer {self.token}"},
                         json=request_body,
                     ) as response:
+                        # An endpoint answered -- whatever the status. Probes
+                        # use this to keep one leg's transport failure from
+                        # being read as "nothing answered" when another leg
+                        # did (see ENDPOINT_ANSWERED_ATTR).
+                        setattr(self, ENDPOINT_ANSWERED_ATTR, True)
                         response_body = await _read_error_body(response)
                         # Raise ClientResponseError for HTTP error status codes (4xx, 5xx)
                         # This allows subclasses to catch and handle specific errors like 429
                         try:
                             response.raise_for_status()
                         except aiohttp.ClientResponseError as e:
+                            # Carry the provider's body on the exception before
+                            # any of the branches below re-raise it. Without
+                            # this the body stays a local, and every caller
+                            # that classifies on it (model_health_check's
+                            # _categorize_http_error) sees only the HTTP reason
+                            # phrase -- "HTTP 400 Bad Request" in place of
+                            # "Your credit balance is too low". RemoteAzureClaude
+                            # attached it on its own transport; this is the
+                            # OpenAI-compatible path, which every other backend
+                            # uses, RemoteAnthropic included.
+                            _attach_error_body(e, response_body)
                             if (
                                 sent_temperature
                                 and _http_error_indicates_unsupported_temperature(
@@ -3430,12 +3467,21 @@ class RemoteOpenLike(RemoteModel):
             # No sleep before returning: there is no retry in here for a delay
             # to pace, callers (e.g. the extraction loop) do their own pacing,
             # and a stall would only slow failover to the backup backend.
-            logger.warning(
-                f"{self}: {model} via {api_base} failed -- {describe_model_error(e)}"
-            )
+            described = describe_model_error(e)
+            logger.warning(f"{self}: {model} via {api_base} failed -- {described}")
             record_ml_failure(model, "transport_error")
+            # Record the cause even when raising is requested. A transport
+            # error deliberately does NOT raise here -- returning None is what
+            # lets the caller fall through to the backup endpoint -- but that
+            # left probes (model_health_check) unable to tell "nothing
+            # answered the socket" from "the model returned nothing", and an
+            # unreachable backend was reported as a malformed response. The
+            # note is read-and-cleared by the probe; normal inference never
+            # looks at it. Strike accounting stays gated: a probe must not
+            # push a backend into the production cooldown.
+            setattr(self, LAST_TRANSPORT_ERROR_ATTR, described)
             if not raise_http_errors:
-                self._note_transport_failure(api_base, model, describe_model_error(e))
+                self._note_transport_failure(api_base, model, described)
             return None
         except Exception:
             logger.opt(exception=True).warning(
@@ -4468,10 +4514,21 @@ class RateLimitedRemoteOpenLike(RemoteFullOpenLike):
                 return None
             raise
         except Exception as e:
+            described = describe_model_error(e)
             logger.warning(
-                f"{type(self).__name__}._infer: {self.model} failed -- "
-                f"{describe_model_error(e)}"
+                f"{type(self).__name__}._infer: {self.model} failed -- {described}"
             )
+            # Backends that override the transport (RemoteAzureClaude speaks
+            # the native Messages API, not /chat/completions) never reach
+            # RemoteOpenLike.__infer, so their connection failures land here
+            # instead. Record the same note that path records, or a Foundry
+            # endpoint that refused every connection is reported as a
+            # malformed response -- the bug this note exists to fix, surviving
+            # on the one provider that does not share the transport. Only for
+            # genuine transport errors: a blanket note would relabel an
+            # ordinary bug as a network failure.
+            if isinstance(e, MODEL_TRANSPORT_ERRORS):
+                setattr(self, LAST_TRANSPORT_ERROR_ATTR, described)
             return None
 
     async def _do_infer(

--- a/fighthealthinsurance/ml/ml_models.py
+++ b/fighthealthinsurance/ml/ml_models.py
@@ -415,20 +415,66 @@ def _attach_error_body(exc: aiohttp.ClientResponseError, body: str) -> None:
     setattr(exc, "fhi_response_body", body)
 
 
-# Attributes a probe reads to tell "no endpoint answered" from "an endpoint
-# answered with nothing". Both are set on the backend INSTANCE and are only
-# meaningful to a caller that armed (cleared) them first -- normal inference
-# never reads them.
+# Per-probe transport observations, for callers (model_health_check) that must
+# tell "no endpoint answered" from "an endpoint answered with nothing".
 #
-# Two are needed, not one. A single _infer can try several endpoints (dual-mode
-# races primary against backup, then falls back sequentially), so a note left
-# by ONE failing leg does not mean nothing answered: the other leg may have
-# returned a 200 with an empty completion, which is a malformed response, not a
-# network failure. ENDPOINT_ANSWERED_ATTR records that some leg got an HTTP
-# response, and it wins -- so the verdict does not depend on which leg finished
-# last.
-LAST_TRANSPORT_ERROR_ATTR = "fhi_last_transport_error"
-ENDPOINT_ANSWERED_ATTR = "fhi_endpoint_answered"
+# Two observations are needed, not one. A single _infer can try several
+# endpoints -- dual-mode races primary against backup, then falls back
+# sequentially -- so a failure noted by ONE leg does not mean nothing answered:
+# another leg may have returned a 200 with an empty completion, which is a
+# malformed response, not a network failure. "endpoint_answered" records that
+# some leg got an HTTP response and it wins, so the verdict does not depend on
+# which leg finished last.
+#
+# This lives in a ContextVar holding a MUTABLE dict, not on the backend
+# instance. The instance is the router's registered singleton, shared with
+# every production request (see model_health_check._registered_instance --
+# probing the real client object is the point), so instance attributes let
+# concurrent inference corrupt a probe's verdict in both directions: a
+# production transport failure turns an empty probe into FAIL_NETWORK, and a
+# production HTTP response hides an unreachable probe as
+# FAIL_MALFORMED_RESPONSE (CodeRabbit, PR 987).
+#
+# A ContextVar alone would not work: _infer runs its dual-mode legs as Tasks,
+# and a Task gets a COPY of the context, so a plain .set() inside a leg is
+# invisible to the probe that started it. Holding a dict and MUTATING it works
+# because the copy carries the same object reference.
+#
+# Inference outside a probe sees None and records nothing, which is the
+# isolation: production traffic cannot write here at all, and two concurrent
+# probes each own a separate dict.
+_PROBE_OBSERVATIONS: contextvars.ContextVar[Optional[dict]] = contextvars.ContextVar(
+    "fhi_probe_observations", default=None
+)
+
+
+def begin_probe_observations() -> dict:
+    """Start recording transport observations for the current probe.
+
+    Returns the dict the probe reads afterwards; only the caller holding it
+    can see what this probe observed.
+
+    No teardown call exists on purpose. run_checks_async dispatches probes
+    through asyncio.gather, which wraps each in a Task, and a Task gets its own
+    copy of the context -- so one probe's binding is invisible to every other
+    and dies with the Task. A direct call re-binds here before it reads, so a
+    stale dict can never be mistaken for a fresh observation either.
+    """
+    observations: dict = {"transport_error": None, "endpoint_answered": False}
+    _PROBE_OBSERVATIONS.set(observations)
+    return observations
+
+
+def _note_probe_transport_error(detail: str) -> None:
+    observations = _PROBE_OBSERVATIONS.get()
+    if observations is not None:
+        observations["transport_error"] = detail
+
+
+def _note_probe_endpoint_answered() -> None:
+    observations = _PROBE_OBSERVATIONS.get()
+    if observations is not None:
+        observations["endpoint_answered"] = True
 
 
 def _error_body_of(exc: aiohttp.ClientResponseError) -> str:
@@ -3309,8 +3355,8 @@ class RemoteOpenLike(RemoteModel):
                         # An endpoint answered -- whatever the status. Probes
                         # use this to keep one leg's transport failure from
                         # being read as "nothing answered" when another leg
-                        # did (see ENDPOINT_ANSWERED_ATTR).
-                        setattr(self, ENDPOINT_ANSWERED_ATTR, True)
+                        # did (see _PROBE_OBSERVATIONS).
+                        _note_probe_endpoint_answered()
                         response_body = await _read_error_body(response)
                         # Raise ClientResponseError for HTTP error status codes (4xx, 5xx)
                         # This allows subclasses to catch and handle specific errors like 429
@@ -3479,7 +3525,7 @@ class RemoteOpenLike(RemoteModel):
             # note is read-and-cleared by the probe; normal inference never
             # looks at it. Strike accounting stays gated: a probe must not
             # push a backend into the production cooldown.
-            setattr(self, LAST_TRANSPORT_ERROR_ATTR, described)
+            _note_probe_transport_error(described)
             if not raise_http_errors:
                 self._note_transport_failure(api_base, model, described)
             return None
@@ -4528,7 +4574,7 @@ class RateLimitedRemoteOpenLike(RemoteFullOpenLike):
             # genuine transport errors: a blanket note would relabel an
             # ordinary bug as a network failure.
             if isinstance(e, MODEL_TRANSPORT_ERRORS):
-                setattr(self, LAST_TRANSPORT_ERROR_ATTR, described)
+                _note_probe_transport_error(described)
             return None
 
     async def _do_infer(

--- a/fighthealthinsurance/ml/model_health_check.py
+++ b/fighthealthinsurance/ml/model_health_check.py
@@ -54,10 +54,14 @@ from loguru import logger
 
 from fighthealthinsurance.ml import ml_router as ml_router_module
 from fighthealthinsurance.ml.ml_models import (
+    ENDPOINT_ANSWERED_ATTR,
+    LAST_TRANSPORT_ERROR_ATTR,
     ModelDescription,
     RateLimitedRemoteOpenLike,
     RemoteModel,
     RemoteModelLike,
+    _error_body_of,
+    _error_text_indicates_missing_model,
     candidate_model_backends,
 )
 from fighthealthinsurance.ml.ml_router import MLRouter
@@ -456,17 +460,79 @@ def enumerate_backend_checks(
 # --- Invocation --------------------------------------------------------------
 
 
+def _arm_transport_probe(instance: RemoteModelLike) -> None:
+    """Clear the transport's last-error note before probing ``instance``.
+
+    Best-effort: a backend that does not carry the attribute (a stub, or a
+    non-RemoteOpenLike implementation) simply has no note to read later, and
+    the caller falls back to the malformed-response reading it used before.
+    """
+    try:
+        setattr(instance, LAST_TRANSPORT_ERROR_ATTR, None)
+        setattr(instance, ENDPOINT_ANSWERED_ATTR, False)
+    except Exception:
+        pass
+
+
+def _consume_transport_error(instance: RemoteModelLike) -> str:
+    """The transport failure recorded during this probe, or "".
+
+    Read-and-clear, so a note can never leak into a later probe of the same
+    instance.
+    """
+    try:
+        note = getattr(instance, LAST_TRANSPORT_ERROR_ATTR, None)
+        answered = getattr(instance, ENDPOINT_ANSWERED_ATTR, False)
+        setattr(instance, LAST_TRANSPORT_ERROR_ATTR, None)
+        setattr(instance, ENDPOINT_ANSWERED_ATTR, False)
+    except Exception:
+        return ""
+    # One _infer can try several endpoints. A note proves SOME leg could not
+    # reach its endpoint; it does not prove none of them did. If any leg got an
+    # HTTP response, the empty result came from a backend that answered, which
+    # is a malformed response -- calling it "no endpoint reachable" would send
+    # the operator to the network layer for a model fault.
+    if answered:
+        return ""
+    return str(note) if note else ""
+
+
 def _categorize_http_error(e: aiohttp.ClientResponseError) -> Tuple[str, str]:
-    detail = sanitize_error(f"HTTP {e.status} {e.message or ''}")
+    """Categorize an HTTP failure, reporting what the PROVIDER actually said.
+
+    ``e.message`` is only the HTTP reason phrase ("Bad Request"). The transport
+    already reads the response body and attaches it (``_attach_error_body``),
+    so the operator-facing detail here uses that body: the difference is
+    "HTTP 400 Bad Request" versus "Your credit balance is too low to access
+    the Anthropic API" -- the first is unactionable, the second names the fix.
+    A real incident was diagnosed by hand for exactly this reason.
+
+    The body also repairs the 400 branch below. It matched
+    ``"model" in e.message``, but e.message is the reason phrase and never
+    contains "model", so the branch was unreachable: every provider that
+    rejects an unknown model id with a 400 rather than a 404 landed in
+    FAIL_OTHER. It now matches on the body via the shared
+    ``_error_text_indicates_missing_model``, which requires a not-found
+    phrasing as well as the word "model" -- so a body that merely mentions a
+    model in passing ("temperature is not supported for this model", or a
+    quota message) does not get mislabelled MODEL_NOT_FOUND.
+    """
+    body = _error_body_of(e)
+    reason = e.message or ""
+    # Body first: it is the part a human acts on. sanitize_error() redacts and
+    # length-caps, so a huge HTML error page cannot reach the report whole.
+    detail = sanitize_error(
+        f"HTTP {e.status} {reason}" + (f" -- {body}" if body else "")
+    )
     if e.status in (401, 403):
         return CATEGORY_AUTH, detail
     if e.status == 404:
         return CATEGORY_MODEL_NOT_FOUND, detail
     if e.status in (429, 402):
         return CATEGORY_RATE_LIMITED, detail
-    if e.status == 400 and "model" in (e.message or "").lower():
-        # Providers that reject unknown model ids with a 400 mentioning the
-        # model field (rather than a clean 404).
+    if e.status == 400 and _error_text_indicates_missing_model(body):
+        # Providers that reject unknown model ids with a 400 naming the model
+        # (rather than a clean 404).
         return CATEGORY_MODEL_NOT_FOUND, detail
     if 500 <= e.status < 600:
         return CATEGORY_NETWORK, detail
@@ -496,6 +562,9 @@ async def check_backend(
         except Exception:  # rate limiter not initialized — proceed to probe
             pass
 
+    # Clear any transport note left by an earlier call so a stale failure
+    # cannot be read as this probe's.
+    _arm_transport_probe(instance)
     start = time.monotonic()
     try:
         text = await asyncio.wait_for(
@@ -525,6 +594,17 @@ async def check_backend(
 
     result.latency_ms = int((time.monotonic() - start) * 1000)
     if text is None or not str(text).strip():
+        # A backend whose every endpoint refused or timed out returns None
+        # here rather than raising: the transport swallows MODEL_TRANSPORT
+        # errors and falls through to its backup, and when the backup fails
+        # too the caller just sees None. Reporting that as "malformed
+        # response" points the operator at the model when the truth is that
+        # nothing answered the socket. Ask the transport what it last saw.
+        transport = _consume_transport_error(instance)
+        if transport:
+            result.category = CATEGORY_NETWORK
+            result.error = sanitize_error(f"no endpoint reachable -- {transport}")
+            return result
         result.category = CATEGORY_MALFORMED_RESPONSE
         result.error = "empty or no text in provider response"
         return result

--- a/fighthealthinsurance/ml/model_health_check.py
+++ b/fighthealthinsurance/ml/model_health_check.py
@@ -54,14 +54,13 @@ from loguru import logger
 
 from fighthealthinsurance.ml import ml_router as ml_router_module
 from fighthealthinsurance.ml.ml_models import (
-    ENDPOINT_ANSWERED_ATTR,
-    LAST_TRANSPORT_ERROR_ATTR,
     ModelDescription,
     RateLimitedRemoteOpenLike,
     RemoteModel,
     RemoteModelLike,
     _error_body_of,
     _error_text_indicates_missing_model,
+    begin_probe_observations,
     candidate_model_backends,
 )
 from fighthealthinsurance.ml.ml_router import MLRouter
@@ -460,40 +459,23 @@ def enumerate_backend_checks(
 # --- Invocation --------------------------------------------------------------
 
 
-def _arm_transport_probe(instance: RemoteModelLike) -> None:
-    """Clear the transport's last-error note before probing ``instance``.
+def _consume_transport_error(observations: Optional[dict]) -> str:
+    """The transport failure this probe observed, or "".
 
-    Best-effort: a backend that does not carry the attribute (a stub, or a
-    non-RemoteOpenLike implementation) simply has no note to read later, and
-    the caller falls back to the malformed-response reading it used before.
+    ``observations`` is the dict handed back by ``begin_probe_observations``:
+    private to this probe, so a concurrent production request through the same
+    backend instance cannot write into it.
     """
-    try:
-        setattr(instance, LAST_TRANSPORT_ERROR_ATTR, None)
-        setattr(instance, ENDPOINT_ANSWERED_ATTR, False)
-    except Exception:
-        pass
-
-
-def _consume_transport_error(instance: RemoteModelLike) -> str:
-    """The transport failure recorded during this probe, or "".
-
-    Read-and-clear, so a note can never leak into a later probe of the same
-    instance.
-    """
-    try:
-        note = getattr(instance, LAST_TRANSPORT_ERROR_ATTR, None)
-        answered = getattr(instance, ENDPOINT_ANSWERED_ATTR, False)
-        setattr(instance, LAST_TRANSPORT_ERROR_ATTR, None)
-        setattr(instance, ENDPOINT_ANSWERED_ATTR, False)
-    except Exception:
+    if not observations:
         return ""
     # One _infer can try several endpoints. A note proves SOME leg could not
     # reach its endpoint; it does not prove none of them did. If any leg got an
     # HTTP response, the empty result came from a backend that answered, which
     # is a malformed response -- calling it "no endpoint reachable" would send
     # the operator to the network layer for a model fault.
-    if answered:
+    if observations.get("endpoint_answered"):
         return ""
+    note = observations.get("transport_error")
     return str(note) if note else ""
 
 
@@ -562,9 +544,10 @@ async def check_backend(
         except Exception:  # rate limiter not initialized — proceed to probe
             pass
 
-    # Clear any transport note left by an earlier call so a stale failure
-    # cannot be read as this probe's.
-    _arm_transport_probe(instance)
+    # Record this probe's transport observations somewhere only this probe can
+    # see, so concurrent production traffic through the same shared backend
+    # instance cannot change the verdict.
+    observations = begin_probe_observations()
     start = time.monotonic()
     try:
         text = await asyncio.wait_for(
@@ -600,7 +583,7 @@ async def check_backend(
         # too the caller just sees None. Reporting that as "malformed
         # response" points the operator at the model when the truth is that
         # nothing answered the socket. Ask the transport what it last saw.
-        transport = _consume_transport_error(instance)
+        transport = _consume_transport_error(observations)
         if transport:
             result.category = CATEGORY_NETWORK
             result.error = sanitize_error(f"no endpoint reachable -- {transport}")

--- a/tests/async-unit/test_model_backend_health.py
+++ b/tests/async-unit/test_model_backend_health.py
@@ -21,8 +21,9 @@ from django.core.management import call_command
 from fighthealthinsurance.ml import ml_router as ml_router_module
 from fighthealthinsurance.ml import model_health_check as mhc
 from fighthealthinsurance.ml.ml_models import (
-    LAST_TRANSPORT_ERROR_ATTR,
     _attach_error_body,
+    _note_probe_transport_error,
+    begin_probe_observations,
 )
 
 
@@ -99,7 +100,7 @@ class _UnreachableBackend(_StubBackend):
         if self._fail_times is None or self._fail_times > 0:
             if self._fail_times is not None:
                 self._fail_times -= 1
-            setattr(self, LAST_TRANSPORT_ERROR_ATTR, self._detail)
+            _note_probe_transport_error(self._detail)
         return None
 
 
@@ -291,11 +292,11 @@ class TestCheckBackendCategorization:
         second = asyncio.run(mhc.check_backend(_result(), backend, timeout=5.0))
         assert second.category == mhc.CATEGORY_MALFORMED_RESPONSE
 
-    def test_stale_transport_note_is_cleared_before_the_probe(self):
-        """A note left on the instance by earlier production traffic must not
-        be read as this probe's result."""
+    def test_a_note_from_before_the_probe_is_not_read_as_this_probe(self):
+        """Observations recorded before check_backend armed its own must not
+        be mistaken for this probe's."""
+        _note_probe_transport_error("stale failure from hours ago")
         backend = _StubBackend(None)
-        setattr(backend, LAST_TRANSPORT_ERROR_ATTR, "stale failure from hours ago")
         res = asyncio.run(mhc.check_backend(_result(), backend, timeout=5.0))
         assert res.category == mhc.CATEGORY_MALFORMED_RESPONSE
 
@@ -768,13 +769,14 @@ class TestRealTransportPlumbing:
         transport, and under raise_http_errors, or the probe cannot tell an
         unreachable backend from an empty answer."""
         model = self._model()
+        observations = begin_probe_observations()
         err = aiohttp.ConnectionTimeoutError("Connection timeout to host")
         with patch.object(aiohttp.ClientSession, "post", side_effect=err):
             result = await model._infer(
                 system_prompts=["sys"], prompt="hi", raise_http_errors=True
             )
         assert result is None
-        assert "timeout" in str(getattr(model, LAST_TRANSPORT_ERROR_ATTR, "")).lower()
+        assert "timeout" in str(observations.get("transport_error") or "").lower()
         # A probe must never push a backend into the production cooldown.
         assert model._transport_strikes == {}
 
@@ -798,12 +800,66 @@ class TestRealTransportPlumbing:
 
         def _post(*a, **k):
             # The note has to be written DURING the probe, the way a failing
-            # leg writes it -- check_backend arms (clears) it beforehand, so a
-            # note planted before the call proves nothing.
-            setattr(model, LAST_TRANSPORT_ERROR_ATTR, "connection refused")
+            # leg writes it -- check_backend arms its own observations first,
+            # so a note recorded before the call proves nothing.
+            _note_probe_transport_error("connection refused")
             return ctx()
 
         with patch.object(aiohttp.ClientSession, "post", _post):
             res = await mhc.check_backend(_result(), model, timeout=10.0)
         assert res.category == mhc.CATEGORY_MALFORMED_RESPONSE
         assert "no endpoint reachable" not in (res.error or "")
+
+    @pytest.mark.asyncio
+    async def test_concurrent_production_traffic_cannot_change_a_probe_verdict(self):
+        """The probe deliberately uses the router's REGISTERED singleton, so
+        it exercises the client real requests use. That instance is shared, so
+        recording transport observations on it let ordinary traffic corrupt a
+        verdict in both directions: a production connection failure turning an
+        empty probe into FAIL_NETWORK, and a production HTTP response hiding an
+        unreachable probe as FAIL_MALFORMED_RESPONSE (CodeRabbit, PR 987).
+
+        Observations live in a ContextVar-held dict instead, so inference
+        outside a probe records nothing. Here one instance serves an empty 200
+        to the probe while a concurrent inference through the SAME instance
+        fails at the transport: the probe must still say MALFORMED.
+        """
+        model = self._model()
+        empty_ok = self._response(200, "")
+        err = aiohttp.ConnectionTimeoutError("Connection timeout to host")
+        started = asyncio.Event()
+
+        def _post(*a, **k):
+            # The probe's own call answers 200-with-no-completion.
+            return empty_ok()
+
+        async def noisy_neighbour():
+            # Ordinary inference, no probe armed: raise_http_errors=False is
+            # the production path, and it must leave no trace a probe reads.
+            await started.wait()
+            with patch.object(aiohttp.ClientSession, "post", side_effect=err):
+                await model._infer(system_prompts=["sys"], prompt="hi")
+
+        async def probe():
+            started.set()
+            with patch.object(aiohttp.ClientSession, "post", _post):
+                return await mhc.check_backend(_result(), model, timeout=10.0)
+
+        neighbour = asyncio.create_task(noisy_neighbour())
+        res = await probe()
+        await neighbour
+
+        assert res.category == mhc.CATEGORY_MALFORMED_RESPONSE, res.error
+        assert "no endpoint reachable" not in (res.error or "")
+
+    @pytest.mark.asyncio
+    async def test_inference_outside_a_probe_records_nothing(self):
+        """The isolation stated plainly: with no probe armed, a transport
+        failure writes nowhere, so nothing can leak into a later probe."""
+        from fighthealthinsurance.ml.ml_models import _PROBE_OBSERVATIONS
+
+        model = self._model()
+        err = aiohttp.ConnectionTimeoutError("Connection timeout to host")
+        with patch.object(aiohttp.ClientSession, "post", side_effect=err):
+            await model._infer(system_prompts=["sys"], prompt="hi")
+        assert _PROBE_OBSERVATIONS.get() is None

--- a/tests/async-unit/test_model_backend_health.py
+++ b/tests/async-unit/test_model_backend_health.py
@@ -10,6 +10,7 @@ and the check_model_backends management command exit codes.
 """
 
 import asyncio
+import contextvars
 import os
 from io import StringIO
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -87,7 +88,8 @@ class _UnreachableBackend(_StubBackend):
 
     Mirrors what ml_models.__infer does for MODEL_TRANSPORT_ERRORS: it does
     NOT raise (returning None is what lets the real transport fall through to
-    its backup); it records the cause on the instance and returns None.
+    its backup); it records the cause through the probe-observation channel
+    and returns None.
     """
 
     def __init__(self, detail, fail_times=None):
@@ -829,25 +831,40 @@ class TestRealTransportPlumbing:
         err = aiohttp.ConnectionTimeoutError("Connection timeout to host")
         started = asyncio.Event()
 
+        # ONE patch covers both callers. Nesting a second patch.object on the
+        # same attribute from a concurrent task corrupts it process-wide: the
+        # inner patch records the OUTER patch as the original and restores
+        # THAT on exit, so ClientSession.post stays patched for every later
+        # test -- it silently answered 200 to an unrelated cooldown test
+        # probing a dead port. Which caller is which is decided by a
+        # ContextVar, which is the same per-task isolation under test here.
+        in_neighbour: contextvars.ContextVar[bool] = contextvars.ContextVar(
+            "fhi_test_in_neighbour", default=False
+        )
+
         def _post(*a, **k):
-            # The probe's own call answers 200-with-no-completion.
+            if in_neighbour.get():
+                raise err
             return empty_ok()
 
         async def noisy_neighbour():
-            # Ordinary inference, no probe armed: raise_http_errors=False is
-            # the production path, and it must leave no trace a probe reads.
+            # Set in THIS task's context only. _infer runs its legs as Tasks
+            # that copy the context, so every call they make raises.
+            in_neighbour.set(True)
             await started.wait()
-            with patch.object(aiohttp.ClientSession, "post", side_effect=err):
-                await model._infer(system_prompts=["sys"], prompt="hi")
+            # Ordinary inference: raise_http_errors=False is the production
+            # path, and it must leave no trace a probe can read.
+            await model._infer(system_prompts=["sys"], prompt="hi")
 
-        async def probe():
-            started.set()
-            with patch.object(aiohttp.ClientSession, "post", _post):
-                return await mhc.check_backend(_result(), model, timeout=10.0)
-
+        # Created BEFORE the probe arms its observations, so the neighbour's
+        # context carries no binding -- the real shape of production traffic
+        # running alongside a probe.
         neighbour = asyncio.create_task(noisy_neighbour())
-        res = await probe()
-        await neighbour
+
+        with patch.object(aiohttp.ClientSession, "post", _post):
+            started.set()
+            res = await mhc.check_backend(_result(), model, timeout=10.0)
+            await neighbour
 
         assert res.category == mhc.CATEGORY_MALFORMED_RESPONSE, res.error
         assert "no endpoint reachable" not in (res.error or "")

--- a/tests/async-unit/test_model_backend_health.py
+++ b/tests/async-unit/test_model_backend_health.py
@@ -20,6 +20,10 @@ from django.core.management import call_command
 
 from fighthealthinsurance.ml import ml_router as ml_router_module
 from fighthealthinsurance.ml import model_health_check as mhc
+from fighthealthinsurance.ml.ml_models import (
+    LAST_TRANSPORT_ERROR_ATTR,
+    _attach_error_body,
+)
 
 
 @pytest.fixture
@@ -77,6 +81,28 @@ class _StubBackend:
         return behavior
 
 
+class _UnreachableBackend(_StubBackend):
+    """Stand-in for a backend whose every endpoint refused or timed out.
+
+    Mirrors what ml_models.__infer does for MODEL_TRANSPORT_ERRORS: it does
+    NOT raise (returning None is what lets the real transport fall through to
+    its backup); it records the cause on the instance and returns None.
+    """
+
+    def __init__(self, detail, fail_times=None):
+        super().__init__(None)
+        self._detail = detail
+        self._fail_times = fail_times
+
+    async def _infer_no_context(self, **kwargs):
+        assert kwargs.get("raise_http_errors") is True
+        if self._fail_times is None or self._fail_times > 0:
+            if self._fail_times is not None:
+                self._fail_times -= 1
+            setattr(self, LAST_TRANSPORT_ERROR_ATTR, self._detail)
+        return None
+
+
 def _result(**overrides):
     base = dict(
         provider="TestProvider",
@@ -90,14 +116,24 @@ def _result(**overrides):
     return mhc.BackendCheckResult(**base)
 
 
-def _http_error(status, message="err", headers=None):
-    return aiohttp.ClientResponseError(
+def _http_error(status, message="err", headers=None, body=None):
+    """Build a ClientResponseError shaped like the ones the transport raises.
+
+    ``message`` is the HTTP REASON PHRASE ("Bad Request") -- that is all
+    aiohttp ever puts there. The provider's actual error text arrives
+    separately, attached by ml_models._attach_error_body, which is what
+    ``body`` simulates here.
+    """
+    exc = aiohttp.ClientResponseError(
         request_info=MagicMock(),
         history=(),
         status=status,
         message=message,
         headers=headers or {},
     )
+    if body is not None:
+        _attach_error_body(exc, body)
+    return exc
 
 
 class TestSanitizeError:
@@ -163,8 +199,44 @@ class TestCheckBackendCategorization:
         assert res.category == mhc.CATEGORY_MODEL_NOT_FOUND
 
     def test_400_mentioning_model_is_model_not_found(self):
-        res = self._check(_http_error(400, "unknown model 'claude-nope'"))
+        res = self._check(
+            _http_error(400, "Bad Request", body="unknown model 'claude-nope'")
+        )
         assert res.category == mhc.CATEGORY_MODEL_NOT_FOUND
+
+    def test_400_model_not_found_is_read_from_body_not_reason_phrase(self):
+        """Regression: this branch used to match on e.message, which aiohttp
+        fills with the reason phrase ("Bad Request") and never the provider
+        text -- so it could not fire in production even though a unit test
+        passed a hand-written message. With no body there is nothing to match
+        and the error must fall through to FAIL_OTHER rather than being
+        guessed at."""
+        res = self._check(_http_error(400, "Bad Request"))
+        assert res.category == mhc.CATEGORY_OTHER
+
+    def test_400_body_is_reported_verbatim(self):
+        """The operator-facing detail must carry what the provider said. A
+        real incident (Anthropic credit exhaustion) was reported only as
+        "HTTP 400 Bad Request", which named neither the cause nor the fix."""
+        res = self._check(
+            _http_error(
+                400,
+                "Bad Request",
+                body='{"error":{"message":"Your credit balance is too low"}}',
+            )
+        )
+        assert res.category == mhc.CATEGORY_OTHER
+        assert "credit balance is too low" in res.error
+
+    def test_400_quota_body_is_not_mistaken_for_a_missing_model(self):
+        """The body match requires a not-found phrasing as well as the word
+        "model", so a message that merely mentions one is not mislabelled."""
+        res = self._check(
+            _http_error(
+                400, "Bad Request", body="temperature unsupported for this model"
+            )
+        )
+        assert res.category == mhc.CATEGORY_OTHER
 
     def test_429_is_rate_limited(self):
         assert self._check(_http_error(429)).category == mhc.CATEGORY_RATE_LIMITED
@@ -191,6 +263,41 @@ class TestCheckBackendCategorization:
         res = self._check(None)
         assert res.category == mhc.CATEGORY_MALFORMED_RESPONSE
         assert res.failed
+
+    def test_all_endpoints_unreachable_is_network_not_malformed(self):
+        """A backend whose every endpoint refused or timed out returns None
+        rather than raising -- returning None is what lets the transport fall
+        through to its backup, and when the backup fails too the caller just
+        sees None. That is a network failure, not a malformed response;
+        reporting the latter points the operator at the model when nothing
+        answered the socket."""
+        res = asyncio.run(
+            mhc.check_backend(
+                _result(), _UnreachableBackend("connection refused"), timeout=5.0
+            )
+        )
+        assert res.category == mhc.CATEGORY_NETWORK
+        assert "connection refused" in res.error
+        assert res.failed
+
+    def test_transport_note_does_not_leak_into_a_later_probe(self):
+        """The note is armed before the call and read-and-cleared after, so a
+        failure recorded by one probe cannot mislabel the next. Here the
+        backend is unreachable on the first probe and merely empty on the
+        second: the second must NOT inherit the first's network verdict."""
+        backend = _UnreachableBackend("connection refused", fail_times=1)
+        first = asyncio.run(mhc.check_backend(_result(), backend, timeout=5.0))
+        assert first.category == mhc.CATEGORY_NETWORK
+        second = asyncio.run(mhc.check_backend(_result(), backend, timeout=5.0))
+        assert second.category == mhc.CATEGORY_MALFORMED_RESPONSE
+
+    def test_stale_transport_note_is_cleared_before_the_probe(self):
+        """A note left on the instance by earlier production traffic must not
+        be read as this probe's result."""
+        backend = _StubBackend(None)
+        setattr(backend, LAST_TRANSPORT_ERROR_ATTR, "stale failure from hours ago")
+        res = asyncio.run(mhc.check_backend(_result(), backend, timeout=5.0))
+        assert res.category == mhc.CATEGORY_MALFORMED_RESPONSE
 
     def test_unexpected_text_response_is_malformed(self):
         """Reachable but garbled (HTML error body, stub text, refusal) must not
@@ -572,3 +679,131 @@ class TestCheckModelBackendsCommand:
         assert run_mock.call_args.kwargs["only_models"] == [
             "anthropic/claude-sonnet-4-6"
         ]
+
+
+class TestRealTransportPlumbing:
+    """End-to-end over the REAL transport, not a hand-mirrored stub.
+
+    The stub-only tests above cannot see whether ml_models actually feeds
+    _categorize_http_error and check_backend what they read. It did not: the
+    body was attached on RemoteAzureClaude's transport only, so on the
+    OpenAI-compatible path -- which RemoteAnthropic and every other backend
+    use -- _error_body_of() was always "" and the reporting fix was inert for
+    the exact incident that motivated it. These pin the plumbing.
+    """
+
+    def _model(self):
+        from fighthealthinsurance.ml.ml_models import RemoteFullOpenLike
+
+        return RemoteFullOpenLike("http://test-api.com", "test-token", "test-model")
+
+    @staticmethod
+    def _response(status, body):
+        class _Resp:
+            def __init__(self):
+                self.status = status
+                self.headers = {}
+                self.request_info = MagicMock()
+                self.history = ()
+
+            async def text(self):
+                return body
+
+            async def json(self):
+                return {}
+
+            def raise_for_status(self):
+                if self.status >= 400:
+                    raise aiohttp.ClientResponseError(
+                        request_info=self.request_info,
+                        history=self.history,
+                        status=self.status,
+                        message="Bad Request",
+                        headers=self.headers,
+                    )
+
+        class _Ctx:
+            async def __aenter__(self_inner):
+                return _Resp()
+
+            async def __aexit__(self_inner, *a):
+                return False
+
+        return _Ctx
+
+    @pytest.mark.asyncio
+    async def test_openai_compatible_path_attaches_the_provider_body(self):
+        """Regression: __infer read the body into a local and re-raised
+        without attaching it, so every caller that classifies on the body saw
+        nothing. This is the plumbing the reporting fix depends on."""
+        from fighthealthinsurance.ml.ml_models import _error_body_of
+
+        model = self._model()
+        body = '{"error":{"message":"Your credit balance is too low"}}'
+        ctx = self._response(400, body)
+        with patch.object(aiohttp.ClientSession, "post", lambda *a, **k: ctx()):
+            with pytest.raises(aiohttp.ClientResponseError) as caught:
+                await model._infer(
+                    system_prompts=["sys"], prompt="hi", raise_http_errors=True
+                )
+        assert "credit balance is too low" in _error_body_of(caught.value)
+        # ...and the reason phrase is left alone for the log sites that read it
+        assert caught.value.message == "Bad Request"
+
+    @pytest.mark.asyncio
+    async def test_provider_body_reaches_the_operator_facing_report(self):
+        """The whole point, end to end: what the provider said must appear in
+        the health report rather than "HTTP 400 Bad Request"."""
+        model = self._model()
+        body = '{"error":{"message":"Your credit balance is too low"}}'
+        ctx = self._response(400, body)
+        with patch.object(aiohttp.ClientSession, "post", lambda *a, **k: ctx()):
+            res = await mhc.check_backend(_result(), model, timeout=10.0)
+        assert res.failed
+        assert "credit balance is too low" in res.error
+
+    @pytest.mark.asyncio
+    async def test_transport_error_records_the_note_even_when_raising(self):
+        """Bug 2's production half: the note must be written on the real
+        transport, and under raise_http_errors, or the probe cannot tell an
+        unreachable backend from an empty answer."""
+        model = self._model()
+        err = aiohttp.ConnectionTimeoutError("Connection timeout to host")
+        with patch.object(aiohttp.ClientSession, "post", side_effect=err):
+            result = await model._infer(
+                system_prompts=["sys"], prompt="hi", raise_http_errors=True
+            )
+        assert result is None
+        assert "timeout" in str(getattr(model, LAST_TRANSPORT_ERROR_ATTR, "")).lower()
+        # A probe must never push a backend into the production cooldown.
+        assert model._transport_strikes == {}
+
+    @pytest.mark.asyncio
+    async def test_unreachable_backend_reports_network_end_to_end(self):
+        model = self._model()
+        err = aiohttp.ConnectionTimeoutError("Connection timeout to host")
+        with patch.object(aiohttp.ClientSession, "post", side_effect=err):
+            res = await mhc.check_backend(_result(), model, timeout=10.0)
+        assert res.category == mhc.CATEGORY_NETWORK
+
+    @pytest.mark.asyncio
+    async def test_endpoint_that_answered_is_not_reported_as_unreachable(self):
+        """An endpoint answering 200 with no completion is a MALFORMED
+        response. One _infer can try several endpoints, so a note left by a
+        failing leg must not outrank a leg that actually answered -- otherwise
+        the fix sends operators to the network layer for a model fault, which
+        is the original misdirection pointed the other way."""
+        model = self._model()
+        ctx = self._response(200, "")
+
+        def _post(*a, **k):
+            # The note has to be written DURING the probe, the way a failing
+            # leg writes it -- check_backend arms (clears) it beforehand, so a
+            # note planted before the call proves nothing.
+            setattr(model, LAST_TRANSPORT_ERROR_ATTR, "connection refused")
+            return ctx()
+
+        with patch.object(aiohttp.ClientSession, "post", _post):
+            res = await mhc.check_backend(_result(), model, timeout=10.0)
+        assert res.category == mhc.CATEGORY_MALFORMED_RESPONSE
+        assert "no endpoint reachable" not in (res.error or "")


### PR DESCRIPTION
Two reporting defects, both found while diagnosing a live incident by hand because the report itself said nothing useful.

1. The provider's error text never reached the report.

_categorize_http_error built its detail from ClientResponseError.message, which is only the HTTP reason phrase. Three Anthropic models failed with a body reading "Your credit balance is too low to access the Anthropic API" and the operator saw "HTTP 400 Bad Request", category FAIL_OTHER -- which names neither the cause nor the fix.

The same root cause left a branch unreachable: the 400-means-missing-model case matched on e.message, and e.message is never anything but the reason phrase, so every provider that rejects an unknown model id with a 400 rather than a 404 landed in FAIL_OTHER. It now matches the body through the shared _error_text_indicates_missing_model, which requires a not-found phrasing as well as the word "model" -- so a quota message, or "temperature unsupported for this model", is not mislabelled.

The plumbing had to be fixed for any of that to do anything. __infer read the body into a local and re-raised without attaching it, so _error_body_of() returned "" for every backend on the OpenAI-compatible path -- RemoteAnthropic included, the class serving the models in the incident. The body was only ever attached on RemoteAzureClaude's separate transport. Attaching it once at the top of the except block covers all three re-raise paths.

2. A backend nothing could reach was reported as a malformed response.

Every endpoint of fhi-2025-nov was refusing or timing out, and the report said "empty or no text in provider response" -- pointing at the model when the truth was that nothing answered the socket. Transport errors return None instead of raising, deliberately: that is what lets the transport fall through to its backup. So they now record the cause on the instance, and the probe reads it. Strike accounting stays gated on raise_http_errors so a probe cannot push a backend into the production cooldown, and the same note is recorded on RateLimitedRemoteOpenLike's handler, which is where backends that override the transport (Azure Foundry Claude) land.

The note alone would have been wrong. One _infer can try several endpoints, so a note proves some leg failed, not that none succeeded: a primary answering 200-with-no-completion while the backup refused would have been reported "no endpoint reachable" -- the original misdirection pointed the other way. A companion flag records that some endpoint answered, and it wins, so the verdict does not depend on which leg finished last.

Tests: the previous test for the 400 branch passed a hand-written message="unknown model 'claude-nope'". aiohttp never puts provider text there, so the test encoded the bug and stayed green while the branch was dead in production. The replacements drive the real transport rather than a stub that mirrors it by hand -- which is what the stub-only tests could not see -- and each was checked to FAIL with its fix reverted.

Whole async-unit suite: 51 failures on this branch and 51 on main, the same 51 (DB-dependent); 1789 passing, up from 1784.


Claude-Session: https://claude.ai/code/session_019SPqa4FZ43ahAjoD53Uj81

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Health checks now distinguish unreachable endpoints from malformed or empty responses.
  * Provider response bodies are included in operator-facing error reports for more accurate diagnosis.
  * Model-not-found and quota-related errors are categorized more reliably.
  * Transport failures no longer carry stale diagnostics into later checks.
  * Endpoints that respond without content are no longer reported as unreachable.
  * Concurrent model traffic can no longer alter an in-progress health-check result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->