### PR TITLE
Scrub form: say when we couldn't read the file, and stop uploading it

### DIFF
--- a/fighthealthinsurance/static/js/scrub.ts
+++ b/fighthealthinsurance/static/js/scrub.ts
@@ -8,7 +8,6 @@ import {
   addText,
   beginOcr,
   clearOcrFailure,
-  denialTextLength,
   endOcr,
   hideErrorMessages,
   notePartialOcrFailure,
@@ -78,8 +77,26 @@ const recognizeEvent = async function (evt: Event) {
   // A fresh selection replaces the previous verdict: the last attempt having
   // failed says nothing about this one.
   clearOcrFailure();
-  const before = denialTextLength();
   let failures = 0;
+  let ocrChars = 0;
+
+  // Guard the CALLBACK, not just the verdict. recognize() invokes this after
+  // async OCR work, so a superseded batch could still append its text into
+  // denial_text long after the user picked different files -- they would get
+  // the old document's text back with no way to know why.
+  //
+  // Counting here also keeps the verdict honest about who produced what.
+  // Measuring the textarea before and after instead would count the USER's
+  // typing: someone typing while a doomed batch runs made it look like OCR
+  // had produced something, which reported partial success and re-posted a
+  // message their typing had just cleared.
+  const addTextForThisSelection = (text: string): void => {
+    if (selection !== latestOcrSelection) {
+      return;
+    }
+    ocrChars += text.trim().length;
+    addText(text);
+  };
 
   beginOcr();
   try {
@@ -89,7 +106,7 @@ const recognizeEvent = async function (evt: Event) {
       // outside, one unreadable page abandoned every page after it and the
       // user was never told which -- or that anything had gone wrong at all.
       try {
-        await recognize(file, addText);
+        await recognize(file, addTextForThisSelection);
       } catch (error) {
         failures += 1;
         // The filename can carry the patient's name; keep it out of logs.
@@ -108,13 +125,13 @@ const recognizeEvent = async function (evt: Event) {
   // "Threw" is not the only failure. Every engine can return cleanly and
   // still yield nothing for a photo too blurry to read, which looks
   // identical to the user: an empty box under a form that says a file is
-  // enough. Treat "no new text" as a failure too.
-  const gainedText = denialTextLength() > before;
-  if (failures > 0 && gainedText) {
+  // enough. Treat "produced no text" as a failure too.
+  const producedText = ocrChars > 0;
+  if (failures > 0 && producedText) {
     // Some pages read and some did not. Saying "we couldn't read your file"
     // here would be plainly false with their text sitting right below it.
     notePartialOcrFailure();
-  } else if (failures > 0 || !gainedText) {
+  } else if (failures > 0 || !producedText) {
     noteOcrFailure();
   }
 };

--- a/fighthealthinsurance/static/js/scrub.ts
+++ b/fighthealthinsurance/static/js/scrub.ts
@@ -7,8 +7,11 @@ import { clean } from "./scrub_scrub";
 import {
   addText,
   beginOcr,
+  clearOcrFailure,
+  denialTextLength,
   endOcr,
   hideErrorMessages,
+  noteOcrFailure,
   validateScrubForm,
 } from "./scrub_client_side_form";
 
@@ -62,13 +65,38 @@ const recognizeEvent = async function (evt: Event) {
   // Mark OCR as in flight for the whole batch so the submit gate can tell the
   // user we are still reading their file rather than letting them submit an
   // empty denial_text. endOcr() must run even when recognize() throws.
+  //
+  // A fresh selection replaces the previous verdict: the last attempt having
+  // failed says nothing about this one.
+  clearOcrFailure();
+  const before = denialTextLength();
+  let failures = 0;
+
   beginOcr();
   try {
     for (const file of filesArray) {
-      await recognize(file, addText);
+      // Catch PER FILE, not around the loop. The uploader is multiple="true"
+      // and people attach a denial one page per image; with a single catch
+      // outside, one unreadable page abandoned every page after it and the
+      // user was never told which -- or that anything had gone wrong at all.
+      try {
+        await recognize(file, addText);
+      } catch (error) {
+        failures += 1;
+        // The filename can carry the patient's name; keep it out of logs.
+        console.error("OCR failed for an uploaded file:", error);
+      }
     }
   } finally {
     endOcr();
+  }
+
+  // "Threw" is not the only failure. Every engine can return cleanly and
+  // still yield nothing for a photo too blurry to read, which looks
+  // identical to the user: an empty box under a form that says a file is
+  // enough. Treat "no new text" as a failure too.
+  if (failures > 0 || denialTextLength() === before) {
+    noteOcrFailure();
   }
 };
 

--- a/fighthealthinsurance/static/js/scrub.ts
+++ b/fighthealthinsurance/static/js/scrub.ts
@@ -11,6 +11,7 @@ import {
   denialTextLength,
   endOcr,
   hideErrorMessages,
+  notePartialOcrFailure,
   noteOcrFailure,
   validateScrubForm,
 } from "./scrub_client_side_form";
@@ -52,6 +53,13 @@ async function initAdvancedOCRCheckbox(): Promise<void> {
   }
 }
 
+// Which selection is current. Reading a batch is slow enough that a user can
+// pick again while one is still running, and only the newest pick describes
+// what is on screen: without this, a slow FAILING batch could finish after a
+// newer successful one and re-post "we couldn't read your file" over text
+// that had just arrived.
+let latestOcrSelection = 0;
+
 const recognizeEvent = async function (evt: Event) {
   const input = evt.target as HTMLInputElement;
   const files = input.files;
@@ -61,6 +69,7 @@ const recognizeEvent = async function (evt: Event) {
   }
 
   const filesArray = Array.from(files);
+  const selection = ++latestOcrSelection;
 
   // Mark OCR as in flight for the whole batch so the submit gate can tell the
   // user we are still reading their file rather than letting them submit an
@@ -91,11 +100,21 @@ const recognizeEvent = async function (evt: Event) {
     endOcr();
   }
 
+  // A superseded batch says nothing about what the user is looking at.
+  if (selection !== latestOcrSelection) {
+    return;
+  }
+
   // "Threw" is not the only failure. Every engine can return cleanly and
   // still yield nothing for a photo too blurry to read, which looks
   // identical to the user: an empty box under a form that says a file is
   // enough. Treat "no new text" as a failure too.
-  if (failures > 0 || denialTextLength() === before) {
+  const gainedText = denialTextLength() > before;
+  if (failures > 0 && gainedText) {
+    // Some pages read and some did not. Saying "we couldn't read your file"
+    // here would be plainly false with their text sitting right below it.
+    notePartialOcrFailure();
+  } else if (failures > 0 || !gainedText) {
     noteOcrFailure();
   }
 };

--- a/fighthealthinsurance/static/js/scrub_client_side_form.ts
+++ b/fighthealthinsurance/static/js/scrub_client_side_form.ts
@@ -73,6 +73,27 @@ export function isOcrInFlight(): boolean {
   return ocrInFlight > 0;
 }
 
+// Reading the file can fail outright (every OCR engine erroring or timing
+// out) or "succeed" while producing nothing usable -- a blurry photo, a
+// scan too faint for tesseract. Both used to be SILENT: recognize() threw
+// into a handler that had a finally and no catch, so the textarea simply
+// stayed empty and the user got "we need your denial text" underneath copy
+// promising they could upload a file instead. Tell them what happened.
+export function noteOcrFailure(): void {
+  showHiddenMessage("ocr_failed");
+}
+
+export function clearOcrFailure(): void {
+  rehideHiddenMessage("ocr_failed");
+}
+
+// The length of what we have so far, so the caller can tell "the engines
+// ran without throwing" from "the engines actually produced text".
+export function denialTextLength(): number {
+  const input = document.getElementById("denial_text") as HTMLTextAreaElement | null;
+  return input ? input.value.trim().length : 0;
+}
+
 export function validateScrubForm(event: Event): void {
   // Listener is bound to the <form>, so currentTarget is always the form
   const form = event.currentTarget as HTMLFormElement;
@@ -124,6 +145,11 @@ export function validateScrubForm(event: Event): void {
   // the user saw a contradiction. personalonly and tos were validated and
   // ungated the same way.
   const denialTextReady = form.denial_text.value.trim().length > 0;
+  if (denialTextReady) {
+    // However the text arrived -- a later file that read fine, or the user
+    // pasting it -- the earlier failure is no longer something to act on.
+    rehideHiddenMessage("ocr_failed");
+  }
   if (!denialTextReady && isOcrInFlight()) {
     // Distinguish "you have not given us the letter" from "we are still
     // reading the file you just gave us".

--- a/fighthealthinsurance/static/js/scrub_client_side_form.ts
+++ b/fighthealthinsurance/static/js/scrub_client_side_form.ts
@@ -45,6 +45,12 @@ export function hideErrorMessages(event: Event): void {
       denialTextLabel.style.color = "";
     }
     rehideHiddenMessage("need_denial");
+    // This runs on every keystroke in denial_text. Without clearing here,
+    // "we couldn't read your file, so the box below is still empty" stayed on
+    // screen while the user typed into that very box -- the gate only
+    // re-evaluates on submit, so nothing else would have taken it down.
+    rehideHiddenMessage("ocr_failed");
+    rehideHiddenMessage("ocr_partial");
   }
 }
 // OCR runs asynchronously after a file is chosen, and for a scanned PDF it
@@ -80,11 +86,21 @@ export function isOcrInFlight(): boolean {
 // stayed empty and the user got "we need your denial text" underneath copy
 // promising they could upload a file instead. Tell them what happened.
 export function noteOcrFailure(): void {
+  rehideHiddenMessage("ocr_partial");
   showHiddenMessage("ocr_failed");
+}
+
+// Some pages read, some did not. Distinct from total failure on purpose: the
+// total-failure copy says the box is still empty, which is plainly false when
+// the rest of the batch just filled it.
+export function notePartialOcrFailure(): void {
+  rehideHiddenMessage("ocr_failed");
+  showHiddenMessage("ocr_partial");
 }
 
 export function clearOcrFailure(): void {
   rehideHiddenMessage("ocr_failed");
+  rehideHiddenMessage("ocr_partial");
 }
 
 // The length of what we have so far, so the caller can tell "the engines
@@ -149,6 +165,7 @@ export function validateScrubForm(event: Event): void {
     // However the text arrived -- a later file that read fine, or the user
     // pasting it -- the earlier failure is no longer something to act on.
     rehideHiddenMessage("ocr_failed");
+    rehideHiddenMessage("ocr_partial");
   }
   if (!denialTextReady && isOcrInFlight()) {
     // Distinguish "you have not given us the letter" from "we are still

--- a/fighthealthinsurance/static/js/scrub_client_side_form.ts
+++ b/fighthealthinsurance/static/js/scrub_client_side_form.ts
@@ -103,13 +103,6 @@ export function clearOcrFailure(): void {
   rehideHiddenMessage("ocr_partial");
 }
 
-// The length of what we have so far, so the caller can tell "the engines
-// ran without throwing" from "the engines actually produced text".
-export function denialTextLength(): number {
-  const input = document.getElementById("denial_text") as HTMLTextAreaElement | null;
-  return input ? input.value.trim().length : 0;
-}
-
 export function validateScrubForm(event: Event): void {
   // Listener is bound to the <form>, so currentTarget is always the form
   const form = event.currentTarget as HTMLFormElement;

--- a/fighthealthinsurance/templates/scrub.html
+++ b/fighthealthinsurance/templates/scrub.html
@@ -102,7 +102,17 @@ Upload your Health Insurance Denial
 		<small class="text-muted">Attach all insurance denial pages below:</small><br>
 		<small class="text-muted">Once uploaded, your file(s) will populate below in plain text.</small><br>
 	    <div class="col-md-4">
-			<input id="uploader" type="file" name="uploader" multiple="true" class="form-control mt-2"><br>
+			{# DELIBERATELY has no name= attribute. The browser only includes
+			   a file input in the multipart body when it has a name, and this
+			   input sits inside the /process form. With a name, every denial
+			   document a user attached was uploaded and buffered server-side
+			   even though BaseDenialForm has no field for it and nothing ever
+			   read it -- an unnecessary disclosure of the exact document this
+			   flow is built to keep in the browser. The OCR binds by
+			   getElementById("uploader"), so the id is all it needs. Do not
+			   add a name back without also changing what the copy below
+			   promises. #}
+			<input id="uploader" type="file" multiple="true" class="form-control mt-2"><br>
 	    </div>
 	</div>
 	{% endif %}
@@ -200,13 +210,21 @@ Upload your Health Insurance Denial
 		Can't proceed as you didn't check that you had removed your personal identifiable information (PII) from the text areas.
 	    </div>
 	    <div class="hidden-error-message" id="need_denial" role="alert" aria-live="polite">
-	      We need you to provide your denial message from your insurance company in the text field right underneath the words "Your Insurance Denial" if you didn't get one you can write that you have not received a denial but describe what was denied (for example: The pharmacy said my PrEP was denied). Normally insurance companies are required to provide denials, but in our experience they do not always comply with that.
+	      We need your denial in the box below. If you never got one, say so and
+	      describe what was denied (for example: the pharmacy said my PrEP was
+	      denied).
 	    </div>
 	    <div class="hidden-error-message" id="ocr_in_progress" role="alert" aria-live="polite">
 	      We're still reading the file you uploaded &mdash; a scanned PDF has to be
 	      processed a page at a time, which can take a little while. The text will
 	      appear in "Your Insurance Denial" below when it's done. You can also type
 	      or paste the denial text yourself instead of waiting.
+	    </div>
+	    <div class="hidden-error-message" id="ocr_failed" role="alert" aria-live="polite">
+	      We couldn't read your file, so there's nothing in the box below yet.
+	      Please copy and paste your denial into it. Your file is read on your
+	      own device and is never uploaded to us, so we can't read it for you
+	      on our end. Clear photos and text PDFs read better than scans.
 	    </div>
 	    <button type="submit" class="btn btn-green" id="submit">Submit</button>
 	</form>

--- a/fighthealthinsurance/templates/scrub.html
+++ b/fighthealthinsurance/templates/scrub.html
@@ -220,6 +220,11 @@ Upload your Health Insurance Denial
 	      appear in "Your Insurance Denial" below when it's done. You can also type
 	      or paste the denial text yourself instead of waiting.
 	    </div>
+	    <div class="hidden-error-message" id="ocr_partial" role="alert" aria-live="polite">
+	      We read some of what you uploaded but not all of it, so check the box
+	      below and add anything that's missing. Clear photos and text PDFs read
+	      better than scans.
+	    </div>
 	    <div class="hidden-error-message" id="ocr_failed" role="alert" aria-live="polite">
 	      We couldn't read your file, so there's nothing in the box below yet.
 	      Please copy and paste your denial into it. Your file is read on your

--- a/tests/async-unit/test_scrub_form_submit_gate.py
+++ b/tests/async-unit/test_scrub_form_submit_gate.py
@@ -13,7 +13,12 @@ There is no JS test harness in this repo, so this asserts on the source.
 import pathlib
 import re
 
-JS = pathlib.Path(__file__).resolve().parents[2] / "fighthealthinsurance" / "static" / "js"
+JS = (
+    pathlib.Path(__file__).resolve().parents[2]
+    / "fighthealthinsurance"
+    / "static"
+    / "js"
+)
 
 
 def _form_source() -> str:
@@ -83,7 +88,9 @@ def test_the_gate_is_not_stricter_than_the_server():
     assert "personalonly" not in gate, gate
     forms_src = (
         pathlib.Path(__file__).resolve().parents[2]
-        / "fighthealthinsurance" / "forms" / "__init__.py"
+        / "fighthealthinsurance"
+        / "forms"
+        / "__init__.py"
     ).read_text()
     assert "personalonly = forms.BooleanField(required=True)" not in forms_src
 
@@ -115,7 +122,9 @@ def test_the_uploader_releases_ocr_state_even_on_error():
     assert "await recognize(" in fn, fn
     assert re.search(r"finally\s*\{\s*endOcr\(\);", fn), fn
     # ...and the release is inside the same function, after the loop.
-    assert fn.index("beginOcr();") < fn.index("await recognize(") < fn.index("endOcr();")
+    assert (
+        fn.index("beginOcr();") < fn.index("await recognize(") < fn.index("endOcr();")
+    )
 
 
 def test_the_gate_actually_consults_ocr_state():
@@ -132,6 +141,99 @@ def test_progress_message_element_exists():
     user gets a silent refusal."""
     tpl = (
         pathlib.Path(__file__).resolve().parents[2]
-        / "fighthealthinsurance" / "templates" / "scrub.html"
+        / "fighthealthinsurance"
+        / "templates"
+        / "scrub.html"
     ).read_text()
     assert 'id="ocr_in_progress"' in tpl
+
+
+def test_a_failed_read_is_reported_instead_of_failing_silently():
+    """recognize() throwing used to land in a handler with a finally and no
+    catch, so every OCR engine failing left the textarea empty with no
+    explanation -- under copy telling the user a file was enough. The
+    production path must notice and say so."""
+    fn = _js_function((JS / "scrub.ts").read_text(), "const recognizeEvent")
+    assert "noteOcrFailure()" in fn, fn
+    # The failure branch has to be reachable: a catch around the recognize
+    # call, not merely the pre-existing finally.
+    assert re.search(r"catch\s*\([^)]*\)\s*\{[^}]*failures", fn), fn
+
+
+def test_one_unreadable_page_does_not_abandon_the_rest():
+    """The uploader is multiple="true" and people attach a denial one page
+    per image. A single catch outside the loop stopped at the first bad page
+    and silently dropped every page after it, so the catch must be INSIDE."""
+    fn = _js_function((JS / "scrub.ts").read_text(), "const recognizeEvent")
+    loop = fn.index("for (const file of filesArray)")
+    catch = fn.index("catch", loop)
+    close = fn.index("finally", loop)
+    assert loop < catch < close, fn
+
+
+def test_producing_no_text_counts_as_a_failure_too():
+    """Engines can return cleanly and still yield nothing for a photo too
+    blurry to read. To the user that is identical to a crash: an empty box.
+    The check must compare the text before and after, not only catch."""
+    fn = _js_function((JS / "scrub.ts").read_text(), "const recognizeEvent")
+    assert "denialTextLength()" in fn, fn
+    assert re.search(r"denialTextLength\(\)\s*===\s*before", fn), fn
+
+
+def test_failure_message_element_exists():
+    """The handler shows #ocr_failed; the template must define it or the
+    report is a no-op and the silence returns."""
+    tpl = (
+        pathlib.Path(__file__).resolve().parents[2]
+        / "fighthealthinsurance"
+        / "templates"
+        / "scrub.html"
+    ).read_text()
+    assert 'id="ocr_failed"' in tpl
+
+
+def test_failure_message_clears_once_the_text_arrives():
+    """However the text turns up -- a later file that read fine, or the user
+    pasting it -- a stale "we couldn't read your file" is just noise."""
+    src = _form_source()
+    for fn in ("noteOcrFailure", "clearOcrFailure", "denialTextLength"):
+        assert f"export function {fn}" in src, fn
+    validate = _js_function(src, "export function validateScrubForm")
+    assert 'rehideHiddenMessage("ocr_failed")' in validate, validate
+
+
+def test_the_need_denial_message_stays_short():
+    """It is the message a blocked user reads. It had grown to four
+    sentences of editorial about insurers, which buries the one thing they
+    have to do."""
+    tpl = (
+        pathlib.Path(__file__).resolve().parents[2]
+        / "fighthealthinsurance"
+        / "templates"
+        / "scrub.html"
+    ).read_text()
+    block = tpl[tpl.index('id="need_denial"') :]
+    block = block[: block.index("</div>")]
+    words = len(re.sub(r"<[^>]+>", " ", block).split())
+    assert words < 45, f"need_denial is {words} words:\n{block}"
+
+
+def test_the_denial_file_is_never_posted_to_the_server():
+    """The whole OCR design keeps the denial document in the browser:
+    BaseDenialForm has no file field and nothing on /process reads one. But
+    the uploader sits INSIDE the /process form, and a file input with a name
+    is included in the multipart body regardless of whether Django binds it
+    -- so every attached denial was uploaded and buffered for nothing. The
+    input must stay nameless, and the copy promises exactly that."""
+    tpl = (
+        pathlib.Path(__file__).resolve().parents[2]
+        / "fighthealthinsurance"
+        / "templates"
+        / "scrub.html"
+    ).read_text()
+    tag = re.search(r"<input[^>]*id=\"uploader\"[^>]*>", tpl)
+    assert tag, "uploader input not found"
+    assert "name=" not in tag.group(0), tag.group(0)
+    # No other named file input may sneak into the same form either.
+    for other in re.findall(r"<input[^>]*type=\"file\"[^>]*>", tpl):
+        assert "name=" not in other, other

--- a/tests/async-unit/test_scrub_form_submit_gate.py
+++ b/tests/async-unit/test_scrub_form_submit_gate.py
@@ -174,14 +174,15 @@ def test_one_unreadable_page_does_not_abandon_the_rest():
 def test_producing_no_text_counts_as_a_failure_too():
     """Engines can return cleanly and still yield nothing for a photo too
     blurry to read. To the user that is identical to a crash: an empty box.
-    The check must compare the text before and after, not only catch."""
+    Catching is therefore not enough -- what OCR produced has to be counted."""
     fn = _js_function((JS / "scrub.ts").read_text(), "const recognizeEvent")
-    assert "denialTextLength()" in fn, fn
-    # Compared against what was there before the batch, so "the engines ran"
-    # is never mistaken for "the engines produced something".
-    assert re.search(r"denialTextLength\(\)\s*[=><!]+\s*before", fn), fn
-    # ...and having gained nothing is what triggers the report.
-    assert re.search(r"!gainedText|gainedText\s*===\s*false", fn), fn
+    # Counted from what OCR actually handed back, NOT by measuring the
+    # textarea: measuring counts the user's own typing, so someone typing
+    # while a doomed batch ran looked like OCR had produced something.
+    assert "ocrChars" in fn, fn
+    assert re.search(r"producedText\s*=\s*ocrChars\s*>\s*0", fn), fn
+    assert re.search(r"!producedText", fn), fn
+    assert "denialTextLength" not in fn, fn
 
 
 def test_failure_message_element_exists():
@@ -200,7 +201,7 @@ def test_failure_message_clears_once_the_text_arrives():
     """However the text turns up -- a later file that read fine, or the user
     pasting it -- a stale "we couldn't read your file" is just noise."""
     src = _form_source()
-    for fn in ("noteOcrFailure", "clearOcrFailure", "denialTextLength"):
+    for fn in ("noteOcrFailure", "notePartialOcrFailure", "clearOcrFailure"):
         assert f"export function {fn}" in src, fn
     validate = _js_function(src, "export function validateScrubForm")
     assert 'rehideHiddenMessage("ocr_failed")' in validate, validate
@@ -264,7 +265,7 @@ def test_partial_and_total_failure_are_different_messages():
     src = (JS / "scrub.ts").read_text()
     fn = _js_function(src, "const recognizeEvent")
     assert "notePartialOcrFailure()" in fn, fn
-    assert "gainedText" in fn, fn
+    assert "producedText" in fn, fn
     form = _form_source()
     for name in ("noteOcrFailure", "notePartialOcrFailure", "clearOcrFailure"):
         assert f"export function {name}" in form, name
@@ -293,3 +294,35 @@ def test_partial_failure_message_element_exists():
         / "scrub.html"
     ).read_text()
     assert 'id="ocr_partial"' in tpl
+
+
+def test_a_superseded_batch_cannot_append_its_text():
+    """Guarding only the verdict is not enough. recognize() invokes its
+    callback after async OCR work, so passing addText straight through let a
+    superseded batch write the OLD document's text into denial_text long
+    after the user picked different files, with nothing on screen explaining
+    where it came from (CodeRabbit, PR 988)."""
+    fn = _js_function((JS / "scrub.ts").read_text(), "const recognizeEvent")
+    # The raw appender must not be handed to recognize().
+    assert not re.search(r"recognize\(\s*file\s*,\s*addText\s*\)", fn), fn
+    assert re.search(r"recognize\(\s*file\s*,\s*addTextForThisSelection\s*\)", fn), fn
+    # ...and that wrapper drops writes once it is no longer the current pick.
+    wrapper = fn[fn.index("addTextForThisSelection = ") :]
+    wrapper = wrapper[: wrapper.index("beginOcr()")]
+    assert "selection !== latestOcrSelection" in wrapper, wrapper
+    assert wrapper.index("selection !== latestOcrSelection") < wrapper.index(
+        "addText(text)"
+    ), wrapper
+
+
+def test_ocr_output_is_counted_separately_from_user_typing():
+    """Measuring the textarea before and after counts the USER's keystrokes.
+    Someone typing while a doomed batch ran therefore looked like OCR had
+    produced something: it reported PARTIAL failure -- wrong -- and re-posted
+    a message their typing had just cleared (CodeRabbit, PR 988)."""
+    fn = _js_function((JS / "scrub.ts").read_text(), "const recognizeEvent")
+    # Counting happens where OCR hands text over, not by reading the DOM.
+    assert re.search(r"ocrChars\s*\+=", fn), fn
+    assert "denialTextLength" not in fn, fn
+    # And nothing reads the textarea to decide the verdict.
+    assert not re.search(r"denial_text[^\n]*\.value", fn), fn

--- a/tests/async-unit/test_scrub_form_submit_gate.py
+++ b/tests/async-unit/test_scrub_form_submit_gate.py
@@ -177,7 +177,11 @@ def test_producing_no_text_counts_as_a_failure_too():
     The check must compare the text before and after, not only catch."""
     fn = _js_function((JS / "scrub.ts").read_text(), "const recognizeEvent")
     assert "denialTextLength()" in fn, fn
-    assert re.search(r"denialTextLength\(\)\s*===\s*before", fn), fn
+    # Compared against what was there before the batch, so "the engines ran"
+    # is never mistaken for "the engines produced something".
+    assert re.search(r"denialTextLength\(\)\s*[=><!]+\s*before", fn), fn
+    # ...and having gained nothing is what triggers the report.
+    assert re.search(r"!gainedText|gainedText\s*===\s*false", fn), fn
 
 
 def test_failure_message_element_exists():
@@ -237,3 +241,55 @@ def test_the_denial_file_is_never_posted_to_the_server():
     # No other named file input may sneak into the same form either.
     for other in re.findall(r"<input[^>]*type=\"file\"[^>]*>", tpl):
         assert "name=" not in other, other
+
+
+def test_a_superseded_selection_does_not_post_a_verdict():
+    """Reading is slow enough that a user can pick again mid-run. Without a
+    selection sequence a slow FAILING batch finishing after a newer
+    successful one re-posts "we couldn't read your file" over text that had
+    just arrived (CodeRabbit and Codex both, PR 988)."""
+    src = (JS / "scrub.ts").read_text()
+    assert "latestOcrSelection" in src, src
+    fn = _js_function(src, "const recognizeEvent")
+    assert "++latestOcrSelection" in fn, fn
+    # The guard must sit BEFORE the reporting, or it guards nothing.
+    guard = fn.index("selection !== latestOcrSelection")
+    assert guard < fn.index("noteOcrFailure()"), fn
+
+
+def test_partial_and_total_failure_are_different_messages():
+    """One page failing while another succeeded is not "we couldn't read your
+    file, the box is still empty" -- that is false with their text directly
+    beneath it."""
+    src = (JS / "scrub.ts").read_text()
+    fn = _js_function(src, "const recognizeEvent")
+    assert "notePartialOcrFailure()" in fn, fn
+    assert "gainedText" in fn, fn
+    form = _form_source()
+    for name in ("noteOcrFailure", "notePartialOcrFailure", "clearOcrFailure"):
+        assert f"export function {name}" in form, name
+    # The two states are mutually exclusive on screen.
+    note_total = _js_function(form, "export function noteOcrFailure")
+    note_partial = _js_function(form, "export function notePartialOcrFailure")
+    assert 'rehideHiddenMessage("ocr_partial")' in note_total, note_total
+    assert 'rehideHiddenMessage("ocr_failed")' in note_partial, note_partial
+
+
+def test_typing_clears_the_failure_message():
+    """hideErrorMessages runs on every keystroke in denial_text and cleared
+    need_denial but not ocr_failed, so "the box below is still empty" stayed
+    on screen while the user typed into that very box. The submit gate does
+    not help: it only re-evaluates on submit."""
+    hide = _js_function(_form_source(), "export function hideErrorMessages")
+    assert 'rehideHiddenMessage("ocr_failed")' in hide, hide
+    assert 'rehideHiddenMessage("ocr_partial")' in hide, hide
+
+
+def test_partial_failure_message_element_exists():
+    tpl = (
+        pathlib.Path(__file__).resolve().parents[2]
+        / "fighthealthinsurance"
+        / "templates"
+        / "scrub.html"
+    ).read_text()
+    assert 'id="ocr_partial"' in tpl


### PR DESCRIPTION
A user reported being told to type their denial while a file was attached, under copy that says a file is enough. Three separate causes.

The read failing was silent. recognizeEvent wrapped its recognize() loop in try/finally with no catch, so when every OCR engine failed the textarea just stayed empty and the submit gate showed "we need your denial" with no hint that we had tried to read the file and could not. There is now an #ocr_failed message saying so, and pointing at the box.

Failing is not the only way to produce nothing. A photo too blurry to read returns cleanly with no text, which to the user is identical to a crash, so "no new text" counts as a failure too.

One unreadable page abandoned the rest. The uploader is multiple="true" and people attach a denial one page per image; the catch was outside the loop, so the first bad page silently dropped every page after it. It now catches per file and reports how the batch as a whole went.

Separately, and the reason this is worth doing carefully: the denial document was being uploaded. The uploader sits inside the /process form and carried name="uploader", and a named file input is included in the multipart body whether or not Django binds it. BaseDenialForm has no file field and nothing on that path ever read one, so every attached denial was transferred and buffered server-side for no purpose -- the exact document this browser-side OCR design exists to keep on the user's machine. The input is now nameless; the OCR binds by getElementById so nothing else changes. Found by adversarial review, not by me: I had written copy promising the file is never sent while it still was.

The #need_denial wall of text is cut to the two facts a blocked user needs.

Tests assert the failure is reported, the catch is inside the loop, an empty result counts as failure, the message element exists, and no file input in that form carries a name. Each was checked to fail with its fix reverted. Whole async-unit suite: 51 failures on this branch and 51 on main, the same 51.


Claude-Session: https://claude.ai/code/session_019SPqa4FZ43ahAjoD53Uj81

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OCR processing continues when an individual page cannot be read.
  * Users are notified when OCR fails, produces no text, or only partially succeeds.
  * Outdated OCR results and failure messages no longer override newer selections.
  * Failure messages clear when usable denial text is entered or typed.
  * OCR failure status now reflects extracted text separately from manually entered text.

* **Privacy**
  * Uploaded denial documents are no longer included in form submissions.

* **Validation**
  * Updated guidance clarifies when denial text is required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->