### PR TITLE
Show TypeSafe scoring health on the staff status page

### DIFF
--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -3512,12 +3512,21 @@ class AppealsBackendHelper:
                 )
                 scoring_active = False
 
+        async def _note_scoring_failure(summary: str) -> None:
+            # Cross-pod record for the status page: why the last call failed.
+            await ExternalServiceHealth.anote_failure(letter_quality.SERVICE, summary)
+
         async def _score_draft(proposed_id: str, draft_text: str) -> Optional[str]:
             score = await letter_quality.score_letter(
-                denial.denial_text, draft_text, identifiers=scoring_identifiers
+                denial.denial_text,
+                draft_text,
+                identifiers=scoring_identifiers,
+                on_failure=_note_scoring_failure,
             )
             if score is None:
                 return None
+            # Same record, the other way: TypeSafe answered. Best effort.
+            await ExternalServiceHealth.anote_success(letter_quality.SERVICE)
             # Only the row whose text is still the text that was scored: an
             # admin can edit a draft during the few seconds of scoring, and
             # a score for text nobody sees any more must not land on the

--- a/fighthealthinsurance/migrations/0206_externalservicehealth.py
+++ b/fighthealthinsurance/migrations/0206_externalservicehealth.py
@@ -1,0 +1,38 @@
+# Cross-pod record of the last outcome of calls to an external service, one
+# row per service (models.ExternalServiceHealth). Written by the TypeSafe
+# scoring call site, read by the staff status page. Unique on service; the
+# other columns are read one row at a time, so no further index.
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("fighthealthinsurance", "0205_proposedappeal_quality_score"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="ExternalServiceHealth",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("service", models.CharField(max_length=64, unique=True)),
+                ("last_success_at", models.DateTimeField(blank=True, null=True)),
+                ("last_failure_at", models.DateTimeField(blank=True, null=True)),
+                (
+                    "last_failure",
+                    models.CharField(blank=True, default="", max_length=80),
+                ),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+            ],
+        ),
+    ]

--- a/fighthealthinsurance/ml/letter_quality.py
+++ b/fighthealthinsurance/ml/letter_quality.py
@@ -71,6 +71,10 @@ RUBRIC_VERSION = 1
 _RUBRIC_SUFFIX = f"/rubric-{RUBRIC_VERSION}"
 SCORER = f"typesafe/{MODEL}{_RUBRIC_SUFFIX}"
 
+# Key of the cross-pod health record (models.ExternalServiceHealth) that the
+# staff status page reads.
+SERVICE = "typesafe"
+
 
 def scorer_for(payload: typing.Any) -> str:
     """The provenance string for a row: the model TypeSafe says answered
@@ -171,6 +175,18 @@ class LetterScore:
 
 class LetterScoringError(Exception):
     """A response we could not turn into a score."""
+
+
+def failure_summary(e: BaseException) -> str:
+    """Why scoring failed, in a form safe for a status page: the HTTP status
+    when the API answered, "timeout", or the exception class name alone.
+    Never the message (a transport error's names the host) and never
+    anything from the document."""
+    if isinstance(e, typesafe.TypeSafeError) and e.status is not None:
+        return f"HTTP {e.status}"
+    if isinstance(e, (TimeoutError, asyncio.TimeoutError)):
+        return "timeout"
+    return type(e).__name__
 
 
 # Process-local request outcomes, exported by letter_quality_metrics.
@@ -485,12 +501,17 @@ async def score_letter(
     *,
     identifiers: typing.Iterable[Redaction] = (),
     timeout_seconds: typing.Optional[float] = None,
+    on_failure: typing.Optional[typing.Callable[[str], typing.Awaitable[None]]] = None,
 ) -> typing.Optional[LetterScore]:
     """Score one draft, or return None. Never raises, never logs the text.
 
     ``identifiers`` is everything we hold that could name the patient or the
     professional; see redact(). Pass it. An empty list only means we hold
     nothing, and the generic patterns still run.
+
+    ``on_failure`` is awaited with failure_summary(e) when the request or
+    the answer fails; it is how the call site records "why" somewhere the
+    status page can see. Its own errors are logged and swallowed.
     """
     if not enabled():
         _count("skipped")
@@ -513,6 +534,13 @@ async def score_letter(
         # status alone and aiohttp's own errors describe the connection.
         _count("failed")
         logger.warning(f"letter scoring unavailable: {type(e).__name__}: {e}")
+        if on_failure is not None:
+            try:
+                await on_failure(failure_summary(e))
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.opt(exception=True).warning("letter scoring failure hook failed")
         return None
     _count("scored")
     return score

--- a/fighthealthinsurance/ml/typesafe.py
+++ b/fighthealthinsurance/ml/typesafe.py
@@ -25,7 +25,16 @@ DOCUMENT_CHAR_CAP = 24_000
 
 
 class TypeSafeError(Exception):
-    """The API did not return a usable answer set."""
+    """The API did not return a usable answer set.
+
+    ``status`` is the HTTP status when the API answered at all, so a caller
+    can tell a rejected key (401, 403) or exhausted credits (402) from an
+    outage (5xx) without parsing the message.
+    """
+
+    def __init__(self, message: str, status: typing.Optional[int] = None):
+        super().__init__(message)
+        self.status = status
 
 
 def configured() -> bool:
@@ -66,5 +75,5 @@ async def ask(
             url, json=body, headers=headers, allow_redirects=False
         ) as response:
             if response.status != 200:
-                raise TypeSafeError(f"HTTP {response.status}")
+                raise TypeSafeError(f"HTTP {response.status}", status=response.status)
             return await response.json()

--- a/fighthealthinsurance/models.py
+++ b/fighthealthinsurance/models.py
@@ -4055,11 +4055,27 @@ class ExternalServiceHealth(models.Model):
 
     @classmethod
     async def anote_success(cls, service: str) -> None:
-        """Best effort: a health record must never break the call it watches."""
+        """Best effort: a health record must never break the call it watches.
+
+        Only ever moves the timestamp forward. Calls overlap (several drafts
+        score at once, on several pods), so a slow write from an older call
+        must not land on top of a newer outcome and fake a recovery (review):
+        a conditional UPDATE does the move, and aget_or_create covers the
+        first-ever row.
+        """
         try:
-            await cls.objects.aupdate_or_create(
-                service=service, defaults={"last_success_at": timezone.now()}
-            )
+            now = timezone.now()
+            moved = await cls.objects.filter(
+                models.Q(service=service)
+                & (
+                    models.Q(last_success_at__isnull=True)
+                    | models.Q(last_success_at__lt=now)
+                )
+            ).aupdate(last_success_at=now)
+            if not moved:
+                await cls.objects.aget_or_create(
+                    service=service, defaults={"last_success_at": now}
+                )
         except Exception:
             logger.opt(exception=True).warning(
                 f"could not record a success for external service {service}"
@@ -4067,16 +4083,24 @@ class ExternalServiceHealth(models.Model):
 
     @classmethod
     async def anote_failure(cls, service: str, summary: str) -> None:
-        """Best effort, see anote_success. ``summary`` must already be
-        allowlisted by the caller; it is stored as given, cut to the column."""
+        """Best effort and forward-only, see anote_success. ``summary`` must
+        already be allowlisted by the caller; it is stored as given, cut to
+        the column, and travels with its timestamp in one statement."""
         try:
-            await cls.objects.aupdate_or_create(
-                service=service,
-                defaults={
-                    "last_failure_at": timezone.now(),
-                    "last_failure": (summary or "")[:80],
-                },
-            )
+            now = timezone.now()
+            text = (summary or "")[:80]
+            moved = await cls.objects.filter(
+                models.Q(service=service)
+                & (
+                    models.Q(last_failure_at__isnull=True)
+                    | models.Q(last_failure_at__lt=now)
+                )
+            ).aupdate(last_failure_at=now, last_failure=text)
+            if not moved:
+                await cls.objects.aget_or_create(
+                    service=service,
+                    defaults={"last_failure_at": now, "last_failure": text},
+                )
         except Exception:
             logger.opt(exception=True).warning(
                 f"could not record a failure for external service {service}"

--- a/fighthealthinsurance/models.py
+++ b/fighthealthinsurance/models.py
@@ -4033,6 +4033,59 @@ class ModelHealthAlertState(models.Model):
         return f"ModelHealthAlertState<{self.key}@{self.last_alert_sent}>"
 
 
+class ExternalServiceHealth(models.Model):
+    """Last outcome of calls to one external service, shared across pods.
+
+    One row per service. The web pods and the Temporal worker each make
+    their own calls, and the staff status page is served by whichever pod
+    the browser is pinned to, so a process-local "last failure" would be
+    blind to most of the traffic. The call site writes here on success and
+    on failure; the status page reads it.
+
+    ``last_failure`` is a short allowlisted summary (an HTTP status,
+    "timeout", or an exception class name), never a response body, a URL,
+    or anything from the document that was sent.
+    """
+
+    service = models.CharField(max_length=64, unique=True)
+    last_success_at = models.DateTimeField(null=True, blank=True)
+    last_failure_at = models.DateTimeField(null=True, blank=True)
+    last_failure = models.CharField(max_length=80, blank=True, default="")
+    updated_at = models.DateTimeField(auto_now=True)
+
+    @classmethod
+    async def anote_success(cls, service: str) -> None:
+        """Best effort: a health record must never break the call it watches."""
+        try:
+            await cls.objects.aupdate_or_create(
+                service=service, defaults={"last_success_at": timezone.now()}
+            )
+        except Exception:
+            logger.opt(exception=True).warning(
+                f"could not record a success for external service {service}"
+            )
+
+    @classmethod
+    async def anote_failure(cls, service: str, summary: str) -> None:
+        """Best effort, see anote_success. ``summary`` must already be
+        allowlisted by the caller; it is stored as given, cut to the column."""
+        try:
+            await cls.objects.aupdate_or_create(
+                service=service,
+                defaults={
+                    "last_failure_at": timezone.now(),
+                    "last_failure": (summary or "")[:80],
+                },
+            )
+        except Exception:
+            logger.opt(exception=True).warning(
+                f"could not record a failure for external service {service}"
+            )
+
+    def __str__(self) -> str:
+        return f"ExternalServiceHealth<{self.service}>"
+
+
 class ModelBackendHealthCheckResult(models.Model):
     """One row per model backend per health-check run.
 

--- a/fighthealthinsurance/models.py
+++ b/fighthealthinsurance/models.py
@@ -4054,28 +4054,37 @@ class ExternalServiceHealth(models.Model):
     updated_at = models.DateTimeField(auto_now=True)
 
     @classmethod
-    async def anote_success(cls, service: str) -> None:
-        """Best effort: a health record must never break the call it watches.
+    async def _advance(cls, service: str, field: str, now, values: dict) -> None:
+        """Forward-only write of ``values`` (which set ``field`` to ``now``).
 
-        Only ever moves the timestamp forward. Calls overlap (several drafts
-        score at once, on several pods), so a slow write from an older call
-        must not land on top of a newer outcome and fake a recovery (review):
-        a conditional UPDATE does the move, and aget_or_create covers the
-        first-ever row.
+        Calls overlap (several drafts score at once, on several pods), so a
+        slow write from an older call must not land on top of a newer
+        outcome and fake a recovery (review). A conditional UPDATE moves the
+        column only when it is empty or older; aget_or_create covers the
+        first-ever row; and if the row appeared between those two statements
+        (another pod's first write), the conditional UPDATE runs once more
+        against it, so the newer outcome still wins (review).
         """
+        older = models.Q(**{f"{field}__isnull": True}) | models.Q(
+            **{f"{field}__lt": now}
+        )
+        if await cls.objects.filter(models.Q(service=service) & older).aupdate(
+            **values
+        ):
+            return
+        _, created = await cls.objects.aget_or_create(service=service, defaults=values)
+        if created:
+            return
+        await cls.objects.filter(models.Q(service=service) & older).aupdate(**values)
+
+    @classmethod
+    async def anote_success(cls, service: str) -> None:
+        """Best effort: a health record must never break the call it watches."""
         try:
             now = timezone.now()
-            moved = await cls.objects.filter(
-                models.Q(service=service)
-                & (
-                    models.Q(last_success_at__isnull=True)
-                    | models.Q(last_success_at__lt=now)
-                )
-            ).aupdate(last_success_at=now)
-            if not moved:
-                await cls.objects.aget_or_create(
-                    service=service, defaults={"last_success_at": now}
-                )
+            await cls._advance(
+                service, "last_success_at", now, {"last_success_at": now}
+            )
         except Exception:
             logger.opt(exception=True).warning(
                 f"could not record a success for external service {service}"
@@ -4088,19 +4097,12 @@ class ExternalServiceHealth(models.Model):
         the column, and travels with its timestamp in one statement."""
         try:
             now = timezone.now()
-            text = (summary or "")[:80]
-            moved = await cls.objects.filter(
-                models.Q(service=service)
-                & (
-                    models.Q(last_failure_at__isnull=True)
-                    | models.Q(last_failure_at__lt=now)
-                )
-            ).aupdate(last_failure_at=now, last_failure=text)
-            if not moved:
-                await cls.objects.aget_or_create(
-                    service=service,
-                    defaults={"last_failure_at": now, "last_failure": text},
-                )
+            await cls._advance(
+                service,
+                "last_failure_at",
+                now,
+                {"last_failure_at": now, "last_failure": (summary or "")[:80]},
+            )
         except Exception:
             logger.opt(exception=True).warning(
                 f"could not record a failure for external service {service}"

--- a/fighthealthinsurance/staff_views.py
+++ b/fighthealthinsurance/staff_views.py
@@ -173,6 +173,7 @@ class AdminStatusView(generic.TemplateView):
         ctx["temporal"] = self._temporal_status()
         ctx["fax_outcomes"] = self._fax_outcome_status()
         ctx["intake_funnel"] = self._intake_funnel_status()
+        ctx["letter_scoring"] = self._letter_scoring_status()
         ctx["storage"] = self._storage_status()
         return ctx
 
@@ -541,6 +542,113 @@ class AdminStatusView(generic.TemplateView):
             logger.opt(exception=True).warning("Temporal status check failed")
             out["ok"] = False
             out["error"] = AdminStatusView._temporal_error_message(e)
+        return out
+
+    @staticmethod
+    def _scoring_failure_hint(summary: str) -> str:
+        """What a recorded scoring failure most likely means, for on-call."""
+        if summary == "HTTP 402":
+            return "payment required: TypeSafe credits or billing"
+        if summary in ("HTTP 401", "HTTP 403"):
+            return "the API key was rejected"
+        if summary == "HTTP 429":
+            return "rate limited"
+        if summary.startswith("HTTP 5"):
+            return "TypeSafe server error"
+        if summary == "timeout":
+            return "no answer within TYPESAFE_TIMEOUT_SECONDS"
+        return ""
+
+    @staticmethod
+    def _letter_scoring_status() -> Dict[str, Any]:
+        """TypeSafe draft scoring (last 24h): on or off, scoring or not, and
+        if not, why. Counts and a short failure summary only, no letter text.
+
+        Built from the database, not from this process's counters: the page
+        is served by whichever web pod the browser is pinned to, and the
+        Temporal worker scores drafts too. The scoring call site keeps one
+        ExternalServiceHealth row current; the draft rows give the counts.
+        """
+        out: Dict[str, Any] = {
+            "ok": True,
+            "error": None,
+            "level": "off",
+            "key_present": False,
+            "flag_on": False,
+            "timeout_seconds": None,
+            "window_hours": 24,
+            "scored": 0,
+            "unscored": 0,
+            "last_success_at": None,
+            "last_failure_at": None,
+            "last_failure": "",
+            "last_failure_hint": "",
+            "recovered": False,
+        }
+        try:
+            from django.conf import settings
+
+            from fighthealthinsurance.letter_quality_metrics import WINDOW
+            from fighthealthinsurance.models import ExternalServiceHealth
+
+            out["key_present"] = bool(getattr(settings, "TYPESAFE_API_KEY", None))
+            out["flag_on"] = bool(
+                getattr(settings, "TYPESAFE_LETTER_RANKING_ENABLED", False)
+            )
+            out["timeout_seconds"] = getattr(settings, "TYPESAFE_TIMEOUT_SECONDS", None)
+            out["window_hours"] = int(WINDOW.total_seconds() // 3600)
+
+            now = timezone.now()
+            since = now - WINDOW
+            out["scored"] = ProposedAppeal.objects.filter(
+                quality_scored_at__gte=since
+            ).count()
+            # Drafts that should have been scored and were not: consented,
+            # real (not speculative), old enough that a score in flight would
+            # have landed, and still without one.
+            settled = now - datetime.timedelta(seconds=letter_quality.DRAIN_SECONDS)
+            out["unscored"] = ProposedAppeal.objects.filter(
+                created_at__gte=since,
+                created_at__lt=settled,
+                speculative=False,
+                for_denial__use_external=True,
+                quality_score__isnull=True,
+            ).count()
+
+            health = ExternalServiceHealth.objects.filter(
+                service=letter_quality.SERVICE
+            ).first()
+            success_at = health.last_success_at if health else None
+            failure_at = health.last_failure_at if health else None
+            out["last_success_at"] = success_at
+            out["last_failure_at"] = failure_at
+            out["last_failure"] = health.last_failure if health else ""
+            out["last_failure_hint"] = AdminStatusView._scoring_failure_hint(
+                out["last_failure"]
+            )
+            out["recovered"] = bool(
+                failure_at and success_at and success_at > failure_at
+            )
+            fresh_failure = bool(
+                failure_at
+                and failure_at >= since
+                and (success_at is None or failure_at > success_at)
+            )
+
+            if not letter_quality.enabled():
+                out["level"] = "off"
+            elif fresh_failure:
+                out["level"] = "failing"
+            elif out["scored"]:
+                out["level"] = "scoring"
+            elif out["unscored"]:
+                out["level"] = "not_scoring"
+            else:
+                out["level"] = "idle"
+        except Exception as e:
+            logger.opt(exception=True).warning("Letter scoring health check failed")
+            out["ok"] = False
+            out["error"] = str(e)
         return out
 
     @staticmethod

--- a/fighthealthinsurance/staff_views.py
+++ b/fighthealthinsurance/staff_views.py
@@ -601,8 +601,14 @@ class AdminStatusView(generic.TemplateView):
 
             now = timezone.now()
             since = now - WINDOW
+            # The same eligibility as the unscored count below, so the two
+            # numbers describe one population and a scored draft that is
+            # speculative or unconsented cannot make the level SCORING by
+            # itself (review).
             out["scored"] = ProposedAppeal.objects.filter(
-                quality_scored_at__gte=since
+                quality_scored_at__gte=since,
+                speculative=False,
+                for_denial__use_external=True,
             ).count()
             # Drafts that should have been scored and were not: consented,
             # real (not speculative), old enough that a score in flight would

--- a/fighthealthinsurance/staff_views.py
+++ b/fighthealthinsurance/staff_views.py
@@ -579,6 +579,7 @@ class AdminStatusView(generic.TemplateView):
             "window_hours": 24,
             "scored": 0,
             "unscored": 0,
+            "stalled": 0,
             "last_success_at": None,
             "last_failure_at": None,
             "last_failure": "",
@@ -607,13 +608,14 @@ class AdminStatusView(generic.TemplateView):
             # real (not speculative), old enough that a score in flight would
             # have landed, and still without one.
             settled = now - datetime.timedelta(seconds=letter_quality.DRAIN_SECONDS)
-            out["unscored"] = ProposedAppeal.objects.filter(
+            eligible_unscored = ProposedAppeal.objects.filter(
                 created_at__gte=since,
                 created_at__lt=settled,
                 speculative=False,
                 for_denial__use_external=True,
                 quality_score__isnull=True,
-            ).count()
+            )
+            out["unscored"] = eligible_unscored.count()
 
             health = ExternalServiceHealth.objects.filter(
                 service=letter_quality.SERVICE
@@ -634,11 +636,21 @@ class AdminStatusView(generic.TemplateView):
                 and failure_at >= since
                 and (success_at is None or failure_at > success_at)
             )
+            # Eligible drafts newer than the last recorded success that never
+            # got a score: scoring stopped in a way the failure hook cannot
+            # see (it never ran), and one older score must not keep the badge
+            # green all day (review).
+            stalled = eligible_unscored
+            if success_at is not None:
+                stalled = stalled.filter(created_at__gt=success_at)
+            out["stalled"] = stalled.count()
 
             if not letter_quality.enabled():
                 out["level"] = "off"
             elif fresh_failure:
                 out["level"] = "failing"
+            elif out["stalled"]:
+                out["level"] = "not_scoring"
             elif out["scored"]:
                 out["level"] = "scoring"
             elif out["unscored"]:

--- a/fighthealthinsurance/templates/admin_status.html
+++ b/fighthealthinsurance/templates/admin_status.html
@@ -343,6 +343,42 @@
     {% endif %}
   </div>
 
+  {# ---------------- Letter scoring ---------------- #}
+  <div class="status-section">
+    <h2>&#127919; Letter scoring (TypeSafe, last {{ letter_scoring.window_hours }}h)</h2>
+    {% if letter_scoring.error %}
+      <p class="summary-line"><span class="badge bad">ERROR</span> <span class="error-text">{{ letter_scoring.error }}</span></p>
+    {% else %}
+      <p class="summary-line">
+        {% if letter_scoring.level == "off" %}<span class="badge unknown">OFF</span>
+        {% elif letter_scoring.level == "failing" %}<span class="badge bad">FAILING</span>
+        {% elif letter_scoring.level == "not_scoring" %}<span class="badge warn">NOT SCORING</span>
+        {% elif letter_scoring.level == "idle" %}<span class="badge ok">IDLE</span>
+        {% else %}<span class="badge ok">SCORING</span>{% endif %}
+        <span class="pill">API key: {% if letter_scoring.key_present %}present{% else %}missing{% endif %}</span>
+        <span class="pill">TYPESAFE_LETTER_RANKING_ENABLED: {% if letter_scoring.flag_on %}on{% else %}off{% endif %}</span>
+        {% if letter_scoring.timeout_seconds %}<span class="pill">timeout: {{ letter_scoring.timeout_seconds }}s</span>{% endif %}
+      </p>
+      <div class="stat-grid">
+        <div class="stat-card">
+          <div class="value">{{ letter_scoring.scored|default:0 }}</div>
+          <div class="label">Drafts scored</div>
+        </div>
+        <div class="stat-card {% if letter_scoring.unscored %}alert{% endif %}">
+          <div class="value">{{ letter_scoring.unscored|default:0 }}</div>
+          <div class="label">Eligible drafts left unscored</div>
+        </div>
+      </div>
+      <p class="summary-line">
+        Last score recorded: {% if letter_scoring.last_success_at %}{{ letter_scoring.last_success_at|timesince }} ago{% else %}never{% endif %}
+        &middot; Last failure: {% if letter_scoring.last_failure_at %}<span class="error-text">{{ letter_scoring.last_failure }}</span>{% if letter_scoring.last_failure_hint %} ({{ letter_scoring.last_failure_hint }}){% endif %}, {{ letter_scoring.last_failure_at|timesince }} ago{% if letter_scoring.recovered %}, recovered since{% endif %}{% else %}none recorded{% endif %}
+      </p>
+      <p class="summary-line">
+        <span class="pill">From the database, across every pod and the Temporal worker; counts and a status only, never letter text. Per-model quality: <a href="{% url 'model_usage_dashboard' %}">model usage dashboard</a>.</span>
+      </p>
+    {% endif %}
+  </div>
+
   {# ---------------- Storage ---------------- #}
   <div class="status-section">
     <h2>💾 External Storage</h2>

--- a/fighthealthinsurance/templates/admin_status.html
+++ b/fighthealthinsurance/templates/admin_status.html
@@ -358,6 +358,7 @@
         <span class="pill">API key: {% if letter_scoring.key_present %}present{% else %}missing{% endif %}</span>
         <span class="pill">TYPESAFE_LETTER_RANKING_ENABLED: {% if letter_scoring.flag_on %}on{% else %}off{% endif %}</span>
         {% if letter_scoring.timeout_seconds %}<span class="pill">timeout: {{ letter_scoring.timeout_seconds }}s</span>{% endif %}
+        {% if letter_scoring.stalled %}<span class="error-text">{{ letter_scoring.stalled }} eligible draft{{ letter_scoring.stalled|pluralize }} since the last score, none scored</span>{% endif %}
       </p>
       <div class="stat-grid">
         <div class="stat-card">

--- a/tests/async-unit/test_letter_quality.py
+++ b/tests/async-unit/test_letter_quality.py
@@ -11,7 +11,10 @@ from unittest.mock import patch
 import pytest
 from django.test import override_settings
 
+import aiohttp
+
 from fighthealthinsurance.ml import letter_quality as lq
+from fighthealthinsurance.ml import typesafe
 
 ENABLED = dict(TYPESAFE_API_KEY="test-key", TYPESAFE_LETTER_RANKING_ENABLED=True)
 
@@ -159,6 +162,76 @@ class TestScoreLetter:
             with patch.object(lq.logger, "warning", side_effect=lambda m, *a, **k: seen.append(str(m))):
                 asyncio.run(lq.score_letter(secret, "letter mentioning " + secret))
         assert seen and all(secret not in m for m in seen)
+
+
+class TestFailureSummary:
+    """What the status page is allowed to know about a failure."""
+
+    def test_the_http_status_when_the_api_answered(self):
+        assert lq.failure_summary(typesafe.TypeSafeError("HTTP 402", status=402)) == "HTTP 402"
+
+    @pytest.mark.parametrize("failure", [TimeoutError(), asyncio.TimeoutError()])
+    def test_timeouts_read_as_timeout(self, failure):
+        assert lq.failure_summary(failure) == "timeout"
+
+    def test_anything_else_is_the_class_name_alone(self):
+        error = aiohttp.ClientConnectionError("Cannot connect to host secret-host.example:443")
+        summary = lq.failure_summary(error)
+        assert summary == "ClientConnectionError"
+        assert "secret-host" not in summary
+        assert lq.failure_summary(lq.LetterScoringError("HTTP 500")) == "LetterScoringError"
+        assert lq.failure_summary(typesafe.TypeSafeError("no status")) == "TypeSafeError"
+
+
+class TestFailureHook:
+    def test_a_failure_reaches_the_hook_as_a_summary_only(self):
+        secret = "PATIENT NAME JANE DOE MRN 998877"
+        seen = []
+
+        async def fake_post(document, timeout):
+            raise typesafe.TypeSafeError("HTTP 402", status=402)
+
+        async def hook(summary):
+            seen.append(summary)
+
+        with override_settings(**ENABLED), patch.object(lq, "_post", fake_post):
+            result = asyncio.run(lq.score_letter(secret, "letter " + secret, on_failure=hook))
+        assert result is None
+        assert seen == ["HTTP 402"]
+
+    def test_a_broken_hook_cannot_break_scoring(self):
+        async def fake_post(document, timeout):
+            raise TimeoutError()
+
+        async def hook(summary):
+            raise RuntimeError("db down")
+
+        with override_settings(**ENABLED), patch.object(lq, "_post", fake_post):
+            assert asyncio.run(lq.score_letter("d", "letter", on_failure=hook)) is None
+
+    def test_cancellation_inside_the_hook_still_propagates(self):
+        async def fake_post(document, timeout):
+            raise TimeoutError()
+
+        async def hook(summary):
+            raise asyncio.CancelledError()
+
+        with override_settings(**ENABLED), patch.object(lq, "_post", fake_post):
+            with pytest.raises(asyncio.CancelledError):
+                asyncio.run(lq.score_letter("d", "letter", on_failure=hook))
+
+    def test_success_does_not_call_the_hook(self):
+        calls = []
+
+        async def fake_post(document, timeout):
+            return _payload()
+
+        async def hook(summary):
+            calls.append(summary)
+
+        with override_settings(**ENABLED), patch.object(lq, "_post", fake_post):
+            assert asyncio.run(lq.score_letter("d", "letter", on_failure=hook)) is not None
+        assert calls == []
 
 
 class TestFrames:

--- a/tests/async-unit/test_letter_ranking_stream.py
+++ b/tests/async-unit/test_letter_ranking_stream.py
@@ -15,8 +15,12 @@ from asgiref.sync import async_to_sync
 from django.test import TransactionTestCase, override_settings
 
 from fighthealthinsurance.generate_appeal import GeneratedAppeal
-from fighthealthinsurance.ml import letter_quality
-from fighthealthinsurance.models import Denial, ProposedAppeal
+from fighthealthinsurance.ml import letter_quality, typesafe
+from fighthealthinsurance.models import (
+    Denial,
+    ExternalServiceHealth,
+    ProposedAppeal,
+)
 
 ENABLED = dict(TYPESAFE_API_KEY="test-key", TYPESAFE_LETTER_RANKING_ENABLED=True)
 
@@ -168,6 +172,38 @@ class TestAScoreLandsOnlyOnTheTextThatWasScored(_StreamBase):
         for row in ProposedAppeal.objects.filter(for_denial=self.denial):
             self.assertIsNone(row.quality_score)
             self.assertIsNone(row.quality_scored_at)
+
+
+class TestTheHealthRowFollowsTheCalls(_StreamBase):
+    """The status page reads one ExternalServiceHealth row, written here."""
+
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_a_success_is_recorded(self, mock_gen):
+        async def fake_post(document, timeout):
+            return _payload()
+
+        with override_settings(**ENABLED), patch.object(letter_quality, "_post", fake_post):
+            self._stream(mock_gen)
+
+        health = ExternalServiceHealth.objects.get(service=letter_quality.SERVICE)
+        self.assertIsNotNone(health.last_success_at)
+        self.assertIsNone(health.last_failure_at)
+        self.assertEqual(health.last_failure, "")
+
+    @patch("fighthealthinsurance.common_view_logic.appealGenerator")
+    def test_why_scoring_failed_is_recorded_and_the_stream_still_finishes(self, mock_gen):
+        async def fake_post(document, timeout):
+            raise typesafe.TypeSafeError("HTTP 402", status=402)
+
+        with override_settings(**ENABLED), patch.object(letter_quality, "_post", fake_post):
+            frames = self._stream(mock_gen)
+
+        self.assertFalse([f for f in frames if f.get("type") == "score"])
+        self.assertTrue([f for f in frames if f.get("phase") == "done"])
+        health = ExternalServiceHealth.objects.get(service=letter_quality.SERVICE)
+        self.assertEqual(health.last_failure, "HTTP 402")
+        self.assertIsNotNone(health.last_failure_at)
+        self.assertIsNone(health.last_success_at)
 
 
 class TestNothingIdentifyingLeaves(_StreamBase):

--- a/tests/async-unit/test_typesafe_transport.py
+++ b/tests/async-unit/test_typesafe_transport.py
@@ -1,8 +1,9 @@
 """ml/typesafe.py: the shared TypeSafe transport.
 
 The request carries the API key and the redacted document, so it only ever
-goes over https; the body of a failed response is never read, because an
-error body could quote the document back.
+goes over https and never follows a redirect. The one thing a caller may
+learn from a failed call is the HTTP status: the body is never read, because
+an error body could quote the document back.
 """
 
 import asyncio
@@ -21,6 +22,7 @@ SETTINGS = dict(
 class _FakeResponse:
     def __init__(self, status):
         self.status = status
+        self.json_calls = 0
 
     async def __aenter__(self):
         return self
@@ -29,6 +31,7 @@ class _FakeResponse:
         return False
 
     async def json(self):
+        self.json_calls += 1
         return {"answers": {}}
 
 
@@ -39,6 +42,7 @@ class _FakeSession:
         self.response = _FakeResponse(status)
         self.posted = []
         self.opened = 0
+        self.post_kwargs = {}
 
     def __call__(self, *args, **kwargs):
         self.opened += 1
@@ -89,9 +93,18 @@ def test_https_in_any_case_is_accepted_and_the_json_comes_back():
     assert body["document"] == "doc"
 
 
-def test_a_non_200_raises():
-    with pytest.raises(typesafe.TypeSafeError, match="HTTP 503"):
-        _ask(_FakeSession(503))
+def test_a_non_200_raises_with_the_status_attached():
+    with pytest.raises(typesafe.TypeSafeError) as info:
+        _ask(_FakeSession(402))
+    assert info.value.status == 402
+    assert str(info.value) == "HTTP 402"
+
+
+def test_the_body_is_never_read_on_a_failure():
+    session = _FakeSession(503)
+    with pytest.raises(typesafe.TypeSafeError):
+        _ask(session)
+    assert session.response.json_calls == 0
 
 
 def test_redirects_are_never_followed():
@@ -101,3 +114,7 @@ def test_redirects_are_never_followed():
     with pytest.raises(typesafe.TypeSafeError, match="HTTP 307"):
         _ask(session)
     assert session.post_kwargs.get("allow_redirects") is False
+
+
+def test_the_status_is_optional_on_the_error():
+    assert typesafe.TypeSafeError("bad answer").status is None

--- a/tests/sync/test_admin_status.py
+++ b/tests/sync/test_admin_status.py
@@ -14,7 +14,12 @@ from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 
-from fighthealthinsurance.models import FaxesToSend
+from fighthealthinsurance.models import (
+    Denial,
+    ExternalServiceHealth,
+    FaxesToSend,
+    ProposedAppeal,
+)
 
 User = get_user_model()
 
@@ -93,6 +98,7 @@ class AdminStatusAccessTest(TestCase):
         self.assertContains(response, "Fax Backends")
         self.assertContains(response, "Fax Queue")
         self.assertContains(response, "External Storage")
+        self.assertContains(response, "Letter scoring")
         # Surfaced details from the mocked subsystems.
         self.assertContains(response, "fhi-2025")
         self.assertContains(response, "fax_polling_actor")
@@ -447,6 +453,172 @@ class AdminStatusStorageTest(TestCase):
         self.assertFalse(status["ok"])
         self.assertIn(missing, status["error"])
         self.assertEqual(status["location"], missing)
+
+
+_SCORING_ON = dict(TYPESAFE_API_KEY="test-key", TYPESAFE_LETTER_RANKING_ENABLED=True)
+
+
+class AdminStatusLetterScoringTest(TestCase):
+    """_letter_scoring_status: on or off, scoring or not, and if not, why.
+
+    Built on the database (draft rows and the ExternalServiceHealth row), not
+    on this process's counters: the page is served by whichever web pod the
+    browser is pinned to, and the Temporal worker scores drafts too.
+    """
+
+    @staticmethod
+    def _status():
+        from fighthealthinsurance.staff_views import AdminStatusView
+
+        return AdminStatusView._letter_scoring_status()
+
+    @staticmethod
+    def _denial(use_external=True):
+        return Denial.objects.create(
+            semi_sekret="sekret",
+            hashed_email=Denial.get_hashed_email("scoring-status@example.com"),
+            use_external=use_external,
+        )
+
+    _drafts_made = 0
+
+    @classmethod
+    def _draft(cls, denial, *, minutes_ago=5, speculative=False, scored=False):
+        # Distinct text per row: (denial, text fingerprint) is unique.
+        cls._drafts_made += 1
+        row = ProposedAppeal.objects.create(
+            for_denial=denial,
+            appeal_text=f"Draft number {cls._drafts_made}, long enough to read as a letter.",
+            speculative=speculative,
+        )
+        stamp = timezone.now() - datetime.timedelta(minutes=minutes_ago)
+        fields = {"created_at": stamp}
+        if scored:
+            fields.update(
+                quality_score=0.8,
+                grounding_score=2.0,
+                quality_scorer="typesafe/speed_latest/rubric-1",
+                quality_scored_at=stamp,
+            )
+        # auto_now_add wins on create, so the clock is set afterwards.
+        ProposedAppeal.objects.filter(pk=row.pk).update(**fields)
+        return row
+
+    @staticmethod
+    def _health(**fields):
+        return ExternalServiceHealth.objects.create(service="typesafe", **fields)
+
+    def test_off_under_the_test_settings(self):
+        status = self._status()
+        self.assertTrue(status["ok"])
+        self.assertIsNone(status["error"])
+        self.assertEqual(status["level"], "off")
+        self.assertFalse(status["key_present"])
+        self.assertFalse(status["flag_on"])
+
+    def test_a_key_without_the_flag_is_off_and_says_which_half_is_missing(self):
+        with override_settings(TYPESAFE_API_KEY="k", TYPESAFE_LETTER_RANKING_ENABLED=False):
+            status = self._status()
+        self.assertEqual(status["level"], "off")
+        self.assertTrue(status["key_present"])
+        self.assertFalse(status["flag_on"])
+
+    def test_scoring_when_a_draft_was_scored_in_the_window(self):
+        self._draft(self._denial(), scored=True)
+        with override_settings(**_SCORING_ON):
+            status = self._status()
+        self.assertEqual(status["level"], "scoring")
+        self.assertEqual(status["scored"], 1)
+        self.assertEqual(status["unscored"], 0)
+
+    def test_not_scoring_when_eligible_drafts_have_no_score(self):
+        self._draft(self._denial())
+        with override_settings(**_SCORING_ON):
+            status = self._status()
+        self.assertEqual(status["level"], "not_scoring")
+        self.assertEqual(status["unscored"], 1)
+
+    def test_drafts_that_were_never_eligible_do_not_count_as_unscored(self):
+        """Still in flight (younger than the drain window), speculative, or
+        from a denial that did not allow external models."""
+        denial = self._denial()
+        self._draft(denial, minutes_ago=0)
+        self._draft(denial, speculative=True)
+        self._draft(self._denial(use_external=False))
+        with override_settings(**_SCORING_ON):
+            status = self._status()
+        self.assertEqual(status["unscored"], 0)
+        self.assertEqual(status["level"], "idle")
+
+    def test_a_score_outside_the_window_does_not_count(self):
+        self._draft(self._denial(), minutes_ago=25 * 60, scored=True)
+        with override_settings(**_SCORING_ON):
+            status = self._status()
+        self.assertEqual(status["scored"], 0)
+        self.assertEqual(status["level"], "idle")
+
+    def test_failing_when_the_last_failure_is_newer_than_the_last_success(self):
+        now = timezone.now()
+        self._health(
+            last_success_at=now - datetime.timedelta(hours=1),
+            last_failure_at=now - datetime.timedelta(minutes=2),
+            last_failure="HTTP 402",
+        )
+        # Even with a score in the window: the freshest signal wins.
+        self._draft(self._denial(), scored=True)
+        with override_settings(**_SCORING_ON):
+            status = self._status()
+        self.assertEqual(status["level"], "failing")
+        self.assertEqual(status["last_failure"], "HTTP 402")
+        self.assertIn("credits", status["last_failure_hint"])
+        self.assertFalse(status["recovered"])
+
+    def test_a_failure_followed_by_a_success_reads_as_recovered(self):
+        now = timezone.now()
+        self._health(
+            last_success_at=now - datetime.timedelta(minutes=1),
+            last_failure_at=now - datetime.timedelta(minutes=30),
+            last_failure="HTTP 503",
+        )
+        with override_settings(**_SCORING_ON):
+            status = self._status()
+        self.assertNotEqual(status["level"], "failing")
+        self.assertTrue(status["recovered"])
+        self.assertIn("server error", status["last_failure_hint"])
+
+    def test_an_old_failure_does_not_fail_the_row_forever(self):
+        self._health(
+            last_failure_at=timezone.now() - datetime.timedelta(days=3),
+            last_failure="timeout",
+        )
+        with override_settings(**_SCORING_ON):
+            status = self._status()
+        self.assertEqual(status["level"], "idle")
+
+    def test_the_helper_degrades_to_an_error_row_instead_of_raising(self):
+        with mock.patch.object(
+            ProposedAppeal.objects, "filter", side_effect=RuntimeError("db down")
+        ):
+            status = self._status()
+        self.assertFalse(status["ok"])
+        self.assertEqual(status["error"], "db down")
+
+    def test_the_page_names_the_failure_and_what_it_means(self):
+        self._health(
+            last_failure_at=timezone.now() - datetime.timedelta(minutes=2),
+            last_failure="HTTP 402",
+        )
+        User.objects.create_user(username="staff", password="pw123", is_staff=True)
+        self.client.login(username="staff", password="pw123")
+        with override_settings(**_SCORING_ON), mock.patch(_MODELS, return_value=[]), mock.patch(
+            _ACTORS, return_value={"alive_actors": 0, "total_actors": 0, "details": []}
+        ), mock.patch(_FAX, return_value=_ok_fax_backends()):
+            response = self.client.get(reverse("admin_status"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "FAILING")
+        self.assertContains(response, "HTTP 402")
+        self.assertContains(response, "credits or billing")
+        self.assertNotContains(response, "test-key")
 
 
 class ComputeModelHealthDetailsTest(TestCase):

--- a/tests/sync/test_admin_status.py
+++ b/tests/sync/test_admin_status.py
@@ -483,7 +483,7 @@ class AdminStatusLetterScoringTest(TestCase):
     _drafts_made = 0
 
     @classmethod
-    def _draft(cls, denial, *, minutes_ago=5, speculative=False, scored=False):
+    def _draft(cls, denial, *, minutes_ago=5, speculative=False, scored=False, now=None):
         # Distinct text per row: (denial, text fingerprint) is unique.
         cls._drafts_made += 1
         row = ProposedAppeal.objects.create(
@@ -491,7 +491,7 @@ class AdminStatusLetterScoringTest(TestCase):
             appeal_text=f"Draft number {cls._drafts_made}, long enough to read as a letter.",
             speculative=speculative,
         )
-        stamp = timezone.now() - datetime.timedelta(minutes=minutes_ago)
+        stamp = (now or timezone.now()) - datetime.timedelta(minutes=minutes_ago)
         fields = {"created_at": stamp}
         if scored:
             fields.update(
@@ -541,14 +541,49 @@ class AdminStatusLetterScoringTest(TestCase):
     def test_drafts_that_were_never_eligible_do_not_count_as_unscored(self):
         """Still in flight (younger than the drain window), speculative, or
         from a denial that did not allow external models."""
+        # The clock is frozen for the helper: the in-flight draft is five
+        # seconds old at the instant the page reads it, however long the
+        # test takes to get there (review).
+        frozen = timezone.now()
         denial = self._denial()
-        self._draft(denial, minutes_ago=0)
-        self._draft(denial, speculative=True)
-        self._draft(self._denial(use_external=False))
-        with override_settings(**_SCORING_ON):
+        ProposedAppeal.objects.filter(pk=self._draft(denial, now=frozen).pk).update(
+            created_at=frozen - datetime.timedelta(seconds=5)
+        )
+        self._draft(denial, speculative=True, now=frozen)
+        self._draft(self._denial(use_external=False), now=frozen)
+        with override_settings(**_SCORING_ON), mock.patch(
+            "django.utils.timezone.now", return_value=frozen
+        ):
             status = self._status()
         self.assertEqual(status["unscored"], 0)
         self.assertEqual(status["level"], "idle")
+
+    def test_unscored_drafts_newer_than_the_last_score_mean_not_scoring(self):
+        """One score in the morning must not keep the badge green all day
+        after scoring silently stopped (review)."""
+        now = timezone.now()
+        self._health(last_success_at=now - datetime.timedelta(hours=2))
+        denial = self._denial()
+        self._draft(denial, minutes_ago=120, scored=True)
+        self._draft(denial, minutes_ago=5)
+        with override_settings(**_SCORING_ON):
+            status = self._status()
+        self.assertEqual(status["scored"], 1)
+        self.assertEqual(status["stalled"], 1)
+        self.assertEqual(status["level"], "not_scoring")
+
+    def test_unscored_drafts_older_than_the_last_score_do_not_stall(self):
+        """A miss followed by a success is scoring again."""
+        now = timezone.now()
+        self._health(last_success_at=now - datetime.timedelta(minutes=1))
+        denial = self._denial()
+        self._draft(denial, minutes_ago=30)
+        self._draft(denial, minutes_ago=1, scored=True)
+        with override_settings(**_SCORING_ON):
+            status = self._status()
+        self.assertEqual(status["unscored"], 1)
+        self.assertEqual(status["stalled"], 0)
+        self.assertEqual(status["level"], "scoring")
 
     def test_a_score_outside_the_window_does_not_count(self):
         self._draft(self._denial(), minutes_ago=25 * 60, scored=True)
@@ -619,6 +654,18 @@ class AdminStatusLetterScoringTest(TestCase):
         self.assertContains(response, "HTTP 402")
         self.assertContains(response, "credits or billing")
         self.assertNotContains(response, "test-key")
+
+    def test_the_page_counts_drafts_stalled_since_the_last_score(self):
+        self._health(last_success_at=timezone.now() - datetime.timedelta(hours=1))
+        self._draft(self._denial(), minutes_ago=5)
+        User.objects.create_user(username="staff", password="pw123", is_staff=True)
+        self.client.login(username="staff", password="pw123")
+        with override_settings(**_SCORING_ON), mock.patch(_MODELS, return_value=[]), mock.patch(
+            _ACTORS, return_value={"alive_actors": 0, "total_actors": 0, "details": []}
+        ), mock.patch(_FAX, return_value=_ok_fax_backends()):
+            response = self.client.get(reverse("admin_status"))
+        self.assertContains(response, "NOT SCORING")
+        self.assertContains(response, "1 eligible draft since the last score, none scored")
 
 
 class ComputeModelHealthDetailsTest(TestCase):

--- a/tests/sync/test_admin_status.py
+++ b/tests/sync/test_admin_status.py
@@ -531,6 +531,16 @@ class AdminStatusLetterScoringTest(TestCase):
         self.assertEqual(status["scored"], 1)
         self.assertEqual(status["unscored"], 0)
 
+    def test_a_scored_draft_that_was_never_eligible_does_not_count(self):
+        """Speculative or unconsented drafts are outside both counts, so a
+        score on one of them cannot read as SCORING by itself (review)."""
+        self._draft(self._denial(), speculative=True, scored=True)
+        self._draft(self._denial(use_external=False), scored=True)
+        with override_settings(**_SCORING_ON):
+            status = self._status()
+        self.assertEqual(status["scored"], 0)
+        self.assertEqual(status["level"], "idle")
+
     def test_not_scoring_when_eligible_drafts_have_no_score(self):
         self._draft(self._denial())
         with override_settings(**_SCORING_ON):

--- a/tests/sync/test_external_service_health.py
+++ b/tests/sync/test_external_service_health.py
@@ -1,0 +1,79 @@
+"""ExternalServiceHealth: the cross-pod "last outcome" record behind the
+status page's letter scoring row.
+
+Writes overlap (several drafts score at once, on several pods), so the one
+property that matters is that a timestamp only ever moves forward: a slow
+write from an older call must not land on top of a newer outcome and fake a
+recovery. And a write must never raise into the call it records.
+"""
+
+import datetime
+from unittest import mock
+
+from asgiref.sync import async_to_sync
+from django.test import TestCase
+from django.utils import timezone
+
+from fighthealthinsurance.models import ExternalServiceHealth
+
+
+def _at(instant):
+    return mock.patch("django.utils.timezone.now", return_value=instant)
+
+
+class ExternalServiceHealthTest(TestCase):
+    def _row(self):
+        return ExternalServiceHealth.objects.get(service="typesafe")
+
+    def test_the_first_call_creates_the_row(self):
+        async_to_sync(ExternalServiceHealth.anote_failure)("typesafe", "HTTP 402")
+        row = self._row()
+        self.assertEqual(row.last_failure, "HTTP 402")
+        self.assertIsNotNone(row.last_failure_at)
+        self.assertIsNone(row.last_success_at)
+
+    def test_a_success_and_a_failure_keep_their_own_columns(self):
+        async_to_sync(ExternalServiceHealth.anote_failure)("typesafe", "timeout")
+        async_to_sync(ExternalServiceHealth.anote_success)("typesafe")
+        row = self._row()
+        self.assertEqual(row.last_failure, "timeout")
+        self.assertIsNotNone(row.last_failure_at)
+        self.assertIsNotNone(row.last_success_at)
+
+    def test_a_stale_failure_cannot_undo_a_newer_one(self):
+        """Failure at T1 stalls; success at T2; failure at T3; then T1 lands.
+        The row must still say: failure T3, so no false recovery."""
+        t1 = timezone.now() - datetime.timedelta(minutes=3)
+        t2 = t1 + datetime.timedelta(minutes=1)
+        t3 = t2 + datetime.timedelta(minutes=1)
+        with _at(t2):
+            async_to_sync(ExternalServiceHealth.anote_success)("typesafe")
+        with _at(t3):
+            async_to_sync(ExternalServiceHealth.anote_failure)("typesafe", "HTTP 503")
+        with _at(t1):
+            async_to_sync(ExternalServiceHealth.anote_failure)("typesafe", "HTTP 402")
+        row = self._row()
+        self.assertEqual(row.last_failure_at, t3)
+        self.assertEqual(row.last_failure, "HTTP 503")
+        self.assertEqual(row.last_success_at, t2)
+
+    def test_a_stale_success_cannot_undo_a_newer_one(self):
+        t1 = timezone.now() - datetime.timedelta(minutes=2)
+        t2 = t1 + datetime.timedelta(minutes=1)
+        with _at(t2):
+            async_to_sync(ExternalServiceHealth.anote_success)("typesafe")
+        with _at(t1):
+            async_to_sync(ExternalServiceHealth.anote_success)("typesafe")
+        self.assertEqual(self._row().last_success_at, t2)
+
+    def test_the_summary_is_cut_to_the_column(self):
+        async_to_sync(ExternalServiceHealth.anote_failure)("typesafe", "x" * 200)
+        self.assertEqual(len(self._row().last_failure), 80)
+
+    def test_a_write_error_never_reaches_the_caller(self):
+        with mock.patch.object(
+            ExternalServiceHealth.objects, "filter", side_effect=RuntimeError("db down")
+        ):
+            async_to_sync(ExternalServiceHealth.anote_failure)("typesafe", "HTTP 402")
+            async_to_sync(ExternalServiceHealth.anote_success)("typesafe")
+        self.assertFalse(ExternalServiceHealth.objects.filter(service="typesafe").exists())

--- a/tests/sync/test_external_service_health.py
+++ b/tests/sync/test_external_service_health.py
@@ -66,6 +66,47 @@ class ExternalServiceHealthTest(TestCase):
             async_to_sync(ExternalServiceHealth.anote_success)("typesafe")
         self.assertEqual(self._row().last_success_at, t2)
 
+    def test_a_row_created_between_the_two_statements_still_takes_the_newer_outcome(self):
+        """Before the row exists: a failure's conditional update finds nothing,
+        another pod's OLDER success creates the row, and the failure's
+        get-or-create comes back with created=False. The failure must still
+        land (review)."""
+        t2 = timezone.now() - datetime.timedelta(minutes=2)
+        t3 = t2 + datetime.timedelta(minutes=1)
+
+        async def racing_get_or_create(**kwargs):
+            row = await ExternalServiceHealth.objects.acreate(
+                service=kwargs["service"], last_success_at=t2
+            )
+            return row, False
+
+        with _at(t3), mock.patch.object(
+            ExternalServiceHealth.objects, "aget_or_create", new=racing_get_or_create
+        ):
+            async_to_sync(ExternalServiceHealth.anote_failure)("typesafe", "HTTP 402")
+        row = self._row()
+        self.assertEqual(row.last_failure, "HTTP 402")
+        self.assertEqual(row.last_failure_at, t3)
+        self.assertEqual(row.last_success_at, t2)
+
+    def test_a_stale_write_arriving_during_creation_still_loses(self):
+        t1 = timezone.now() - datetime.timedelta(minutes=3)
+        t3 = t1 + datetime.timedelta(minutes=2)
+
+        async def racing_get_or_create(**kwargs):
+            row = await ExternalServiceHealth.objects.acreate(
+                service=kwargs["service"], last_failure_at=t3, last_failure="HTTP 503"
+            )
+            return row, False
+
+        with _at(t1), mock.patch.object(
+            ExternalServiceHealth.objects, "aget_or_create", new=racing_get_or_create
+        ):
+            async_to_sync(ExternalServiceHealth.anote_failure)("typesafe", "HTTP 402")
+        row = self._row()
+        self.assertEqual(row.last_failure, "HTTP 503")
+        self.assertEqual(row.last_failure_at, t3)
+
     def test_the_summary_is_cut_to_the_column(self):
         async_to_sync(ExternalServiceHealth.anote_failure)("typesafe", "x" * 200)
         self.assertEqual(len(self._row().last_failure), 80)


### PR DESCRIPTION
Stacked on #996 (base is `typesafe-letter-ranking`, where the TypeSafe settings live; GitHub retargets to `main` when that merges).

Melanie asked to see when TypeSafe stops scoring and why, so an out-of-credits day reads differently from an outage. The staff status page gets a Letter scoring section.

**What it shows** (last 24h, the same window as the Prometheus gauges)

- A level: OFF (key or flag missing, each shown on its own), SCORING, IDLE (nothing eligible), NOT SCORING (eligible drafts arrived since the last score and none got one), FAILING (the last failure is newer than the last success), or ERROR when the check itself failed.
- Drafts scored; eligible drafts left unscored (consented, real, older than the drain window); how many of those arrived since the last score.
- When the last score was recorded, and the last failure with what it most likely means: HTTP 402 is credits or billing, 401 or 403 a rejected key, 429 rate limited, 5xx a TypeSafe server error, or a timeout. "Recovered since" when a success followed it.
- Never the key and never letter text. A link to the model usage dashboard for per-model quality.

**How**

- Built from the database, not from this process's counters: the app runs as several web pods plus the Temporal worker, and a browser is pinned to one pod by cookie, so a process-local last failure would be blind to most of the traffic. `letter_quality.outcomes` stays as it is for Prometheus.
- A new one-row-per-service table, `ExternalServiceHealth` (migration 0206). The scoring call site writes it on success and on failure with an allowlisted summary: an HTTP status, "timeout", or an exception class name. Writes are forward-only and best effort. They never raise into scoring, and a stale write from an overlapping call cannot undo a newer outcome, including while the row is first being created.
- `TypeSafeError` now carries the HTTP status. `letter_quality.failure_summary` and an `on_failure` hook on `score_letter` carry it to the record. The warning log line is unchanged.

**Tests.** Direct helper tests for every level, the exclusions, the stall rule and the never-raise contract; page renders naming the failure and its meaning and never the key; the health record's forward-only writes under both interleavings; the failure summary allowlist and the hook contract; the transport attaching the status and never reading a body; the stream writing the row both ways. Full sync and async-unit suites, black and mypy are green.

**Review.** Codex (gpt-6-astra, read-only sandbox), three rounds. Round 1: a stale write could fake a recovery, one morning score hid a silent stop all day, and a test depended on the wall clock. Round 2: the first-row creation race dropped the newer outcome. Round 3: clean. Every fix was verified by a sabotage that failed the new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYruQVRyBbFzUxy9YGcHTb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Letter Scoring status panel to the admin status page.
  * Admins can view scoring configuration, progress, stalled drafts, recent successes, failures, recovery status, and usage-dashboard access.
  * Added clearer status information for API key, feature, timeout, and service availability issues.

* **Bug Fixes**
  * Letter-scoring failures are now recorded with safe, user-facing summaries.
  * Temporary scoring errors no longer prevent the appeal workflow from completing.
  * Added safeguards to keep service health information accurate during concurrent updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->