### PR TITLE
Show the OCR progress box while reading, not only on submit

### DIFF
--- a/fighthealthinsurance/static/css/custom.css
+++ b/fighthealthinsurance/static/css/custom.css
@@ -646,6 +646,14 @@ a.link:hover::after {
   padding: initial; /* Restores padding */
 }
 
+/* Same show/hide machinery, but for messages that are NOT errors. Progress
+   ("we are reading your file") shares the markup and the .visible toggle with
+   the validation errors, and inheriting their red made a normal wait look like
+   something had gone wrong. */
+.hidden-error-message.hidden-progress-message {
+    color: #2c3e50;
+}
+
 .appeal_text {
     width: 100%;
     height: 20em;

--- a/fighthealthinsurance/static/js/scrub.ts
+++ b/fighthealthinsurance/static/js/scrub.ts
@@ -124,7 +124,7 @@ const recognizeEvent = async function (evt: Event) {
     addText(text);
   };
 
-  beginOcr();
+  beginOcr(selection);
   try {
     for (const file of filesArray) {
       // Catch PER FILE, not around the loop. The uploader is multiple="true"
@@ -140,7 +140,7 @@ const recognizeEvent = async function (evt: Event) {
       }
     }
   } finally {
-    endOcr();
+    endOcr(selection);
   }
 
   // A superseded batch says nothing about what the user is looking at.

--- a/fighthealthinsurance/static/js/scrub_client_side_form.ts
+++ b/fighthealthinsurance/static/js/scrub_client_side_form.ts
@@ -59,10 +59,19 @@ export function hideErrorMessages(event: Event): void {
 // "denial_text: This field is required" while the page was visibly still
 // working. Track it so the submit gate can say "still reading your file"
 // instead.
-let ocrInFlight = 0;
+//
+// "In flight" means the LATEST file selection is being read, not "any batch is
+// still running". Reading a batch is slow enough that a user can pick again
+// while one is running, and scrub.ts drops every write from a superseded
+// batch, so its text is never going to land. A plain counter got both
+// directions wrong: a superseded batch finishing early hid the indicator for
+// its successor, and a superseded batch still running kept the indicator up
+// (and told the submit gate text was coming) after its successor had already
+// reported failure (review).
+let activeOcrSelection: number | null = null;
 
-export function beginOcr(): void {
-  ocrInFlight += 1;
+export function beginOcr(selection: number): void {
+  activeOcrSelection = selection;
   // Show it as soon as reading starts, not just when the user hits submit.
   // Reading one photographed page takes several seconds and nothing else on
   // screen says so, so the page looked idle and people retyped their denial by
@@ -72,18 +81,20 @@ export function beginOcr(): void {
   showHiddenMessage("ocr_in_progress");
 }
 
-export function endOcr(): void {
-  ocrInFlight = Math.max(0, ocrInFlight - 1);
-  if (ocrInFlight === 0) {
-    // The gate only re-evaluates on submit, so without this the "still
-    // reading your file" message stays on screen after the file has
-    // finished being read (external review).
-    rehideHiddenMessage("ocr_in_progress");
+export function endOcr(selection: number): void {
+  if (selection !== activeOcrSelection) {
+    // A superseded batch ending says nothing about the batch that replaced it.
+    return;
   }
+  activeOcrSelection = null;
+  // The gate only re-evaluates on submit, so without this the "still
+  // reading your file" message stays on screen after the file has
+  // finished being read (external review).
+  rehideHiddenMessage("ocr_in_progress");
 }
 
 export function isOcrInFlight(): boolean {
-  return ocrInFlight > 0;
+  return activeOcrSelection !== null;
 }
 
 // Reading the file can fail outright (every OCR engine erroring or timing
@@ -171,7 +182,10 @@ export function validateScrubForm(event: Event): void {
     // Distinguish "you have not given us the letter" from "we are still
     // reading the file you just gave us".
     showHiddenMessage("ocr_in_progress");
-  } else {
+  } else if (!isOcrInFlight()) {
+    // Only clear it once nothing is being read. With page one already in the
+    // box, a submit blocked on some other field used to hide the indicator
+    // while the remaining pages were still being read (review).
     rehideHiddenMessage("ocr_in_progress");
   }
   // Gate on exactly what the SERVER requires: forms/__init__.py marks pii,

--- a/fighthealthinsurance/static/js/scrub_client_side_form.ts
+++ b/fighthealthinsurance/static/js/scrub_client_side_form.ts
@@ -63,6 +63,13 @@ let ocrInFlight = 0;
 
 export function beginOcr(): void {
   ocrInFlight += 1;
+  // Show it as soon as reading starts, not just when the user hits submit.
+  // Reading one photographed page takes several seconds and nothing else on
+  // screen says so, so the page looked idle and people retyped their denial by
+  // hand or gave up. The submit gate still shows this same box; it is now a
+  // second entry point to a message that is already up rather than the only
+  // way to ever see it.
+  showHiddenMessage("ocr_in_progress");
 }
 
 export function endOcr(): void {

--- a/fighthealthinsurance/templates/scrub.html
+++ b/fighthealthinsurance/templates/scrub.html
@@ -215,7 +215,7 @@ Upload your Health Insurance Denial
 	      describe what was denied (for example: the pharmacy said my PrEP was
 	      denied).
 	    </div>
-	    <div class="hidden-error-message hidden-progress-message" id="ocr_in_progress" role="status" aria-live="polite">
+	    <div class="hidden-error-message hidden-progress-message" id="ocr_in_progress" role="alert" aria-live="polite">
 	      We're reading the file you uploaded. A scanned PDF is processed a page at
 	      a time, so this can take a little while. The text will appear in "Your
 	      Insurance Denial" below when it's done. You can also type or paste the

--- a/fighthealthinsurance/templates/scrub.html
+++ b/fighthealthinsurance/templates/scrub.html
@@ -116,6 +116,16 @@ Upload your Health Insurance Denial
 			<input id="uploader" type="file" multiple="true" class="form-control mt-2"><br>
 	    </div>
 	</div>
+	{% comment %} Sits right under the uploader, where the read is triggered: on a
+	   phone the message boxes at the bottom of the form are a full screen away
+	   from the file picker, and an indicator nobody can see is no indicator
+	   (review). Same element the submit gate toggles. {% endcomment %}
+	    <div class="hidden-error-message hidden-progress-message" id="ocr_in_progress" role="alert" aria-live="polite">
+	      We're reading the file you uploaded. A scanned PDF is processed a page at
+	      a time, so this can take a little while. The text will appear in "Your
+	      Insurance Denial" below when it's done. You can also type or paste the
+	      denial text yourself instead of waiting.
+	    </div>
 	{% endif %}
 	<div class="form-group">
 	    <label for="denial_text" id="denial_text_label" class="form-label">
@@ -214,12 +224,6 @@ Upload your Health Insurance Denial
 	      We need your denial in the box below. If you never got one, say so and
 	      describe what was denied (for example: the pharmacy said my PrEP was
 	      denied).
-	    </div>
-	    <div class="hidden-error-message hidden-progress-message" id="ocr_in_progress" role="alert" aria-live="polite">
-	      We're reading the file you uploaded. A scanned PDF is processed a page at
-	      a time, so this can take a little while. The text will appear in "Your
-	      Insurance Denial" below when it's done. You can also type or paste the
-	      denial text yourself instead of waiting.
 	    </div>
 	    <div class="hidden-error-message" id="ocr_partial" role="alert" aria-live="polite">
 	      We read some of what you uploaded but not all of it, so check the box

--- a/fighthealthinsurance/templates/scrub.html
+++ b/fighthealthinsurance/templates/scrub.html
@@ -215,11 +215,11 @@ Upload your Health Insurance Denial
 	      describe what was denied (for example: the pharmacy said my PrEP was
 	      denied).
 	    </div>
-	    <div class="hidden-error-message" id="ocr_in_progress" role="alert" aria-live="polite">
-	      We're still reading the file you uploaded &mdash; a scanned PDF has to be
-	      processed a page at a time, which can take a little while. The text will
-	      appear in "Your Insurance Denial" below when it's done. You can also type
-	      or paste the denial text yourself instead of waiting.
+	    <div class="hidden-error-message hidden-progress-message" id="ocr_in_progress" role="status" aria-live="polite">
+	      We're reading the file you uploaded. A scanned PDF is processed a page at
+	      a time, so this can take a little while. The text will appear in "Your
+	      Insurance Denial" below when it's done. You can also type or paste the
+	      denial text yourself instead of waiting.
 	    </div>
 	    <div class="hidden-error-message" id="ocr_partial" role="alert" aria-live="polite">
 	      We read some of what you uploaded but not all of it, so check the box

--- a/tests/async-unit/test_ocr_progress_indicator.py
+++ b/tests/async-unit/test_ocr_progress_indicator.py
@@ -55,7 +55,9 @@ def _rgb(value: str):
     if m:
         h = m.group(1)
         return tuple(int(h[i : i + 2], 16) for i in (0, 2, 4))
-    m = re.fullmatch(r"rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)", value)
+    # Comma or space separated: rgb(44, 62, 80) and rgb(44 62 80) are the
+    # same colour (review).
+    m = re.fullmatch(r"rgb\(\s*(\d+)\s*[, ]\s*(\d+)\s*[, ]\s*(\d+)\s*\)", value)
     if m:
         return tuple(int(x) for x in m.groups())
     return None
@@ -112,8 +114,10 @@ def test_end_ocr_hides_only_for_the_batch_that_is_still_current():
     early would clear the indicator for the batch that replaced it.
     """
     body = _js_function(_form_source(), "export function endOcr")
+    # Either operand order: `selection !== activeOcrSelection` or the reverse
+    # is the same guard (review).
     guard = re.search(
-        r"if\s*\(\s*selection\s*!==\s*activeOcrSelection\s*\)\s*\{[^}]*\breturn\s*;",
+        r"if\s*\(\s*(?:selection\s*!==\s*activeOcrSelection|activeOcrSelection\s*!==\s*selection)\s*\)\s*\{[^}]*\breturn\s*;",
         body,
         re.DOTALL,
     )

--- a/tests/async-unit/test_ocr_progress_indicator.py
+++ b/tests/async-unit/test_ocr_progress_indicator.py
@@ -3,10 +3,17 @@
 Reading one photographed page takes several seconds. The box existed, but the
 only thing that ever showed it was the submit gate, so a user who waited quietly
 saw an idle page and no explanation. It now shows when reading starts and hides
-when the last read finishes.
+when the latest selection finishes.
+
+"Latest" matters. A user can pick files again while a batch is still running,
+and scrub.ts drops every write from the superseded batch, so the indicator must
+follow the batch whose text can actually land: a superseded batch finishing must
+not hide it, and a superseded batch still running must not keep it up.
 
 There is no JS test harness in this repo, so this asserts on the source, matching
-``test_scrub_ocr_quality.py``.
+``test_scrub_ocr_quality.py``. Structural checks brace-match; the plain
+substring checks that review showed could be satisfied by a broken
+implementation are gone.
 """
 
 import pathlib
@@ -22,13 +29,38 @@ def _form_source() -> str:
     return (JS / "scrub_client_side_form.ts").read_text()
 
 
-def _js_function(src: str, name: str) -> str:
-    """The body of one JS/TS function, brace-matched from the parameter list."""
-    start = src.index(name)
-    paren = src.index("(", start)
+def _scrub_source() -> str:
+    return (JS / "scrub.ts").read_text()
+
+
+def _brace_block(src: str, open_at: int) -> str:
+    assert src[open_at] == "{", src[open_at : open_at + 20]
+    depth = 0
+    for i in range(open_at, len(src)):
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[open_at : i + 1]
+    raise AssertionError("unbalanced braces")
+
+
+def _js_function(src: str, declaration: str) -> str:
+    """Body of the function declared exactly as ``declaration`` followed by ``(``."""
+    return _js_function_at(src, re.escape(declaration) + r"\s*\(")
+
+
+def _js_function_at(src: str, head: str) -> str:
+    """Body of the function whose head matches ``head``, which must end at ``(``.
+
+    Covers the assignment form too: ``const recognizeEvent = async function (``.
+    """
+    match = re.search(head, src)
+    assert match is not None, f"{head} not found"
     depth = 0
     end_of_params = None
-    for i in range(paren, len(src)):
+    for i in range(match.end() - 1, len(src)):
         if src[i] == "(":
             depth += 1
         elif src[i] == ")":
@@ -36,17 +68,8 @@ def _js_function(src: str, name: str) -> str:
             if depth == 0:
                 end_of_params = i
                 break
-    assert end_of_params is not None, f"unbalanced parens reading {name}"
-    body_start = src.index("{", end_of_params)
-    depth = 0
-    for i in range(body_start, len(src)):
-        if src[i] == "{":
-            depth += 1
-        elif src[i] == "}":
-            depth -= 1
-            if depth == 0:
-                return src[body_start : i + 1]
-    raise AssertionError(f"unbalanced braces reading {name}")
+    assert end_of_params is not None, f"unbalanced parens reading {declaration}"
+    return _brace_block(src, src.index("{", end_of_params))
 
 
 def test_begin_ocr_shows_the_progress_box():
@@ -58,18 +81,78 @@ def test_begin_ocr_shows_the_progress_box():
     )
 
 
-def test_end_ocr_hides_the_progress_box_when_the_last_read_finishes():
-    """And hide it after, or it outlives the work it describes."""
+def test_end_ocr_hides_only_for_the_batch_that_is_still_current():
+    """Hide after, but only when the batch ending is the latest one.
+
+    The guard has to come BEFORE the hide, or a superseded batch finishing
+    early would clear the indicator for the batch that replaced it.
+    """
     body = _js_function(_form_source(), "export function endOcr")
-    assert 'rehideHiddenMessage("ocr_in_progress")' in body
-    assert "ocrInFlight === 0" in body, (
-        "the hide is no longer guarded on the in-flight count, so one finished "
-        "file would clear the message while other files are still being read"
+    guard = re.search(
+        r"if\s*\(\s*selection\s*!==\s*activeOcrSelection\s*\)\s*\{[^}]*\breturn\s*;",
+        body,
+        re.DOTALL,
+    )
+    assert guard is not None, (
+        "endOcr no longer returns early for a superseded batch, so an old "
+        "batch finishing would hide the indicator for the current one"
+    )
+    hide = body.find('rehideHiddenMessage("ocr_in_progress")')
+    assert hide > guard.end(), "the hide runs before the superseded-batch guard"
+    assert re.search(r"activeOcrSelection\s*=\s*null\s*;", body[guard.end() :]), (
+        "endOcr no longer clears the active selection, so the submit gate "
+        "would keep saying the file is being read"
+    )
+
+
+def test_in_flight_means_the_latest_selection_only():
+    """A superseded batch that is still running must not count as in flight.
+
+    Its text is dropped by scrub.ts, so telling the submit gate text is coming
+    would be false, and keeping the indicator up alongside a failure message
+    for the newer batch is a contradiction on screen (review).
+    """
+    body = _js_function(_form_source(), "export function isOcrInFlight")
+    assert re.search(r"return\s+activeOcrSelection\s*!==\s*null\s*;", body), body
+
+
+def test_the_uploader_passes_its_selection_through():
+    """scrub.ts must hand the selection number to both ends of the read."""
+    fn = _js_function_at(
+        _scrub_source(), r"const recognizeEvent\s*=\s*async\s+function\s*\("
+    )
+    assert "beginOcr(selection);" in fn, fn
+    assert re.search(r"finally\s*\{\s*endOcr\(selection\);", fn), fn
+
+
+def test_submit_gate_keeps_the_box_up_while_reading_continues():
+    """A blocked submit with page one already in the box used to hide it.
+
+    Only clear it when nothing is being read; otherwise the remaining pages
+    are read with no indicator (review).
+    """
+    validate = _js_function(_form_source(), "export function validateScrubForm")
+    m = re.search(
+        r"else\s+if\s*\(\s*!\s*isOcrInFlight\(\)\s*\)\s*\{", validate
+    )
+    assert m is not None, (
+        "the submit gate clears ocr_in_progress unconditionally again"
+    )
+    block = _brace_block(validate, m.end() - 1)
+    assert 'rehideHiddenMessage("ocr_in_progress")' in block, block
+    # ...and it must not ALSO clear it on some unconditional path.
+    outside = validate.replace(block, "")
+    assert 'rehideHiddenMessage("ocr_in_progress")' not in outside, (
+        "ocr_in_progress is still cleared outside the !isOcrInFlight() branch"
     )
 
 
 def test_progress_box_is_not_styled_as_an_error():
-    """A normal wait must not look like a failure."""
+    """A normal wait must not look like a failure.
+
+    The declaration is checked, not just the selector: a rule that exists but
+    sets red would pass a selector-only check (review).
+    """
     html = (TEMPLATES / "scrub.html").read_text()
     tag = re.search(r'<div[^>]*id="ocr_in_progress"[^>]*>', html)
     assert tag is not None, "ocr_in_progress box not found in scrub.html"
@@ -77,15 +160,34 @@ def test_progress_box_is_not_styled_as_an_error():
         "the progress box lost its neutral styling class and inherits the red "
         "of .hidden-error-message again"
     )
-    assert 'role="status"' in tag.group(0), (
-        "progress is a status, not an alert; role=alert interrupts screen "
-        "reader users for a routine wait"
-    )
     css = (CSS / "custom.css").read_text()
-    assert ".hidden-error-message.hidden-progress-message" in css, (
-        "the neutral colour rule is gone, so the class in the template does "
-        "nothing"
+    rule = re.search(
+        r"\.hidden-error-message\.hidden-progress-message\s*\{([^}]*)\}", css
     )
+    assert rule is not None, "the neutral colour rule is gone"
+    color = re.search(r"color\s*:\s*([^;]+);", rule.group(1))
+    assert color is not None, "the rule no longer sets a colour"
+    value = color.group(1).strip().lower()
+    assert value not in {"red", "#f00", "#ff0000", "rgb(255, 0, 0)", "rgb(255,0,0)"}, (
+        f"the progress box is red again: {value}"
+    )
+
+
+def test_progress_box_keeps_the_sibling_live_region_role():
+    """role=alert, like every other message box on this form.
+
+    A first cut changed it to role=status. Review pointed out that these boxes
+    are toggled by visibility on already-populated markup, which live regions
+    do not reliably treat as a change; alert has the special handling that
+    made the existing boxes announce at all. Fixing that properly (an exposed,
+    empty region whose text is set on show) is a change to the shared pattern
+    and belongs in its own PR; until then this box must not be the one that
+    announces less than its siblings.
+    """
+    html = (TEMPLATES / "scrub.html").read_text()
+    tag = re.search(r'<div[^>]*id="ocr_in_progress"[^>]*>', html)
+    assert tag is not None
+    assert 'role="alert"' in tag.group(0), tag.group(0)
 
 
 def test_progress_copy_has_no_em_dash():

--- a/tests/async-unit/test_ocr_progress_indicator.py
+++ b/tests/async-unit/test_ocr_progress_indicator.py
@@ -68,13 +68,22 @@ def _js_function_at(src: str, head: str) -> str:
             if depth == 0:
                 end_of_params = i
                 break
-    assert end_of_params is not None, f"unbalanced parens reading {declaration}"
+    assert end_of_params is not None, f"unbalanced parens reading {head}"
     return _brace_block(src, src.index("{", end_of_params))
 
 
-def test_begin_ocr_shows_the_progress_box():
-    """Show it when reading starts. This is the whole fix."""
+def test_begin_ocr_records_the_selection_and_shows_the_progress_box():
+    """Show it when reading starts, and record WHICH batch is being read.
+
+    The recording is the central state transition: without it every read
+    reports "not in flight", a mid-read submit hides the box, and a read that
+    finishes without a submit leaves it up forever because endOcr returns
+    early for a selection that was never recorded (review).
+    """
     body = _js_function(_form_source(), "export function beginOcr")
+    assert re.search(r"activeOcrSelection\s*=\s*selection\s*;", body), (
+        "beginOcr no longer records the active selection"
+    )
     assert 'showHiddenMessage("ocr_in_progress")' in body, (
         "beginOcr no longer shows the progress box; the user is back to "
         "staring at an idle page while their file is read"
@@ -167,10 +176,11 @@ def test_progress_box_is_not_styled_as_an_error():
     assert rule is not None, "the neutral colour rule is gone"
     color = re.search(r"color\s*:\s*([^;]+);", rule.group(1))
     assert color is not None, "the rule no longer sets a colour"
-    value = color.group(1).strip().lower()
-    assert value not in {"red", "#f00", "#ff0000", "rgb(255, 0, 0)", "rgb(255,0,0)"}, (
-        f"the progress box is red again: {value}"
-    )
+    # Pin the chosen neutral, with any !important stripped: a deny-list of
+    # reds accepted "red !important" (review). Change this and the CSS
+    # together.
+    value = re.sub(r"\s*!important\s*$", "", color.group(1).strip().lower())
+    assert value == "#2c3e50", f"the progress box colour changed: {value}"
 
 
 def test_progress_box_keeps_the_sibling_live_region_role():

--- a/tests/async-unit/test_ocr_progress_indicator.py
+++ b/tests/async-unit/test_ocr_progress_indicator.py
@@ -1,0 +1,98 @@
+"""The "we're reading your file" box must appear while reading, not only on submit.
+
+Reading one photographed page takes several seconds. The box existed, but the
+only thing that ever showed it was the submit gate, so a user who waited quietly
+saw an idle page and no explanation. It now shows when reading starts and hides
+when the last read finishes.
+
+There is no JS test harness in this repo, so this asserts on the source, matching
+``test_scrub_ocr_quality.py``.
+"""
+
+import pathlib
+import re
+
+REPO = pathlib.Path(__file__).resolve().parents[2] / "fighthealthinsurance"
+JS = REPO / "static" / "js"
+TEMPLATES = REPO / "templates"
+CSS = REPO / "static" / "css"
+
+
+def _form_source() -> str:
+    return (JS / "scrub_client_side_form.ts").read_text()
+
+
+def _js_function(src: str, name: str) -> str:
+    """The body of one JS/TS function, brace-matched from the parameter list."""
+    start = src.index(name)
+    paren = src.index("(", start)
+    depth = 0
+    end_of_params = None
+    for i in range(paren, len(src)):
+        if src[i] == "(":
+            depth += 1
+        elif src[i] == ")":
+            depth -= 1
+            if depth == 0:
+                end_of_params = i
+                break
+    assert end_of_params is not None, f"unbalanced parens reading {name}"
+    body_start = src.index("{", end_of_params)
+    depth = 0
+    for i in range(body_start, len(src)):
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[body_start : i + 1]
+    raise AssertionError(f"unbalanced braces reading {name}")
+
+
+def test_begin_ocr_shows_the_progress_box():
+    """Show it when reading starts. This is the whole fix."""
+    body = _js_function(_form_source(), "export function beginOcr")
+    assert 'showHiddenMessage("ocr_in_progress")' in body, (
+        "beginOcr no longer shows the progress box; the user is back to "
+        "staring at an idle page while their file is read"
+    )
+
+
+def test_end_ocr_hides_the_progress_box_when_the_last_read_finishes():
+    """And hide it after, or it outlives the work it describes."""
+    body = _js_function(_form_source(), "export function endOcr")
+    assert 'rehideHiddenMessage("ocr_in_progress")' in body
+    assert "ocrInFlight === 0" in body, (
+        "the hide is no longer guarded on the in-flight count, so one finished "
+        "file would clear the message while other files are still being read"
+    )
+
+
+def test_progress_box_is_not_styled_as_an_error():
+    """A normal wait must not look like a failure."""
+    html = (TEMPLATES / "scrub.html").read_text()
+    tag = re.search(r'<div[^>]*id="ocr_in_progress"[^>]*>', html)
+    assert tag is not None, "ocr_in_progress box not found in scrub.html"
+    assert "hidden-progress-message" in tag.group(0), (
+        "the progress box lost its neutral styling class and inherits the red "
+        "of .hidden-error-message again"
+    )
+    assert 'role="status"' in tag.group(0), (
+        "progress is a status, not an alert; role=alert interrupts screen "
+        "reader users for a routine wait"
+    )
+    css = (CSS / "custom.css").read_text()
+    assert ".hidden-error-message.hidden-progress-message" in css, (
+        "the neutral colour rule is gone, so the class in the template does "
+        "nothing"
+    )
+
+
+def test_progress_copy_has_no_em_dash():
+    """House style: no em dashes in user-facing copy."""
+    html = (TEMPLATES / "scrub.html").read_text()
+    start = html.index('id="ocr_in_progress"')
+    block = html[start : html.index("</div>", start)]
+    assert "&mdash;" not in block and "—" not in block, (
+        "an em dash is back in the OCR progress copy"
+    )

--- a/tests/async-unit/test_ocr_progress_indicator.py
+++ b/tests/async-unit/test_ocr_progress_indicator.py
@@ -46,6 +46,21 @@ def _brace_block(src: str, open_at: int) -> str:
     raise AssertionError("unbalanced braces")
 
 
+def _rgb(value: str):
+    """(r, g, b) for #rgb, #rrggbb, or rgb(r, g, b); None for anything else."""
+    m = re.fullmatch(r"#([0-9a-f]{3})", value)
+    if m:
+        return tuple(int(c * 2, 16) for c in m.group(1))
+    m = re.fullmatch(r"#([0-9a-f]{6})", value)
+    if m:
+        h = m.group(1)
+        return tuple(int(h[i : i + 2], 16) for i in (0, 2, 4))
+    m = re.fullmatch(r"rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)", value)
+    if m:
+        return tuple(int(x) for x in m.groups())
+    return None
+
+
 def _js_function(src: str, declaration: str) -> str:
     """Body of the function declared exactly as ``declaration`` followed by ``(``."""
     return _js_function_at(src, re.escape(declaration) + r"\s*\(")
@@ -141,8 +156,11 @@ def test_submit_gate_keeps_the_box_up_while_reading_continues():
     are read with no indicator (review).
     """
     validate = _js_function(_form_source(), "export function validateScrubForm")
+    # `else if` or a standalone `if`: both guard the clear on nothing being in
+    # flight, and the standalone form is a behaviour-preserving refactor
+    # because the preceding branch requires a read in flight (review).
     m = re.search(
-        r"else\s+if\s*\(\s*!\s*isOcrInFlight\(\)\s*\)\s*\{", validate
+        r"(?:else\s+)?if\s*\(\s*!\s*isOcrInFlight\(\)\s*\)\s*\{", validate
     )
     assert m is not None, (
         "the submit gate clears ocr_in_progress unconditionally again"
@@ -176,11 +194,12 @@ def test_progress_box_is_not_styled_as_an_error():
     assert rule is not None, "the neutral colour rule is gone"
     color = re.search(r"color\s*:\s*([^;]+);", rule.group(1))
     assert color is not None, "the rule no longer sets a colour"
-    # Pin the chosen neutral, with any !important stripped: a deny-list of
-    # reds accepted "red !important" (review). Change this and the CSS
-    # together.
+    # Pin the chosen neutral by its parsed RGB, with any !important stripped:
+    # a deny-list of reds accepted "red !important", and an exact-string pin
+    # rejected rgb(44, 62, 80), which is the same colour (review). Change
+    # this and the CSS together.
     value = re.sub(r"\s*!important\s*$", "", color.group(1).strip().lower())
-    assert value == "#2c3e50", f"the progress box colour changed: {value}"
+    assert _rgb(value) == (44, 62, 80), f"the progress box colour changed: {value}"
 
 
 def test_progress_box_keeps_the_sibling_live_region_role():
@@ -198,6 +217,23 @@ def test_progress_box_keeps_the_sibling_live_region_role():
     tag = re.search(r'<div[^>]*id="ocr_in_progress"[^>]*>', html)
     assert tag is not None
     assert 'role="alert"' in tag.group(0), tag.group(0)
+
+
+def test_progress_box_sits_by_the_uploader():
+    """Under the file picker, above the textarea, not a screen away.
+
+    The box used to live with the submit-gate messages below a 20-row
+    textarea, so on a phone the person who had just picked a file saw
+    nothing change (review). It must come after the uploader and before the
+    denial textarea, which also makes its "below" wording true.
+    """
+    html = (TEMPLATES / "scrub.html").read_text()
+    uploader = html.index('id="uploader"')
+    box = html.index('id="ocr_in_progress"')
+    textarea = html.index('id="denial_text"')
+    assert uploader < box < textarea, (
+        "the progress box is no longer between the uploader and the textarea"
+    )
 
 
 def test_progress_copy_has_no_em_dash():

--- a/tests/async-unit/test_scrub_form_submit_gate.py
+++ b/tests/async-unit/test_scrub_form_submit_gate.py
@@ -111,7 +111,10 @@ def test_ocr_progress_message_is_cleared_when_the_last_run_finishes():
     end_ocr = _js_function(_form_source(), "export function endOcr")
     # Only the batch that is still current may clear it; a superseded batch
     # ending must not hide the indicator for the batch that replaced it.
-    assert "selection !== activeOcrSelection" in end_ocr, end_ocr
+    assert re.search(
+        r"selection\s*!==\s*activeOcrSelection|activeOcrSelection\s*!==\s*selection",
+        end_ocr,
+    ), end_ocr
     assert 'rehideHiddenMessage("ocr_in_progress")' in end_ocr, end_ocr
 
 

--- a/tests/async-unit/test_scrub_form_submit_gate.py
+++ b/tests/async-unit/test_scrub_form_submit_gate.py
@@ -109,7 +109,9 @@ def test_ocr_progress_message_is_cleared_when_the_last_run_finishes():
     """The gate only re-evaluates on submit, so endOcr must clear the message
     itself or it stays on screen after the file has been read."""
     end_ocr = _js_function(_form_source(), "export function endOcr")
-    assert "ocrInFlight === 0" in end_ocr, end_ocr
+    # Only the batch that is still current may clear it; a superseded batch
+    # ending must not hide the indicator for the batch that replaced it.
+    assert "selection !== activeOcrSelection" in end_ocr, end_ocr
     assert 'rehideHiddenMessage("ocr_in_progress")' in end_ocr, end_ocr
 
 
@@ -118,12 +120,14 @@ def test_the_uploader_releases_ocr_state_even_on_error():
     recognize() loop and release in a finally, or a failed parse leaves the
     form permanently unsubmittable."""
     fn = _js_function((JS / "scrub.ts").read_text(), "const recognizeEvent")
-    assert "beginOcr();" in fn, fn
+    assert "beginOcr(selection);" in fn, fn
     assert "await recognize(" in fn, fn
-    assert re.search(r"finally\s*\{\s*endOcr\(\);", fn), fn
+    assert re.search(r"finally\s*\{\s*endOcr\(selection\);", fn), fn
     # ...and the release is inside the same function, after the loop.
     assert (
-        fn.index("beginOcr();") < fn.index("await recognize(") < fn.index("endOcr();")
+        fn.index("beginOcr(selection);")
+        < fn.index("await recognize(")
+        < fn.index("endOcr(selection);")
     )
 
 
@@ -308,7 +312,7 @@ def test_a_superseded_batch_cannot_append_its_text():
     assert re.search(r"recognize\(\s*file\s*,\s*addTextForThisSelection\s*\)", fn), fn
     # ...and that wrapper drops writes once it is no longer the current pick.
     wrapper = fn[fn.index("addTextForThisSelection = ") :]
-    wrapper = wrapper[: wrapper.index("beginOcr()")]
+    wrapper = wrapper[: wrapper.index("beginOcr(")]
     assert "selection !== latestOcrSelection" in wrapper, wrapper
     assert wrapper.index("selection !== latestOcrSelection") < wrapper.index(
         "addText(text)"


### PR DESCRIPTION
Reading one photographed page takes several seconds and nothing on screen said so. The "we're still reading your file" box already existed, but the only thing that ever showed it was the submit gate, so a user who waited quietly saw an idle page. People retyped their denial by hand instead.

**What changes**

- The box appears the moment a file is picked and disappears when the latest selection finishes reading. "Latest" is deliberate: a user can pick files again while a batch is running, and `scrub.ts` drops every write from the superseded batch, so the indicator follows the batch whose text can actually land. `beginOcr`/`endOcr` take the selection number; a superseded batch finishing does not hide the box, and a superseded batch still running does not keep it up or tell the submit gate text is coming.
- The submit gate clears the box only when nothing is in flight. Before, a submit blocked on some other field with page one already in the textarea hid the indicator while later pages were still being read.
- It sits directly under the file picker, above the denial textarea. It used to live with the submit-gate messages below a 20-row textarea, so on a phone the person who had just picked a file saw nothing change, which was the original complaint. That also makes its "will appear below" wording true.
- It is no longer red. A new `.hidden-progress-message` class keeps the shared show/hide machinery and overrides only the colour.
- Copy is a first draft for Melanie and drops the em dash.

**Accepted, and said in the code and tests:** the box keeps `role="alert"` like its six siblings. Review pointed out these boxes are toggled by visibility on already-populated markup, which live regions do not reliably treat as a change; the proper fix (an exposed, empty region whose text is set on show) is a change to the shared pattern and belongs in its own PR. Also a layout call for Melanie: the submit gate toggles this same element, so a submit with empty text mid-read now shows the message near the picker rather than near the button.

**Tests.** `tests/async-unit/test_ocr_progress_indicator.py` pins the show, the selection recording, the guard order in `endOcr`, the gate branch, the placement, the colour by parsed RGB, the role, and the copy. Three assertions in `test_scrub_form_submit_gate.py` follow the new signature; their intent is unchanged. Full async-unit and async suites and tsc are green.

**Review.** Codex (gpt-6-astra, read-only sandbox), five rounds. Round 1 found three real lifecycle gaps (the gate hiding the box mid-read, overlapping selections contradicting each other, the role change) and a coverage gap; all fixed or accepted as above, each fix verified by applying Codex's scenario and watching it fail. Rounds 2 to 4: no production defect, coverage and false-failure fixes, plus the placement move. Round 5: nothing at the agreed threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYruQVRyBbFzUxy9YGcHTb