### PR TITLE
Fix/pdf worker mime

### DIFF
--- a/fighthealthinsurance/static/js/shared.ts
+++ b/fighthealthinsurance/static/js/shared.ts
@@ -131,8 +131,10 @@ const storeTextareaLocal = async function (event: Event) {
 // and OCR in production. tests/async-unit/test_worker_assets.py pins this.
 const workers_path = "/static/js/dist/workers/";
 
-// pdf.js
-pdfjsLib.GlobalWorkerOptions.workerSrc = workers_path + "pdf.worker.min.mjs";
+// pdf.js. The worker is published under a .js name (see webpack.config.js):
+// nginx serves .mjs as application/octet-stream, which no browser will run as
+// a module worker, and that broke every PDF upload in production.
+pdfjsLib.GlobalWorkerOptions.workerSrc = workers_path + "pdf.worker.min.js";
 
 /**
  * Get CSRF token from cookies for Django requests.

--- a/fighthealthinsurance/static/js/webpack.config.js
+++ b/fighthealthinsurance/static/js/webpack.config.js
@@ -11,7 +11,15 @@ const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 // which ships with the bundles. Nothing at runtime may reference a
 // node_modules URL; tests/async-unit/test_worker_assets.py pins that.
 const workerAssets = [
-  { from: 'node_modules/pdfjs-dist/build/pdf.worker.min.mjs', to: 'workers/pdf.worker.min.mjs' },
+  // Published as .js on purpose. nginx in the web image (Debian bookworm's
+  // mime.types) has no entry for .mjs, so the worker went out as
+  // application/octet-stream, and browsers refuse to run a module worker or
+  // dynamic import() without a JavaScript MIME type. pdf.js then fell back to
+  // its "fake worker", which does the same import and failed the same way, so
+  // every PDF a user attached on /scan was unreadable ("Setting up fake worker
+  // failed"). Same bytes; only the extension decides the MIME type.
+  // tests/async-unit/test_worker_assets.py pins the extension.
+  { from: 'node_modules/pdfjs-dist/build/pdf.worker.min.mjs', to: 'workers/pdf.worker.min.js' },
   { from: 'node_modules/tesseract.js/dist/worker.min.js', to: 'workers/tesseract.js/worker.min.js' },
   { from: 'node_modules/tesseract.js-core/*.{js,wasm}', to: 'workers/tesseract.js-core/[name][ext]' },
 ];

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -82,7 +82,7 @@ else
 fi
 
 # BUILDKIT_NO_CLIENT_TOKEN=true
-FHI_VERSION=v0.23.5a
+FHI_VERSION=v0.23.6a
 
 
 MYORG=${MYORG:-totallylegitco}

--- a/tests/async-unit/test_worker_assets.py
+++ b/tests/async-unit/test_worker_assets.py
@@ -33,7 +33,7 @@ def test_webpack_copies_every_runtime_worker_asset_into_dist_workers():
     text = WEBPACK.read_text()
     assert "copy-webpack-plugin" in text
     for src, dest in (
-        ("pdfjs-dist/build/pdf.worker.min.mjs", "workers/pdf.worker.min.mjs"),
+        ("pdfjs-dist/build/pdf.worker.min.mjs", "workers/pdf.worker.min.js"),
         ("tesseract.js/dist/worker.min.js", "workers/tesseract.js/worker.min.js"),
         ("tesseract.js-core/", "workers/tesseract.js-core/"),
     ):
@@ -45,6 +45,28 @@ def test_sources_point_at_the_copied_workers():
     shared = (JS_DIR / "shared.ts").read_text()
     ocr = (JS_DIR / "scrub_ocr.ts").read_text()
     assert '"/static/js/dist/workers/"' in shared
-    assert 'workers_path + "pdf.worker.min.mjs"' in shared
+    assert 'workers_path + "pdf.worker.min.js"' in shared
     assert 'workers_path + "tesseract.js-core"' in ocr
     assert 'workers_path + "tesseract.js/worker.min.js"' in ocr
+
+
+def test_no_runtime_worker_is_published_or_loaded_with_an_mjs_extension():
+    """The web image's nginx has no MIME entry for .mjs.
+
+    It served dist/workers/pdf.worker.min.mjs as application/octet-stream,
+    browsers refuse to run a module worker (or dynamic import()) without a
+    JavaScript MIME type, and pdf.js's fake-worker fallback does the same
+    import -- so every PDF attached on /scan failed with "Setting up fake
+    worker failed" while images read fine. Publishing the same bytes under
+    .js is what fixed it; keep it that way.
+    """
+    webpack = WEBPACK.read_text()
+    published_as_mjs = re.findall(r"to:\s*'workers/[^']*\.mjs'", webpack)
+    assert published_as_mjs == [], published_as_mjs
+
+    loaded_as_mjs = {
+        p.name: re.findall(r'workers_path\s*\+\s*"[^"]*\.mjs"', p.read_text())
+        for p in SOURCES
+    }
+    loaded_as_mjs = {k: v for k, v in loaded_as_mjs.items() if v}
+    assert loaded_as_mjs == {}, loaded_as_mjs


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PDF uploads and scanning in production by ensuring the PDF worker loads correctly in browsers.
  * Prevented worker loading failures caused by unsupported `.mjs` MIME types.

* **Chores**
  * Updated the application version to `v0.23.6a`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->