### PR TITLE
Build production bundles by default

### DIFF
--- a/fighthealthinsurance/static/js/package.json
+++ b/fighthealthinsurance/static/js/package.json
@@ -6,12 +6,13 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "webpack",
+    "build:dev": "NODE_ENV=development webpack",
     "build:analyze": "ANALYZE=true webpack",
     "watch": "npm-watch",
     "auto-fix": "prettier --write *.ts *.tsx"
   },
   "watch": {
-    "build": {
+    "build:dev": {
       "patterns": [
         "src"
       ],

--- a/fighthealthinsurance/static/js/webpack.config.js
+++ b/fighthealthinsurance/static/js/webpack.config.js
@@ -188,8 +188,16 @@ module.exports = async (env, argv) => {
         });
         compiler.hooks.afterEmit.tap('BuildModeMarker', (compilation) => {
           if (compilation.errors.length > 0) return;
-          fs.writeFileSync(marker, (isProduction ? 'production' : 'development') + '\n');
+          // The EFFECTIVE mode, not isProduction: `webpack --mode development`
+          // overrides the configured mode after this file has run, and the
+          // marker has to describe what was actually built (review).
+          const mode = compiler.options.mode === 'production' ? 'production' : 'development';
+          fs.writeFileSync(marker, mode + '\n');
         });
+        // Not covered, on purpose: two webpack processes writing this dist/ at
+        // once. They corrupt the bundles themselves, marker or not, so
+        // concurrent builds in one working tree are unsupported, and
+        // build_static.sh runs one build at a time.
       },
     },
     ...(shouldAnalyze ? [

--- a/fighthealthinsurance/static/js/webpack.config.js
+++ b/fighthealthinsurance/static/js/webpack.config.js
@@ -56,9 +56,20 @@ try {
 // console.log/info/debug as a defense against logging PHI to the browser
 // console. Defaulting the other way means the safe build is the one you get
 // by accident. `npm run build:dev` (or NODE_ENV=development) opts out.
-const isProduction = process.env.NODE_ENV !== 'development';
+// isProduction is decided INSIDE the exported function, from the CLI's --mode
+// when one is given, so see below.
 
 module.exports = async (env, argv) => {
+  // One source of truth for mode, optimization and the BUILD_MODE marker.
+  // `webpack --mode X` overrides the configured mode after this file has
+  // run, so if this flag came only from NODE_ENV the two could disagree:
+  // `NODE_ENV=development npm run build -- --mode production` produced
+  // production-mode bundles WITHOUT the pure_funcs console stripping, under
+  // a marker that said production (review). When the CLI passes a mode, it
+  // decides; otherwise production unless NODE_ENV=development.
+  const isProduction = argv && argv.mode
+    ? argv.mode === 'production'
+    : process.env.NODE_ENV !== 'development';
   // Load ESM-only plugins with dynamic import()
   const [{ default: remarkGfm }, { default: rehypeHighlight }] = await Promise.all([
     import('remark-gfm'),

--- a/fighthealthinsurance/static/js/webpack.config.js
+++ b/fighthealthinsurance/static/js/webpack.config.js
@@ -173,11 +173,22 @@ module.exports = async (env, argv) => {
     // next build_static.sh would skip webpack and collect it (review).
     {
       apply(compiler) {
-        compiler.hooks.afterEmit.tap('BuildModeMarker', () => {
-          fs.writeFileSync(
-            path.resolve(__dirname, 'dist', 'BUILD_MODE'),
-            (isProduction ? 'production' : 'development') + '\n'
-          );
+        const marker = path.resolve(__dirname, 'dist', 'BUILD_MODE');
+        // Invalidate first, write last. An interrupted or failed build must
+        // not leave the previous mode's marker next to partially overwritten
+        // output, or build_static.sh would trust it and skip the rebuild
+        // (review). So the marker is removed before every compilation and
+        // written back only after an error-free emit.
+        compiler.hooks.beforeCompile.tap('BuildModeMarker', () => {
+          try {
+            fs.unlinkSync(marker);
+          } catch (e) {
+            if (e.code !== 'ENOENT') throw e;
+          }
+        });
+        compiler.hooks.afterEmit.tap('BuildModeMarker', (compilation) => {
+          if (compilation.errors.length > 0) return;
+          fs.writeFileSync(marker, (isProduction ? 'production' : 'development') + '\n');
         });
       },
     },

--- a/fighthealthinsurance/static/js/webpack.config.js
+++ b/fighthealthinsurance/static/js/webpack.config.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const fs = require('fs');
 const glob = require('glob');
 const TerserPlugin = require('terser-webpack-plugin');
 const CopyPlugin = require('copy-webpack-plugin');
@@ -60,13 +59,16 @@ try {
 // when one is given, so see below.
 
 module.exports = async (env, argv) => {
-  // One source of truth for mode, optimization and the BUILD_MODE marker.
+  // One source of truth for mode and optimization.
   // `webpack --mode X` overrides the configured mode after this file has
   // run, so if this flag came only from NODE_ENV the two could disagree:
   // `NODE_ENV=development npm run build -- --mode production` produced
   // production-mode bundles WITHOUT the pure_funcs console stripping, under
   // a marker that said production (review). When the CLI passes a mode, it
   // decides; otherwise production unless NODE_ENV=development.
+  // Whether dist/ still holds what the deploy build produced is not this
+  // file's problem: scripts/build_static.sh fingerprints its own output and
+  // rebuilds when the bundles changed underneath it, whoever changed them.
   const isProduction = argv && argv.mode
     ? argv.mode === 'production'
     : process.env.NODE_ENV !== 'development';
@@ -177,40 +179,6 @@ module.exports = async (env, argv) => {
   // Plugins - the worker asset copy always; the bundle analyzer on request
   plugins: [
     new CopyPlugin({ patterns: workerAssets }),
-    // Record which mode produced dist/, so scripts/build_static.sh can tell a
-    // production build from a development one. Its cache keys on source
-    // checksums only, so without this an `npm run build:dev` in between would
-    // leave development output in place under an unchanged checksum and the
-    // next build_static.sh would skip webpack and collect it (review).
-    {
-      apply(compiler) {
-        const marker = path.resolve(__dirname, 'dist', 'BUILD_MODE');
-        // Invalidate first, write last. An interrupted or failed build must
-        // not leave the previous mode's marker next to partially overwritten
-        // output, or build_static.sh would trust it and skip the rebuild
-        // (review). So the marker is removed before every compilation and
-        // written back only after an error-free emit.
-        compiler.hooks.beforeCompile.tap('BuildModeMarker', () => {
-          try {
-            fs.unlinkSync(marker);
-          } catch (e) {
-            if (e.code !== 'ENOENT') throw e;
-          }
-        });
-        compiler.hooks.afterEmit.tap('BuildModeMarker', (compilation) => {
-          if (compilation.errors.length > 0) return;
-          // The EFFECTIVE mode, not isProduction: `webpack --mode development`
-          // overrides the configured mode after this file has run, and the
-          // marker has to describe what was actually built (review).
-          const mode = compiler.options.mode === 'production' ? 'production' : 'development';
-          fs.writeFileSync(marker, mode + '\n');
-        });
-        // Not covered, on purpose: two webpack processes writing this dist/ at
-        // once. They corrupt the bundles themselves, marker or not, so
-        // concurrent builds in one working tree are unsupported, and
-        // build_static.sh runs one build at a time.
-      },
-    },
     ...(shouldAnalyze ? [
       new BundleAnalyzerPlugin({
         analyzerMode: 'static',

--- a/fighthealthinsurance/static/js/webpack.config.js
+++ b/fighthealthinsurance/static/js/webpack.config.js
@@ -44,7 +44,18 @@ try {
 }
 
 // Determine if we're in production mode
-const isProduction = process.env.NODE_ENV === 'production';
+// Production unless a developer explicitly asks for a development build.
+//
+// This used to test for NODE_ENV === 'production', and nothing in the repo
+// ever set it: not `npm run build`, not scripts/ci_npm_build.sh,
+// build_static.sh or setup_templates.sh, not the CI workflow. So every build,
+// including the one collected into the deployed image, was a development
+// bundle: unminified, about 3.5x the size, and -- the part that matters --
+// skipping the optimization block below, whose Terser pure_funcs strip
+// console.log/info/debug as a defense against logging PHI to the browser
+// console. Defaulting the other way means the safe build is the one you get
+// by accident. `npm run build:dev` (or NODE_ENV=development) opts out.
+const isProduction = process.env.NODE_ENV !== 'development';
 
 module.exports = async (env, argv) => {
   // Load ESM-only plugins with dynamic import()

--- a/fighthealthinsurance/static/js/webpack.config.js
+++ b/fighthealthinsurance/static/js/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const fs = require('fs');
 const glob = require('glob');
 const TerserPlugin = require('terser-webpack-plugin');
 const CopyPlugin = require('copy-webpack-plugin');
@@ -165,6 +166,21 @@ module.exports = async (env, argv) => {
   // Plugins - the worker asset copy always; the bundle analyzer on request
   plugins: [
     new CopyPlugin({ patterns: workerAssets }),
+    // Record which mode produced dist/, so scripts/build_static.sh can tell a
+    // production build from a development one. Its cache keys on source
+    // checksums only, so without this an `npm run build:dev` in between would
+    // leave development output in place under an unchanged checksum and the
+    // next build_static.sh would skip webpack and collect it (review).
+    {
+      apply(compiler) {
+        compiler.hooks.afterEmit.tap('BuildModeMarker', () => {
+          fs.writeFileSync(
+            path.resolve(__dirname, 'dist', 'BUILD_MODE'),
+            (isProduction ? 'production' : 'development') + '\n'
+          );
+        });
+      },
+    },
     ...(shouldAnalyze ? [
       new BundleAnalyzerPlugin({
         analyzerMode: 'static',

--- a/scripts/build_static.sh
+++ b/scripts/build_static.sh
@@ -54,18 +54,25 @@ if [ -d "${JS_PATH}" ]; then
     STORED_JS_CHECKSUM=$(cat "$JS_CHECKSUM_FILE")
   fi
 
-  # The checksum covers sources, not the build mode. A `npm run build:dev`
-  # in between leaves development output (unminified, console.log intact)
-  # under an unchanged checksum, so also require the BUILD_MODE marker that
-  # webpack writes into dist/ to name the mode this run wants (review).
+  # The source checksum says whether a rebuild is NEEDED. It says nothing
+  # about whether dist/ still holds what this script last built: anything run
+  # in between (`npm run build:dev`, a `--mode` or `--no-optimization-minimize`
+  # override, an interrupted build) rewrites bundles under an unchanged
+  # source checksum. A marker written by webpack is only a claim by whoever
+  # ran webpack, so the stored key instead carries the build mode this run
+  # wants and a fingerprint of the bundles as they were when this script
+  # last built them. The skip requires all three to match (review).
   EXPECTED_BUILD_MODE=production
   if [ "${NODE_ENV:-}" = "development" ]; then
     EXPECTED_BUILD_MODE=development
   fi
-  BUILT_MODE=$(cat "${JS_PATH}/dist/BUILD_MODE" 2>/dev/null || true)
+  dist_fingerprint() {
+    find "${JS_PATH}/dist" -maxdepth 1 -type f -name "*.bundle.js" -exec md5sum {} \; 2>/dev/null | sort | md5sum | cut -d ' ' -f 1
+  }
+  CURRENT_BUILD_KEY="${CURRENT_JS_CHECKSUM}:${EXPECTED_BUILD_MODE}:$(dist_fingerprint)"
 
-  if [ "$CURRENT_JS_CHECKSUM" = "$STORED_JS_CHECKSUM" ] && [ -d "${JS_PATH}/dist" ] && [ "$BUILT_MODE" = "$EXPECTED_BUILD_MODE" ]; then
-    echo "JavaScript source files unchanged and dist is a ${BUILT_MODE} build, skipping build..."
+  if [ "$CURRENT_BUILD_KEY" = "$STORED_JS_CHECKSUM" ] && [ -d "${JS_PATH}/dist" ]; then
+    echo "JavaScript sources unchanged and dist matches the last ${EXPECTED_BUILD_MODE} build, skipping build..."
     SKIP_JS_BUILD=true
   fi
 fi
@@ -83,9 +90,10 @@ if [ "$SKIP_JS_BUILD" = false ]; then
   npm run build
   popd
 
-  # Save the checksum after successful build
+  # Save the key after a successful build: sources, the mode built, and the
+  # fingerprint of the bundles that build produced.
   if [ -n "$CURRENT_JS_CHECKSUM" ]; then
-    echo "$CURRENT_JS_CHECKSUM" > "$JS_CHECKSUM_FILE"
+    echo "${CURRENT_JS_CHECKSUM}:${EXPECTED_BUILD_MODE}:$(dist_fingerprint)" > "$JS_CHECKSUM_FILE"
   fi
 else
   set -ex

--- a/scripts/build_static.sh
+++ b/scripts/build_static.sh
@@ -54,8 +54,18 @@ if [ -d "${JS_PATH}" ]; then
     STORED_JS_CHECKSUM=$(cat "$JS_CHECKSUM_FILE")
   fi
 
-  if [ "$CURRENT_JS_CHECKSUM" = "$STORED_JS_CHECKSUM" ] && [ -d "${JS_PATH}/dist" ]; then
-    echo "JavaScript source files unchanged, skipping build..."
+  # The checksum covers sources, not the build mode. A `npm run build:dev`
+  # in between leaves development output (unminified, console.log intact)
+  # under an unchanged checksum, so also require the BUILD_MODE marker that
+  # webpack writes into dist/ to name the mode this run wants (review).
+  EXPECTED_BUILD_MODE=production
+  if [ "${NODE_ENV:-}" = "development" ]; then
+    EXPECTED_BUILD_MODE=development
+  fi
+  BUILT_MODE=$(cat "${JS_PATH}/dist/BUILD_MODE" 2>/dev/null || true)
+
+  if [ "$CURRENT_JS_CHECKSUM" = "$STORED_JS_CHECKSUM" ] && [ -d "${JS_PATH}/dist" ] && [ "$BUILT_MODE" = "$EXPECTED_BUILD_MODE" ]; then
+    echo "JavaScript source files unchanged and dist is a ${BUILT_MODE} build, skipping build..."
     SKIP_JS_BUILD=true
   fi
 fi

--- a/scripts/build_static.sh
+++ b/scripts/build_static.sh
@@ -66,8 +66,12 @@ if [ -d "${JS_PATH}" ]; then
   if [ "${NODE_ENV:-}" = "development" ]; then
     EXPECTED_BUILD_MODE=development
   fi
+  # Every file under dist/, recursively: the bundles, but also the worker
+  # scripts, the wasm, the .mjs and the source maps that collectstatic ships
+  # and the pages load by URL. A missing worker with untouched bundles used
+  # to pass the check and then break PDF uploads (review).
   dist_fingerprint() {
-    find "${JS_PATH}/dist" -maxdepth 1 -type f -name "*.bundle.js" -exec md5sum {} \; 2>/dev/null | sort | md5sum | cut -d ' ' -f 1
+    find "${JS_PATH}/dist" -type f -exec md5sum {} \; 2>/dev/null | sort | md5sum | cut -d ' ' -f 1
   }
   CURRENT_BUILD_KEY="${CURRENT_JS_CHECKSUM}:${EXPECTED_BUILD_MODE}:$(dist_fingerprint)"
 

--- a/scripts/build_static.sh
+++ b/scripts/build_static.sh
@@ -70,12 +70,20 @@ if [ -d "${JS_PATH}" ]; then
   # scripts, the wasm, the .mjs and the source maps that collectstatic ships
   # and the pages load by URL. A missing worker with untouched bundles used
   # to pass the check and then break PDF uploads (review).
+  # -H: follow dist/ itself if it is a symlink. Without it, find examines the
+  # link rather than the directory, the fingerprint becomes the hash of
+  # nothing, and a stale key matches forever (review).
   dist_fingerprint() {
-    find "${JS_PATH}/dist" -type f -exec md5sum {} \; 2>/dev/null | sort | md5sum | cut -d ' ' -f 1
+    find -H "${JS_PATH}/dist" -type f -exec md5sum {} \; 2>/dev/null | sort | md5sum | cut -d ' ' -f 1
+  }
+  # A dist/ with no files in it (missing, empty, unreadable, a dangling
+  # link) is never something to skip a build for, whatever the key says.
+  dist_has_files() {
+    [ -n "$(find -H "${JS_PATH}/dist" -type f -print -quit 2>/dev/null)" ]
   }
   CURRENT_BUILD_KEY="${CURRENT_JS_CHECKSUM}:${EXPECTED_BUILD_MODE}:$(dist_fingerprint)"
 
-  if [ "$CURRENT_BUILD_KEY" = "$STORED_JS_CHECKSUM" ] && [ -d "${JS_PATH}/dist" ]; then
+  if [ "$CURRENT_BUILD_KEY" = "$STORED_JS_CHECKSUM" ] && dist_has_files; then
     echo "JavaScript sources unchanged and dist matches the last ${EXPECTED_BUILD_MODE} build, skipping build..."
     SKIP_JS_BUILD=true
   fi

--- a/tests/async-unit/test_production_bundle_default.py
+++ b/tests/async-unit/test_production_bundle_default.py
@@ -120,11 +120,19 @@ def test_cache_key_covers_mode_and_the_bundles_actually_in_dist():
         sh,
         re.S,
     ), "build_static.sh no longer expects development only when NODE_ENV=development"
-    assert re.search(
-        r"dist_fingerprint\(\)\s*\{.*?find\s+\"\$\{JS_PATH\}/dist\".*?-name\s+\"\*\.bundle\.js\".*?md5sum",
-        sh,
-        re.S,
-    ), "the dist fingerprint no longer hashes the bundles in dist/"
+    fp = re.search(r"dist_fingerprint\(\)\s*\{(.*?)\n\s*\}", sh, re.S)
+    assert fp is not None, "dist_fingerprint is gone from build_static.sh"
+    body = fp.group(1)
+    assert re.search(r"find\s+\"\$\{JS_PATH\}/dist\".*?-type\s+f.*?md5sum", body, re.S), (
+        "the dist fingerprint no longer hashes the files in dist/"
+    )
+    # Recursive and unfiltered: workers/, the wasm, .mjs and .map files ship
+    # too, and a missing worker with untouched bundles broke PDF uploads
+    # while the narrower fingerprint still matched (review).
+    assert "-maxdepth" not in body and "-name" not in body, (
+        "the dist fingerprint is restricted again; it must cover every file "
+        "under dist/, recursively"
+    )
     assert re.search(
         r"CURRENT_BUILD_KEY=\"\$\{CURRENT_JS_CHECKSUM\}:\$\{EXPECTED_BUILD_MODE\}:\$\(dist_fingerprint\)\"",
         sh,

--- a/tests/async-unit/test_production_bundle_default.py
+++ b/tests/async-unit/test_production_bundle_default.py
@@ -1,0 +1,53 @@
+"""The webpack build must be a production build unless a developer opts out.
+
+For as long as the config tested ``NODE_ENV === 'production'``, nothing set it:
+not ``npm run build``, not any of the three build scripts, not CI. So every
+build, including the one collected into the deployed image, was a development
+bundle: unminified, about three times the size, and skipping the optimization
+block whose Terser ``pure_funcs`` strip ``console.log/info/debug`` as a defense
+against logging PHI to the browser console.
+
+The default is now production; ``npm run build:dev`` opts out. These pin both
+halves so the safe build stays the one you get by accident.
+"""
+
+import json
+import pathlib
+import re
+
+JS = pathlib.Path(__file__).resolve().parents[2] / "fighthealthinsurance" / "static" / "js"
+
+
+def _webpack_config() -> str:
+    return (JS / "webpack.config.js").read_text()
+
+
+def _scripts() -> dict:
+    return json.loads((JS / "package.json").read_text())["scripts"]
+
+
+def test_production_is_the_default_mode():
+    src = _webpack_config()
+    assert re.search(
+        r"const\s+isProduction\s*=\s*process\.env\.NODE_ENV\s*!==\s*['\"]development['\"]\s*;",
+        src,
+    ), "isProduction no longer defaults to true; the deployed bundle is a dev build again"
+    assert not re.search(
+        r"isProduction\s*=\s*process\.env\.NODE_ENV\s*===\s*['\"]production['\"]",
+        src,
+    ), "the opt-in production test is back; nothing in the repo sets NODE_ENV=production"
+
+
+def test_developers_can_still_opt_out():
+    scripts = _scripts()
+    assert "build:dev" in scripts, "npm run build:dev is gone"
+    assert "NODE_ENV=development" in scripts["build:dev"], scripts["build:dev"]
+
+
+def test_console_stripping_still_covers_the_chatty_levels():
+    """The PHI defense is the reason production mode matters; keep it intact."""
+    src = _webpack_config()
+    m = re.search(r"pure_funcs\s*:\s*\[([^\]]*)\]", src)
+    assert m is not None, "the Terser pure_funcs list is gone"
+    listed = set(re.findall(r"['\"]([\w.]+)['\"]", m.group(1)))
+    assert {"console.log", "console.info", "console.debug"} <= listed, listed

--- a/tests/async-unit/test_production_bundle_default.py
+++ b/tests/async-unit/test_production_bundle_default.py
@@ -99,45 +99,18 @@ def test_console_stripping_covers_exactly_the_chatty_levels():
     assert listed == {"console.log", "console.info", "console.debug"}, listed
 
 
-def test_build_marks_its_mode_and_the_cache_checks_it():
-    """build_static.sh must not reuse a dist built in a different mode.
+def test_cache_key_covers_mode_and_the_bundles_actually_in_dist():
+    """build_static.sh must not reuse bundles it did not produce.
 
-    webpack removes dist/BUILD_MODE before every compilation and writes it
-    back, with the real mode, only after an error-free emit, so an
-    interrupted or failed build leaves no marker. build_static.sh wants
-    production unless NODE_ENV=development, and skips only when the marker
-    says so (review). Regexes tolerate wrapping and quote style; they pin
-    the values and the wiring, not the formatting.
+    Any intervening build (`build:dev`, a CLI `--mode` or
+    `--no-optimization-minimize` override, an interrupted run) rewrites
+    bundles under an unchanged source checksum, and a marker written by
+    webpack is only a claim by whoever ran webpack. So the stored key is
+    source checksum + wanted mode + a fingerprint of dist/*.bundle.js, saved
+    after this script's own successful build, and the skip requires the
+    whole key to match (review). Regexes tolerate wrapping; they pin the
+    shape and the wiring, not the formatting.
     """
-    src = _webpack_config()
-    q = r"['\"]"
-    assert re.search(
-        r"path\.resolve\(\s*__dirname\s*,\s*" + q + r"dist" + q + r"\s*,\s*" + q + r"BUILD_MODE" + q + r"\s*\)",
-        src,
-        re.S,
-    ), "the marker is no longer dist/BUILD_MODE"
-    assert re.search(r"beforeCompile\.tap\(\s*" + q + r"BuildModeMarker", src, re.S) and re.search(
-        r"unlinkSync\(\s*marker\s*\)", src
-    ), "the marker is no longer removed before compilation"
-    assert re.search(
-        r"afterEmit\.tap\(\s*" + q + r"BuildModeMarker.*?compilation\.errors\.length\s*>\s*0\s*\)\s*return",
-        src,
-        re.S,
-    ), "the marker is written even when the compilation had errors"
-    # The marker must come from the compiler's EFFECTIVE mode, not from the
-    # isProduction flag: `webpack --mode development` overrides the configured
-    # mode after the config has run (review). A hardcoded value, or one
-    # derived from the flag, would let a development build pass as production.
-    assert re.search(
-        r"compiler\.options\.mode\s*===\s*" + q + r"production" + q
-        + r"\s*\?\s*" + q + r"production" + q + r"\s*:\s*" + q + r"development" + q,
-        src,
-        re.S,
-    ), "the marker no longer records the compiler's effective mode"
-    assert re.search(r"writeFileSync\(\s*marker\s*,\s*mode\s*\+", src, re.S), (
-        "the marker is no longer written from the effective mode"
-    )
-
     sh = (JS.parents[2] / "scripts" / "build_static.sh").read_text()
     assert re.search(r"^\s*EXPECTED_BUILD_MODE=production\s*$", sh, re.M), (
         "build_static.sh no longer expects production by default"
@@ -147,11 +120,26 @@ def test_build_marks_its_mode_and_the_cache_checks_it():
         sh,
         re.S,
     ), "build_static.sh no longer expects development only when NODE_ENV=development"
-    assert re.search(r"BUILT_MODE=\$\(cat\s+\"\$\{JS_PATH\}/dist/BUILD_MODE\"", sh), (
-        "build_static.sh no longer reads dist/BUILD_MODE"
-    )
     assert re.search(
-        r"\"\$CURRENT_JS_CHECKSUM\"\s*=\s*\"\$STORED_JS_CHECKSUM\".*?\"\$BUILT_MODE\"\s*=\s*\"\$EXPECTED_BUILD_MODE\"",
+        r"dist_fingerprint\(\)\s*\{.*?find\s+\"\$\{JS_PATH\}/dist\".*?-name\s+\"\*\.bundle\.js\".*?md5sum",
         sh,
         re.S,
-    ), "the cache skip no longer requires the built mode to match"
+    ), "the dist fingerprint no longer hashes the bundles in dist/"
+    assert re.search(
+        r"CURRENT_BUILD_KEY=\"\$\{CURRENT_JS_CHECKSUM\}:\$\{EXPECTED_BUILD_MODE\}:\$\(dist_fingerprint\)\"",
+        sh,
+    ), "the cache key no longer combines sources, mode and the dist fingerprint"
+    assert re.search(
+        r"\[\s*\"\$CURRENT_BUILD_KEY\"\s*=\s*\"\$STORED_JS_CHECKSUM\"\s*\].*?SKIP_JS_BUILD=true",
+        sh,
+        re.S,
+    ), "the skip no longer requires the whole key to match"
+    assert re.search(
+        r"echo\s+\"\$\{CURRENT_JS_CHECKSUM\}:\$\{EXPECTED_BUILD_MODE\}:\$\(dist_fingerprint\)\"\s*>\s*\"\$JS_CHECKSUM_FILE\"",
+        sh,
+    ), "the saved key no longer records the mode and fingerprint of the build just made"
+    src = _webpack_config()
+    assert "BUILD_MODE" not in src, (
+        "a webpack-written build-mode marker is back; it is only a claim by "
+        "whoever ran webpack, and the cache must validate output instead"
+    )

--- a/tests/async-unit/test_production_bundle_default.py
+++ b/tests/async-unit/test_production_bundle_default.py
@@ -44,10 +44,68 @@ def test_developers_can_still_opt_out():
     assert "NODE_ENV=development" in scripts["build:dev"], scripts["build:dev"]
 
 
-def test_console_stripping_still_covers_the_chatty_levels():
-    """The PHI defense is the reason production mode matters; keep it intact."""
+def _brace_block(src: str, open_at: int) -> str:
+    assert src[open_at] == "{", src[open_at : open_at + 20]
+    depth = 0
+    for i in range(open_at, len(src)):
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[open_at : i + 1]
+    raise AssertionError("unbalanced braces")
+
+
+def test_mode_and_optimization_are_wired_to_the_flag():
+    """A correct flag that nothing consumes is no fix (review).
+
+    A hardcoded mode, or an optimization block kept as text but no longer
+    conditional on the flag, would ship development output again with the
+    default test above still green.
+    """
     src = _webpack_config()
-    m = re.search(r"pure_funcs\s*:\s*\[([^\]]*)\]", src)
-    assert m is not None, "the Terser pure_funcs list is gone"
+    assert re.search(
+        r"mode\s*:\s*isProduction\s*\?\s*['\"]production['\"]\s*:\s*['\"]development['\"]",
+        src,
+    ), "webpack mode is no longer selected by isProduction"
+    assert re.search(r"optimization\s*:\s*isProduction\s*\?\s*\{", src), (
+        "the optimization block is no longer conditional on isProduction"
+    )
+
+
+def test_console_stripping_covers_exactly_the_chatty_levels():
+    """The PHI defense is the reason production mode matters; keep it intact.
+
+    Exactly log/info/debug: warn and error stay, on purpose, so production
+    issues remain debuggable. The list must live inside the optimization
+    block, where it is actually consumed.
+    """
+    src = _webpack_config()
+    opt = re.search(r"optimization\s*:\s*isProduction\s*\?\s*\{", src)
+    assert opt is not None
+    block = _brace_block(src, opt.end() - 1)
+    m = re.search(r"pure_funcs\s*:\s*\[([^\]]*)\]", block)
+    assert m is not None, "the Terser pure_funcs list is gone from the optimization block"
     listed = set(re.findall(r"['\"]([\w.]+)['\"]", m.group(1)))
-    assert {"console.log", "console.info", "console.debug"} <= listed, listed
+    assert listed == {"console.log", "console.info", "console.debug"}, listed
+
+
+def test_build_marks_its_mode_and_the_cache_checks_it():
+    """build_static.sh must not reuse a development dist under a matching checksum.
+
+    webpack writes dist/BUILD_MODE after emit; the cache skip requires it to
+    name the mode this run wants (review).
+    """
+    src = _webpack_config()
+    assert "BuildModeMarker" in src and "'dist', 'BUILD_MODE'" in src, (
+        "webpack no longer records the build mode in dist/BUILD_MODE"
+    )
+    sh = (JS.parents[2] / "scripts" / "build_static.sh").read_text()
+    assert 'BUILT_MODE=$(cat "${JS_PATH}/dist/BUILD_MODE"' in sh, (
+        "build_static.sh no longer reads dist/BUILD_MODE"
+    )
+    assert re.search(
+        r'\[ "\$CURRENT_JS_CHECKSUM" = "\$STORED_JS_CHECKSUM" \].*\[ "\$BUILT_MODE" = "\$EXPECTED_BUILD_MODE" \]',
+        sh,
+    ), "the cache skip no longer requires the built mode to match"

--- a/tests/async-unit/test_production_bundle_default.py
+++ b/tests/async-unit/test_production_bundle_default.py
@@ -116,12 +116,19 @@ def test_build_marks_its_mode_and_the_cache_checks_it():
         src,
         re.S,
     ), "the marker is written even when the compilation had errors"
+    # The marker must come from the compiler's EFFECTIVE mode, not from the
+    # isProduction flag: `webpack --mode development` overrides the configured
+    # mode after the config has run (review). A hardcoded value, or one
+    # derived from the flag, would let a development build pass as production.
     assert re.search(
-        r"writeFileSync\(\s*marker\s*,\s*\(\s*isProduction\s*\?\s*" + q + r"production" + q
-        + r"\s*:\s*" + q + r"development" + q + r"\s*\)",
+        r"compiler\.options\.mode\s*===\s*" + q + r"production" + q
+        + r"\s*\?\s*" + q + r"production" + q + r"\s*:\s*" + q + r"development" + q,
         src,
         re.S,
-    ), "the marker no longer records the real mode (a hardcoded value would let a dev build pass as production)"
+    ), "the marker no longer records the compiler's effective mode"
+    assert re.search(r"writeFileSync\(\s*marker\s*,\s*mode\s*\+", src, re.S), (
+        "the marker is no longer written from the effective mode"
+    )
 
     sh = (JS.parents[2] / "scripts" / "build_static.sh").read_text()
     assert re.search(r"^\s*EXPECTED_BUILD_MODE=production\s*$", sh, re.M), (

--- a/tests/async-unit/test_production_bundle_default.py
+++ b/tests/async-unit/test_production_bundle_default.py
@@ -99,19 +99,22 @@ def test_console_stripping_covers_exactly_the_chatty_levels():
     assert listed == {"console.log", "console.info", "console.debug"}, listed
 
 
-def test_cache_key_covers_mode_and_the_bundles_actually_in_dist():
-    """build_static.sh must not reuse bundles it did not produce.
+def _build_static_sh() -> str:
+    return (JS.parents[2] / "scripts" / "build_static.sh").read_text()
 
-    Any intervening build (`build:dev`, a CLI `--mode` or
-    `--no-optimization-minimize` override, an interrupted run) rewrites
-    bundles under an unchanged source checksum, and a marker written by
-    webpack is only a claim by whoever ran webpack. So the stored key is
-    source checksum + wanted mode + a fingerprint of dist/*.bundle.js, saved
-    after this script's own successful build, and the skip requires the
-    whole key to match (review). Regexes tolerate wrapping; they pin the
-    shape and the wiring, not the formatting.
-    """
-    sh = (JS.parents[2] / "scripts" / "build_static.sh").read_text()
+
+# build_static.sh must not reuse bundles it did not produce. Any intervening
+# build (`build:dev`, a CLI `--mode` or `--no-optimization-minimize` override,
+# an interrupted run) rewrites bundles under an unchanged source checksum, and
+# a marker written by webpack is only a claim by whoever ran webpack. So the
+# stored key is source checksum + wanted mode + a fingerprint of every file
+# under dist/, saved after this script's own successful build, and the skip
+# requires the whole key to match. One contract per test below (second
+# reviewer); regexes tolerate wrapping and pin the wiring, not the formatting.
+
+
+def test_cache_expects_production_unless_development_is_asked_for():
+    sh = _build_static_sh()
     assert re.search(r"^\s*EXPECTED_BUILD_MODE=production\s*$", sh, re.M), (
         "build_static.sh no longer expects production by default"
     )
@@ -120,37 +123,56 @@ def test_cache_key_covers_mode_and_the_bundles_actually_in_dist():
         sh,
         re.S,
     ), "build_static.sh no longer expects development only when NODE_ENV=development"
+
+
+def test_dist_fingerprint_covers_every_file_recursively_following_a_linked_dist():
+    sh = _build_static_sh()
     fp = re.search(r"dist_fingerprint\(\)\s*\{(.*?)\n\s*\}", sh, re.S)
     assert fp is not None, "dist_fingerprint is gone from build_static.sh"
     body = fp.group(1)
     # -H so a symlinked dist/ is followed; without it the fingerprint is the
-    # hash of nothing and a stale key matches forever (review).
+    # hash of nothing and a stale key matches forever.
     assert re.search(r"find\s+-H\s+\"\$\{JS_PATH\}/dist\".*?-type\s+f.*?md5sum", body, re.S), (
         "the dist fingerprint no longer hashes the files in dist/ following a symlinked dist"
     )
-    assert re.search(r"dist_has_files\(\)\s*\{.*?find\s+-H\s+\"\$\{JS_PATH\}/dist\".*?-print\s+-quit", sh, re.S), (
-        "the empty-dist guard is gone"
-    )
     # Recursive and unfiltered: workers/, the wasm, .mjs and .map files ship
     # too, and a missing worker with untouched bundles broke PDF uploads
-    # while the narrower fingerprint still matched (review).
+    # while a narrower fingerprint still matched.
     assert "-maxdepth" not in body and "-name" not in body, (
         "the dist fingerprint is restricted again; it must cover every file "
         "under dist/, recursively"
     )
-    assert re.search(
-        r"CURRENT_BUILD_KEY=\"\$\{CURRENT_JS_CHECKSUM\}:\$\{EXPECTED_BUILD_MODE\}:\$\(dist_fingerprint\)\"",
-        sh,
-    ), "the cache key no longer combines sources, mode and the dist fingerprint"
+
+
+def test_an_empty_or_missing_dist_never_skips_the_build():
+    sh = _build_static_sh()
+    assert re.search(r"dist_has_files\(\)\s*\{.*?find\s+-H\s+\"\$\{JS_PATH\}/dist\".*?-print\s+-quit", sh, re.S), (
+        "the empty-dist guard is gone"
+    )
     assert re.search(
         r"\[\s*\"\$CURRENT_BUILD_KEY\"\s*=\s*\"\$STORED_JS_CHECKSUM\"\s*\]\s*&&\s*dist_has_files.*?SKIP_JS_BUILD=true",
         sh,
         re.S,
     ), "the skip no longer requires the whole key to match AND a non-empty dist/"
+
+
+def test_cache_key_combines_sources_mode_and_the_dist_fingerprint():
+    sh = _build_static_sh()
+    assert re.search(
+        r"CURRENT_BUILD_KEY=\"\$\{CURRENT_JS_CHECKSUM\}:\$\{EXPECTED_BUILD_MODE\}:\$\(dist_fingerprint\)\"",
+        sh,
+    ), "the cache key no longer combines sources, mode and the dist fingerprint"
+
+
+def test_the_saved_key_records_the_build_just_made():
+    sh = _build_static_sh()
     assert re.search(
         r"echo\s+\"\$\{CURRENT_JS_CHECKSUM\}:\$\{EXPECTED_BUILD_MODE\}:\$\(dist_fingerprint\)\"\s*>\s*\"\$JS_CHECKSUM_FILE\"",
         sh,
     ), "the saved key no longer records the mode and fingerprint of the build just made"
+
+
+def test_no_webpack_written_build_mode_marker():
     src = _webpack_config()
     assert "BUILD_MODE" not in src, (
         "a webpack-written build-mode marker is back; it is only a claim by "

--- a/tests/async-unit/test_production_bundle_default.py
+++ b/tests/async-unit/test_production_bundle_default.py
@@ -65,19 +65,21 @@ def _brace_block(src: str, open_at: int) -> str:
     raise AssertionError("unbalanced braces")
 
 
-def test_mode_and_optimization_are_wired_to_the_flag():
-    """A correct flag that nothing consumes is no fix (review).
+# A correct flag that nothing consumes is no fix (review): a hardcoded mode,
+# or an optimization block kept as text but no longer conditional on the
+# flag, would ship development output again with the default test above
+# still green. One contract per test (second reviewer).
 
-    A hardcoded mode, or an optimization block kept as text but no longer
-    conditional on the flag, would ship development output again with the
-    default test above still green.
-    """
-    src = _webpack_config()
+
+def test_mode_is_selected_by_the_flag():
     assert re.search(
         r"mode\s*:\s*isProduction\s*\?\s*['\"]production['\"]\s*:\s*['\"]development['\"]",
-        src,
+        _webpack_config(),
     ), "webpack mode is no longer selected by isProduction"
-    assert re.search(r"optimization\s*:\s*isProduction\s*\?\s*\{", src), (
+
+
+def test_the_optimization_block_is_conditional_on_the_flag():
+    assert re.search(r"optimization\s*:\s*isProduction\s*\?\s*\{", _webpack_config()), (
         "the optimization block is no longer conditional on isProduction"
     )
 
@@ -125,33 +127,43 @@ def test_cache_expects_production_unless_development_is_asked_for():
     ), "build_static.sh no longer expects development only when NODE_ENV=development"
 
 
-def test_dist_fingerprint_covers_every_file_recursively_following_a_linked_dist():
-    sh = _build_static_sh()
-    fp = re.search(r"dist_fingerprint\(\)\s*\{(.*?)\n\s*\}", sh, re.S)
+def _dist_fingerprint_body() -> str:
+    fp = re.search(r"dist_fingerprint\(\)\s*\{(.*?)\n\s*\}", _build_static_sh(), re.S)
     assert fp is not None, "dist_fingerprint is gone from build_static.sh"
-    body = fp.group(1)
+    return fp.group(1)
+
+
+def test_dist_fingerprint_follows_a_linked_dist():
     # -H so a symlinked dist/ is followed; without it the fingerprint is the
     # hash of nothing and a stale key matches forever.
-    assert re.search(r"find\s+-H\s+\"\$\{JS_PATH\}/dist\".*?-type\s+f.*?md5sum", body, re.S), (
-        "the dist fingerprint no longer hashes the files in dist/ following a symlinked dist"
-    )
-    # Recursive and unfiltered: workers/, the wasm, .mjs and .map files ship
-    # too, and a missing worker with untouched bundles broke PDF uploads
-    # while a narrower fingerprint still matched.
+    assert re.search(
+        r"find\s+-H\s+\"\$\{JS_PATH\}/dist\".*?-type\s+f.*?md5sum", _dist_fingerprint_body(), re.S
+    ), "the dist fingerprint no longer hashes the files in dist/ following a symlinked dist"
+
+
+def test_dist_fingerprint_is_recursive_and_unfiltered():
+    # workers/, the wasm, .mjs and .map files ship too, and a missing worker
+    # with untouched bundles broke PDF uploads while a narrower fingerprint
+    # still matched.
+    body = _dist_fingerprint_body()
     assert "-maxdepth" not in body and "-name" not in body, (
         "the dist fingerprint is restricted again; it must cover every file "
         "under dist/, recursively"
     )
 
 
-def test_an_empty_or_missing_dist_never_skips_the_build():
-    sh = _build_static_sh()
-    assert re.search(r"dist_has_files\(\)\s*\{.*?find\s+-H\s+\"\$\{JS_PATH\}/dist\".*?-print\s+-quit", sh, re.S), (
-        "the empty-dist guard is gone"
-    )
+def test_the_empty_dist_guard_looks_for_a_real_file():
+    assert re.search(
+        r"dist_has_files\(\)\s*\{.*?find\s+-H\s+\"\$\{JS_PATH\}/dist\".*?-print\s+-quit",
+        _build_static_sh(),
+        re.S,
+    ), "the empty-dist guard is gone"
+
+
+def test_the_skip_requires_the_whole_key_and_a_non_empty_dist():
     assert re.search(
         r"\[\s*\"\$CURRENT_BUILD_KEY\"\s*=\s*\"\$STORED_JS_CHECKSUM\"\s*\]\s*&&\s*dist_has_files.*?SKIP_JS_BUILD=true",
-        sh,
+        _build_static_sh(),
         re.S,
     ), "the skip no longer requires the whole key to match AND a non-empty dist/"
 

--- a/tests/async-unit/test_production_bundle_default.py
+++ b/tests/async-unit/test_production_bundle_default.py
@@ -92,20 +92,51 @@ def test_console_stripping_covers_exactly_the_chatty_levels():
 
 
 def test_build_marks_its_mode_and_the_cache_checks_it():
-    """build_static.sh must not reuse a development dist under a matching checksum.
+    """build_static.sh must not reuse a dist built in a different mode.
 
-    webpack writes dist/BUILD_MODE after emit; the cache skip requires it to
-    name the mode this run wants (review).
+    webpack removes dist/BUILD_MODE before every compilation and writes it
+    back, with the real mode, only after an error-free emit, so an
+    interrupted or failed build leaves no marker. build_static.sh wants
+    production unless NODE_ENV=development, and skips only when the marker
+    says so (review). Regexes tolerate wrapping and quote style; they pin
+    the values and the wiring, not the formatting.
     """
     src = _webpack_config()
-    assert "BuildModeMarker" in src and "'dist', 'BUILD_MODE'" in src, (
-        "webpack no longer records the build mode in dist/BUILD_MODE"
-    )
+    q = r"['\"]"
+    assert re.search(
+        r"path\.resolve\(\s*__dirname\s*,\s*" + q + r"dist" + q + r"\s*,\s*" + q + r"BUILD_MODE" + q + r"\s*\)",
+        src,
+        re.S,
+    ), "the marker is no longer dist/BUILD_MODE"
+    assert re.search(r"beforeCompile\.tap\(\s*" + q + r"BuildModeMarker", src, re.S) and re.search(
+        r"unlinkSync\(\s*marker\s*\)", src
+    ), "the marker is no longer removed before compilation"
+    assert re.search(
+        r"afterEmit\.tap\(\s*" + q + r"BuildModeMarker.*?compilation\.errors\.length\s*>\s*0\s*\)\s*return",
+        src,
+        re.S,
+    ), "the marker is written even when the compilation had errors"
+    assert re.search(
+        r"writeFileSync\(\s*marker\s*,\s*\(\s*isProduction\s*\?\s*" + q + r"production" + q
+        + r"\s*:\s*" + q + r"development" + q + r"\s*\)",
+        src,
+        re.S,
+    ), "the marker no longer records the real mode (a hardcoded value would let a dev build pass as production)"
+
     sh = (JS.parents[2] / "scripts" / "build_static.sh").read_text()
-    assert 'BUILT_MODE=$(cat "${JS_PATH}/dist/BUILD_MODE"' in sh, (
+    assert re.search(r"^\s*EXPECTED_BUILD_MODE=production\s*$", sh, re.M), (
+        "build_static.sh no longer expects production by default"
+    )
+    assert re.search(
+        r"\[\s*\"\$\{NODE_ENV:-\}\"\s*=\s*\"development\"\s*\].*?EXPECTED_BUILD_MODE=development",
+        sh,
+        re.S,
+    ), "build_static.sh no longer expects development only when NODE_ENV=development"
+    assert re.search(r"BUILT_MODE=\$\(cat\s+\"\$\{JS_PATH\}/dist/BUILD_MODE\"", sh), (
         "build_static.sh no longer reads dist/BUILD_MODE"
     )
     assert re.search(
-        r'\[ "\$CURRENT_JS_CHECKSUM" = "\$STORED_JS_CHECKSUM" \].*\[ "\$BUILT_MODE" = "\$EXPECTED_BUILD_MODE" \]',
+        r"\"\$CURRENT_JS_CHECKSUM\"\s*=\s*\"\$STORED_JS_CHECKSUM\".*?\"\$BUILT_MODE\"\s*=\s*\"\$EXPECTED_BUILD_MODE\"",
         sh,
+        re.S,
     ), "the cache skip no longer requires the built mode to match"

--- a/tests/async-unit/test_production_bundle_default.py
+++ b/tests/async-unit/test_production_bundle_default.py
@@ -27,11 +27,19 @@ def _scripts() -> dict:
 
 
 def test_production_is_the_default_mode():
+    """Production unless NODE_ENV=development, with a CLI --mode taking precedence.
+
+    The CLI clause matters: `webpack --mode X` overrides the configured mode
+    after the config has run, so a flag derived only from NODE_ENV could
+    disagree with the mode actually built (review).
+    """
     src = _webpack_config()
     assert re.search(
-        r"const\s+isProduction\s*=\s*process\.env\.NODE_ENV\s*!==\s*['\"]development['\"]\s*;",
+        r"const\s+isProduction\s*=\s*argv\s*&&\s*argv\.mode\s*\?\s*argv\.mode\s*===\s*['\"]production['\"]"
+        r"\s*:\s*process\.env\.NODE_ENV\s*!==\s*['\"]development['\"]\s*;",
         src,
-    ), "isProduction no longer defaults to true; the deployed bundle is a dev build again"
+        re.S,
+    ), "isProduction is no longer: CLI --mode if given, else production unless NODE_ENV=development"
     assert not re.search(
         r"isProduction\s*=\s*process\.env\.NODE_ENV\s*===\s*['\"]production['\"]",
         src,

--- a/tests/async-unit/test_production_bundle_default.py
+++ b/tests/async-unit/test_production_bundle_default.py
@@ -123,8 +123,13 @@ def test_cache_key_covers_mode_and_the_bundles_actually_in_dist():
     fp = re.search(r"dist_fingerprint\(\)\s*\{(.*?)\n\s*\}", sh, re.S)
     assert fp is not None, "dist_fingerprint is gone from build_static.sh"
     body = fp.group(1)
-    assert re.search(r"find\s+\"\$\{JS_PATH\}/dist\".*?-type\s+f.*?md5sum", body, re.S), (
-        "the dist fingerprint no longer hashes the files in dist/"
+    # -H so a symlinked dist/ is followed; without it the fingerprint is the
+    # hash of nothing and a stale key matches forever (review).
+    assert re.search(r"find\s+-H\s+\"\$\{JS_PATH\}/dist\".*?-type\s+f.*?md5sum", body, re.S), (
+        "the dist fingerprint no longer hashes the files in dist/ following a symlinked dist"
+    )
+    assert re.search(r"dist_has_files\(\)\s*\{.*?find\s+-H\s+\"\$\{JS_PATH\}/dist\".*?-print\s+-quit", sh, re.S), (
+        "the empty-dist guard is gone"
     )
     # Recursive and unfiltered: workers/, the wasm, .mjs and .map files ship
     # too, and a missing worker with untouched bundles broke PDF uploads
@@ -138,10 +143,10 @@ def test_cache_key_covers_mode_and_the_bundles_actually_in_dist():
         sh,
     ), "the cache key no longer combines sources, mode and the dist fingerprint"
     assert re.search(
-        r"\[\s*\"\$CURRENT_BUILD_KEY\"\s*=\s*\"\$STORED_JS_CHECKSUM\"\s*\].*?SKIP_JS_BUILD=true",
+        r"\[\s*\"\$CURRENT_BUILD_KEY\"\s*=\s*\"\$STORED_JS_CHECKSUM\"\s*\]\s*&&\s*dist_has_files.*?SKIP_JS_BUILD=true",
         sh,
         re.S,
-    ), "the skip no longer requires the whole key to match"
+    ), "the skip no longer requires the whole key to match AND a non-empty dist/"
     assert re.search(
         r"echo\s+\"\$\{CURRENT_JS_CHECKSUM\}:\$\{EXPECTED_BUILD_MODE\}:\$\(dist_fingerprint\)\"\s*>\s*\"\$JS_CHECKSUM_FILE\"",
         sh,


### PR DESCRIPTION
`webpack.config.js` chose production only when `NODE_ENV` was exactly `production`, and nothing in the repo ever set it: not `npm run build`, not `ci_npm_build.sh`, `build_static.sh` or `setup_templates.sh`, not CI. So every build, including the one collected into the deployed image, was a development bundle. That skipped the whole optimization block, and with it the Terser `pure_funcs` rule that strips `console.log/info/debug` as a defence against logging PHI to the browser console. The config's own comment calls that defence-in-depth; it has never been in effect.

**What changes**

- Production is the default. `isProduction` comes from the CLI's `--mode` when one is given, otherwise production unless `NODE_ENV=development`, so mode and the optimization block can never disagree within a build. `npm run build:dev` opts out and npm-watch uses it.
- `build_static.sh`'s cache validates its own output. It used to skip webpack on an unchanged source checksum alone, so any build run in between (`build:dev`, a CLI override, an interrupted run) left its output in place and the next run collected it. The stored key is now `source checksum : wanted mode : md5 of every file under dist/`, written after this script's own successful build, and the skip requires the whole key to match and `dist/` to be non-empty. A symlinked `dist/` is followed.
- A test pins the default, the opt-out, both consumers of the flag, the exact `pure_funcs` set (`warn`/`error` stay), and the cache-key wiring.

**Measured on this tree, same sources**

| | before | after |
|---|---|---|
| total `*.bundle.js` | 24.0 MB | 8.3 MB |
| `scrub_ocr.bundle.js` | 2.1 MB | 0.9 MB |
| `console.log(` call sites in it | 20 | 1 |
| build time | 3.9 s | 14 s |

The surviving call site is transformers.js's own download-progress callback, where the call is an arrow's return value; it prints progress text. React now ships its production build. Source maps are emitted as before. Production mode turns on webpack's asset-size hints, so the build prints two size warnings alongside the pre-existing `import.meta` one; CI's npm-build job does not fail on warnings.

**Review.** Codex (gpt-6-astra, read-only sandbox), eight rounds. Round 1 found the cache-reuse gap. Rounds 2 to 5 each defeated a webpack-written build-mode marker with a different override (interrupted emit, CLI `--mode`, `NODE_ENV` versus `--mode`, `--no-optimization-minimize`), which is what showed the marker was the wrong design: a marker written by webpack is a claim by whoever ran webpack. It was replaced with output fingerprinting. Rounds 6 and 7 widened the fingerprint (workers, wasm, maps; symlinked `dist/`, empty `dist/`). Round 8: no findings at the agreed threshold. Every fix was verified both ways with real builds or a simulation of the decision block.

**Accepted, and written at the code:** concurrent builds in one working tree are unsupported (they corrupt the bundles themselves); exotic filesystem layouts beyond a symlinked `dist/` are out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYruQVRyBbFzUxy9YGcHTb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved static asset build reliability by detecting missing, incomplete, or outdated build output before reusing cached results.
  * Production builds now consistently apply production optimizations by default, helping deliver smaller, more efficient assets.
  * Development workflows, including watch mode, now explicitly use development settings for faster iteration.

* **Tests**
  * Added coverage for production defaults, development builds, build-mode selection, and build-cache validation.
  * Verified cached assets are rebuilt when output changes or is incomplete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->