### PR TITLE
Rank drafts live as scores land, three visible, the rest behind Show more

### DIFF
--- a/fighthealthinsurance/static/js/appeal_fetcher.ts
+++ b/fighthealthinsurance/static/js/appeal_fetcher.ts
@@ -510,6 +510,11 @@ let focusListenerArmed = false;
 // Once the final pass has run, every later pass is final too: a live pass
 // queued behind a focusout must not undo the terminal state (review).
 let finalApplied = false;
+// Bumped when a fresh generation starts on the same page. A deferred pass
+// queued in the previous generation captured its own `pending` value, so
+// resetting rankingPending cannot reach it; it checks this instead and
+// does nothing if the page has moved on (review).
+let rankingGeneration = 0;
 
 function recordDraftScore(proposedId: unknown, quality: unknown, grounding: unknown, scorer: unknown): void {
   if (proposedId === undefined || proposedId === null || proposedId === "unknown") return;
@@ -564,8 +569,13 @@ function applyRanking(final: boolean): void {
         () => {
           focusListenerArmed = false;
           const pending = rankingPending;
+          const generation = rankingGeneration;
           rankingPending = null;
-          if (pending !== null) setTimeout(() => applyRanking(pending), 0);
+          if (pending !== null) {
+            setTimeout(() => {
+              if (generation === rankingGeneration) applyRanking(pending);
+            }, 0);
+          }
         },
         { once: true },
       );
@@ -1194,6 +1204,7 @@ async function requestExternalModels(
     // under a partial caption with live ordering suppressed (review).
     finalApplied = false;
     rankingPending = null;
+    rankingGeneration += 1;
     // The wait for the next appeal starts now, not when the last pre-rerun
     // appeal arrived — otherwise the "Current appeal" clock would include
     // however long the user spent reading drafts before opting in. The

--- a/fighthealthinsurance/static/js/appeal_fetcher.ts
+++ b/fighthealthinsurance/static/js/appeal_fetcher.ts
@@ -461,11 +461,16 @@ let hasAutoScrolledToFirstAppeal = false;
 // Draft ordering. The server scores each saved draft on how well it addresses
 // THIS denial (fighthealthinsurance/ml/letter_quality.py) and sends the score
 // as a {"type": "score", "id": <proposed id>} frame after the letter, or on
-// the letter frame itself for a re-served draft. Nothing moves while letters
-// are still arriving: a list that reshuffles under someone reading it is
-// worse than a list in arrival order. Once the server says done, the drafts
-// are ordered once, the top one is labelled, and everything past
-// RANKED_VISIBLE_LIMIT is folded behind a button rather than dropped.
+// the letter frame itself for a re-served draft.
+//
+// Ordering is LIVE: every landed draft and every score re-runs the pass.
+// Scored drafts sit first in rank order, the best one labelled, and scored
+// drafts past RANKED_VISIBLE_LIMIT fold behind a button rather than being
+// dropped. A draft that has just landed and has no score yet is appended at
+// the end and stays visible until its score arrives; it then takes its
+// place. Two rules keep the live reorder from being hostile: nothing moves
+// while the reader is typing in a draft (the pass waits for focus to leave),
+// and a draft the reader has edited is never hidden and never labelled.
 //
 // The score is a criteria score, not a success probability, and the caption
 // says exactly that. Never render it as a percentage or a "chance".
@@ -473,6 +478,12 @@ let hasAutoScrolledToFirstAppeal = false;
 const RANKED_VISIBLE_LIMIT = 3;
 const RANKING_CAPTION =
   "Ordered by how well each letter addresses your denial, not by a prediction of the outcome.";
+// At the end of generation with some drafts never scored (the scorer failed
+// or rate-limited, or a save never returned a row id): the order stays but is
+// only partly informed, so the caption says so and nothing is labelled or
+// folded. Same promise about the outcome as the full caption.
+const RANKING_CAPTION_PARTIAL =
+  "Scored letters are ordered by how well they address your denial, not by a prediction of the outcome. Some letters could not be scored and are listed in the order they arrived.";
 const RECOMMENDED_LABEL = "Recommended";
 // Drafts that scored 0 on "no invented facts" sort below every grounded draft
 // whatever their other marks (matches letter_quality.sort_key).
@@ -484,6 +495,14 @@ interface DraftScore {
   scorer: string;
 }
 let draftScores = new Map<string, DraftScore>();
+// The reader pressed "Show more": nothing folds again for the rest of the
+// session, whatever lands or is re-served (doQuery does not reset this, the
+// same way it keeps draftScores across a retry).
+let showAllDrafts = false;
+// A pass asked for while the reader was typing. `true` means the deferred
+// pass is the final one.
+let rankingPending: boolean | null = null;
+let focusListenerArmed = false;
 
 function recordDraftScore(proposedId: unknown, quality: unknown, grounding: unknown, scorer: unknown): void {
   if (proposedId === undefined || proposedId === null || proposedId === "unknown") return;
@@ -497,114 +516,144 @@ function recordDraftScore(proposedId: unknown, quality: unknown, grounding: unkn
   });
 }
 
+function scoreOf(el: HTMLElement): DraftScore | undefined {
+  const id = el.getAttribute("data-proposed-id");
+  return id ? draftScores.get(id) : undefined;
+}
+
 // Higher sorts first. Unscored drafts keep arrival order at the bottom.
 function draftSortKey(el: HTMLElement): [number, number] {
-  const id = el.getAttribute("data-proposed-id");
-  const score = id ? draftScores.get(id) : undefined;
+  const score = scoreOf(el);
   if (!score) return [0, 0];
   const demoted = score.grounding !== null && score.grounding < GROUNDING_DEMOTE_BELOW;
   return [demoted ? 1 : 2, score.quality];
 }
 
-function rankedDrafts(): HTMLElement[] {
-  const drafts = outputContainer.children('[id^="magic"]').toArray() as HTMLElement[];
-  const withIndex = drafts.map((el, index) => ({ el, index, key: draftSortKey(el) }));
-  withIndex.sort((a, b) => {
-    if (a.key[0] !== b.key[0]) return b.key[0] - a.key[0];
-    if (a.key[1] !== b.key[1]) return b.key[1] - a.key[1];
-    return a.index - b.index;
-  });
-  return withIndex.map((entry) => entry.el);
+function draftArrival(el: HTMLElement): number {
+  return Number(el.getAttribute("data-arrival-index") || 0);
 }
 
-function finalizeRanking(): void {
-  if (draftScores.size === 0) return;
-  // Idempotent: a retry can reach done more than once. Rebuild from scratch
-  // so there is never a second "Recommended" or a stale fold.
+function readerIsTyping(): boolean {
+  const active = document.activeElement as HTMLElement | null;
+  return !!active && active.tagName === "TEXTAREA" && outputContainer[0].contains(active);
+}
+
+function applyRanking(final: boolean): void {
+  // Never move a draft out from under someone typing in it. Remember the
+  // strongest pass that was asked for and run it once focus leaves the
+  // drafts. focusout bubbles from the textarea to the container; the
+  // timeout lets focus settle first, and if it settled on another draft's
+  // textarea the pass simply defers again.
+  if (readerIsTyping()) {
+    rankingPending = rankingPending === true || final;
+    if (!focusListenerArmed) {
+      focusListenerArmed = true;
+      outputContainer[0].addEventListener(
+        "focusout",
+        () => {
+          focusListenerArmed = false;
+          const pending = rankingPending;
+          rankingPending = null;
+          if (pending !== null) setTimeout(() => applyRanking(pending), 0);
+        },
+        { once: true },
+      );
+    }
+    return;
+  }
+
+  // Idempotent: rebuild from scratch on every pass so there is never a
+  // second "Recommended", a stale caption, or a fold that no longer fits.
   document.getElementById("appeal-ranking-note")?.remove();
   document.getElementById("appeal-show-more")?.remove();
   for (const badge of Array.from(document.querySelectorAll(".appeal-recommended-badge"))) badge.remove();
   const drafts = outputContainer.children('[id^="magic"]').toArray() as HTMLElement[];
   for (const el of drafts) el.hidden = false;
-  // All or nothing. A scorer that answered for one draft and rate-limited
-  // the rest would put that one first and fold the unassessed ones away,
-  // which is an ordering by luck. Without full coverage the page is put
-  // BACK in arrival order (an earlier, fully scored pass may have sorted
-  // it), with no caption and no fold.
-  // A draft that never got a row id (its save failed) can never be scored,
-  // so it counts as uncovered too: ranking the rest around it would be the
-  // same partial ordering.
-  // ...and all on ONE scale: a score from a repointed model is not
-  // comparable with one from the previous model, whatever the dashboard
-  // does with them.
-  const scorers = new Set(
-    drafts.map((el) => draftScores.get(el.getAttribute("data-proposed-id") || "")?.scorer ?? ""),
-  );
-  const everyDraftScored =
-    scorers.size === 1 &&
-    drafts.every((el) => {
-      const id = el.getAttribute("data-proposed-id");
-      return !!id && draftScores.has(id);
-    });
-  if (!everyDraftScored) {
-    const byArrival = drafts.slice().sort(
-      (a, b) => Number(a.getAttribute("data-arrival-index") || 0) - Number(b.getAttribute("data-arrival-index") || 0),
-    );
-    for (const el of byArrival) outputContainer.append(el);
-    return;
-  }
-  const ordered = rankedDrafts();
-  if (ordered.length === 0) return;
+  if (drafts.length === 0) return;
+
+  // One scale only: a score from a repointed model is not comparable with
+  // one from the previous model. With two scorers in play, rank nothing.
+  const scorers = new Set(drafts.map((el) => scoreOf(el)?.scorer).filter((x): x is string => x !== undefined));
+  const oneScale = scorers.size <= 1;
+  const scored = oneScale ? drafts.filter((el) => scoreOf(el) !== undefined) : [];
+  const unscored = drafts.filter((el) => !scored.includes(el));
+  scored.sort((a, b) => {
+    const ka = draftSortKey(a);
+    const kb = draftSortKey(b);
+    if (ka[0] !== kb[0]) return kb[0] - ka[0];
+    if (ka[1] !== kb[1]) return kb[1] - ka[1];
+    return draftArrival(a) - draftArrival(b);
+  });
+  unscored.sort((a, b) => draftArrival(a) - draftArrival(b));
+  const ordered = [...scored, ...unscored];
 
   // Re-appending moves the existing nodes, so anything the user has typed
   // into a draft's textarea comes along with it.
   for (const el of ordered) outputContainer.append(el);
+  if (scored.length === 0) return;
 
-  if (!document.getElementById("appeal-ranking-note")) {
-    const note = document.createElement("p");
-    note.id = "appeal-ranking-note";
-    note.className = "text-muted";
-    note.style.margin = "8px 20px";
-    note.textContent = RANKING_CAPTION;
-    ordered[0].before(note);
-  }
-
-  const top = ordered[0];
-  // A draft the reader has already rewritten is not the draft that was
-  // scored: it keeps its place in the order but never gets the label.
-  const topIsDirty = top.getAttribute("data-dirty") === "1";
-  if (!topIsDirty && draftSortKey(top)[0] === 2 && !top.querySelector(".appeal-recommended-badge")) {
-    const badge = document.createElement("div");
-    badge.className = "appeal-recommended-badge";
-    badge.textContent = RECOMMENDED_LABEL;
-    badge.style.cssText =
-      "display:inline-block;padding:4px 10px;margin:0 0 8px;border-radius:4px;" +
-      "background:#2e7d32;color:#fff;font-weight:600;font-size:0.9em;";
-    top.prepend(badge);
-  }
-
-  const hidden = ordered.slice(RANKED_VISIBLE_LIMIT);
-  if (hidden.length > 0 && !document.getElementById("appeal-show-more")) {
-    for (const el of hidden) el.hidden = true;
-    const button = document.createElement("button");
-    button.id = "appeal-show-more";
-    button.type = "button";
-    button.className = "btn btn-outline-secondary";
-    button.style.margin = "8px 20px 24px";
-    button.textContent = `Show ${hidden.length} more draft${hidden.length === 1 ? "" : "s"}`;
-    button.setAttribute("aria-expanded", "false");
-    button.setAttribute("aria-controls", hidden.map((el) => el.id).join(" "));
-    button.addEventListener("click", () => {
-      for (const el of hidden) el.hidden = false;
-      button.setAttribute("aria-expanded", "true");
-      // Keep keyboard and screen-reader users where the new content is,
-      // instead of dropping focus on the body when the button goes away.
-      const first = hidden[0].querySelector("textarea") as HTMLElement | null;
-      (first ?? hidden[0]).focus();
-      button.remove();
+  // A draft that never got a row id (its save failed) can never be scored,
+  // so it counts as unscored too. At the end of generation, any unscored
+  // draft makes the order partly luck: the order the reader has been
+  // watching stays, but nothing is labelled over a draft that was never
+  // assessed, and nothing is hidden behind one.
+  const complete =
+    oneScale &&
+    drafts.every((el) => {
+      const id = el.getAttribute("data-proposed-id");
+      return !!id && draftScores.has(id);
     });
-    ordered[RANKED_VISIBLE_LIMIT - 1].after(button);
+  const partialAtEnd = final && !complete;
+
+  const note = document.createElement("p");
+  note.id = "appeal-ranking-note";
+  note.className = "text-muted";
+  note.style.margin = "8px 20px";
+  note.textContent = partialAtEnd ? RANKING_CAPTION_PARTIAL : RANKING_CAPTION;
+  ordered[0].before(note);
+
+  if (!partialAtEnd) {
+    const top = scored[0];
+    // A draft the reader has already rewritten is not the draft that was
+    // scored: it keeps its place in the order but never gets the label.
+    const topIsDirty = top.getAttribute("data-dirty") === "1";
+    if (!topIsDirty && draftSortKey(top)[0] === 2) {
+      const badge = document.createElement("div");
+      badge.className = "appeal-recommended-badge";
+      badge.textContent = RECOMMENDED_LABEL;
+      badge.style.cssText =
+        "display:inline-block;padding:4px 10px;margin:0 0 8px;border-radius:4px;" +
+        "background:#2e7d32;color:#fff;font-weight:600;font-size:0.9em;";
+      top.prepend(badge);
+    }
   }
+
+  if (partialAtEnd || showAllDrafts) return;
+  // Fold scored drafts past the limit. Unscored drafts are never hidden:
+  // they just landed and sit revealed at the end until their score arrives.
+  // A draft the reader has edited is never hidden either.
+  const hidden = scored.slice(RANKED_VISIBLE_LIMIT).filter((el) => el.getAttribute("data-dirty") !== "1");
+  if (hidden.length === 0) return;
+  for (const el of hidden) el.hidden = true;
+  const button = document.createElement("button");
+  button.id = "appeal-show-more";
+  button.type = "button";
+  button.className = "btn btn-outline-secondary";
+  button.style.margin = "8px 20px 24px";
+  button.textContent = `Show ${hidden.length} more draft${hidden.length === 1 ? "" : "s"}`;
+  button.setAttribute("aria-expanded", "false");
+  button.setAttribute("aria-controls", hidden.map((el) => el.id).join(" "));
+  button.addEventListener("click", () => {
+    showAllDrafts = true;
+    for (const el of hidden) el.hidden = false;
+    button.setAttribute("aria-expanded", "true");
+    // Keep keyboard and screen-reader users where the new content is,
+    // instead of dropping focus on the body when the button goes away.
+    const first = hidden[0].querySelector("textarea") as HTMLElement | null;
+    (first ?? hidden[0]).focus();
+    button.remove();
+  });
+  scored[RANKED_VISIBLE_LIMIT - 1].after(button);
 }
 
 // Diagnostic counters used in the client error report so server logs
@@ -968,10 +1017,9 @@ function done(): void {
     retries = retries + 1;
     doQuery(my_backend_url, my_data, my_rest_fallback_url);
   } else {
-    // Generation is really over (no further automatic attempt): only now
-    // may the drafts be ordered, so a page never reshuffles under a reader
-    // while a retry is still adding letters.
-    finalizeRanking();
+    // Generation is really over (no further automatic attempt): the final
+    // pass decides the caption, the label and the fold for good.
+    applyRanking(true);
     if (appealsSoFar.length === 0) {
       const transport = usingRestFallback ? 'rest-fallback' : 'websocket';
       // Be explicit about *why* we ended with nothing. The common iOS case is
@@ -1398,9 +1446,11 @@ function processResponseChunk(chunk: string): void {
         }
 
         // A draft's score, sent after the letter it belongs to (or never,
-        // when scoring is off or failed). Recorded now, applied at done.
+        // when scoring is off or failed). Recorded, then the order is
+        // updated on the spot.
         if (parsedLine.type === 'score') {
           recordDraftScore(parsedLine.id, parsedLine.quality_score, parsedLine.grounding_score, parsedLine.scorer);
+          applyRanking(false);
           return;
         }
 
@@ -1517,6 +1567,9 @@ function processResponseChunk(chunk: string): void {
         }
 
         outputContainer.append(clonedForm);
+        // Appended at the end and visible: an unscored draft is never folded.
+        // The pass puts already-scored drafts in rank order around it.
+        applyRanking(false);
 
         if (!hasAutoScrolledToFirstAppeal) {
           hasAutoScrolledToFirstAppeal = true;

--- a/fighthealthinsurance/static/js/appeal_fetcher.ts
+++ b/fighthealthinsurance/static/js/appeal_fetcher.ts
@@ -484,6 +484,10 @@ const RANKING_CAPTION =
 // folded. Same promise about the outcome as the full caption.
 const RANKING_CAPTION_PARTIAL =
   "Scored letters are ordered by how well they address your denial, not by a prediction of the outcome. Some letters could not be scored and are listed in the order they arrived.";
+// Two scorers in play means nothing can be ranked on one scale; at the end
+// the page says so rather than silently showing arrival order.
+const RANKING_CAPTION_UNRANKED =
+  "Letters are listed in the order they arrived. They could not be scored on one scale, so none is ordered or recommended.";
 const RECOMMENDED_LABEL = "Recommended";
 // Drafts that scored 0 on "no invented facts" sort below every grounded draft
 // whatever their other marks (matches letter_quality.sort_key).
@@ -503,6 +507,9 @@ let showAllDrafts = false;
 // pass is the final one.
 let rankingPending: boolean | null = null;
 let focusListenerArmed = false;
+// Once the final pass has run, every later pass is final too: a live pass
+// queued behind a focusout must not undo the terminal state (review).
+let finalApplied = false;
 
 function recordDraftScore(proposedId: unknown, quality: unknown, grounding: unknown, scorer: unknown): void {
   if (proposedId === undefined || proposedId === null || proposedId === "unknown") return;
@@ -533,18 +540,22 @@ function draftArrival(el: HTMLElement): number {
   return Number(el.getAttribute("data-arrival-index") || 0);
 }
 
-function readerIsTyping(): boolean {
+function readerIsInteracting(): boolean {
+  // Any focused element inside the drafts: a textarea being typed in, a
+  // "Choose this one" button reached by keyboard, the Show more button.
+  // Re-appending the node under it would drop that focus (review).
   const active = document.activeElement as HTMLElement | null;
-  return !!active && active.tagName === "TEXTAREA" && outputContainer[0].contains(active);
+  return !!active && active !== document.body && outputContainer[0].contains(active);
 }
 
 function applyRanking(final: boolean): void {
-  // Never move a draft out from under someone typing in it. Remember the
+  final = final || finalApplied;
+  // Never move a draft out from under someone using it. Remember the
   // strongest pass that was asked for and run it once focus leaves the
-  // drafts. focusout bubbles from the textarea to the container; the
-  // timeout lets focus settle first, and if it settled on another draft's
-  // textarea the pass simply defers again.
-  if (readerIsTyping()) {
+  // drafts. focusout bubbles from the element to the container; the timeout
+  // lets focus settle first, and if it settled on another element inside
+  // the drafts the pass simply defers again.
+  if (readerIsInteracting()) {
     rankingPending = rankingPending === true || final;
     if (!focusListenerArmed) {
       focusListenerArmed = true;
@@ -561,9 +572,11 @@ function applyRanking(final: boolean): void {
     }
     return;
   }
+  if (final) finalApplied = true;
 
-  // Idempotent: rebuild from scratch on every pass so there is never a
-  // second "Recommended", a stale caption, or a fold that no longer fits.
+  // Idempotent: rebuild the caption, the label and the fold from scratch on
+  // every pass so there is never a second "Recommended", a stale caption,
+  // or a fold that no longer fits.
   document.getElementById("appeal-ranking-note")?.remove();
   document.getElementById("appeal-show-more")?.remove();
   for (const badge of Array.from(document.querySelectorAll(".appeal-recommended-badge"))) badge.remove();
@@ -575,6 +588,7 @@ function applyRanking(final: boolean): void {
   // one from the previous model. With two scorers in play, rank nothing.
   const scorers = new Set(drafts.map((el) => scoreOf(el)?.scorer).filter((x): x is string => x !== undefined));
   const oneScale = scorers.size <= 1;
+  const anyScore = drafts.some((el) => scoreOf(el) !== undefined);
   const scored = oneScale ? drafts.filter((el) => scoreOf(el) !== undefined) : [];
   const unscored = drafts.filter((el) => !scored.includes(el));
   scored.sort((a, b) => {
@@ -585,18 +599,8 @@ function applyRanking(final: boolean): void {
     return draftArrival(a) - draftArrival(b);
   });
   unscored.sort((a, b) => draftArrival(a) - draftArrival(b));
-  const ordered = [...scored, ...unscored];
-
-  // Re-appending moves the existing nodes, so anything the user has typed
-  // into a draft's textarea comes along with it.
-  for (const el of ordered) outputContainer.append(el);
-  if (scored.length === 0) return;
-
-  // A draft that never got a row id (its save failed) can never be scored,
-  // so it counts as unscored too. At the end of generation, any unscored
-  // draft makes the order partly luck: the order the reader has been
-  // watching stays, but nothing is labelled over a draft that was never
-  // assessed, and nothing is hidden behind one.
+  // Coverage is decided BEFORE anything moves. A draft that never got a row
+  // id (its save failed) can never be scored, so it counts as unscored too.
   const complete =
     oneScale &&
     drafts.every((el) => {
@@ -605,30 +609,61 @@ function applyRanking(final: boolean): void {
     });
   const partialAtEnd = final && !complete;
 
+  // Scoring off, or nothing scored yet: the page is exactly as it was
+  // before ranking existed, and nothing is touched.
+  if (!anyScore) return;
+
+  if (!oneScale) {
+    if (final) {
+      const note = document.createElement("p");
+      note.id = "appeal-ranking-note";
+      note.className = "text-muted";
+      note.style.margin = "8px 20px";
+      note.textContent = RANKING_CAPTION_UNRANKED;
+      drafts[0].before(note);
+    }
+    return;
+  }
+
+  // Order: scored first in rank order, then unscored in arrival order. The
+  // DOM is touched only when that differs from what is on screen (moving a
+  // node drops its focus, and a no-op move still costs layout), and never
+  // at the partial end: the order the reader has been watching stays.
+  // Re-appending moves the existing nodes, so anything the user has typed
+  // into a draft's textarea comes along with it.
+  const ordered = [...scored, ...unscored];
+  if (!partialAtEnd) {
+    const changed = ordered.some((el, i) => el !== drafts[i]);
+    if (changed) for (const el of ordered) outputContainer.append(el);
+  }
+  const first = (outputContainer.children('[id^="magic"]').toArray() as HTMLElement[])[0];
+
   const note = document.createElement("p");
   note.id = "appeal-ranking-note";
   note.className = "text-muted";
   note.style.margin = "8px 20px";
   note.textContent = partialAtEnd ? RANKING_CAPTION_PARTIAL : RANKING_CAPTION;
-  ordered[0].before(note);
+  first.before(note);
 
-  if (!partialAtEnd) {
-    const top = scored[0];
-    // A draft the reader has already rewritten is not the draft that was
-    // scored: it keeps its place in the order but never gets the label.
-    const topIsDirty = top.getAttribute("data-dirty") === "1";
-    if (!topIsDirty && draftSortKey(top)[0] === 2) {
-      const badge = document.createElement("div");
-      badge.className = "appeal-recommended-badge";
-      badge.textContent = RECOMMENDED_LABEL;
-      badge.style.cssText =
-        "display:inline-block;padding:4px 10px;margin:0 0 8px;border-radius:4px;" +
-        "background:#2e7d32;color:#fff;font-weight:600;font-size:0.9em;";
-      top.prepend(badge);
-    }
+  // At the partial end nothing is labelled over a draft that was never
+  // assessed, and nothing is hidden behind one.
+  if (partialAtEnd) return;
+
+  const top = scored[0];
+  // A draft the reader has already rewritten is not the draft that was
+  // scored: it keeps its place in the order but never gets the label.
+  const topIsDirty = top.getAttribute("data-dirty") === "1";
+  if (!topIsDirty && draftSortKey(top)[0] === 2) {
+    const badge = document.createElement("div");
+    badge.className = "appeal-recommended-badge";
+    badge.textContent = RECOMMENDED_LABEL;
+    badge.style.cssText =
+      "display:inline-block;padding:4px 10px;margin:0 0 8px;border-radius:4px;" +
+      "background:#2e7d32;color:#fff;font-weight:600;font-size:0.9em;";
+    top.prepend(badge);
   }
 
-  if (partialAtEnd || showAllDrafts) return;
+  if (showAllDrafts) return;
   // Fold scored drafts past the limit. Unscored drafts are never hidden:
   // they just landed and sit revealed at the end until their score arrives.
   // A draft the reader has edited is never hidden either.
@@ -1476,6 +1511,10 @@ function processResponseChunk(chunk: string): void {
         ) {
           duplicatesSkipped++;
           console.log("Duplicate appeal found. Skipping.");
+          // The letter is not rendered again, but the score it carried was
+          // just recorded and may change the order of what is on screen
+          // (a REST re-serve after a WebSocket failure) (review).
+          if (parsedLine.quality_score !== undefined) applyRanking(false);
           return;
         }
 

--- a/fighthealthinsurance/static/js/appeal_fetcher.ts
+++ b/fighthealthinsurance/static/js/appeal_fetcher.ts
@@ -614,13 +614,18 @@ function applyRanking(final: boolean): void {
   if (!anyScore) return;
 
   if (!oneScale) {
+    // Nothing is ranked, so the page must actually be in arrival order: an
+    // earlier single-scorer pass may have moved drafts (review). Same rule
+    // as below, the DOM is touched only if the order differs.
+    const byArrival = drafts.slice().sort((a, b) => draftArrival(a) - draftArrival(b));
+    if (byArrival.some((el, i) => el !== drafts[i])) for (const el of byArrival) outputContainer.append(el);
     if (final) {
       const note = document.createElement("p");
       note.id = "appeal-ranking-note";
       note.className = "text-muted";
       note.style.margin = "8px 20px";
       note.textContent = RANKING_CAPTION_UNRANKED;
-      drafts[0].before(note);
+      byArrival[0].before(note);
     }
     return;
   }
@@ -1183,6 +1188,12 @@ async function requestExternalModels(
     retries = 0;
     respBuffer = "";
     hasAutoScrolledToFirstAppeal = false;
+    // A fresh generation, not a retry: the ranking's terminal state ends
+    // with the run it belonged to. Scores and an opened fold are kept, the
+    // "every pass is final now" latch is not, or the new drafts would land
+    // under a partial caption with live ordering suppressed (review).
+    finalApplied = false;
+    rankingPending = null;
     // The wait for the next appeal starts now, not when the last pre-rerun
     // appeal arrived — otherwise the "Current appeal" clock would include
     // however long the user spent reading drafts before opting in. The

--- a/fighthealthinsurance/static/js/appeal_fetcher.ts
+++ b/fighthealthinsurance/static/js/appeal_fetcher.ts
@@ -619,11 +619,13 @@ function applyRanking(final: boolean): void {
     });
   const partialAtEnd = final && !complete;
 
-  // Scoring off, or nothing scored yet: the page is exactly as it was
-  // before ranking existed, and nothing is touched.
-  if (!anyScore) return;
+  // Scoring off, or nothing scored yet: live passes touch nothing, so the
+  // page is exactly as it was before ranking existed while drafts land. The
+  // final pass still folds past the limit in arrival order (owner's call:
+  // unranked is not the same as unfolded).
+  if (!anyScore && !final) return;
 
-  if (!oneScale) {
+  if (anyScore && !oneScale) {
     // Nothing is ranked, so the page must actually be in arrival order: an
     // earlier single-scorer pass may have moved drafts (review). Same rule
     // as below, the DOM is touched only if the order differs.
@@ -637,52 +639,55 @@ function applyRanking(final: boolean): void {
       note.textContent = RANKING_CAPTION_UNRANKED;
       byArrival[0].before(note);
     }
-    return;
-  }
+  } else if (anyScore) {
+    // Order: scored first in rank order, then unscored in arrival order. The
+    // DOM is touched only when that differs from what is on screen (moving a
+    // node drops its focus, and a no-op move still costs layout), and never
+    // at the partial end: the order the reader has been watching stays.
+    // Re-appending moves the existing nodes, so anything the user has typed
+    // into a draft's textarea comes along with it.
+    const ordered = [...scored, ...unscored];
+    if (!partialAtEnd) {
+      const changed = ordered.some((el, i) => el !== drafts[i]);
+      if (changed) for (const el of ordered) outputContainer.append(el);
+    }
+    const first = (outputContainer.children('[id^="magic"]').toArray() as HTMLElement[])[0];
 
-  // Order: scored first in rank order, then unscored in arrival order. The
-  // DOM is touched only when that differs from what is on screen (moving a
-  // node drops its focus, and a no-op move still costs layout), and never
-  // at the partial end: the order the reader has been watching stays.
-  // Re-appending moves the existing nodes, so anything the user has typed
-  // into a draft's textarea comes along with it.
-  const ordered = [...scored, ...unscored];
-  if (!partialAtEnd) {
-    const changed = ordered.some((el, i) => el !== drafts[i]);
-    if (changed) for (const el of ordered) outputContainer.append(el);
-  }
-  const first = (outputContainer.children('[id^="magic"]').toArray() as HTMLElement[])[0];
+    const note = document.createElement("p");
+    note.id = "appeal-ranking-note";
+    note.className = "text-muted";
+    note.style.margin = "8px 20px";
+    note.textContent = partialAtEnd ? RANKING_CAPTION_PARTIAL : RANKING_CAPTION;
+    first.before(note);
 
-  const note = document.createElement("p");
-  note.id = "appeal-ranking-note";
-  note.className = "text-muted";
-  note.style.margin = "8px 20px";
-  note.textContent = partialAtEnd ? RANKING_CAPTION_PARTIAL : RANKING_CAPTION;
-  first.before(note);
-
-  // At the partial end nothing is labelled over a draft that was never
-  // assessed, and nothing is hidden behind one.
-  if (partialAtEnd) return;
-
-  const top = scored[0];
-  // A draft the reader has already rewritten is not the draft that was
-  // scored: it keeps its place in the order but never gets the label.
-  const topIsDirty = top.getAttribute("data-dirty") === "1";
-  if (!topIsDirty && draftSortKey(top)[0] === 2) {
-    const badge = document.createElement("div");
-    badge.className = "appeal-recommended-badge";
-    badge.textContent = RECOMMENDED_LABEL;
-    badge.style.cssText =
-      "display:inline-block;padding:4px 10px;margin:0 0 8px;border-radius:4px;" +
-      "background:#2e7d32;color:#fff;font-weight:600;font-size:0.9em;";
-    top.prepend(badge);
+    // At the partial end nothing is labelled over a draft that was never
+    // assessed.
+    if (!partialAtEnd) {
+      const top = scored[0];
+      // A draft the reader has already rewritten is not the draft that was
+      // scored: it keeps its place in the order but never gets the label.
+      const topIsDirty = top.getAttribute("data-dirty") === "1";
+      if (!topIsDirty && draftSortKey(top)[0] === 2) {
+        const badge = document.createElement("div");
+        badge.className = "appeal-recommended-badge";
+        badge.textContent = RECOMMENDED_LABEL;
+        badge.style.cssText =
+          "display:inline-block;padding:4px 10px;margin:0 0 8px;border-radius:4px;" +
+          "background:#2e7d32;color:#fff;font-weight:600;font-size:0.9em;";
+        top.prepend(badge);
+      }
+    }
   }
 
   if (showAllDrafts) return;
-  // Fold scored drafts past the limit. Unscored drafts are never hidden:
-  // they just landed and sit revealed at the end until their score arrives.
-  // A draft the reader has edited is never hidden either.
-  const hidden = scored.slice(RANKED_VISIBLE_LIMIT).filter((el) => el.getAttribute("data-dirty") !== "1");
+  // The fold. Live: only scored drafts past the limit fold, so a draft that
+  // has just landed stays revealed until its score arrives. At the end:
+  // whatever is past the limit in the DISPLAYED order folds, scored or not,
+  // because an unranked page still should not open with a wall of letters
+  // (owner's call). A draft the reader has edited is never hidden.
+  const displayed = outputContainer.children('[id^="magic"]').toArray() as HTMLElement[];
+  const foldable = final ? displayed : oneScale ? scored : [];
+  const hidden = foldable.slice(RANKED_VISIBLE_LIMIT).filter((el) => el.getAttribute("data-dirty") !== "1");
   if (hidden.length === 0) return;
   for (const el of hidden) el.hidden = true;
   const button = document.createElement("button");
@@ -703,7 +708,7 @@ function applyRanking(final: boolean): void {
     (first ?? hidden[0]).focus();
     button.remove();
   });
-  scored[RANKED_VISIBLE_LIMIT - 1].after(button);
+  foldable[RANKED_VISIBLE_LIMIT - 1].after(button);
 }
 
 // Diagnostic counters used in the client error report so server logs

--- a/tests/async-unit/test_appeal_ranking_client.py
+++ b/tests/async-unit/test_appeal_ranking_client.py
@@ -94,12 +94,16 @@ def test_after_the_final_pass_every_pass_is_final():
 
 def test_coverage_is_decided_before_anything_moves_and_a_partial_end_never_reorders():
     body = _fn("applyRanking")
-    move = body.index("outputContainer.append(el)")
+    # The ranked-order move specifically (the mixed-scorer branch has its
+    # own arrival-order move, earlier in the function).
+    ranked_move = "if (changed) for (const el of ordered) outputContainer.append(el);"
+    assert ranked_move in body
+    move = body.index(ranked_move)
     assert body.index("const partialAtEnd = final && !complete;") < move
-    assert body.index("if (!anyScore) return;") < move, "no scores: the DOM is not touched"
+    first_move = body.index("outputContainer.append(el)")
+    assert body.index("if (!anyScore) return;") < first_move, "no scores: the DOM is not touched"
     assert body.index("if (!partialAtEnd) {") < move < body.index("const first = ")
     assert "const changed = ordered.some((el, i) => el !== drafts[i]);" in body
-    assert "if (changed) for (const el of ordered) outputContainer.append(el);" in body
 
 
 def test_a_deduplicated_reserved_letter_with_a_score_still_reranks():
@@ -107,12 +111,26 @@ def test_a_deduplicated_reserved_letter_with_a_score_still_reranks():
     assert "if (parsedLine.quality_score !== undefined) applyRanking(false);" in dup
 
 
-def test_two_scorers_are_explained_at_the_end():
+def test_two_scorers_restore_arrival_order_and_say_so_at_the_end():
     body = _fn("applyRanking")
     start = body.index("if (!oneScale) {")
     two = _brace_block(body, body.index("{", start))
-    assert "if (final) {" in two and "RANKING_CAPTION_UNRANKED" in two
-    assert two.rstrip().endswith("return;\n  }"), two[-60:]
+    # The caption claims arrival order, so the block must produce it: an
+    # earlier single-scorer pass may have moved drafts (review).
+    assert "const byArrival = drafts.slice().sort((a, b) => draftArrival(a) - draftArrival(b));" in two
+    assert "if (byArrival.some((el, i) => el !== drafts[i])) for (const el of byArrival) outputContainer.append(el);" in two
+    assert two.index("outputContainer.append(el)") < two.index("RANKING_CAPTION_UNRANKED")
+    assert "if (final) {" in two and two.rstrip().endswith("return;\n  }"), two[-60:]
+
+
+def test_a_fresh_generation_drops_the_final_latch_but_keeps_scores_and_the_open_fold():
+    # The "external models enabled" handler is the one place a NEW generation
+    # starts on the same page (everything else is an automatic retry).
+    start = SRC.index("External models enabled. Generating additional appeals")
+    handler = SRC[start : SRC.index("doQuery(my_backend_url, my_data, my_rest_fallback_url);", start)]
+    assert "retries = 0;" in handler
+    assert "finalApplied = false;" in handler and "rankingPending = null;" in handler
+    assert "draftScores = new Map" not in handler and "showAllDrafts = false" not in handler
 
 
 def test_caption_makes_no_promise_about_the_outcome():

--- a/tests/async-unit/test_appeal_ranking_client.py
+++ b/tests/async-unit/test_appeal_ranking_client.py
@@ -216,14 +216,15 @@ def test_every_pass_rebuilds_from_scratch():
     assert "for (const el of drafts) el.hidden = false;" in body
 
 
-def test_one_scale_only_and_partial_coverage_at_the_end_drops_label_and_fold():
+def test_partial_coverage_at_the_end_drops_the_label_but_still_folds_the_displayed_order():
     body = _fn("applyRanking")
     assert "const oneScale = scorers.size <= 1;" in body
     assert "const scored = oneScale ? drafts.filter" in body
     assert "return !!id && draftScores.has(id);" in body, "an unsaved draft is uncovered"
     assert "const partialAtEnd = final && !complete;" in body
-    # Partial at the end: the caption says so, no badge, no fold; the order
-    # already on screen stays (no reshuffle back to arrival order).
+    # Partial at the end: the caption says so and there is no badge; the
+    # order already on screen stays (no reshuffle back to arrival order) and
+    # the fold still applies to it.
     assert "partialAtEnd ? RANKING_CAPTION_PARTIAL : RANKING_CAPTION" in body
     # Partial end: no label, but the fold still applies to the displayed order.
     assert body.index("if (!partialAtEnd) {\n      const top = scored[0];") < body.index("top.prepend(badge)")

--- a/tests/async-unit/test_appeal_ranking_client.py
+++ b/tests/async-unit/test_appeal_ranking_client.py
@@ -105,8 +105,8 @@ def test_coverage_is_decided_before_anything_moves_and_a_partial_end_never_reord
     move = body.index(ranked_move)
     assert body.index("const partialAtEnd = final && !complete;") < move
     first_move = body.index("outputContainer.append(el)")
-    assert body.index("if (!anyScore) return;") < first_move, "no scores: the DOM is not touched"
-    assert body.index("if (!partialAtEnd) {") < move < body.index("const first = ")
+    assert body.index("if (!anyScore && !final) return;") < first_move, "no scores, not final: the DOM is not touched"
+    assert body.index("if (!partialAtEnd) {\n      const changed") < move < body.index("const first = ")
     assert "const changed = ordered.some((el, i) => el !== drafts[i]);" in body
 
 
@@ -117,14 +117,16 @@ def test_a_deduplicated_reserved_letter_with_a_score_still_reranks():
 
 def test_two_scorers_restore_arrival_order_and_say_so_at_the_end():
     body = _fn("applyRanking")
-    start = body.index("if (!oneScale) {")
+    start = body.index("if (anyScore && !oneScale) {")
     two = _brace_block(body, body.index("{", start))
     # The caption claims arrival order, so the block must produce it: an
     # earlier single-scorer pass may have moved drafts (review).
     assert "const byArrival = drafts.slice().sort((a, b) => draftArrival(a) - draftArrival(b));" in two
     assert "if (byArrival.some((el, i) => el !== drafts[i])) for (const el of byArrival) outputContainer.append(el);" in two
     assert two.index("outputContainer.append(el)") < two.index("RANKING_CAPTION_UNRANKED")
-    assert "if (final) {" in two and two.rstrip().endswith("return;\n  }"), two[-60:]
+    assert "if (final) {" in two
+    # The branch no longer returns: the shared fold below applies at the end.
+    assert "return;" not in two
 
 
 def test_a_fresh_generation_drops_the_final_latch_but_keeps_scores_and_the_open_fold():
@@ -150,22 +152,35 @@ def test_caption_makes_no_promise_about_the_outcome():
 def test_three_visible_then_a_show_more_button_not_a_delete():
     assert re.search(r"const RANKED_VISIBLE_LIMIT = 3;", SRC)
     assert "Show ${hidden.length} more draft" in SRC
-    fold = SRC.split("const hidden = scored.slice(RANKED_VISIBLE_LIMIT)", 1)[1].split("button.remove()", 1)[0]
+    fold = SRC.split("const hidden = foldable.slice(RANKED_VISIBLE_LIMIT)", 1)[1].split("button.remove()", 1)[0]
     assert "el.hidden = true" in fold and ".remove()" not in fold
 
 
-def test_fresh_and_edited_drafts_are_never_hidden():
+def test_live_folds_only_scored_drafts_and_the_end_folds_whatever_is_displayed():
     body = _fn("applyRanking")
-    # Only SCORED drafts past the limit fold; unscored ones are appended after
-    # them and stay revealed. An edited draft is filtered out of the fold.
-    assert 'const hidden = scored.slice(RANKED_VISIBLE_LIMIT).filter((el) => el.getAttribute("data-dirty") !== "1");' in body
+    # Live: only SCORED drafts past the limit fold; unscored ones are appended
+    # after them and stay revealed. At the end: the displayed order folds,
+    # scored or not (arrival order when unranked). An edited draft is never
+    # hidden.
+    assert "const foldable = final ? displayed : oneScale ? scored : [];" in body
+    assert 'const hidden = foldable.slice(RANKED_VISIBLE_LIMIT).filter((el) => el.getAttribute("data-dirty") !== "1");' in body
     assert "const ordered = [...scored, ...unscored];" in body
+    assert "foldable[RANKED_VISIBLE_LIMIT - 1].after(button);" in body
+
+
+def test_with_no_scores_live_passes_touch_nothing_but_the_end_still_folds():
+    body = _fn("applyRanking")
+    assert "if (!anyScore && !final) return;" in body
+    # ...and that return precedes every DOM move and the fold.
+    assert body.index("if (!anyScore && !final) return;") < body.index("outputContainer.append(el)")
+    assert body.index("if (!anyScore && !final) return;") < body.index("const foldable = ")
 
 
 def test_show_more_is_sticky_for_the_session():
     body = _fn("applyRanking")
     assert "showAllDrafts = true;" in body
     assert "if (showAllDrafts) return;" in body
+    assert body.index("if (showAllDrafts) return;") < body.index("const foldable = ")
     # doQuery also drives the automatic retries: resetting there would refold
     # what the reader chose to open.
     assert "showAllDrafts = false;" not in SRC.split("export function doQuery", 1)[1]
@@ -203,8 +218,9 @@ def test_one_scale_only_and_partial_coverage_at_the_end_drops_label_and_fold():
     # Partial at the end: the caption says so, no badge, no fold; the order
     # already on screen stays (no reshuffle back to arrival order).
     assert "partialAtEnd ? RANKING_CAPTION_PARTIAL : RANKING_CAPTION" in body
-    assert body.index("if (partialAtEnd) return;") < body.index("top.prepend(badge)")
-    assert body.index("if (partialAtEnd) return;") < body.index("const hidden = scored.slice")
+    # Partial end: no label, but the fold still applies to the displayed order.
+    assert body.index("if (!partialAtEnd) {\n      const top = scored[0];") < body.index("top.prepend(badge)")
+    assert "const foldable = final ? displayed : oneScale ? scored : [];" in body
 
 
 def test_an_edited_draft_never_carries_the_label():

--- a/tests/async-unit/test_appeal_ranking_client.py
+++ b/tests/async-unit/test_appeal_ranking_client.py
@@ -2,8 +2,13 @@
 
 There is no JS test runner in this repo, so the client half of the ranking
 feature is pinned by reading appeal_fetcher.ts: the frame it must accept, the
-moment it may reorder, the copy it shows, and the limit it folds at. Each of
+moments it reorders, the copy it shows, and the limit it folds at. Each of
 these is a promise the server side or the owner relies on.
+
+Ordering is live: a landed draft, a score frame, and the end of generation
+each run the pass. Nothing moves while the reader is typing in a draft. Fresh
+unscored drafts are appended and stay revealed; scored drafts past the limit
+fold behind a button; a draft the reader edited is never hidden or labelled.
 """
 
 import re
@@ -18,38 +23,80 @@ SRC = (
 ).read_text()
 
 
+def _fn(name: str) -> str:
+    start = SRC.index(f"function {name}(")
+    return SRC[start : SRC.index("\nfunction ", start + 10)]
+
+
 def test_score_frames_are_handled_before_the_no_content_skip():
     score_branch = SRC.index("parsedLine.type === 'score'")
     content_skip = SRC.index("Skipping non-appeal frame without content")
     assert score_branch < content_skip
 
 
-def test_ordering_is_applied_only_when_generation_is_really_over():
-    # One call site (the definition does not end in a semicolon), in the
-    # terminal branch of done(): the server's per-attempt done frame must
-    # not trigger it, because done() may still start another attempt.
-    assert SRC.count("finalizeRanking();") == 1
+def test_ranking_runs_live_and_once_more_at_the_real_end():
+    # A landed draft: appended, then a live pass.
+    landed = SRC.index("outputContainer.append(clonedForm);")
+    assert SRC.index("applyRanking(false);", landed) < SRC.index("hasAutoScrolledToFirstAppeal", landed)
+    # A score frame: recorded, then a live pass, before it returns.
+    branch = SRC[SRC.index("parsedLine.type === 'score'") :].split("return;", 1)[0]
+    assert "recordDraftScore(" in branch and "applyRanking(false);" in branch
+    assert branch.index("recordDraftScore(") < branch.index("applyRanking(false);")
+    # The final pass: exactly once, in done()'s no-retry branch, never on the
+    # per-attempt done frame (done() may still start another attempt).
+    assert SRC.count("applyRanking(true);") == 1
     done_fn = SRC.index("function done(): void {")
-    call = SRC.index("finalizeRanking();")
+    call = SRC.index("applyRanking(true);")
     assert done_fn < call < SRC.index("\nfunction ", done_fn + 10)
     assert SRC.index("} else {", done_fn) < call, "in the no-retry branch"
-    assert "finalizeRanking" not in SRC[SRC.index("if (phase === 'done')") : SRC.index("if (phase === 'done')") + 2500]
-    # A score frame records and returns; it must not reorder mid-stream.
-    branch = SRC[SRC.index("parsedLine.type === 'score'") :].split("return;", 1)[0]
-    assert "finalizeRanking" not in branch and "rankedDrafts" not in branch
+    phase_done = SRC.index("if (phase === 'done')")
+    assert "applyRanking" not in SRC[phase_done : phase_done + 2500]
+
+
+def test_nothing_moves_while_the_reader_is_typing():
+    body = _fn("applyRanking")
+    assert body.index("if (readerIsTyping()) {") < body.index('getElementById("appeal-ranking-note")?.remove()')
+    typing = _fn("readerIsTyping")
+    assert "document.activeElement" in typing and 'tagName === "TEXTAREA"' in typing
+    assert "outputContainer[0].contains(active)" in typing
+    # ...and the pass is not lost: it runs once focus leaves the drafts, and
+    # a deferred final pass stays final.
+    deferred = body[body.index("if (readerIsTyping()) {") : body.index('getElementById("appeal-ranking-note")?.remove()')]
+    assert 'addEventListener(\n        "focusout"' in deferred or 'addEventListener("focusout"' in deferred
+    assert "rankingPending = rankingPending === true || final;" in deferred
+    assert "setTimeout(() => applyRanking(pending), 0)" in deferred
 
 
 def test_caption_makes_no_promise_about_the_outcome():
-    caption = re.search(r'RANKING_CAPTION =\s*"([^"]+)"', SRC).group(1)
-    assert "not by a prediction of the outcome" in caption
-    for banned in ("%", "chance", "likely", "success"):
-        assert banned not in caption.lower()
+    for name in ("RANKING_CAPTION", "RANKING_CAPTION_PARTIAL"):
+        caption = re.search(name + r' =\s*"([^"]+)"', SRC).group(1)
+        assert "not by a prediction of the outcome" in caption
+        for banned in ("%", "chance", "likely", "success"):
+            assert banned not in caption.lower()
 
 
 def test_three_visible_then_a_show_more_button_not_a_delete():
     assert re.search(r"const RANKED_VISIBLE_LIMIT = 3;", SRC)
     assert "Show ${hidden.length} more draft" in SRC
-    assert "el.hidden = true" in SRC and ".remove()" not in SRC.split("const hidden = ordered.slice")[1].split("button.remove()")[0]
+    fold = SRC.split("const hidden = scored.slice(RANKED_VISIBLE_LIMIT)", 1)[1].split("button.remove()", 1)[0]
+    assert "el.hidden = true" in fold and ".remove()" not in fold
+
+
+def test_fresh_and_edited_drafts_are_never_hidden():
+    body = _fn("applyRanking")
+    # Only SCORED drafts past the limit fold; unscored ones are appended after
+    # them and stay revealed. An edited draft is filtered out of the fold.
+    assert 'const hidden = scored.slice(RANKED_VISIBLE_LIMIT).filter((el) => el.getAttribute("data-dirty") !== "1");' in body
+    assert "const ordered = [...scored, ...unscored];" in body
+
+
+def test_show_more_is_sticky_for_the_session():
+    body = _fn("applyRanking")
+    assert "showAllDrafts = true;" in body
+    assert "if (partialAtEnd || showAllDrafts) return;" in body
+    # doQuery also drives the automatic retries: resetting there would refold
+    # what the reader chose to open.
+    assert "showAllDrafts = false;" not in SRC.split("export function doQuery", 1)[1]
 
 
 def test_ungrounded_drafts_are_demoted_like_the_server_does():
@@ -67,33 +114,32 @@ def test_scores_survive_retries_and_embedded_scores_beat_dedup():
     assert handler.index("recordDraftScore(parsedLine.id, parsedLine.quality_score") < handler.index("appealsSoFar.some(")
 
 
-def test_finalize_rebuilds_from_scratch():
-    body = SRC[SRC.index("function finalizeRanking()") : SRC.index("const ordered = rankedDrafts();")]
+def test_every_pass_rebuilds_from_scratch():
+    body = _fn("applyRanking")
+    head = body[: body.index("const drafts = outputContainer.children")]
     for cleanup in ('getElementById("appeal-ranking-note")?.remove()', 'getElementById("appeal-show-more")?.remove()', ".appeal-recommended-badge"):
-        assert cleanup in body
-    assert "el.hidden = false;" in SRC[SRC.index("function finalizeRanking()") :]
+        assert cleanup in head
+    assert "for (const el of drafts) el.hidden = false;" in body
 
 
-def test_nothing_moves_unless_every_draft_with_a_row_id_was_scored():
-    start = SRC.index("function finalizeRanking()")
-    body = SRC[start : SRC.index("\nfunction ", start + 10)]  # the whole function
+def test_one_scale_only_and_partial_coverage_at_the_end_drops_label_and_fold():
+    body = _fn("applyRanking")
+    assert "const oneScale = scorers.size <= 1;" in body
+    assert "const scored = oneScale ? drafts.filter" in body
     assert "return !!id && draftScores.has(id);" in body, "an unsaved draft is uncovered"
-    assert "scorers.size === 1 &&" in body, "one scale only"
-    gate = body.index("if (!everyDraftScored) {")
-    # ...and an earlier, fully scored pass is undone: back to arrival order.
-    incomplete = body[gate : body.index("const ordered = rankedDrafts();")]
-    assert 'data-arrival-index' in incomplete and "outputContainer.append(el)" in incomplete
-    assert 'clonedForm.attr("data-arrival-index"' in SRC
-    assert gate < body.index("const ordered = rankedDrafts();")
-    assert gate < body.index('note.id = "appeal-ranking-note"')
-    assert gate < body.index("const hidden = ordered.slice")
+    assert "const partialAtEnd = final && !complete;" in body
+    # Partial at the end: the caption says so, no badge, no fold; the order
+    # already on screen stays (no reshuffle back to arrival order).
+    assert "partialAtEnd ? RANKING_CAPTION_PARTIAL : RANKING_CAPTION" in body
+    assert "if (!partialAtEnd) {" in body and body.index("if (!partialAtEnd) {") < body.index("top.prepend(badge)")
+    assert body.index("if (partialAtEnd || showAllDrafts) return;") < body.index("const hidden = scored.slice")
 
 
 def test_an_edited_draft_never_carries_the_label():
     assert 'clonedForm.attr("data-dirty", "1");' in SRC
-    body = SRC[SRC.index("function finalizeRanking()") : SRC.index("\nfunction ", SRC.index("function finalizeRanking()") + 10)]
+    body = _fn("applyRanking")
     assert 'top.getAttribute("data-dirty") === "1"' in body
-    assert "if (!topIsDirty && draftSortKey(top)[0] === 2" in body
+    assert "if (!topIsDirty && draftSortKey(top)[0] === 2)" in body
 
 
 def test_show_more_keeps_keyboard_focus_and_exposes_state():

--- a/tests/async-unit/test_appeal_ranking_client.py
+++ b/tests/async-unit/test_appeal_ranking_client.py
@@ -24,8 +24,15 @@ SRC = (
 
 
 def _fn(name: str) -> str:
+    """The declaration and brace-matched body of ``name``, nothing after it.
+
+    Slicing to the next top-level declaration used to carry ninety lines of
+    module state along with applyRanking, so an assertion naming it could
+    pass on text outside it (review).
+    """
     start = SRC.index(f"function {name}(")
-    return SRC[start : SRC.index("\nfunction ", start + 10)]
+    open_at = SRC.index("{", start)
+    return SRC[start:open_at] + _brace_block(SRC, open_at)
 
 
 def test_score_frames_are_handled_before_the_no_content_skip():

--- a/tests/async-unit/test_appeal_ranking_client.py
+++ b/tests/async-unit/test_appeal_ranking_client.py
@@ -81,7 +81,11 @@ def test_nothing_moves_while_the_reader_is_using_a_draft():
     # ...and the pass is not lost: it runs once focus leaves the drafts, and
     # a deferred final pass stays final.
     assert "rankingPending = rankingPending === true || final;" in block
-    assert "setTimeout(() => applyRanking(pending), 0)" in block
+    # A queued pass belongs to the generation that queued it: it captures
+    # the counter and does nothing once a fresh generation has bumped it
+    # (review).
+    assert "const generation = rankingGeneration;" in block
+    assert "if (generation === rankingGeneration) applyRanking(pending);" in block
 
 
 def test_after_the_final_pass_every_pass_is_final():
@@ -130,6 +134,7 @@ def test_a_fresh_generation_drops_the_final_latch_but_keeps_scores_and_the_open_
     handler = SRC[start : SRC.index("doQuery(my_backend_url, my_data, my_rest_fallback_url);", start)]
     assert "retries = 0;" in handler
     assert "finalApplied = false;" in handler and "rankingPending = null;" in handler
+    assert "rankingGeneration += 1;" in handler
     assert "draftScores = new Map" not in handler and "showAllDrafts = false" not in handler
 
 

--- a/tests/async-unit/test_appeal_ranking_client.py
+++ b/tests/async-unit/test_appeal_ranking_client.py
@@ -53,26 +53,75 @@ def test_ranking_runs_live_and_once_more_at_the_real_end():
     assert "applyRanking" not in SRC[phase_done : phase_done + 2500]
 
 
-def test_nothing_moves_while_the_reader_is_typing():
+def _brace_block(src: str, open_at: int) -> str:
+    depth = 0
+    for i in range(open_at, len(src)):
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[open_at : i + 1]
+    raise AssertionError("unbalanced braces")
+
+
+def test_nothing_moves_while_the_reader_is_using_a_draft():
     body = _fn("applyRanking")
-    assert body.index("if (readerIsTyping()) {") < body.index('getElementById("appeal-ranking-note")?.remove()')
-    typing = _fn("readerIsTyping")
-    assert "document.activeElement" in typing and 'tagName === "TEXTAREA"' in typing
-    assert "outputContainer[0].contains(active)" in typing
+    guard = body.index("if (readerIsInteracting()) {")
+    assert guard < body.index('getElementById("appeal-ranking-note")?.remove()')
+    block = _brace_block(body, body.index("{", guard))
+    # The block must END by returning, and must touch nothing: delete that
+    # return and the pass runs under the reader's hands (review).
+    assert block.rstrip().endswith("return;\n  }"), block[-80:]
+    for mutation in ("outputContainer.append", ".remove()", "el.hidden", "finalApplied ="):
+        assert mutation not in block, mutation
+    interacting = _fn("readerIsInteracting")
+    assert "document.activeElement" in interacting
+    assert "active !== document.body" in interacting and "outputContainer[0].contains(active)" in interacting
     # ...and the pass is not lost: it runs once focus leaves the drafts, and
     # a deferred final pass stays final.
-    deferred = body[body.index("if (readerIsTyping()) {") : body.index('getElementById("appeal-ranking-note")?.remove()')]
-    assert 'addEventListener(\n        "focusout"' in deferred or 'addEventListener("focusout"' in deferred
-    assert "rankingPending = rankingPending === true || final;" in deferred
-    assert "setTimeout(() => applyRanking(pending), 0)" in deferred
+    assert "rankingPending = rankingPending === true || final;" in block
+    assert "setTimeout(() => applyRanking(pending), 0)" in block
+
+
+def test_after_the_final_pass_every_pass_is_final():
+    body = _fn("applyRanking")
+    assert body.index("final = final || finalApplied;") < body.index("if (readerIsInteracting()) {")
+    assert "if (final) finalApplied = true;" in body
+    assert body.index("if (final) finalApplied = true;") < body.index('getElementById("appeal-ranking-note")?.remove()')
+    assert "finalApplied = false;" not in SRC.split("export function doQuery", 1)[1]
+
+
+def test_coverage_is_decided_before_anything_moves_and_a_partial_end_never_reorders():
+    body = _fn("applyRanking")
+    move = body.index("outputContainer.append(el)")
+    assert body.index("const partialAtEnd = final && !complete;") < move
+    assert body.index("if (!anyScore) return;") < move, "no scores: the DOM is not touched"
+    assert body.index("if (!partialAtEnd) {") < move < body.index("const first = ")
+    assert "const changed = ordered.some((el, i) => el !== drafts[i]);" in body
+    assert "if (changed) for (const el of ordered) outputContainer.append(el);" in body
+
+
+def test_a_deduplicated_reserved_letter_with_a_score_still_reranks():
+    dup = SRC[SRC.index('console.log("Duplicate appeal found. Skipping.");') :].split("return;", 1)[0]
+    assert "if (parsedLine.quality_score !== undefined) applyRanking(false);" in dup
+
+
+def test_two_scorers_are_explained_at_the_end():
+    body = _fn("applyRanking")
+    start = body.index("if (!oneScale) {")
+    two = _brace_block(body, body.index("{", start))
+    assert "if (final) {" in two and "RANKING_CAPTION_UNRANKED" in two
+    assert two.rstrip().endswith("return;\n  }"), two[-60:]
 
 
 def test_caption_makes_no_promise_about_the_outcome():
-    for name in ("RANKING_CAPTION", "RANKING_CAPTION_PARTIAL"):
+    for name in ("RANKING_CAPTION", "RANKING_CAPTION_PARTIAL", "RANKING_CAPTION_UNRANKED"):
         caption = re.search(name + r' =\s*"([^"]+)"', SRC).group(1)
-        assert "not by a prediction of the outcome" in caption
         for banned in ("%", "chance", "likely", "success"):
             assert banned not in caption.lower()
+    for name in ("RANKING_CAPTION", "RANKING_CAPTION_PARTIAL"):
+        assert "not by a prediction of the outcome" in re.search(name + r' =\s*"([^"]+)"', SRC).group(1)
 
 
 def test_three_visible_then_a_show_more_button_not_a_delete():
@@ -93,7 +142,7 @@ def test_fresh_and_edited_drafts_are_never_hidden():
 def test_show_more_is_sticky_for_the_session():
     body = _fn("applyRanking")
     assert "showAllDrafts = true;" in body
-    assert "if (partialAtEnd || showAllDrafts) return;" in body
+    assert "if (showAllDrafts) return;" in body
     # doQuery also drives the automatic retries: resetting there would refold
     # what the reader chose to open.
     assert "showAllDrafts = false;" not in SRC.split("export function doQuery", 1)[1]
@@ -131,8 +180,8 @@ def test_one_scale_only_and_partial_coverage_at_the_end_drops_label_and_fold():
     # Partial at the end: the caption says so, no badge, no fold; the order
     # already on screen stays (no reshuffle back to arrival order).
     assert "partialAtEnd ? RANKING_CAPTION_PARTIAL : RANKING_CAPTION" in body
-    assert "if (!partialAtEnd) {" in body and body.index("if (!partialAtEnd) {") < body.index("top.prepend(badge)")
-    assert body.index("if (partialAtEnd || showAllDrafts) return;") < body.index("const hidden = scored.slice")
+    assert body.index("if (partialAtEnd) return;") < body.index("top.prepend(badge)")
+    assert body.index("if (partialAtEnd) return;") < body.index("const hidden = scored.slice")
 
 
 def test_an_edited_draft_never_carries_the_label():


### PR DESCRIPTION
Stacked on #996 (base is `typesafe-letter-ranking`; GitHub will retarget to `main` when that merges). That branch orders the drafts once, at the end of generation, with a Recommended label and a fold past three. This makes the page move as it goes, per Melanie's direction: drafts land in arrival order, and as TypeSafe scores come in they shuffle into rank order, only the top three showing, the rest a click away, with a freshly generated draft appended at the end and revealed. When nothing is ranked the drafts stay in arrival order and still fold past three.

**What changes** (all in `appeal_fetcher.ts`)

- `applyRanking` replaces `finalizeRanking` and runs when a draft lands, when a score frame arrives, when a deduplicated re-served letter carries a score, and once more at the real end of generation.
- Scored drafts sit first in rank order (grounded before ungrounded, then quality, then arrival). A draft with no score yet is appended after them and stays visible until its score arrives. While drafts are landing, only scored drafts past three fold behind "Show N more drafts", so a draft that just arrived stays revealed until its score does. At the end, whatever is past three in the displayed order folds, scored or not. Opening the fold is sticky for the session.
- Nothing moves while any element inside the drafts has focus: a textarea being typed in, a button reached by keyboard. The pass waits for focus to leave; a deferred final pass stays final; a deferred pass from a previous generation is discarded.
- With no score at all, live passes do not touch the DOM, so with scoring off the page behaves exactly as before while drafts land; the final pass still folds past three in arrival order (Melanie's call: unranked is not the same as unfolded). Nodes move only when the order actually differs.
- At the end with any draft unscored, the order on screen stays, the caption says some letters could not be scored, and nothing is labelled; the fold still applies to the order on screen. With two scorers in play nothing is ranked, the drafts sit in arrival order, and the caption says so. Both are deliberate changes from #996, which snapped back to arrival order; with live ordering that would be one more reshuffle at the very end.
- Enabling external models starts a new generation on the same page; the ranking's terminal state ends with the run it belonged to, while scores and an opened fold are kept.

**Tests.** `test_appeal_ranking_client.py` is rewritten to the new intent and pins the trigger points, the guard shape, the focus deferral, the generation counter, the fold rules, the captions, and the partial and mixed-scorer endings. Full async-unit suite (including #996's server-side ranking tests), tsc, and the webpack build are green.

**Review.** Codex (gpt-6-astra, read-only sandbox), five rounds. Round 1 found six real problems in the first cut: focus lost on buttons and DOM moves with no scores, a queued pass undoing the final state, the partial end reordering before deciding, deduplicated re-served letters never re-ranking, silent mixed scorers, and a deferral test that could not fail. Round 2: a fresh generation inheriting the final latch, and a mixed-scorer caption that lied. Round 3: a queued timeout surviving the fresh-generation reset. Round 4: clean. Round 5, after the arrival-order fold was added at Melanie's request: clean. Every fix was verified by applying the reviewer's scenario and watching it fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYruQVRyBbFzUxy9YGcHTb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Drafts now reorder live as scores and new results arrive.
  - Edited drafts remain preserved during ranking updates.
  - Users can permanently expand folded drafts.
  - Partial and mixed scoring results are supported.
  - Ranking pauses while readers interact with a draft, preventing unexpected movement.
  - Draft arrival order is maintained when rankings are otherwise equal.

- **Bug Fixes**
  - Ranking state resets correctly when rerunning evaluations.
  - Final captions, recommendations, and draft folding are applied consistently when processing completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->