### PR TITLE
Tell the model which appeal law governs the plan, and invite it to cite it

### DIFF
--- a/fighthealthinsurance/generate_appeal.py
+++ b/fighthealthinsurance/generate_appeal.py
@@ -2341,6 +2341,7 @@ class AppealGenerator(object):
             from fighthealthinsurance.regulatory_citations import (
                 classify_plan,
                 get_regulatory_citation_context,
+                self_insured_from,
             )
         except Exception as e:
             logger.opt(exception=True).debug(f"regulatory_citations unavailable: {e}")
@@ -2348,21 +2349,18 @@ class AppealGenerator(object):
 
         try:
             names, is_tpa, alt_name = AppealGenerator._plan_signals(denial)
-            # Best-effort self-insured/ERISA signal from the linked carrier; a
-            # TPA administers self-funded employer (ERISA) plans. None when we
-            # cannot tell, which selects the neutral caveat wording.
-            self_insured: Optional[bool] = True if is_tpa else None
+            # Same classification as the plan-law block, so the two never
+            # contradict each other (review). The self-insured (ERISA) signal
+            # comes from the TPA flag, unless a source says the plan cannot
+            # be ERISA: a government plan is exempt whoever administers it.
+            programs = classify_plan(names, is_tpa=is_tpa, regulator_alt_name=alt_name)
             return get_regulatory_citation_context(
                 state=getattr(denial, "your_state", None),
                 denial_text=getattr(denial, "denial_text", None),
                 procedure=getattr(denial, "procedure", None),
                 diagnosis=getattr(denial, "diagnosis", None),
-                self_insured=self_insured,
-                # Same classification as the plan-law block, so the two never
-                # contradict each other (review).
-                programs=classify_plan(
-                    names, is_tpa=is_tpa, regulator_alt_name=alt_name
-                ),
+                self_insured=self_insured_from(programs),
+                programs=programs,
             )
         except Exception as e:
             logger.opt(exception=True).debug(f"_collect_regulatory_context failed: {e}")

--- a/fighthealthinsurance/generate_appeal.py
+++ b/fighthealthinsurance/generate_appeal.py
@@ -2339,6 +2339,7 @@ class AppealGenerator(object):
         """
         try:
             from fighthealthinsurance.regulatory_citations import (
+                classify_plan,
                 get_regulatory_citation_context,
             )
         except Exception as e:
@@ -2346,23 +2347,55 @@ class AppealGenerator(object):
             return None
 
         try:
+            names, is_tpa, alt_name = AppealGenerator._plan_signals(denial)
             # Best-effort self-insured/ERISA signal from the linked carrier; a
             # TPA administers self-funded employer (ERISA) plans. None when we
             # cannot tell, which selects the neutral caveat wording.
-            self_insured: Optional[bool] = None
-            ico = getattr(denial, "insurance_company_obj", None)
-            if ico is not None and getattr(ico, "is_tpa", False):
-                self_insured = True
+            self_insured: Optional[bool] = True if is_tpa else None
             return get_regulatory_citation_context(
                 state=getattr(denial, "your_state", None),
                 denial_text=getattr(denial, "denial_text", None),
                 procedure=getattr(denial, "procedure", None),
                 diagnosis=getattr(denial, "diagnosis", None),
                 self_insured=self_insured,
+                # Same classification as the plan-law block, so the two never
+                # contradict each other (review).
+                programs=classify_plan(
+                    names, is_tpa=is_tpa, regulator_alt_name=alt_name
+                ),
             )
         except Exception as e:
             logger.opt(exception=True).debug(f"_collect_regulatory_context failed: {e}")
             return None
+
+    @staticmethod
+    def _plan_signals(denial) -> tuple[list[str], bool, Optional[str]]:
+        """What intake and the denial say about the plan: the plan source
+        names, the carrier's TPA flag, and the matched regulator's alt name.
+        Every read is defensive; a relation that fails reads as unknown, so
+        one bad lookup never costs the whole block."""
+        names: list[str] = []
+        try:
+            manager = getattr(denial, "plan_source", None)
+            if manager is not None and hasattr(manager, "all"):
+                names = [getattr(s, "name", "") or "" for s in manager.all()]
+        except Exception as e:
+            logger.opt(exception=True).debug(f"plan_source unavailable: {e}")
+            names = []
+        is_tpa = False
+        try:
+            ico = getattr(denial, "insurance_company_obj", None)
+            is_tpa = bool(ico is not None and getattr(ico, "is_tpa", False))
+        except Exception:
+            is_tpa = False
+        alt_name: Optional[str] = None
+        try:
+            regulator = getattr(denial, "regulator", None)
+            if regulator is not None:
+                alt_name = getattr(regulator, "alt_name", None)
+        except Exception:
+            alt_name = None
+        return names, is_tpa, alt_name
 
     @staticmethod
     def _collect_plan_law_context(denial) -> Optional[str]:
@@ -2373,9 +2406,10 @@ class AppealGenerator(object):
         the ERISA regulator match).
 
         Always returns a block when it can (an unknown plan gets hedged
-        guidance); None only when the lookup itself fails, so generation
-        never depends on it. Runs where make_appeals runs, in a sync
-        context, like the sibling collectors.
+        guidance, and so does a plan whose lookup failed); None only when the
+        block itself cannot be built, so generation never depends on it. Runs
+        where make_appeals runs, in a sync context, like the sibling
+        collectors.
         """
         try:
             from fighthealthinsurance.regulatory_citations import (
@@ -2386,21 +2420,7 @@ class AppealGenerator(object):
             return None
 
         try:
-            names: list[str] = []
-            manager = getattr(denial, "plan_source", None)
-            if manager is not None and hasattr(manager, "all"):
-                names = [getattr(s, "name", "") or "" for s in manager.all()]
-            ico = getattr(denial, "insurance_company_obj", None)
-            is_tpa = bool(ico is not None and getattr(ico, "is_tpa", False))
-            alt_name: Optional[str] = None
-            try:
-                regulator = getattr(denial, "regulator", None)
-                if regulator is not None:
-                    alt_name = getattr(regulator, "alt_name", None)
-            except Exception:
-                # The regulator is a lazy FK; losing it must not lose the
-                # block, the plan sources still say what governs.
-                alt_name = None
+            names, is_tpa, alt_name = AppealGenerator._plan_signals(denial)
             return get_plan_law_context(
                 names, is_tpa=is_tpa, regulator_alt_name=alt_name
             )

--- a/fighthealthinsurance/generate_appeal.py
+++ b/fighthealthinsurance/generate_appeal.py
@@ -833,6 +833,10 @@ _PROMPT_TIER1_NULLS: tuple[str, ...] = (
     "payer_policy_context",
     "medication_context",
 )
+# ``plan_law_context`` is deliberately NOT sheddable: a few hundred characters
+# naming which appeal law governs the plan, the one legal instruction every
+# letter gets (Melanie, 2026-09-07). Shedding it would drop the citation from
+# exactly the long, complicated denials where it helps most.
 
 # ``pa_context`` is the one tier-1 section ``make_open_prompt`` gates on
 # ``.strip()`` (line ~1661) rather than ``!= ""``: a whitespace-only value
@@ -2120,6 +2124,7 @@ class AppealGenerator(object):
         clinical_trials_context=None,
         medication_context=None,
         regulatory_citation_context=None,
+        plan_law_context=None,
     ) -> Optional[str]:
         """
         Constructs a prompt for generating a health insurance appeal based on denial details and optional contextual information.
@@ -2266,6 +2271,11 @@ class AppealGenerator(object):
             # regulatory_citations.get_regulatory_citation_context, so just
             # append it as its own section.
             base = f"{base}\n\n{regulatory_citation_context}"
+        if plan_law_context:
+            # Which appeal law governs this plan (ERISA, the ACA appeal rules,
+            # Medicare, ...) and an invitation to cite it where it helps.
+            # Pre-framed by regulatory_citations.get_plan_law_context.
+            base = f"{base}\n\n{plan_law_context}"
         if (
             insurance_company is not None
             and insurance_company != ""
@@ -2352,6 +2362,50 @@ class AppealGenerator(object):
             )
         except Exception as e:
             logger.opt(exception=True).debug(f"_collect_regulatory_context failed: {e}")
+            return None
+
+    @staticmethod
+    def _collect_plan_law_context(denial) -> Optional[str]:
+        """Which appeal law governs this plan, for the prompt: ERISA for
+        private employer and union plans, the ACA appeal rules for
+        marketplace plans, the Medicare and Medicaid processes, and so on,
+        from what intake collected (plan sources, the carrier's TPA flag,
+        the ERISA regulator match).
+
+        Always returns a block when it can (an unknown plan gets hedged
+        guidance); None only when the lookup itself fails, so generation
+        never depends on it. Runs where make_appeals runs, in a sync
+        context, like the sibling collectors.
+        """
+        try:
+            from fighthealthinsurance.regulatory_citations import (
+                get_plan_law_context,
+            )
+        except Exception as e:
+            logger.opt(exception=True).debug(f"regulatory_citations unavailable: {e}")
+            return None
+
+        try:
+            names: list[str] = []
+            manager = getattr(denial, "plan_source", None)
+            if manager is not None and hasattr(manager, "all"):
+                names = [getattr(s, "name", "") or "" for s in manager.all()]
+            ico = getattr(denial, "insurance_company_obj", None)
+            is_tpa = bool(ico is not None and getattr(ico, "is_tpa", False))
+            alt_name: Optional[str] = None
+            try:
+                regulator = getattr(denial, "regulator", None)
+                if regulator is not None:
+                    alt_name = getattr(regulator, "alt_name", None)
+            except Exception:
+                # The regulator is a lazy FK; losing it must not lose the
+                # block, the plan sources still say what governs.
+                alt_name = None
+            return get_plan_law_context(
+                names, is_tpa=is_tpa, regulator_alt_name=alt_name
+            )
+        except Exception as e:
+            logger.opt(exception=True).debug(f"_collect_plan_law_context failed: {e}")
             return None
 
     @staticmethod
@@ -2530,6 +2584,7 @@ class AppealGenerator(object):
 
         medication_context = self._collect_medication_context(denial)
         regulatory_citation_context = self._collect_regulatory_context(denial)
+        plan_law_context = self._collect_plan_law_context(denial)
 
         # Captured as a dict so the tier-shed retry path can re-render the
         # prompt with enrichment kwargs nulled or truncated — otherwise the
@@ -2566,6 +2621,7 @@ class AppealGenerator(object):
             clinical_trials_context=clinical_trials_context,
             medication_context=medication_context,
             regulatory_citation_context=regulatory_citation_context,
+            plan_law_context=plan_law_context,
         )
         open_prompt = self.make_open_prompt(**open_prompt_kwargs)
         open_medically_necessary_prompt = self.make_open_med_prompt(

--- a/fighthealthinsurance/regulatory_citations.py
+++ b/fighthealthinsurance/regulatory_citations.py
@@ -49,7 +49,9 @@ def self_insured_from(programs: Iterable[str]) -> Optional[bool]:
     exempt from ERISA whoever administers it, and marketplace coverage is
     insured). None when we cannot tell, which selects neutral wording."""
     keys = set(programs)
-    if TPA in keys and not keys & (EXCLUSIVE_OF_ERISA | {MARKETPLACE}):
+    # "Other Group" is group coverage that may not be an employer plan at
+    # all, so a TPA beside it is inconclusive too (review).
+    if TPA in keys and not keys & (EXCLUSIVE_OF_ERISA | {MARKETPLACE, OTHER_GROUP}):
         return True
     return None
 

--- a/fighthealthinsurance/regulatory_citations.py
+++ b/fighthealthinsurance/regulatory_citations.py
@@ -420,20 +420,24 @@ _TPA_ONLY = (
 )
 _OTHER_GROUP = (
     "This is group coverage that is not clearly an employer or union plan. If "
-    "an employer or union sponsors it, ERISA governs (29 C.F.R. § "
-    "2560.503-1); if it is an association or membership plan, ERISA may not "
-    "apply, and for non-grandfathered coverage the ACA internal appeal and "
-    "external review rules (45 C.F.R. § 147.136) apply along with state "
-    "insurance law. Name ERISA only if the denial letter or the plan "
-    "documents show an employer or union sponsor."
+    "a private employer or union sponsors it, ERISA governs (29 C.F.R. § "
+    "2560.503-1); a government or church employer's plan is exempt "
+    "(29 U.S.C. § 1003(b)); and if it is an association or membership plan, "
+    "ERISA may not apply, and for non-grandfathered coverage the ACA internal "
+    "appeal and external review rules (45 C.F.R. § 147.136) apply along with "
+    "state insurance law. Name ERISA only if the denial letter or the plan "
+    "documents show a private employer or union sponsor."
 )
 _ACA_MARKETPLACE = (
-    "This is a marketplace (Affordable Care Act) plan, so ERISA does not "
-    "apply. The plan owes an internal appeal and, for a denial that turns on "
-    "medical judgment or is a rescission, an independent external review "
-    "under the ACA (45 C.F.R. § 147.136), and it must cover the ten essential "
-    "health benefit categories (42 U.S.C. § 18022), so if the service falls "
-    "in one of them, say so."
+    "This is marketplace (Affordable Care Act) coverage. If it is an "
+    "individual plan bought on the marketplace, ERISA does not apply; the "
+    "plan owes an internal appeal and, for a denial that turns on medical "
+    "judgment or is a rescission, an independent external review under the "
+    "ACA (45 C.F.R. § 147.136), and it must cover the ten essential health "
+    "benefit categories (42 U.S.C. § 18022), so if the service falls in one "
+    "of them, say so. If it is small employer (SHOP) coverage, it is an "
+    "employer plan and ERISA governs it as for any private employer plan "
+    "(29 C.F.R. § 2560.503-1)."
 )
 _GOVERNMENT_EMPLOYER = (
     "This is a state or local government employer plan, so ERISA does not "
@@ -497,9 +501,10 @@ _TWO_SOURCES = (
 )
 _INVITATION = (
     "If citing the applicable law strengthens this appeal (for example to "
-    "demand the clinical criteria the plan relied on, or to insist on the "
-    "independent external review that a medical-judgment denial is owed), "
-    "cite it by name and section exactly as given here; a reviewer takes a "
+    "demand the clinical criteria the plan relied on, or, only where the "
+    "paragraph above says the plan owes one, to insist on an independent "
+    "external review), cite it by name and section exactly as given here; a "
+    "reviewer takes a "
     "letter more seriously when it names the rule the plan must follow. Cite "
     "it only where it applies and where it helps the argument. Never cite a "
     "law that does not govern this plan, and do not invent section numbers, "

--- a/fighthealthinsurance/regulatory_citations.py
+++ b/fighthealthinsurance/regulatory_citations.py
@@ -13,8 +13,9 @@ into the prompt (to avoid the model parroting URLs it cannot verify).
 """
 
 import datetime
+import re
 from dataclasses import dataclass
-from typing import Optional
+from typing import Iterable, Optional
 
 
 @dataclass(frozen=True)
@@ -373,3 +374,153 @@ def get_regulatory_citation_context(
         "section numbers, dates, or quotations beyond what is provided here."
     )
     return f"{header}\n{bullet_lines}\n{caveat}"
+
+
+# ---------------------------------------------------------------------------
+# Which appeal law governs the plan, from what intake collected.
+#
+# Intake asks "How do you get your insurance?" (PlanSource) and knows when the
+# carrier is a TPA for self-funded employer plans, and the denial text can
+# match the ERISA regulator. None of that used to reach the prompt, so a letter
+# cited ERISA or the ACA only when a clinical template or a state hook happened
+# to fire. This block names the governing law, says which law does NOT apply,
+# and invites the model to cite the applicable one where it helps (Melanie,
+# 2026-09-07: encourage, not order). Every citation here is a real statute or
+# rule cited by name and section; nothing is quoted.
+# ---------------------------------------------------------------------------
+
+PLAN_LAW_HEADER = "APPLICABLE APPEAL LAW"
+
+_ERISA = (
+    "This looks like a private employer or union plan, so ERISA governs the "
+    "appeal (ERISA section 503, 29 U.S.C. § 1133, and the claims-procedure "
+    "rule at 29 C.F.R. § 2560.503-1). The plan must give the specific reasons "
+    "for the denial and the plan provisions it relied on, must provide on "
+    "request the internal rule or clinical criteria it applied and identify "
+    "any medical expert it consulted, and must give a full and fair review by "
+    "someone who did not make the original decision. A non-grandfathered plan "
+    "also owes an independent external review (45 C.F.R. § 147.136, applied "
+    "to group plans by 29 C.F.R. § 2590.715-2719). ERISA does not apply to "
+    "government or church employer plans."
+)
+_ACA_MARKETPLACE = (
+    "This is a marketplace (Affordable Care Act) plan, so ERISA does not "
+    "apply. The plan owes an internal appeal and an independent external "
+    "review under the ACA (45 C.F.R. § 147.136), and it must cover the ten "
+    "essential health benefit categories (42 U.S.C. § 18022), so if the "
+    "service falls in one of them, say so."
+)
+_GOVERNMENT_EMPLOYER = (
+    "This is a state or local government employer plan, so ERISA does not "
+    "apply (29 U.S.C. § 1003(b)(1)). A non-grandfathered plan still owes the "
+    "ACA internal appeal and external review process (45 C.F.R. § 147.136), "
+    "and state insurance law may apply if the plan is fully insured."
+)
+_FEDERAL_EMPLOYER = (
+    "This is a federal employee (FEHB) plan under 5 U.S.C. chapter 89, so "
+    "ERISA does not apply. A disputed claim goes first to the carrier for "
+    "reconsideration and then to the Office of Personnel Management "
+    "(5 C.F.R. § 890.105)."
+)
+_MEDICARE_ADVANTAGE = (
+    "This is a Medicare Advantage plan. Neither ERISA nor the ACA appeal rules "
+    "apply; the appeal follows the Medicare Advantage organization "
+    "determination and reconsideration process (42 C.F.R. Part 422, Subpart "
+    "M), with automatic review by the independent review entity if the plan "
+    "upholds its denial."
+)
+_MEDICARE = (
+    "This is Original Medicare. Neither ERISA nor the ACA appeal rules apply; "
+    "the appeal follows the Medicare redetermination and reconsideration "
+    "process (42 C.F.R. Part 405, Subpart I)."
+)
+_MEDICAID = (
+    "This is a Medicaid plan. Neither ERISA nor the ACA appeal rules apply; a "
+    "managed care plan owes an internal appeal (42 C.F.R. Part 438, Subpart "
+    "F) and the patient has the right to a state fair hearing (42 C.F.R. "
+    "Part 431, Subpart E)."
+)
+_VA = (
+    "This is Veterans Affairs coverage. Neither ERISA nor the ACA appeal "
+    "rules apply; VA has its own clinical appeal process, so argue the "
+    "medical case and do not cite either law."
+)
+_UNKNOWN = (
+    "We do not know how the patient gets this coverage. If the denial letter "
+    "or the plan documents show it is a private employer or union plan, "
+    "ERISA's claims-procedure rule (29 C.F.R. § 2560.503-1) most likely "
+    "applies; if they show it is a marketplace or individual plan, the ACA "
+    "internal appeal and external review rules (45 C.F.R. § 147.136) apply. "
+    "Name one of them only when the letter itself supports it; otherwise ask "
+    "for the plan's internal appeal and independent external review in plain "
+    "words rather than naming a statute."
+)
+_TWO_SOURCES = (
+    "More than one coverage source was given. Use the one the denial letter "
+    "itself supports."
+)
+_INVITATION = (
+    "If citing the applicable law strengthens this appeal (for example to "
+    "demand the clinical criteria the plan relied on, or to insist on an "
+    "independent external review), cite it by name and section exactly as "
+    "given here; a reviewer takes a letter more seriously when it names the "
+    "rule the plan must follow. Cite it only where it applies and where it "
+    "helps the argument. Never cite a law that does not govern this plan, and "
+    "do not invent section numbers, deadlines, quotations, or case names "
+    "beyond what is listed here."
+)
+
+# (marker in the lower-cased plan source name, paragraph). First match wins,
+# so the more specific markers come first ("medicare advantage" before
+# "medicare", "federal government" before "government").
+_PLAN_SOURCE_LAW: tuple[tuple[str, str], ...] = (
+    ("medicare advantage", _MEDICARE_ADVANTAGE),
+    ("medicare", _MEDICARE),
+    ("medicaid", _MEDICAID),
+    ("veterans", _VA),
+    ("marketplace", _ACA_MARKETPLACE),
+    ("affordable care", _ACA_MARKETPLACE),
+    ("federal government", _FEDERAL_EMPLOYER),
+    ("government", _GOVERNMENT_EMPLOYER),
+    ("employer", _ERISA),
+    ("union", _ERISA),
+    ("other group", _ERISA),
+)
+
+
+def _law_for_plan_source(name: str) -> Optional[str]:
+    label = re.sub(r"\s+", " ", (name or "").strip().lower())
+    if not label:
+        return None
+    for marker, paragraph in _PLAN_SOURCE_LAW:
+        if marker in label:
+            return paragraph
+    return None  # "Other", "Don't know": nothing to say
+
+
+def get_plan_law_context(
+    plan_sources: Iterable[str],
+    is_tpa: bool = False,
+    regulator_alt_name: Optional[str] = None,
+) -> str:
+    """Return the APPLICABLE APPEAL LAW block for the appeal prompt.
+
+    ``plan_sources`` are the PlanSource names the person picked at intake;
+    ``is_tpa`` says the carrier administers self-funded employer plans; and
+    ``regulator_alt_name`` is "ERISA" when the denial text matched the ERISA
+    regulator. Always returns a block: an unknown plan gets the hedged
+    paragraph, so the model is never left to guess in silence.
+    """
+    paragraphs: list[str] = []
+    if is_tpa or (regulator_alt_name or "").strip().upper() == "ERISA":
+        paragraphs.append(_ERISA)
+    for name in plan_sources:
+        paragraph = _law_for_plan_source(name)
+        if paragraph is not None and paragraph not in paragraphs:
+            paragraphs.append(paragraph)
+    if not paragraphs:
+        paragraphs.append(_UNKNOWN)
+    elif len(paragraphs) > 1:
+        paragraphs.append(_TWO_SOURCES)
+    body = "\n".join(paragraphs)
+    return f"{PLAN_LAW_HEADER}: {body}\n{_INVITATION}"

--- a/fighthealthinsurance/regulatory_citations.py
+++ b/fighthealthinsurance/regulatory_citations.py
@@ -38,8 +38,9 @@ PUBLIC_PROGRAMS = frozenset({MEDICARE_ADVANTAGE, MEDICARE, MEDICAID, VA, FEHB})
 # does not override these; the block names the conflict instead.
 EXCLUSIVE_OF_ERISA = PUBLIC_PROGRAMS | {GOVERNMENT}
 # Sources that describe private or government-employer coverage, which state
-# insurance law and the ACA appeal rules can reach.
-PRIVATE_COVERAGE = frozenset({ERISA, OTHER_GROUP, MARKETPLACE, GOVERNMENT, TPA})
+# insurance law and the ACA appeal rules can reach. The TPA flag is not one:
+# it says who administers the plan, not that a second plan exists (review).
+PRIVATE_COVERAGE = frozenset({ERISA, OTHER_GROUP, MARKETPLACE, GOVERNMENT})
 
 
 def self_insured_from(programs: Iterable[str]) -> Optional[bool]:

--- a/fighthealthinsurance/regulatory_citations.py
+++ b/fighthealthinsurance/regulatory_citations.py
@@ -17,6 +17,27 @@ import re
 from dataclasses import dataclass
 from typing import Iterable, Optional
 
+# Plan programs, as far as intake and the denial tell us: the plan source
+# ("How do you get your insurance?"), the carrier's TPA flag, and whether the
+# denial letter matched the ERISA regulator. One classification shared by
+# both prompt blocks below, so they cannot contradict each other (review).
+ERISA = "erisa"  # private employer or union plan
+TPA = "tpa"  # carrier administers self-funded employer plans
+ERISA_LETTER = "erisa_letter"  # the denial letter itself named ERISA rights
+OTHER_GROUP = "other_group"
+MARKETPLACE = "marketplace"
+GOVERNMENT = "government"  # state or local government employer
+FEHB = "fehb"  # federal employee
+MEDICARE_ADVANTAGE = "medicare_advantage"
+MEDICARE = "medicare"
+MEDICAID = "medicaid"
+VA = "va"
+
+PUBLIC_PROGRAMS = frozenset({MEDICARE_ADVANTAGE, MEDICARE, MEDICAID, VA, FEHB})
+# Coverage ERISA cannot govern. A denial letter that mentions ERISA rights
+# does not override these; the block names the conflict instead.
+EXCLUSIVE_OF_ERISA = PUBLIC_PROGRAMS | {GOVERNMENT}
+
 
 @dataclass(frozen=True)
 class RegulatoryHook:
@@ -36,6 +57,11 @@ class RegulatoryHook:
     # before it applies (the ``effective`` string above is the human-readable
     # companion). ``None`` means "already in force / no gate".
     effective_date: Optional[datetime.date] = None
+    # The public programs (PUBLIC_PROGRAMS keys) this hook still reaches. Empty
+    # means commercial and government-employer coverage only: state insurance
+    # law and the ACA appeal rules do not bind Medicare, Medicaid, VA or FEHB
+    # coverage, so for those only hooks written for the program are listed.
+    public_programs: frozenset[str] = frozenset()
 
 
 # Federal hooks apply broadly (subject to plan type); included alongside any
@@ -59,6 +85,7 @@ FEDERAL_HOOKS: tuple[RegulatoryHook, ...] = (
         # CMS limits impacted payers to MA orgs, Medicaid/CHIP, and FFE QHP
         # issuers — not self-funded employer (ERISA) plans.
         applies_to_self_insured=False,
+        public_programs=frozenset({MEDICARE_ADVANTAGE, MEDICAID}),
     ),
     RegulatoryHook(
         name=(
@@ -81,6 +108,7 @@ FEDERAL_HOOKS: tuple[RegulatoryHook, ...] = (
         # This is a Medicare Advantage rule; it does not bind self-funded
         # commercial employer plans.
         applies_to_self_insured=False,
+        public_programs=frozenset({MEDICARE_ADVANTAGE}),
     ),
     RegulatoryHook(
         name="ACA internal appeal and external review rights (45 C.F.R. § 147.136)",
@@ -319,8 +347,16 @@ def get_regulatory_citation_context(
     diagnosis: Optional[str] = None,
     self_insured: Optional[bool] = None,
     as_of: Optional[datetime.date] = None,
+    programs: Iterable[str] = (),
 ) -> Optional[str]:
     """Return a conservatively-framed regulatory block for the denial's state.
+
+    ``programs`` is classify_plan()'s result. For a public program (Medicare
+    Advantage, Original Medicare, Medicaid, VA, FEHB) only hooks that declare
+    they reach it are kept, because state insurance law and the ACA appeal
+    rules do not bind such coverage and the plan-law block says so; listing
+    them here too would put two contradicting instructions in one prompt
+    (review). With nothing left, no block.
 
     Returns ``None`` unless the state has at least one verified hook, so the
     overwhelming majority of appeals are unaffected. ``denial_text`` /
@@ -345,12 +381,25 @@ def get_regulatory_citation_context(
         return None
 
     hooks = [h for h in FEDERAL_HOOKS if _hook_in_effect(h, today)] + state_hooks
+    public = set(programs) & PUBLIC_PROGRAMS
+    if public:
+        hooks = [h for h in hooks if h.public_programs & public]
     if self_insured is True:
         hooks = [h for h in hooks if h.applies_to_self_insured]
+    if not hooks:
+        return None
 
     bullet_lines = "\n".join(f"- {h.name} ({h.effective}): {h.summary}" for h in hooks)
 
-    if self_insured is True:
+    if public:
+        label = next(_PROGRAM_LABELS[k] for k in _PROGRAM_ORDER if k in public)
+        caveat = (
+            f"Note: this is {label} coverage. State insurance mandates and the "
+            "ACA appeal rules do not bind it; only the federal rules written "
+            "for the program are listed, so rely on those and on the program's "
+            "own appeal process."
+        )
+    elif self_insured is True:
         caveat = (
             "Note: this appears to be a self-insured (ERISA) employer plan. "
             "State insurance mandates and Medicare/Medicaid/Marketplace-specific "
@@ -512,32 +561,80 @@ _INVITATION = (
     "deadlines, quotations, or case names beyond what is listed here."
 )
 
-# (marker in the lower-cased plan source name, paragraph). First match wins,
-# so the more specific markers come first ("medicare advantage" before
-# "medicare", "federal government" before "government").
-_PLAN_SOURCE_LAW: tuple[tuple[str, str], ...] = (
-    ("medicare advantage", _MEDICARE_ADVANTAGE),
-    ("medicare", _MEDICARE),
-    ("medicaid", _MEDICAID),
-    ("veterans", _VA),
-    ("marketplace", _ACA_MARKETPLACE),
-    ("affordable care", _ACA_MARKETPLACE),
-    ("federal government", _FEDERAL_EMPLOYER),
-    ("government", _GOVERNMENT_EMPLOYER),
-    ("employer", _ERISA),
-    ("union", _ERISA),
-    ("other group", _OTHER_GROUP),
+_LETTER_CONFLICT = (
+    "The denial letter mentions ERISA appeal rights, but the coverage source "
+    "given is one that ERISA does not govern. Follow the letter only if the "
+    "plan documents confirm a private employer or union plan; otherwise rely "
+    "on the process described above and do not cite ERISA."
 )
 
+# (marker in the lower-cased plan source name, program). First match wins, so
+# the more specific markers come first ("medicare advantage" before
+# "medicare", "federal government" before "government").
+_PLAN_SOURCE_PROGRAM: tuple[tuple[str, str], ...] = (
+    ("medicare advantage", MEDICARE_ADVANTAGE),
+    ("medicare", MEDICARE),
+    ("medicaid", MEDICAID),
+    ("veterans", VA),
+    ("marketplace", MARKETPLACE),
+    ("affordable care", MARKETPLACE),
+    ("federal government", FEHB),
+    ("government", GOVERNMENT),
+    ("employer", ERISA),
+    ("union", ERISA),
+    ("other group", OTHER_GROUP),
+)
 
-def _law_for_plan_source(name: str) -> Optional[str]:
+_PARAGRAPHS: dict[str, str] = {
+    ERISA: _ERISA,
+    OTHER_GROUP: _OTHER_GROUP,
+    MARKETPLACE: _ACA_MARKETPLACE,
+    GOVERNMENT: _GOVERNMENT_EMPLOYER,
+    FEHB: _FEDERAL_EMPLOYER,
+    MEDICARE_ADVANTAGE: _MEDICARE_ADVANTAGE,
+    MEDICARE: _MEDICARE,
+    MEDICAID: _MEDICAID,
+    VA: _VA,
+}
+
+_PROGRAM_ORDER: tuple[str, ...] = (MEDICARE_ADVANTAGE, MEDICARE, MEDICAID, VA, FEHB)
+_PROGRAM_LABELS: dict[str, str] = {
+    MEDICARE_ADVANTAGE: "Medicare Advantage",
+    MEDICARE: "Original Medicare",
+    MEDICAID: "Medicaid",
+    VA: "Veterans Affairs",
+    FEHB: "federal employee (FEHB)",
+}
+
+
+def _program_for_plan_source(name: str) -> Optional[str]:
     label = re.sub(r"\s+", " ", (name or "").strip().lower())
     if not label:
         return None
-    for marker, paragraph in _PLAN_SOURCE_LAW:
+    for marker, program in _PLAN_SOURCE_PROGRAM:
         if marker in label:
-            return paragraph
+            return program
     return None  # "Other", "Don't know": nothing to say
+
+
+def classify_plan(
+    plan_sources: Iterable[str],
+    is_tpa: bool = False,
+    regulator_alt_name: Optional[str] = None,
+) -> tuple[str, ...]:
+    """Program keys for this denial, in the order the signals were given:
+    the plan sources' programs first, then TPA, then ERISA_LETTER. Empty when
+    nothing is known."""
+    programs: list[str] = []
+    for name in plan_sources:
+        program = _program_for_plan_source(name)
+        if program is not None and program not in programs:
+            programs.append(program)
+    if is_tpa:
+        programs.append(TPA)
+    if (regulator_alt_name or "").strip().upper() == "ERISA":
+        programs.append(ERISA_LETTER)
+    return tuple(programs)
 
 
 def get_plan_law_context(
@@ -553,23 +650,34 @@ def get_plan_law_context(
     regulator. Always returns a block: an unknown plan gets the hedged
     paragraph, so the model is never left to guess in silence.
     """
+    programs = classify_plan(
+        plan_sources, is_tpa=is_tpa, regulator_alt_name=regulator_alt_name
+    )
+    sources = [k for k in programs if k in _PARAGRAPHS]
     paragraphs: list[str] = []
-    # The denial letter naming ERISA rights is the strongest signal we have.
-    if (regulator_alt_name or "").strip().upper() == "ERISA":
-        paragraphs.append(_ERISA)
-    for name in plan_sources:
-        paragraph = _law_for_plan_source(name)
-        if paragraph is not None and paragraph not in paragraphs:
-            paragraphs.append(paragraph)
+    conflict: Optional[str] = None
+    # The denial letter naming ERISA rights is the strongest signal we have,
+    # except against coverage ERISA cannot govern: there the source wins and
+    # the conflict is named (review).
+    if ERISA_LETTER in programs:
+        if any(k in EXCLUSIVE_OF_ERISA for k in sources):
+            conflict = _LETTER_CONFLICT
+        elif ERISA not in sources:
+            paragraphs.append(_ERISA)
+    for k in sources:
+        if _PARAGRAPHS[k] not in paragraphs:
+            paragraphs.append(_PARAGRAPHS[k])
     # A TPA administers self-funded plans, and a self-funded plan can belong
     # to a city as easily as to a company, so the flag alone does not make it
     # ERISA (review). With a plan source, the source decides; without one,
     # the hedged self-funded paragraph.
-    if is_tpa and not paragraphs:
+    if TPA in programs and not paragraphs:
         paragraphs.append(_TPA_ONLY)
     if not paragraphs:
         paragraphs.append(_UNKNOWN)
     elif len(paragraphs) > 1:
         paragraphs.append(_TWO_SOURCES)
+    if conflict is not None:
+        paragraphs.append(conflict)
     body = "\n".join(paragraphs)
     return f"{PLAN_LAW_HEADER}: {body}\n{_INVITATION}"

--- a/fighthealthinsurance/regulatory_citations.py
+++ b/fighthealthinsurance/regulatory_citations.py
@@ -398,23 +398,49 @@ _ERISA = (
     "for the denial and the plan provisions it relied on, must provide on "
     "request the internal rule or clinical criteria it applied and identify "
     "any medical expert it consulted, and must give a full and fair review by "
-    "someone who did not make the original decision. A non-grandfathered plan "
-    "also owes an independent external review (45 C.F.R. § 147.136, applied "
-    "to group plans by 29 C.F.R. § 2590.715-2719). ERISA does not apply to "
-    "government or church employer plans."
+    "someone who did not make the original decision. If the plan is not "
+    "grandfathered and the denial turns on medical judgment (medical "
+    "necessity, appropriateness, level of care, or an experimental label) or "
+    "is a rescission, the patient is also owed an independent external review "
+    "(45 C.F.R. § 147.136, applied to group plans by 29 C.F.R. § "
+    "2590.715-2719); a denial for ineligibility is not. ERISA does not apply "
+    "to government or church employer plans (29 U.S.C. § 1003(b))."
+)
+_TPA_ONLY = (
+    "The carrier administers self-funded employer plans as a third-party "
+    "administrator, so this is most likely a self-funded plan. If the "
+    "employer is a private company or a union, ERISA governs the appeal "
+    "(ERISA section 503, 29 U.S.C. § 1133, and 29 C.F.R. § 2560.503-1: the "
+    "specific reasons, the criteria relied on, and a full and fair review). "
+    "If the employer is a government or a church, ERISA does not apply "
+    "(29 U.S.C. § 1003(b)); the plan's own appeal terms apply, and for a "
+    "non-grandfathered plan the ACA internal appeal and external review rules "
+    "(45 C.F.R. § 147.136) as well. Use whichever the denial letter or the "
+    "plan documents support."
+)
+_OTHER_GROUP = (
+    "This is group coverage that is not clearly an employer or union plan. If "
+    "an employer or union sponsors it, ERISA governs (29 C.F.R. § "
+    "2560.503-1); if it is an association or membership plan, ERISA may not "
+    "apply, and for non-grandfathered coverage the ACA internal appeal and "
+    "external review rules (45 C.F.R. § 147.136) apply along with state "
+    "insurance law. Name ERISA only if the denial letter or the plan "
+    "documents show an employer or union sponsor."
 )
 _ACA_MARKETPLACE = (
     "This is a marketplace (Affordable Care Act) plan, so ERISA does not "
-    "apply. The plan owes an internal appeal and an independent external "
-    "review under the ACA (45 C.F.R. § 147.136), and it must cover the ten "
-    "essential health benefit categories (42 U.S.C. § 18022), so if the "
-    "service falls in one of them, say so."
+    "apply. The plan owes an internal appeal and, for a denial that turns on "
+    "medical judgment or is a rescission, an independent external review "
+    "under the ACA (45 C.F.R. § 147.136), and it must cover the ten essential "
+    "health benefit categories (42 U.S.C. § 18022), so if the service falls "
+    "in one of them, say so."
 )
 _GOVERNMENT_EMPLOYER = (
     "This is a state or local government employer plan, so ERISA does not "
     "apply (29 U.S.C. § 1003(b)(1)). A non-grandfathered plan still owes the "
-    "ACA internal appeal and external review process (45 C.F.R. § 147.136), "
-    "and state insurance law may apply if the plan is fully insured."
+    "ACA internal appeal and, for a denial that turns on medical judgment, an "
+    "independent external review (45 C.F.R. § 147.136), and state insurance "
+    "law may apply if the plan is fully insured."
 )
 _FEDERAL_EMPLOYER = (
     "This is a federal employee (FEHB) plan under 5 U.S.C. chapter 89, so "
@@ -424,15 +450,21 @@ _FEDERAL_EMPLOYER = (
 )
 _MEDICARE_ADVANTAGE = (
     "This is a Medicare Advantage plan. Neither ERISA nor the ACA appeal rules "
-    "apply; the appeal follows the Medicare Advantage organization "
-    "determination and reconsideration process (42 C.F.R. Part 422, Subpart "
-    "M), with automatic review by the independent review entity if the plan "
-    "upholds its denial."
+    "apply. A denial of a medical service or item follows the Medicare "
+    "Advantage organization determination and reconsideration process "
+    "(42 C.F.R. Part 422, Subpart M), and the plan must itself forward an "
+    "upheld denial to the independent review entity. A denial of a "
+    "prescription drug under the plan's Part D benefit follows the Part D "
+    "process instead (42 C.F.R. Part 423, Subpart M), where after the plan's "
+    "redetermination the patient must ask the independent review entity for "
+    "reconsideration themselves."
 )
 _MEDICARE = (
-    "This is Original Medicare. Neither ERISA nor the ACA appeal rules apply; "
-    "the appeal follows the Medicare redetermination and reconsideration "
-    "process (42 C.F.R. Part 405, Subpart I)."
+    "This is Original Medicare. Neither ERISA nor the ACA appeal rules apply. "
+    "A claim denial follows the Medicare redetermination and reconsideration "
+    "process (42 C.F.R. Part 405, Subpart I); a prescription drug denial "
+    "under a Part D plan follows the Part D process (42 C.F.R. Part 423, "
+    "Subpart M)."
 )
 _MEDICAID = (
     "This is a Medicaid plan. Neither ERISA nor the ACA appeal rules apply; a "
@@ -442,18 +474,22 @@ _MEDICAID = (
 )
 _VA = (
     "This is Veterans Affairs coverage. Neither ERISA nor the ACA appeal "
-    "rules apply; VA has its own clinical appeal process, so argue the "
-    "medical case and do not cite either law."
+    "rules apply. VA has its own processes: a clinical appeal for a decision "
+    "about treatment, and a benefits decision review for a claim such as "
+    "reimbursement of care outside VA. Argue the medical case and do not cite "
+    "either law."
 )
 _UNKNOWN = (
     "We do not know how the patient gets this coverage. If the denial letter "
     "or the plan documents show it is a private employer or union plan, "
     "ERISA's claims-procedure rule (29 C.F.R. § 2560.503-1) most likely "
-    "applies; if they show it is a marketplace or individual plan, the ACA "
-    "internal appeal and external review rules (45 C.F.R. § 147.136) apply. "
+    "applies; if they show it is a marketplace plan or other non-grandfathered "
+    "individual coverage, the ACA internal appeal and external review rules "
+    "(45 C.F.R. § 147.136) apply to a denial that turns on medical judgment. "
     "Name one of them only when the letter itself supports it; otherwise ask "
-    "for the plan's internal appeal and independent external review in plain "
-    "words rather than naming a statute."
+    "for the plan's internal appeal and, where the denial is about medical "
+    "judgment, an independent external review in plain words rather than "
+    "naming a statute."
 )
 _TWO_SOURCES = (
     "More than one coverage source was given. Use the one the denial letter "
@@ -461,13 +497,13 @@ _TWO_SOURCES = (
 )
 _INVITATION = (
     "If citing the applicable law strengthens this appeal (for example to "
-    "demand the clinical criteria the plan relied on, or to insist on an "
-    "independent external review), cite it by name and section exactly as "
-    "given here; a reviewer takes a letter more seriously when it names the "
-    "rule the plan must follow. Cite it only where it applies and where it "
-    "helps the argument. Never cite a law that does not govern this plan, and "
-    "do not invent section numbers, deadlines, quotations, or case names "
-    "beyond what is listed here."
+    "demand the clinical criteria the plan relied on, or to insist on the "
+    "independent external review that a medical-judgment denial is owed), "
+    "cite it by name and section exactly as given here; a reviewer takes a "
+    "letter more seriously when it names the rule the plan must follow. Cite "
+    "it only where it applies and where it helps the argument. Never cite a "
+    "law that does not govern this plan, and do not invent section numbers, "
+    "deadlines, quotations, or case names beyond what is listed here."
 )
 
 # (marker in the lower-cased plan source name, paragraph). First match wins,
@@ -484,7 +520,7 @@ _PLAN_SOURCE_LAW: tuple[tuple[str, str], ...] = (
     ("government", _GOVERNMENT_EMPLOYER),
     ("employer", _ERISA),
     ("union", _ERISA),
-    ("other group", _ERISA),
+    ("other group", _OTHER_GROUP),
 )
 
 
@@ -512,12 +548,19 @@ def get_plan_law_context(
     paragraph, so the model is never left to guess in silence.
     """
     paragraphs: list[str] = []
-    if is_tpa or (regulator_alt_name or "").strip().upper() == "ERISA":
+    # The denial letter naming ERISA rights is the strongest signal we have.
+    if (regulator_alt_name or "").strip().upper() == "ERISA":
         paragraphs.append(_ERISA)
     for name in plan_sources:
         paragraph = _law_for_plan_source(name)
         if paragraph is not None and paragraph not in paragraphs:
             paragraphs.append(paragraph)
+    # A TPA administers self-funded plans, and a self-funded plan can belong
+    # to a city as easily as to a company, so the flag alone does not make it
+    # ERISA (review). With a plan source, the source decides; without one,
+    # the hedged self-funded paragraph.
+    if is_tpa and not paragraphs:
+        paragraphs.append(_TPA_ONLY)
     if not paragraphs:
         paragraphs.append(_UNKNOWN)
     elif len(paragraphs) > 1:

--- a/fighthealthinsurance/regulatory_citations.py
+++ b/fighthealthinsurance/regulatory_citations.py
@@ -436,8 +436,9 @@ _ACA_MARKETPLACE = (
     "ACA (45 C.F.R. § 147.136), and it must cover the ten essential health "
     "benefit categories (42 U.S.C. § 18022), so if the service falls in one "
     "of them, say so. If it is small employer (SHOP) coverage, it is an "
-    "employer plan and ERISA governs it as for any private employer plan "
-    "(29 C.F.R. § 2560.503-1)."
+    "employer plan: ERISA governs it when a private employer sponsors it "
+    "(29 C.F.R. § 2560.503-1), and a government or church employer's plan "
+    "is exempt (29 U.S.C. § 1003(b))."
 )
 _GOVERNMENT_EMPLOYER = (
     "This is a state or local government employer plan, so ERISA does not "

--- a/fighthealthinsurance/regulatory_citations.py
+++ b/fighthealthinsurance/regulatory_citations.py
@@ -37,6 +37,20 @@ PUBLIC_PROGRAMS = frozenset({MEDICARE_ADVANTAGE, MEDICARE, MEDICAID, VA, FEHB})
 # Coverage ERISA cannot govern. A denial letter that mentions ERISA rights
 # does not override these; the block names the conflict instead.
 EXCLUSIVE_OF_ERISA = PUBLIC_PROGRAMS | {GOVERNMENT}
+# Sources that describe private or government-employer coverage, which state
+# insurance law and the ACA appeal rules can reach.
+PRIVATE_COVERAGE = frozenset({ERISA, OTHER_GROUP, MARKETPLACE, GOVERNMENT, TPA})
+
+
+def self_insured_from(programs: Iterable[str]) -> Optional[bool]:
+    """True when the TPA flag stands for a self-funded ERISA employer plan:
+    the flag is set and no source says otherwise (a government plan is
+    exempt from ERISA whoever administers it, and marketplace coverage is
+    insured). None when we cannot tell, which selects neutral wording."""
+    keys = set(programs)
+    if TPA in keys and not keys & (EXCLUSIVE_OF_ERISA | {MARKETPLACE}):
+        return True
+    return None
 
 
 @dataclass(frozen=True)
@@ -71,7 +85,8 @@ FEDERAL_HOOKS: tuple[RegulatoryHook, ...] = (
         name="CMS Interoperability and Prior Authorization Final Rule (CMS-0057-F)",
         summary=(
             "Impacted payers must send a specific reason for every "
-            "prior-authorization denial and publicly report PA approval, "
+            "prior-authorization denial of an item or service (prescription "
+            "drugs are outside this rule) and publicly report PA approval, "
             "denial, and appeal metrics. Use it to demand the specific denial "
             "rationale and the exact criteria applied."
         ),
@@ -381,8 +396,15 @@ def get_regulatory_citation_context(
         return None
 
     hooks = [h for h in FEDERAL_HOOKS if _hook_in_effect(h, today)] + state_hooks
-    public = set(programs) & PUBLIC_PROGRAMS
-    if public:
+    keys = set(programs)
+    public = keys & PUBLIC_PROGRAMS
+    # Only public coverage: keep the rules written for the program. Public
+    # AND private coverage (a Medicare Advantage member with an employer
+    # plan too): we do not know which plan denied, so the private plan's
+    # rules stay, with a sentence saying whom they reach, the same
+    # tie-break the plan-law block uses (review).
+    public_only = bool(public) and not keys & PRIVATE_COVERAGE
+    if public_only:
         hooks = [h for h in hooks if h.public_programs & public]
     if self_insured is True:
         hooks = [h for h in hooks if h.applies_to_self_insured]
@@ -391,13 +413,26 @@ def get_regulatory_citation_context(
 
     bullet_lines = "\n".join(f"- {h.name} ({h.effective}): {h.summary}" for h in hooks)
 
-    if public:
-        label = next(_PROGRAM_LABELS[k] for k in _PROGRAM_ORDER if k in public)
+    label = (
+        next(_PROGRAM_LABELS[k] for k in _PROGRAM_ORDER if k in public)
+        if public
+        else None
+    )
+    if public_only:
         caveat = (
             f"Note: this is {label} coverage. State insurance mandates and the "
             "ACA appeal rules do not bind it; only the federal rules written "
             "for the program are listed, so rely on those and on the program's "
             "own appeal process."
+        )
+    elif public:
+        caveat = (
+            "Note: the state laws listed above generally apply to fully-insured "
+            "plans; self-insured (ERISA) employer plans are typically exempt, so "
+            "confirm the plan type before relying on a state mandate. More than "
+            f"one coverage source was given: the state and ACA items above reach "
+            f"the private plan, not the {label} coverage, so apply them only if "
+            "the denial concerns the private plan."
         )
     elif self_insured is True:
         caveat = (

--- a/tests/async-unit/test_plan_law_context.py
+++ b/tests/async-unit/test_plan_law_context.py
@@ -60,6 +60,8 @@ class TestWhichLawGoverns:
         assert "not clearly an employer or union plan" in block
         assert "Name ERISA only if" in block
         assert "ERISA governs the appeal" not in block
+        # A church's or a city's employee plan is group coverage too (review).
+        assert "government or church employer's plan is exempt (29 U.S.C. § 1003(b))" in block
 
     @pytest.mark.parametrize(
         "source",
@@ -89,9 +91,17 @@ class TestWhichLawGoverns:
 
     def test_marketplace_plans_are_aca_not_erisa(self):
         block = _block("State Marketplace / Affordable Care Act")
-        assert "ERISA does not apply" in block
+        assert "individual plan bought on the marketplace, ERISA does not apply" in block
         assert "45 C.F.R. § 147.136" in block
         assert "42 U.S.C. § 18022" in block
+
+    def test_small_employer_shop_coverage_is_still_an_erisa_plan(self):
+        """A small business buys group coverage on the SHOP marketplace; that
+        is an employer plan, so a blanket "ERISA does not apply" would be
+        wrong (review)."""
+        block = _block("State Marketplace / Affordable Care Act")
+        assert "small employer (SHOP) coverage" in block
+        assert "ERISA governs it as for any private employer plan" in block
 
     @pytest.mark.parametrize(
         "source, marker",
@@ -170,8 +180,12 @@ class TestWhichLawGoverns:
         assert block.count("ERISA governs the appeal") == 1
         assert "More than one coverage source" not in block
 
-    def test_the_invitation_limits_external_review_to_medical_judgment_denials(self):
-        assert "independent external review that a medical-judgment denial is owed" in _block()
+    def test_the_invitation_defers_to_the_paragraph_on_external_review(self):
+        """The closing invitation must not promise an external review on its
+        own; a grandfathered self-funded plan owes none (review)."""
+        block = _block()
+        assert "only where the paragraph above says the plan owes one" in block
+        assert "is owed" not in block.split("If citing the applicable law", 1)[1]
 
 
 class TestTheBlockItself:
@@ -253,7 +267,7 @@ class TestCollector:
     def test_reads_plan_sources_from_the_denial(self):
         denial = SimpleNamespace(plan_source=_Sources("State Marketplace / Affordable Care Act"))
         block = AppealGenerator._collect_plan_law_context(denial)
-        assert block is not None and "marketplace (Affordable Care Act) plan" in block
+        assert block is not None and "marketplace (Affordable Care Act) coverage" in block
 
     def test_reads_the_tpa_flag_and_the_regulator(self):
         denial = SimpleNamespace(

--- a/tests/async-unit/test_plan_law_context.py
+++ b/tests/async-unit/test_plan_law_context.py
@@ -101,7 +101,9 @@ class TestWhichLawGoverns:
         wrong (review)."""
         block = _block("State Marketplace / Affordable Care Act")
         assert "small employer (SHOP) coverage" in block
-        assert "ERISA governs it as for any private employer plan" in block
+        assert "ERISA governs it when a private employer sponsors it" in block
+        # ...and SHOP does not make a church's or a city's plan ERISA (review).
+        assert "government or church employer's plan is exempt (29 U.S.C. § 1003(b))" in block
 
     @pytest.mark.parametrize(
         "source, marker",

--- a/tests/async-unit/test_plan_law_context.py
+++ b/tests/async-unit/test_plan_law_context.py
@@ -1,0 +1,230 @@
+"""The APPLICABLE APPEAL LAW block: which law governs the plan, from what
+intake collected, and an invitation to cite it where it helps.
+
+Every statute here is cited by name and section and nothing is quoted; the
+allowlist below is the full set, kept in the test on purpose so adding a
+citation means touching this file and checking the authority.
+"""
+
+import inspect
+import re
+from types import SimpleNamespace
+
+import pytest
+
+from fighthealthinsurance import generate_appeal
+from fighthealthinsurance.generate_appeal import AppealGenerator
+from fighthealthinsurance.regulatory_citations import (
+    PLAN_LAW_HEADER,
+    get_plan_law_context,
+)
+
+CITATION_ALLOWLIST = {
+    "29 U.S.C. § 1133",
+    "29 C.F.R. § 2560.503-1",
+    "45 C.F.R. § 147.136",
+    "29 C.F.R. § 2590.715-2719",
+    "42 U.S.C. § 18022",
+    "29 U.S.C. § 1003(b)(1)",
+    "5 U.S.C. chapter 89",
+    "5 C.F.R. § 890.105",
+    "42 C.F.R. Part 422, Subpart M",
+    "42 C.F.R. Part 405, Subpart I",
+    "42 C.F.R. Part 438, Subpart F",
+    "42 C.F.R. Part 431, Subpart E",
+}
+# A section number is digits, dots and dashes, then any number of
+# parenthesised subsections; trailing prose punctuation is not part of it.
+_CITATION = re.compile(
+    r"\d+ (?:U\.S\.C\.|C\.F\.R\.) "
+    r"(?:§ \d[\d.-]*(?:\([a-z0-9]+\))*|Part \d+, Subpart [A-Z]|chapter \d+)"
+)
+
+
+def _block(*sources, **kw):
+    return get_plan_law_context(list(sources), **kw)
+
+
+class TestWhichLawGoverns:
+    @pytest.mark.parametrize("source", ["Employer -- Private   ", "Union", "Other Group"])
+    def test_private_employer_and_union_plans_are_erisa(self, source):
+        block = _block(source)
+        assert "ERISA governs the appeal" in block
+        assert "29 C.F.R. § 2560.503-1" in block
+        assert "45 C.F.R. § 147.136" in block  # external review for non-grandfathered
+
+    @pytest.mark.parametrize(
+        "source", ["Employer -- State Government ", "Employer -- Other Government"]
+    )
+    def test_government_employer_plans_are_not_erisa_but_keep_aca_rights(self, source):
+        block = _block(source)
+        assert "ERISA does not apply (29 U.S.C. § 1003(b)(1))" in block
+        assert "45 C.F.R. § 147.136" in block
+        assert "ERISA governs" not in block
+
+    def test_federal_employees_get_fehb_not_erisa(self):
+        block = _block("Employer -- Federal Government")
+        assert "5 C.F.R. § 890.105" in block
+        assert "ERISA does not apply" in block
+        assert "ERISA governs" not in block
+
+    def test_marketplace_plans_are_aca_not_erisa(self):
+        block = _block("State Marketplace / Affordable Care Act")
+        assert "ERISA does not apply" in block
+        assert "45 C.F.R. § 147.136" in block
+        assert "42 U.S.C. § 18022" in block
+
+    @pytest.mark.parametrize(
+        "source, marker",
+        [
+            ("Medicare Advantage", "42 C.F.R. Part 422, Subpart M"),
+            ("Medicare Regular", "42 C.F.R. Part 405, Subpart I"),
+            ("Medicaid  ", "42 C.F.R. Part 438, Subpart F"),
+            ("Veterans Affairs", "VA has its own clinical appeal process"),
+        ],
+    )
+    def test_public_programs_name_their_own_process_and_rule_out_both_laws(self, source, marker):
+        block = _block(source)
+        assert marker in block
+        assert "Neither ERISA nor the ACA appeal rules apply" in block
+
+    def test_medicare_advantage_is_not_read_as_original_medicare(self):
+        block = _block("Medicare Advantage")
+        assert "Part 405" not in block
+
+    @pytest.mark.parametrize("sources", [(), ("Other",), ("Don't know",), ("",)])
+    def test_an_unknown_source_gets_the_hedged_paragraph(self, sources):
+        block = _block(*sources)
+        assert "We do not know how the patient gets this coverage" in block
+        assert "only when the letter itself supports it" in block
+        assert "ERISA governs" not in block
+
+    def test_a_tpa_carrier_means_erisa_even_with_no_source(self):
+        block = _block(is_tpa=True)
+        assert "ERISA governs the appeal" in block
+        assert "We do not know" not in block
+
+    def test_the_erisa_regulator_match_means_erisa(self):
+        block = _block("Don't know", regulator_alt_name="erisa")
+        assert "ERISA governs the appeal" in block
+
+    def test_two_sources_both_appear_with_a_tie_break(self):
+        block = _block("Medicare Advantage", "Employer -- Private")
+        assert "Medicare Advantage plan" in block
+        assert "ERISA governs the appeal" in block
+        assert "More than one coverage source was given" in block
+
+    def test_one_source_twice_is_one_paragraph(self):
+        block = _block("Employer -- Private", "Union", is_tpa=True)
+        assert block.count("ERISA governs the appeal") == 1
+        assert "More than one coverage source" not in block
+
+
+class TestTheBlockItself:
+    ALL = [
+        _block("Employer -- Private"),
+        _block("Employer -- State Government"),
+        _block("Employer -- Federal Government"),
+        _block("State Marketplace / Affordable Care Act"),
+        _block("Medicare Advantage"),
+        _block("Medicare Regular"),
+        _block("Medicaid"),
+        _block("Veterans Affairs"),
+        _block(),
+        _block("Medicare Advantage", "Employer -- Private"),
+    ]
+
+    @pytest.mark.parametrize("block", ALL)
+    def test_every_block_invites_and_guards(self, block):
+        assert block.startswith(f"{PLAN_LAW_HEADER}: ")
+        assert "If citing the applicable law strengthens this appeal" in block
+        assert "Never cite a law that does not govern this plan" in block
+        assert "do not invent section numbers" in block
+
+    @pytest.mark.parametrize("block", ALL)
+    def test_every_citation_is_on_the_allowlist(self, block):
+        # The VA paragraph cites nothing on purpose; every other block does.
+        found = set(_CITATION.findall(block))
+        assert found or "Veterans Affairs" in block, block
+        assert found <= CITATION_ALLOWLIST, found - CITATION_ALLOWLIST
+
+    def test_the_allowlist_is_all_used(self):
+        used = set()
+        for block in self.ALL:
+            used |= set(_CITATION.findall(block))
+        assert used == CITATION_ALLOWLIST
+
+    @pytest.mark.parametrize("block", ALL)
+    def test_house_style(self, block):
+        assert "\u2014" not in block
+
+
+class TestPromptWiring:
+    def test_make_open_prompt_appends_the_block_when_given(self):
+        block = _block("Employer -- Private")
+        prompt = AppealGenerator().make_open_prompt(
+            denial_text="Service denied.", plan_law_context=block
+        )
+        assert prompt is not None
+        assert block in prompt
+
+    def test_make_open_prompt_is_unchanged_without_it(self):
+        prompt = AppealGenerator().make_open_prompt(denial_text="Service denied.")
+        assert prompt is not None
+        assert PLAN_LAW_HEADER not in prompt
+
+    def test_the_block_survives_context_shedding(self):
+        assert "plan_law_context" not in generate_appeal._PROMPT_TIER1_NULLS
+
+    def test_make_appeals_passes_the_block_through(self):
+        src = inspect.getsource(AppealGenerator.make_appeals)
+        assert "plan_law_context = self._collect_plan_law_context(denial)" in src
+        assert "plan_law_context=plan_law_context," in src
+
+
+class _Sources:
+    def __init__(self, *names, raise_=None):
+        self._names = names
+        self._raise = raise_
+
+    def all(self):
+        if self._raise:
+            raise self._raise
+        return [SimpleNamespace(name=n) for n in self._names]
+
+
+class TestCollector:
+    def test_reads_plan_sources_from_the_denial(self):
+        denial = SimpleNamespace(plan_source=_Sources("State Marketplace / Affordable Care Act"))
+        block = AppealGenerator._collect_plan_law_context(denial)
+        assert block is not None and "marketplace (Affordable Care Act) plan" in block
+
+    def test_reads_the_tpa_flag_and_the_regulator(self):
+        denial = SimpleNamespace(
+            plan_source=_Sources(),
+            insurance_company_obj=SimpleNamespace(is_tpa=True),
+        )
+        assert "ERISA governs" in (AppealGenerator._collect_plan_law_context(denial) or "")
+        denial = SimpleNamespace(
+            plan_source=_Sources(), regulator=SimpleNamespace(alt_name="ERISA")
+        )
+        assert "ERISA governs" in (AppealGenerator._collect_plan_law_context(denial) or "")
+
+    def test_a_bare_denial_still_gets_the_hedged_block(self):
+        block = AppealGenerator._collect_plan_law_context(SimpleNamespace())
+        assert block is not None and "We do not know" in block
+
+    def test_a_failing_lookup_returns_none_instead_of_raising(self):
+        denial = SimpleNamespace(plan_source=_Sources(raise_=RuntimeError("db down")))
+        assert AppealGenerator._collect_plan_law_context(denial) is None
+
+    def test_a_lazy_regulator_that_raises_does_not_lose_the_block(self):
+        class Denial:
+            plan_source = _Sources("Employer -- Private")
+
+            @property
+            def regulator(self):
+                raise RuntimeError("SynchronousOnlyOperation")
+
+        block = AppealGenerator._collect_plan_law_context(Denial())
+        assert block is not None and "ERISA governs" in block

--- a/tests/async-unit/test_plan_law_context.py
+++ b/tests/async-unit/test_plan_law_context.py
@@ -16,6 +16,7 @@ from fighthealthinsurance import generate_appeal
 from fighthealthinsurance.generate_appeal import AppealGenerator
 from fighthealthinsurance.regulatory_citations import (
     PLAN_LAW_HEADER,
+    classify_plan,
     get_plan_law_context,
 )
 
@@ -171,6 +172,45 @@ class TestWhichLawGoverns:
         block = _block("Don't know", regulator_alt_name="erisa")
         assert "ERISA governs the appeal" in block
 
+    @pytest.mark.parametrize(
+        "source",
+        [
+            "Employer -- State Government",
+            "Employer -- Federal Government",
+            "Medicare Advantage",
+            "Medicare Regular",
+            "Medicaid",
+            "Veterans Affairs",
+        ],
+    )
+    def test_a_source_erisa_cannot_govern_outranks_the_letter_and_names_the_conflict(self, source):
+        block = _block(source, regulator_alt_name="ERISA")
+        assert "ERISA governs the appeal" not in block
+        assert "The denial letter mentions ERISA appeal rights" in block
+        assert "do not cite ERISA" in block
+        assert "More than one coverage source" not in block
+
+    def test_the_letter_still_counts_beside_a_compatible_source(self):
+        # Marketplace coverage can be SHOP employer coverage, so a letter
+        # naming ERISA rights is not a contradiction there.
+        block = _block("State Marketplace / Affordable Care Act", regulator_alt_name="ERISA")
+        assert "ERISA governs the appeal" in block
+        assert "More than one coverage source" in block
+        assert "The denial letter mentions ERISA appeal rights" not in block
+
+
+class TestClassifyPlan:
+    def test_keys_follow_the_sources_then_the_flags(self):
+        assert classify_plan(
+            ["Medicare Advantage", "Employer -- Private"], is_tpa=True, regulator_alt_name="ERISA"
+        ) == ("medicare_advantage", "erisa", "tpa", "erisa_letter")
+
+    def test_unknown_sources_give_nothing(self):
+        assert classify_plan(["Other", "Don't know", ""]) == ()
+
+    def test_one_program_once(self):
+        assert classify_plan(["Employer -- Private", "Union"]) == ("erisa",)
+
     def test_two_sources_both_appear_with_a_tie_break(self):
         block = _block("Medicare Advantage", "Employer -- Private")
         assert "Medicare Advantage plan" in block
@@ -204,6 +244,7 @@ class TestTheBlockItself:
         _block("Medicare Advantage", "Employer -- Private"),
         _block(is_tpa=True),
         _block("Other Group"),
+        _block("Medicare Advantage", regulator_alt_name="ERISA"),
     ]
 
     @pytest.mark.parametrize("block", ALL)
@@ -286,9 +327,10 @@ class TestCollector:
         block = AppealGenerator._collect_plan_law_context(SimpleNamespace())
         assert block is not None and "We do not know" in block
 
-    def test_a_failing_lookup_returns_none_instead_of_raising(self):
+    def test_a_failing_lookup_degrades_to_the_hedged_block_instead_of_raising(self):
         denial = SimpleNamespace(plan_source=_Sources(raise_=RuntimeError("db down")))
-        assert AppealGenerator._collect_plan_law_context(denial) is None
+        block = AppealGenerator._collect_plan_law_context(denial)
+        assert block is not None and "We do not know" in block
 
     def test_a_lazy_regulator_that_raises_does_not_lose_the_block(self):
         class Denial:

--- a/tests/async-unit/test_plan_law_context.py
+++ b/tests/async-unit/test_plan_law_context.py
@@ -32,6 +32,8 @@ CITATION_ALLOWLIST = {
     "42 C.F.R. Part 405, Subpart I",
     "42 C.F.R. Part 438, Subpart F",
     "42 C.F.R. Part 431, Subpart E",
+    "42 C.F.R. Part 423, Subpart M",
+    "29 U.S.C. § 1003(b)",
 }
 # A section number is digits, dots and dashes, then any number of
 # parenthesised subsections; trailing prose punctuation is not part of it.
@@ -46,12 +48,29 @@ def _block(*sources, **kw):
 
 
 class TestWhichLawGoverns:
-    @pytest.mark.parametrize("source", ["Employer -- Private   ", "Union", "Other Group"])
+    @pytest.mark.parametrize("source", ["Employer -- Private   ", "Union"])
     def test_private_employer_and_union_plans_are_erisa(self, source):
         block = _block(source)
         assert "ERISA governs the appeal" in block
         assert "29 C.F.R. § 2560.503-1" in block
         assert "45 C.F.R. § 147.136" in block  # external review for non-grandfathered
+
+    def test_other_group_is_hedged_because_an_association_plan_may_not_be_erisa(self):
+        block = _block("Other Group")
+        assert "not clearly an employer or union plan" in block
+        assert "Name ERISA only if" in block
+        assert "ERISA governs the appeal" not in block
+
+    @pytest.mark.parametrize(
+        "source",
+        ["Employer -- Private", "Employer -- State Government", "State Marketplace / Affordable Care Act"],
+    )
+    def test_external_review_is_owed_for_medical_judgment_denials_only(self, source):
+        block = _block(source)
+        assert "medical judgment" in block
+
+    def test_an_ineligibility_denial_is_not_owed_external_review_under_erisa(self):
+        assert "a denial for ineligibility is not" in _block("Employer -- Private")
 
     @pytest.mark.parametrize(
         "source", ["Employer -- State Government ", "Employer -- Other Government"]
@@ -80,7 +99,7 @@ class TestWhichLawGoverns:
             ("Medicare Advantage", "42 C.F.R. Part 422, Subpart M"),
             ("Medicare Regular", "42 C.F.R. Part 405, Subpart I"),
             ("Medicaid  ", "42 C.F.R. Part 438, Subpart F"),
-            ("Veterans Affairs", "VA has its own clinical appeal process"),
+            ("Veterans Affairs", "VA has its own processes"),
         ],
     )
     def test_public_programs_name_their_own_process_and_rule_out_both_laws(self, source, marker):
@@ -92,17 +111,49 @@ class TestWhichLawGoverns:
         block = _block("Medicare Advantage")
         assert "Part 405" not in block
 
+    @pytest.mark.parametrize("source", ["Medicare Advantage", "Medicare Regular"])
+    def test_a_part_d_drug_denial_has_its_own_process(self, source):
+        block = _block(source)
+        assert "42 C.F.R. Part 423, Subpart M" in block
+
+    def test_medicare_advantage_forwards_medical_denials_but_drug_denials_must_be_requested(self):
+        block = _block("Medicare Advantage")
+        assert "must itself forward an upheld denial" in block
+        assert "must ask the independent review entity for reconsideration themselves" in block
+
+    def test_va_separates_treatment_decisions_from_benefits_claims(self):
+        block = _block("Veterans Affairs")
+        assert "clinical appeal for a decision about treatment" in block
+        assert "benefits decision review" in block
+
     @pytest.mark.parametrize("sources", [(), ("Other",), ("Don't know",), ("",)])
     def test_an_unknown_source_gets_the_hedged_paragraph(self, sources):
         block = _block(*sources)
         assert "We do not know how the patient gets this coverage" in block
         assert "only when the letter itself supports it" in block
+        assert "non-grandfathered individual coverage" in block
         assert "ERISA governs" not in block
 
-    def test_a_tpa_carrier_means_erisa_even_with_no_source(self):
+    def test_a_tpa_carrier_alone_is_hedged_not_asserted(self):
+        """A TPA administers self-funded plans, and a city's plan is
+        self-funded too; ERISA excludes it (review)."""
         block = _block(is_tpa=True)
-        assert "ERISA governs the appeal" in block
+        assert "most likely a self-funded plan" in block
+        assert "If the employer is a private company or a union, ERISA governs" in block
+        assert "government or a church, ERISA does not apply (29 U.S.C. § 1003(b))" in block
         assert "We do not know" not in block
+
+    def test_a_tpa_flag_defers_to_a_government_source(self):
+        block = _block("Employer -- State Government", is_tpa=True)
+        assert "ERISA does not apply (29 U.S.C. § 1003(b)(1))" in block
+        assert "ERISA governs" not in block
+        assert "self-funded" not in block
+
+    def test_a_tpa_flag_adds_nothing_to_a_private_employer_source(self):
+        block = _block("Employer -- Private", is_tpa=True)
+        assert block.count("ERISA governs the appeal") == 1
+        assert "third-party administrator" not in block
+        assert "More than one coverage source" not in block
 
     def test_the_erisa_regulator_match_means_erisa(self):
         block = _block("Don't know", regulator_alt_name="erisa")
@@ -119,6 +170,9 @@ class TestWhichLawGoverns:
         assert block.count("ERISA governs the appeal") == 1
         assert "More than one coverage source" not in block
 
+    def test_the_invitation_limits_external_review_to_medical_judgment_denials(self):
+        assert "independent external review that a medical-judgment denial is owed" in _block()
+
 
 class TestTheBlockItself:
     ALL = [
@@ -132,6 +186,8 @@ class TestTheBlockItself:
         _block("Veterans Affairs"),
         _block(),
         _block("Medicare Advantage", "Employer -- Private"),
+        _block(is_tpa=True),
+        _block("Other Group"),
     ]
 
     @pytest.mark.parametrize("block", ALL)
@@ -204,7 +260,7 @@ class TestCollector:
             plan_source=_Sources(),
             insurance_company_obj=SimpleNamespace(is_tpa=True),
         )
-        assert "ERISA governs" in (AppealGenerator._collect_plan_law_context(denial) or "")
+        assert "self-funded plan" in (AppealGenerator._collect_plan_law_context(denial) or "")
         denial = SimpleNamespace(
             plan_source=_Sources(), regulator=SimpleNamespace(alt_name="ERISA")
         )

--- a/tests/async-unit/test_regulatory_citations.py
+++ b/tests/async-unit/test_regulatory_citations.py
@@ -184,6 +184,16 @@ class TestPublicProgramFiltering(unittest.TestCase):
         self.assertIn("not the Medicare Advantage coverage", block)
         self.assertNotIn("this is Medicare Advantage coverage", block)
 
+    def test_a_tpa_carrier_is_not_a_second_plan(self):
+        """The flag says who administers the plan; beside a public program it
+        must not turn the coverage into "more than one source" (review)."""
+        self.assertIsNone(get_regulatory_citation_context("MA", programs=("medicare", "tpa")))
+        block = get_regulatory_citation_context("MA", programs=("medicare_advantage", "tpa"))
+        assert block is not None
+        self.assertIn("this is Medicare Advantage coverage", block)
+        self.assertNotIn("More than one coverage source", block)
+        self.assertNotIn("Massachusetts", block)
+
     def test_the_self_insured_signal_defers_to_a_source_erisa_cannot_govern(self):
         self.assertTrue(self_insured_from(("tpa",)))
         self.assertTrue(self_insured_from(("erisa", "tpa")))

--- a/tests/async-unit/test_regulatory_citations.py
+++ b/tests/async-unit/test_regulatory_citations.py
@@ -129,6 +129,61 @@ class TestGetRegulatoryCitationContext(unittest.TestCase):
         self.assertNotIn("Massachusetts", block)
 
 
+class TestPublicProgramFiltering(unittest.TestCase):
+    """For Medicare, Medicaid, VA and FEHB coverage the block keeps only the
+    federal rules written for the program: the plan-law block tells the model
+    that state insurance law and the ACA appeal rules do not apply, and the
+    prompt must not say both (review)."""
+
+    def test_medicare_advantage_keeps_only_the_rules_written_for_it(self):
+        block = get_regulatory_citation_context("MA", programs=("medicare_advantage",))
+        assert block is not None
+        self.assertIn("CMS-0057-F", block)
+        self.assertIn("algorithms and artificial", block)
+        self.assertNotIn("147.136", block)
+        self.assertNotIn("Massachusetts", block)
+        self.assertIn("this is Medicare Advantage coverage", block)
+
+    def test_medicaid_keeps_cms_0057_f_only(self):
+        block = get_regulatory_citation_context("MA", programs=("medicaid",))
+        assert block is not None
+        self.assertIn("CMS-0057-F", block)
+        self.assertNotIn("algorithms and artificial", block)
+        self.assertNotIn("147.136", block)
+        self.assertNotIn("Massachusetts", block)
+
+    def test_original_medicare_va_and_fehb_get_no_block(self):
+        for program in ("medicare", "va", "fehb"):
+            with self.subTest(program=program):
+                self.assertIsNone(get_regulatory_citation_context("MA", programs=(program,)))
+
+    def test_a_government_employer_plan_keeps_state_and_aca_hooks(self):
+        block = get_regulatory_citation_context("MA", programs=("government",))
+        assert block is not None
+        self.assertIn("Massachusetts", block)
+        self.assertIn("147.136", block)
+
+    def test_private_coverage_is_unchanged_by_the_classification(self):
+        self.assertEqual(
+            get_regulatory_citation_context("MA", programs=("erisa", "tpa")),
+            get_regulatory_citation_context("MA"),
+        )
+
+    def test_the_collector_classifies_from_the_plan_source(self):
+        denial = SimpleNamespace(
+            your_state="MA",
+            denial_text=None,
+            procedure=None,
+            diagnosis=None,
+            plan_source=SimpleNamespace(all=lambda: [SimpleNamespace(name="Medicare Advantage")]),
+        )
+        result = AppealGenerator._collect_regulatory_context(denial)
+        assert result is not None
+        self.assertNotIn("147.136", result)
+        self.assertNotIn("Massachusetts", result)
+        self.assertIn("CMS-0057-F", result)
+
+
 class TestRegulatoryPromptInjection(unittest.TestCase):
     def setUp(self):
         self.gen = AppealGenerator()

--- a/tests/async-unit/test_regulatory_citations.py
+++ b/tests/async-unit/test_regulatory_citations.py
@@ -197,7 +197,14 @@ class TestPublicProgramFiltering(unittest.TestCase):
     def test_the_self_insured_signal_defers_to_a_source_erisa_cannot_govern(self):
         self.assertTrue(self_insured_from(("tpa",)))
         self.assertTrue(self_insured_from(("erisa", "tpa")))
-        for source in ("government", "fehb", "medicare_advantage", "medicaid", "marketplace"):
+        for source in (
+            "government",
+            "fehb",
+            "medicare_advantage",
+            "medicaid",
+            "marketplace",
+            "other_group",
+        ):
             with self.subTest(source=source):
                 self.assertIsNone(self_insured_from((source, "tpa")))
         self.assertIsNone(self_insured_from(("erisa",)))

--- a/tests/async-unit/test_regulatory_citations.py
+++ b/tests/async-unit/test_regulatory_citations.py
@@ -13,6 +13,7 @@ from types import SimpleNamespace
 from fighthealthinsurance.generate_appeal import AppealGenerator
 from fighthealthinsurance.regulatory_citations import (
     get_regulatory_citation_context,
+    self_insured_from,
 )
 
 
@@ -168,6 +169,52 @@ class TestPublicProgramFiltering(unittest.TestCase):
             get_regulatory_citation_context("MA", programs=("erisa", "tpa")),
             get_regulatory_citation_context("MA"),
         )
+
+    def test_public_and_private_coverage_together_keeps_the_private_rules(self):
+        """A Medicare Advantage member with an employer plan too: we do not
+        know which plan denied, so the state and ACA items stay, with a
+        sentence saying whom they reach (review)."""
+        block = get_regulatory_citation_context(
+            "MA", programs=("medicare_advantage", "erisa")
+        )
+        assert block is not None
+        self.assertIn("Massachusetts", block)
+        self.assertIn("147.136", block)
+        self.assertIn("More than one coverage source was given", block)
+        self.assertIn("not the Medicare Advantage coverage", block)
+        self.assertNotIn("this is Medicare Advantage coverage", block)
+
+    def test_the_self_insured_signal_defers_to_a_source_erisa_cannot_govern(self):
+        self.assertTrue(self_insured_from(("tpa",)))
+        self.assertTrue(self_insured_from(("erisa", "tpa")))
+        for source in ("government", "fehb", "medicare_advantage", "medicaid", "marketplace"):
+            with self.subTest(source=source):
+                self.assertIsNone(self_insured_from((source, "tpa")))
+        self.assertIsNone(self_insured_from(("erisa",)))
+
+    def test_a_government_plan_with_a_tpa_gets_the_neutral_caveat(self):
+        denial = SimpleNamespace(
+            your_state="MA",
+            denial_text=None,
+            procedure=None,
+            diagnosis=None,
+            insurance_company_obj=SimpleNamespace(is_tpa=True),
+            plan_source=SimpleNamespace(
+                all=lambda: [SimpleNamespace(name="Employer -- State Government")]
+            ),
+        )
+        result = AppealGenerator._collect_regulatory_context(denial)
+        assert result is not None
+        # The neutral caveat, not the self-insured one (which opens with
+        # "this appears to be a self-insured (ERISA) employer plan").
+        self.assertNotIn("this appears to be a self-insured", result)
+        self.assertIn("confirm the plan type before relying on a state mandate", result)
+        self.assertIn("Massachusetts", result)
+
+    def test_cms_0057_f_says_it_excludes_drugs(self):
+        block = get_regulatory_citation_context("MA", programs=("medicaid",))
+        assert block is not None
+        self.assertIn("prescription drugs are outside this rule", block)
 
     def test_the_collector_classifies_from_the_plan_source(self):
         denial = SimpleNamespace(

--- a/tests/sync/test_plan_law_context_wiring.py
+++ b/tests/sync/test_plan_law_context_wiring.py
@@ -1,0 +1,42 @@
+"""The APPLICABLE APPEAL LAW collector against real rows: the plan-source
+many-to-many (through PlanSourceRelation) and the carrier's TPA flag."""
+
+from django.test import TestCase
+
+from fighthealthinsurance.generate_appeal import AppealGenerator
+from fighthealthinsurance.models import (
+    Denial,
+    InsuranceCompany,
+    PlanSource,
+    PlanSourceRelation,
+)
+
+
+class PlanLawContextWiringTest(TestCase):
+    def _denial(self, **fields):
+        return Denial.objects.create(
+            denial_text="Your claim was denied.", hashed_email="law@example.com", **fields
+        )
+
+    def test_the_intake_plan_source_reaches_the_block(self):
+        denial = self._denial()
+        source = PlanSource.objects.create(name="State Marketplace / Affordable Care Act")
+        PlanSourceRelation.objects.create(denial=denial, plan_source=source)
+        block = AppealGenerator._collect_plan_law_context(denial)
+        self.assertIsNotNone(block)
+        self.assertIn("marketplace (Affordable Care Act) plan", block)
+        self.assertIn("45 C.F.R. § 147.136", block)
+
+    def test_a_tpa_carrier_reaches_the_block(self):
+        company = InsuranceCompany.objects.create(
+            name="Meritain Health", regex=r"meritain", is_tpa=True
+        )
+        denial = self._denial(insurance_company="Meritain", insurance_company_obj=company)
+        block = AppealGenerator._collect_plan_law_context(denial)
+        self.assertIsNotNone(block)
+        self.assertIn("ERISA governs the appeal", block)
+
+    def test_a_denial_with_nothing_known_gets_the_hedged_block(self):
+        block = AppealGenerator._collect_plan_law_context(self._denial())
+        self.assertIsNotNone(block)
+        self.assertIn("We do not know how the patient gets this coverage", block)

--- a/tests/sync/test_plan_law_context_wiring.py
+++ b/tests/sync/test_plan_law_context_wiring.py
@@ -34,7 +34,7 @@ class PlanLawContextWiringTest(TestCase):
         denial = self._denial(insurance_company="Meritain", insurance_company_obj=company)
         block = AppealGenerator._collect_plan_law_context(denial)
         self.assertIsNotNone(block)
-        self.assertIn("ERISA governs the appeal", block)
+        self.assertIn("most likely a self-funded plan", block)
 
     def test_a_denial_with_nothing_known_gets_the_hedged_block(self):
         block = AppealGenerator._collect_plan_law_context(self._denial())

--- a/tests/sync/test_plan_law_context_wiring.py
+++ b/tests/sync/test_plan_law_context_wiring.py
@@ -24,7 +24,7 @@ class PlanLawContextWiringTest(TestCase):
         PlanSourceRelation.objects.create(denial=denial, plan_source=source)
         block = AppealGenerator._collect_plan_law_context(denial)
         self.assertIsNotNone(block)
-        self.assertIn("marketplace (Affordable Care Act) plan", block)
+        self.assertIn("marketplace (Affordable Care Act) coverage", block)
         self.assertIn("45 C.F.R. § 147.136", block)
 
     def test_a_tpa_carrier_reaches_the_block(self):


### PR DESCRIPTION
Melanie: letters should cite ERISA or the ACA when that is relevant and will help the appeal. An audit found they did so only when a proxy fired: the carrier flagged as a TPA, one of five clinical templates, or a state hook that exists for eleven states. Intake already asks how the person gets their insurance (employer, union, marketplace, Medicare, Medicaid, VA, ...), and that answer never reached the prompt.

**What changes**

- `regulatory_citations.get_plan_law_context` turns the plan sources, the carrier's TPA flag and an ERISA regulator match into a short APPLICABLE APPEAL LAW block: which law governs, which does not apply, and an invitation to cite the applicable one by name and section where it strengthens the appeal, with the usual guard against inventing anything.
  - Private employer and union plans: ERISA section 503 and 29 C.F.R. 2560.503-1 (the reasons, the criteria relied on, a full and fair review), plus an independent external review for medical-judgment denials under non-grandfathered plans.
  - Marketplace coverage: an individual plan gets the ACA internal appeal and external review rule and the essential health benefits; small employer SHOP coverage is an employer plan, ERISA when a private employer sponsors it.
  - State and local government plans, federal employee (FEHB) plans, Original Medicare, Medicare Advantage (Part 422 for medical denials, Part 423 for Part D drug denials), Medicaid and VA each get their own paragraph saying what applies and what does not.
  - A TPA flag alone yields a hedged self-funded paragraph rather than an ERISA assertion, because a city's plan is self-funded too. "Other Group" is hedged because an association plan may not be ERISA. An unknown source gets a hedged paragraph instead of silence. Two sources are both named, with a tie-break to what the denial letter supports.
- `AppealGenerator._collect_plan_law_context` gathers the signals defensively and `make_appeals` passes the block into `make_open_prompt`, where it is deliberately not sheddable under context pressure. The existing TPA note is unchanged.
- The state regulatory block now shares the same plan classification (`classify_plan`), so the two blocks cannot contradict each other: for Medicare, Medicare Advantage, Medicaid, VA or FEHB coverage it keeps only the federal rules written for that program (CMS-0057-F for Medicare Advantage and Medicaid, the CMS 2024 AI rule for Medicare Advantage) and drops state insurance laws and the ACA appeal-rights hook; with a public program and a private plan together it keeps the private plan's rules and says whom they reach. A denial letter that names ERISA rights no longer outranks a source ERISA cannot govern; the block names the conflict instead. The self-insured caveat comes from the TPA flag only when no source says otherwise, and the flag never counts as a second plan.

**Tests.** The mapping for every plan source, the hedges, the TPA and regulator paths, two sources, the invitation and guard in every block, an allowlist of every citation kept in the test so adding one means checking the authority, the prompt wiring, the collector's failure modes, and the real many-to-many through table. Ten sabotages were each confirmed failing. Full async-unit suite, the sync wiring and prompt tests, black and mypy are green.

**Review.** Codex (gpt-6-astra, read-only sandbox), four rounds, aimed at legal accuracy. Round 1: Part D drug appeals, TPA-administered government plans, association plans, the grandfathered and medical-judgment limits on external review, and VA benefits reviews. Round 2: the exemptions in the group hedge, SHOP coverage, and the closing invitation's external-review promise. Round 3: SHOP conditioned on a private sponsor. Round 4: clean. CodeRabbit then found the two blocks could contradict each other and that a letter naming ERISA could override a public program; both fixed. Round 5: mixed public and private sources, a government plan with a TPA, and CMS-0057-F's drug exclusion. Round 6: the TPA flag counted as a second plan. Round 7: clean.

**Follow-ups, not in this PR.** #997 has TypeSafe classify the plan from the denial text into these same categories; once it merges, that result can feed this block. A rubric question in the TypeSafe letter scorer (#996) would let the ranking reward a letter that cites the applicable law.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYruQVRyBbFzUxy9YGcHTb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Appeal generation now provides more accurate plan-law guidance across ERISA, ACA, Medicare, Medicaid, VA, and federal employee coverage.
  * Regulatory guidance is tailored to identified public programs and self-funded plans, with incompatible citations filtered out.
  * Appeals now include clearer hedging when plan information is missing or conflicting.

* **Tests**
  * Added coverage for plan classification, law selection, public-program filtering, citation guidance, and appeal integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
