### PR TITLE
Thank the companies that give us free resources, on About Us

### DIFF
--- a/fighthealthinsurance/templates/about_us.html
+++ b/fighthealthinsurance/templates/about_us.html
@@ -27,7 +27,7 @@ About Us
         If that sounds like you (or your business), we would love <a class="link" href="{% url 'pro_version' %}">to keep in touch</a> (and optionally, a small amount of
         money if you are interested in being a first beta user).
         <br><br>
-    <h5>As Featured In</h5>
+    <h4>As Featured In</h4>
     <div class="row no-gutters">
         <div class="col-md-12">
             <div class="row no-gutters">
@@ -171,6 +171,23 @@ About Us
             </a>
             </div>
         </div>
+    </div>
+    <div class="spacer" style="margin-top: 5vh;"></div>
+    <div id="acknowledgements">
+        <h4>Thank you</h4>
+        <p>
+            Fight Health Insurance is a small team, and we could not do this alone.
+            <a href="https://azure.microsoft.com/" target="_blank" rel="noopener noreferrer">Microsoft Azure</a>,
+            <a href="https://github.com/" target="_blank" rel="noopener noreferrer">GitHub</a>,
+            <a href="https://www.anthropic.com/" target="_blank" rel="noopener noreferrer">Anthropic</a>,
+            <a href="https://openai.com/" target="_blank" rel="noopener noreferrer">OpenAI</a> and
+            <a href="https://typesafe.ai/" target="_blank" rel="noopener noreferrer">TypeSafe</a>
+            have all given us free resources, and we are grateful to every one of them.
+        </p>
+        <p>
+            Want to join them? If you or your company can help with compute, credits or engineering time,
+            <a class="link" href="{% url 'how-to-help' %}">here is how to help</a>.
+        </p>
     </div>
 </div>
 {% endblock content %}

--- a/tests/sync/test_about_us_acknowledgements.py
+++ b/tests/sync/test_about_us_acknowledgements.py
@@ -1,0 +1,33 @@
+"""About Us thanks the companies that give us free resources, and ends the
+section with a link to How to Help so the next one knows where to start."""
+
+from bs4 import BeautifulSoup
+from django.test import Client, TestCase
+from django.urls import reverse
+
+
+class AboutUsAcknowledgementsTest(TestCase):
+    SUPPORTERS = ("Microsoft Azure", "GitHub", "Anthropic", "OpenAI", "TypeSafe")
+
+    def setUp(self):
+        body = Client().get(reverse("about")).content.decode("utf-8")
+        self.page = BeautifulSoup(body, "html.parser")
+        self.section = self.page.find("div", id="acknowledgements")
+        self.assertIsNotNone(self.section, "acknowledgements section missing")
+
+    def test_every_supporter_is_named(self):
+        text = self.section.get_text(" ")
+        for name in self.SUPPORTERS:
+            self.assertIn(name, text)
+
+    def test_the_section_ends_with_a_real_link_to_how_to_help(self):
+        paragraphs = self.section.find_all("p")
+        self.assertGreaterEqual(len(paragraphs), 2)
+        links = paragraphs[-1].find_all("a", href=True)
+        self.assertEqual([a["href"] for a in links], [reverse("how-to-help")])
+
+    def test_thanks_are_a_subsection_of_the_page_heading(self):
+        heading = self.section.find(["h1", "h2", "h3", "h4", "h5", "h6"])
+        self.assertIsNotNone(heading)
+        self.assertEqual(heading.name, "h4")
+        self.assertEqual(heading.get_text(strip=True), "Thank you")


### PR DESCRIPTION
A short "Thank you" section at the end of About Us naming Microsoft Azure, GitHub, Anthropic, OpenAI and TypeSafe, who have all provided free resources, and closing with a link to How to Help for the next one. No per-company detail and no claims about how the resources are used, at the owner's request.

Both subsection headings on the page ("As Featured In" and the new one) become h4: they sit under the page's h3, and an h5 there implied a heading level that does not exist.

The test parses the page, checks every name is in the section, that the section's last paragraph links to exactly How to Help, and that the heading is an h4.


Claude-Session: https://claude.ai/code/session_019SPqa4FZ43ahAjoD53Uj81