### PR TITLE
Decide Stripe reachability lazily, not with a request at import

### DIFF
--- a/tests/async-unit/test_stripe_probe_is_lazy.py
+++ b/tests/async-unit/test_stripe_probe_is_lazy.py
@@ -44,17 +44,17 @@ def test_importing_conftest_with_a_key_makes_no_network_call():
     """
     import importlib.util
     import socket
-    import urllib.request
 
     def _no_network(*args, **kwargs):
         raise AssertionError("network access during conftest import")
 
+    # Only real network operations are guarded. Building an opener constructs
+    # handlers and does not connect; a refactor that builds one at module
+    # scope must not fail this (review).
     path = Path(root_conftest.__file__)
     with patch.dict(os.environ, {"STRIPE_TEST_SECRET_KEY": "sk_test_not_real"}), patch.object(
         socket, "create_connection", _no_network
-    ), patch.object(socket.socket, "connect", _no_network), patch.object(
-        urllib.request, "build_opener", _no_network
-    ):
+    ), patch.object(socket.socket, "connect", _no_network):
         spec = importlib.util.spec_from_file_location("_root_conftest_isolated", path)
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)  # raises if anything reached the network
@@ -94,3 +94,64 @@ def test_a_blocked_probe_skips_with_the_proxy_reason():
     ), patch.dict(os.environ, {"STRIPE_TEST_SECRET_KEY": "sk_test_not_real"}):
         with pytest.raises(pytest.skip.Exception, match="proxy"):
             root_conftest.pytest_runtest_setup(_Item(marked=True))
+
+
+REPO_ROOT = Path(root_conftest.__file__).resolve().parents[1]
+_INNER_FLAG = "_STRIPE_LAZY_INNER_RUN"
+
+# Runs pytest for real, in a subprocess, with every socket connect patched to
+# raise BEFORE pytest starts. A probe hidden in any hook of the lifecycle
+# (pytest_sessionstart, collection hooks, setup) would connect, raise, and
+# surface in the output (review). Nothing else in the test process is touched.
+_RUNNER = """
+import socket, sys
+def _deny(*args, **kwargs):
+    raise RuntimeError("NETWORK ACCESS DURING PYTEST LIFECYCLE")
+socket.create_connection = _deny
+socket.socket.connect = _deny
+import pytest
+sys.exit(pytest.main(sys.argv[1:]))
+"""
+
+
+def _inner_pytest(tmp_path, *args):
+    import subprocess
+    import sys
+
+    runner = tmp_path / "runner.py"
+    runner.write_text(_RUNNER)
+    env = dict(os.environ, STRIPE_TEST_SECRET_KEY="sk_test_not_real", **{_INNER_FLAG: "1"})
+    return subprocess.run(
+        [sys.executable, str(runner), "-q", "-p", "no:cacheprovider", "-p", "no:randomly", *args],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+
+
+@pytest.mark.skipif(os.environ.get(_INNER_FLAG) == "1", reason="inner run")
+def test_a_real_pytest_session_over_unmarked_tests_never_reaches_the_network(tmp_path):
+    """The whole lifecycle, with a key in the environment: still no connect."""
+    result = _inner_pytest(tmp_path, "tests/async-unit/test_worker_assets.py")
+    assert "NETWORK ACCESS" not in result.stdout + result.stderr, result.stdout + result.stderr
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+@pytest.mark.skipif(os.environ.get(_INNER_FLAG) == "1", reason="inner run")
+def test_a_marked_test_is_what_triggers_the_probe(tmp_path):
+    """Positive control: the guard is real, and the probe runs for a marked
+    test, at setup, not before."""
+    marked = tmp_path / "test_marked_probe.py"
+    marked.write_text(
+        "import pytest\n"
+        "@pytest.mark.stripe_e2e\n"
+        "def test_marked():\n"
+        "    pass\n"
+    )
+    result = _inner_pytest(tmp_path, "-p", "tests.conftest", str(marked))
+    out = result.stdout + result.stderr
+    # The probe ran (the guard fired) and, because the connect "failed", the
+    # marked test was skipped with the proxy reason rather than run.
+    assert "SSL-intercepting proxy" in out or "NETWORK ACCESS" in out, out

--- a/tests/async-unit/test_stripe_probe_is_lazy.py
+++ b/tests/async-unit/test_stripe_probe_is_lazy.py
@@ -63,7 +63,16 @@ def test_importing_conftest_with_a_key_makes_no_network_call():
         spec = importlib.util.spec_from_file_location("tests._root_conftest_isolated", path)
         module = importlib.util.module_from_spec(spec)
         module.__package__ = "tests"
-        spec.loader.exec_module(module)  # raises if anything reached the network
+        # Registered while it executes, as a real import would be: dataclass
+        # processing under `from __future__ import annotations` looks the
+        # module up in sys.modules (review).
+        import sys
+
+        sys.modules[spec.name] = module
+        try:
+            spec.loader.exec_module(module)  # raises if anything reached the network
+        finally:
+            sys.modules.pop(spec.name, None)
     assert callable(module.pytest_runtest_setup)
 
 

--- a/tests/async-unit/test_stripe_probe_is_lazy.py
+++ b/tests/async-unit/test_stripe_probe_is_lazy.py
@@ -146,7 +146,10 @@ if os.environ.get("%s") == "1":
         if _log:
             with open(_log, "a") as fh:
                 fh.write(repr(address) + "\\n")
-        raise RuntimeError("NETWORK ACCESS DURING PYTEST LIFECYCLE: %%r" %% (address,))
+        # OSError, not RuntimeError: the conftest's probe classifies OSError
+        # as "blocked" and skips, so the positive control below can prove the
+        # real skip path rather than a setup error (second reviewer).
+        raise OSError("NETWORK ACCESS DURING PYTEST LIFECYCLE: %%r" %% (address,))
 
     def _guard_method(real):
         # socket.socket.connect / connect_ex, called as (self, address, ...).
@@ -236,7 +239,9 @@ def test_a_marked_test_is_what_triggers_the_probe(tmp_path):
     attempts = tmp_path / "attempts.log"
     # The probe ran, inside a worker (a non-loopback attempt is on the
     # record) and, because the connect "failed", the marked test was
-    # skipped with the proxy reason rather than run. The hostname is not
-    # asserted: what matters is that an outbound attempt happened at all.
+    # SKIPPED with the proxy reason: a clean session, not a setup error.
+    # The hostname is not asserted: what matters is that an outbound
+    # attempt happened at all.
     assert attempts.exists() and attempts.read_text().strip(), out
-    assert "SSL-intercepting proxy" in out or "NETWORK ACCESS" in out, out
+    assert "SSL-intercepting proxy" in out, out
+    assert result.returncode == 0, out

--- a/tests/async-unit/test_stripe_probe_is_lazy.py
+++ b/tests/async-unit/test_stripe_probe_is_lazy.py
@@ -57,8 +57,12 @@ def test_importing_conftest_with_a_key_makes_no_network_call():
     ), patch.object(socket.socket, "connect", _no_network), patch.object(
         socket.socket, "connect_ex", _no_network
     ):
-        spec = importlib.util.spec_from_file_location("_root_conftest_isolated", path)
+        # Loaded under the `tests` package, as pytest loads it, so a relative
+        # import inside the conftest (a helper extracted to tests/x.py)
+        # resolves here too (review).
+        spec = importlib.util.spec_from_file_location("tests._root_conftest_isolated", path)
         module = importlib.util.module_from_spec(spec)
+        module.__package__ = "tests"
         spec.loader.exec_module(module)  # raises if anything reached the network
     assert callable(module.pytest_runtest_setup)
 

--- a/tests/async-unit/test_stripe_probe_is_lazy.py
+++ b/tests/async-unit/test_stripe_probe_is_lazy.py
@@ -36,16 +36,29 @@ def _fresh_decision():
     root_conftest._stripe_e2e_skip_reason = None
 
 
-def test_the_probe_is_never_called_at_import():
-    """Every call site of the probe sits inside a function, none at module level."""
-    src = Path(root_conftest.__file__).read_text()
-    assert "_skip_stripe_ssl = (" not in src, "the import-time probe is back"
-    # Call sites only; the definition line itself starts at column 0.
-    for m in re.finditer(r"(?<!def )_has_ssl_intercepting_proxy\(\)", src):
-        line_start = src.rfind("\n", 0, m.start()) + 1
-        assert src[line_start:m.start()].startswith(" "), (
-            "the probe is called at module level again"
-        )
+def test_importing_conftest_with_a_key_makes_no_network_call():
+    """Behavioural, not textual: load the conftest source fresh, with a key in
+    the environment and every socket connect patched to raise, and require
+    the import to complete. A guarded probe at module scope (review's
+    counterexample) would connect, raise, and fail the import.
+    """
+    import importlib.util
+    import socket
+    import urllib.request
+
+    def _no_network(*args, **kwargs):
+        raise AssertionError("network access during conftest import")
+
+    path = Path(root_conftest.__file__)
+    with patch.dict(os.environ, {"STRIPE_TEST_SECRET_KEY": "sk_test_not_real"}), patch.object(
+        socket, "create_connection", _no_network
+    ), patch.object(socket.socket, "connect", _no_network), patch.object(
+        urllib.request, "build_opener", _no_network
+    ):
+        spec = importlib.util.spec_from_file_location("_root_conftest_isolated", path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)  # raises if anything reached the network
+    assert callable(module.pytest_runtest_setup)
 
 
 def test_an_unmarked_test_never_triggers_the_probe():

--- a/tests/async-unit/test_stripe_probe_is_lazy.py
+++ b/tests/async-unit/test_stripe_probe_is_lazy.py
@@ -1,0 +1,83 @@
+"""The Stripe reachability probe must never run for a test that is not a Stripe test.
+
+The root conftest used to probe api.stripe.com at import whenever
+STRIPE_TEST_SECRET_KEY was in the environment, so running any test from a
+shell holding the key made a real HTTPS request before a single test ran.
+The decision is now taken lazily by a setup hook, once per process, only when
+a test carrying the ``stripe_e2e`` marker is about to run.
+"""
+
+import os
+import re
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tests import conftest as root_conftest
+
+
+class _Item:
+    """The two attributes of a pytest item the hook reads."""
+
+    def __init__(self, marked: bool):
+        self._marked = marked
+
+    def get_closest_marker(self, name):
+        return object() if self._marked and name == root_conftest.STRIPE_E2E_MARKER else None
+
+
+@pytest.fixture(autouse=True)
+def _fresh_decision():
+    root_conftest._stripe_e2e_decided = False
+    root_conftest._stripe_e2e_skip_reason = None
+    yield
+    root_conftest._stripe_e2e_decided = False
+    root_conftest._stripe_e2e_skip_reason = None
+
+
+def test_the_probe_is_never_called_at_import():
+    """Every call site of the probe sits inside a function, none at module level."""
+    src = Path(root_conftest.__file__).read_text()
+    assert "_skip_stripe_ssl = (" not in src, "the import-time probe is back"
+    # Call sites only; the definition line itself starts at column 0.
+    for m in re.finditer(r"(?<!def )_has_ssl_intercepting_proxy\(\)", src):
+        line_start = src.rfind("\n", 0, m.start()) + 1
+        assert src[line_start:m.start()].startswith(" "), (
+            "the probe is called at module level again"
+        )
+
+
+def test_an_unmarked_test_never_triggers_the_probe():
+    with patch.object(root_conftest, "_has_ssl_intercepting_proxy") as probe, patch.dict(
+        os.environ, {"STRIPE_TEST_SECRET_KEY": "sk_test_not_real"}
+    ):
+        root_conftest.pytest_runtest_setup(_Item(marked=False))
+        probe.assert_not_called()
+
+
+def test_a_marked_test_without_a_key_skips_without_probing():
+    with patch.object(root_conftest, "_has_ssl_intercepting_proxy") as probe, patch.dict(
+        os.environ
+    ):
+        os.environ.pop("STRIPE_TEST_SECRET_KEY", None)
+        with pytest.raises(pytest.skip.Exception, match="not configured"):
+            root_conftest.pytest_runtest_setup(_Item(marked=True))
+        probe.assert_not_called()
+
+
+def test_a_marked_test_with_a_key_probes_once_and_caches():
+    with patch.object(
+        root_conftest, "_has_ssl_intercepting_proxy", return_value=False
+    ) as probe, patch.dict(os.environ, {"STRIPE_TEST_SECRET_KEY": "sk_test_not_real"}):
+        root_conftest.pytest_runtest_setup(_Item(marked=True))
+        root_conftest.pytest_runtest_setup(_Item(marked=True))
+        assert probe.call_count == 1
+
+
+def test_a_blocked_probe_skips_with_the_proxy_reason():
+    with patch.object(
+        root_conftest, "_has_ssl_intercepting_proxy", return_value=True
+    ), patch.dict(os.environ, {"STRIPE_TEST_SECRET_KEY": "sk_test_not_real"}):
+        with pytest.raises(pytest.skip.Exception, match="proxy"):
+            root_conftest.pytest_runtest_setup(_Item(marked=True))

--- a/tests/async-unit/test_stripe_probe_is_lazy.py
+++ b/tests/async-unit/test_stripe_probe_is_lazy.py
@@ -171,6 +171,12 @@ def _inner_pytest(tmp_path, *args):
         PYTHONPATH=str(site_dir) + os.pathsep + os.environ.get("PYTHONPATH", ""),
         **{_INNER_FLAG: "1", _DENY_FLAG: "1", _ATTEMPT_LOG_FLAG: str(attempts)},
     )
+    # No proxy in the child: behind an HTTPS proxy the probe's first connect
+    # is to the proxy, not to Stripe, and the attempt log would name the
+    # proxy (review). With these gone the target is deterministic.
+    for name in ("HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY"):
+        env.pop(name, None)
+        env.pop(name.lower(), None)
     return subprocess.run(
         [sys.executable, "-m", "pytest", "-q", "-p", "no:cacheprovider", "-p", "no:randomly", "-n", "2", *args],
         cwd=REPO_ROOT,
@@ -211,8 +217,9 @@ def test_a_marked_test_is_what_triggers_the_probe(tmp_path):
     result = _inner_pytest(tmp_path, "-p", "tests.conftest", "-rs", str(marked))
     out = result.stdout + result.stderr
     attempts = tmp_path / "attempts.log"
-    # The probe ran, inside a worker (the attempt is on the record) and,
-    # because the connect "failed", the marked test was skipped with the
-    # proxy reason rather than run.
-    assert attempts.exists() and "api.stripe.com" in attempts.read_text(), out
+    # The probe ran, inside a worker (a non-loopback attempt is on the
+    # record) and, because the connect "failed", the marked test was
+    # skipped with the proxy reason rather than run. The hostname is not
+    # asserted: what matters is that an outbound attempt happened at all.
+    assert attempts.exists() and attempts.read_text().strip(), out
     assert "SSL-intercepting proxy" in out or "NETWORK ACCESS" in out, out

--- a/tests/async-unit/test_stripe_probe_is_lazy.py
+++ b/tests/async-unit/test_stripe_probe_is_lazy.py
@@ -101,6 +101,7 @@ def test_a_blocked_probe_skips_with_the_proxy_reason():
 REPO_ROOT = Path(root_conftest.__file__).resolve().parents[1]
 _INNER_FLAG = "_STRIPE_LAZY_INNER_RUN"
 _DENY_FLAG = "_STRIPE_LAZY_DENY_NETWORK"
+_ATTEMPT_LOG_FLAG = "_STRIPE_LAZY_ATTEMPT_LOG"
 
 # Installed as sitecustomize.py on PYTHONPATH, so it runs at interpreter start
 # in the pytest process AND in every xdist worker (workers are separate
@@ -115,6 +116,7 @@ if os.environ.get("%s") == "1":
     _real_create_connection = socket.create_connection
     _real_connect = socket.socket.connect
     _real_connect_ex = socket.socket.connect_ex
+    _log = os.environ.get("%s")
 
     def _is_local(address):
         # Loopback and Unix sockets stay open: xdist's own plumbing and
@@ -125,18 +127,34 @@ if os.environ.get("%s") == "1":
         host = address[0] if isinstance(address, tuple) and address else address
         return host in ("", "localhost", "127.0.0.1", "::1", "0.0.0.0")
 
-    def _guard(real):
-        def wrapped(*args, **kwargs):
-            address = args[1] if len(args) > 1 else args[0] if args else kwargs.get("address")
+    def _attempt(address):
+        # Recorded BEFORE raising, so a probe that swallows the error is
+        # still on the record (review).
+        if _log:
+            with open(_log, "a") as fh:
+                fh.write(repr(address) + "\\n")
+        raise RuntimeError("NETWORK ACCESS DURING PYTEST LIFECYCLE: %%r" %% (address,))
+
+    def _guard_method(real):
+        # socket.socket.connect / connect_ex, called as (self, address, ...).
+        def wrapped(self, address, *args, **kwargs):
             if not _is_local(address):
-                raise RuntimeError("NETWORK ACCESS DURING PYTEST LIFECYCLE: %%r" %% (address,))
-            return real(*args, **kwargs)
+                _attempt(address)
+            return real(self, address, *args, **kwargs)
         return wrapped
 
-    socket.create_connection = _guard(_real_create_connection)
-    socket.socket.connect = _guard(_real_connect)
-    socket.socket.connect_ex = _guard(_real_connect_ex)
-""" % _DENY_FLAG
+    def _guard_create_connection(real):
+        # socket.create_connection(address, timeout=..., ...): address first.
+        def wrapped(address, *args, **kwargs):
+            if not _is_local(address):
+                _attempt(address)
+            return real(address, *args, **kwargs)
+        return wrapped
+
+    socket.create_connection = _guard_create_connection(_real_create_connection)
+    socket.socket.connect = _guard_method(_real_connect)
+    socket.socket.connect_ex = _guard_method(_real_connect_ex)
+""" % (_DENY_FLAG, _ATTEMPT_LOG_FLAG)
 
 
 def _inner_pytest(tmp_path, *args):
@@ -146,11 +164,12 @@ def _inner_pytest(tmp_path, *args):
     site_dir = tmp_path / "site"
     site_dir.mkdir(exist_ok=True)
     (site_dir / "sitecustomize.py").write_text(_SITECUSTOMIZE)
+    attempts = tmp_path / "attempts.log"
     env = dict(
         os.environ,
         STRIPE_TEST_SECRET_KEY="sk_test_not_real",
         PYTHONPATH=str(site_dir) + os.pathsep + os.environ.get("PYTHONPATH", ""),
-        **{_INNER_FLAG: "1", _DENY_FLAG: "1"},
+        **{_INNER_FLAG: "1", _DENY_FLAG: "1", _ATTEMPT_LOG_FLAG: str(attempts)},
     )
     return subprocess.run(
         [sys.executable, "-m", "pytest", "-q", "-p", "no:cacheprovider", "-p", "no:randomly", "-n", "2", *args],
@@ -167,6 +186,10 @@ def test_a_real_pytest_session_over_unmarked_tests_never_reaches_the_network(tmp
     """The whole lifecycle, with a key in the environment: still no connect."""
     result = _inner_pytest(tmp_path, "tests/async-unit/test_worker_assets.py")
     out = result.stdout + result.stderr
+    attempts = tmp_path / "attempts.log"
+    # The record, not the exception: a probe that swallows the error is
+    # still an attempt (review).
+    assert not attempts.exists() or attempts.read_text() == "", attempts.read_text()
     assert "NETWORK ACCESS" not in out, out
     assert result.returncode == 0, out
     # The guard was live in the workers too: xdist actually ran. Under -q
@@ -187,7 +210,9 @@ def test_a_marked_test_is_what_triggers_the_probe(tmp_path):
     )
     result = _inner_pytest(tmp_path, "-p", "tests.conftest", "-rs", str(marked))
     out = result.stdout + result.stderr
-    # The probe ran, inside a worker (the guard fired there) and, because
-    # the connect "failed", the marked test was skipped with the proxy
-    # reason rather than run.
+    attempts = tmp_path / "attempts.log"
+    # The probe ran, inside a worker (the attempt is on the record) and,
+    # because the connect "failed", the marked test was skipped with the
+    # proxy reason rather than run.
+    assert attempts.exists() and "api.stripe.com" in attempts.read_text(), out
     assert "SSL-intercepting proxy" in out or "NETWORK ACCESS" in out, out

--- a/tests/async-unit/test_stripe_probe_is_lazy.py
+++ b/tests/async-unit/test_stripe_probe_is_lazy.py
@@ -54,7 +54,9 @@ def test_importing_conftest_with_a_key_makes_no_network_call():
     path = Path(root_conftest.__file__)
     with patch.dict(os.environ, {"STRIPE_TEST_SECRET_KEY": "sk_test_not_real"}), patch.object(
         socket, "create_connection", _no_network
-    ), patch.object(socket.socket, "connect", _no_network):
+    ), patch.object(socket.socket, "connect", _no_network), patch.object(
+        socket.socket, "connect_ex", _no_network
+    ):
         spec = importlib.util.spec_from_file_location("_root_conftest_isolated", path)
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)  # raises if anything reached the network
@@ -98,36 +100,65 @@ def test_a_blocked_probe_skips_with_the_proxy_reason():
 
 REPO_ROOT = Path(root_conftest.__file__).resolve().parents[1]
 _INNER_FLAG = "_STRIPE_LAZY_INNER_RUN"
+_DENY_FLAG = "_STRIPE_LAZY_DENY_NETWORK"
 
-# Runs pytest for real, in a subprocess, with every socket connect patched to
-# raise BEFORE pytest starts. A probe hidden in any hook of the lifecycle
-# (pytest_sessionstart, collection hooks, setup) would connect, raise, and
-# surface in the output (review). Nothing else in the test process is touched.
-_RUNNER = """
-import socket, sys
-def _deny(*args, **kwargs):
-    raise RuntimeError("NETWORK ACCESS DURING PYTEST LIFECYCLE")
-socket.create_connection = _deny
-socket.socket.connect = _deny
-import pytest
-sys.exit(pytest.main(sys.argv[1:]))
-"""
+# Installed as sitecustomize.py on PYTHONPATH, so it runs at interpreter start
+# in the pytest process AND in every xdist worker (workers are separate
+# interpreters that inherit the environment, not the parent's monkeypatches).
+# A probe hidden in any hook of the lifecycle, in the controller or a worker,
+# would connect, raise, and surface in the output (review). It is gated on an
+# environment flag so it can never affect anything else.
+_SITECUSTOMIZE = """
+import os
+if os.environ.get("%s") == "1":
+    import socket
+    _real_create_connection = socket.create_connection
+    _real_connect = socket.socket.connect
+    _real_connect_ex = socket.socket.connect_ex
+
+    def _is_local(address):
+        # Loopback and Unix sockets stay open: xdist's own plumbing and
+        # pytest-rerunfailures' shared-state server connect to localhost at
+        # configure time. api.stripe.com is never loopback.
+        if isinstance(address, (str, bytes)):
+            return True
+        host = address[0] if isinstance(address, tuple) and address else address
+        return host in ("", "localhost", "127.0.0.1", "::1", "0.0.0.0")
+
+    def _guard(real):
+        def wrapped(*args, **kwargs):
+            address = args[1] if len(args) > 1 else args[0] if args else kwargs.get("address")
+            if not _is_local(address):
+                raise RuntimeError("NETWORK ACCESS DURING PYTEST LIFECYCLE: %%r" %% (address,))
+            return real(*args, **kwargs)
+        return wrapped
+
+    socket.create_connection = _guard(_real_create_connection)
+    socket.socket.connect = _guard(_real_connect)
+    socket.socket.connect_ex = _guard(_real_connect_ex)
+""" % _DENY_FLAG
 
 
 def _inner_pytest(tmp_path, *args):
     import subprocess
     import sys
 
-    runner = tmp_path / "runner.py"
-    runner.write_text(_RUNNER)
-    env = dict(os.environ, STRIPE_TEST_SECRET_KEY="sk_test_not_real", **{_INNER_FLAG: "1"})
+    site_dir = tmp_path / "site"
+    site_dir.mkdir(exist_ok=True)
+    (site_dir / "sitecustomize.py").write_text(_SITECUSTOMIZE)
+    env = dict(
+        os.environ,
+        STRIPE_TEST_SECRET_KEY="sk_test_not_real",
+        PYTHONPATH=str(site_dir) + os.pathsep + os.environ.get("PYTHONPATH", ""),
+        **{_INNER_FLAG: "1", _DENY_FLAG: "1"},
+    )
     return subprocess.run(
-        [sys.executable, str(runner), "-q", "-p", "no:cacheprovider", "-p", "no:randomly", *args],
+        [sys.executable, "-m", "pytest", "-q", "-p", "no:cacheprovider", "-p", "no:randomly", "-n", "2", *args],
         cwd=REPO_ROOT,
         env=env,
         capture_output=True,
         text=True,
-        timeout=300,
+        timeout=600,
     )
 
 
@@ -135,8 +166,12 @@ def _inner_pytest(tmp_path, *args):
 def test_a_real_pytest_session_over_unmarked_tests_never_reaches_the_network(tmp_path):
     """The whole lifecycle, with a key in the environment: still no connect."""
     result = _inner_pytest(tmp_path, "tests/async-unit/test_worker_assets.py")
-    assert "NETWORK ACCESS" not in result.stdout + result.stderr, result.stdout + result.stderr
-    assert result.returncode == 0, result.stdout + result.stderr
+    out = result.stdout + result.stderr
+    assert "NETWORK ACCESS" not in out, out
+    assert result.returncode == 0, out
+    # The guard was live in the workers too: xdist actually ran. Under -q
+    # its only trace is the "bringing up nodes" line.
+    assert "bringing up nodes" in out or "[gw0]" in out or "2 workers" in out, out
 
 
 @pytest.mark.skipif(os.environ.get(_INNER_FLAG) == "1", reason="inner run")
@@ -150,8 +185,9 @@ def test_a_marked_test_is_what_triggers_the_probe(tmp_path):
         "def test_marked():\n"
         "    pass\n"
     )
-    result = _inner_pytest(tmp_path, "-p", "tests.conftest", str(marked))
+    result = _inner_pytest(tmp_path, "-p", "tests.conftest", "-rs", str(marked))
     out = result.stdout + result.stderr
-    # The probe ran (the guard fired) and, because the connect "failed", the
-    # marked test was skipped with the proxy reason rather than run.
+    # The probe ran, inside a worker (the guard fired there) and, because
+    # the connect "failed", the marked test was skipped with the proxy
+    # reason rather than run.
     assert "SSL-intercepting proxy" in out or "NETWORK ACCESS" in out, out

--- a/tests/async-unit/test_stripe_probe_is_lazy.py
+++ b/tests/async-unit/test_stripe_probe_is_lazy.py
@@ -171,10 +171,14 @@ def _inner_pytest(tmp_path, *args):
         PYTHONPATH=str(site_dir) + os.pathsep + os.environ.get("PYTHONPATH", ""),
         **{_INNER_FLAG: "1", _DENY_FLAG: "1", _ATTEMPT_LOG_FLAG: str(attempts)},
     )
-    # No proxy in the child: behind an HTTPS proxy the probe's first connect
-    # is to the proxy, not to Stripe, and the attempt log would name the
-    # proxy (review). With these gone the target is deterministic.
-    for name in ("HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY"):
+    # The child runs with the outer environment minus two things. No proxy:
+    # behind an HTTPS proxy the probe's first connect is to the proxy, not to
+    # Stripe, and the attempt log would name the proxy. And no inherited
+    # pytest selection: a PYTEST_ADDOPTS of `-m "not stripe_e2e"` on the
+    # outer run would deselect the positive control's own marked test
+    # (review). Anything else the outer environment carries is inherited
+    # as is; that is the documented boundary of these two tests.
+    for name in ("HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY", "PYTEST_ADDOPTS"):
         env.pop(name, None)
         env.pop(name.lower(), None)
     return subprocess.run(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,19 +52,49 @@ def _has_ssl_intercepting_proxy() -> bool:
         return True
 
 
-# Only probe when Stripe is actually configured. The E2E tests gated on this
-# need STRIPE_TEST_SECRET_KEY and can't run without it, so when it's unset we
-# skip them without paying ~5s for a network probe to api.stripe.com whose
-# result can't change the outcome (pure waste in firewalled CI that never
-# configures Stripe).
-_skip_stripe_ssl = (
-    _has_ssl_intercepting_proxy() if os.environ.get("STRIPE_TEST_SECRET_KEY") else True
-)
+# The Stripe end-to-end tests need STRIPE_TEST_SECRET_KEY and a reachable
+# api.stripe.com. Deciding that used to happen HERE, at import, with a real
+# HTTPS request whenever the key was in the environment: running any test at
+# all from a shell that happened to hold the key contacted Stripe before a
+# single test ran (review; the hermeticity rule in AGENTS.md). The decision is
+# now made lazily, once per process, the first time a test carrying the marker
+# is about to run. A test that never touches Stripe never triggers it.
+STRIPE_E2E_MARKER = "stripe_e2e"
+skip_if_stripe_ssl_blocked = pytest.mark.stripe_e2e
 
-skip_if_stripe_ssl_blocked = pytest.mark.skipif(
-    _skip_stripe_ssl,
-    reason="Stripe not configured (STRIPE_TEST_SECRET_KEY unset) or SSL-intercepting proxy blocks api.stripe.com",
-)
+_stripe_e2e_decided = False
+_stripe_e2e_skip_reason: str | None = None
+
+
+def _stripe_e2e_skip_reason_lazy() -> str | None:
+    """Why a Stripe E2E test should be skipped, or None to run it. Decided once."""
+    global _stripe_e2e_decided, _stripe_e2e_skip_reason
+    if not _stripe_e2e_decided:
+        if not os.environ.get("STRIPE_TEST_SECRET_KEY"):
+            _stripe_e2e_skip_reason = "Stripe not configured (STRIPE_TEST_SECRET_KEY unset)"
+        elif _has_ssl_intercepting_proxy():
+            _stripe_e2e_skip_reason = "SSL-intercepting proxy blocks api.stripe.com"
+        else:
+            _stripe_e2e_skip_reason = None
+        _stripe_e2e_decided = True
+    return _stripe_e2e_skip_reason
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        f"{STRIPE_E2E_MARKER}: end-to-end test against the live Stripe test API; "
+        "skipped unless STRIPE_TEST_SECRET_KEY is set and api.stripe.com is "
+        "reachable, decided lazily the first time such a test is about to run",
+    )
+
+
+def pytest_runtest_setup(item):
+    if item.get_closest_marker(STRIPE_E2E_MARKER) is None:
+        return
+    reason = _stripe_e2e_skip_reason_lazy()
+    if reason:
+        pytest.skip(reason)
 
 skip_if_no_pandoc = pytest.mark.skipif(
     shutil.which("pandoc") is None,


### PR DESCRIPTION
The root `tests/conftest.py` probed api.stripe.com at import whenever `STRIPE_TEST_SECRET_KEY` was in the environment, to decide whether the Stripe end-to-end tests could run. So running any test at all from a shell holding the key made a real HTTPS request before a single test ran, which is the hermeticity rule in `AGENTS.md` broken by the harness itself. Melanie asked for this to stop.

**What changes**

- The decision moves into a `pytest_runtest_setup` hook and is taken once per process, the first time a test carrying the `stripe_e2e` marker is about to run. `skip_if_stripe_ssl_blocked` keeps its name and both call sites; it is now that marker. A test that never touches Stripe never triggers the probe.
- The end-to-end Stripe tests themselves still run against the live Stripe test API when CI provides the key. That is what they are for; verified here with no key that all eleven skip with the "not configured" reason.
- The marker is registered in `pytest_configure`, so no unknown-marker warning.

**Tests.** `test_stripe_probe_is_lazy.py` pins it three ways: an isolated import of the conftest with a key present and every socket connect patched to raise must complete; two subprocess runs drive pytest itself under xdist with a network guard installed by `sitecustomize` in every worker, one over an unmarked module (must make no non-loopback attempt, recorded to a log independent of any exception) and one over a temp module carrying the marker (the positive control, must record an attempt and skip with the proxy reason). The hook's four decisions are unit-tested directly.

**Review.** Codex (gpt-6-astra, read-only sandbox), nine rounds. Every round found a way an accidental edit could reintroduce a probe or a way the tests could fail on legitimate code, and each was fixed and verified in both directions: indentation as proof; hooks at collection; `connect_ex`; xdist workers; a probe wrapped in `try/except`; `create_connection`'s positional timeout; an inherited HTTPS proxy; an inherited `PYTEST_ADDOPTS`; relative imports and dataclass helpers in the isolated import. Round 9: nothing at the agreed bar. Boundaries accepted and written at the code: the guard is in-process and catches accidents, not deliberate evasion; the child sessions run with the outer environment minus proxies and `PYTEST_ADDOPTS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYruQVRyBbFzUxy9YGcHTb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Stripe end-to-end checks now run only when explicitly marked.
  - Unmarked tests no longer initiate Stripe network requests.
  - Stripe connectivity checks are performed lazily and cached within each test process.
  - Tests automatically skip when credentials are unavailable or connectivity is blocked.
  - Coverage now includes standard pytest runs, parallel execution, and controller/worker processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->