### PR TITLE
Order appeal drafts by a TypeSafe quality score, and watch it per bac…

### DIFF
--- a/fighthealthinsurance/apps.py
+++ b/fighthealthinsurance/apps.py
@@ -22,6 +22,14 @@ class FightHealthInsuranceConfig(AppConfig):
 
         register_intake_outbox_collector()
 
+        # Draft quality per backend from ml/letter_quality.py, same shape:
+        # DB read at scrape time, degrades to a log line before migration.
+        from fighthealthinsurance.letter_quality_metrics import (
+            register_letter_quality_collector,
+        )
+
+        register_letter_quality_collector()
+
         # Soft-fail visibility for IP geo lookups (chat state guessing +
         # ASN tracking): warn once, naming FHI_GEOIP_CITY_DB, when they are
         # disabled — otherwise the features silently return nothing.

--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -3502,8 +3502,16 @@ class AppealsBackendHelper:
             )
             if score is None:
                 return None
+            # Only the row whose text is still the text that was scored: an
+            # admin can edit a draft during the few seconds of scoring, and
+            # a score for text nobody sees any more must not land on the
+            # edited row or reach the page (review). Legacy rows have no
+            # fingerprint, so the guard is the text itself.
+            updated = 1
             try:
-                await ProposedAppeal.objects.filter(pk=proposed_id).aupdate(
+                updated = await ProposedAppeal.objects.filter(
+                    pk=proposed_id, appeal_text=draft_text
+                ).aupdate(
                     quality_score=score.quality,
                     grounding_score=score.grounding,
                     quality_scorer=score.scorer,
@@ -3516,6 +3524,12 @@ class AppealsBackendHelper:
                     f"[gen_id={generation_id}] could not record a draft score "
                     f"for denial {denial_id}"
                 )
+            if not updated:
+                logger.info(
+                    f"[gen_id={generation_id}] draft {proposed_id} changed while "
+                    "it was being scored; score dropped"
+                )
+                return None
             return json.dumps(letter_quality.score_frame(proposed_id, score)) + "\n"
 
         def _start_scoring(proposed_id: str, draft_text: str) -> None:

--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -2918,6 +2918,20 @@ def scoring_redactions(denial: Denial) -> list[tuple[str, str]]:
         add(contact.address1, "ADDRESS")
         add(contact.address2, "ADDRESS")
 
+    def add_username(user: Any) -> None:
+        # An identifier, not a name: matched whole-word in any case, where a
+        # name only matches its capitalised spellings (review). A
+        # domain-scoped login is stored as raw🐼domain_id
+        # (fhi_users.auth.auth_utils.combine_domain_and_username); the raw
+        # login is the spelling a person would write, so both go in (review).
+        # A login spelled "unknown" falls to add()'s sentinel filter on
+        # purpose: it identifies nobody, and redacting that word would blank
+        # ordinary prose in most letters (review, accepted).
+        username = str(getattr(user, "username", "") or "")
+        add(username, "USERNAME")
+        if "🐼" in username:
+            add(username.split("🐼", 1)[0], "USERNAME")
+
     add(denial.raw_email, "EMAIL")
     add(denial.claim_id, "CLAIM_ID")
     add(denial.plan_id, "PLAN_ID")
@@ -2930,6 +2944,7 @@ def scoring_redactions(denial: Denial) -> list[tuple[str, str]]:
         add(patient.user.first_name, "PATIENT#patient")
         add(patient.user.last_name, "PATIENT#patient")
         add(patient.user.email, "EMAIL")
+        add_username(patient.user)
         add_contact(patient.user)
     for field in ("primary_professional", "creating_professional"):
         professional = getattr(denial, field)
@@ -2941,6 +2956,7 @@ def scoring_redactions(denial: Denial) -> list[tuple[str, str]]:
         add(professional.user.first_name, person)
         add(professional.user.last_name, person)
         add(professional.user.email, "EMAIL")
+        add_username(professional.user)
         add(professional.npi_number, "NPI")
         add(professional.fax_number, "PHONE")
         add_contact(professional.user)

--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -84,6 +84,7 @@ from fighthealthinsurance.medical_code_extractor import (
     extract_icd10_codes,
     extract_procedure_codes,
 )
+from fighthealthinsurance.ml import letter_quality
 from fighthealthinsurance.ml.bad_output_utils import strip_boilerplate_service
 from fighthealthinsurance.reliability_events import capture_reliability_event
 from fighthealthinsurance.form_utils import *
@@ -2884,6 +2885,70 @@ def deliverable_candidates(qs: QuerySet) -> QuerySet:
     return narrowed
 
 
+def scoring_redactions(denial: Denial) -> list[tuple[str, str]]:
+    """The identifiers held in this denial's profile fields, as (value,
+    category) pairs for letter_quality.Redactor: the denial's email, claim
+    id, plan id, fax and employer; the patient's and each professional's
+    names, user names and emails; the professional's NPI and fax; each
+    user's contact phone and address lines; the practice address. Nothing
+    that lives only in the letter text itself.
+
+    Sync on purpose (it walks FK relations; call it through
+    database_sync_to_async). ALL or nothing: a relation that cannot be read
+    raises, and the caller turns scoring off for the run. A partial list
+    that quietly dropped the patient's name would be worse than no scoring.
+    """
+    out: list[tuple[str, str]] = []
+
+    def add(value: Any, category: str) -> None:
+        text = str(value).strip() if value is not None else ""
+        if text and text.upper() != "UNKNOWN":
+            out.append((text, category))
+
+    def add_contact(user: Any) -> None:
+        # The user's contact record: phone and address lines. Absent is
+        # fine; unreadable is not.
+        from django.core.exceptions import ObjectDoesNotExist
+
+        try:
+            contact = user.usercontactinfo
+        except ObjectDoesNotExist:
+            return
+        add(contact.phone_number, "PHONE")
+        add(contact.address1, "ADDRESS")
+        add(contact.address2, "ADDRESS")
+
+    add(denial.raw_email, "EMAIL")
+    add(denial.claim_id, "CLAIM_ID")
+    add(denial.plan_id, "PLAN_ID")
+    add(denial.appeal_fax_number, "PHONE")
+    add(denial.employer_name, "EMPLOYER")
+    patient = denial.patient_user
+    if patient is not None:
+        add(patient.get_legal_name(), "PATIENT#patient")
+        add(patient.get_display_name(), "PATIENT#patient")
+        add(patient.user.first_name, "PATIENT#patient")
+        add(patient.user.last_name, "PATIENT#patient")
+        add(patient.user.email, "EMAIL")
+        add_contact(patient.user)
+    for field in ("primary_professional", "creating_professional"):
+        professional = getattr(denial, field)
+        if professional is None:
+            continue
+        person = f"PROFESSIONAL#{professional.pk}"  # one token per person
+        add(professional.get_full_name(), person)
+        add(professional.display_name, person)
+        add(professional.user.first_name, person)
+        add(professional.user.last_name, person)
+        add(professional.user.email, "EMAIL")
+        add(professional.npi_number, "NPI")
+        add(professional.fax_number, "PHONE")
+        add_contact(professional.user)
+    if denial.domain is not None:
+        add(denial.domain.get_address(), "ADDRESS")
+    return out
+
+
 class AppealsBackendHelper:
     regex_denial_processor = ProcessDenialRegex()
     pmt = PubMedTools()
@@ -3078,6 +3143,8 @@ class AppealsBackendHelper:
             "domain",
             "primary_professional",
             "primary_professional__user",
+            "creating_professional",
+            "creating_professional__user",
         )
         denial = await denial_query.aget()
         if not background:
@@ -3400,6 +3467,102 @@ class AppealsBackendHelper:
             return fingerprint_text(text) or str(text).strip()
 
         # Yield the existing appeals first
+        # Draft scoring for ORDERING (ml/letter_quality.py). One task per saved
+        # draft, never on the letter's own path: the letter streams the moment
+        # it is saved, and its score follows as a {"type": "score"} frame,
+        # drained between letters and once more (bounded) before the done
+        # frame. Whatever the client sees, the score lands on the row for the
+        # staff dashboard. Gated on the user's external-model consent, because
+        # TypeSafe is one more external processor of the denial text.
+        scoring_active = letter_quality.enabled() and bool(
+            getattr(denial, "use_external", False)
+        )
+        score_tasks: list["asyncio.Task[Optional[str]]"] = []
+        # Collected once, before any draft exists: the prompt asks the model
+        # to write the patient's and professional's details INTO the letter,
+        # so a draft is redacted against everything we hold before it leaves.
+        scoring_identifiers: list[tuple[str, str]] = []
+        if scoring_active:
+            try:
+                scoring_identifiers = await database_sync_to_async(scoring_redactions)(
+                    denial
+                )
+            except Exception:
+                # No identifier list means no scoring at all: the generic
+                # patterns alone are not a promise we can keep.
+                logger.opt(exception=True).warning(
+                    f"[gen_id={generation_id}] could not collect redactions for "
+                    f"denial {denial_id}; draft scoring off for this run"
+                )
+                scoring_active = False
+
+        async def _score_draft(proposed_id: str, draft_text: str) -> Optional[str]:
+            score = await letter_quality.score_letter(
+                denial.denial_text, draft_text, identifiers=scoring_identifiers
+            )
+            if score is None:
+                return None
+            try:
+                await ProposedAppeal.objects.filter(pk=proposed_id).aupdate(
+                    quality_score=score.quality,
+                    grounding_score=score.grounding,
+                    quality_scorer=score.scorer,
+                    quality_scored_at=timezone.now(),
+                )
+            except Exception:
+                # The frame still goes out: ordering this run matters more
+                # than the analytics row, and the failure is logged.
+                logger.opt(exception=True).warning(
+                    f"[gen_id={generation_id}] could not record a draft score "
+                    f"for denial {denial_id}"
+                )
+            return json.dumps(letter_quality.score_frame(proposed_id, score)) + "\n"
+
+        def _start_scoring(proposed_id: str, draft_text: str) -> None:
+            existing = letter_quality.in_flight_task(proposed_id)
+            if existing is not None:
+                # A sibling stream on this worker (a reconnect) already
+                # asked: share its answer instead of paying for it twice.
+                if existing not in score_tasks:
+                    score_tasks.append(existing)
+                return
+            task = asyncio.create_task(_score_draft(proposed_id, draft_text))
+            letter_quality.keep_alive(task, proposed_id)
+            score_tasks.append(task)
+
+        def _finished_score_frames() -> list[str]:
+            frames: list[str] = []
+            for task in list(score_tasks):
+                if not task.done():
+                    continue
+                score_tasks.remove(task)
+                if task.cancelled():
+                    continue
+                exc = task.exception()
+                if exc is not None:
+                    logger.warning(
+                        f"[gen_id={generation_id}] draft scoring task failed: "
+                        f"{type(exc).__name__}"
+                    )
+                    continue
+                frame = task.result()
+                if frame:
+                    frames.append(frame)
+            return frames
+
+        # A drain waits, with its own budget, only on tasks no earlier drain
+        # has waited on: a task stalled at the first drain is not waited on
+        # again before done, while a draft saved later (synthesis, the
+        # reconciliation) still gets a full DRAIN_SECONDS of its own.
+        waited: set["asyncio.Task[Optional[str]]"] = set()
+
+        async def _drain_score_frames(timeout: float) -> list[str]:
+            fresh = [task for task in score_tasks if task not in waited]
+            if fresh and timeout > 0:
+                waited.update(fresh)
+                await asyncio.wait(fresh, timeout=timeout)
+            return _finished_score_frames()
+
         old = 0
         new = 0
         async for appeal in existing_appeals:
@@ -3419,8 +3582,14 @@ class AppealsBackendHelper:
                 old = old + 1
                 logger.debug(f"Found existing appeal {appeal}, yielding")
                 served_keys.add(key)
+                if scoring_active and letter_quality.needs_scoring(appeal):
+                    # An unscored (or older-rubric) draft must not sort
+                    # below every fresh one just for being older.
+                    _start_scoring(str(appeal.id), appeal.appeal_text)
                 existing_appeal_dict = await sub_in_appeals(
-                    {"id": str(appeal.id), "content": appeal.appeal_text}
+                    letter_quality.with_score_fields(
+                        {"id": str(appeal.id), "content": appeal.appeal_text}, appeal
+                    )
                 )
                 yield await format_response(existing_appeal_dict)
             elif appeal.appeal_text is not None and str(appeal.appeal_text).strip():
@@ -3575,8 +3744,12 @@ class AppealsBackendHelper:
                                 ),
                             }
                         ) + "\n"
+                    if scoring_active and letter_quality.needs_scoring(row):
+                        _start_scoring(str(row.id), row.appeal_text)
                     row_dict = await sub_in_appeals(
-                        {"id": str(row.id), "content": row.appeal_text}
+                        letter_quality.with_score_fields(
+                            {"id": str(row.id), "content": row.appeal_text}, row
+                        )
                     )
                     yield await format_response(row_dict)
                     served_keys.add(_served_key(normalized))
@@ -4361,6 +4534,8 @@ class AppealsBackendHelper:
                     await database_sync_to_async(close_old_connections)()
                     await database_sync_to_async(_insert_fenced)()
                 id = str(pa.id)
+                if scoring_active and letter_quality.needs_scoring(pa):
+                    _start_scoring(id, appeal_text)
             except generation_lease.LeaseSuperseded as e:
                 # Superseded by a newer steal: the draft is NOT persisted and
                 # goes out flagged as unsaved (the existing contract for a
@@ -4751,6 +4926,8 @@ class AppealsBackendHelper:
             else:
                 logger.debug("Sending keep alive....")
             yield i
+            for score_json in _finished_score_frames():
+                yield score_json
             if superseded:
                 # A newer run owns this denial now (a second tab, a reconnect
                 # replacing this socket, a retry through a proxy): stop
@@ -4768,6 +4945,12 @@ class AppealsBackendHelper:
             # minutes still gets the reserve at the deadline.
             async for _spec in serve_reserve_if_stalled():
                 yield _spec
+        # Scores still in flight get a bounded wait so the client can rank
+        # before the done frame; a superseded run only collects what finished.
+        for score_json in await _drain_score_frames(
+            0.0 if superseded else letter_quality.DRAIN_SECONDS
+        ):
+            yield score_json
         logger.debug(
             f"Normal appeals sent {new} and {old} "
             f"(runt_count={runts}, dupe_count={dupes})"
@@ -4984,7 +5167,13 @@ class AppealsBackendHelper:
                     ).aupdate(speculative=False):
                         continue
                     row.speculative = False
-                row_dict = await sub_in_appeals({"id": str(row.id), "content": text})
+                if scoring_active and letter_quality.needs_scoring(row):
+                    _start_scoring(str(row.id), text)
+                row_dict = await sub_in_appeals(
+                    letter_quality.with_score_fields(
+                        {"id": str(row.id), "content": text}, row
+                    )
+                )
                 yield await format_response(row_dict)
                 served_keys.add(_served_key(normalized))
                 new += 1
@@ -5091,6 +5280,14 @@ class AppealsBackendHelper:
         # (The form_completed intake event is recorded and delivered at the
         # START of generation, above; the generation lease is what keeps the
         # journey's child from racing this run, not signal timing.)
+
+        # Synthesis and the reconciliation above save drafts after the first
+        # drain, so drain once more, bounded, right before done: a score that
+        # arrives after this frame is telemetry only.
+        for score_json in await _drain_score_frames(
+            0.0 if superseded else letter_quality.DRAIN_SECONDS
+        ):
+            yield score_json
 
         # Explicit end-of-stream so the client knows exactly what was sent.
         # Carries the correlation id + generating-phase instrumentation so a

--- a/fighthealthinsurance/letter_quality_metrics.py
+++ b/fighthealthinsurance/letter_quality_metrics.py
@@ -1,0 +1,139 @@
+"""Prometheus export of draft quality per backend (ml/letter_quality.py).
+
+Read from ``ProposedAppeal`` at scrape time, over the last 24 hours, the same
+way the intake outbox gauges are: no extra writes on the request path, and any
+failure (column not migrated yet, database away) degrades to a log line and
+an empty scrape, never a 500 on ``/metrics``.
+
+- ``fhi_letter_quality_avg{model_name,scorer}`` -- mean 0..1 composite score
+- ``fhi_letter_quality_scored_total{model_name,scorer}`` -- drafts scored in the
+  window (by scoring time, since older drafts are rescored on re-serve)
+- ``fhi_letter_quality_ungrounded_total{model_name,scorer}`` -- of those, drafts
+  that scored below the grounding threshold (invented facts)
+
+``scorer`` is the provenance string recorded on the row (the model TypeSafe
+reported plus our rubric version), so a provider-side repoint of the alias
+shows up as a second series rather than a blended one -- when TypeSafe names
+the model it used; a response without one records the alias.
+- ``fhi_letter_quality_requests_total{outcome}`` -- process-local scorer calls
+  by outcome (scored / failed / skipped), so a dead key or a rate limit shows
+  up as ``failed`` climbing while ``scored`` stops
+
+This is the leading indicator for backend drift: win rate needs users to pick
+drafts and weeks of them to mean anything; this moves the minute a backend
+starts producing worse letters.
+"""
+
+import datetime
+from typing import Dict, Iterable, Iterator, Tuple
+
+from loguru import logger
+from prometheus_client import REGISTRY
+from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily, Metric
+from prometheus_client.registry import Collector
+
+WINDOW = datetime.timedelta(hours=24)
+
+_AVG = (
+    "fhi_letter_quality_avg",
+    "Mean draft quality score (0..1) per backend, last 24h",
+)
+_SCORED = ("fhi_letter_quality_scored_total", "Drafts scored per backend, last 24h")
+_UNGROUNDED = (
+    "fhi_letter_quality_ungrounded_total",
+    "Scored drafts below the grounding threshold per backend, last 24h",
+)
+_REQUESTS = (
+    "fhi_letter_quality_requests",
+    "Draft scoring calls by outcome (this process)",
+)
+
+
+def quality_by_model(now: datetime.datetime) -> Dict[Tuple[str, str], Dict[str, float]]:
+    """{(model_name, scorer): {"avg", "scored", "ungrounded"}} for current-rubric
+    drafts in the window."""
+    from django.db.models import Avg, Count, Q
+
+    from fighthealthinsurance.ml import letter_quality
+    from fighthealthinsurance.models import ProposedAppeal
+
+    rows = (
+        ProposedAppeal.objects.filter(
+            quality_score__isnull=False,
+            # One rubric per series; the answering model is recorded per row
+            # so a provider-side repoint is visible, not averaged away.
+            quality_scorer__endswith=letter_quality._RUBRIC_SUFFIX,
+            model_name__isnull=False,
+            quality_scored_at__gte=now - WINDOW,
+        )
+        .values_list("model_name", "quality_scorer")
+        .annotate(
+            avg=Avg("quality_score"),
+            scored=Count("id"),
+            ungrounded=Count(
+                "id",
+                filter=Q(grounding_score__lt=letter_quality.GROUNDING_DEMOTE_BELOW),
+            ),
+        )
+        .values_list("model_name", "quality_scorer", "avg", "scored", "ungrounded")
+    )
+    return {
+        (str(name), str(scorer)): {
+            "avg": float(avg or 0.0),
+            "scored": float(scored),
+            "ungrounded": float(ungrounded),
+        }
+        for name, scorer, avg, scored, ungrounded in rows
+        if letter_quality.same_rubric(scorer)
+    }
+
+
+class LetterQualityCollector(Collector):
+    def describe(self) -> Iterable[Metric]:
+        yield GaugeMetricFamily(*_AVG, labels=["model_name", "scorer"])
+        yield GaugeMetricFamily(*_SCORED, labels=["model_name", "scorer"])
+        yield GaugeMetricFamily(*_UNGROUNDED, labels=["model_name", "scorer"])
+        yield CounterMetricFamily(*_REQUESTS, labels=["outcome"])
+
+    def collect(self) -> Iterator[Metric]:
+        avg = GaugeMetricFamily(*_AVG, labels=["model_name", "scorer"])
+        scored = GaugeMetricFamily(*_SCORED, labels=["model_name", "scorer"])
+        ungrounded = GaugeMetricFamily(*_UNGROUNDED, labels=["model_name", "scorer"])
+        requests = CounterMetricFamily(*_REQUESTS, labels=["outcome"])
+        try:
+            from django.utils import timezone
+
+            for (model_name, scorer), stats in quality_by_model(timezone.now()).items():
+                avg.add_metric([model_name, scorer], stats["avg"])
+                scored.add_metric([model_name, scorer], stats["scored"])
+                ungrounded.add_metric([model_name, scorer], stats["ungrounded"])
+        except Exception:
+            logger.opt(exception=True).warning("letter quality metrics unavailable")
+        try:
+            from fighthealthinsurance.ml import letter_quality
+
+            for outcome, count in letter_quality.outcomes.items():
+                requests.add_metric([outcome], float(count))
+        except Exception:
+            logger.opt(exception=True).warning(
+                "letter quality request counters unavailable"
+            )
+        yield avg
+        yield scored
+        yield ungrounded
+        yield requests
+
+
+_registered = False
+
+
+def register_letter_quality_collector() -> None:
+    global _registered
+    if _registered:
+        return
+    try:
+        REGISTRY.register(LetterQualityCollector())
+        _registered = True
+    except ValueError:
+        # Already registered (e.g. the app registry loaded twice in tests).
+        _registered = True

--- a/fighthealthinsurance/letter_quality_metrics.py
+++ b/fighthealthinsurance/letter_quality_metrics.py
@@ -51,10 +51,18 @@ _REQUESTS = (
 
 def quality_by_model(now: datetime.datetime) -> Dict[Tuple[str, str], Dict[str, float]]:
     """{(model_name, scorer): {"avg", "scored", "ungrounded"}} for current-rubric
-    drafts in the window."""
+    drafts in the window.
+
+    The stored model name is normalized the way the staff dashboard does
+    it (a legacy object repr collapses to its class, whitespace is
+    stripped), and rows that land on one label are merged with a
+    scored-weighted mean and summed counts, so one backend is one
+    Prometheus series rather than one per stored spelling (review).
+    """
     from django.db.models import Avg, Count, Q
 
     from fighthealthinsurance.ml import letter_quality
+    from fighthealthinsurance.ml.model_identity import normalize_model_label
     from fighthealthinsurance.models import ProposedAppeal
 
     rows = (
@@ -77,15 +85,25 @@ def quality_by_model(now: datetime.datetime) -> Dict[Tuple[str, str], Dict[str, 
         )
         .values_list("model_name", "quality_scorer", "avg", "scored", "ungrounded")
     )
-    return {
-        (str(name), str(scorer)): {
-            "avg": float(avg or 0.0),
-            "scored": float(scored),
-            "ungrounded": float(ungrounded),
-        }
-        for name, scorer, avg, scored, ungrounded in rows
-        if letter_quality.same_rubric(scorer)
-    }
+    merged: Dict[Tuple[str, str], Dict[str, float]] = {}
+    for name, scorer, avg, scored, ungrounded in rows:
+        if not letter_quality.same_rubric(scorer):
+            continue
+        label = normalize_model_label(name)
+        if label is None:
+            continue  # a blank name labels nothing
+        entry = merged.setdefault(
+            (label, str(scorer)), {"avg": 0.0, "scored": 0.0, "ungrounded": 0.0}
+        )
+        count = float(scored)
+        total = entry["scored"] + count
+        if total:
+            entry["avg"] = (
+                entry["avg"] * entry["scored"] + float(avg or 0.0) * count
+            ) / total
+        entry["scored"] = total
+        entry["ungrounded"] += float(ungrounded)
+    return merged
 
 
 class LetterQualityCollector(Collector):

--- a/fighthealthinsurance/migrations/0205_proposedappeal_quality_score.py
+++ b/fighthealthinsurance/migrations/0205_proposedappeal_quality_score.py
@@ -1,0 +1,35 @@
+# Draft quality scores from TypeSafe System One (ml/letter_quality.py).
+# Three nullable columns, no index: the dashboard aggregates by model_name and
+# created_at, both already indexed, and the page never queries by score.
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("fighthealthinsurance", "0204_intakejourneyevent"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="proposedappeal",
+            name="quality_score",
+            field=models.FloatField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="proposedappeal",
+            name="grounding_score",
+            field=models.FloatField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="proposedappeal",
+            name="quality_scorer",
+            field=models.CharField(blank=True, max_length=80, null=True),
+        ),
+        migrations.AddField(
+            model_name="proposedappeal",
+            name="quality_scored_at",
+            field=models.DateTimeField(blank=True, db_index=True, null=True),
+        ),
+    ]

--- a/fighthealthinsurance/ml/letter_quality.py
+++ b/fighthealthinsurance/ml/letter_quality.py
@@ -1,0 +1,622 @@
+"""Score appeal drafts for ORDERING with TypeSafe's System One API.
+
+Why this exists: the router fans a denial out to up to nine backends and every
+draft that comes back lands on the page in arrival order, so the reader gets a
+wall of letters with nothing to tell the strong one from the weak one. This
+module puts a number on each draft so the client can show the best first, and
+so the staff dashboard can watch draft quality per backend without waiting
+weeks for appeal outcomes to trickle in.
+
+What the number is, and is not. The four questions below are the ones our
+model evaluation validated: across 12,536 letters the composite correlated
+0.74 with the judge ensemble per letter (higher than the judges agreed with
+each other) and ranked backends at Spearman 0.90. It is a criteria score --
+does the letter engage the stated denial reason, argue medical necessity for
+THIS case, invent nothing, read as send-ready. It is NOT a probability that
+the appeal succeeds: nobody has calibrated it against real outcomes, and
+insurers overturn roughly a third to a half of internal appeals, so any
+honest "chance of success" would read as discouraging for nearly everyone.
+Never surface it as one. The client copy says "ordered by how well each
+letter addresses your denial", and that is the whole claim.
+
+``no_invented_facts`` doubles as a grounding signal. Our evaluation's biggest
+finding was fabrication, and this question caught it at precision 0.69 /
+recall 0.51 for about a thousandth of a cent per letter: good enough to
+DEMOTE a draft, not to delete one. Treat a low grounding score that way.
+
+Data protection, stated exactly. TypeSafe receives the denial text and the
+draft: the same two things the external language models that WROTE the draft
+already received and produced, under the same consent (``denial.use_external``).
+It never receives the form fields. Before sending, ``Redactor`` strips the
+identifiers ``scoring_redactions`` (common_view_logic) reads from the profile
+fields we hold -- patient and professional names, user first/last names,
+emails, phone and fax numbers, NPI, claim and plan ids, employer, the
+professional's practice address, and the address lines and phone on each
+user's contact record -- and, in the text itself, every email address (Unicode letters allowed,
+alphabetic or punycode top-level domain) and every North American style
+phone number, each distinct value getting its own stable token so the
+"invented facts" comparison still works. Other phone formats are not
+recognised. That is a reduction, NOT de-identification: a
+dependent's name, a member id, a date of birth or an address that exists only
+in the free text of the letter is not something we hold, and it goes
+through; a one-word name is only caught in its Capitalised and ALL-CAPS
+spellings. A draft is not clean by construction either -- the
+generation prompt asks the model to "include and fill in" the patient's and
+professional's details. So the gate for turning this on is contractual, not
+technical: TypeSafe must be under the same data terms as the other providers
+and named in the privacy policy first. If collecting the identifiers fails,
+scoring is off for the run. The module is inert until BOTH
+``TYPESAFE_API_KEY`` and ``TYPESAFE_LETTER_RANKING_ENABLED`` are set, and it
+fails closed: any error, timeout or malformed answer means "no score", never a
+broken stream and never a logged document.
+"""
+
+import asyncio
+import dataclasses
+import re
+import typing
+
+from django.conf import settings
+from loguru import logger
+
+from fighthealthinsurance.ml import typesafe
+
+# Recorded on every scored row, and every aggregate filters on it. Two things
+# move the scale: TypeSafe's "speed_latest" is an alias they can repoint, and
+# the questions below are our half of the rubric. Bump RUBRIC_VERSION whenever
+# the questions change; either change starts a fresh series on the dashboard
+# instead of averaging two scales into one line called "drift".
+MODEL = typesafe.DEFAULT_MODEL
+RUBRIC_VERSION = 1
+_RUBRIC_SUFFIX = f"/rubric-{RUBRIC_VERSION}"
+SCORER = f"typesafe/{MODEL}{_RUBRIC_SUFFIX}"
+
+
+def scorer_for(payload: typing.Any) -> str:
+    """The provenance string for a row: the model TypeSafe says answered
+    plus our rubric version.
+
+    Known limit, accepted: System One only exposes the moving alias
+    ("speed_latest") and, in some responses, the resolved model it used. When
+    the response names none, the alias is recorded, and a repoint that hides
+    behind the alias is invisible to us. The rubric half is ours and exact;
+    the model half is as good as the provider makes it."""
+    answered = None
+    if isinstance(payload, dict):
+        answered = payload.get("model")
+    model = str(answered).strip() if answered else MODEL
+    if not re.fullmatch(r"[A-Za-z0-9._-]{1,48}", model):
+        model = MODEL  # never let an odd answer forge the provenance format
+    return f"typesafe/{model}{_RUBRIC_SUFFIX}"
+
+
+_SCORER_RE = re.compile(r"^typesafe/([A-Za-z0-9._-]{1,48})/rubric-(\d{1,4})$")
+
+
+def same_rubric(scorer: typing.Optional[str]) -> bool:
+    """Whether a stored score was produced by TypeSafe under the CURRENT
+    rubric, and so may be reused or ranked against fresh scores. The whole
+    string must be ours: a hand-imported "manual/rubric-1" is not."""
+    match = _SCORER_RE.match(str(scorer or ""))
+    return match is not None and int(match.group(2)) == RUBRIC_VERSION
+
+
+DOCUMENT_CHAR_CAP = typesafe.DOCUMENT_CHAR_CAP
+# Longer than this and we do not score at all: cutting raw text could split
+# an identifier, and every scan is bounded by this. It is eight times what
+# can be sent, so a real letter never comes near it.
+RAW_CHAR_BOUND = 8 * DOCUMENT_CHAR_CAP
+
+# Verbatim from the validated evaluation pass. Changing the wording changes
+# the scale, so a change here must also bump SCORER.
+QUESTIONS: dict[str, dict[str, typing.Any]] = {
+    "cites_denial": {
+        "type": "score",
+        "instructions": "How directly the appeal letter engages the insurer's stated denial reason",
+        "criteria": [
+            "Never engages with the stated reason",
+            "Vague or generic engagement",
+            "Quotes or clearly restates the reason and rebuts it",
+        ],
+    },
+    "medical_necessity": {
+        "type": "score",
+        "instructions": "How specific the medical-necessity argument is to this patient's case",
+        "criteria": [
+            "Absent",
+            "Boilerplate",
+            "Specific to the case, points to guidelines or plan terms where sensible",
+        ],
+    },
+    "no_invented_facts": {
+        "type": "score",
+        "instructions": (
+            "Whether the letter invents facts (dates, dollar amounts, policy numbers, "
+            "providers, results, history) not present in the request; placeholders "
+            "like [DATE] are fine"
+        ),
+        "criteria": [
+            "Fabricates facts",
+            "Minor embellishment that would not mislead",
+            "Clean",
+        ],
+    },
+    "tone_and_form": {
+        "type": "score",
+        "instructions": (
+            "Whether this reads as a send-ready appeal letter; trailing advice or "
+            "bracketed slots for substantive facts cap it below ready"
+        ),
+        "criteria": ["Not a letter or rambles", "Rough but usable", "Ready to send"],
+    },
+}
+SCORE_QUESTIONS: tuple[str, ...] = tuple(QUESTIONS)
+# Three criteria -> levels 0, 1, 2. System One returns the probability-weighted
+# EXPECTED level, so an answer is a float like 1.3, not an integer: keep it.
+MAX_PER_QUESTION = 2.0
+GROUNDING_QUESTION = "no_invented_facts"
+
+# Ungrounded drafts sort below everything that scored at or above this.
+GROUNDING_DEMOTE_BELOW = 1
+
+
+@dataclasses.dataclass(frozen=True)
+class LetterScore:
+    quality: float  # 0..1 composite of the four questions
+    grounding: float  # 0..2, the no_invented_facts answer on its own
+    scores: dict[str, float]
+    input_tokens: int
+    scorer: str = SCORER
+
+
+class LetterScoringError(Exception):
+    """A response we could not turn into a score."""
+
+
+# Process-local request outcomes, exported by letter_quality_metrics.
+outcomes: dict[str, int] = {"scored": 0, "failed": 0, "skipped": 0}
+
+
+def _count(outcome: str) -> None:
+    outcomes[outcome] = outcomes.get(outcome, 0) + 1
+
+
+def enabled() -> bool:
+    return bool(getattr(settings, "TYPESAFE_API_KEY", None)) and bool(
+        getattr(settings, "TYPESAFE_LETTER_RANKING_ENABLED", False)
+    )
+
+
+# (identifier as we hold it, category). A category may carry an entity
+# suffix, "PROFESSIONAL#primary": every alias of that one person (legal
+# name, display name, first name, last name) then shares ONE token, so a
+# draft that says "Sam Smith MD" where the denial said "Sam Smith" is not
+# read as introducing a second provider.
+Redaction = tuple[str, str]
+
+# Bounded, linear scans, never a backtracking regex: the denial text is
+# unbounded user input and this runs on the event loop.
+_EMAIL_LOCAL_EXTRA = set("!#$%&'*+-/=?^_`{|}~.")  # RFC 5322 atext, plus the dot
+_EMAIL_DOMAIN_EXTRA = set(".-")
+_EMAIL_LOCAL_MAX = 64
+_EMAIL_DOMAIN_MAX = 253
+_PHONE_RE = re.compile(
+    r"(?<!\d)(?:\+?1[\s.-]?)?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}(?!\d)"
+)
+# A one-word name can be two letters ("Li"); anything else that short would
+# hit ordinary text.
+MIN_NAME_CHARS = 2
+MIN_IDENTIFIER_CHARS = 3
+_NAME_CATEGORIES = {"PATIENT", "PROFESSIONAL"}
+_UNKNOWN = "UNKNOWN"
+
+
+def _is_local_char(ch: str) -> bool:
+    return ch.isalnum() or ch in _EMAIL_LOCAL_EXTRA
+
+
+def _is_domain_char(ch: str) -> bool:
+    return ch.isalnum() or ch in _EMAIL_DOMAIN_EXTRA
+
+
+def _email_spans(text: str) -> list[tuple[int, int]]:
+    """Linear email finder: from each '@', walk left over local-part characters
+    and right over domain characters (both length-capped, Unicode letters
+    allowed), and require a dot followed by at least two letters."""
+    spans: list[tuple[int, int]] = []
+    last_end = 0
+    for at in range(len(text)):
+        if text[at] != "@" or at < last_end:
+            continue
+        start = at
+        while (
+            start > last_end
+            and at - start < _EMAIL_LOCAL_MAX
+            and _is_local_char(text[start - 1])
+        ):
+            start -= 1
+        if start == at:
+            continue
+        end = at + 1
+        while (
+            end < len(text)
+            and end - at - 1 < _EMAIL_DOMAIN_MAX
+            and _is_domain_char(text[end])
+        ):
+            end += 1
+        domain = text[at + 1 : end].rstrip(".-")
+        end = at + 1 + len(domain)
+        dot = domain.rfind(".")
+        tld = domain[dot + 1 :]
+        if (
+            dot <= 0
+            or len(tld) < 2
+            or not (tld.isalpha() or tld.lower().startswith("xn--"))
+        ):
+            continue
+        spans.append((start, end))
+        last_end = end
+    return spans
+
+
+def _phone_key(value: str) -> str:
+    digits = "".join(ch for ch in value if ch.isdigit())
+    return digits[-10:] if len(digits) > 10 else digits
+
+
+# (start, end, category, matched text, generic?)
+_Span = tuple[int, int, str, str, bool]
+
+
+class Redactor:
+    """Replace identifiers with stable, DISTINCT tokens, in ONE pass.
+
+    Every candidate span -- known identifiers, emails, phone-shaped values --
+    is found on the original text; overlaps are settled by "longest wins"
+    (a stored plan id that contains a phone number beats the phone, an email
+    that contains a first name beats the name), and the output is assembled
+    from the surviving spans. No pattern ever sees replaced text, so a token
+    can never be re-matched and no fence characters are needed.
+
+    Rules that matter for the score, not just for privacy:
+
+    * Every distinct value gets its own numbered token ("[PHONE_1]",
+      "[PHONE_2]"), shared across the denial and the draft. If both collapsed
+      to "[PHONE]" a draft that invented a phone number would look grounded.
+      Phone and fax values share one namespace keyed by digits, so
+      "(415) 555-0100" and "415-555-0100" are one token.
+    * A one-word name is matched only in its Capitalised and ALL-CAPS
+      spellings (never lowercase, however the profile stores it), so a
+      patient called Will or May does not blank every "will" and "may" in
+      the letter; multi-word names, ids and emails are matched
+      case-insensitively, whole-word.
+    """
+
+    def __init__(self, identifiers: typing.Iterable[Redaction] = ()):
+        self._tokens: dict[str, str] = {}  # category:key -> token
+        self._counts: dict[str, int] = {}
+        self._known: list[tuple[re.Pattern[str], str]] = []
+        seen: set[tuple[str, str]] = set()
+        for value, category in identifiers:
+            text = str(value).strip() if value is not None else ""
+            if not text or text.upper() == _UNKNOWN:
+                continue
+            category = "PHONE" if category == "FAX" else category
+            is_name = category.partition("#")[0] in _NAME_CATEGORIES
+            floor = MIN_NAME_CHARS if is_name else MIN_IDENTIFIER_CHARS
+            if len(text) < floor or (text, category) in seen:
+                continue
+            seen.add((text, category))
+            if is_name and " " not in text:
+                spellings = {text.capitalize(), text.upper()}
+                if text[0].isupper():
+                    spellings.add(text)
+                alternatives = "|".join(re.escape(v) for v in sorted(spellings))
+                pattern = re.compile(r"(?<!\w)(?:" + alternatives + r")(?!\w)")
+            else:
+                pattern = re.compile(
+                    r"(?<!\w)" + re.escape(text) + r"(?!\w)", re.IGNORECASE
+                )
+            self._known.append((pattern, category))
+
+    def _token(self, value: str, category: str) -> str:
+        display, _, entity = category.partition("#")
+        if entity:
+            key = f"{display}#{entity}"  # one token per person, whatever the alias
+        elif display == "PHONE":
+            key = f"PHONE:{_phone_key(value)}"
+        else:
+            key = f"{display}:{value.lower()}"
+        if key not in self._tokens:
+            self._counts[display] = self._counts.get(display, 0) + 1
+            self._tokens[key] = f"[{display}_{self._counts[display]}]"
+        return self._tokens[key]
+
+    def _spans(self, text: str) -> list[_Span]:
+        """Non-overlapping spans covering EVERY character any candidate
+        covered.
+
+        Two partially overlapping identifiers ("Alice Smith" and "Smith
+        Jones" on "Alice Smith Jones") become one span over their union, so
+        no fragment of either can leave; the union takes the category of its
+        longest member (ties: known before generic, then category name). A
+        sorted sweep, so it is O(n log n) in the number of candidates.
+        """
+        found: list[_Span] = []
+        for start, end in _email_spans(text):
+            found.append((start, end, "EMAIL", text[start:end], True))
+        for match in _PHONE_RE.finditer(text):
+            found.append((match.start(), match.end(), "PHONE", match.group(0), True))
+        for pattern, category in self._known:
+            for match in pattern.finditer(text):
+                found.append(
+                    (match.start(), match.end(), category, match.group(0), False)
+                )
+        found.sort(key=lambda span: (span[0], -span[1]))
+        merged: list[_Span] = []
+        group: list[_Span] = []
+        group_end = -1
+        for span in found:
+            if group and span[0] >= group_end:
+                merged.append(self._union(text, group))
+                group = []
+            group.append(span)
+            group_end = max(group_end, span[1])
+        if group:
+            merged.append(self._union(text, group))
+        return merged
+
+    @staticmethod
+    def _union(text: str, group: list[_Span]) -> _Span:
+        if len(group) == 1:
+            return group[0]
+        start = min(span[0] for span in group)
+        end = max(span[1] for span in group)
+        longest = min(
+            group, key=lambda span: (-(span[1] - span[0]), span[4], span[2], span[0])
+        )
+        return (start, end, longest[2], text[start:end], longest[4])
+
+    def redact(self, text: typing.Optional[str]) -> str:
+        source = text or ""
+        pieces: list[str] = []
+        cursor = 0
+        for start, end, category, value, _generic in self._spans(source):
+            pieces.append(source[cursor:start])
+            pieces.append(self._token(value, category))
+            cursor = end
+        pieces.append(source[cursor:])
+        return "".join(pieces)
+
+
+def redact(text: typing.Optional[str], identifiers: typing.Iterable[Redaction]) -> str:
+    """One-shot convenience over Redactor (tokens numbered within this call)."""
+    return Redactor(identifiers).redact(text)
+
+
+def _cut(text: str, limit: int) -> str:
+    """Truncate without splitting a token: a "[PAT" at the end would look
+    like an invented word to the scorer."""
+    if len(text) <= limit:
+        return text
+    cut = text[:limit]
+    open_at = cut.rfind("[")
+    if open_at != -1 and cut.rfind("]") < open_at:
+        cut = cut[:open_at]
+    return cut
+
+
+def build_document(
+    denial_text: typing.Optional[str],
+    letter_text: str,
+    identifiers: typing.Iterable[Redaction] = (),
+) -> str:
+    """The letter always fits; the denial gives way first. Both redacted.
+
+    A denial is usually reason-first, so when it must be cut it is cut from
+    the end. A draft longer than the whole cap is its own problem and is
+    truncated rather than dropped, so an over-long draft still gets a score
+    for the part a reader will actually see.
+    """
+    denial_header = "THE DENIAL:\n"
+    letter_header = "\n\nTHE APPEAL LETTER:\n"
+    room = DOCUMENT_CHAR_CAP - len(denial_header) - len(letter_header)
+    # One redactor for both texts, so a value that appears in each gets the
+    # SAME token and one that appears in only the draft gets a NEW one.
+    redactor = Redactor(identifiers)
+    if (
+        len(denial_text or "") > RAW_CHAR_BOUND
+        or len(letter_text or "") > RAW_CHAR_BOUND
+    ):
+        raise LetterScoringError("input over the raw bound; not scored")
+    # Redact FIRST, then cut: cutting raw text could split an identifier at
+    # the boundary and send its head.
+    denial = _cut(redactor.redact(denial_text or "").strip(), room)
+    letter = _cut(redactor.redact(letter_text or "").strip(), room)
+    denial = _cut(denial, max(0, room - len(letter)))
+    return denial_header + denial + letter_header + letter
+
+
+def parse_answers(payload: typing.Any) -> LetterScore:
+    """Turn a System One response into a LetterScore, strictly.
+
+    Strict on purpose: a missing question or an out-of-range score means the
+    API changed under us, and a silently wrong number would quietly reorder
+    every letter on the site. Better no score.
+    """
+    try:
+        answers = payload["answers"]
+        scores: dict[str, float] = {}
+        for question in SCORE_QUESTIONS:
+            value = float(answers[question]["score"])
+            if not 0.0 <= value <= MAX_PER_QUESTION:
+                raise LetterScoringError(
+                    f"{question} scored {value}, expected 0..{MAX_PER_QUESTION}"
+                )
+            scores[question] = value
+        usage = payload.get("usage") or {}
+        input_tokens = int(usage.get("input_tokens") or 0)
+    except LetterScoringError:
+        raise
+    except (KeyError, TypeError, ValueError) as e:
+        raise LetterScoringError(
+            f"unexpected response shape: {type(e).__name__}"
+        ) from e
+    quality = sum(scores.values()) / (MAX_PER_QUESTION * len(SCORE_QUESTIONS))
+    return LetterScore(
+        quality=quality,
+        grounding=scores[GROUNDING_QUESTION],
+        scores=scores,
+        input_tokens=input_tokens,
+        scorer=scorer_for(payload),
+    )
+
+
+async def _post(document: str, timeout_seconds: float) -> typing.Any:
+    # Kept as a seam: tests stub this one function to stay off the network.
+    return await typesafe.ask(
+        document, QUESTIONS, timeout_seconds=timeout_seconds, model=MODEL
+    )
+
+
+async def score_letter(
+    denial_text: typing.Optional[str],
+    letter_text: typing.Optional[str],
+    *,
+    identifiers: typing.Iterable[Redaction] = (),
+    timeout_seconds: typing.Optional[float] = None,
+) -> typing.Optional[LetterScore]:
+    """Score one draft, or return None. Never raises, never logs the text.
+
+    ``identifiers`` is everything we hold that could name the patient or the
+    professional; see redact(). Pass it. An empty list only means we hold
+    nothing, and the generic patterns still run.
+    """
+    if not enabled():
+        _count("skipped")
+        return None
+    if not (letter_text or "").strip():
+        _count("skipped")
+        return None
+    timeout = timeout_seconds or float(
+        getattr(settings, "TYPESAFE_TIMEOUT_SECONDS", 20)
+    )
+    try:
+        payload = await _post(
+            build_document(denial_text, letter_text or "", identifiers), timeout
+        )
+        score = parse_answers(payload)
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        # The exception text never carries the document: _post raises on
+        # status alone and aiohttp's own errors describe the connection.
+        _count("failed")
+        logger.warning(f"letter scoring unavailable: {type(e).__name__}: {e}")
+        return None
+    _count("scored")
+    return score
+
+
+def sort_key(
+    quality: typing.Optional[float], grounding: typing.Optional[float]
+) -> tuple[int, float]:
+    """Ordering shared by server and dashboard: grounded before ungrounded,
+    then by quality; unscored last. Higher sorts first when reversed."""
+    if quality is None:
+        return (0, 0.0)
+    demoted = grounding is not None and grounding < GROUNDING_DEMOTE_BELOW
+    return (1 if demoted else 2, quality)
+
+
+# How long the stream waits for in-flight scores before the done frame. A
+# score that misses this window still lands on the row for the dashboard; the
+# reader just sees that draft unranked.
+DRAIN_SECONDS = 15.0
+
+# In-flight scoring tasks keyed by (row id, rubric). Two jobs: a strong
+# reference so a straggler that outlives its stream (a slow answer after the
+# drain window) is not collected mid-request, and a guard so a reconnect on
+# this worker does not send the same row to TypeSafe twice while the first
+# answer is still in flight. Another worker process can still race; that
+# costs a fraction of a cent and last write wins, which is acceptable.
+_in_flight: dict[tuple[str, int], "asyncio.Task[typing.Any]"] = {}
+
+
+def in_flight_task(row_id: str) -> "typing.Optional[asyncio.Task[typing.Any]]":
+    """The task already scoring this row on this worker, if any. A second
+    stream (a reconnect) attaches to it instead of asking TypeSafe again,
+    and still gets the frame when it lands."""
+    task = _in_flight.get((str(row_id), RUBRIC_VERSION))
+    if task is None or task.done():
+        return None
+    return task
+
+
+def in_flight(row_id: str) -> bool:
+    return in_flight_task(row_id) is not None
+
+
+def keep_alive(task: "asyncio.Task[typing.Any]", row_id: str) -> None:
+    key = (str(row_id), RUBRIC_VERSION)
+    _in_flight[key] = task
+
+    def _forget(done: "asyncio.Future[typing.Any]") -> None:
+        # Only if the slot still holds THIS task: a newer task for the same
+        # row (after a rubric bump, or a very late straggler) keeps its own.
+        if _in_flight.get(key) is done:
+            _in_flight.pop(key, None)
+
+    task.add_done_callback(_forget)
+
+
+def score_frame(proposed_id: str, score: LetterScore) -> dict[str, typing.Any]:
+    """The stream frame that carries a score to the client, keyed by row id
+    so it can arrive after the letter it belongs to."""
+    return {
+        "type": "score",
+        "id": str(proposed_id),
+        "quality_score": round(score.quality, 4),
+        "grounding_score": round(score.grounding, 4),
+        # The client ranks only drafts scored on ONE scale.
+        "scorer": score.scorer,
+    }
+
+
+def with_score_fields(
+    frame: dict[str, typing.Any], row: typing.Any
+) -> dict[str, typing.Any]:
+    """Re-served rows carry their stored score on the letter frame itself,
+    while ranking is enabled: the flag is also the kill switch for scores
+    already in the database."""
+    if not enabled():
+        return frame
+    quality = getattr(row, "quality_score", None)
+    grounding = getattr(row, "grounding_score", None)
+    # Numbers only: the frame is JSON, and a row here can be anything that
+    # quacks like ProposedAppeal (the citation tests hand in mocks). And only
+    # a score from the current rubric: an older scale must not rank against
+    # fresh scores (the run rescores such rows instead).
+    if (
+        isinstance(quality, (int, float))
+        and not isinstance(quality, bool)
+        and same_rubric(getattr(row, "quality_scorer", None))
+    ):
+        frame["quality_score"] = round(float(quality), 4)
+        frame["scorer"] = str(getattr(row, "quality_scorer", ""))
+        frame["grounding_score"] = (
+            round(float(grounding), 4)
+            if isinstance(grounding, (int, float)) and not isinstance(grounding, bool)
+            else None
+        )
+    return frame
+
+
+def needs_scoring(row: typing.Any) -> bool:
+    """A re-served draft is scored (again) unless it already carries a score
+    from the current rubric."""
+    text = getattr(row, "appeal_text", None)
+    if not isinstance(text, str) or not text.strip():
+        return False
+    quality = getattr(row, "quality_score", None)
+    return quality is None or not same_rubric(getattr(row, "quality_scorer", None))

--- a/fighthealthinsurance/ml/typesafe.py
+++ b/fighthealthinsurance/ml/typesafe.py
@@ -1,0 +1,60 @@
+"""Transport for TypeSafe's System One API, shared by every feature that asks it
+typed questions about a document (draft scoring in letter_quality.py, and
+denial triage). One place for the URL, the auth header, the timeout and the
+status check, so a feature module only decides WHAT to ask.
+
+Never logs the document. A response body is never surfaced either: on a
+non-200 the error carries the status alone, because an error body could quote
+the document back.
+"""
+
+import typing
+
+import aiohttp
+from django.conf import settings
+
+# Cheapest current model; features pin their own scorer name so a model change
+# here is visible in the data they record.
+DEFAULT_MODEL = "speed_latest"
+
+# Measured in the evaluation run; System One rejects longer documents.
+DOCUMENT_CHAR_CAP = 24_000
+
+
+class TypeSafeError(Exception):
+    """The API did not return a usable answer set."""
+
+
+def configured() -> bool:
+    return bool(getattr(settings, "TYPESAFE_API_KEY", None))
+
+
+async def ask(
+    document: str,
+    questions: dict[str, dict[str, typing.Any]],
+    *,
+    timeout_seconds: float,
+    model: str = DEFAULT_MODEL,
+) -> typing.Any:
+    """POST one document and a set of typed questions; return the raw JSON.
+
+    Raises TypeSafeError on a non-200, and lets aiohttp/asyncio errors
+    propagate: callers decide what a failure means for their feature.
+    """
+    body = {
+        "document": document[:DOCUMENT_CHAR_CAP],
+        "model": model,
+        "questions": questions,
+    }
+    headers = {
+        "Authorization": f"Bearer {settings.TYPESAFE_API_KEY}",
+        "Content-Type": "application/json",
+    }
+    client_timeout = aiohttp.ClientTimeout(total=timeout_seconds)
+    async with aiohttp.ClientSession(timeout=client_timeout) as session:
+        async with session.post(
+            settings.TYPESAFE_API_URL, json=body, headers=headers
+        ) as response:
+            if response.status != 200:
+                raise TypeSafeError(f"HTTP {response.status}")
+            return await response.json()

--- a/fighthealthinsurance/ml/typesafe.py
+++ b/fighthealthinsurance/ml/typesafe.py
@@ -5,10 +5,13 @@ status check, so a feature module only decides WHAT to ask.
 
 Never logs the document. A response body is never surfaced either: on a
 non-200 the error carries the status alone, because an error body could quote
-the document back.
+the document back. And the request, which carries the API key and the
+document, only ever goes over https: a URL with any other scheme is refused
+before a session exists.
 """
 
 import typing
+from urllib.parse import urlsplit
 
 import aiohttp
 from django.conf import settings
@@ -41,6 +44,11 @@ async def ask(
     Raises TypeSafeError on a non-200, and lets aiohttp/asyncio errors
     propagate: callers decide what a failure means for their feature.
     """
+    url = str(getattr(settings, "TYPESAFE_API_URL", "") or "")
+    if urlsplit(url).scheme.lower() != "https":
+        # The bearer token and the document must never travel in the clear
+        # (review). Refused here, before anything is built or sent.
+        raise TypeSafeError("TYPESAFE_API_URL must use https")
     body = {
         "document": document[:DOCUMENT_CHAR_CAP],
         "model": model,
@@ -52,9 +60,7 @@ async def ask(
     }
     client_timeout = aiohttp.ClientTimeout(total=timeout_seconds)
     async with aiohttp.ClientSession(timeout=client_timeout) as session:
-        async with session.post(
-            settings.TYPESAFE_API_URL, json=body, headers=headers
-        ) as response:
+        async with session.post(url, json=body, headers=headers) as response:
             if response.status != 200:
                 raise TypeSafeError(f"HTTP {response.status}")
             return await response.json()

--- a/fighthealthinsurance/ml/typesafe.py
+++ b/fighthealthinsurance/ml/typesafe.py
@@ -60,7 +60,11 @@ async def ask(
     }
     client_timeout = aiohttp.ClientTimeout(total=timeout_seconds)
     async with aiohttp.ClientSession(timeout=client_timeout) as session:
-        async with session.post(url, json=body, headers=headers) as response:
+        # No redirects: a 307 or 308 toward http would make aiohttp resend
+        # the document in the clear (review). A 3xx is just a non-200 here.
+        async with session.post(
+            url, json=body, headers=headers, allow_redirects=False
+        ) as response:
             if response.status != 200:
                 raise TypeSafeError(f"HTTP {response.status}")
             return await response.json()

--- a/fighthealthinsurance/models.py
+++ b/fighthealthinsurance/models.py
@@ -2621,6 +2621,19 @@ class ProposedAppeal(ExportModelOperationsMixin("ProposedAppeal"), models.Model)
     text_fingerprint = models.CharField(
         max_length=64, null=True, blank=True, db_index=True
     )
+    # Criteria score from ml/letter_quality.py, used to ORDER drafts on the
+    # page and to watch draft quality per backend on the staff dashboard.
+    # quality_score is a 0..1 composite; grounding_score is the
+    # no_invented_facts answer alone (0..2, an expected level so it can be
+    # fractional), kept separate because a draft that
+    # invents facts is demoted regardless of how well it reads. quality_scorer
+    # names the scorer + question set so a re-tuned rubric never mixes scales.
+    # Null for unscored rows: scoring is optional, fails closed, and only runs
+    # when the user allowed external models.
+    quality_score = models.FloatField(null=True, blank=True)
+    grounding_score = models.FloatField(null=True, blank=True)
+    quality_scorer = models.CharField(max_length=80, null=True, blank=True)
+    quality_scored_at = models.DateTimeField(null=True, blank=True, db_index=True)
 
     class Meta:
         constraints = [

--- a/fighthealthinsurance/settings.py
+++ b/fighthealthinsurance/settings.py
@@ -81,6 +81,27 @@ def _env_list(name: str) -> list:
 POD_IP = (os.getenv("POD_IP") or "").strip()
 
 
+def _env_int(name: str, default: int, *, minimum: int, maximum: int) -> int:
+    """An int from the environment within [minimum, maximum], or the default.
+
+    Read at import, so a stray unit suffix ("20s"), an empty value, or a
+    value outside the plausible range must not crash-loop every web and
+    worker process over an optional setting -- and a zero or negative
+    timeout, which aiohttp reads as "no timeout at all", must never get
+    through.
+    """
+    raw = os.getenv(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        value = int(raw.strip())
+    except ValueError:
+        return default
+    if not minimum <= value <= maximum:
+        return default
+    return value
+
+
 class Base(Configuration):
     SENTRY_ENDPOINT = os.getenv("SENTRY_ENDPOINT")
     COOKIE_CONSENT_ENABLED = False
@@ -143,6 +164,20 @@ class Base(Configuration):
     # journey would strand completions.
     TEMPORAL_INTAKE_JOURNEY_ENABLED = (
         os.getenv("TEMPORAL_INTAKE_JOURNEY_ENABLED", "false").lower() == "true"
+    )
+
+    # TypeSafe System One letter scoring (ml/letter_quality.py). Inert until
+    # BOTH the key and the flag are set: the key alone must not start sending
+    # denial text to a new processor before the privacy policy names it.
+    TYPESAFE_API_KEY = os.getenv("TYPESAFE_API_KEY")
+    TYPESAFE_API_URL = os.getenv(
+        "TYPESAFE_API_URL", "https://api.typesafe.ai/v1/systemone"
+    )
+    TYPESAFE_LETTER_RANKING_ENABLED = (
+        os.getenv("TYPESAFE_LETTER_RANKING_ENABLED", "false").lower() == "true"
+    )
+    TYPESAFE_TIMEOUT_SECONDS = _env_int(
+        "TYPESAFE_TIMEOUT_SECONDS", 20, minimum=1, maximum=300
     )
     TEMPORAL_HOST = os.getenv("TEMPORAL_HOST", "localhost:7233")
     TEMPORAL_NAMESPACE = os.getenv("TEMPORAL_NAMESPACE", "default")
@@ -796,6 +831,15 @@ class Dev(Base):
 
 
 class Test(Dev):
+    # TypeSafe is hard-off under test: a developer's key and flag in the
+    # environment must never let an exercised generation path send test
+    # denial text to a real endpoint. Scorer tests opt in with
+    # override_settings and stub the transport.
+    TYPESAFE_API_KEY = None
+    TYPESAFE_API_URL = "http://typesafe.invalid/v1/systemone"
+    TYPESAFE_LETTER_RANKING_ENABLED = False
+    TYPESAFE_DENIAL_TRIAGE_ENABLED = False
+
     # Barrier no-ops in tests: mock denials have no DB row, so any positive
     # timeout would poll until it expires on every generate_appeals test.
     FHI_CONTEXT_BARRIER_TIMEOUT_S = 0
@@ -852,6 +896,15 @@ class Test(Dev):
 
 
 class TestSync(Dev):
+    # TypeSafe is hard-off under test: a developer's key and flag in the
+    # environment must never let an exercised generation path send test
+    # denial text to a real endpoint. Scorer tests opt in with
+    # override_settings and stub the transport.
+    TYPESAFE_API_KEY = None
+    TYPESAFE_API_URL = "http://typesafe.invalid/v1/systemone"
+    TYPESAFE_LETTER_RANKING_ENABLED = False
+    TYPESAFE_DENIAL_TRIAGE_ENABLED = False
+
     DEBUG = True
     # Barrier no-ops in tests (see Test class).
     FHI_CONTEXT_BARRIER_TIMEOUT_S = 0
@@ -884,6 +937,15 @@ class TestSync(Dev):
 
 
 class TestActor(Dev):
+    # TypeSafe is hard-off under test: a developer's key and flag in the
+    # environment must never let an exercised generation path send test
+    # denial text to a real endpoint. Scorer tests opt in with
+    # override_settings and stub the transport.
+    TYPESAFE_API_KEY = None
+    TYPESAFE_API_URL = "http://typesafe.invalid/v1/systemone"
+    TYPESAFE_LETTER_RANKING_ENABLED = False
+    TYPESAFE_DENIAL_TRIAGE_ENABLED = False
+
     DEBUG = True
     # Barrier no-ops in tests (see Test class).
     FHI_CONTEXT_BARRIER_TIMEOUT_S = 0

--- a/fighthealthinsurance/settings.py
+++ b/fighthealthinsurance/settings.py
@@ -836,7 +836,7 @@ class Test(Dev):
     # denial text to a real endpoint. Scorer tests opt in with
     # override_settings and stub the transport.
     TYPESAFE_API_KEY = None
-    TYPESAFE_API_URL = "http://typesafe.invalid/v1/systemone"
+    TYPESAFE_API_URL = "https://typesafe.invalid/v1/systemone"
     TYPESAFE_LETTER_RANKING_ENABLED = False
     TYPESAFE_DENIAL_TRIAGE_ENABLED = False
 
@@ -901,7 +901,7 @@ class TestSync(Dev):
     # denial text to a real endpoint. Scorer tests opt in with
     # override_settings and stub the transport.
     TYPESAFE_API_KEY = None
-    TYPESAFE_API_URL = "http://typesafe.invalid/v1/systemone"
+    TYPESAFE_API_URL = "https://typesafe.invalid/v1/systemone"
     TYPESAFE_LETTER_RANKING_ENABLED = False
     TYPESAFE_DENIAL_TRIAGE_ENABLED = False
 
@@ -942,7 +942,7 @@ class TestActor(Dev):
     # denial text to a real endpoint. Scorer tests opt in with
     # override_settings and stub the transport.
     TYPESAFE_API_KEY = None
-    TYPESAFE_API_URL = "http://typesafe.invalid/v1/systemone"
+    TYPESAFE_API_URL = "https://typesafe.invalid/v1/systemone"
     TYPESAFE_LETTER_RANKING_ENABLED = False
     TYPESAFE_DENIAL_TRIAGE_ENABLED = False
 

--- a/fighthealthinsurance/staff_views.py
+++ b/fighthealthinsurance/staff_views.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from django.core.exceptions import ValidationError
 from django.db import transaction
-from django.db.models import Count, F, QuerySet
+from django.db.models import Avg, Count, F, Max, QuerySet
 from django.db.models.functions import Lower
 from django.http import HttpResponse, HttpResponseBase, StreamingHttpResponse
 from django.shortcuts import redirect, render
@@ -45,7 +45,7 @@ from fighthealthinsurance.models import (
 )
 from fighthealthinsurance.email_utils import is_sendable_email
 from fighthealthinsurance.business_hours import describe_send_window
-from fighthealthinsurance.ml import model_query
+from fighthealthinsurance.ml import letter_quality, model_query
 from fighthealthinsurance.ml.model_identity import (
     LEGACY_UNATTRIBUTED_LABEL,
     normalize_model_label,
@@ -1065,7 +1065,9 @@ UNKNOWN_MODEL_LABEL = "(unattributed)"
 
 
 def _merge_stats(
-    chosen: Dict[str, int], presented: Dict[str, int]
+    chosen: Dict[str, int],
+    presented: Dict[str, int],
+    quality: Optional[Dict[str, Dict[str, Any]]] = None,
 ) -> List[Dict[str, Any]]:
     """Combine per-model chosen + presented counts into a sorted list of dicts.
 
@@ -1073,18 +1075,32 @@ def _merge_stats(
     model has no presented count (no denominator — e.g. legacy chosen rows
     without presentation records). Templates render ``None`` as an em dash;
     it must never be displayed as 0.0%.
+
+    ``quality`` (optional) is per-model draft-quality aggregates from
+    ``ml/letter_quality.py``: ``{"avg": 0..1, "scored": n, "ungrounded": n}``.
+    Win rate is the lagging signal (it needs a user to pick a draft, weeks of
+    them to mean anything); the quality average is the leading one, available
+    the minute a backend ships. A model with no scored drafts gets ``None``
+    for the average, rendered as a dash, never as 0.
     """
+    quality = quality or {}
     rows: List[Dict[str, Any]] = []
-    for model_name in set(chosen) | set(presented):
+    for model_name in set(chosen) | set(presented) | set(quality):
         c = chosen.get(model_name, 0)
         p = presented.get(model_name, 0)
         win_rate = (c / p * 100.0) if p > 0 else None
+        q = quality.get(model_name) or {}
         rows.append(
             {
                 "model_name": model_name,
                 "chosen": c,
                 "presented": p,
                 "win_rate": win_rate,
+                "quality_avg": q.get("avg"),
+                "quality_scored": int(q.get("scored") or 0),
+                "quality_ungrounded": int(q.get("ungrounded") or 0),
+                "quality_scorer": q.get("scorer"),
+                "quality_other_scorer": int(q.get("other_scorer") or 0),
             }
         )
     rows.sort(
@@ -1254,7 +1270,95 @@ class ModelUsageDashboardView(generic.TemplateView):
             presented_label = normalize_model_label(name)
             if presented_label is not None:
                 presented[presented_label] += count
-        return _merge_stats(dict(chosen), dict(presented))
+        return _merge_stats(
+            dict(chosen),
+            dict(presented),
+            ModelUsageDashboardView._draft_quality_stats(since),
+        )
+
+    @staticmethod
+    def _draft_quality_stats(
+        since: Optional[datetime.datetime],
+    ) -> Dict[str, Dict[str, Any]]:
+        """Per-model draft quality (ml/letter_quality.py) over the window.
+
+        Every scored, non-speculative draft counts, chosen or not: this is
+        about what each backend PRODUCES, not what users picked, so it is
+        anchored on the draft's own created_at rather than on a later pick.
+        Labels are normalized the same way as chosen/presented so the three
+        line up in one row.
+
+        One EXACT scorer per table: the provenance string of the most
+        recently SCORED row (by quality_scored_at, not the draft's age: old
+        drafts are rescored) in the window. Rows scored by any other scorer
+        (an older rubric, or the same rubric answered by a repointed
+        model) are counted in ``other_scorer`` and never averaged in, so a
+        change on TypeSafe's side cannot masquerade as backend drift.
+        """
+        scored_qs = ProposedAppeal.objects.filter(
+            quality_score__isnull=False,
+            speculative=False,
+            model_name__isnull=False,
+        )
+        if since is not None:
+            scored_qs = scored_qs.filter(created_at__gte=since)
+        latest = None
+        for candidate in (
+            scored_qs.filter(
+                quality_scorer__startswith="typesafe/",
+                quality_scorer__endswith=letter_quality._RUBRIC_SUFFIX,
+            )
+            .values("quality_scorer")
+            .annotate(newest=Max("quality_scored_at"))
+            .order_by("-newest")
+            .values_list("quality_scorer", flat=True)[:20]
+        ):
+            if letter_quality.same_rubric(candidate):
+                latest = candidate
+                break
+        out: Dict[str, Dict[str, Any]] = {}
+        for name, avg, scored, ungrounded in (
+            (scored_qs.filter(quality_scorer=latest) if latest else scored_qs.none())
+            .values_list("model_name")
+            .annotate(
+                avg=Avg("quality_score"),
+                scored=Count("id"),
+                ungrounded=Count(
+                    "id",
+                    filter=Q(grounding_score__lt=letter_quality.GROUNDING_DEMOTE_BELOW),
+                ),
+            )
+            .values_list("model_name", "avg", "scored", "ungrounded")
+        ):
+            label = normalize_model_label(name)
+            if label is None:
+                continue
+            bucket = out.setdefault(
+                label, {"sum": 0.0, "scored": 0, "ungrounded": 0, "other_scorer": 0}
+            )
+            bucket["sum"] += float(avg or 0.0) * int(scored)
+            bucket["scored"] += int(scored)
+            bucket["ungrounded"] += int(ungrounded)
+        for name, count in (
+            scored_qs.exclude(quality_scorer=latest)
+            .values_list("model_name")
+            .annotate(c=Count("id"))
+            .values_list("model_name", "c")
+        ):
+            label = normalize_model_label(name)
+            if label is None:
+                continue
+            bucket = out.setdefault(
+                label, {"sum": 0.0, "scored": 0, "ungrounded": 0, "other_scorer": 0}
+            )
+            bucket["other_scorer"] += int(count)
+        for bucket in out.values():
+            bucket["avg"] = (
+                bucket["sum"] / bucket["scored"] if bucket["scored"] else None
+            )
+            bucket["scorer"] = latest
+            del bucket["sum"]
+        return out
 
     @staticmethod
     def _context_level_stats(

--- a/fighthealthinsurance/static/js/appeal_fetcher.ts
+++ b/fighthealthinsurance/static/js/appeal_fetcher.ts
@@ -457,6 +457,156 @@ let handingOffToRest = false;
 let wsGaveUp = false;
 let hasAutoScrolledToFirstAppeal = false;
 
+// ---------------------------------------------------------------------------
+// Draft ordering. The server scores each saved draft on how well it addresses
+// THIS denial (fighthealthinsurance/ml/letter_quality.py) and sends the score
+// as a {"type": "score", "id": <proposed id>} frame after the letter, or on
+// the letter frame itself for a re-served draft. Nothing moves while letters
+// are still arriving: a list that reshuffles under someone reading it is
+// worse than a list in arrival order. Once the server says done, the drafts
+// are ordered once, the top one is labelled, and everything past
+// RANKED_VISIBLE_LIMIT is folded behind a button rather than dropped.
+//
+// The score is a criteria score, not a success probability, and the caption
+// says exactly that. Never render it as a percentage or a "chance".
+// ---------------------------------------------------------------------------
+const RANKED_VISIBLE_LIMIT = 3;
+const RANKING_CAPTION =
+  "Ordered by how well each letter addresses your denial, not by a prediction of the outcome.";
+const RECOMMENDED_LABEL = "Recommended";
+// Drafts that scored 0 on "no invented facts" sort below every grounded draft
+// whatever their other marks (matches letter_quality.sort_key).
+const GROUNDING_DEMOTE_BELOW = 1;
+
+interface DraftScore {
+  quality: number;
+  grounding: number | null;
+  scorer: string;
+}
+let draftScores = new Map<string, DraftScore>();
+
+function recordDraftScore(proposedId: unknown, quality: unknown, grounding: unknown, scorer: unknown): void {
+  if (proposedId === undefined || proposedId === null || proposedId === "unknown") return;
+  const q = Number(quality);
+  if (!Number.isFinite(q)) return;
+  const g = grounding === undefined || grounding === null ? null : Number(grounding);
+  draftScores.set(String(proposedId), {
+    quality: q,
+    grounding: Number.isFinite(g as number) ? (g as number) : null,
+    scorer: typeof scorer === "string" ? scorer : "",
+  });
+}
+
+// Higher sorts first. Unscored drafts keep arrival order at the bottom.
+function draftSortKey(el: HTMLElement): [number, number] {
+  const id = el.getAttribute("data-proposed-id");
+  const score = id ? draftScores.get(id) : undefined;
+  if (!score) return [0, 0];
+  const demoted = score.grounding !== null && score.grounding < GROUNDING_DEMOTE_BELOW;
+  return [demoted ? 1 : 2, score.quality];
+}
+
+function rankedDrafts(): HTMLElement[] {
+  const drafts = outputContainer.children('[id^="magic"]').toArray() as HTMLElement[];
+  const withIndex = drafts.map((el, index) => ({ el, index, key: draftSortKey(el) }));
+  withIndex.sort((a, b) => {
+    if (a.key[0] !== b.key[0]) return b.key[0] - a.key[0];
+    if (a.key[1] !== b.key[1]) return b.key[1] - a.key[1];
+    return a.index - b.index;
+  });
+  return withIndex.map((entry) => entry.el);
+}
+
+function finalizeRanking(): void {
+  if (draftScores.size === 0) return;
+  // Idempotent: a retry can reach done more than once. Rebuild from scratch
+  // so there is never a second "Recommended" or a stale fold.
+  document.getElementById("appeal-ranking-note")?.remove();
+  document.getElementById("appeal-show-more")?.remove();
+  for (const badge of Array.from(document.querySelectorAll(".appeal-recommended-badge"))) badge.remove();
+  const drafts = outputContainer.children('[id^="magic"]').toArray() as HTMLElement[];
+  for (const el of drafts) el.hidden = false;
+  // All or nothing. A scorer that answered for one draft and rate-limited
+  // the rest would put that one first and fold the unassessed ones away,
+  // which is an ordering by luck. Without full coverage the page is put
+  // BACK in arrival order (an earlier, fully scored pass may have sorted
+  // it), with no caption and no fold.
+  // A draft that never got a row id (its save failed) can never be scored,
+  // so it counts as uncovered too: ranking the rest around it would be the
+  // same partial ordering.
+  // ...and all on ONE scale: a score from a repointed model is not
+  // comparable with one from the previous model, whatever the dashboard
+  // does with them.
+  const scorers = new Set(
+    drafts.map((el) => draftScores.get(el.getAttribute("data-proposed-id") || "")?.scorer ?? ""),
+  );
+  const everyDraftScored =
+    scorers.size === 1 &&
+    drafts.every((el) => {
+      const id = el.getAttribute("data-proposed-id");
+      return !!id && draftScores.has(id);
+    });
+  if (!everyDraftScored) {
+    const byArrival = drafts.slice().sort(
+      (a, b) => Number(a.getAttribute("data-arrival-index") || 0) - Number(b.getAttribute("data-arrival-index") || 0),
+    );
+    for (const el of byArrival) outputContainer.append(el);
+    return;
+  }
+  const ordered = rankedDrafts();
+  if (ordered.length === 0) return;
+
+  // Re-appending moves the existing nodes, so anything the user has typed
+  // into a draft's textarea comes along with it.
+  for (const el of ordered) outputContainer.append(el);
+
+  if (!document.getElementById("appeal-ranking-note")) {
+    const note = document.createElement("p");
+    note.id = "appeal-ranking-note";
+    note.className = "text-muted";
+    note.style.margin = "8px 20px";
+    note.textContent = RANKING_CAPTION;
+    ordered[0].before(note);
+  }
+
+  const top = ordered[0];
+  // A draft the reader has already rewritten is not the draft that was
+  // scored: it keeps its place in the order but never gets the label.
+  const topIsDirty = top.getAttribute("data-dirty") === "1";
+  if (!topIsDirty && draftSortKey(top)[0] === 2 && !top.querySelector(".appeal-recommended-badge")) {
+    const badge = document.createElement("div");
+    badge.className = "appeal-recommended-badge";
+    badge.textContent = RECOMMENDED_LABEL;
+    badge.style.cssText =
+      "display:inline-block;padding:4px 10px;margin:0 0 8px;border-radius:4px;" +
+      "background:#2e7d32;color:#fff;font-weight:600;font-size:0.9em;";
+    top.prepend(badge);
+  }
+
+  const hidden = ordered.slice(RANKED_VISIBLE_LIMIT);
+  if (hidden.length > 0 && !document.getElementById("appeal-show-more")) {
+    for (const el of hidden) el.hidden = true;
+    const button = document.createElement("button");
+    button.id = "appeal-show-more";
+    button.type = "button";
+    button.className = "btn btn-outline-secondary";
+    button.style.margin = "8px 20px 24px";
+    button.textContent = `Show ${hidden.length} more draft${hidden.length === 1 ? "" : "s"}`;
+    button.setAttribute("aria-expanded", "false");
+    button.setAttribute("aria-controls", hidden.map((el) => el.id).join(" "));
+    button.addEventListener("click", () => {
+      for (const el of hidden) el.hidden = false;
+      button.setAttribute("aria-expanded", "true");
+      // Keep keyboard and screen-reader users where the new content is,
+      // instead of dropping focus on the body when the button goes away.
+      const first = hidden[0].querySelector("textarea") as HTMLElement | null;
+      (first ?? hidden[0]).focus();
+      button.remove();
+    });
+    ordered[RANKED_VISIBLE_LIMIT - 1].after(button);
+  }
+}
+
 // Diagnostic counters used in the client error report so server logs
 // can distinguish "we never reached the server" from "we reached the
 // server, got status frames, but never saw an appeal payload".
@@ -818,6 +968,10 @@ function done(): void {
     retries = retries + 1;
     doQuery(my_backend_url, my_data, my_rest_fallback_url);
   } else {
+    // Generation is really over (no further automatic attempt): only now
+    // may the drafts be ordered, so a page never reshuffles under a reader
+    // while a retry is still adding letters.
+    finalizeRanking();
     if (appealsSoFar.length === 0) {
       const transport = usingRestFallback ? 'rest-fallback' : 'websocket';
       // Be explicit about *why* we ended with nothing. The common iOS case is
@@ -1243,12 +1397,26 @@ function processResponseChunk(chunk: string): void {
           return;
         }
 
+        // A draft's score, sent after the letter it belongs to (or never,
+        // when scoring is off or failed). Recorded now, applied at done.
+        if (parsedLine.type === 'score') {
+          recordDraftScore(parsedLine.id, parsedLine.quality_score, parsedLine.grounding_score, parsedLine.scorer);
+          return;
+        }
+
         // Handle regular appeal content
         const appealText = parsedLine.content;
         if (appealText === undefined || appealText === null) {
           // Frames come from the appeal stream; log field names only, not values.
           console.warn('Skipping non-appeal frame without content, keys:', Object.keys(parsedLine));
           return;
+        }
+
+        // A re-served draft carries its stored score on the frame. Record it
+        // BEFORE the duplicate check: on a retry the letter itself is a
+        // duplicate we skip, but its score is what keeps it ranked.
+        if (parsedLine.quality_score !== undefined) {
+          recordDraftScore(parsedLine.id, parsedLine.quality_score, parsedLine.grounding_score, parsedLine.scorer);
         }
 
         if (
@@ -1263,6 +1431,7 @@ function processResponseChunk(chunk: string): void {
 
         appealsSoFar.push(appealText);
         appealId++;
+        const arrivalIndex = appealId;
 
         // Record arrival timing for the wait-time indicators: freeze the
         // first-appeal clock on the first arrival, and reset the
@@ -1286,6 +1455,9 @@ function processResponseChunk(chunk: string): void {
           .clone()
           .prop("id", `magic${appealId}`);
         clonedForm.removeAttr("style");
+        // Arrival order is the fallback ordering; keep it on the node so a
+        // later pass can restore it after an earlier pass reordered.
+        clonedForm.attr("data-arrival-index", String(arrivalIndex));
 
         // Add padding/margin to the cloned form container
         clonedForm.css({
@@ -1324,6 +1496,12 @@ function processResponseChunk(chunk: string): void {
         submitButton.prop("id", `submit${appealId}`);
 
         const appealTextElem = clonedForm.find("textarea");
+        // The score was for the text as generated; once a person edits a
+        // draft the label no longer describes what they will send.
+        appealTextElem.on("input", () => {
+          clonedForm.attr("data-dirty", "1");
+          clonedForm.find(".appeal-recommended-badge").remove();
+        });
         appealTextElem.text(appealText);
         appealTextElem.val(appealText);
         appealTextElem.prop("form", `form_${appealId}`);
@@ -1335,6 +1513,7 @@ function processResponseChunk(chunk: string): void {
         const proposedId = parsedLine.id;
         if (proposedId !== undefined && proposedId !== null && proposedId !== "unknown") {
           clonedForm.find("input.proposed_appeal_id").val(String(proposedId));
+          clonedForm.attr("data-proposed-id", String(proposedId));
         }
 
         outputContainer.append(clonedForm);
@@ -1601,6 +1780,10 @@ export function doQuery(backend_url: string, data: AppealQueryData, rest_fallbac
   // accumulating it across attempts would inflate `accountedFor` and mask a
   // genuine partial delivery on attempts 2+.
   duplicatesSkipped = 0;
+  // draftScores is deliberately NOT reset here: doQuery also runs the
+  // automatic retries, whose re-served letters are deduped by content while
+  // their scores (keyed by stable row id) must survive. A new denial is a
+  // new page load.
   // Start the aggregate wait clock only on the first call. doQuery
   // recurses on retry via done(), and we want the total to span the
   // entire user-visible wait, not just the latest retry.

--- a/fighthealthinsurance/templates/model_usage_table_partial.html
+++ b/fighthealthinsurance/templates/model_usage_table_partial.html
@@ -6,6 +6,10 @@
       <th class="num">Chosen</th>
       <th class="num">Presented</th>
       <th class="num">Win rate</th>
+      <th class="num" title="Mean draft quality 0..1 from the letter scorer (ml/letter_quality.py); a criteria score, not a success rate">Quality</th>
+      <th class="num" title="Drafts scored in the window">Scored</th>
+      <th class="num" title="Scored drafts that invented facts (grounding below threshold)">Ungrounded</th>
+      <th class="num" title="Scored drafts from a different scorer or rubric than the current one; never averaged in">Other scorer</th>
     </tr>
   </thead>
   <tbody>
@@ -20,6 +24,15 @@
       {% else %}
       <td class="num">{{ r.win_rate|floatformat:1 }}%</td>
       {% endif %}
+      {% if r.quality_avg is None %}
+      {# Nothing scored for this model in the window; a dash, never 0.00. #}
+      <td class="num">&mdash;</td>
+      {% else %}
+      <td class="num">{{ r.quality_avg|floatformat:2 }}</td>
+      {% endif %}
+      <td class="num">{{ r.quality_scored|default:0 }}</td>
+      <td class="num">{{ r.quality_ungrounded|default:0 }}</td>
+      <td class="num">{{ r.quality_other_scorer|default:0 }}</td>
     </tr>
     {% endfor %}
   </tbody>

--- a/tests/async-unit/conftest.py
+++ b/tests/async-unit/conftest.py
@@ -38,6 +38,12 @@ _AMBIENT_BACKEND_ENV_VARS = (
     "PERPLEXITY_API",
     "SECONDARY_NEW_HEALTH_BACKEND_HOST",
     "SECONDARY_NEW_HEALTH_BACKEND_PORT",
+    # Not a router backend, but the same hazard: a developer's TypeSafe key in
+    # the environment must never let a unit test score a letter for real.
+    "TYPESAFE_API_KEY",
+    "TYPESAFE_LETTER_RANKING_ENABLED",
+    "TYPESAFE_TIMEOUT_SECONDS",
+    "TYPESAFE_API_URL",
 )
 for _name in _AMBIENT_BACKEND_ENV_VARS:
     os.environ.pop(_name, None)

--- a/tests/async-unit/test_appeal_ranking_client.py
+++ b/tests/async-unit/test_appeal_ranking_client.py
@@ -1,0 +1,103 @@
+"""The appeal page's draft ordering, pinned at the source level.
+
+There is no JS test runner in this repo, so the client half of the ranking
+feature is pinned by reading appeal_fetcher.ts: the frame it must accept, the
+moment it may reorder, the copy it shows, and the limit it folds at. Each of
+these is a promise the server side or the owner relies on.
+"""
+
+import re
+from pathlib import Path
+
+SRC = (
+    Path(__file__).resolve().parents[2]
+    / "fighthealthinsurance"
+    / "static"
+    / "js"
+    / "appeal_fetcher.ts"
+).read_text()
+
+
+def test_score_frames_are_handled_before_the_no_content_skip():
+    score_branch = SRC.index("parsedLine.type === 'score'")
+    content_skip = SRC.index("Skipping non-appeal frame without content")
+    assert score_branch < content_skip
+
+
+def test_ordering_is_applied_only_when_generation_is_really_over():
+    # One call site (the definition does not end in a semicolon), in the
+    # terminal branch of done(): the server's per-attempt done frame must
+    # not trigger it, because done() may still start another attempt.
+    assert SRC.count("finalizeRanking();") == 1
+    done_fn = SRC.index("function done(): void {")
+    call = SRC.index("finalizeRanking();")
+    assert done_fn < call < SRC.index("\nfunction ", done_fn + 10)
+    assert SRC.index("} else {", done_fn) < call, "in the no-retry branch"
+    assert "finalizeRanking" not in SRC[SRC.index("if (phase === 'done')") : SRC.index("if (phase === 'done')") + 2500]
+    # A score frame records and returns; it must not reorder mid-stream.
+    branch = SRC[SRC.index("parsedLine.type === 'score'") :].split("return;", 1)[0]
+    assert "finalizeRanking" not in branch and "rankedDrafts" not in branch
+
+
+def test_caption_makes_no_promise_about_the_outcome():
+    caption = re.search(r'RANKING_CAPTION =\s*"([^"]+)"', SRC).group(1)
+    assert "not by a prediction of the outcome" in caption
+    for banned in ("%", "chance", "likely", "success"):
+        assert banned not in caption.lower()
+
+
+def test_three_visible_then_a_show_more_button_not_a_delete():
+    assert re.search(r"const RANKED_VISIBLE_LIMIT = 3;", SRC)
+    assert "Show ${hidden.length} more draft" in SRC
+    assert "el.hidden = true" in SRC and ".remove()" not in SRC.split("const hidden = ordered.slice")[1].split("button.remove()")[0]
+
+
+def test_ungrounded_drafts_are_demoted_like_the_server_does():
+    from fighthealthinsurance.ml import letter_quality
+
+    client = int(re.search(r"const GROUNDING_DEMOTE_BELOW = (\d+);", SRC).group(1))
+    assert client == letter_quality.GROUNDING_DEMOTE_BELOW
+
+
+def test_scores_survive_retries_and_embedded_scores_beat_dedup():
+    # doQuery also drives the automatic retries: resetting there would drop
+    # every re-served draft's score right before dedup skips its letter.
+    assert "draftScores = new Map();" not in SRC.split("export function doQuery", 1)[1]
+    handler = SRC[SRC.index("const appealText = parsedLine.content;") :]
+    assert handler.index("recordDraftScore(parsedLine.id, parsedLine.quality_score") < handler.index("appealsSoFar.some(")
+
+
+def test_finalize_rebuilds_from_scratch():
+    body = SRC[SRC.index("function finalizeRanking()") : SRC.index("const ordered = rankedDrafts();")]
+    for cleanup in ('getElementById("appeal-ranking-note")?.remove()', 'getElementById("appeal-show-more")?.remove()', ".appeal-recommended-badge"):
+        assert cleanup in body
+    assert "el.hidden = false;" in SRC[SRC.index("function finalizeRanking()") :]
+
+
+def test_nothing_moves_unless_every_draft_with_a_row_id_was_scored():
+    start = SRC.index("function finalizeRanking()")
+    body = SRC[start : SRC.index("\nfunction ", start + 10)]  # the whole function
+    assert "return !!id && draftScores.has(id);" in body, "an unsaved draft is uncovered"
+    assert "scorers.size === 1 &&" in body, "one scale only"
+    gate = body.index("if (!everyDraftScored) {")
+    # ...and an earlier, fully scored pass is undone: back to arrival order.
+    incomplete = body[gate : body.index("const ordered = rankedDrafts();")]
+    assert 'data-arrival-index' in incomplete and "outputContainer.append(el)" in incomplete
+    assert 'clonedForm.attr("data-arrival-index"' in SRC
+    assert gate < body.index("const ordered = rankedDrafts();")
+    assert gate < body.index('note.id = "appeal-ranking-note"')
+    assert gate < body.index("const hidden = ordered.slice")
+
+
+def test_an_edited_draft_never_carries_the_label():
+    assert 'clonedForm.attr("data-dirty", "1");' in SRC
+    body = SRC[SRC.index("function finalizeRanking()") : SRC.index("\nfunction ", SRC.index("function finalizeRanking()") + 10)]
+    assert 'top.getAttribute("data-dirty") === "1"' in body
+    assert "if (!topIsDirty && draftSortKey(top)[0] === 2" in body
+
+
+def test_show_more_keeps_keyboard_focus_and_exposes_state():
+    body = SRC[SRC.index('button.id = "appeal-show-more";') :]
+    assert 'setAttribute("aria-expanded", "false")' in body
+    assert 'setAttribute("aria-controls"' in body
+    assert ".focus();" in body.split("button.remove();", 1)[0]

--- a/tests/async-unit/test_letter_quality.py
+++ b/tests/async-unit/test_letter_quality.py
@@ -1,0 +1,396 @@
+"""ml/letter_quality.py: the TypeSafe draft scorer.
+
+The scorer decides the ORDER letters appear in for every user, so its failure
+mode matters more than its happy path: any doubt must mean "no score", never a
+wrong score and never a broken stream.
+"""
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+from django.test import override_settings
+
+from fighthealthinsurance.ml import letter_quality as lq
+
+ENABLED = dict(TYPESAFE_API_KEY="test-key", TYPESAFE_LETTER_RANKING_ENABLED=True)
+
+
+def _payload(**scores):
+    answers = {q: {"score": scores.get(q, 2)} for q in lq.SCORE_QUESTIONS}
+    return {"answers": answers, "usage": {"input_tokens": 1234}}
+
+
+class TestEnabled:
+    def test_off_without_a_key(self):
+        with override_settings(TYPESAFE_API_KEY=None, TYPESAFE_LETTER_RANKING_ENABLED=True):
+            assert lq.enabled() is False
+
+    def test_off_without_the_flag(self):
+        with override_settings(TYPESAFE_API_KEY="k", TYPESAFE_LETTER_RANKING_ENABLED=False):
+            assert lq.enabled() is False
+
+    def test_on_with_both(self):
+        with override_settings(**ENABLED):
+            assert lq.enabled() is True
+
+
+class TestBuildDocument:
+    def test_letter_follows_denial_under_labelled_headers(self):
+        doc = lq.build_document("Denied: not medically necessary.", "Dear reviewer,")
+        assert doc.startswith("THE DENIAL:\nDenied: not medically necessary.")
+        assert doc.endswith("THE APPEAL LETTER:\nDear reviewer,")
+
+    def test_denial_gives_way_before_the_letter(self):
+        letter = "L" * 20_000
+        denial = "D" * 20_000
+        doc = lq.build_document(denial, letter)
+        assert len(doc) <= lq.DOCUMENT_CHAR_CAP
+        assert doc.endswith(letter), "the letter must survive intact"
+        assert doc.count("D") < 20_000
+
+    def test_denial_is_cut_from_the_end(self):
+        denial = "REASON FIRST " + "x" * 30_000
+        doc = lq.build_document(denial, "short letter")
+        assert "REASON FIRST" in doc
+
+    def test_missing_denial_is_tolerated(self):
+        doc = lq.build_document(None, "letter")
+        assert "THE DENIAL:\n\n\nTHE APPEAL LETTER:\nletter" == doc
+
+
+class TestParseAnswers:
+    def test_composite_is_the_mean_over_the_max(self):
+        score = lq.parse_answers(_payload(cites_denial=2, medical_necessity=1, no_invented_facts=2, tone_and_form=1))
+        assert score.quality == pytest.approx(6 / 8)
+        assert score.grounding == 2
+        assert score.input_tokens == 1234
+
+    def test_grounding_is_the_invented_facts_answer_alone(self):
+        score = lq.parse_answers(_payload(no_invented_facts=0))
+        assert score.grounding == 0
+        assert score.quality == pytest.approx(6 / 8)
+
+    def test_out_of_range_score_is_rejected(self):
+        with pytest.raises(lq.LetterScoringError):
+            lq.parse_answers(_payload(cites_denial=2.01))
+
+    def test_expected_levels_are_fractional_and_kept(self):
+        # System One returns the probability-weighted expected level.
+        score = lq.parse_answers(_payload(no_invented_facts=1.3, tone_and_form=0.5))
+        assert score.grounding == pytest.approx(1.3)
+        assert score.quality == pytest.approx((2 + 2 + 1.3 + 0.5) / 8)
+
+    def test_missing_question_is_rejected(self):
+        payload = _payload()
+        del payload["answers"]["tone_and_form"]
+        with pytest.raises(lq.LetterScoringError):
+            lq.parse_answers(payload)
+
+    def test_garbage_is_rejected_not_crashed(self):
+        with pytest.raises(lq.LetterScoringError):
+            lq.parse_answers({"answers": "nope"})
+
+    def test_missing_usage_is_fine(self):
+        payload = _payload()
+        del payload["usage"]
+        assert lq.parse_answers(payload).input_tokens == 0
+
+
+class TestScoreLetter:
+    def test_disabled_returns_none_without_a_request(self):
+        with override_settings(TYPESAFE_API_KEY=None), patch.object(lq, "_post") as post:
+            assert asyncio.run(lq.score_letter("d", "letter")) is None
+            post.assert_not_called()
+
+    def test_empty_letter_is_not_sent(self):
+        with override_settings(**ENABLED), patch.object(lq, "_post") as post:
+            assert asyncio.run(lq.score_letter("d", "   ")) is None
+            post.assert_not_called()
+
+    def test_happy_path(self):
+        async def fake_post(document, timeout):
+            assert "THE APPEAL LETTER:\nDear reviewer" in document
+            return _payload(cites_denial=1)
+
+        with override_settings(**ENABLED), patch.object(lq, "_post", fake_post):
+            score = asyncio.run(lq.score_letter("denial", "Dear reviewer"))
+        assert score is not None
+        assert score.quality == pytest.approx(7 / 8)
+
+    @pytest.mark.parametrize(
+        "failure",
+        [
+            lq.LetterScoringError("HTTP 429"),
+            asyncio.TimeoutError(),
+            ConnectionError("boom"),
+        ],
+    )
+    def test_any_failure_means_no_score(self, failure):
+        async def fake_post(document, timeout):
+            raise failure
+
+        with override_settings(**ENABLED), patch.object(lq, "_post", fake_post):
+            assert asyncio.run(lq.score_letter("denial", "letter")) is None
+
+    def test_malformed_answer_means_no_score(self):
+        async def fake_post(document, timeout):
+            return {"answers": {}}
+
+        with override_settings(**ENABLED), patch.object(lq, "_post", fake_post):
+            assert asyncio.run(lq.score_letter("denial", "letter")) is None
+
+    def test_cancellation_propagates(self):
+        async def fake_post(document, timeout):
+            raise asyncio.CancelledError()
+
+        with override_settings(**ENABLED), patch.object(lq, "_post", fake_post):
+            with pytest.raises(asyncio.CancelledError):
+                asyncio.run(lq.score_letter("denial", "letter"))
+
+    def test_failure_log_never_carries_the_document(self):
+        secret = "PATIENT NAME JANE DOE MRN 998877"
+        seen = []
+
+        async def fake_post(document, timeout):
+            raise lq.LetterScoringError("HTTP 500")
+
+        with override_settings(**ENABLED), patch.object(lq, "_post", fake_post):
+            with patch.object(lq.logger, "warning", side_effect=lambda m, *a, **k: seen.append(str(m))):
+                asyncio.run(lq.score_letter(secret, "letter mentioning " + secret))
+        assert seen and all(secret not in m for m in seen)
+
+
+class TestFrames:
+    def test_score_frame_is_keyed_by_row_id(self):
+        score = lq.parse_answers(_payload(medical_necessity=0))
+        frame = lq.score_frame("42", score)
+        assert frame == {
+            "type": "score",
+            "id": "42",
+            "quality_score": 0.75,
+            "grounding_score": 2,
+            "scorer": lq.SCORER,
+        }
+
+    def test_with_score_fields_only_when_scored_under_the_current_rubric_and_enabled(self):
+        class Row:
+            quality_score = None
+            grounding_score = None
+            quality_scorer = None
+
+        with override_settings(**ENABLED):
+            assert lq.with_score_fields({"id": "1", "content": "x"}, Row()) == {"id": "1", "content": "x"}
+            Row.quality_score, Row.grounding_score, Row.quality_scorer = 0.5, 1, "typesafe/x/rubric-0"
+            assert lq.with_score_fields({"id": "1", "content": "x"}, Row()) == {"id": "1", "content": "x"}
+            Row.quality_scorer = lq.SCORER
+            assert lq.with_score_fields({"id": "1", "content": "x"}, Row()) == {
+                "id": "1",
+                "content": "x",
+                "quality_score": 0.5,
+                "scorer": lq.SCORER,
+                "grounding_score": 1.0,
+            }
+        # The flag is the kill switch for scores already in the database too.
+        with override_settings(TYPESAFE_LETTER_RANKING_ENABLED=False):
+            assert lq.with_score_fields({"id": "1", "content": "x"}, Row()) == {"id": "1", "content": "x"}
+
+
+    def test_with_score_fields_ignores_non_numeric_rows(self):
+        from unittest.mock import MagicMock
+
+        frame = lq.with_score_fields({"id": "1", "content": "x"}, MagicMock())
+        assert frame == {"id": "1", "content": "x"}
+
+
+class TestRedact:
+    IDS = [
+        ("Jane Q. Doe", "PATIENT"),
+        ("Doe", "PATIENT"),
+        ("TLH-2026-0091827", "CLAIM_ID"),
+        ("Al", "PATIENT"),  # two letters is a real surname; whole-word keeps it safe
+        ("UNKNOWN", "PLAN_ID"),  # the sentinel, never a value
+    ]
+
+    def test_longest_identifier_wins_and_each_value_gets_its_own_token(self):
+        text = "Re: JANE Q. DOE (claim TLH-2026-0091827). The Doe family. Doesn't apply. Alaska. Al too."
+        out = lq.redact(text, self.IDS)
+        assert out == (
+            "Re: [PATIENT_1] (claim [CLAIM_ID_1]). The [PATIENT_2] family. "
+            "Doesn't apply. Alaska. [PATIENT_3] too."
+        )
+
+    def test_one_word_names_match_capitalised_and_all_caps_only(self):
+        out = lq.redact(
+            "Will will call. PATIENT: WILL. Dr. WILL SMITH will not. Li and LI, not li.",
+            [("Will", "PATIENT"), ("Will Smith", "PROFESSIONAL"), ("Li", "PATIENT")],
+        )
+        assert out == (
+            "[PATIENT_1] will call. PATIENT: [PATIENT_1]. Dr. [PROFESSIONAL_1] will not. "
+            "[PATIENT_2] and [PATIENT_2], not li."
+        )
+
+    def test_emails_are_taken_before_names_so_an_address_stays_whole(self):
+        out = lq.redact("write May@clinic.example or May", [("May", "PATIENT")])
+        assert out == "write [EMAIL_1] or [PATIENT_1]"
+
+    def test_tokens_are_never_re_redacted(self):
+        out = lq.redact("Alice Smith, claim PATIENT_1", [("Alice Smith", "PATIENT"), ("PATIENT_1", "CLAIM_ID")])
+        assert out == "[PATIENT_1], claim [CLAIM_ID_1]"
+
+    def test_fax_and_phone_share_one_namespace_keyed_by_digits(self):
+        doc = lq.build_document("Fax (415) 555-0100.", "Fax 415-555-0100.", [("(415) 555-0100", "FAX")])
+        assert doc.count("[PHONE_1]") == 2 and "[FAX" not in doc
+
+    def test_unicode_adjacent_and_punycode_emails(self):
+        out = lq.redact("josé@example.com,a@exämple.com and x@y.co, p@example.xn--p1ai.", [])
+        assert out == "[EMAIL_1],[EMAIL_2] and [EMAIL_3], [EMAIL_4]."
+
+    def test_local_parts_with_rfc_atext_characters_are_whole(self):
+        out = lq.redact("o'connor@example.com and first+tag@example.org or a!b#c@example.net", [])
+        assert out == "[EMAIL_1] and [EMAIL_2] or [EMAIL_3]"
+
+    def test_over_bound_input_is_not_scored_at_all(self):
+        huge = "x" * (lq.RAW_CHAR_BOUND + 1)
+        with pytest.raises(lq.LetterScoringError):
+            lq.build_document("", huge)
+
+        async def fake_post(document, timeout):
+            raise AssertionError("must not be called")
+
+        with override_settings(**ENABLED), patch.object(lq, "_post", fake_post):
+            assert asyncio.run(lq.score_letter("d", huge)) is None
+
+    def test_a_longer_known_identifier_beats_a_generic_match_inside_it(self):
+        out = lq.redact("plan ABC-415-555-0100-Z, call 415-555-0100", [("ABC-415-555-0100-Z", "PLAN_ID")])
+        assert out == "plan [PLAN_ID_1], call [PHONE_1]"
+
+    def test_a_lowercase_stored_name_never_matches_ordinary_prose(self):
+        out = lq.redact("the plan will cover Will; MAY and may", [("will", "PATIENT"), ("may", "PATIENT")])
+        assert out == "the plan will cover [PATIENT_1]; [PATIENT_2] and may"
+
+    def test_partially_overlapping_identifiers_become_one_span_so_nothing_leaks(self):
+        out = lq.redact(
+            "Re: Alice Smith Jones, MD", [("Alice Smith", "PATIENT"), ("Smith Jones", "PROFESSIONAL")]
+        )
+        assert out == "Re: [PATIENT_1], MD"
+
+    def test_an_identifier_straddling_the_sent_boundary_never_leaks_a_fragment(self):
+        plan = "PLAN-" + "7" * 60
+        # Straddles the cap: the value is redacted BEFORE the cut, so what
+        # falls off the end is a whole token (or nothing), never "PLAN-777".
+        letter = "x" * (lq.DOCUMENT_CHAR_CAP - 40) + " " + plan + " tail"
+        doc = lq.build_document("", letter, [(plan, "PLAN_ID")])
+        assert "7777" not in doc and "PLAN-" not in doc and "[PLAN" not in doc.rsplit("]", 1)[-1]
+        # Just inside the cap: the whole token is kept.
+        letter = "x" * (lq.DOCUMENT_CHAR_CAP - 200) + " " + plan + " tail"
+        doc = lq.build_document("", letter, [(plan, "PLAN_ID")])
+        assert "[PLAN_ID_1]" in doc and "7777" not in doc
+
+    def test_every_alias_of_one_person_shares_a_token(self):
+        ids = [("Sam Smith", "PROFESSIONAL#7"), ("Sam Smith MD", "PROFESSIONAL#7"), ("Smith", "PROFESSIONAL#7"), ("Ann Lee", "PROFESSIONAL#9")]
+        doc = lq.build_document("Denied by Sam Smith.", "Dr. Smith, Sam Smith MD, and Ann Lee agree.", ids)
+        assert doc.count("[PROFESSIONAL_1]") == 3 and doc.count("[PROFESSIONAL_2]") == 1
+
+    def test_raw_private_use_characters_are_just_text(self):
+        weird = "before \ue0000\ue001 after"
+        assert lq.redact(weird, []) == weird
+
+    def test_truncation_never_splits_a_token(self):
+        assert lq._cut("hello [PATIENT_1] world", 12) == "hello "
+        assert lq._cut("x [A_1] y", 7) == "x [A_1]"
+        assert lq._cut("short", 99) == "short"
+        doc = lq.build_document("d" * 30_000, "[PATIENT_1]" * 3_000)
+        assert "[PAT\n" not in doc and not doc.endswith("[PAT")
+
+    def test_the_email_scan_is_linear_on_a_pathological_input(self):
+        import time
+
+        text = "a" * 48_000 + "@" + "b" * 48_000  # no final dot, no email
+        started = time.perf_counter()
+        out = lq.redact(text, [])
+        assert time.perf_counter() - started < 0.5
+        assert out == text
+        assert lq._email_spans("x jane.doe@example.org, y") == [(2, 22)]
+        assert lq._email_spans("bad@nodot or @lone or a@b.c") == []
+
+    def test_generic_email_and_phone_patterns_number_distinct_values(self):
+        out = lq.redact(
+            "write to jane.doe@example.org or call (415) 555-0100, again 415-555-0100, NPI 1234567890.", []
+        )
+        assert out == "write to [EMAIL_1] or call [PHONE_1], again [PHONE_1], NPI [PHONE_2]."
+
+    def test_a_shared_redactor_keeps_tokens_stable_across_denial_and_draft(self):
+        doc = lq.build_document("Call 415-555-0100.", "Call 415-555-0100 or 212-555-0199.")
+        assert doc.count("[PHONE_1]") == 2 and doc.count("[PHONE_2]") == 1
+
+    def test_dates_and_amounts_survive(self):
+        text = "denied on 10/15/2026 for $2,340.00; appeal within 180 days"
+        assert lq.redact(text, []) == text
+
+    def test_unknown_sentinel_is_never_redacted(self):
+        assert lq.redact("status UNKNOWN", [("UNKNOWN", "[X]")]) == "status UNKNOWN"
+
+    def test_document_is_built_from_redacted_parts(self):
+        doc = lq.build_document(
+            "Member Jane Q. Doe was denied.", "Dear reviewer, Jane Q. Doe needs the MRI.",
+            [("Jane Q. Doe", "PATIENT")],
+        )
+        assert "Jane" not in doc
+        assert doc.count("[PATIENT_1]") == 2
+
+    def test_score_letter_sends_the_redacted_document(self):
+        seen = []
+
+        async def fake_post(document, timeout):
+            seen.append(document)
+            return _payload()
+
+        with override_settings(**ENABLED), patch.object(lq, "_post", fake_post):
+            asyncio.run(lq.score_letter("denial for Jane Q. Doe", "letter for Jane Q. Doe, fax 415-555-0100",
+                                        identifiers=[("Jane Q. Doe", "PATIENT")]))
+        assert seen and "Jane" not in seen[0] and "555-0100" not in seen[0]
+
+
+class TestScorerIdentity:
+    def test_scorer_names_model_and_rubric_version(self):
+        assert lq.SCORER == f"typesafe/{lq.MODEL}/rubric-{lq.RUBRIC_VERSION}"
+
+    def test_the_answering_model_is_recorded_when_typesafe_names_it(self):
+        assert lq.scorer_for({"model": "speed_20260401"}) == f"typesafe/speed_20260401/rubric-{lq.RUBRIC_VERSION}"
+        assert lq.scorer_for({}) == lq.SCORER
+        assert lq.parse_answers({**_payload(), "model": "speed_20260401"}).scorer.startswith("typesafe/speed_20260401/")
+
+    def test_same_rubric_is_what_decides_reuse_and_the_whole_string_must_be_ours(self):
+        assert lq.same_rubric(f"typesafe/anything/rubric-{lq.RUBRIC_VERSION}")
+        assert not lq.same_rubric(f"typesafe/{lq.MODEL}/rubric-{lq.RUBRIC_VERSION + 1}")
+        assert not lq.same_rubric(f"manual-import/rubric-{lq.RUBRIC_VERSION}")
+        assert not lq.same_rubric(f"typesafe/x/y/rubric-{lq.RUBRIC_VERSION}")
+        assert not lq.same_rubric(None)
+
+    def test_an_odd_model_name_in_the_answer_cannot_forge_provenance(self):
+        assert lq.scorer_for({"model": "weird value!"}) == lq.SCORER
+        assert lq.scorer_for({"model": "x" * 200}) == lq.SCORER
+
+    def test_needs_scoring(self):
+        class Row:
+            appeal_text = "a real draft"
+            quality_score = None
+            quality_scorer = None
+
+        assert lq.needs_scoring(Row())
+        Row.quality_score, Row.quality_scorer = 0.5, lq.SCORER
+        assert not lq.needs_scoring(Row())
+        Row.quality_scorer = "typesafe/x/rubric-0"
+        assert lq.needs_scoring(Row())
+        Row.appeal_text = "  "
+        assert not lq.needs_scoring(Row())
+
+
+class TestSortKey:
+    def test_unscored_sorts_last_then_ungrounded_then_quality(self):
+        keys = sorted(
+            [lq.sort_key(None, None), lq.sort_key(0.9, 0), lq.sort_key(0.4, 2), lq.sort_key(0.8, 1)],
+            reverse=True,
+        )
+        assert keys == [(2, 0.8), (2, 0.4), (1, 0.9), (0, 0.0)]

--- a/tests/async-unit/test_letter_ranking_stream.py
+++ b/tests/async-unit/test_letter_ranking_stream.py
@@ -181,12 +181,16 @@ class TestNothingIdentifyingLeaves(_StreamBase):
         from fhi_users.models import PatientUser, ProfessionalUser
 
         User = get_user_model()
+        # Handles that look nothing like the names, so only the username
+        # entries can catch them (review).
         patient_user = User.objects.create_user(
-            username="jane", email="jane.doe@example.org", first_name="Jane", last_name="Doe"
+            username="jqd1984", email="jane.doe@example.org", first_name="Jane", last_name="Doe"
         )
         patient = PatientUser.objects.create(user=patient_user, display_name="Jane Q. Doe")
+        # The professional's login is domain-scoped (raw🐼domain_id, as
+        # auth_utils stores it); the draft carries the raw spelling.
         prof_user = User.objects.create_user(
-            username="drsam", email="sam@clinic.example", first_name="Sam", last_name="Smith"
+            username="clinic-user-77🐼12", email="sam@clinic.example", first_name="Sam", last_name="Smith"
         )
         professional = ProfessionalUser.objects.create(
             user=prof_user, active=True, npi_number="1234567890", fax_number="(415) 555-0100",
@@ -203,7 +207,8 @@ class TestNothingIdentifyingLeaves(_StreamBase):
             "TLH-2026-0091827. Her physician, Sam Smith MD (NPI 1234567890, fax (415) 555-0100), "
             "documented months of conservative treatment without improvement before this imaging.",
             "To the appeals board: Ms. Doe's plan states imaging is covered after failed conservative "
-            "care, which the records from Dr. Smith demonstrate; reply to jane.doe@example.org.",
+            "care, which the records from Dr. Smith demonstrate; reply to jane.doe@example.org. "
+            "Portal login JQD1984; submitted by clinic-user-77.",
         ]
         mock_gen.make_appeals.side_effect = lambda *a, **k: iter(
             [GeneratedAppeal(text=t, model_name="fhi-internal", context_level="full") for t in leaky]
@@ -229,8 +234,11 @@ class TestNothingIdentifyingLeaves(_StreamBase):
         for doc in seen:
             for secret in ("Jane", "Doe", "Smith", "1234567890", "555-0100", "jane.doe@", "sam@", "TLH-2026-0091827"):
                 self.assertNotIn(secret, doc)
+            self.assertNotIn("jqd1984", doc.lower())
+            self.assertNotIn("clinic-user-77", doc)
             self.assertIn("[PATIENT_", doc)
             self.assertIn("[CLAIM_ID_", doc)
+        self.assertIn("[USERNAME_", seen[1])
 
     @patch("fighthealthinsurance.common_view_logic.appealGenerator")
     def test_redaction_failure_turns_scoring_off_for_the_run(self, mock_gen):

--- a/tests/async-unit/test_letter_ranking_stream.py
+++ b/tests/async-unit/test_letter_ranking_stream.py
@@ -1,0 +1,394 @@
+"""Draft scores ride the appeal stream as {"type": "score"} frames.
+
+Drives the REAL generator with only the model layer and the scorer's HTTP
+call stubbed (same harness as test_generation_lease), because the promises
+here are about the stream: a score frame names a row that was streamed, it
+lands before the done frame, the row keeps the score, and every way scoring
+can be off or broken leaves the letters exactly as they were.
+"""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, patch
+
+from asgiref.sync import async_to_sync
+from django.test import TransactionTestCase, override_settings
+
+from fighthealthinsurance.generate_appeal import GeneratedAppeal
+from fighthealthinsurance.ml import letter_quality
+from fighthealthinsurance.models import Denial, ProposedAppeal
+
+ENABLED = dict(TYPESAFE_API_KEY="test-key", TYPESAFE_LETTER_RANKING_ENABLED=True)
+
+LETTERS = [
+    "Dear Reviewer, appeal draft one: my physician documented months of "
+    "conservative treatment without improvement before this imaging.",
+    "To the appeals board: the plan's own coverage policy states imaging is "
+    "covered after failed conservative care, which my records demonstrate.",
+]
+
+
+def _drafts():
+    return [
+        GeneratedAppeal(text=t, model_name="fhi-internal", context_level="full")
+        for t in LETTERS
+    ]
+
+
+def _payload(grounding=2, other=2):
+    answers = {q: {"score": other} for q in letter_quality.SCORE_QUESTIONS}
+    answers[letter_quality.GROUNDING_QUESTION] = {"score": grounding}
+    return {"answers": answers, "usage": {"input_tokens": 10}}
+
+
+def _frames(chunks):
+    out = []
+    for chunk in chunks:
+        try:
+            data = json.loads(chunk)
+        except (TypeError, json.JSONDecodeError):
+            continue
+        if isinstance(data, dict):
+            out.append(data)
+    return out
+
+
+class _StreamBase(TransactionTestCase):
+    def setUp(self):
+        super().setUp()
+        for target in (
+            "fighthealthinsurance.common_view_logic.get_rag_context_for_denial",
+            "fighthealthinsurance.common_view_logic.MLCitationsHelper.generate_citations_for_denial",
+        ):
+            patcher = patch(target, new_callable=AsyncMock, return_value=None)
+            patcher.start()
+            self.addCleanup(patcher.stop)
+        pmt_patcher = patch(
+            "fighthealthinsurance.common_view_logic.AppealsBackendHelper.pmt"
+        )
+        pmt = pmt_patcher.start()
+        pmt.find_context_for_denial = AsyncMock(return_value=None)
+        self.addCleanup(pmt_patcher.stop)
+        self.email = "rank@example.com"
+        self.denial = Denial.objects.create(
+            denial_id=9301,
+            denial_text="Coverage for the requested MRI was denied as not medically necessary.",
+            semi_sekret="sekret",
+            hashed_email=Denial.get_hashed_email(self.email),
+            gen_attempts=3,
+        )
+
+    def _stream(self, mock_gen):
+        from fighthealthinsurance.common_view_logic import AppealsBackendHelper
+
+        mock_gen.make_appeals.side_effect = lambda *a, **k: iter(_drafts())
+
+        async def drive():
+            chunks = []
+            async for chunk in AppealsBackendHelper.generate_appeals(
+                {
+                    "denial_id": self.denial.denial_id,
+                    "email": self.email,
+                    "semi_sekret": "sekret",
+                }
+            ):
+                chunks.append(chunk)
+            return chunks
+
+        return _frames(async_to_sync(drive)())
+
+
+class TestScoresRideTheStream(_StreamBase):
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_each_streamed_draft_gets_a_score_frame_before_done(self, mock_gen):
+        seen_docs = []
+
+        async def fake_post(document, timeout):
+            seen_docs.append(document)
+            return _payload()
+
+        with override_settings(**ENABLED), patch.object(letter_quality, "_post", fake_post):
+            frames = self._stream(mock_gen)
+
+        letters = [f for f in frames if "content" in f and f.get("id") not in (None, "unknown")]
+        scores = [f for f in frames if f.get("type") == "score"]
+        self.assertEqual(len(letters), 2)
+        self.assertEqual({s["id"] for s in scores}, {l["id"] for l in letters})
+        for s in scores:
+            self.assertEqual(s["quality_score"], 1.0)
+            self.assertEqual(s["grounding_score"], 2)
+
+        done_at = next(i for i, f in enumerate(frames) if f.get("phase") == "done")
+        last_score_at = max(i for i, f in enumerate(frames) if f.get("type") == "score")
+        self.assertLess(last_score_at, done_at)
+
+        # The scorer saw the pre-substitution draft and the denial, nothing else.
+        self.assertEqual(len(seen_docs), 2)
+        for doc in seen_docs:
+            self.assertIn("THE DENIAL:\nCoverage for the requested MRI", doc)
+            self.assertNotIn(self.email, doc)
+
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_the_row_keeps_the_score(self, mock_gen):
+        async def fake_post(document, timeout):
+            return _payload(grounding=0, other=1)
+
+        with override_settings(**ENABLED), patch.object(letter_quality, "_post", fake_post):
+            self._stream(mock_gen)
+
+        rows = list(ProposedAppeal.objects.filter(for_denial=self.denial, speculative=False))
+        self.assertEqual(len(rows), 2)
+        for row in rows:
+            self.assertAlmostEqual(row.quality_score, 3 / 8)
+            self.assertEqual(row.grounding_score, 0)
+            self.assertEqual(row.quality_scorer, letter_quality.SCORER)
+            self.assertIsNotNone(row.quality_scored_at)
+
+
+class TestNothingIdentifyingLeaves(_StreamBase):
+    """The prompt asks the model to write the patient and professional INTO
+    the letter, so the redaction is the promise, not the placeholders."""
+
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_known_identifiers_are_redacted_before_scoring(self, mock_gen):
+        from django.contrib.auth import get_user_model
+
+        from fhi_users.models import PatientUser, ProfessionalUser
+
+        User = get_user_model()
+        patient_user = User.objects.create_user(
+            username="jane", email="jane.doe@example.org", first_name="Jane", last_name="Doe"
+        )
+        patient = PatientUser.objects.create(user=patient_user, display_name="Jane Q. Doe")
+        prof_user = User.objects.create_user(
+            username="drsam", email="sam@clinic.example", first_name="Sam", last_name="Smith"
+        )
+        professional = ProfessionalUser.objects.create(
+            user=prof_user, active=True, npi_number="1234567890", fax_number="(415) 555-0100",
+            display_name="Sam Smith MD",
+        )
+        Denial.objects.filter(pk=self.denial.pk).update(
+            patient_user=patient, primary_professional=professional,
+            raw_email="jane.doe@example.org", claim_id="TLH-2026-0091827",
+            denial_text="Member Jane Q. Doe (claim TLH-2026-0091827) was denied an MRI. "
+            "Questions: jane.doe@example.org or 415-555-0100.",
+        )
+        leaky = [
+            "Dear Reviewer, I am writing on behalf of my patient Jane Q. Doe regarding claim "
+            "TLH-2026-0091827. Her physician, Sam Smith MD (NPI 1234567890, fax (415) 555-0100), "
+            "documented months of conservative treatment without improvement before this imaging.",
+            "To the appeals board: Ms. Doe's plan states imaging is covered after failed conservative "
+            "care, which the records from Dr. Smith demonstrate; reply to jane.doe@example.org.",
+        ]
+        mock_gen.make_appeals.side_effect = lambda *a, **k: iter(
+            [GeneratedAppeal(text=t, model_name="fhi-internal", context_level="full") for t in leaky]
+        )
+        seen = []
+
+        async def fake_post(document, timeout):
+            seen.append(document)
+            return _payload()
+
+        from fighthealthinsurance.common_view_logic import AppealsBackendHelper
+
+        async def drive():
+            async for _ in AppealsBackendHelper.generate_appeals(
+                {"denial_id": self.denial.denial_id, "email": self.email, "semi_sekret": "sekret"}
+            ):
+                pass
+
+        with override_settings(**ENABLED), patch.object(letter_quality, "_post", fake_post):
+            async_to_sync(drive)()
+
+        self.assertEqual(len(seen), 2)
+        for doc in seen:
+            for secret in ("Jane", "Doe", "Smith", "1234567890", "555-0100", "jane.doe@", "sam@", "TLH-2026-0091827"):
+                self.assertNotIn(secret, doc)
+            self.assertIn("[PATIENT_", doc)
+            self.assertIn("[CLAIM_ID_", doc)
+
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_redaction_failure_turns_scoring_off_for_the_run(self, mock_gen):
+        with override_settings(**ENABLED), patch(
+            "fighthealthinsurance.common_view_logic.scoring_redactions",
+            side_effect=RuntimeError("relation walk failed"),
+        ), patch.object(letter_quality, "_post") as post:
+            frames = self._stream(mock_gen)
+            post.assert_not_called()
+        self.assertEqual([f for f in frames if f.get("type") == "score"], [])
+        self.assertEqual(len([f for f in frames if "content" in f]), 2)
+
+
+class TestSynthesisIsScoredToo(_StreamBase):
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_the_synthesized_draft_gets_its_score_frame_before_done(self, mock_gen):
+        synthesized = (
+            "Dear Reviewer, this combined appeal draws on my physician's documentation of "
+            "months of conservative treatment and the plan's own coverage policy, which "
+            "states imaging is covered after failed conservative care."
+        )
+        mock_gen.synthesize_appeals = AsyncMock(return_value=synthesized)
+
+        async def fake_post(document, timeout):
+            return _payload()
+
+        with override_settings(**ENABLED), patch.object(letter_quality, "_post", fake_post):
+            frames = self._stream(mock_gen)
+
+        synth_row = ProposedAppeal.objects.get(for_denial=self.denial, synthesized=True)
+        self.assertIsNotNone(synth_row.quality_score)
+        done_at = next(i for i, f in enumerate(frames) if f.get("phase") == "done")
+        synth_scores = [i for i, f in enumerate(frames) if f.get("type") == "score" and f["id"] == str(synth_row.id)]
+        self.assertEqual(len(synth_scores), 1)
+        self.assertLess(synth_scores[0], done_at)
+
+
+class TestReServedDraftsAreScoredToo(_StreamBase):
+    """A draft saved before scoring existed (or under an older rubric) must
+    not sort below every fresh draft just for being older."""
+
+    def _existing(self, text, **fields):
+        return ProposedAppeal.objects.create(
+            for_denial=self.denial, appeal_text=text, model_name="fhi-internal",
+            speculative=False, **fields,
+        )
+
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_an_unscored_existing_draft_gets_scored_and_framed_before_done(self, mock_gen):
+        row = self._existing(
+            "Dear Reviewer, an earlier draft: my physician documented months of "
+            "conservative treatment without improvement before this imaging was ordered."
+        )
+
+        async def fake_post(document, timeout):
+            return _payload()
+
+        with override_settings(**ENABLED), patch.object(letter_quality, "_post", fake_post):
+            frames = self._stream(mock_gen)
+
+        row.refresh_from_db()
+        self.assertIsNotNone(row.quality_score)
+        done_at = next(i for i, f in enumerate(frames) if f.get("phase") == "done")
+        mine = [i for i, f in enumerate(frames) if f.get("type") == "score" and f["id"] == str(row.id)]
+        self.assertEqual(len(mine), 1)
+        self.assertLess(mine[0], done_at)
+
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_an_older_rubric_score_is_neither_served_nor_kept(self, mock_gen):
+        row = self._existing(
+            "Dear Reviewer, an earlier draft: my physician documented months of "
+            "conservative treatment without improvement before this imaging was ordered.",
+            quality_score=0.1, grounding_score=0.0, quality_scorer="typesafe/speed_latest/rubric-0",
+        )
+
+        async def fake_post(document, timeout):
+            return _payload()
+
+        with override_settings(**ENABLED), patch.object(letter_quality, "_post", fake_post):
+            frames = self._stream(mock_gen)
+
+        letter = next(f for f in frames if f.get("id") == str(row.id) and "content" in f)
+        self.assertNotIn("quality_score", letter, "a stale score must not ride the letter frame")
+        row.refresh_from_db()
+        self.assertEqual(row.quality_score, 1.0)
+        self.assertEqual(row.quality_scorer, letter_quality.SCORER)
+
+
+class TestInFlightGuard:
+    def test_a_row_already_being_scored_on_this_worker_is_not_sent_again(self):
+        async def run():
+            started = asyncio.Event()
+            release = asyncio.Event()
+
+            async def slow():
+                started.set()
+                await release.wait()
+
+            task = asyncio.create_task(slow())
+            letter_quality.keep_alive(task, "42")
+            await started.wait()
+            assert letter_quality.in_flight("42")
+            assert letter_quality.in_flight_task("42") is task, "a reconnect attaches to THIS task"
+            assert not letter_quality.in_flight("43")
+            release.set()
+            await task
+            assert not letter_quality.in_flight("42")
+
+        asyncio.run(run())
+
+    def test_finishing_an_older_task_does_not_forget_a_newer_one_for_the_same_row(self):
+        async def run():
+            gate_old, gate_new = asyncio.Event(), asyncio.Event()
+
+            async def wait_on(gate):
+                await gate.wait()
+
+            old = asyncio.create_task(wait_on(gate_old))
+            letter_quality.keep_alive(old, "7")
+            new = asyncio.create_task(wait_on(gate_new))
+            letter_quality.keep_alive(new, "7")  # replaces the slot
+            gate_old.set()
+            await old
+            await asyncio.sleep(0)  # let the done-callback run
+            assert letter_quality.in_flight_task("7") is new
+            gate_new.set()
+            await new
+            await asyncio.sleep(0)
+            assert letter_quality.in_flight_task("7") is None
+
+        asyncio.run(run())
+
+
+class TestScoringStaysOutOfTheWay(_StreamBase):
+    def _assert_plain_stream(self, frames):
+        letters = [f for f in frames if "content" in f]
+        self.assertEqual(len(letters), 2)
+        self.assertEqual([f for f in frames if f.get("type") == "score"], [])
+        self.assertTrue(any(f.get("phase") == "done" for f in frames))
+        for row in ProposedAppeal.objects.filter(for_denial=self.denial):
+            self.assertIsNone(row.quality_score)
+
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_off_by_default(self, mock_gen):
+        with patch.object(letter_quality, "_post") as post:
+            frames = self._stream(mock_gen)
+            post.assert_not_called()
+        self._assert_plain_stream(frames)
+
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_no_external_consent_means_no_scoring_even_when_enabled(self, mock_gen):
+        Denial.objects.filter(pk=self.denial.pk).update(use_external=False)
+        with override_settings(**ENABLED), patch.object(letter_quality, "_post") as post:
+            frames = self._stream(mock_gen)
+            post.assert_not_called()
+        self._assert_plain_stream(frames)
+
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_a_dead_scorer_changes_nothing_for_the_reader(self, mock_gen):
+        async def fake_post(document, timeout):
+            raise letter_quality.LetterScoringError("HTTP 503")
+
+        with override_settings(**ENABLED), patch.object(letter_quality, "_post", fake_post):
+            frames = self._stream(mock_gen)
+        self._assert_plain_stream(frames)
+
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_a_slow_scorer_is_waited_for_once_not_per_drain(self, mock_gen):
+        import time
+
+        async def fake_post(document, timeout):
+            await asyncio.sleep(30)
+            return _payload()
+
+        drain = 1.0
+        started = time.monotonic()
+        with override_settings(**ENABLED), patch.object(letter_quality, "_post", fake_post), patch.object(letter_quality, "DRAIN_SECONDS", drain):
+            frames = self._stream(mock_gen)
+        elapsed = time.monotonic() - started
+        letters = [f for f in frames if "content" in f]
+        self.assertEqual(len(letters), 2)
+        self.assertEqual([f for f in frames if f.get("type") == "score"], [])
+        self.assertTrue(any(f.get("phase") == "done" for f in frames))
+        # Two drains (before synthesis and before done) share ONE deadline:
+        # well under two full waits.
+        self.assertLess(elapsed, drain * 1.8 + 3.0)

--- a/tests/async-unit/test_letter_ranking_stream.py
+++ b/tests/async-unit/test_letter_ranking_stream.py
@@ -145,6 +145,31 @@ class TestScoresRideTheStream(_StreamBase):
             self.assertIsNotNone(row.quality_scored_at)
 
 
+class TestAScoreLandsOnlyOnTheTextThatWasScored(_StreamBase):
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_an_edit_during_scoring_drops_the_score_and_the_frame(self, mock_gen):
+        """An admin rewrites the draft in the few seconds it takes TypeSafe
+        to answer. The score describes text nobody sees now: it must not
+        land on the edited row, and no score frame may reach the page
+        (review)."""
+        denial_id = self.denial.denial_id
+
+        async def fake_post(document, timeout):
+            await ProposedAppeal.objects.filter(for_denial_id=denial_id).aupdate(
+                appeal_text="Rewritten by staff while the scorer was busy."
+            )
+            return _payload()
+
+        with override_settings(**ENABLED), patch.object(letter_quality, "_post", fake_post):
+            frames = self._stream(mock_gen)
+
+        self.assertFalse([f for f in frames if f.get("type") == "score"])
+        self.assertTrue([f for f in frames if f.get("phase") == "done"])
+        for row in ProposedAppeal.objects.filter(for_denial=self.denial):
+            self.assertIsNone(row.quality_score)
+            self.assertIsNone(row.quality_scored_at)
+
+
 class TestNothingIdentifyingLeaves(_StreamBase):
     """The prompt asks the model to write the patient and professional INTO
     the letter, so the redaction is the promise, not the placeholders."""

--- a/tests/async-unit/test_typesafe_transport.py
+++ b/tests/async-unit/test_typesafe_transport.py
@@ -1,0 +1,93 @@
+"""ml/typesafe.py: the shared TypeSafe transport.
+
+The request carries the API key and the redacted document, so it only ever
+goes over https; the body of a failed response is never read, because an
+error body could quote the document back.
+"""
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+from django.test import override_settings
+
+from fighthealthinsurance.ml import typesafe
+
+SETTINGS = dict(
+    TYPESAFE_API_KEY="test-key", TYPESAFE_API_URL="https://typesafe.invalid/v1/systemone"
+)
+
+
+class _FakeResponse:
+    def __init__(self, status):
+        self.status = status
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def json(self):
+        return {"answers": {}}
+
+
+class _FakeSession:
+    """Stands in for aiohttp.ClientSession: the constructor and the context."""
+
+    def __init__(self, status=200):
+        self.response = _FakeResponse(status)
+        self.posted = []
+        self.opened = 0
+
+    def __call__(self, *args, **kwargs):
+        self.opened += 1
+        return self
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def post(self, url, json=None, headers=None):
+        self.posted.append((url, json, headers))
+        return self.response
+
+
+def _ask(session, **overrides):
+    conf = {**SETTINGS, **overrides}
+    with override_settings(**conf), patch.object(typesafe.aiohttp, "ClientSession", session):
+        return asyncio.run(typesafe.ask("doc", {"q": {"type": "int"}}, timeout_seconds=1))
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://typesafe.invalid/v1/systemone",
+        "ftp://typesafe.invalid/v1/systemone",
+        "typesafe.invalid/v1/systemone",
+        "",
+        None,
+    ],
+)
+def test_anything_but_https_is_refused_before_a_session_exists(url):
+    session = _FakeSession()
+    with pytest.raises(typesafe.TypeSafeError, match="https"):
+        _ask(session, TYPESAFE_API_URL=url)
+    assert session.opened == 0
+    assert session.posted == []
+
+
+def test_https_in_any_case_is_accepted_and_the_json_comes_back():
+    session = _FakeSession()
+    assert _ask(session, TYPESAFE_API_URL="HTTPS://typesafe.invalid/v1/systemone") == {"answers": {}}
+    url, body, headers = session.posted[0]
+    assert url == "HTTPS://typesafe.invalid/v1/systemone"
+    assert headers["Authorization"] == "Bearer test-key"
+    assert body["document"] == "doc"
+
+
+def test_a_non_200_raises():
+    with pytest.raises(typesafe.TypeSafeError, match="HTTP 503"):
+        _ask(_FakeSession(503))

--- a/tests/async-unit/test_typesafe_transport.py
+++ b/tests/async-unit/test_typesafe_transport.py
@@ -50,8 +50,9 @@ class _FakeSession:
     async def __aexit__(self, *exc):
         return False
 
-    def post(self, url, json=None, headers=None):
+    def post(self, url, json=None, headers=None, **kwargs):
         self.posted.append((url, json, headers))
+        self.post_kwargs = kwargs
         return self.response
 
 
@@ -91,3 +92,12 @@ def test_https_in_any_case_is_accepted_and_the_json_comes_back():
 def test_a_non_200_raises():
     with pytest.raises(typesafe.TypeSafeError, match="HTTP 503"):
         _ask(_FakeSession(503))
+
+
+def test_redirects_are_never_followed():
+    """An https endpoint answering 307 toward http would otherwise make the
+    client resend the document in the clear (review)."""
+    session = _FakeSession(307)
+    with pytest.raises(typesafe.TypeSafeError, match="HTTP 307"):
+        _ask(session)
+    assert session.post_kwargs.get("allow_redirects") is False

--- a/tests/sync/test_letter_quality_metrics.py
+++ b/tests/sync/test_letter_quality_metrics.py
@@ -1,0 +1,75 @@
+"""letter_quality_metrics: draft quality per backend on /metrics."""
+
+import datetime
+
+from django.test import TestCase
+from django.utils import timezone
+
+from fighthealthinsurance.letter_quality_metrics import (
+    LetterQualityCollector,
+    quality_by_model,
+)
+from fighthealthinsurance.ml import letter_quality
+from fighthealthinsurance.models import Denial, ProposedAppeal
+
+
+class LetterQualityMetricsTest(TestCase):
+    def setUp(self):
+        self.denial = Denial.objects.create(hashed_email="h", denial_text="denied")
+
+    def _draft(self, model_name, quality, grounding, days_ago=0, scorer=None):
+        return ProposedAppeal.objects.create(
+            for_denial=self.denial,
+            appeal_text=f"draft {model_name} {quality} {days_ago} {scorer}",
+            model_name=model_name,
+            quality_score=quality,
+            grounding_score=grounding,
+            quality_scorer=scorer or letter_quality.SCORER,
+            quality_scored_at=timezone.now() - datetime.timedelta(days=days_ago),
+        )
+
+    def test_aggregates_per_model_inside_the_window(self):
+        self._draft("m1", 0.8, 2)
+        self._draft("m1", 0.4, 0)
+        self._draft("m2", 1.0, 2)
+        self._draft("m1", 0.0, 0, days_ago=3)  # outside the 24h window
+        ProposedAppeal.objects.create(  # unscored: invisible here
+            for_denial=self.denial, appeal_text="unscored", model_name="m1"
+        )
+        stats = quality_by_model(timezone.now())
+        key = ("m1", letter_quality.SCORER)
+        self.assertAlmostEqual(stats[key]["avg"], 0.6)
+        self.assertEqual(stats[key]["scored"], 2)
+        self.assertEqual(stats[key]["ungrounded"], 1)
+        self.assertEqual(stats[("m2", letter_quality.SCORER)]["ungrounded"], 0)
+
+    def test_each_scorer_is_its_own_series_and_old_rubrics_are_dropped(self):
+        self._draft("m1", 0.8, 2)
+        self._draft("m1", 0.0, 0, scorer="typesafe/other/rubric-0")
+        repointed = f"typesafe/other/rubric-{letter_quality.RUBRIC_VERSION}"
+        self._draft("m1", 0.6, 2, scorer=repointed)
+        stats = quality_by_model(timezone.now())
+        self.assertAlmostEqual(stats[("m1", letter_quality.SCORER)]["avg"], 0.8)
+        self.assertAlmostEqual(stats[("m1", repointed)]["avg"], 0.6)
+        self.assertEqual(len(stats), 2, "rubric-0 rows are not a series")
+
+    def test_collector_emits_labelled_samples(self):
+        self._draft("m1", 0.5, 1)
+        families = {m.name: m for m in LetterQualityCollector().collect()}
+        avg = families["fhi_letter_quality_avg"]
+        self.assertEqual(
+            [(s.labels["model_name"], s.labels["scorer"], s.value) for s in avg.samples],
+            [("m1", letter_quality.SCORER, 0.5)],
+        )
+        self.assertIn("fhi_letter_quality_requests", families)
+
+    def test_collector_never_raises(self):
+        with self.settings():
+            from unittest.mock import patch
+
+            with patch(
+                "fighthealthinsurance.letter_quality_metrics.quality_by_model",
+                side_effect=RuntimeError("db away"),
+            ):
+                families = list(LetterQualityCollector().collect())
+        self.assertEqual(len(families), 4)

--- a/tests/sync/test_letter_quality_metrics.py
+++ b/tests/sync/test_letter_quality_metrics.py
@@ -10,6 +10,7 @@ from fighthealthinsurance.letter_quality_metrics import (
     quality_by_model,
 )
 from fighthealthinsurance.ml import letter_quality
+from fighthealthinsurance.ml.model_identity import legacy_unresolved_label
 from fighthealthinsurance.models import Denial, ProposedAppeal
 
 
@@ -42,6 +43,30 @@ class LetterQualityMetricsTest(TestCase):
         self.assertEqual(stats[key]["scored"], 2)
         self.assertEqual(stats[key]["ungrounded"], 1)
         self.assertEqual(stats[("m2", letter_quality.SCORER)]["ungrounded"], 0)
+
+    def test_two_stored_spellings_of_one_backend_are_one_series(self):
+        """Legacy rows hold object reprs with a memory address; every address
+        used to be its own Prometheus series (review). They collapse to the
+        class, and the merge is a scored-weighted mean with summed counts."""
+        cls = "fighthealthinsurance.ml.ml_models.RemoteFullOpenLike"
+        self._draft(f"<{cls} object at 0x7f0000000010>", 0.8, 2)
+        self._draft(f"<{cls} object at 0x7f0000000020>", 0.2, 0)
+        self._draft(f"<{cls} object at 0x7f0000000030>", 0.2, 0)
+        stats = quality_by_model(timezone.now())
+        key = (legacy_unresolved_label("RemoteFullOpenLike"), letter_quality.SCORER)
+        self.assertEqual(list(stats), [key])
+        self.assertAlmostEqual(stats[key]["avg"], (0.8 + 0.2 + 0.2) / 3)
+        self.assertEqual(stats[key]["scored"], 3)
+        self.assertEqual(stats[key]["ungrounded"], 2)
+
+    def test_padded_names_merge_and_blank_names_are_skipped(self):
+        self._draft(" m1 ", 1.0, 2)
+        self._draft("m1", 0.0, 2)
+        self._draft("   ", 0.5, 2)
+        stats = quality_by_model(timezone.now())
+        self.assertEqual(list(stats), [("m1", letter_quality.SCORER)])
+        self.assertAlmostEqual(stats[("m1", letter_quality.SCORER)]["avg"], 0.5)
+        self.assertEqual(stats[("m1", letter_quality.SCORER)]["scored"], 2)
 
     def test_each_scorer_is_its_own_series_and_old_rubrics_are_dropped(self):
         self._draft("m1", 0.8, 2)

--- a/tests/sync/test_model_usage_dashboard.py
+++ b/tests/sync/test_model_usage_dashboard.py
@@ -20,7 +20,11 @@ from fighthealthinsurance.models import (
     Denial,
     ProposedAppeal,
 )
-from fighthealthinsurance.staff_views import UNKNOWN_MODEL_LABEL, _merge_stats
+from fighthealthinsurance.staff_views import (
+    UNKNOWN_MODEL_LABEL,
+    ModelUsageDashboardView,
+    _merge_stats,
+)
 
 User = get_user_model()
 
@@ -708,3 +712,131 @@ class ModelUsageDashboardChartTableAgreementTest(ChooserStatsHelperMixin, TestCa
                 for name, y in points.items():
                     if y:
                         self.assertEqual(table.get(name, 0), y, (w["slug"], name))
+
+
+class DraftQualityColumnsTest(TestCase):
+    """The leading indicator beside the lagging one: draft quality per model
+    (ml/letter_quality.py) shares the window and the labels of win rate."""
+
+    def setUp(self):
+        self.staff = User.objects.create_user(
+            username="staff-q", password="pw123", is_staff=True
+        )
+        self.client.login(username="staff-q", password="pw123")
+        self.denial = Denial.objects.create(
+            hashed_email="hash-q",
+            denial_text="denied",
+            procedure="MRI",
+            diagnosis="back pain",
+            insurance_company="TestIns",
+        )
+
+    def _scored(self, model_name, quality, grounding, days_ago=0, chosen=False, scorer=None):
+        from fighthealthinsurance.ml import letter_quality
+
+        pa = ProposedAppeal.objects.create(
+            for_denial=self.denial,
+            appeal_text=f"draft-{model_name}-{quality}-{days_ago}-{scorer}",
+            model_name=model_name,
+            chosen=chosen,
+            quality_score=quality,
+            grounding_score=grounding,
+            quality_scorer=scorer or letter_quality.SCORER,
+            quality_scored_at=timezone.now() - datetime.timedelta(days=days_ago),
+        )
+        if days_ago > 0:
+            ProposedAppeal.objects.filter(pk=pa.pk).update(
+                created_at=timezone.now() - datetime.timedelta(days=days_ago)
+            )
+        return pa
+
+    def test_quality_is_averaged_per_model_in_the_window(self):
+        self._scored("m1", 0.9, 2)
+        self._scored("m1", 0.5, 0, chosen=True)
+        self._scored("m1", 0.1, 0, days_ago=45)  # outside a 30-day window
+        self._scored("m2", 0.7, 2)
+        since = timezone.now() - datetime.timedelta(days=30)
+        rows = {
+            r["model_name"]: r
+            for r in ModelUsageDashboardView._proposed_appeal_stats(since)
+        }
+        self.assertAlmostEqual(rows["m1"]["quality_avg"], 0.7)
+        self.assertEqual(rows["m1"]["quality_scored"], 2)
+        self.assertEqual(rows["m1"]["quality_ungrounded"], 1)
+        self.assertAlmostEqual(rows["m2"]["quality_avg"], 0.7)
+
+    def test_unscored_models_show_no_average_not_zero(self):
+        ProposedAppeal.objects.create(
+            for_denial=self.denial, appeal_text="plain", model_name="m3", chosen=True
+        )
+        rows = {
+            r["model_name"]: r
+            for r in ModelUsageDashboardView._proposed_appeal_stats(None)
+        }
+        self.assertIsNone(rows["m3"]["quality_avg"])
+        self.assertEqual(rows["m3"]["quality_scored"], 0)
+
+    def test_only_the_latest_scorer_is_averaged_and_the_rest_are_counted(self):
+        from fighthealthinsurance.ml import letter_quality
+
+        older = f"typesafe/speed_20260401/rubric-{letter_quality.RUBRIC_VERSION}"
+        self._scored("m1", 0.1, 0, scorer="typesafe/speed_latest/rubric-0", days_ago=3)
+        self._scored("m1", 0.7, 2, scorer=older, days_ago=2)
+        self._scored("m1", 0.9, 2, days_ago=1)  # the current SCORER, most recent
+        rows = {
+            r["model_name"]: r
+            for r in ModelUsageDashboardView._proposed_appeal_stats(None)
+        }
+        self.assertAlmostEqual(rows["m1"]["quality_avg"], 0.9)
+        self.assertEqual(rows["m1"]["quality_scored"], 1)
+        self.assertEqual(rows["m1"]["quality_scorer"], letter_quality.SCORER)
+        self.assertEqual(rows["m1"]["quality_other_scorer"], 2)
+
+    def test_a_newer_old_rubric_row_does_not_hide_the_current_series(self):
+        from fighthealthinsurance.ml import letter_quality
+
+        self._scored("m1", 0.9, 2, days_ago=2)  # current rubric
+        self._scored("m1", 0.1, 0, scorer="typesafe/speed_latest/rubric-0", days_ago=1)  # newer, old rubric
+        rows = {
+            r["model_name"]: r
+            for r in ModelUsageDashboardView._proposed_appeal_stats(None)
+        }
+        self.assertAlmostEqual(rows["m1"]["quality_avg"], 0.9)
+        self.assertEqual(rows["m1"]["quality_other_scorer"], 1)
+
+    def test_twenty_newer_old_rubric_rows_do_not_hide_the_current_scorer(self):
+        self._scored("m1", 0.9, 2, days_ago=5)  # current rubric, oldest
+        for i in range(20):
+            # Distinct text per row: drafts are unique per denial by fingerprint.
+            self._scored("m1", 0.1 + i * 0.001, 0, scorer="typesafe/speed_latest/rubric-0", days_ago=1)
+        rows = {
+            r["model_name"]: r
+            for r in ModelUsageDashboardView._proposed_appeal_stats(None)
+        }
+        self.assertAlmostEqual(rows["m1"]["quality_avg"], 0.9)
+        self.assertEqual(rows["m1"]["quality_other_scorer"], 20)
+
+    def test_twenty_distinct_newer_old_scorers_do_not_hide_the_current_one(self):
+        self._scored("m1", 0.9, 2, days_ago=5)
+        for i in range(20):
+            self._scored("m1", 0.1 + i * 0.001, 0, scorer=f"typesafe/old-{i}/rubric-0", days_ago=1)
+        rows = {
+            r["model_name"]: r
+            for r in ModelUsageDashboardView._proposed_appeal_stats(None)
+        }
+        self.assertAlmostEqual(rows["m1"]["quality_avg"], 0.9)
+        self.assertEqual(rows["m1"]["quality_other_scorer"], 20)
+
+    def test_only_old_rubric_rows_still_count_as_other_scorer(self):
+        self._scored("m1", 0.1, 0, scorer="typesafe/speed_latest/rubric-0")
+        rows = {
+            r["model_name"]: r
+            for r in ModelUsageDashboardView._proposed_appeal_stats(None)
+        }
+        self.assertIsNone(rows["m1"]["quality_avg"])
+        self.assertEqual(rows["m1"]["quality_other_scorer"], 1)
+
+    def test_merge_keeps_old_callers_working(self):
+        rows = _merge_stats({"a": 1}, {"a": 2})
+        self.assertIsNone(rows[0]["quality_avg"])
+        self.assertEqual(rows[0]["quality_scored"], 0)

--- a/tests/sync/test_scoring_redactions.py
+++ b/tests/sync/test_scoring_redactions.py
@@ -1,0 +1,79 @@
+"""common_view_logic.scoring_redactions: the identifiers held in the
+denial's profile fields, gathered per denial for letter_quality. Not a
+promise about the letter text itself."""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from fhi_users.models import PatientUser, ProfessionalUser
+from fighthealthinsurance.common_view_logic import scoring_redactions
+from fighthealthinsurance.models import Denial
+
+
+class ScoringRedactionsTest(TestCase):
+    def test_collects_names_emails_numbers_and_ids(self):
+        User = get_user_model()
+        patient = PatientUser.objects.create(
+            user=User.objects.create_user(
+                username="jane", email="jane@example.org", first_name="Jane", last_name="Doe"
+            ),
+            display_name="JD",
+        )
+        professional = ProfessionalUser.objects.create(
+            user=User.objects.create_user(
+                username="sam", email="sam@clinic.example", first_name="Sam", last_name="Smith"
+            ),
+            active=True,
+            npi_number="1234567890",
+            fax_number="415-555-0100",
+            display_name="Sam Smith MD",
+        )
+        from fhi_users.models import UserContactInfo
+
+        UserContactInfo.objects.create(
+            user=patient.user, phone_number="212-555-0199", address1="14 Oak St", address2="Apt 2"
+        )
+        denial = Denial.objects.create(
+            hashed_email="h",
+            denial_text="denied",
+            raw_email="jane@example.org",
+            claim_id="TLH-1",
+            plan_id="UNKNOWN",
+            employer_name="Totally Legit Co",
+            patient_user=patient,
+            primary_professional=professional,
+        )
+        found = dict(scoring_redactions(denial))
+        for value, category in {
+            "Jane Doe": "PATIENT#patient",
+            "Doe": "PATIENT#patient",
+            "jane@example.org": "EMAIL",
+            "Sam Smith": f"PROFESSIONAL#{professional.pk}",
+            "Sam Smith MD": f"PROFESSIONAL#{professional.pk}",
+            "sam@clinic.example": "EMAIL",
+            "1234567890": "NPI",
+            "415-555-0100": "PHONE",  # fax numbers share the phone namespace
+            "TLH-1": "CLAIM_ID",
+            "Totally Legit Co": "EMPLOYER",
+            "14 Oak St": "ADDRESS",
+            "Apt 2": "ADDRESS",
+            "212-555-0199": "PHONE",
+        }.items():
+            self.assertEqual(found.get(value), category, value)
+        self.assertNotIn("UNKNOWN", found)
+
+    def test_a_relation_that_cannot_be_read_raises_instead_of_dropping_it(self):
+        from unittest.mock import patch
+
+        User = get_user_model()
+        patient = PatientUser.objects.create(
+            user=User.objects.create_user(username="p", email="p@example.org"), display_name="P"
+        )
+        denial = Denial.objects.create(hashed_email="h", denial_text="denied", patient_user=patient)
+        with patch.object(PatientUser, "get_legal_name", side_effect=RuntimeError("db away")):
+            with self.assertRaises(RuntimeError):
+                scoring_redactions(denial)
+
+    def test_a_bare_denial_yields_nothing_and_never_raises(self):
+        denial = Denial.objects.create(hashed_email="h", denial_text="denied")
+        self.assertEqual(scoring_redactions(denial), [])

--- a/tests/sync/test_scoring_redactions.py
+++ b/tests/sync/test_scoring_redactions.py
@@ -21,7 +21,8 @@ class ScoringRedactionsTest(TestCase):
         )
         professional = ProfessionalUser.objects.create(
             user=User.objects.create_user(
-                username="sam", email="sam@clinic.example", first_name="Sam", last_name="Smith"
+                # A domain-scoped login, stored the way auth_utils stores it.
+                username="sam🐼12", email="sam@clinic.example", first_name="Sam", last_name="Smith"
             ),
             active=True,
             npi_number="1234567890",
@@ -48,9 +49,12 @@ class ScoringRedactionsTest(TestCase):
             "Jane Doe": "PATIENT#patient",
             "Doe": "PATIENT#patient",
             "jane@example.org": "EMAIL",
+            "jane": "USERNAME",  # the login, an identifier rather than a name
             "Sam Smith": f"PROFESSIONAL#{professional.pk}",
             "Sam Smith MD": f"PROFESSIONAL#{professional.pk}",
             "sam@clinic.example": "EMAIL",
+            "sam🐼12": "USERNAME",  # as stored
+            "sam": "USERNAME",  # the raw login the person actually writes
             "1234567890": "NPI",
             "415-555-0100": "PHONE",  # fax numbers share the phone namespace
             "TLH-1": "CLAIM_ID",

--- a/tests/sync/test_settings_env_int.py
+++ b/tests/sync/test_settings_env_int.py
@@ -1,0 +1,32 @@
+"""settings._env_int: an optional integer setting must never crash import."""
+
+import os
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+from fighthealthinsurance.settings import _env_int
+
+
+class EnvIntTest(SimpleTestCase):
+    def _read(self, default=7):
+        return _env_int("FHI_TEST_INT", default, minimum=1, maximum=300)
+
+    def test_parses_a_plain_integer(self):
+        with patch.dict(os.environ, {"FHI_TEST_INT": " 42 "}):
+            self.assertEqual(self._read(), 42)
+
+    def test_falls_back_on_garbage_or_empty(self):
+        for raw in ("20s", "", "   ", "twenty"):
+            with patch.dict(os.environ, {"FHI_TEST_INT": raw}):
+                self.assertEqual(self._read(), 7, repr(raw))
+
+    def test_out_of_range_falls_back_so_a_zero_timeout_never_means_no_timeout(self):
+        for raw in ("0", "-5", "301"):
+            with patch.dict(os.environ, {"FHI_TEST_INT": raw}):
+                self.assertEqual(self._read(), 7, repr(raw))
+
+    def test_falls_back_when_unset(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("FHI_TEST_INT", None)
+            self.assertEqual(self._read(), 7)


### PR DESCRIPTION
Order appeal drafts by a TypeSafe quality score, and watch it per backend

  **Why.** The router fans a denial out to up to nine backends and every draft lands on the page in arrival order. Each saved
  draft is now scored by TypeSafe System One on the four criteria our model evaluation validated (per-letter r=0.74 vs the
  judge ensemble, backend ranking Spearman 0.90); the client shows the best first, and the staff dashboard gets a leading
  quality signal beside the lagging win rate.

  **What it is not.** A success probability. Nothing is calibrated against outcomes and insurers overturn a third to a half of
  internal appeals, so the page says "Ordered by how well each letter addresses your denial, not by a prediction of the
  outcome" and never shows a number.

  **What TypeSafe receives, exactly.** The same denial text and draft the external LLMs already receive and produce, under the
  same consent (`denial.use_external`); never the form fields. Before sending, every identifier we hold in profile fields
  (names, user names, emails, phone/fax, NPI, claim/plan ids, employer, contact address lines, practice address) and every
  email/phone-shaped value becomes a stable, distinct token. **This is a reduction, not de-identification**: free-text names,
  member ids or addresses in the letter itself go through, and the generation prompt writes the patient's details into the
  draft. So enabling this is a contractual decision: TypeSafe under the same data terms as the other providers, and named in
  the privacy policy. **The flag stays off until then.**

  **What changes**
  - `ml/typesafe.py` transport; `ml/letter_quality.py` questions, float scores, single-pass `Redactor` (linear scans,
  overlapping spans merged, tokens shared across denial and draft), token-safe truncation, versioned provenance.
  - `common_view_logic`: one fire-and-forget scoring task per saved *or re-served* draft; `{"type":"score","id":…}` frames
  drained between letters and once more before `done`; identifier collection all-or-nothing; in-process in-flight guard shared
  across reconnecting streams.
  - `appeal_fetcher.ts`: nothing moves until generation is really over (`done()`'s no-retry branch), and only when every draft
  has a row id, a score and the same scorer (a partial scorer outage or a mid-run model repoint leaves arrival order);
  grounded first, then quality; caption; "Recommended" (dropped once the draft is edited); drafts past 3 folded behind an
  accessible button.
  - `ProposedAppeal.quality_score/grounding_score/quality_scorer/quality_scored_at` + migration 0205 (nullable ADD COLUMNs,
  sub-second on 26k rows).
  - Staff model usage table: Quality / Scored / Ungrounded / Other scorer, one exact scorer per window, never blended.
  `/metrics`: `fhi_letter_quality_*{model_name,scorer}`.
  - Settings: `TYPESAFE_API_KEY`, `TYPESAFE_API_URL`, `TYPESAFE_LETTER_RANKING_ENABLED`, `TYPESAFE_TIMEOUT_SECONDS` (bounded).
  Inert until key + flag; hard-off in every test configuration.

  **Before turning it on in prod:** TypeSafe's data terms in writing; add TypeSafe to the privacy policy's AI-provider list
  (`privacy_policy.html` still says OctoAI/Perplexity/TogetherAI); key in the web secret; flag on.

  **Known limits, accepted:** TypeSafe exposes a moving alias and only sometimes the resolved model, so a repoint hidden
  behind the alias is invisible to us (documented in `scorer_for`); a reconnect on another worker process can score a row
  twice (fraction of a cent); the score is of the draft as generated, before placeholders are filled (the redactor would token
  those names back out anyway).

  **Testing.** ~90 async-unit tests (scorer, redaction incl. Unicode/overlap/boundary, stream integration driving the real
  generator with real `PatientUser`/`ProfessionalUser` rows, client wiring), ~45 sync (dashboard, collector, identifier
  collection, settings). Full async-unit and sync suites green locally except the known live-backend `DenialEndToEnd` tests.
  Nine Codex adversarial rounds. Not verified in a browser (no JS runner; the appeals page needs live backends); the bundle
  compiles.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically evaluates generated appeal drafts for quality, factual grounding, and tone.
  * Ranks drafts, highlights a recommended option, and groups additional drafts behind “Show more.”
  * Redacts personal and claim information before evaluation.
  * Adds draft-quality statistics to the model usage dashboard and monitoring.

* **Bug Fixes**
  * Edited drafts no longer retain recommendation labels.
  * Incomplete or inconsistent scoring preserves the original draft order.

* **Tests**
  * Added coverage for scoring, redaction, ranking, metrics, and configuration handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->