### PR TITLE
Put the polling actors back when the Ray head takes them down

### DIFF
--- a/fighthealthinsurance/management/commands/reconcile_polling_actors.py
+++ b/fighthealthinsurance/management/commands/reconcile_polling_actors.py
@@ -1,0 +1,115 @@
+"""Put back any polling actor that has gone missing.
+
+The polling actors are created once per deploy, by the ``web-actor-launch``
+Job, and they are ``lifetime="detached"`` so they outlive the pod that made
+them. What nothing covered is them DYING: the Ray head going away takes every
+actor with it, and since the launcher only runs at deploy time there is
+nothing to notice or to put them back. Production sat with 0 of 5 alive after
+a node reboot until someone happened to read the status page -- email polling,
+chooser refill and three refresh loops all silently stopped, and a deploy was
+the only thing that would have fixed it.
+
+This is the missing half: cheap, idempotent, and safe to run on a schedule.
+It relaunches only what is actually absent, so a healthy cluster costs one
+health check and nothing else.
+
+Exit codes: 0 when every actor is alive at the end (including when nothing
+needed doing), 1 when any is still missing, so a CronJob failure means
+"could not restore" rather than "checked".
+"""
+
+from typing import Any
+
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = "Relaunch any polling actor that is missing (idempotent)."
+
+    def add_arguments(self, parser: Any) -> None:
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report what is missing without relaunching anything.",
+        )
+
+    def handle(self, *args: str, **options: Any) -> None:
+        import sys
+
+        from fighthealthinsurance.actor_health_status import (
+            check_actor_health,
+            relaunch_actors,
+        )
+        from fighthealthinsurance.base_actor_ref import ray_cluster_available
+
+        dry_run: bool = options.get("dry_run", False)
+
+        # Gate before touching Ray at all. Ray auto-initializes on first use
+        # and that is NOT a no-op: with no cluster configured it starts a
+        # brand-new local one inside this process, which would then report
+        # every actor missing, "restore" them into a cluster that dies with
+        # the pod, and report success. Answering "no cluster" is the honest
+        # outcome, and it is a failure because a scheduled reconcile that
+        # cannot see the cluster has not done its job.
+        if not ray_cluster_available():
+            self.stdout.write(
+                self.style.ERROR(
+                    "No Ray cluster reachable; not reconciling. "
+                    "(Set RAY_ADDRESS to the cluster, or run this where it is reachable.)"
+                )
+            )
+            sys.exit(1)
+
+        before = check_actor_health()
+        missing = [d for d in before.get("details", []) if not d.get("alive")]
+        total = before.get("total_actors", 0)
+
+        if not missing:
+            self.stdout.write(
+                self.style.SUCCESS(f"All {total} polling actors alive; nothing to do.")
+            )
+            return
+
+        names = ", ".join(sorted(d.get("name", "?") for d in missing))
+        self.stdout.write(f"Missing {len(missing)} of {total}: {names}")
+
+        if dry_run:
+            self.stdout.write("--dry-run: not relaunching.")
+            sys.exit(1)
+
+        # force=False is the whole point: it attaches to actors that are alive
+        # and only creates the ones that are not, so a partial outage is
+        # repaired without disturbing the survivors. A force relaunch here
+        # would kill healthy actors mid-work on every scheduled run.
+        results = relaunch_actors(force=False)
+        for actor_name in sorted(results):
+            result = results[actor_name]
+            status = result.get("status")
+            if status in ("launched", "exists", "alive"):
+                self.stdout.write(self.style.SUCCESS(f"  {actor_name}: {status}"))
+            else:
+                self.stdout.write(
+                    self.style.ERROR(
+                        f"  {actor_name}: {status} - {result.get('error', 'unknown error')}"
+                    )
+                )
+
+        # Report on what is true afterwards, not on what relaunch_actors
+        # claimed: an actor can be created and still fail to come up.
+        after = check_actor_health()
+        still_missing = [d for d in after.get("details", []) if not d.get("alive")]
+        alive = after.get("alive_actors", 0)
+        total_after = after.get("total_actors", 0)
+
+        if still_missing:
+            names = ", ".join(sorted(d.get("name", "?") for d in still_missing))
+            self.stdout.write(
+                self.style.ERROR(
+                    f"Still missing after relaunch ({alive}/{total_after} alive): {names}"
+                )
+            )
+            sys.exit(1)
+
+        self.stdout.write(
+            self.style.SUCCESS(f"Restored; {alive}/{total_after} polling actors alive.")
+        )

--- a/k8s/actor-reconcile-alerts.yaml
+++ b/k8s/actor-reconcile-alerts.yaml
@@ -1,0 +1,54 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  # The reconciler exists because losing the polling actors was SILENT: Ray
+  # itself stayed healthy, the web app stayed healthy, and email polling plus
+  # three refresh loops simply stopped. A reconciler that cannot do its job is
+  # the same silence again, so it needs its own alert.
+  #
+  # Deliberately about the CRONJOB, not about actor count: the app cannot
+  # report on actors it has no cluster to ask, which is precisely the outage.
+  # kube-state-metrics can see the CronJob from outside.
+  name: fhi-actor-reconcile-alerts
+  namespace: totallylegitco
+  labels:
+    app: fight-health-insurance-prod
+spec:
+  groups:
+    - name: fhi-actor-reconcile
+      rules:
+        - alert: FHIActorReconcileNotSucceeding
+          # Two arms, and the second is the one that matters. kube-state-metrics
+          # emits NO last_successful_time series at all for a CronJob that has
+          # never succeeded, so `time() - <absent>` is an empty vector and a
+          # single-armed expression cannot fire for a reconciler that has been
+          # broken since the day it shipped. That exact hole kept the intake
+          # outbox relay silent for six hours (PR 986).
+          #
+          # `and on()` is required: absent() yields only the labels named in its
+          # matcher while kube_cronjob_created carries namespace/job/instance, so
+          # a bare `and` matches no label set and is silently empty. The
+          # created-guard stops the arm firing where the CronJob does not exist.
+          expr: >-
+            (time() - kube_cronjob_status_last_successful_time{cronjob="fhi-actor-reconcile",namespace="totallylegitco"} > 1800)
+            or
+            ((absent(kube_cronjob_status_last_successful_time{cronjob="fhi-actor-reconcile",namespace="totallylegitco"}) == 1)
+             and on()
+             ((time() - kube_cronjob_created{cronjob="fhi-actor-reconcile",namespace="totallylegitco"}) > 1800))
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Ray polling-actor reconciler has not succeeded in 30+ minutes"
+            description: >-
+              The reconciler runs every five minutes and exits non-zero when a
+              polling actor is missing and could not be restored, or when no Ray
+              cluster is reachable. Sustained failure means the actors are down
+              and staying down: email polling and the IMR/UCR/PA refresh loops
+              are not running. Read the success time explicitly -- the default
+              `kubectl get cronjob` columns show LAST SCHEDULE, which keeps
+              advancing even while every run fails:
+                kubectl -n totallylegitco get cronjob fhi-actor-reconcile \
+                  -o jsonpath='{.status.lastSuccessfulTime}'
+              Then check the most recent Job pod's logs, and /timbit/help/status
+              for the live actor count.

--- a/k8s/actor-reconcile-cronjob.yaml
+++ b/k8s/actor-reconcile-cronjob.yaml
@@ -1,0 +1,78 @@
+# =============================================================================
+# Ray polling-actor reconciler.
+#
+# The polling actors (email polling, chooser refill, IMR/UCR/PA refresh) are
+# created ONCE per deploy by the web-actor-launch Job in k8s/deploy.yaml, which
+# has ttlSecondsAfterFinished: 10 and never runs again. They are detached, so
+# they survive the pod that made them -- but not the Ray head. When the head
+# goes away, every actor goes with it, and nothing notices or puts them back.
+#
+# That happened: a node reboot took the Ray head, Ray itself recovered fine,
+# and the actors stayed dead. The status page read 0/5 and stayed that way
+# until someone read it. Email polling and three refresh loops were simply not
+# running, and only a deploy would have fixed it.
+#
+# So: check every five minutes, relaunch only what is missing. The command is
+# idempotent and attaches to healthy actors rather than restarting them, so a
+# healthy cluster costs one health check and nothing else.
+# =============================================================================
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: fhi-actor-reconcile
+  namespace: totallylegitco
+spec:
+  schedule: "*/5 * * * *"
+  # Never overlap two reconcilers: two pods creating the same detached actor
+  # at once is exactly the race the get-or-create is not designed to win.
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 120
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      # No retry: the schedule IS the retry, five minutes later. A backoff
+      # loop here would stack attempts against a cluster that is still down.
+      backoffLimit: 0
+      activeDeadlineSeconds: 300
+      ttlSecondsAfterFinished: 600
+      template:
+        metadata:
+          labels:
+            group: fight-health-insurance-prod-webbackend-batch
+        spec:
+          containers:
+            - image: ${FHI_BASE}:${FHI_VERSION}
+              name: totallylegitco
+              # start-server.sh runs the reconcile command when this is set.
+              env:
+                - name: RECONCILE_POLLING_ACTORS
+                  value: "1"
+                - name: PDBHOST
+                  valueFrom:
+                    configMapKeyRef:
+                      name: fhi-db-config
+                      key: PDBHOST
+              envFrom:
+                - secretRef:
+                    name: fight-health-insurance-secret
+                - secretRef:
+                    name: fight-health-insurance-primary-secret
+              imagePullPolicy: Always
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+                seccompProfile:
+                  type: RuntimeDefault
+              # Same Django/ML import footprint every pod on this image pays;
+              # see k8s/temporal/intake-outbox-cronjob.yaml, which was OOMKilled
+              # on every run for being sized below it.
+              resources:
+                requests:
+                  cpu: "100m"
+                  memory: 1536Mi
+                limits:
+                  cpu: "500m"
+                  memory: 3Gi
+          restartPolicy: Never

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -386,6 +386,21 @@ if crd_present prometheusrules.monitoring.coreos.com; then
 else
     echo "WARNING: no PrometheusRule CRD in this cluster -- intake outbox alerts not installed"
 fi
+# Ray polling-actor reconciler: a CronJob (every five minutes, no overlap)
+# that relaunches any polling actor that has gone missing. The actors are
+# created ONCE, by the web-actor-launch Job below, and are detached -- so they
+# survive their creating pod but NOT the Ray head. A node reboot left
+# production at 0 of 5 alive with nothing to restore them until the next
+# deploy. Idempotent: it attaches to healthy actors and creates only the
+# absent ones.
+envsubst < k8s/actor-reconcile-cronjob.yaml | kubectl apply -f -
+# ...and an alert, because a reconciler that cannot restore them is exactly
+# the state that previously went unnoticed for hours.
+if crd_present prometheusrules.monitoring.coreos.com; then
+    kubectl apply -f k8s/actor-reconcile-alerts.yaml
+else
+    echo "WARNING: no PrometheusRule CRD in this cluster -- actor reconcile alerts not installed"
+fi
 
 # ROLLOUT GATE. Independent of the backfill: a Deployment that never finishes
 # rolling is a broken deploy whether or not we are about to fingerprint

--- a/scripts/start-server.sh
+++ b/scripts/start-server.sh
@@ -49,6 +49,13 @@ elif [ -n "$BACKFILL_APPEAL_FINGERPRINTS" ]; then
   # while pre-fingerprint writers are still active, so the Job's backoff
   # retries until the database is quiescent.
   exec python manage.py backfill_appeal_fingerprints --strict
+elif [ -n "$RECONCILE_POLLING_ACTORS" ]; then
+  # Actor reconciler (k8s/actor-reconcile-cronjob.yaml). The polling actors
+  # are detached and created ONCE, by the POLLING_ACTORS job above, so losing
+  # the Ray head loses all of them with nothing to put them back until the
+  # next deploy -- production ran 0 of 5 after a node reboot. This relaunches
+  # only what is missing; a healthy cluster costs one health check.
+  exec python manage.py reconcile_polling_actors
 elif [ -n "$DELIVER_INTAKE_EVENTS" ]; then
   # Intake outbox relay (k8s/temporal/intake-outbox-cronjob.yaml, every
   # minute): re-deliver intake-journey events whose Temporal ack never

--- a/tests/async-unit/test_actor_reconcile.py
+++ b/tests/async-unit/test_actor_reconcile.py
@@ -1,0 +1,130 @@
+"""Guards for the Ray polling-actor reconciler.
+
+The polling actors are created once per deploy and are detached, so they
+survive the pod that made them but not the Ray head. When a node reboot took
+the head, Ray recovered and the actors did not: production ran 0 of 5 alive,
+with email polling and three refresh loops silently stopped, until someone
+read the status page. Only a deploy would have restored them.
+"""
+
+import pathlib
+import re
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+COMMAND = (
+    REPO
+    / "fighthealthinsurance"
+    / "management"
+    / "commands"
+    / "reconcile_polling_actors.py"
+)
+CRONJOB = REPO / "k8s" / "actor-reconcile-cronjob.yaml"
+ALERTS = REPO / "k8s" / "actor-reconcile-alerts.yaml"
+ENTRYPOINT = REPO / "scripts" / "start-server.sh"
+BUILD = REPO / "scripts" / "build.sh"
+
+
+class TestReconcileCommand:
+    def test_it_refuses_to_run_without_a_real_cluster(self):
+        """Ray auto-initializes on first use and that is NOT a no-op: with no
+        cluster configured it starts a brand-new LOCAL one in this process.
+        The reconciler would then find every actor missing, "restore" them
+        into a cluster that dies with the pod, and report success -- worse
+        than doing nothing, because it would look fixed."""
+        src = COMMAND.read_text()
+        assert "ray_cluster_available()" in src, src
+        # The gate has to come before anything that touches Ray.
+        assert src.index("ray_cluster_available()") < src.index(
+            "check_actor_health()"
+        ), src
+        # ...and it is a failure, not a quiet success.
+        gate = src[src.index("ray_cluster_available()") :]
+        assert "sys.exit(1)" in gate[: gate.index("before = ")], gate
+
+    def test_it_only_relaunches_what_is_missing(self):
+        """A force relaunch on a schedule would kill healthy actors mid-work
+        every five minutes."""
+        src = COMMAND.read_text()
+        assert "relaunch_actors(force=False)" in src, src
+        assert "force=True" not in src, src
+
+    def test_a_healthy_cluster_costs_one_health_check(self):
+        """It runs every five minutes forever; doing work when nothing is
+        wrong is how a reconciler becomes the problem."""
+        src = COMMAND.read_text()
+        # Returns before relaunching when nothing is missing.
+        assert re.search(r"if not missing:.*?return", src, re.S), src
+        assert src.index("if not missing:") < src.index("relaunch_actors("), src
+
+    def test_success_is_measured_after_the_relaunch(self):
+        """An actor can be created and still fail to come up, so the exit code
+        must reflect a fresh health check rather than what relaunch claimed."""
+        src = COMMAND.read_text()
+        assert src.count("check_actor_health()") >= 2, src
+        assert "still_missing" in src, src
+        # Non-zero when any actor is still absent, so a CronJob failure means
+        # "could not restore" and the alert is real.
+        tail = src[src.index("still_missing") :]
+        assert "sys.exit(1)" in tail, tail
+
+
+class TestReconcileSchedule:
+    def test_runs_are_never_overlapped(self):
+        """Two pods creating the same detached actor at once is exactly the
+        race get-or-create cannot win."""
+        text = CRONJOB.read_text()
+        assert "concurrencyPolicy: Forbid" in text, text
+
+    def test_it_does_not_retry_into_a_cluster_that_is_still_down(self):
+        """The schedule is the retry. A backoff loop would stack attempts."""
+        text = CRONJOB.read_text()
+        assert "backoffLimit: 0" in text, text
+        assert "activeDeadlineSeconds:" in text, text
+
+    def test_it_is_sized_for_the_image_it_runs(self):
+        """The intake outbox relay was OOMKilled on every run for months
+        because it was sized below this image's Django/ML import footprint."""
+        text = CRONJOB.read_text()
+        assert "memory: 1536Mi" in text, text
+        assert "memory: 3Gi" in text, text
+
+    def test_the_entrypoint_dispatches_it(self):
+        text = ENTRYPOINT.read_text()
+        assert "RECONCILE_POLLING_ACTORS" in text, text
+        assert "python manage.py reconcile_polling_actors" in text, text
+
+    def test_the_deploy_applies_it(self):
+        text = BUILD.read_text()
+        assert "k8s/actor-reconcile-cronjob.yaml" in text, text
+        assert "k8s/actor-reconcile-alerts.yaml" in text, text
+
+
+class TestReconcileAlert:
+    def test_it_can_fire_for_a_reconciler_broken_from_birth(self):
+        """kube-state-metrics emits NO last_successful_time series for a
+        CronJob that has never succeeded, so a single-armed expression is an
+        empty vector and cannot fire for the one case that matters. That exact
+        hole kept the intake outbox relay silent for six hours."""
+        text = ALERTS.read_text()
+        assert "absent(kube_cronjob_status_last_successful_time" in text, text
+        assert "kube_cronjob_created" in text, text
+
+    def test_the_arm_is_joined_with_on(self):
+        """absent() yields only the labels in its matcher while
+        kube_cronjob_created carries namespace/job/instance, so a bare `and`
+        matches no label set and is silently empty."""
+        text = ALERTS.read_text()
+        assert "and on()" in text, text
+
+    def test_both_selectors_pin_the_namespace(self):
+        """Otherwise absent() can be satisfied by a same-named CronJob
+        elsewhere in the cluster."""
+        text = ALERTS.read_text()
+        assert text.count('namespace="totallylegitco"') >= 3, text
+
+    def test_the_runbook_does_not_point_at_last_schedule(self):
+        """`kubectl get cronjob` shows LAST SCHEDULE, which keeps advancing
+        every five minutes even while every single run fails -- it reads
+        healthy during exactly this failure."""
+        text = ALERTS.read_text()
+        assert ".status.lastSuccessfulTime" in text, text

--- a/tests/async-unit/test_appeal_journey_core.py
+++ b/tests/async-unit/test_appeal_journey_core.py
@@ -277,8 +277,9 @@ class TestFingerprintCompleteness(_JourneyTestBase):
         ProposedAppeal.objects.create(for_denial=denial, appeal_text=text)
         with _pytest.raises(IntegrityError):
             ProposedAppeal.objects.create(
-                for_denial=denial, appeal_text="  dear   reviewer, THE same "
-                "letter twice must be one row."
+                for_denial=denial,
+                appeal_text="  dear   reviewer, THE same "
+                "letter twice must be one row.",
             )
 
     def test_backfill_fingerprints_skips_duplicates_and_fills_the_rest(self):
@@ -359,9 +360,7 @@ class TestFingerprintCompleteness(_JourneyTestBase):
         assert keeper.pk != dup.pk
 
     @patch("fighthealthinsurance.common_view_logic.appealGenerator")
-    def test_live_draft_matching_unserved_reserve_promotes_the_reserve(
-        self, mock_gen
-    ):
+    def test_live_draft_matching_unserved_reserve_promotes_the_reserve(self, mock_gen):
         """A fast live generation can produce the same letter a speculative
         reserve already holds. The insert conflicts on the fingerprint; the
         reuse path must atomically PROMOTE the reserve row, or the streamed
@@ -460,9 +459,7 @@ class TestFingerprintCompleteness(_JourneyTestBase):
 
         async def collect():
             frames = []
-            async for chunk in AppealsBackendHelper.generate_appeals_for_denial(
-                denial
-            ):
+            async for chunk in AppealsBackendHelper.generate_appeals_for_denial(denial):
                 if appeal_journey_core._appeal_text_from_chunk(chunk) is None:
                     continue
                 data = _json.loads(chunk)
@@ -550,9 +547,7 @@ class TestFingerprintCompleteness(_JourneyTestBase):
 
         async def collect():
             frames = []
-            async for chunk in AppealsBackendHelper.generate_appeals_for_denial(
-                denial
-            ):
+            async for chunk in AppealsBackendHelper.generate_appeals_for_denial(denial):
                 if appeal_journey_core._appeal_text_from_chunk(chunk) is None:
                     continue
                 data = _json.loads(chunk)
@@ -908,7 +903,7 @@ def test_deployment_presence_check_distinguishes_notfound_from_an_api_error():
                 "set -e\n"
                 "KGET=(kubectl -n totallylegitco)\n"
                 + fn
-                + '\nif deployment_present web; then echo PRESENT; else echo ABSENT; fi\n'
+                + "\nif deployment_present web; then echo PRESENT; else echo ABSENT; fi\n"
             )
             return subprocess.run(
                 ["bash", "-c", script],
@@ -922,7 +917,7 @@ def test_deployment_presence_check_distinguishes_notfound_from_an_api_error():
     assert found.returncode == 0 and "PRESENT" in found.stdout
 
     missing = run_against(
-        'echo \'Error from server (NotFound): deployments.apps "web" not found\' >&2; exit 1'
+        "echo 'Error from server (NotFound): deployments.apps \"web\" not found' >&2; exit 1"
     )
     assert missing.returncode == 0 and "ABSENT" in missing.stdout
 
@@ -1004,8 +999,11 @@ def test_ray_gate_requires_the_pre_delete_pods_to_be_gone():
     assert "ray_old_pods_remaining" in build
     # The old delete masked every failure -- 403, timeout, API error -- as an
     # absent cluster.
-    assert 'delete raycluster -n totallylegitco raycluster-kuberay --ignore-not-found' in build
-    assert 'raycluster-kuberay || echo' not in build
+    assert (
+        "delete raycluster -n totallylegitco raycluster-kuberay --ignore-not-found"
+        in build
+    )
+    assert "raycluster-kuberay || echo" not in build
 
 
 def test_ray_terminating_check_does_not_discard_kubectls_exit_status():
@@ -1015,7 +1013,7 @@ def test_ray_terminating_check_does_not_discard_kubectls_exit_status():
     build = _build_script()
     code = [ln for ln in build.splitlines() if not ln.lstrip().startswith("#")]
     assert not any(
-        'terminating_pods' in ln and '-n "$(' in ln for ln in code
+        "terminating_pods" in ln and '-n "$(' in ln for ln in code
     ), "a terminating_pods read is still inside a bare test substitution"
     assert 'if ! ray_terminating="$(terminating_pods' in build
     at = build.index('if ! ray_terminating="$(terminating_pods')
@@ -1054,7 +1052,11 @@ def test_ray_readiness_counts_pods_against_the_size_the_cluster_should_reach():
             shim.chmod(0o755)
             env = {**os.environ, "PATH": f"{tmp}:{os.environ['PATH']}"}
             r = subprocess.run(
-                ["bash", "-c", "set -e\nKGET=(kubectl)\n" + fns + "\nray_expected_pods\n"],
+                [
+                    "bash",
+                    "-c",
+                    "set -e\nKGET=(kubectl)\n" + fns + "\nray_expected_pods\n",
+                ],
                 capture_output=True,
                 text=True,
                 env=env,
@@ -1112,10 +1114,18 @@ def test_crd_probes_do_not_read_an_api_error_as_a_missing_operator():
     apply ordering exists to close (external review)."""
     build = _build_script()
     code = [ln for ln in build.splitlines() if not ln.lstrip().startswith("#")]
-    assert not any("get crd" in ln and "2>&1; then" in ln for ln in code), (
-        "a CRD probe is still swallowing errors"
-    )
-    assert build.count("if crd_present ") == 4
+    assert not any(
+        "get crd" in ln and "2>&1; then" in ln for ln in code
+    ), "a CRD probe is still swallowing errors"
+    # A tripwire, not a fact about the number 5: adding a CRD-gated apply
+    # should make someone confirm the new one uses crd_present rather than
+    # hand-rolling a probe that swallows errors. Bumped when the Ray
+    # actor-reconcile alerts were added.
+    assert build.count("if crd_present ") == 5
+    # The real invariant: every CRD-gated apply goes through the helper, so
+    # the count above and the number of guarded blocks agree.
+    guarded = build.count("no PrometheusRule CRD") + build.count("no PodMonitor CRD")
+    assert guarded == build.count("if crd_present "), build
     fn = _extract_shell_function(build, "crd_present")
     assert "not found" in fn and "exit 1" in fn
 


### PR DESCRIPTION
The polling actors are created once, by the web-actor-launch Job, which has ttlSecondsAfterFinished: 10 and never runs again. They are detached, so they outlive the pod that made them -- but not the Ray head. Nothing covered them dying.

That is not hypothetical. A node reboot took the head; Ray itself recovered cleanly, the RayCluster went back to ready, and the actors stayed dead. Production ran 0 of 5: email polling and the IMR, UCR and PA refresh loops simply stopped, silently, and the only thing that would have restored them was a deploy. It was found by reading the status page.

So: a CronJob every five minutes that relaunches only what is missing. force=False is load-bearing -- a force relaunch on a schedule would kill healthy actors mid-work every five minutes. A healthy cluster costs one health check and returns.

The command refuses to run without a real cluster, and that refusal is the subtle part. Ray auto-initializes on first use and it is not a no-op: with no cluster configured it starts a brand-new LOCAL one inside the calling process. A reconciler that did not gate would find every actor missing, "restore" them into a cluster that dies with the pod, and exit 0 -- worse than doing nothing, because the alert would go quiet while nothing was running. It exits non-zero instead, and success is measured by a SECOND health check rather than by what relaunch reported, since an actor can be created and still fail to come up.

The alert is about the CronJob rather than the actor count, because the app cannot report on actors when it has no cluster to ask -- which is precisely the outage. It carries the absent() arm too: kube-state-metrics emits no last_successful_time series for a CronJob that has never succeeded, so a single-armed expression cannot fire for a reconciler broken since the day it shipped. That exact hole kept the intake outbox relay silent for six hours in
986. Its runbook says to read .status.lastSuccessfulTime explicitly, because LAST SCHEDULE keeps advancing every five minutes while every run fails.

Sized to 1536Mi/3Gi like the rest of this image, since the intake relay spent months being OOMKilled on every run for being sized below the import footprint.

13 tests. One existing assertion counted CRD-gated applies in build.sh as a tripwire; it is bumped, and now also checks that the count and the number of guarded blocks agree, so the number cannot drift from the thing it guards.

Suite via tox -e py313-django52-async-unit: 1868 passed, 0 failed. Manifests pass kubectl apply --dry-run=server. py313-mypy clean.


Claude-Session: https://claude.ai/code/session_019SPqa4FZ43ahAjoD53Uj81