### PR TITLE
Cap the stored-draft replay at 3, newest first

### DIFF
--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -2909,6 +2909,14 @@ class AppealsBackendHelper:
     # ranking flags off there are no scores to sort by, and the page still must
     # not open with a haystack. Ranking sits on top of this rather than
     # replacing it.
+    #
+    # The cap limits what is SHOWN at the start of a run. It does not fence the
+    # held-back rows off from the rest of the run, and that is deliberate:
+    # synthesis below still draws on every stored draft for the denial (it is
+    # choosing inputs, not showing them), and if the model regenerates text
+    # identical to a held-back row, the uniqueness handler streams that stored
+    # row -- a draft the user has not seen this session, which is the right
+    # outcome even though the done frame counts it as new (review).
     MAX_REPLAYED_APPEALS = 3
 
     # Deadlines, measured from the start of the generation flow, after which a

--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -3431,6 +3431,13 @@ class AppealsBackendHelper:
         # Yield the existing appeals first
         old = 0
         new = 0
+        # Stored drafts the cap keeps off the screen, by normalized text. They
+        # are NOT served: a synthesis result or a live draft that lands on one
+        # of them is new to this user and must be delivered (the uniqueness
+        # handler streams the stored row). They ARE kept out of the
+        # end-of-flow reconciliation, or the cap would be undone at the end
+        # (review).
+        held_back_keys: set[str] = set()
         async for appeal in existing_appeals:
             # Enforce the deliverability rules on previously-saved appeals too:
             # the DB may hold short or wordless drafts saved before those
@@ -3438,12 +3445,20 @@ class AppealsBackendHelper:
             # not re-deliver them.
             if is_real_appeal(appeal.appeal_text):
                 key = _served_key(appeal.appeal_text)
-                if key in served_keys:
+                if key in served_keys or key in held_back_keys:
                     # Legacy duplicate rows (NULL fingerprints, equivalent
                     # normalized text) are one draft to the user: stream
                     # the first, skip its twins, and don't count them in
                     # `old` (review).
                     logger.debug(f"Skipping duplicate existing appeal {appeal}")
+                    continue
+                if old >= cls.MAX_REPLAYED_APPEALS:
+                    # Past the cap: remember it, don't show it. The cap counts
+                    # DELIVERED rows, not rows examined: duplicates and
+                    # unusable drafts are skipped above and must not spend the
+                    # budget, or a denial whose recent rows happen to be twins
+                    # would replay nothing at all.
+                    held_back_keys.add(key)
                     continue
                 old = old + 1
                 logger.debug(f"Found existing appeal {appeal}, yielding")
@@ -3452,22 +3467,18 @@ class AppealsBackendHelper:
                     {"id": str(appeal.id), "content": appeal.appeal_text}
                 )
                 yield await format_response(existing_appeal_dict)
-                # Count DELIVERED rows, not rows examined: duplicates and
-                # unusable drafts are skipped above and must not spend the
-                # budget, or a denial whose recent rows happen to be twins
-                # would replay nothing at all.
-                if old >= cls.MAX_REPLAYED_APPEALS:
-                    logger.info(
-                        f"[gen_id={generation_id}] replay cap reached for "
-                        f"denial {denial_id}: served {old} stored drafts "
-                        f"(newest first), holding back the rest"
-                    )
-                    break
             elif appeal.appeal_text is not None and str(appeal.appeal_text).strip():
                 warn_unusable_appeal(
                     appeal.appeal_text,
                     f"saved appeal id={appeal.id} for denial {denial_id}",
                 )
+
+        if held_back_keys:
+            logger.info(
+                f"[gen_id={generation_id}] replay cap for denial {denial_id}: "
+                f"served {old} stored drafts (newest first), held back "
+                f"{len(held_back_keys)}"
+            )
 
         # --- Early speculative fallback ---
         # What the precompute had ready before this run started. Logged here so
@@ -4851,7 +4862,17 @@ class AppealsBackendHelper:
         # streams the draft; such a draft has no row here, but the streaming
         # path already recorded its text, so the reconciliation still won't
         # re-serve it.
-        served_keys.update({_served_key(s) for s in saved_appeal_texts if s})
+        # ...except the rows the replay cap held back. Those were never sent,
+        # and a synthesis result that lands on one of them is new to this user:
+        # marking it served here would make the guard below discard the only
+        # copy the user would ever see (review).
+        served_keys.update(
+            {
+                k
+                for k in (_served_key(s) for s in saved_appeal_texts if s)
+                if k not in held_back_keys
+            }
+        )
         # Synthesis requires >=2 drafts to be meaningful: with a single
         # input, models often regurgitate it verbatim. The client dedupes
         # by content, so a verbatim copy gets silently dropped, which then
@@ -4997,7 +5018,11 @@ class AppealsBackendHelper:
                 if not is_real_appeal(text):
                     continue
                 normalized = str(text).strip()
-                if _served_key(text) in served_keys:
+                key = _served_key(text)
+                # Held-back rows stay held back: the reconciliation exists to
+                # land drafts that no yield path saw, and these were skipped
+                # on purpose, not missed.
+                if key in served_keys or key in held_back_keys:
                     continue
                 is_mini = bool(row.speculative) or row.context_level in MINI_LEVELS
                 # Re-evaluate the threshold each iteration: serving increments new.

--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -2896,6 +2896,21 @@ class AppealsBackendHelper:
     # sufficient result with weaker drafts adds no value.
     ENOUGH_APPEALS = 3
 
+    # How many previously-saved drafts to replay before this run's own drafts.
+    #
+    # Rows accumulate per denial across retries, reconnects and re-runs, and the
+    # replay had no cap at all, so a denial that had been through generation a
+    # few times opened with a wall of stored letters and put the fresh one at
+    # the bottom. Eighteen old drafts ahead of one new one is not a listing, it
+    # is a haystack.
+    #
+    # Newest first, because the most recent drafts were generated with the most
+    # context. This is deliberately independent of TypeSafe scoring: with the
+    # ranking flags off there are no scores to sort by, and the page still must
+    # not open with a haystack. Ranking sits on top of this rather than
+    # replacing it.
+    MAX_REPLAYED_APPEALS = 3
+
     # Deadlines, measured from the start of the generation flow, after which a
     # run starts serving the speculative reserve instead of holding it to the
     # very end. Research + make_appeals routinely run for minutes, and a reserve
@@ -3381,9 +3396,15 @@ class AppealsBackendHelper:
         # Exclude speculative rows: those are the background precompute held in
         # reserve and are served ONLY as a fallback below, not as normal
         # existing appeals.
-        existing_appeals = ProposedAppeal.objects.filter(
-            for_denial=denial, speculative=False
-        ).all()
+        # Newest first so the cap below keeps the most recent drafts rather than
+        # whatever the database happened to return. created_at is null on legacy
+        # rows, and Postgres sorts NULLs first on DESC, which would have handed
+        # those rows the whole budget; nulls_last puts them where they belong.
+        existing_appeals = (
+            ProposedAppeal.objects.filter(for_denial=denial, speculative=False)
+            .order_by(F("created_at").desc(nulls_last=True), "-id")
+            .all()
+        )
         # Everything already delivered to this client, by normalized raw text.
         # Grown by every path that ships an appeal (existing rows, streamed
         # drafts, the early reserve flush, synthesis, the end-of-flow
@@ -3423,6 +3444,17 @@ class AppealsBackendHelper:
                     {"id": str(appeal.id), "content": appeal.appeal_text}
                 )
                 yield await format_response(existing_appeal_dict)
+                # Count DELIVERED rows, not rows examined: duplicates and
+                # unusable drafts are skipped above and must not spend the
+                # budget, or a denial whose recent rows happen to be twins
+                # would replay nothing at all.
+                if old >= cls.MAX_REPLAYED_APPEALS:
+                    logger.info(
+                        f"[gen_id={generation_id}] replay cap reached for "
+                        f"denial {denial_id}: served {old} stored drafts "
+                        f"(newest first), holding back the rest"
+                    )
+                    break
             elif appeal.appeal_text is not None and str(appeal.appeal_text).strip():
                 warn_unusable_appeal(
                     appeal.appeal_text,

--- a/tests/async-unit/test_appeal_replay_cap.py
+++ b/tests/async-unit/test_appeal_replay_cap.py
@@ -6,9 +6,15 @@ times opened with a wall of stored letters and buried the fresh draft at the
 bottom. Melanie hit exactly this on prod: eighteen stored drafts, then one new
 one, last.
 
-These pin the cap and the ordering. They are deliberately independent of
-TypeSafe scoring: with the ranking flags off there are no scores to sort by, and
-the page still must not open with a haystack.
+These pin the cap and the ordering of what is SHOWN. They are deliberately
+independent of TypeSafe scoring: with the ranking flags off there are no scores
+to sort by, and the page still must not open with a haystack.
+
+What the cap does not do, on purpose: rows it holds back stay available to the
+rest of the run. Synthesis still draws on every stored draft, because it is
+choosing inputs rather than showing them; and if the model regenerates text
+identical to a held-back row, the uniqueness handler streams that stored row,
+which is a draft the user has not seen this session and is the right outcome.
 """
 
 import json
@@ -29,11 +35,16 @@ class AppealReplayCapTest(TestCase):
 
     def _create_denial(self):
         email = "replay-cap@example.com"
+        # gen_attempts=3 skips the research phase, the same way the sibling
+        # tests in test_common_view_logic.py do. At 1, generation bumps it to
+        # 2 and enters research, and the RAG helper's health check makes a
+        # real HTTP request to whatever RAG_SERVICE_URL is in the ambient
+        # environment (review). Nothing here is about research.
         denial = Denial.objects.create(
             denial_id=self.DENIAL_ID,
             semi_sekret="sekret",
             hashed_email=Denial.get_hashed_email(email),
-            gen_attempts=1,
+            gen_attempts=3,
         )
         return email, denial
 

--- a/tests/async-unit/test_appeal_replay_cap.py
+++ b/tests/async-unit/test_appeal_replay_cap.py
@@ -18,16 +18,27 @@ which is a draft the user has not seen this session and is the right outcome.
 """
 
 import json
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from asgiref.sync import async_to_sync
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from fighthealthinsurance.common_view_logic import AppealsBackendHelper
 from fighthealthinsurance.models import Denial, ProposedAppeal
 
 
+# Temporal off, explicitly. The interactive path records a durable intake
+# intent and tries an inline delivery to the Temporal cluster when the three
+# flags are on; they are read from the environment at settings import, so an
+# ambient TEMPORAL_ENABLED=true would make these tests open a connection to a
+# real backend (review). The flags are read through getattr(settings, ...) at
+# call time, so an override here is enough.
+@override_settings(
+    TEMPORAL_ENABLED=False,
+    TEMPORAL_APPEAL_JOURNEY_ENABLED=False,
+    TEMPORAL_INTAKE_JOURNEY_ENABLED=False,
+)
 class AppealReplayCapTest(TestCase):
     """The replay budget is spent on the newest deliverable drafts, and no more."""
 
@@ -209,6 +220,64 @@ class AppealReplayCapTest(TestCase):
                     len([c for c in replayed if "duplicated newest draft" in c]),
                     1,
                     "the duplicate was delivered twice",
+                )
+            finally:
+                await Denial.objects.filter(denial_id=self.DENIAL_ID).adelete()
+
+        async_to_sync(test)()
+
+    @pytest.mark.django_db
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_a_synthesis_result_matching_a_held_back_draft_is_still_delivered(
+        self, mock_appeal_generator
+    ):
+        """The cap hides a draft; it must not make the synthesis of it vanish.
+
+        Synthesis inputs are marked served so the end-of-flow reconciliation
+        does not dump them. Marking a HELD-BACK input served made the
+        verbatim-copy guard discard a synthesis result that matched it, so the
+        user never saw the one copy they could have (review). Held-back rows
+        now stay out of served_keys; the result lands as the stored row.
+        """
+        email, denial = self._create_denial()
+        texts = [
+            (
+                f"Stored draft {i} for this denial, long enough to be a "
+                "deliverable appeal rather than a runt row."
+            )
+            for i in range(18)
+        ]
+        for text in texts:
+            ProposedAppeal.objects.create(
+                for_denial=denial, appeal_text=text, speculative=False
+            )
+        mock_appeal_generator.make_appeals.return_value = iter([])
+        # Draft 5 is well past the cap of three (17, 16, 15 are replayed).
+        mock_appeal_generator.synthesize_appeals = AsyncMock(return_value=texts[5])
+
+        async def test():
+            try:
+                contents = await self._collect_contents(
+                    {
+                        "denial_id": self.DENIAL_ID,
+                        "email": email,
+                        "semi_sekret": denial.semi_sekret,
+                    }
+                )
+                stored = [c for c in contents if "Stored draft" in c]
+                fives = [c for c in stored if "Stored draft 5 " in c]
+                self.assertEqual(
+                    len(fives),
+                    1,
+                    "the synthesis result that matched a held-back draft was "
+                    f"discarded (or duplicated): {len(fives)} copies",
+                )
+                # Three replayed plus the one synthesis landed on, and nothing
+                # else: the held-back rows must not come back at the end.
+                self.assertEqual(
+                    len(stored),
+                    AppealsBackendHelper.MAX_REPLAYED_APPEALS + 1,
+                    f"unexpected stored drafts on screen: {len(stored)}",
                 )
             finally:
                 await Denial.objects.filter(denial_id=self.DENIAL_ID).adelete()

--- a/tests/async-unit/test_appeal_replay_cap.py
+++ b/tests/async-unit/test_appeal_replay_cap.py
@@ -1,0 +1,205 @@
+"""Stored drafts are replayed newest-first and capped, not dumped in full.
+
+Rows accumulate per denial across retries, reconnects and re-runs of the same
+denial. The replay had no cap, so a denial that had been generated against a few
+times opened with a wall of stored letters and buried the fresh draft at the
+bottom. Melanie hit exactly this on prod: eighteen stored drafts, then one new
+one, last.
+
+These pin the cap and the ordering. They are deliberately independent of
+TypeSafe scoring: with the ranking flags off there are no scores to sort by, and
+the page still must not open with a haystack.
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+from asgiref.sync import async_to_sync
+from django.test import TestCase
+
+from fighthealthinsurance.common_view_logic import AppealsBackendHelper
+from fighthealthinsurance.models import Denial, ProposedAppeal
+
+
+class AppealReplayCapTest(TestCase):
+    """The replay budget is spent on the newest deliverable drafts, and no more."""
+
+    DENIAL_ID = 4101
+
+    def _create_denial(self):
+        email = "replay-cap@example.com"
+        denial = Denial.objects.create(
+            denial_id=self.DENIAL_ID,
+            semi_sekret="sekret",
+            hashed_email=Denial.get_hashed_email(email),
+            gen_attempts=1,
+        )
+        return email, denial
+
+    @staticmethod
+    async def _collect_contents(data):
+        contents = []
+        async for chunk in AppealsBackendHelper.generate_appeals(data):
+            if not chunk or not chunk.strip():
+                continue
+            try:
+                parsed = json.loads(chunk)
+            except json.JSONDecodeError:
+                continue
+            if "content" in parsed:
+                contents.append(parsed["content"])
+        return contents
+
+    @pytest.mark.django_db
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_replay_is_capped_and_newest_first(self, mock_appeal_generator):
+        """Eighteen stored drafts must not all come back."""
+        email, denial = self._create_denial()
+        # Created oldest to newest, so "Stored draft 17" is the most recent.
+        for i in range(18):
+            ProposedAppeal.objects.create(
+                for_denial=denial,
+                appeal_text=(
+                    f"Stored draft {i} for this denial, long enough to be a "
+                    "deliverable appeal rather than a runt row."
+                ),
+                speculative=False,
+            )
+        mock_appeal_generator.make_appeals.return_value = iter([])
+
+        async def test():
+            try:
+                contents = await self._collect_contents(
+                    {
+                        "denial_id": self.DENIAL_ID,
+                        "email": email,
+                        "semi_sekret": denial.semi_sekret,
+                    }
+                )
+                replayed = [c for c in contents if "Stored draft" in c]
+                self.assertEqual(
+                    len(replayed),
+                    AppealsBackendHelper.MAX_REPLAYED_APPEALS,
+                    "the stored-draft replay is uncapped again; the page opens "
+                    f"with a wall of letters. Got {len(replayed)}",
+                )
+                # Newest first: 17, 16, 15 -- never 0, 1, 2.
+                self.assertIn("Stored draft 17", replayed[0])
+                self.assertNotIn(
+                    "Stored draft 0",
+                    " ".join(replayed),
+                    "the oldest draft was replayed, so the ordering is not "
+                    "newest-first",
+                )
+            finally:
+                await Denial.objects.filter(denial_id=self.DENIAL_ID).adelete()
+
+        async_to_sync(test)()
+
+    @pytest.mark.django_db
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_a_denial_under_the_cap_is_unaffected(self, mock_appeal_generator):
+        """The common case, a first-time user, must not lose anything."""
+        email, denial = self._create_denial()
+        for i in range(2):
+            ProposedAppeal.objects.create(
+                for_denial=denial,
+                appeal_text=(
+                    f"Only draft {i} for this denial, long enough to count as "
+                    "a deliverable appeal rather than a runt row."
+                ),
+                speculative=False,
+            )
+        mock_appeal_generator.make_appeals.return_value = iter([])
+
+        async def test():
+            try:
+                contents = await self._collect_contents(
+                    {
+                        "denial_id": self.DENIAL_ID,
+                        "email": email,
+                        "semi_sekret": denial.semi_sekret,
+                    }
+                )
+                replayed = [c for c in contents if "Only draft" in c]
+                self.assertEqual(len(replayed), 2)
+            finally:
+                await Denial.objects.filter(denial_id=self.DENIAL_ID).adelete()
+
+        async_to_sync(test)()
+
+    @pytest.mark.django_db
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_the_cap_counts_delivered_drafts_not_rows_examined(
+        self, mock_appeal_generator
+    ):
+        """Duplicates and runts are skipped and must not spend the budget.
+
+        Otherwise a denial whose newest rows happen to be twins would replay
+        almost nothing, which is the same bug in the other direction.
+        """
+        email, denial = self._create_denial()
+        # Oldest: three distinct, deliverable drafts.
+        for i in range(3):
+            ProposedAppeal.objects.create(
+                for_denial=denial,
+                appeal_text=(
+                    f"Distinct draft {i} for this denial, long enough to be a "
+                    "deliverable appeal rather than a runt row."
+                ),
+                speculative=False,
+            )
+        # Newest: a runt, then two rows holding the same normalized text.
+        ProposedAppeal.objects.create(
+            for_denial=denial, appeal_text="tiny", speculative=False
+        )
+        dup_text = (
+            "A duplicated newest draft, long enough to be deliverable but "
+            "present twice over."
+        )
+        # The partial unique constraint on (for_denial, text_fingerprint) makes
+        # this shape impossible to CREATE today, which is the point: it only
+        # exists as legacy rows written before the fingerprint field, where the
+        # fingerprint is NULL and the constraint does not apply. Null them out
+        # to reproduce that, rather than testing a state the DB now prevents.
+        for i in range(2):
+            row = ProposedAppeal.objects.create(
+                for_denial=denial,
+                appeal_text=f"{dup_text} {i}",
+                speculative=False,
+            )
+            ProposedAppeal.objects.filter(pk=row.pk).update(
+                appeal_text=dup_text, text_fingerprint=None
+            )
+        mock_appeal_generator.make_appeals.return_value = iter([])
+
+        async def test():
+            try:
+                contents = await self._collect_contents(
+                    {
+                        "denial_id": self.DENIAL_ID,
+                        "email": email,
+                        "semi_sekret": denial.semi_sekret,
+                    }
+                )
+                replayed = [
+                    c
+                    for c in contents
+                    if "Distinct draft" in c or "duplicated newest draft" in c
+                ]
+                self.assertEqual(
+                    len(replayed),
+                    AppealsBackendHelper.MAX_REPLAYED_APPEALS,
+                    "skipped rows spent the replay budget, so the user got "
+                    f"fewer drafts than the cap allows. Got {len(replayed)}",
+                )
+                self.assertEqual(
+                    len([c for c in replayed if "duplicated newest draft" in c]),
+                    1,
+                    "the duplicate was delivered twice",
+                )
+            finally:
+                await Denial.objects.filter(denial_id=self.DENIAL_ID).adelete()
+
+        async_to_sync(test)()

--- a/tests/async-unit/test_appeal_replay_cap.py
+++ b/tests/async-unit/test_appeal_replay_cap.py
@@ -73,12 +73,9 @@ class AppealReplayCapTest(TestCase):
                 contents.append(parsed["content"])
         return contents
 
-    @pytest.mark.django_db
-    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
-    def test_replay_is_capped_and_newest_first(self, mock_appeal_generator):
-        """Eighteen stored drafts must not all come back."""
+    def _replay_of_eighteen(self, mock_appeal_generator):
+        """Eighteen stored drafts, created oldest to newest; the drafts replayed."""
         email, denial = self._create_denial()
-        # Created oldest to newest, so "Stored draft 17" is the most recent.
         for i in range(18):
             ProposedAppeal.objects.create(
                 for_denial=denial,
@@ -90,7 +87,7 @@ class AppealReplayCapTest(TestCase):
             )
         mock_appeal_generator.make_appeals.return_value = iter([])
 
-        async def test():
+        async def run():
             try:
                 contents = await self._collect_contents(
                     {
@@ -99,25 +96,35 @@ class AppealReplayCapTest(TestCase):
                         "semi_sekret": denial.semi_sekret,
                     }
                 )
-                replayed = [c for c in contents if "Stored draft" in c]
-                self.assertEqual(
-                    len(replayed),
-                    AppealsBackendHelper.MAX_REPLAYED_APPEALS,
-                    "the stored-draft replay is uncapped again; the page opens "
-                    f"with a wall of letters. Got {len(replayed)}",
-                )
-                # Newest first: 17, 16, 15 -- never 0, 1, 2.
-                self.assertIn("Stored draft 17", replayed[0])
-                self.assertNotIn(
-                    "Stored draft 0",
-                    " ".join(replayed),
-                    "the oldest draft was replayed, so the ordering is not "
-                    "newest-first",
-                )
+                return [c for c in contents if "Stored draft" in c]
             finally:
                 await Denial.objects.filter(denial_id=self.DENIAL_ID).adelete()
 
-        async_to_sync(test)()
+        return async_to_sync(run)()
+
+    @pytest.mark.django_db
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_replay_is_capped(self, mock_appeal_generator):
+        """Eighteen stored drafts must not all come back."""
+        replayed = self._replay_of_eighteen(mock_appeal_generator)
+        self.assertEqual(
+            len(replayed),
+            AppealsBackendHelper.MAX_REPLAYED_APPEALS,
+            "the stored-draft replay is uncapped again; the page opens "
+            f"with a wall of letters. Got {len(replayed)}",
+        )
+
+    @pytest.mark.django_db
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_replay_is_newest_first(self, mock_appeal_generator):
+        """The budget goes to the most recent drafts: 17, 16, 15, never 0."""
+        replayed = self._replay_of_eighteen(mock_appeal_generator)
+        self.assertIn("Stored draft 17", replayed[0])
+        self.assertNotIn(
+            "Stored draft 0",
+            " ".join(replayed),
+            "the oldest draft was replayed, so the ordering is not newest-first",
+        )
 
     @pytest.mark.django_db
     @patch("fighthealthinsurance.common_view_logic.appealGenerator")

--- a/tests/async-unit/test_appeals_backend_citations.py
+++ b/tests/async-unit/test_appeals_backend_citations.py
@@ -105,6 +105,9 @@ def _make_empty_proposed_appeal_query():
 
     mock_queryset = MagicMock()
     mock_queryset.all.return_value = empty_async_iter()
+    # The existing-appeals replay orders newest-first before it calls .all(),
+    # so the chain has to come back to this same mock.
+    mock_queryset.order_by.return_value = mock_queryset
     return mock_queryset
 
 
@@ -162,9 +165,13 @@ def _make_proposed_appeal_query_with_texts(texts, existing_texts=None):
         only = exclude
 
         def order_by(self, *args, **kwargs):
-            # Mock ignores the sort key; the reconciliation query uses
-            # order_by("id") for deterministic FIFO promotion in production.
-            return self._gen()
+            # Mock ignores the sort key. Two production callers order: the
+            # reconciliation query uses order_by("id") for deterministic FIFO
+            # promotion and then iterates, and the existing-appeals replay
+            # orders newest-first and then calls .all(). Returning self serves
+            # both, since __aiter__ yields the same rows the old
+            # generator-returning version did.
+            return self
 
         def __aiter__(self):
             return self._gen()


### PR DESCRIPTION
The appeals page replayed every stored draft for a denial before any fresh one, with no cap and no ordering. On prod that was eighteen old letters, then one new one, at the bottom. Rows accumulate per denial across retries, reconnects and re-runs, so a denial that has been generated against a few times opened with a haystack.

**What changes**

- The replay stops after `MAX_REPLAYED_APPEALS` (3) delivered drafts, newest first (`created_at` DESC with NULLs last, then `-id`; legacy rows have NULL `created_at` and Postgres would otherwise sort them first).
- The cap counts delivered rows, not rows examined: duplicates and runts are skipped before the count, so a denial whose newest rows are twins still replays three real drafts.
- Rows the cap holds back are recorded in a separate set. They are not marked served, so a synthesis result or live draft that lands on one of them is delivered as the stored row, and they are skipped explicitly by the end-of-flow reconciliation, so the cap is not undone at the end.
- Deliberately independent of TypeSafe. With the ranking flags off there are no scores to sort by and the page still must not open with a haystack, so this sits underneath #996's ranking rather than competing with it. It touches only `common_view_logic.py`; `appeal_fetcher.ts` is untouched, so the #996 rebase is unaffected.

**Accepted, and written at the constant:** held-back rows stay available to synthesis as inputs (it chooses, it does not show), and a live draft that regenerates a held-back row's text is streamed as that stored row. Both are the right outcome for the user.

**Not done here, because it is a UI call:** the fresh draft still arrives after the replayed ones rather than at the top, and there is no fold for older drafts. Melanie's direction (TypeSafe re-ranking as scores land, top 3 to 5 visible, a "show more", fresh draft appended and revealed) is the design that sits on top of this; most of it already exists on the letter-ranking branch.

**Tests:** three new tests pin the cap, the ordering, and the delivered-not-examined rule; a fourth reproduces the synthesis regression Codex found. They override the three Temporal flags and use `gen_attempts=3` to skip research; verified hermetic with `TEMPORAL_*=true` and `RAG_SERVICE_URL` pointed at a closed port. Two mocks in `test_appeals_backend_citations.py` learned `order_by()`; they assert what they did before. Full async-unit, async and sync suites, black and mypy green.

**Review:** Codex (gpt-6-astra, read-only sandbox), four rounds. Round 1: hermeticity (fixed) plus two input-selection points (accepted, documented). Round 2: a real regression, synthesis inputs marked served hid a matching synthesis result (fixed, test added), and Temporal reach (fixed). Round 3: clean apart from an inherited item. Round 4: confirming clean.

**Follow-up to file separately:** the repository root `tests/conftest.py` makes a real request to api.stripe.com at collection when `STRIPE_TEST_SECRET_KEY` is in the environment. Predates this branch, affects every test equally, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYruQVRyBbFzUxy9YGcHTb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Limited replay of previously saved appeal drafts to the three most recent items.
  - Preserved delivery of relevant drafts when they match newly generated appeal results.
  - Skipped incomplete or duplicate drafts without consuming the replay limit.

- **Tests**
  - Added coverage for replay limits, newest-first ordering, duplicate handling, and deduplication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->