### PR TITLE
Merge the two 0206 migrations (deploy blocker)

### DIFF
--- a/fighthealthinsurance/migrations/0207_merge_0206_denial_triage_0206_externalservicehealth.py
+++ b/fighthealthinsurance/migrations/0207_merge_0206_denial_triage_0206_externalservicehealth.py
@@ -1,0 +1,16 @@
+# Two branches each added migration 0206 off 0205 and merged the same night:
+# the denial triage columns (0206_denial_triage) and the external service
+# health table (0206_externalservicehealth). They touch different tables, so
+# this merge node only joins the graph; it has no operations.
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("fighthealthinsurance", "0206_denial_triage"),
+        ("fighthealthinsurance", "0206_externalservicehealth"),
+    ]
+
+    operations = []


### PR DESCRIPTION
**Deploy blocker.** #997 and #1006 each added a migration numbered 0206 off 0205 and both merged tonight, so main has two leaf migrations. `manage.py migrate` refuses to run ("Conflicting migrations detected") and every test suite fails at setup. This is the standard merge node from `makemigrations --merge`; the two migrations touch different tables, so it has no operations.

Verified: `makemigrations --check` is clean again; the migration-state, status page, triage lifecycle and health record tests pass. No Codex round on this one: it is a generated graph node with no code, and a deploy is waiting on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYruQVRyBbFzUxy9YGcHTb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reconciled two migration branches to keep database migration history consistent.
  * No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->