### PR TITLE
Temporal panel: drop the ORDER BY the visibility store cannot run

### DIFF
--- a/fighthealthinsurance/staff_views.py
+++ b/fighthealthinsurance/staff_views.py
@@ -83,6 +83,11 @@ from fighthealthinsurance.proconnector import (
 from fighthealthinsurance.type_utils import User
 from fighthealthinsurance.utils import mask_email_for_logging
 
+# Sort key standing in for a workflow row whose start time is missing, so such
+# a row lands last instead of raising. Timezone-aware because everything it is
+# compared against (the Temporal SDK's timestamps) is.
+_UNDATED = datetime.datetime.min.replace(tzinfo=datetime.timezone.utc)
+
 
 class AdminDeleteDataView(generic.FormView):
     """Staff view to delete all data for a user by email address.
@@ -148,6 +153,14 @@ class AdminStatusView(generic.TemplateView):
     """
 
     template_name = "admin_status.html"
+
+    # How many recent SendFaxWorkflow runs the Temporal panel lists.
+    _RECENT_WORKFLOW_LIMIT = 10
+    # Candidates pulled before sorting. Wider than the limit because the store
+    # cannot order by start time for us (see _temporal_status), so a run that
+    # started recently may sit well down the store's own ordering. Bounded so a
+    # busy namespace cannot turn a status page into a full scan.
+    _RECENT_WORKFLOW_SCAN = 100
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
@@ -354,6 +367,43 @@ class AdminStatusView(generic.TemplateView):
             return {"error": str(e)}
 
     @staticmethod
+    def _temporal_error_message(exc: Exception) -> str:
+        """One operator-readable sentence for a Temporal failure.
+
+        The strings the frontend hands back name a symptom and nothing else
+        ("invalid query: operation is not supported: 'ORDER BY' clause"), which
+        on a status page reads as an outage even when the cluster is perfectly
+        healthy. The failures we can explain get a hint that says whose problem
+        it is; anything else falls back to the exception type plus its text, so
+        an unrecognised error is still attributable and never renders blank.
+        """
+        detail = str(exc).strip()
+        lowered = detail.lower()
+        if isinstance(exc, TimeoutError):
+            return (
+                "Temporal did not answer within the status page's 8s budget: "
+                "the frontend is unreachable or overloaded. Fax dispatch may "
+                "be affected -- check the temporal-frontend pods."
+            )
+        if "order by" in lowered:
+            return (
+                "Temporal rejected the status page's visibility query: this "
+                "cluster keeps visibility in Postgres, and only an "
+                "Elasticsearch-backed cluster accepts an ORDER BY clause. That "
+                "is a bug in this page, not a fax outage -- the counts above "
+                f"are still live. Detail: {detail}"
+            )
+        if "invalid query" in lowered or "is not supported" in lowered:
+            return (
+                "Temporal rejected the status page's visibility query -- a bug "
+                "in this page rather than a fax outage. "
+                f"Detail: {detail}"
+            )
+        if not detail:
+            return f"{type(exc).__name__} (no detail)"
+        return f"{type(exc).__name__}: {detail}"
+
+    @staticmethod
     def _temporal_status() -> Dict[str, Any]:
         """Temporal fax orchestration: connectivity, recent SendFaxWorkflow runs.
 
@@ -378,6 +428,7 @@ class AdminStatusView(generic.TemplateView):
             "task_queue": getattr(settings, "TEMPORAL_TASK_QUEUE", None),
             "counts": {},
             "recent": [],
+            "recent_error": None,
         }
         if not enabled:
             return out
@@ -409,28 +460,60 @@ class AdminStatusView(generic.TemplateView):
                         f"{scope} AND ExecutionStatus='{status}'"
                     )
                     counts[status] = int(result.count)
+                limit = AdminStatusView._RECENT_WORKFLOW_LIMIT
+                scan = AdminStatusView._RECENT_WORKFLOW_SCAN
                 recent: List[Dict[str, Any]] = []
-                async for wf in client.list_workflows(
-                    "WorkflowType='SendFaxWorkflow' ORDER BY StartTime DESC",
-                    page_size=10,
-                ):
-                    duration = None
-                    if wf.start_time and wf.close_time:
-                        duration = round(
-                            (wf.close_time - wf.start_time).total_seconds()
+                recent_error: Optional[str] = None
+                try:
+                    # Deliberately no ORDER BY. Visibility here is the Postgres
+                    # store (k8s/temporal/values.yaml -- no Elasticsearch), and
+                    # a SQL visibility store rejects the entire query with
+                    # "operation is not supported: 'ORDER BY' clause".
+                    #
+                    # Which means the store's own order is not the one this
+                    # panel wants. Temporal's default is
+                    # "ClosedTime DESC NULL FIRST, StartTime DESC", so taking
+                    # the first ten and sorting THOSE lets an old workflow that
+                    # closed recently push out a genuinely recent one, and the
+                    # panel quietly shows the wrong ten. Scan a wider bounded
+                    # candidate set, then sort and slice locally.
+                    async for wf in client.list_workflows(
+                        "WorkflowType='SendFaxWorkflow'",
+                        page_size=scan,
+                    ):
+                        duration = None
+                        if wf.start_time and wf.close_time:
+                            duration = round(
+                                (wf.close_time - wf.start_time).total_seconds()
+                            )
+                        recent.append(
+                            {
+                                "id": wf.id,
+                                "status": wf.status.name if wf.status else "UNKNOWN",
+                                "started": wf.start_time,
+                                "closed": wf.close_time,
+                                "duration_s": duration,
+                            }
                         )
-                    recent.append(
-                        {
-                            "id": wf.id,
-                            "status": wf.status.name if wf.status else "UNKNOWN",
-                            "started": wf.start_time,
-                            "closed": wf.close_time,
-                            "duration_s": duration,
-                        }
+                        if len(recent) >= scan:
+                            break
+                except Exception as e:
+                    # The counts are the numbers on-call actually pages on, so
+                    # a listing that blows up costs the table, not the panel.
+                    logger.opt(exception=True).warning(
+                        "Temporal recent-workflow listing failed"
                     )
-                    if len(recent) >= 10:
-                        break
-                return {"counts": counts, "recent": recent}
+                    recent_error = AdminStatusView._temporal_error_message(e)
+                # Sort the whole candidate set, THEN take the ten. Slicing
+                # before sorting is what let the store's ordering decide which
+                # runs the panel could even consider.
+                recent.sort(key=lambda row: row["started"] or _UNDATED, reverse=True)
+                recent = recent[:limit]
+                return {
+                    "counts": counts,
+                    "recent": recent,
+                    "recent_error": recent_error,
+                }
 
             async def bounded() -> Dict[str, Any]:
                 return await asyncio.wait_for(gather(), timeout=8.0)
@@ -438,10 +521,11 @@ class AdminStatusView(generic.TemplateView):
             data = async_to_sync(bounded)()
             out["counts"] = data["counts"]
             out["recent"] = data["recent"]
+            out["recent_error"] = data["recent_error"]
         except Exception as e:
             logger.opt(exception=True).warning("Temporal status check failed")
             out["ok"] = False
-            out["error"] = str(e)
+            out["error"] = AdminStatusView._temporal_error_message(e)
         return out
 
     @staticmethod

--- a/fighthealthinsurance/staff_views.py
+++ b/fighthealthinsurance/staff_views.py
@@ -477,8 +477,23 @@ class AdminStatusView(generic.TemplateView):
                     # closed recently push out a genuinely recent one, and the
                     # panel quietly shows the wrong ten. Scan a wider bounded
                     # candidate set, then sort and slice locally.
+                    #
+                    # `base` and not a bare type filter: it carries the same
+                    # seven-day window the counts use. Without it the scan is
+                    # over ALL history, and since we can neither order in the
+                    # query nor scan without a bound, a namespace with more
+                    # than `scan` old runs would fill the candidate set with
+                    # them and crowd out the recent ones -- the bounded scan
+                    # would then reintroduce the very defect it was added to
+                    # fix, and the panel and its own counts would disagree.
+                    #
+                    # It follows the TERMINAL counts, not the Running one:
+                    # Running is deliberately unscoped above because a live
+                    # run matters however old it is, but this is a "recent
+                    # runs" table. A fax still open after seven days is
+                    # reported by the Running count rather than listed here.
                     async for wf in client.list_workflows(
-                        "WorkflowType='SendFaxWorkflow'",
+                        base,
                         page_size=scan,
                     ):
                         duration = None

--- a/fighthealthinsurance/templates/admin_status.html
+++ b/fighthealthinsurance/templates/admin_status.html
@@ -224,6 +224,12 @@
           <div class="label">Timed out / terminated (last 7 days)</div>
         </div>
       </div>
+      {% if temporal.recent_error %}
+      <p class="summary-line">
+        <span class="badge bad">RECENT RUNS UNAVAILABLE</span>
+        <span class="error-text">{{ temporal.recent_error }}</span>
+      </p>
+      {% else %}
       <table class="status">
         <thead>
           <tr><th>Workflow</th><th>Status</th><th>Started</th><th>Duration</th></tr>
@@ -245,6 +251,7 @@
         {% endfor %}
         </tbody>
       </table>
+      {% endif %}
       <p class="summary-line">
         <span class="pill">Full event histories: the Temporal Web UI is cluster-internal by design.</span>
         <code>kubectl -n totallylegitco port-forward svc/temporal-web 8080:8080</code> then <code>http://localhost:8080</code>

--- a/tests/sync/test_admin_status.py
+++ b/tests/sync/test_admin_status.py
@@ -216,39 +216,99 @@ class _FakeStatus:
 
 
 class _FakeWorkflow:
-    id = "send-fax-test-1234"
-    status = _FakeStatus()
-    start_time = timezone.now() - datetime.timedelta(seconds=42)
-    close_time = timezone.now()
+    def __init__(self, id="send-fax-test-1234", started_seconds_ago=42, closed=True):
+        self.id = id
+        self.status = _FakeStatus()
+        self.start_time = timezone.now() - datetime.timedelta(
+            seconds=started_seconds_ago
+        )
+        self.close_time = timezone.now() if closed else None
 
 
 class _FakeTemporalClient:
     """Stands in for a temporalio Client: two completed runs, one listed.
 
-    Records every visibility query so tests can check their shape.
+    Records every visibility query so tests can check their shape. Subclasses
+    vary only what the listing does; the counts behave the same everywhere.
     """
+
+    #: Runs the visibility store yields, in the order it yields them.
+    listed: tuple = (_FakeWorkflow(),)
 
     def __init__(self):
         self.queries: list = []
+        self.list_queries: list = []
 
     async def count_workflows(self, query):
         self.queries.append(query)
         return _FakeCount(2 if "Completed" in query else 0)
 
+    def _listing(self):
+        return self.listed
+
     def list_workflows(self, query, page_size=10):
+        self.list_queries.append(query)
+
         async def gen():
-            yield _FakeWorkflow()
+            for wf in self._listing():
+                yield wf
 
         return gen()
+
+
+class _UnorderedTemporalClient(_FakeTemporalClient):
+    """A visibility store that hands its runs back oldest-first."""
+
+    listed = (
+        _FakeWorkflow(id="send-fax-oldest", started_seconds_ago=900),
+        _FakeWorkflow(id="send-fax-newest", started_seconds_ago=30),
+        _FakeWorkflow(id="send-fax-middle", started_seconds_ago=300),
+    )
+
+
+class _StoreOrderTemporalClient(_FakeTemporalClient):
+    """A visibility store ordering the way Temporal actually does.
+
+    Temporal's default is "ClosedTime DESC NULL FIRST, StartTime DESC" and the
+    SQL store will not accept an ORDER BY, so old runs that merely CLOSED
+    recently come back ahead of a genuinely recent one. Enough of them to fill
+    the panel, then the newest run last.
+    """
+
+    listed = tuple(
+        [
+            _FakeWorkflow(id=f"send-fax-old-{i}", started_seconds_ago=900 + i)
+            for i in range(10)
+        ]
+        + [_FakeWorkflow(id="send-fax-newest", started_seconds_ago=5)]
+    )
+
+
+class _RejectingListTemporalClient(_FakeTemporalClient):
+    """Counts fine, refuses the listing the way SQL visibility refuses a
+    clause it does not implement."""
+
+    def _listing(self):
+        raise RuntimeError(
+            "invalid query: operation is not supported: 'ORDER BY' clause"
+        )
 
 
 _FAKE_CLIENTS: list = []  # every fake handed to the view, newest last
 
 
-async def _fake_get_client():
-    client = _FakeTemporalClient()
-    _FAKE_CLIENTS.append(client)
-    return client
+def _client_factory(cls):
+    """A ``get_temporal_client`` stand-in that hands out *cls* instances."""
+
+    async def _get_client(*args, **kwargs):
+        client = cls()
+        _FAKE_CLIENTS.append(client)
+        return client
+
+    return _get_client
+
+
+_fake_get_client = _client_factory(_FakeTemporalClient)
 
 
 async def _broken_get_client():
@@ -309,6 +369,54 @@ class AdminStatusTemporalTest(TestCase):
         self.assertTrue(completed and all("StartTime" in q for q in completed))
         self.assertContains(response, "CONNECTED")
         self.assertContains(response, "send-fax-test-1234")
+
+    @override_settings(TEMPORAL_ENABLED=True)
+    @mock.patch(_TEMPORAL_CLIENT, new=_fake_get_client)
+    def test_recent_runs_query_carries_no_order_by_clause(self):
+        # Visibility on this cluster is SQL (Postgres, no Elasticsearch), and
+        # only Elasticsearch-backed visibility accepts ORDER BY -- a listing
+        # query carrying one is rejected outright with
+        # "operation is not supported: 'ORDER BY' clause".
+        self._get()
+        listed = _FAKE_CLIENTS[0].list_queries
+        self.assertEqual(len(listed), 1)
+        self.assertNotIn("ORDER BY", listed[0].upper())
+
+    @override_settings(TEMPORAL_ENABLED=True)
+    @mock.patch(_TEMPORAL_CLIENT, new=_client_factory(_UnorderedTemporalClient))
+    def test_recent_runs_are_sorted_most_recent_first(self):
+        # Ordering is the panel's own guarantee now that the store cannot be
+        # asked for it, so a store yielding oldest-first still renders newest
+        # at the top.
+        response = self._get()
+        ids = [row["id"] for row in response.context["temporal"]["recent"]]
+        self.assertEqual(ids, ["send-fax-newest", "send-fax-middle", "send-fax-oldest"])
+
+    @override_settings(TEMPORAL_ENABLED=True)
+    @mock.patch(_TEMPORAL_CLIENT, new=_client_factory(_RejectingListTemporalClient))
+    def test_rejected_listing_keeps_the_counts_and_explains_itself(self):
+        # A refused listing costs the table, not the whole panel: the counts
+        # are what on-call pages on.
+        response = self._get()
+        t = response.context["temporal"]
+        self.assertTrue(t["ok"])
+        self.assertIsNone(t["error"])
+        self.assertEqual(t["counts"]["Completed"], 2)
+        self.assertEqual(t["recent"], [])
+        self.assertContains(response, "CONNECTED")
+        self.assertContains(response, "RECENT RUNS UNAVAILABLE")
+
+    @override_settings(TEMPORAL_ENABLED=True)
+    @mock.patch(_TEMPORAL_CLIENT, new=_client_factory(_RejectingListTemporalClient))
+    def test_rejected_listing_message_is_not_the_raw_grpc_string(self):
+        # The raw text names a symptom and nothing else; an operator needs to
+        # be told whose problem it is.
+        response = self._get()
+        message = response.context["temporal"]["recent_error"]
+        self.assertIn("Elasticsearch", message)
+        self.assertNotEqual(
+            message, "invalid query: operation is not supported: 'ORDER BY' clause"
+        )
 
 
 class AdminStatusStorageTest(TestCase):
@@ -576,3 +684,32 @@ class SonicCheckHealthTest(TestCase):
         mock_get.return_value = _members_response(text="Please Member Login")
         with self.assertRaisesRegex(Exception, "not authenticated"):
             SonicFax().check_health()
+
+
+class AdminStatusTemporalOrderingTest(AdminStatusTemporalTest):
+    """The panel's ordering must be its own, not the visibility store's."""
+
+    @override_settings(TEMPORAL_ENABLED=True)
+    @mock.patch(_TEMPORAL_CLIENT, new=_client_factory(_StoreOrderTemporalClient))
+    def test_a_recently_closed_old_run_cannot_displace_a_recent_one(self):
+        """Taking the first ten in the STORE's order and sorting only those
+        lets an old workflow that merely closed recently push a genuinely
+        recent run off the list. The panel then shows the wrong ten and looks
+        entirely correct doing it."""
+        from fighthealthinsurance.staff_views import AdminStatusView
+
+        response = self._get()
+        rows = response.context["temporal"]["recent"]
+        self.assertEqual(len(rows), AdminStatusView._RECENT_WORKFLOW_LIMIT)
+        self.assertEqual(rows[0]["id"], "send-fax-newest", [r["id"] for r in rows])
+
+    def test_the_candidate_scan_is_wider_than_the_panel_but_bounded(self):
+        """It has to look past the store's ordering to sort honestly, without
+        turning a status page into a full scan of a busy namespace."""
+        from fighthealthinsurance.staff_views import AdminStatusView
+
+        self.assertGreater(
+            AdminStatusView._RECENT_WORKFLOW_SCAN,
+            AdminStatusView._RECENT_WORKFLOW_LIMIT,
+        )
+        self.assertLessEqual(AdminStatusView._RECENT_WORKFLOW_SCAN, 500)

--- a/tests/sync/test_admin_status.py
+++ b/tests/sync/test_admin_status.py
@@ -713,3 +713,48 @@ class AdminStatusTemporalOrderingTest(AdminStatusTemporalTest):
             AdminStatusView._RECENT_WORKFLOW_LIMIT,
         )
         self.assertLessEqual(AdminStatusView._RECENT_WORKFLOW_SCAN, 500)
+
+
+class AdminStatusTemporalScopeTest(AdminStatusTemporalTest):
+    """The listing must carry the same window as the counts beside it."""
+
+    @override_settings(TEMPORAL_ENABLED=True)
+    @mock.patch(_TEMPORAL_CLIENT, new=_client_factory(_FakeTemporalClient))
+    def test_the_listing_is_scoped_to_the_same_seven_days_as_the_counts(self):
+        """Dropping ORDER BY meant rebuilding the query, and the time scope
+        went with it. Unscoped, the bounded candidate scan runs over ALL
+        history: a namespace with more old runs than the scan limit fills the
+        candidates with them and crowds out the recent ones, so the bounded
+        scan would reintroduce exactly the defect it was added to fix -- and
+        the table would disagree with the counts printed above it."""
+        self._get()
+        client = _FAKE_CLIENTS[-1]
+        assert client.list_queries, "no visibility listing was issued"
+        listed = client.list_queries[-1]
+        assert "StartTime >" in listed, listed
+        # ...and still no ORDER BY, which is what started all this.
+        assert "ORDER BY" not in listed.upper(), listed
+
+    @override_settings(TEMPORAL_ENABLED=True)
+    @mock.patch(_TEMPORAL_CLIENT, new=_client_factory(_FakeTemporalClient))
+    def test_the_listing_shares_the_window_of_the_terminal_counts(self):
+        """The counts are deliberately NOT uniform: Running is a live state
+        and is counted unscoped, while the terminal states are bounded to
+        seven days. The listing belongs with the terminal ones -- it is a
+        "recent runs" table, and a run still open after seven days is
+        reported by the Running count rather than dropped."""
+        self._get()
+        client = _FAKE_CLIENTS[-1]
+        listed = client.list_queries[-1]
+        terminal = [
+            q for q in client.queries if "ExecutionStatus" in q and "Running" not in q
+        ]
+        assert terminal, client.queries
+        for q in terminal:
+            assert q.startswith(listed), (q, listed)
+        # ...and Running really is exempt, so this is a documented asymmetry
+        # rather than one query that got missed.
+        running = [q for q in client.queries if "Running" in q]
+        assert running, client.queries
+        for q in running:
+            assert "StartTime >" not in q, q


### PR DESCRIPTION
The fax workflows panel rendered "ERROR invalid query: operation is not supported: 'ORDER BY' clause" and showed nothing. It sent "WorkflowType='SendFaxWorkflow' ORDER BY StartTime DESC", and every SQL-backed visibility store rejects ORDER BY -- only Elasticsearch implements it.

Worth naming the trap: this cluster runs Postgres visibility, which k8s/temporal/README.md calls "advanced visibility ... no Elasticsearch needed". That is true for custom search attributes and NOT for ordering, so the README reads like a licence to write this query.

The counts were fine all along -- comparison filters on StartTime are supported -- but one try wrapped the whole panel, so a rejected listing took the numbers down with it. The listing now has its own boundary: a refused query costs the table, not the stat cards on-call actually page on. And the message is translated rather than dumped, because "invalid query" reads like a fax outage when it is a page bug; it now says so, and says the counts above are still live.

Ordering is the panel's own guarantee now. Sorting is done here, with a timezone-aware sentinel so a run with no start time sorts last instead of raising on a None comparison. That sort happens across a WIDER candidate set than the ten displayed: Temporal's default order is "ClosedTime DESC NULL FIRST, StartTime DESC", so taking ten and sorting those let an old workflow that merely closed recently push a genuinely recent run off the list -- the panel would show the wrong ten and look right doing it. The scan is bounded so a busy namespace cannot turn a status page into a full table scan.

Six tests, including one that fills the panel with old-but-recently-closed runs and requires the newest to survive; it fails if the slice happens before the sort.

tox -e py313-django52-sync -k test_admin_status: 35 passed. py313-mypy clean.


Claude-Session: https://claude.ai/code/session_019SPqa4FZ43ahAjoD53Uj81

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the staff status page’s recent workflow listing to display runs in the correct most-recent-first order.
  - Prevented older runs from displacing genuinely recent activity.
  - Recent workflow data failures no longer prevent workflow counts and other status information from loading.

- **User Experience**
  - Added a clear “Recent Runs Unavailable” message when recent workflow details cannot be retrieved.
  - Error messages are now presented in operator-friendly language instead of displaying raw service errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->