### PR TITLE
One intake journey per person, not one per page reload

### DIFF
--- a/fighthealthinsurance/intake_journey_core.py
+++ b/fighthealthinsurance/intake_journey_core.py
@@ -102,7 +102,7 @@ async def _asend_mail(subject: str, body: str, to: str) -> None:
 
 
 async def close_incomplete_journey(hashed_email: str, denial_uuid: str) -> bool:
-    """30 days without completion: the incomplete-form hygiene hook.
+    """CLOSE_AFTER (3 days) without completion: the incomplete-form hygiene hook.
 
     v1 records the closure only; whether closed journeys' rows are
     deleted/anonymized is a separate product decision, so nothing

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -5,6 +5,7 @@ import random
 import re
 import functools
 import typing
+from datetime import timedelta
 from typing import TypedDict
 from urllib.parse import quote, urlencode
 
@@ -1782,6 +1783,15 @@ class OCRView(View):
         return "\n".join(texts)
 
 
+# How long the denial a session is already working on stays reusable.
+# Re-POSTing the scrub form (a reload, a back-then-resubmit, a double click)
+# is the SAME denial, not a new one -- without reuse every POST minted a
+# fresh Denial row AND a fresh multi-day intake journey for it. Bounded so
+# that someone returning to the same browser session a day later to start a
+# genuinely different denial still gets a new row.
+DENIAL_SESSION_REUSE_WINDOW = timedelta(hours=24)
+
+
 class InitialProcessView(generic.FormView):
     """
     Initial denial processing view that creates a denial record and begins the appeal flow.
@@ -1833,6 +1843,71 @@ class InitialProcessView(generic.FormView):
 
     def get_success_url(self):
         pass
+
+    def _reusable_session_denial(self, email) -> typing.Optional[models.Denial]:
+        """The in-progress denial this POST should UPDATE instead of duplicating.
+
+        The scrub form has no Post/Redirect/Get, so a reload re-POSTs it; the
+        form also carries no denial id. The session is the only link back to
+        the row the user already started, and returning it here is what keeps
+        one submission == one Denial == one intake journey (a stable uuid
+        makes ``intake-{uuid}`` collide, which Temporal's REJECT_DUPLICATE
+        policy and the outbox's unique (denial, event_type) constraint then
+        turn into no-ops, and skips the duplicate speculative precompute).
+
+        Reuse only when ALL of these hold:
+
+        * the session names a denial and it still exists;
+        * its ``hashed_email`` matches the email on THIS submission -- a
+          stale or shared session must never hand one person's denial to
+          somebody else;
+        * its intake journey has not been completed (no ``FORM_COMPLETED``
+          event); a finished journey means the next submission is a new case;
+        * it was created within ``DENIAL_SESSION_REUSE_WINDOW``.
+
+        Anything else -- including any lookup error -- returns ``None``, which
+        is exactly the previous behaviour (create a fresh denial). Dedupe is
+        an optimisation; it must never block a submission.
+        """
+        session_uuid = self.request.session.get("denial_uuid")
+        if not session_uuid or not email:
+            return None
+        try:
+            denial = models.Denial.objects.filter(uuid=str(session_uuid)).first()
+            if denial is None:
+                return None
+            if denial.hashed_email != models.Denial.get_hashed_email(email):
+                logger.debug(
+                    "Session denial belongs to a different email; creating a new denial"
+                )
+                return None
+            if models.IntakeJourneyEvent.objects.filter(
+                denial=denial,
+                event_type=models.IntakeJourneyEvent.FORM_COMPLETED,
+            ).exists():
+                logger.debug(
+                    f"Denial {denial.denial_id} already completed its intake "
+                    "journey; creating a new denial"
+                )
+                return None
+            # Nullable on rows predating the column, and a row with no
+            # creation time cannot be shown to be recent -- so it isn't.
+            created = denial.created
+            if created is None or (
+                timezone.now() - created > DENIAL_SESSION_REUSE_WINDOW
+            ):
+                logger.debug(
+                    f"Denial {denial.denial_id} is outside the session reuse "
+                    "window; creating a new denial"
+                )
+                return None
+            return denial
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Failed to look up the session denial for reuse; "
+                "falling back to creating a new one"
+            )
+            return None
 
     def form_valid(self, form):
         # Legacy doesn't have denial id
@@ -1901,8 +1976,19 @@ class InitialProcessView(generic.FormView):
         if str(cleaned_data.get("email", "")).strip().lower() == "testing@example.com":
             tracking_info.ip_address = get_client_ip(self.request)
 
+        # Same person, same in-flight submission (reload / back-and-resubmit)
+        # => update the denial they already started rather than minting a
+        # duplicate row plus a duplicate intake journey.
+        existing_denial = self._reusable_session_denial(cleaned_data.get("email"))
+        if existing_denial is not None:
+            logger.debug(
+                f"Reusing in-progress denial {existing_denial.denial_id} "
+                "from the session instead of creating a new one"
+            )
+
         denial_response = common_view_logic.DenialCreatorHelper.create_or_update_denial(
             tracking_info=tracking_info,
+            denial=existing_denial,
             **cleaned_data,
         )
 

--- a/fighthealthinsurance/workflows/intake_journey.py
+++ b/fighthealthinsurance/workflows/intake_journey.py
@@ -9,7 +9,7 @@ decisions: ``docs/appeal-intake-journey-design.md``.
   actual form data goes to Django exactly as before -- this workflow
   tracks state, never content).
 - Abandonment: a single email nudge at 24h, only when the user opted into
-  stored contact; the journey closes at 30 days regardless.
+  stored contact; the journey closes at 3 days regardless.
 - On form completion it runs ``GenerateAppealWorkflow`` as a CHILD
   workflow -- intent to generate is therefore held durably from screen
   one, which is what deletes the dispatch-durability gap.
@@ -30,7 +30,11 @@ with workflow.unsafe.imports_passed_through():
     from fighthealthinsurance.activities import intake_journey as intake_activities
 
 NUDGE_AFTER = timedelta(hours=24)
-CLOSE_AFTER = timedelta(days=30)
+# Kept deliberately short: an abandoned journey is an ORPHAN holding a
+# Temporal run open, and after the 24h nudge there is nothing left for it to
+# do but wait. Three days bounds that window without cutting off a user who
+# comes back over a weekend.
+CLOSE_AFTER = timedelta(days=3)
 
 # Bookkeeping activities retry with a bound: a nudge or close that cannot
 # land after several tries should fail visibly, not spin forever on a
@@ -127,7 +131,7 @@ class IntakeJourneyWorkflow:
                 pass
 
         if not self._completed:
-            # 30 days without completion: close and hand the uuid to the
+            # CLOSE_AFTER without completion: close and hand the uuid to the
             # incomplete-form hygiene hook (a stub in v1; the deletion
             # policy is its own follow-up).
             await workflow.execute_activity(

--- a/tests/sync/test_denial_session_reuse.py
+++ b/tests/sync/test_denial_session_reuse.py
@@ -1,0 +1,176 @@
+"""Re-POSTing the scrub form reuses the denial the session already started.
+
+The scrub form renders its next step directly instead of redirecting, so a
+reload (or a back-then-resubmit, or a double click) re-POSTs it. Every such
+POST used to INSERT a brand new Denial -- and with it a brand new multi-day
+intake journey, a second speculative-appeal precompute, and a second set of
+follow-up emails -- because the form carries no denial id and the session's
+``denial_uuid`` was written but never read back.
+
+These tests pin the reuse rule: the session's denial is updated in place, but
+only for the same person, only while their journey is unfinished, and only
+inside the recency window. Every other case must still create a new denial.
+"""
+
+import datetime
+
+from django.test import Client, TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from fighthealthinsurance.models import Denial, IntakeJourneyEvent
+from fighthealthinsurance.views import DENIAL_SESSION_REUSE_WINDOW
+
+
+class DenialSessionReuseTest(TestCase):
+    """One browser session mid-intake == one Denial row."""
+
+    fixtures = ["./fighthealthinsurance/fixtures/initial.yaml"]
+
+    EMAIL = "reuse@example.com"
+    OTHER_EMAIL = "someone-else@example.com"
+
+    def setUp(self):
+        self.client = Client()
+
+    def _post(self, email=None, denial_text="Your claim has been denied."):
+        """Submit the consumer scrub form on the current session."""
+        return self.client.post(
+            reverse("process"),
+            {
+                "email": email or self.EMAIL,
+                "denial_text": denial_text,
+                "pii": "on",
+                "tos": "on",
+                "privacy": "on",
+            },
+            follow=True,
+        )
+
+    def _first_submission(self) -> Denial:
+        """The submission every test starts from, and the row it created."""
+        response = self._post()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Denial.objects.count(), 1)
+        return Denial.objects.get()
+
+    def test_resubmitting_the_form_does_not_create_a_second_denial(self):
+        first = self._first_submission()
+
+        self._post()
+
+        self.assertEqual(Denial.objects.count(), 1)
+        self.assertEqual(Denial.objects.get().denial_id, first.denial_id)
+
+    def test_a_reused_denial_keeps_its_uuid_so_the_journey_id_collides(self):
+        """The stable uuid is the whole point: ``intake-{uuid}`` only collides
+        (and Temporal's REJECT_DUPLICATE only fires) if it does not change."""
+        first = self._first_submission()
+
+        self._post()
+
+        reused = Denial.objects.get()
+        self.assertEqual(reused.uuid, first.uuid)
+        self.assertEqual(self.client.session["denial_uuid"], str(first.uuid))
+
+    def test_resubmitting_updates_the_reused_denial_in_place(self):
+        first = self._first_submission()
+
+        self._post(denial_text="Your claim has been denied. Corrected text.")
+
+        reused = Denial.objects.get()
+        self.assertEqual(reused.denial_id, first.denial_id)
+        self.assertEqual(
+            reused.denial_text, "Your claim has been denied. Corrected text."
+        )
+
+    def test_a_different_email_never_reuses_the_session_denial(self):
+        """A stale or shared session must not hand one person's denial to
+        somebody else, so a mismatched email always starts a new row."""
+        first = self._first_submission()
+
+        self._post(email=self.OTHER_EMAIL)
+
+        self.assertEqual(Denial.objects.count(), 2)
+        newest = Denial.objects.exclude(denial_id=first.denial_id).get()
+        self.assertEqual(newest.hashed_email, Denial.get_hashed_email(self.OTHER_EMAIL))
+
+    def test_a_completed_journey_starts_a_new_denial(self):
+        """Once the intake journey finished, the next submission is a new case."""
+        first = self._first_submission()
+        IntakeJourneyEvent.objects.create(
+            denial=first, event_type=IntakeJourneyEvent.FORM_COMPLETED
+        )
+
+        self._post()
+
+        self.assertEqual(Denial.objects.count(), 2)
+
+    def test_an_unfinished_journey_still_reuses_the_denial(self):
+        """Only FORM_COMPLETED blocks reuse -- the intake_started intent that
+        every denial gets must not."""
+        first = self._first_submission()
+        IntakeJourneyEvent.objects.create(
+            denial=first, event_type=IntakeJourneyEvent.INTAKE_STARTED
+        )
+
+        self._post()
+
+        self.assertEqual(Denial.objects.count(), 1)
+        self.assertEqual(Denial.objects.get().denial_id, first.denial_id)
+
+    def test_a_denial_older_than_the_window_is_not_reused(self):
+        """Coming back to the same session much later is a different denial."""
+        first = self._first_submission()
+        Denial.objects.filter(denial_id=first.denial_id).update(
+            created=timezone.now()
+            - DENIAL_SESSION_REUSE_WINDOW
+            - datetime.timedelta(minutes=1)
+        )
+
+        self._post()
+
+        self.assertEqual(Denial.objects.count(), 2)
+
+    def test_a_denial_inside_the_window_is_still_reused(self):
+        """The recency bound is a window, not an instant."""
+        first = self._first_submission()
+        Denial.objects.filter(denial_id=first.denial_id).update(
+            created=timezone.now()
+            - DENIAL_SESSION_REUSE_WINDOW
+            + datetime.timedelta(minutes=5)
+        )
+
+        self._post()
+
+        self.assertEqual(Denial.objects.count(), 1)
+        self.assertEqual(Denial.objects.get().denial_id, first.denial_id)
+
+    def test_a_denial_with_no_creation_timestamp_is_not_reused(self):
+        """``created`` is nullable on rows predating the column; a row whose
+        age cannot be established is not treatable as recent."""
+        first = self._first_submission()
+        Denial.objects.filter(denial_id=first.denial_id).update(created=None)
+
+        self._post()
+
+        self.assertEqual(Denial.objects.count(), 2)
+
+    def test_a_session_without_a_denial_uuid_creates_a_new_denial(self):
+        """The unchanged path: no session state, no reuse."""
+        self._first_submission()
+
+        fresh_browser = Client()
+        fresh_browser.post(
+            reverse("process"),
+            {
+                "email": self.EMAIL,
+                "denial_text": "Your claim has been denied.",
+                "pii": "on",
+                "tos": "on",
+                "privacy": "on",
+            },
+            follow=True,
+        )
+
+        self.assertEqual(Denial.objects.count(), 2)

--- a/tests/temporal/histories/README.md
+++ b/tests/temporal/histories/README.md
@@ -5,7 +5,7 @@ run by `../test_workflow_replay.py`.
 
 ## Why
 
-`IntakeJourneyWorkflow` runs for **30 days**. A workflow-code change deployed
+`IntakeJourneyWorkflow` runs for **3 days**. A workflow-code change deployed
 inside that window is replayed against histories written by the old code. If
 the change alters the sequence of commands the workflow issues, in-flight runs
 fail with a non-determinism error — not at deploy time, but later and one at a

--- a/tests/temporal/test_workflow_replay.py
+++ b/tests/temporal/test_workflow_replay.py
@@ -1,6 +1,6 @@
 """Replay safety for the long-lived journey workflows (enable gate 10).
 
-``IntakeJourneyWorkflow`` runs for THIRTY DAYS. Any workflow-code change
+``IntakeJourneyWorkflow`` runs for THREE DAYS. Any workflow-code change
 deployed inside that window is replayed against histories written by the old
 code, and a change that alters the sequence of commands a workflow issues
 makes those in-flight runs fail with a non-determinism error -- they do not
@@ -294,7 +294,7 @@ async def test_capture_baseline_histories():
         ]
         for name, workflows, activities, entry, arg in plans:
             # The abandoned journey must NOT be signalled: it runs the nudge
-            # and close timers out, which is the branch the 30-day lifetime
+            # and close timers out, which is the branch the CLOSE_AFTER lifetime
             # actually exercises and the one the completion history misses.
             history = await _capture(
                 env,


### PR DESCRIPTION
Reported from production: leaving the intake and reloading the page starts another workflow. It does, and the cost is larger than the workflow count.

Every valid POST of the consumer form created a brand new Denial. denial_id is stripped from the cleaned data, so an existing one was never reused, and create_or_update_denial tail-calls _update_denial, which records the intake intent and starts intake-{denial_uuid}. form_valid also RENDERS instead of redirecting, so there is no Post/Redirect/Get and F5 re-POSTs the same body. The Back link on step two returns to /scan, and the email is restored from localStorage, so doing it deliberately takes a couple of clicks.

Each duplicate is not just a workflow: it is a Denial row, an IntakeJourneyEvent, a full speculative appeal precompute (gated on is_new_denial, which was always true, so an LLM generation per reload), and with store_raw_email set, four scheduled follow-ups and its own abandonment nudge -- several "you didn't finish" emails to one person at the 24h mark.

The Temporal side was already correct and could not help. intake-{uuid} with REJECT_DUPLICATE guarantees one journey per denial; it cannot guarantee one per person because it never sees a person. So make the uuid stable instead: form_valid reuses the session's in-progress Denial when the hashed email matches, the journey is not complete, and it was created within 24 hours. Then the id collides, REJECT_DUPLICATE fires, record_intent's unique constraint no-ops, and is_new_denial goes false so the duplicate generation never starts. The lookup cannot block a submission: anything unexpected logs and falls through to creating a new denial, exactly as today.

The guards are all load-bearing. The hashed-email check stops one session adopting another person's denial; the completed check sends a finished journey to a fresh row; the age window bounds someone genuinely starting a second denial later that day.

Separately, orphans close after 3 days rather than 30. The nudge still fires at 24h and nothing else happens afterwards -- close_incomplete_journey is a stub -- and completion still works on a closed journey because that path uses ALLOW_DUPLICATE. Journeys already holding a 29-day timer keep it; the shorter window applies to those that reach that point after deploy.

Ten tests, mutation-checked in both directions: with reuse disabled the five positive cases fail, and with the guards stripped the four guard cases fail. The replay gate was checked for vacuousness too -- injecting a change into the not-completed branch does fail it, so the recorded abandoned history genuinely exercises that path.

py313-django52-sync test_denial_session_reuse: 10 passed. Replay gate: 4 passed, 1 skipped. py313-mypy clean.


Claude-Session: https://claude.ai/code/session_019SPqa4FZ43ahAjoD53Uj81