### PR TITLE
Bump to v0.23.8a for the TypeSafe, OCR and privacy-policy deploy

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -82,7 +82,7 @@ else
 fi
 
 # BUILDKIT_NO_CLIENT_TOKEN=true
-FHI_VERSION=v0.23.7a
+FHI_VERSION=v0.23.8a
 
 
 MYORG=${MYORG:-totallylegitco}


### PR DESCRIPTION
Thirteen PRs since v0.23.7a (#996-#1008): TypeSafe draft ranking and denial triage (inert until a key and flag are set), staff-page scoring health, appeal-law hint in the prompt, capped stored-draft replay, OCR progress box, advanced OCR default off, production bundles by default, lazy Stripe reachability, privacy-policy provider list, temporal README. Migrations 0205 through 0207, all additive.


Claude-Session: https://claude.ai/code/session_019SPqa4FZ43ahAjoD53Uj81

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the release version to **v0.23.8a**.
  - Container builds and generated deployment manifests now use the updated version tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->