### PR TITLE
Default advanced OCR off, and stop pinning a 404ing wasm path

### DIFF
--- a/fighthealthinsurance/static/js/qwen_webgpu_ocr.ts
+++ b/fighthealthinsurance/static/js/qwen_webgpu_ocr.ts
@@ -1,5 +1,22 @@
 // Optional Qwen WebGPU OCR path.
 // This module must fail closed: if WebGPU/model init fails, callers keep using baseline OCR.
+//
+// KNOWN BROKEN, and that is why the checkbox now defaults to off. On prod this
+// engine has never once produced text: init throws
+// "Unsupported model type: qwen3_5" and every caller silently falls back to
+// tesseract. The cause is the pipeline task below, not the dependency version.
+// pipeline("image-to-text") resolves to AutoModelForVision2Seq, whose registry
+// holds only vision-encoder-decoder, idefics3 and smolvlm; qwen3_5 is
+// registered under image-text-to-text, which transformers.js does not expose as
+// a pipeline task at all. So there is no task string that makes this call work.
+//
+// Making it work means driving the model directly rather than through
+// pipeline(): AutoProcessor with the chat template, an explicit resize (a
+// 300 DPI letter page is ~33k vision patches, past what WebGPU will bind),
+// model.generate, then batch_decode with the prompt sliced off. That is a
+// rewrite, and it should not land before someone measures this model against
+// tesseract on real denial scans -- a fluent VLM misreading a claim number is
+// worse than tesseract garble, because garble is visibly garble.
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const memoizeOne = require("async-memoize-one");
@@ -24,14 +41,6 @@ type ImageToTextCallable = (
 interface TransformersModule {
   env: {
     allowLocalModels: boolean;
-    backends?: {
-      onnx?: {
-        wasm?: {
-          // Ensure browser runtime backend paths are web-compatible.
-          wasmPaths?: string;
-        };
-      };
-    };
   };
   pipeline: (
     task: string,
@@ -85,11 +94,14 @@ async function loadQwenOCRPipelineRaw(): Promise<ImageToTextCallable | null> {
     const transformers = require("@huggingface/transformers") as TransformersModule;
     transformers.env.allowLocalModels = false;
 
-    // Explicitly target web ONNX runtime assets.
-    if (transformers.env.backends?.onnx?.wasm) {
-      transformers.env.backends.onnx.wasm.wasmPaths =
-        "https://cdn.jsdelivr.net/npm/onnxruntime-web@1.22.0/dist/";
-    }
+    // No wasmPaths override here on purpose. This used to pin
+    // onnxruntime-web@1.22.0 on the CDN, which 404s: the ORT build webpack
+    // actually bundles (1.24.2) asks for ort-wasm-simd-threaded.asyncify.*,
+    // and 1.22.0's dist has no asyncify files at all. Left alone, the library
+    // derives the URL from the runtime it shipped with, so the version can
+    // never drift out of sync again. It also passes an object rather than a
+    // string, which is what re-enables the Cache API path for the multi-MB
+    // runtime instead of refetching it on every page load.
 
     const pipe = (await transformers.pipeline("image-to-text", QWEN_VL_MODEL_ID, {
       device: "webgpu",

--- a/fighthealthinsurance/static/js/scrub.ts
+++ b/fighthealthinsurance/static/js/scrub.ts
@@ -40,6 +40,15 @@ function userAskedToSaveData(): boolean {
   return connection?.saveData === true;
 }
 
+/**
+ * Screens the advanced-OCR checkbox down, never up.
+ *
+ * The box now ships unchecked, so today every branch here is a no-op and the
+ * screening below is belt-and-braces. It is kept rather than deleted because
+ * the moment the engine works and the default goes back on, these are exactly
+ * the devices that must not get it, and rebuilding the screening from scratch
+ * is how it comes back wrong.
+ */
 async function initAdvancedOCRCheckbox(): Promise<void> {
   const checkbox = document.getElementById("advanced_ocr_enabled") as HTMLInputElement | null;
   if (!checkbox) return;

--- a/fighthealthinsurance/static/js/scrub_ocr.ts
+++ b/fighthealthinsurance/static/js/scrub_ocr.ts
@@ -500,8 +500,11 @@ function isAdvancedOCREnabled(): boolean {
   const checkbox = document.getElementById(
     "advanced_ocr_enabled",
   ) as HTMLInputElement | null;
-  // Default to true when the checkbox is absent (non-scrub pages).
-  return checkbox ? checkbox.checked : true;
+  // Default to FALSE when the checkbox is absent. The pages with no checkbox
+  // (explain_denial, chat_interface) have no way to opt out, so defaulting on
+  // there started a ~684 MB model download that those users never asked for
+  // and, because the engine is broken, could never benefit from.
+  return checkbox ? checkbox.checked : false;
 }
 
 async function recognizeImageText(

--- a/fighthealthinsurance/templates/scrub.html
+++ b/fighthealthinsurance/templates/scrub.html
@@ -88,12 +88,12 @@ Upload your Health Insurance Denial
 	</div>
 	{% if upload_more %}
 	<div class="form-check mt-2 mb-2" id="advanced_ocr_section">
-	    <input type="checkbox" id="advanced_ocr_enabled" class="form-check-input" checked>
+	    <input type="checkbox" id="advanced_ocr_enabled" class="form-check-input">
 	    <label for="advanced_ocr_enabled" class="form-check-label">
 		<b>Enable advanced OCR</b> – uses a WebGPU-accelerated AI model to improve text extraction accuracy.
-		<small class="text-muted d-block">Downloads a model to your device the first time. Unchecked by default when your
-		browser is set to save data, when a compatible GPU is not detected, or on a very low-memory device.
-		Uncheck to use standard OCR only.</small>
+		<small class="text-muted d-block">Off by default. Turning it on downloads about 684 MB to your device
+		the first time, from huggingface.co, and the model runs on your own device. Standard OCR is used
+		otherwise, and it needs no download.</small>
 	    </label>
 	</div>
 	<div id="image_select_magic" style="visibility:visible">

--- a/fighthealthinsurance/templates/scrub.html
+++ b/fighthealthinsurance/templates/scrub.html
@@ -93,7 +93,7 @@ Upload your Health Insurance Denial
 		<b>Enable advanced OCR</b> – uses a WebGPU-accelerated AI model to improve text extraction accuracy.
 		<small class="text-muted d-block">Off by default. Turning it on downloads about 684 MB to your device
 		the first time, from huggingface.co, and the model runs on your own device. Standard OCR is used
-		otherwise, and it needs no download.</small>
+		otherwise. It fetches a much smaller language file the first time, and no model.</small>
 	    </label>
 	</div>
 	<div id="image_select_magic" style="visibility:visible">

--- a/fighthealthinsurance/templates/scrub.html
+++ b/fighthealthinsurance/templates/scrub.html
@@ -91,9 +91,10 @@ Upload your Health Insurance Denial
 	    <input type="checkbox" id="advanced_ocr_enabled" class="form-check-input">
 	    <label for="advanced_ocr_enabled" class="form-check-label">
 		<b>Enable advanced OCR</b> – uses a WebGPU-accelerated AI model to improve text extraction accuracy.
-		<small class="text-muted d-block">Off by default. Turning it on downloads about 684 MB to your device
-		the first time, from huggingface.co, and the model runs on your own device. Standard OCR is used
-		otherwise. It fetches a much smaller language file the first time, and no model.</small>
+		<small class="text-muted d-block">Off by default, and not working in this release: the model fails to
+		load, so standard OCR is used either way. Once it works, turning it on will download about 684 MB
+		from huggingface.co the first time and run on your own device. Standard OCR downloads a much
+		smaller language file the first time.</small>
 	    </label>
 	</div>
 	<div id="image_select_magic" style="visibility:visible">

--- a/fighthealthinsurance/templates/scrub.html
+++ b/fighthealthinsurance/templates/scrub.html
@@ -92,9 +92,10 @@ Upload your Health Insurance Denial
 	    <label for="advanced_ocr_enabled" class="form-check-label">
 		<b>Enable advanced OCR</b> – uses a WebGPU-accelerated AI model to improve text extraction accuracy.
 		<small class="text-muted d-block">Off by default, and not working in this release: the model fails to
-		load, so standard OCR is used either way. Once it works, turning it on will download about 684 MB
-		from huggingface.co the first time and run on your own device. Standard OCR downloads a much
-		smaller language file the first time.</small>
+		load, so standard OCR is used either way. Turning it on today still fetches about 20 MB of model
+		files from huggingface.co before that failure. Once it works, the full model is about 684 MB,
+		downloaded the first time and run on your own device. Standard OCR downloads a much smaller
+		language file the first time.</small>
 	    </label>
 	</div>
 	<div id="image_select_magic" style="visibility:visible">

--- a/tests/async-unit/test_advanced_ocr_default_off.py
+++ b/tests/async-unit/test_advanced_ocr_default_off.py
@@ -29,6 +29,7 @@ Delete these only together with a measurement showing the engine beats tesseract
 on real denial scans. See ``qwen_webgpu_ocr.ts`` for what a working version needs.
 """
 
+import html as html_lib
 import pathlib
 import re
 
@@ -286,8 +287,12 @@ def test_pages_without_the_checkbox_default_off():
     body = _js_function(_ocr_structural(), "isAdvancedOCREnabled")
     returns = re.findall(r"\breturn\b[^;]*;", body)
     assert len(returns) == 1, f"expected exactly one return, found {returns}"
+    # Either spelling of "the box if present, else false": the ternary, or
+    # optional chaining with a nullish default (review).
     assert re.fullmatch(
-        r"return\s+checkbox\s*\?\s*checkbox\.checked\s*:\s*false\s*;", returns[0]
+        r"return\s+checkbox\s*\?\s*checkbox\.checked\s*:\s*false\s*;"
+        r"|return\s+checkbox\?\.checked\s*\?\?\s*false\s*;",
+        returns[0],
     ), (
         "isAdvancedOCREnabled no longer returns `checkbox ? checkbox.checked : "
         f"false`; the no-opt-out pages would start downloading again. Got: "
@@ -309,7 +314,7 @@ def test_qwen_engine_only_runs_inside_the_checkbox_gate():
         "recognizeWithQwenWebGPU is launched more than once, or not at all, in "
         "recognizeImageText"
     )
-    gate = re.search(r"if\s*\(\s*isAdvancedOCREnabled\(\)\s*\)\s*\{", body)
+    gate = re.search(r"if\s*\(\s*isAdvancedOCREnabled\s*\(\s*\)\s*\)\s*\{", body)
     assert gate is not None, "no `if (isAdvancedOCREnabled())` block in recognizeImageText"
     block = _brace_block(body, gate.end() - 1)
     assert re.search(launch, block), (
@@ -327,10 +332,11 @@ def test_no_hardcoded_onnxruntime_version_pin():
     the same bug waiting to happen, because the two versions drift
     independently. Strings, nested templates included, are kept in this view.
     """
-    # The identifier is checked on the string-blanked view: a diagnostic like
-    # console.debug("wasmPaths:", env) mentions it without touching it (review).
-    # The version pin is checked with strings kept, because a pin lives in one.
-    assert "wasmPaths" not in _qwen_structural(), (
+    # What is forbidden is ASSIGNING wasmPaths. A read-only diagnostic of
+    # env.backends.onnx.wasm.wasmPaths is fine, and so is a string mentioning
+    # it; the check runs on the string-blanked view and looks for the
+    # identifier followed by a single `=` (review).
+    assert not re.search(r"\bwasmPaths\s*=(?!=)", _qwen_structural()), (
         "wasmPaths is being set again; let transformers.js derive it from the "
         "onnxruntime build it actually shipped with"
     )
@@ -353,9 +359,11 @@ def test_label_states_the_download_cost_truthfully():
     """
     html = _scrub_template()
     start = html.index('id="advanced_ocr_section"')
-    # Rendered whitespace: a line wrap inside a phrase is the same text to a
-    # browser and must be the same text to this test (review).
-    label = re.sub(r"\s+", " ", html[start : html.index("</label>", start)])
+    # Rendered text: a line wrap inside a phrase, or an &nbsp; used to stop
+    # one, is the same text to a browser and must be the same text to this
+    # test (review). Entities are decoded, then whitespace normalized.
+    label = html_lib.unescape(html[start : html.index("</label>", start)])
+    label = re.sub(r"\s+", " ", label)
     assert re.search(r"not working|does not work|fails to load", label, re.I), (
         "the label no longer says the engine is broken, but it still is"
     )

--- a/tests/async-unit/test_advanced_ocr_default_off.py
+++ b/tests/async-unit/test_advanced_ocr_default_off.py
@@ -6,10 +6,13 @@ resolves to ``AutoModelForVision2Seq``, whose registry does not contain
 falls back to tesseract. Meanwhile the box was checked by default, so anyone
 with WebGPU was offered a ~684 MB download for a feature that could not run.
 
-These pin the off-by-default state in all three places it is decided, because
-the default is one attribute and one boolean and both drift easily. There is no
-JS test harness in this repo, so the client half asserts on the source, matching
-``test_scrub_ocr_quality.py``.
+These pin the off-by-default state in every place it is decided, because the
+default is one attribute and one boolean and both drift easily. There is no JS
+test harness in this repo, so the client half asserts on the source, matching
+``test_scrub_ocr_quality.py``. Comments are stripped before asserting, with
+string literals preserved, so explaining the old bug in a comment is not the
+same as reintroducing it, and a version pin hiding inside a URL string is still
+caught (the first cut of these tests got both of those wrong).
 
 Delete these only together with a measurement showing the engine beats tesseract
 on real denial scans. See ``qwen_webgpu_ocr.ts`` for what a working version needs.
@@ -23,32 +26,92 @@ JS = REPO / "static" / "js"
 TEMPLATES = REPO / "templates"
 
 
-def _scrub_template() -> str:
-    return (TEMPLATES / "scrub.html").read_text()
+def _strip_ts_comments(src: str) -> str:
+    """TypeScript source with // and /* */ comments removed, strings kept.
 
-
-def _ocr_source() -> str:
-    return (JS / "scrub_ocr.ts").read_text()
-
-
-def _qwen_source() -> str:
-    return (JS / "qwen_webgpu_ocr.ts").read_text()
-
-
-def _without_comments(src: str) -> str:
-    """Source with // and /* */ comments removed.
-
-    The comments in this module deliberately name the old broken pin so the next
-    reader knows what not to reintroduce. Asserting against raw text would make
-    explaining the bug indistinguishable from committing it.
+    A regex that drops everything after ``//`` also drops the tail of
+    ``"https://..."`` and so lets a versioned URL escape any assertion about
+    it. This walks the source and skips over string literals (single, double,
+    template) so a comment marker inside one is left alone. Regex literals
+    containing ``//`` are not recognized and would be cut short; none of the
+    files asserted on here contain one.
     """
-    src = re.sub(r"/\*.*?\*/", "", src, flags=re.DOTALL)
-    return re.sub(r"//[^\n]*", "", src)
+    out = []
+    i, n = 0, len(src)
+    while i < n:
+        c = src[i]
+        if c in ('"', "'", "`"):
+            j = i + 1
+            while j < n and src[j] != c:
+                if src[j] == "\\":
+                    j += 1
+                j += 1
+            out.append(src[i : j + 1])
+            i = j + 1
+        elif src.startswith("//", i):
+            j = src.find("\n", i)
+            i = n if j < 0 else j
+        elif src.startswith("/*", i):
+            j = src.find("*/", i + 2)
+            i = n if j < 0 else j + 2
+        else:
+            out.append(c)
+            i += 1
+    return "".join(out)
+
+
+def _strip_template_comments(html: str) -> str:
+    """Django ``{# #}`` and HTML ``<!-- -->`` comments removed."""
+    html = re.sub(r"\{#.*?#\}", "", html, flags=re.DOTALL)
+    return re.sub(r"<!--.*?-->", "", html, flags=re.DOTALL)
+
+
+def _js_function(src: str, name: str) -> str:
+    """The body of one function, brace-matched from after its parameter list."""
+    start = src.index(name)
+    paren = src.index("(", start)
+    depth = 0
+    end_of_params = None
+    for i in range(paren, len(src)):
+        if src[i] == "(":
+            depth += 1
+        elif src[i] == ")":
+            depth -= 1
+            if depth == 0:
+                end_of_params = i
+                break
+    assert end_of_params is not None, f"unbalanced parens reading {name}"
+    body_start = src.index("{", end_of_params)
+    depth = 0
+    for i in range(body_start, len(src)):
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[body_start : i + 1]
+    raise AssertionError(f"unbalanced braces reading {name}")
+
+
+def _scrub_template() -> str:
+    return _strip_template_comments((TEMPLATES / "scrub.html").read_text())
+
+
+def _ocr_code() -> str:
+    return _strip_ts_comments((JS / "scrub_ocr.ts").read_text())
+
+
+def _scrub_code() -> str:
+    return _strip_ts_comments((JS / "scrub.ts").read_text())
+
+
+def _qwen_code() -> str:
+    return _strip_ts_comments((JS / "qwen_webgpu_ocr.ts").read_text())
 
 
 def _checkbox_tag(html: str) -> str:
-    """The advanced-OCR <input> tag, whole."""
-    match = re.search(r"<input[^>]*id=\"advanced_ocr_enabled\"[^>]*>", html)
+    """The live advanced-OCR <input> tag, whole. Case-insensitive: HTML is."""
+    match = re.search(r"<input[^>]*id=\"advanced_ocr_enabled\"[^>]*>", html, re.I)
     assert match is not None, "advanced_ocr_enabled checkbox not found in scrub.html"
     return match.group(0)
 
@@ -56,9 +119,22 @@ def _checkbox_tag(html: str) -> str:
 def test_scrub_checkbox_markup_is_not_checked():
     """The rendered box is what a user sees before they touch anything."""
     tag = _checkbox_tag(_scrub_template())
-    assert not re.search(r"\bchecked\b", tag), (
+    assert not re.search(r"\bchecked\b", tag, re.I), (
         "advanced OCR is checked by default again; the engine is still broken "
         f"and this offers a ~684 MB download for nothing. Tag: {tag}"
+    )
+
+
+def test_checkbox_init_never_turns_it_on():
+    """scrub.ts may screen the box DOWN, never up.
+
+    initAdvancedOCRCheckbox only ever sets checked=false. A single
+    ``checkbox.checked = true`` there would restore the download for every
+    WebGPU visitor while the markup test above still passed.
+    """
+    assert not re.search(r"\.checked\s*=\s*true\b", _scrub_code()), (
+        "scrub.ts sets a checkbox to true; the advanced OCR box must never be "
+        "turned on by initialization, only by the user"
     )
 
 
@@ -66,14 +142,36 @@ def test_pages_without_the_checkbox_default_off():
     """explain_denial and chat_interface render no checkbox, so they cannot opt out.
 
     ``isAdvancedOCREnabled`` decides for them, and defaulting true there started
-    the download on pages that never showed the user a choice.
+    the download on pages that never showed the user a choice. Pin the exact
+    return, and that it is the only one, so a second early ``return true`` above
+    it is caught too.
     """
-    src = _ocr_source()
-    start = src.index("function isAdvancedOCREnabled")
-    body = src[start : src.index("}", src.index("return", start))]
-    assert "checkbox.checked : false" in body, (
-        "isAdvancedOCREnabled no longer defaults to false when the checkbox is "
-        "absent; the no-opt-out pages would start downloading the model again"
+    body = _js_function(_ocr_code(), "function isAdvancedOCREnabled")
+    returns = re.findall(r"\breturn\b[^;]*;", body)
+    assert len(returns) == 1, f"expected exactly one return, found {returns}"
+    assert re.fullmatch(
+        r"return\s+checkbox\s*\?\s*checkbox\.checked\s*:\s*false\s*;", returns[0]
+    ), (
+        "isAdvancedOCREnabled no longer returns `checkbox ? checkbox.checked : "
+        f"false`; the no-opt-out pages would start downloading again. Got: "
+        f"{returns[0]}"
+    )
+
+
+def test_qwen_engine_only_runs_inside_the_checkbox_gate():
+    """The gate is worthless if the engine is launched outside it."""
+    body = _js_function(_ocr_code(), "async function recognizeImageText")
+    assert body.count("recognizeWithQwenWebGPU(") == 1, (
+        "recognizeWithQwenWebGPU is launched more than once, or not at all, in "
+        "recognizeImageText"
+    )
+    assert re.search(
+        r"if\s*\(\s*isAdvancedOCREnabled\(\)\s*\)\s*\{[^}]*recognizeWithQwenWebGPU\(",
+        body,
+        re.DOTALL,
+    ), (
+        "the qwen engine is no longer launched inside `if "
+        "(isAdvancedOCREnabled())`; the checkbox would stop meaning anything"
     )
 
 
@@ -84,9 +182,10 @@ def test_no_hardcoded_onnxruntime_version_pin():
     bundled 1.24.2, so the runtime asked for ``asyncify`` files that 1.22.0's
     dist does not contain and the fetch 404'd. Any literal version pin here is
     the same bug waiting to happen, because the two versions drift
-    independently.
+    independently. Strings survive the comment strip, so a pin inside a URL
+    literal is caught.
     """
-    code = _without_comments(_qwen_source())
+    code = _qwen_code()
     assert "wasmPaths" not in code, (
         "wasmPaths is being set again; let transformers.js derive it from the "
         "onnxruntime build it actually shipped with"
@@ -96,11 +195,20 @@ def test_no_hardcoded_onnxruntime_version_pin():
     ), "a hardcoded onnxruntime-web version is back in qwen_webgpu_ocr.ts"
 
 
-def test_label_states_the_download_cost():
-    """Off-by-default is only honest if the label says what turning it on costs."""
+def test_label_states_the_download_cost_truthfully():
+    """Off-by-default is only honest if the label says what turning it on costs.
+
+    And it must not overclaim the other way: standard OCR is not download-free,
+    tesseract fetches its language data from a CDN on first use.
+    """
     html = _scrub_template()
-    section = html[html.index('id="advanced_ocr_section"') :][:1200]
-    assert "684" in section, "the advanced OCR label no longer states the download size"
+    start = html.index('id="advanced_ocr_section"')
+    label = html[start : html.index("</label>", start)]
+    assert "684" in label, "the advanced OCR label no longer states the download size"
     assert (
-        "huggingface.co" in section
+        "huggingface.co" in label
     ), "the advanced OCR label no longer says where the model is downloaded from"
+    assert not re.search(r"needs\s+no\s+download", label, re.I), (
+        "the label claims standard OCR needs no download; tesseract downloads "
+        "its language file from a CDN on first use"
+    )

--- a/tests/async-unit/test_advanced_ocr_default_off.py
+++ b/tests/async-unit/test_advanced_ocr_default_off.py
@@ -4,15 +4,20 @@ The engine has never produced a character on prod: ``pipeline("image-to-text")``
 resolves to ``AutoModelForVision2Seq``, whose registry does not contain
 ``qwen3_5``, so init throws ``Unsupported model type: qwen3_5`` and every caller
 falls back to tesseract. Meanwhile the box was checked by default, so anyone
-with WebGPU was offered a ~684 MB download for a feature that could not run.
+with WebGPU was offered a large download for a feature that could not run.
 
 These pin the off-by-default state in every place it is decided, because the
 default is one attribute and one boolean and both drift easily. There is no JS
 test harness in this repo, so the client half asserts on the source, matching
-``test_scrub_ocr_quality.py``. Comments are stripped before asserting, with
-string literals preserved, so explaining the old bug in a comment is not the
-same as reintroducing it, and a version pin hiding inside a URL string is still
-caught (the first cut of these tests got both of those wrong).
+``test_scrub_ocr_quality.py``.
+
+Source is tokenized, not regexed, before asserting. Two views come out of it:
+one with comments removed and string literals kept, for "no version pin
+anywhere in executable code" (a pin inside a URL literal must still be caught);
+and one with string literals blanked as well, for every structural check, so a
+string containing ``if (isAdvancedOCREnabled()) {`` or a stray ``}`` cannot
+impersonate syntax. Both earlier cuts of this file were beaten exactly those
+ways in review.
 
 Delete these only together with a measurement showing the engine beats tesseract
 on real denial scans. See ``qwen_webgpu_ocr.ts`` for what a working version needs.
@@ -26,38 +31,103 @@ JS = REPO / "static" / "js"
 TEMPLATES = REPO / "templates"
 
 
-def _strip_ts_comments(src: str) -> str:
-    """TypeScript source with // and /* */ comments removed, strings kept.
+def _tokenize_ts(src: str):
+    """Split TypeScript into ('code' | 'string' | 'comment', text) segments.
 
-    A regex that drops everything after ``//`` also drops the tail of
-    ``"https://..."`` and so lets a versioned URL escape any assertion about
-    it. This walks the source and skips over string literals (single, double,
-    template) so a comment marker inside one is left alone. Regex literals
-    containing ``//`` are not recognized and would be cut short; none of the
-    files asserted on here contain one.
+    A template literal is one 'string' token INCLUDING its ``${...}``
+    interpolations, which are scanned recursively so a nested template or a
+    brace inside one cannot end the outer literal early. Regex literals are not
+    recognized; none of the files asserted on contain one with ``//`` in it.
     """
-    out = []
-    i, n = 0, len(src)
+    n = len(src)
+
+    def string_end(i: int, quote: str) -> int:
+        j = i + 1
+        while j < n:
+            c = src[j]
+            if c == "\\":
+                j += 2
+                continue
+            if c == quote:
+                return j + 1
+            if quote == "`" and src.startswith("${", j):
+                j = interpolation_end(j + 2)
+                continue
+            j += 1
+        return n
+
+    def interpolation_end(i: int) -> int:
+        """Index just past the ``}`` closing the ``${`` opened before ``i``."""
+        depth = 0
+        j = i
+        while j < n:
+            c = src[j]
+            if c in "\"'`":
+                j = string_end(j, c)
+                continue
+            if src.startswith("//", j):
+                k = src.find("\n", j)
+                j = n if k < 0 else k
+                continue
+            if src.startswith("/*", j):
+                k = src.find("*/", j + 2)
+                j = n if k < 0 else k + 2
+                continue
+            if c == "{":
+                depth += 1
+            elif c == "}":
+                if depth == 0:
+                    return j + 1
+                depth -= 1
+            j += 1
+        return n
+
+    tokens = []
+    buf = []
+    i = 0
+
+    def flush():
+        if buf:
+            tokens.append(("code", "".join(buf)))
+            buf.clear()
+
     while i < n:
         c = src[i]
-        if c in ('"', "'", "`"):
-            j = i + 1
-            while j < n and src[j] != c:
-                if src[j] == "\\":
-                    j += 1
-                j += 1
-            out.append(src[i : j + 1])
-            i = j + 1
+        if c in "\"'`":
+            flush()
+            j = string_end(i, c)
+            tokens.append(("string", src[i:j]))
+            i = j
         elif src.startswith("//", i):
-            j = src.find("\n", i)
-            i = n if j < 0 else j
+            flush()
+            k = src.find("\n", i)
+            j = n if k < 0 else k
+            tokens.append(("comment", src[i:j]))
+            i = j
         elif src.startswith("/*", i):
-            j = src.find("*/", i + 2)
-            i = n if j < 0 else j + 2
+            flush()
+            k = src.find("*/", i + 2)
+            j = n if k < 0 else k + 2
+            tokens.append(("comment", src[i:j]))
+            i = j
         else:
-            out.append(c)
+            buf.append(c)
             i += 1
-    return "".join(out)
+    flush()
+    return tokens
+
+
+def _executable(src: str) -> str:
+    """Comments removed, string literals kept verbatim."""
+    return "".join(t for k, t in _tokenize_ts(src) if k != "comment")
+
+
+def _structural(src: str) -> str:
+    """Comments removed AND every string literal replaced by an empty one."""
+    return "".join(
+        t if k == "code" else ('""' if k == "string" else "")
+        for k, t in _tokenize_ts(src)
+    )
 
 
 def _strip_template_comments(html: str) -> str:
@@ -66,13 +136,33 @@ def _strip_template_comments(html: str) -> str:
     return re.sub(r"<!--.*?-->", "", html, flags=re.DOTALL)
 
 
-def _js_function(src: str, name: str) -> str:
-    """The body of one function, brace-matched from after its parameter list."""
-    start = src.index(name)
-    paren = src.index("(", start)
+def _brace_block(src: str, open_at: int) -> str:
+    """``src[open_at:]`` up to and including the brace that closes ``open_at``."""
+    assert src[open_at] == "{", src[open_at : open_at + 20]
+    depth = 0
+    for i in range(open_at, len(src)):
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[open_at : i + 1]
+    raise AssertionError("unbalanced braces")
+
+
+def _js_function(src: str, declaration: str) -> str:
+    """Body of the function declared EXACTLY as ``declaration`` followed by ``(``.
+
+    ``function isAdvancedOCREnabled`` must not match
+    ``function isAdvancedOCREnabledForCheckbox``; requiring the parameter list
+    to open right after the name is what stops a look-alike helper from being
+    inspected in place of the real thing.
+    """
+    match = re.search(re.escape(declaration) + r"\s*\(", src)
+    assert match is not None, f"{declaration}( not found"
     depth = 0
     end_of_params = None
-    for i in range(paren, len(src)):
+    for i in range(match.end() - 1, len(src)):
         if src[i] == "(":
             depth += 1
         elif src[i] == ")":
@@ -80,33 +170,24 @@ def _js_function(src: str, name: str) -> str:
             if depth == 0:
                 end_of_params = i
                 break
-    assert end_of_params is not None, f"unbalanced parens reading {name}"
-    body_start = src.index("{", end_of_params)
-    depth = 0
-    for i in range(body_start, len(src)):
-        if src[i] == "{":
-            depth += 1
-        elif src[i] == "}":
-            depth -= 1
-            if depth == 0:
-                return src[body_start : i + 1]
-    raise AssertionError(f"unbalanced braces reading {name}")
+    assert end_of_params is not None, f"unbalanced parens reading {declaration}"
+    return _brace_block(src, src.index("{", end_of_params))
 
 
 def _scrub_template() -> str:
     return _strip_template_comments((TEMPLATES / "scrub.html").read_text())
 
 
-def _ocr_code() -> str:
-    return _strip_ts_comments((JS / "scrub_ocr.ts").read_text())
+def _ocr_structural() -> str:
+    return _structural((JS / "scrub_ocr.ts").read_text())
 
 
-def _scrub_code() -> str:
-    return _strip_ts_comments((JS / "scrub.ts").read_text())
+def _scrub_structural() -> str:
+    return _structural((JS / "scrub.ts").read_text())
 
 
-def _qwen_code() -> str:
-    return _strip_ts_comments((JS / "qwen_webgpu_ocr.ts").read_text())
+def _qwen_executable() -> str:
+    return _executable((JS / "qwen_webgpu_ocr.ts").read_text())
 
 
 def _checkbox_tag(html: str) -> str:
@@ -116,12 +197,20 @@ def _checkbox_tag(html: str) -> str:
     return match.group(0)
 
 
+def test_tokenizer_keeps_a_pin_inside_a_nested_template_literal():
+    """Guard the guard: the exact construct that beat the previous stripper."""
+    sample = "const u = `${`https://cdn.jsdelivr.net/npm/onnxruntime-web@1.22.0/dist/`}`; // x\n"
+    assert "onnxruntime-web@1.22.0" in _executable(sample)
+    assert "onnxruntime-web@1.22.0" not in _structural(sample)
+    assert "// x" not in _executable(sample)
+
+
 def test_scrub_checkbox_markup_is_not_checked():
     """The rendered box is what a user sees before they touch anything."""
     tag = _checkbox_tag(_scrub_template())
     assert not re.search(r"\bchecked\b", tag, re.I), (
         "advanced OCR is checked by default again; the engine is still broken "
-        f"and this offers a ~684 MB download for nothing. Tag: {tag}"
+        f"and this offers a large download for nothing. Tag: {tag}"
     )
 
 
@@ -132,7 +221,7 @@ def test_checkbox_init_never_turns_it_on():
     ``checkbox.checked = true`` there would restore the download for every
     WebGPU visitor while the markup test above still passed.
     """
-    assert not re.search(r"\.checked\s*=\s*true\b", _scrub_code()), (
+    assert not re.search(r"\.checked\s*=\s*true\b", _scrub_structural()), (
         "scrub.ts sets a checkbox to true; the advanced OCR box must never be "
         "turned on by initialization, only by the user"
     )
@@ -144,9 +233,10 @@ def test_pages_without_the_checkbox_default_off():
     ``isAdvancedOCREnabled`` decides for them, and defaulting true there started
     the download on pages that never showed the user a choice. Pin the exact
     return, and that it is the only one, so a second early ``return true`` above
-    it is caught too.
+    it is caught too. Strings are blanked first, so a string cannot supply the
+    expected text.
     """
-    body = _js_function(_ocr_code(), "function isAdvancedOCREnabled")
+    body = _js_function(_ocr_structural(), "function isAdvancedOCREnabled")
     returns = re.findall(r"\breturn\b[^;]*;", body)
     assert len(returns) == 1, f"expected exactly one return, found {returns}"
     assert re.fullmatch(
@@ -159,19 +249,23 @@ def test_pages_without_the_checkbox_default_off():
 
 
 def test_qwen_engine_only_runs_inside_the_checkbox_gate():
-    """The gate is worthless if the engine is launched outside it."""
-    body = _js_function(_ocr_code(), "async function recognizeImageText")
+    """The gate is worthless if the engine is launched outside it.
+
+    Brace-match the ``if (isAdvancedOCREnabled())`` block on string-blanked
+    source and require the one launch to sit inside it. A string containing the
+    gate's text, or a ``}`` inside a string, cannot fake a gate here.
+    """
+    body = _js_function(_ocr_structural(), "async function recognizeImageText")
     assert body.count("recognizeWithQwenWebGPU(") == 1, (
         "recognizeWithQwenWebGPU is launched more than once, or not at all, in "
         "recognizeImageText"
     )
-    assert re.search(
-        r"if\s*\(\s*isAdvancedOCREnabled\(\)\s*\)\s*\{[^}]*recognizeWithQwenWebGPU\(",
-        body,
-        re.DOTALL,
-    ), (
-        "the qwen engine is no longer launched inside `if "
-        "(isAdvancedOCREnabled())`; the checkbox would stop meaning anything"
+    gate = re.search(r"if\s*\(\s*isAdvancedOCREnabled\(\)\s*\)\s*\{", body)
+    assert gate is not None, "no `if (isAdvancedOCREnabled())` block in recognizeImageText"
+    block = _brace_block(body, gate.end() - 1)
+    assert "recognizeWithQwenWebGPU(" in block, (
+        "the qwen engine is launched outside the `if (isAdvancedOCREnabled())` "
+        "block; the checkbox would stop meaning anything"
     )
 
 
@@ -182,10 +276,9 @@ def test_no_hardcoded_onnxruntime_version_pin():
     bundled 1.24.2, so the runtime asked for ``asyncify`` files that 1.22.0's
     dist does not contain and the fetch 404'd. Any literal version pin here is
     the same bug waiting to happen, because the two versions drift
-    independently. Strings survive the comment strip, so a pin inside a URL
-    literal is caught.
+    independently. Strings, nested templates included, are kept in this view.
     """
-    code = _qwen_code()
+    code = _qwen_executable()
     assert "wasmPaths" not in code, (
         "wasmPaths is being set again; let transformers.js derive it from the "
         "onnxruntime build it actually shipped with"
@@ -196,19 +289,26 @@ def test_no_hardcoded_onnxruntime_version_pin():
 
 
 def test_label_states_the_download_cost_truthfully():
-    """Off-by-default is only honest if the label says what turning it on costs.
+    """Off-by-default is only honest if the label tells the truth in both directions.
 
-    And it must not overclaim the other way: standard OCR is not download-free,
-    tesseract fetches its language data from a CDN on first use.
+    It must state the size in MB (not just the digits) and the source. It must
+    not claim standard OCR needs no download or no model: tesseract fetches
+    English trained data, which is an LSTM model, from a CDN on first use.
     """
     html = _scrub_template()
     start = html.index('id="advanced_ocr_section"')
     label = html[start : html.index("</label>", start)]
-    assert "684" in label, "the advanced OCR label no longer states the download size"
+    assert re.search(r"\b684\s*MB\b", label), (
+        "the advanced OCR label no longer states the download size in MB"
+    )
     assert (
         "huggingface.co" in label
     ), "the advanced OCR label no longer says where the model is downloaded from"
     assert not re.search(r"needs\s+no\s+download", label, re.I), (
         "the label claims standard OCR needs no download; tesseract downloads "
         "its language file from a CDN on first use"
+    )
+    assert not re.search(r"\bno\s+model\b", label, re.I), (
+        "the label claims standard OCR uses no model; tesseract's trained data "
+        "is an LSTM model"
     )

--- a/tests/async-unit/test_advanced_ocr_default_off.py
+++ b/tests/async-unit/test_advanced_ocr_default_off.py
@@ -224,6 +224,10 @@ def _qwen_executable() -> str:
     return _executable((JS / "qwen_webgpu_ocr.ts").read_text())
 
 
+def _qwen_structural() -> str:
+    return _structural((JS / "qwen_webgpu_ocr.ts").read_text())
+
+
 def _checkbox_tag(html: str) -> str:
     """The live advanced-OCR <input> tag, whole. Case-insensitive: HTML is."""
     match = re.search(r"<input[^>]*id=\"advanced_ocr_enabled\"[^>]*>", html, re.I)
@@ -300,14 +304,15 @@ def test_qwen_engine_only_runs_inside_the_checkbox_gate():
     interpolation cannot fake or evade the gate here.
     """
     body = _js_function(_ocr_structural(), "recognizeImageText")
-    assert body.count("recognizeWithQwenWebGPU(") == 1, (
+    launch = r"recognizeWithQwenWebGPU\s*\("
+    assert len(re.findall(launch, body)) == 1, (
         "recognizeWithQwenWebGPU is launched more than once, or not at all, in "
         "recognizeImageText"
     )
     gate = re.search(r"if\s*\(\s*isAdvancedOCREnabled\(\)\s*\)\s*\{", body)
     assert gate is not None, "no `if (isAdvancedOCREnabled())` block in recognizeImageText"
     block = _brace_block(body, gate.end() - 1)
-    assert "recognizeWithQwenWebGPU(" in block, (
+    assert re.search(launch, block), (
         "the qwen engine is launched outside the `if (isAdvancedOCREnabled())` "
         "block; the checkbox would stop meaning anything"
     )
@@ -322,13 +327,15 @@ def test_no_hardcoded_onnxruntime_version_pin():
     the same bug waiting to happen, because the two versions drift
     independently. Strings, nested templates included, are kept in this view.
     """
-    code = _qwen_executable()
-    assert "wasmPaths" not in code, (
+    # The identifier is checked on the string-blanked view: a diagnostic like
+    # console.debug("wasmPaths:", env) mentions it without touching it (review).
+    # The version pin is checked with strings kept, because a pin lives in one.
+    assert "wasmPaths" not in _qwen_structural(), (
         "wasmPaths is being set again; let transformers.js derive it from the "
         "onnxruntime build it actually shipped with"
     )
     assert not re.search(
-        r"onnxruntime-web@\d", code
+        r"onnxruntime-web@\d", _qwen_executable()
     ), "a hardcoded onnxruntime-web version is back in qwen_webgpu_ocr.ts"
 
 
@@ -346,7 +353,9 @@ def test_label_states_the_download_cost_truthfully():
     """
     html = _scrub_template()
     start = html.index('id="advanced_ocr_section"')
-    label = html[start : html.index("</label>", start)]
+    # Rendered whitespace: a line wrap inside a phrase is the same text to a
+    # browser and must be the same text to this test (review).
+    label = re.sub(r"\s+", " ", html[start : html.index("</label>", start)])
     assert re.search(r"not working|does not work|fails to load", label, re.I), (
         "the label no longer says the engine is broken, but it still is"
     )

--- a/tests/async-unit/test_advanced_ocr_default_off.py
+++ b/tests/async-unit/test_advanced_ocr_default_off.py
@@ -1,0 +1,106 @@
+"""Advanced OCR must ship OFF, on every surface, until the engine actually works.
+
+The engine has never produced a character on prod: ``pipeline("image-to-text")``
+resolves to ``AutoModelForVision2Seq``, whose registry does not contain
+``qwen3_5``, so init throws ``Unsupported model type: qwen3_5`` and every caller
+falls back to tesseract. Meanwhile the box was checked by default, so anyone
+with WebGPU was offered a ~684 MB download for a feature that could not run.
+
+These pin the off-by-default state in all three places it is decided, because
+the default is one attribute and one boolean and both drift easily. There is no
+JS test harness in this repo, so the client half asserts on the source, matching
+``test_scrub_ocr_quality.py``.
+
+Delete these only together with a measurement showing the engine beats tesseract
+on real denial scans. See ``qwen_webgpu_ocr.ts`` for what a working version needs.
+"""
+
+import pathlib
+import re
+
+REPO = pathlib.Path(__file__).resolve().parents[2] / "fighthealthinsurance"
+JS = REPO / "static" / "js"
+TEMPLATES = REPO / "templates"
+
+
+def _scrub_template() -> str:
+    return (TEMPLATES / "scrub.html").read_text()
+
+
+def _ocr_source() -> str:
+    return (JS / "scrub_ocr.ts").read_text()
+
+
+def _qwen_source() -> str:
+    return (JS / "qwen_webgpu_ocr.ts").read_text()
+
+
+def _without_comments(src: str) -> str:
+    """Source with // and /* */ comments removed.
+
+    The comments in this module deliberately name the old broken pin so the next
+    reader knows what not to reintroduce. Asserting against raw text would make
+    explaining the bug indistinguishable from committing it.
+    """
+    src = re.sub(r"/\*.*?\*/", "", src, flags=re.DOTALL)
+    return re.sub(r"//[^\n]*", "", src)
+
+
+def _checkbox_tag(html: str) -> str:
+    """The advanced-OCR <input> tag, whole."""
+    match = re.search(r"<input[^>]*id=\"advanced_ocr_enabled\"[^>]*>", html)
+    assert match is not None, "advanced_ocr_enabled checkbox not found in scrub.html"
+    return match.group(0)
+
+
+def test_scrub_checkbox_markup_is_not_checked():
+    """The rendered box is what a user sees before they touch anything."""
+    tag = _checkbox_tag(_scrub_template())
+    assert not re.search(r"\bchecked\b", tag), (
+        "advanced OCR is checked by default again; the engine is still broken "
+        f"and this offers a ~684 MB download for nothing. Tag: {tag}"
+    )
+
+
+def test_pages_without_the_checkbox_default_off():
+    """explain_denial and chat_interface render no checkbox, so they cannot opt out.
+
+    ``isAdvancedOCREnabled`` decides for them, and defaulting true there started
+    the download on pages that never showed the user a choice.
+    """
+    src = _ocr_source()
+    start = src.index("function isAdvancedOCREnabled")
+    body = src[start : src.index("}", src.index("return", start))]
+    assert "checkbox.checked : false" in body, (
+        "isAdvancedOCREnabled no longer defaults to false when the checkbox is "
+        "absent; the no-opt-out pages would start downloading the model again"
+    )
+
+
+def test_no_hardcoded_onnxruntime_version_pin():
+    """The wasm path must be derived, never pinned.
+
+    A hardcoded ``onnxruntime-web@1.22.0`` shipped for months while webpack
+    bundled 1.24.2, so the runtime asked for ``asyncify`` files that 1.22.0's
+    dist does not contain and the fetch 404'd. Any literal version pin here is
+    the same bug waiting to happen, because the two versions drift
+    independently.
+    """
+    code = _without_comments(_qwen_source())
+    assert "wasmPaths" not in code, (
+        "wasmPaths is being set again; let transformers.js derive it from the "
+        "onnxruntime build it actually shipped with"
+    )
+    assert not re.search(
+        r"onnxruntime-web@\d", code
+    ), "a hardcoded onnxruntime-web version is back in qwen_webgpu_ocr.ts"
+
+
+def test_label_states_the_download_cost():
+    """Off-by-default is only honest if the label says what turning it on costs."""
+    html = _scrub_template()
+    section = html[html.index('id="advanced_ocr_section"') :][:1200]
+    assert "684" in section, "the advanced OCR label no longer states the download size"
+    assert (
+        "huggingface.co" in section
+    ), "the advanced OCR label no longer says where the model is downloaded from"

--- a/tests/async-unit/test_advanced_ocr_default_off.py
+++ b/tests/async-unit/test_advanced_ocr_default_off.py
@@ -15,9 +15,15 @@ Source is tokenized, not regexed, before asserting. Two views come out of it:
 one with comments removed and string literals kept, for "no version pin
 anywhere in executable code" (a pin inside a URL literal must still be caught);
 and one with string literals blanked as well, for every structural check, so a
-string containing ``if (isAdvancedOCREnabled()) {`` or a stray ``}`` cannot
-impersonate syntax. Both earlier cuts of this file were beaten exactly those
-ways in review.
+string cannot impersonate syntax. Template interpolations are code and stay
+code in both views. Function declarations must be unique and at statement
+position, so a decoy expression cannot be inspected in place of the real thing.
+
+What these guards are for, and what they are not: they catch DRIFT, a future
+edit that flips a default or reintroduces a pin without meaning to. They are
+not a defence against someone deliberately writing evasive TypeScript in the
+same file to defeat them; three review rounds have shown that game has no
+floor. The defence against that is a reviewer reading the diff.
 
 Delete these only together with a measurement showing the engine beats tesseract
 on real denial scans. See ``qwen_webgpu_ocr.ts`` for what a working version needs.
@@ -31,60 +37,34 @@ JS = REPO / "static" / "js"
 TEMPLATES = REPO / "templates"
 
 
-def _tokenize_ts(src: str):
+def _simple_string_end(src: str, i: int, quote: str) -> int:
+    j = i + 1
+    while j < len(src):
+        if src[j] == "\\":
+            j += 2
+            continue
+        if src[j] == quote:
+            return j + 1
+        j += 1
+    return len(src)
+
+
+def _tokenize_ts(src: str, start: int = 0, until_close_brace: bool = False):
     """Split TypeScript into ('code' | 'string' | 'comment', text) segments.
 
-    A template literal is one 'string' token INCLUDING its ``${...}``
-    interpolations, which are scanned recursively so a nested template or a
-    brace inside one cannot end the outer literal early. Regex literals are not
-    recognized; none of the files asserted on contain one with ``//`` in it.
+    Returns ``(tokens, index)``. A template literal's quoted text is 'string';
+    each ``${...}`` interpolation is tokenized recursively as code (with its
+    own nested strings and comments), because an interpolation is executable
+    and blanking it would hide ``${(checkbox.checked = true)}``. With
+    ``until_close_brace`` the scan stops at the ``}`` that closes the
+    interpolation it was called for. Regex literals are not recognized; none
+    of the files asserted on contain one with ``//`` in it.
     """
-    n = len(src)
-
-    def string_end(i: int, quote: str) -> int:
-        j = i + 1
-        while j < n:
-            c = src[j]
-            if c == "\\":
-                j += 2
-                continue
-            if c == quote:
-                return j + 1
-            if quote == "`" and src.startswith("${", j):
-                j = interpolation_end(j + 2)
-                continue
-            j += 1
-        return n
-
-    def interpolation_end(i: int) -> int:
-        """Index just past the ``}`` closing the ``${`` opened before ``i``."""
-        depth = 0
-        j = i
-        while j < n:
-            c = src[j]
-            if c in "\"'`":
-                j = string_end(j, c)
-                continue
-            if src.startswith("//", j):
-                k = src.find("\n", j)
-                j = n if k < 0 else k
-                continue
-            if src.startswith("/*", j):
-                k = src.find("*/", j + 2)
-                j = n if k < 0 else k + 2
-                continue
-            if c == "{":
-                depth += 1
-            elif c == "}":
-                if depth == 0:
-                    return j + 1
-                depth -= 1
-            j += 1
-        return n
-
     tokens = []
     buf = []
-    i = 0
+    i = start
+    n = len(src)
+    depth = 0
 
     def flush():
         if buf:
@@ -93,10 +73,15 @@ def _tokenize_ts(src: str):
 
     while i < n:
         c = src[i]
-        if c in "\"'`":
+        if c in "\"'":
             flush()
-            j = string_end(i, c)
+            j = _simple_string_end(src, i, c)
             tokens.append(("string", src[i:j]))
+            i = j
+        elif c == "`":
+            flush()
+            sub, j = _template_tokens(src, i)
+            tokens.extend(sub)
             i = j
         elif src.startswith("//", i):
             flush()
@@ -110,23 +95,60 @@ def _tokenize_ts(src: str):
             j = n if k < 0 else k + 2
             tokens.append(("comment", src[i:j]))
             i = j
+        elif until_close_brace and c == "}" and depth == 0:
+            flush()
+            return tokens, i + 1
         else:
+            if c == "{":
+                depth += 1
+            elif c == "}":
+                depth -= 1
             buf.append(c)
             i += 1
     flush()
-    return tokens
+    return tokens, n
+
+
+def _template_tokens(src: str, i: int):
+    """Tokens for the template literal opening at ``src[i]``, and the end index."""
+    assert src[i] == "`"
+    tokens = [("string", "`")]
+    chunk = []
+    j = i + 1
+    n = len(src)
+    while j < n:
+        c = src[j]
+        if c == "\\":
+            chunk.append(src[j : j + 2])
+            j += 2
+            continue
+        if c == "`":
+            tokens.append(("string", "".join(chunk) + "`"))
+            return tokens, j + 1
+        if src.startswith("${", j):
+            tokens.append(("string", "".join(chunk)))
+            chunk = []
+            tokens.append(("code", "${"))
+            inner, j = _tokenize_ts(src, j + 2, until_close_brace=True)
+            tokens.extend(inner)
+            tokens.append(("code", "}"))
+            continue
+        chunk.append(c)
+        j += 1
+    tokens.append(("string", "".join(chunk)))
+    return tokens, n
 
 
 def _executable(src: str) -> str:
     """Comments removed, string literals kept verbatim."""
-    return "".join(t for k, t in _tokenize_ts(src) if k != "comment")
+    return "".join(t for k, t in _tokenize_ts(src)[0] if k != "comment")
 
 
 def _structural(src: str) -> str:
     """Comments removed AND every string literal replaced by an empty one."""
     return "".join(
         t if k == "code" else ('""' if k == "string" else "")
-        for k, t in _tokenize_ts(src)
+        for k, t in _tokenize_ts(src)[0]
     )
 
 
@@ -150,16 +172,28 @@ def _brace_block(src: str, open_at: int) -> str:
     raise AssertionError("unbalanced braces")
 
 
-def _js_function(src: str, declaration: str) -> str:
-    """Body of the function declared EXACTLY as ``declaration`` followed by ``(``.
+def _js_function(src: str, name: str) -> str:
+    """Body of the one function DECLARED as ``name``.
 
-    ``function isAdvancedOCREnabled`` must not match
-    ``function isAdvancedOCREnabledForCheckbox``; requiring the parameter list
-    to open right after the name is what stops a look-alike helper from being
-    inspected in place of the real thing.
+    Two rules, each because review defeated the previous version:
+    the name must appear as a function name exactly once in the file, so a
+    decoy named function expression (``const d = function name() {...}``)
+    cannot be inspected in place of the real one; and the declaration must sit
+    at statement position (optionally ``export``/``async``), not after ``=``.
     """
-    match = re.search(re.escape(declaration) + r"\s*\(", src)
-    assert match is not None, f"{declaration}( not found"
+    occurrences = re.findall(r"\bfunction\s+" + re.escape(name) + r"\b", src)
+    assert len(occurrences) == 1, (
+        f"expected exactly one `function {name}` in the file, found "
+        f"{len(occurrences)}; a second one is a decoy the guard would inspect "
+        "instead of the real function"
+    )
+    match = re.search(
+        r"(?m)^[ \t]*(?:export\s+)?(?:async\s+)?function\s+"
+        + re.escape(name)
+        + r"\s*\(",
+        src,
+    )
+    assert match is not None, f"function {name} is not declared at statement position"
     depth = 0
     end_of_params = None
     for i in range(match.end() - 1, len(src)):
@@ -170,7 +204,7 @@ def _js_function(src: str, declaration: str) -> str:
             if depth == 0:
                 end_of_params = i
                 break
-    assert end_of_params is not None, f"unbalanced parens reading {declaration}"
+    assert end_of_params is not None, f"unbalanced parens reading {name}"
     return _brace_block(src, src.index("{", end_of_params))
 
 
@@ -198,11 +232,19 @@ def _checkbox_tag(html: str) -> str:
 
 
 def test_tokenizer_keeps_a_pin_inside_a_nested_template_literal():
-    """Guard the guard: the exact construct that beat the previous stripper."""
+    """Guard the guard: the exact construct that beat an earlier stripper."""
     sample = "const u = `${`https://cdn.jsdelivr.net/npm/onnxruntime-web@1.22.0/dist/`}`; // x\n"
     assert "onnxruntime-web@1.22.0" in _executable(sample)
     assert "onnxruntime-web@1.22.0" not in _structural(sample)
     assert "// x" not in _executable(sample)
+
+
+def test_tokenizer_keeps_interpolation_code_in_the_structural_view():
+    """And the construct that beat the next one: code hidden in ``${...}``."""
+    sample = 'void `${(checkbox.checked = true)}`; const s = "if (x) {";\n'
+    structural = _structural(sample)
+    assert "checkbox.checked = true" in structural
+    assert "if (x) {" not in structural
 
 
 def test_scrub_checkbox_markup_is_not_checked():
@@ -218,8 +260,9 @@ def test_checkbox_init_never_turns_it_on():
     """scrub.ts may screen the box DOWN, never up.
 
     initAdvancedOCRCheckbox only ever sets checked=false. A single
-    ``checkbox.checked = true`` there would restore the download for every
-    WebGPU visitor while the markup test above still passed.
+    ``checkbox.checked = true`` there, including inside a template
+    interpolation, would restore the download for every WebGPU visitor while
+    the markup test above still passed.
     """
     assert not re.search(r"\.checked\s*=\s*true\b", _scrub_structural()), (
         "scrub.ts sets a checkbox to true; the advanced OCR box must never be "
@@ -236,7 +279,7 @@ def test_pages_without_the_checkbox_default_off():
     it is caught too. Strings are blanked first, so a string cannot supply the
     expected text.
     """
-    body = _js_function(_ocr_structural(), "function isAdvancedOCREnabled")
+    body = _js_function(_ocr_structural(), "isAdvancedOCREnabled")
     returns = re.findall(r"\breturn\b[^;]*;", body)
     assert len(returns) == 1, f"expected exactly one return, found {returns}"
     assert re.fullmatch(
@@ -253,9 +296,10 @@ def test_qwen_engine_only_runs_inside_the_checkbox_gate():
 
     Brace-match the ``if (isAdvancedOCREnabled())`` block on string-blanked
     source and require the one launch to sit inside it. A string containing the
-    gate's text, or a ``}`` inside a string, cannot fake a gate here.
+    gate's text, a ``}`` inside a string, or a launch hidden in a template
+    interpolation cannot fake or evade the gate here.
     """
-    body = _js_function(_ocr_structural(), "async function recognizeImageText")
+    body = _js_function(_ocr_structural(), "recognizeImageText")
     assert body.count("recognizeWithQwenWebGPU(") == 1, (
         "recognizeWithQwenWebGPU is launched more than once, or not at all, in "
         "recognizeImageText"
@@ -291,15 +335,26 @@ def test_no_hardcoded_onnxruntime_version_pin():
 def test_label_states_the_download_cost_truthfully():
     """Off-by-default is only honest if the label tells the truth in both directions.
 
-    It must state the size in MB (not just the digits) and the source. It must
-    not claim standard OCR needs no download or no model: tesseract fetches
-    English trained data, which is an LSTM model, from a CDN on first use.
+    While the engine is broken the label must say so, and must disclose that
+    turning it on still fetches model files (the tokenizer alone is ~19 MB)
+    before the load fails. It must state the eventual size in MB with the unit.
+    It must not claim standard OCR needs no download or no model: tesseract
+    fetches English trained data, an LSTM model, from a CDN on first use.
+
+    When the engine works, drop the "not working" assertion together with the
+    label sentence it pins; keep the rest.
     """
     html = _scrub_template()
     start = html.index('id="advanced_ocr_section"')
     label = html[start : html.index("</label>", start)]
+    assert re.search(r"not working|does not work|fails to load", label, re.I), (
+        "the label no longer says the engine is broken, but it still is"
+    )
+    assert re.search(r"\b(19|20)\s*MB\b", label), (
+        "the label no longer discloses the ~20 MB fetched before the load fails"
+    )
     assert re.search(r"\b684\s*MB\b", label), (
-        "the advanced OCR label no longer states the download size in MB"
+        "the advanced OCR label no longer states the eventual download size in MB"
     )
     assert (
         "huggingface.co" in label


### PR DESCRIPTION
Advanced OCR has never produced a character on prod. Init throws `Unsupported model type: qwen3_5` and every caller silently falls back to tesseract, while the checkbox shipped checked for anyone with WebGPU.

**The premise of the brief was wrong, and so was its proposed fix.** The pinned `@huggingface/transformers` 4.0.0-next.5 already contains full Qwen3.5 support; bumping it changes nothing. The suggested task string `image-text-to-text` is not a pipeline task in any transformers.js version. The real cause is that `pipeline("image-to-text")` resolves to `AutoModelForVision2Seq`, whose registry holds only three model types, none of them Qwen. There is no task string that makes this call work. Making the engine work is a rewrite (AutoProcessor with the chat template, an explicit resize, generate, batch_decode) and should not land before someone measures it against tesseract on real denial scans: at 300 DPI a letter page is ~33k vision patches, past what WebGPU will bind, and a fluent model misreading a claim number is worse than tesseract garble.

So this does what the brief named as the honest alternative:

- **Off by default** on `/scan`, and off on the two pages that render no checkbox (explain_denial, chat_interface), which had no way to opt out of the download.
- **The label tells the truth in both directions.** It says the feature is not working in this release, that turning it on today still fetches about 20 MB (tokenizer and configs) before the load fails, what the full model will cost once it works (684 MB from huggingface.co), and that standard OCR fetches a much smaller language file. It no longer claims standard OCR needs no download or no model. Copy is Melanie's to reword.
- **Deletes the hardcoded `onnxruntime-web@1.22.0` wasm path.** Webpack bundles 1.24.2, which requests `ort-wasm-simd-threaded.asyncify.*`; 1.22.0's dist has no asyncify files, so the fetch 404'd. Left alone, transformers.js derives the URL from the runtime it shipped with and also restores the Cache API path the string form disabled.
- The root cause and the rewrite requirements are written at the top of `qwen_webgpu_ocr.ts`.

**Tests.** `tests/async-unit/test_advanced_ocr_default_off.py` pins the default in every place it is decided, the absence of a version pin, the gate around the engine launch, and the label's claims. Because there is no JS harness, it asserts on source through a small tokenizer (comments stripped; strings kept for the version-pin check and blanked for structural checks; template interpolations kept as code). Its docstring states the boundary: these are drift guards, not a defence against deliberately evasive code. Full async-unit suite, black, tsc, and the webpack build are green.

**Review.** Codex (gpt-6-astra, read-only sandbox), six rounds. Rounds 1 to 3 each defeated the guards with a construct the previous version missed (uppercase `CHECKED`, a comment-only stripper eating URLs, a nested template literal, a decoy named function expression, code hidden in `${}`), and caught two label overclaims; each fix was verified by applying Codex's counterexample and watching it fail. Rounds 4 and 5 found no production defect and only false-failure risks on harmless edits, each fixed and verified both ways. Round 6: no findings at the agreed threshold.

**Follow-up for a human decision:** whether to hide the checkbox entirely while the engine is broken, rather than show a control that explains it does nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYruQVRyBbFzUxy9YGcHTb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Advanced OCR is now disabled by default across supported pages.
  * Pages without the advanced OCR option no longer attempt to download or run its model.
  * Standard OCR remains available as the fallback when advanced OCR cannot load.

* **Documentation**
  * Updated guidance explains that advanced OCR is currently non-functional, may download approximately 20 MB before failing, and has a future estimated model size of 684 MB.
  * Clarified that standard OCR requires a substantially smaller download and existing safeguards remain in place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->