### PR TITLE
Offer advanced OCR only when it works, and say it in plain words

### DIFF
--- a/fighthealthinsurance/context_processors.py
+++ b/fighthealthinsurance/context_processors.py
@@ -1,5 +1,7 @@
 """Custom context processors for Fight Health Insurance."""
 
+from django.conf import settings
+
 from django.urls import reverse
 
 from loguru import logger
@@ -113,3 +115,14 @@ def agent_docs_context(request):
     if not agent_docs.twin_eligible(url_name):
         return {}
     return {"markdown_twin_url": agent_docs.twin_path_for(request.path)}
+
+
+def advanced_ocr_context(request):
+    """Whether the upload page offers the on-device advanced OCR option.
+
+    One flag, read from settings, so the template shows nothing at all
+    while the engine is broken instead of a checkbox with an apology.
+    """
+    return {
+        "advanced_ocr_offered": bool(getattr(settings, "ADVANCED_OCR_OFFERED", False))
+    }

--- a/fighthealthinsurance/settings.py
+++ b/fighthealthinsurance/settings.py
@@ -176,6 +176,11 @@ class Base(Configuration):
     TYPESAFE_LETTER_RANKING_ENABLED = (
         os.getenv("TYPESAFE_LETTER_RANKING_ENABLED", "false").lower() == "true"
     )
+    # Whether the upload page offers the on-device advanced OCR option at
+    # all. Off until the engine actually loads: a person uploading a letter
+    # must not be offered a broken option. Flip it with the environment when
+    # the engine works again; the checkbox itself still defaults to off.
+    ADVANCED_OCR_OFFERED = os.getenv("ADVANCED_OCR_OFFERED", "false").lower() == "true"
     TYPESAFE_TIMEOUT_SECONDS = _env_int(
         "TYPESAFE_TIMEOUT_SECONDS", 20, minimum=1, maximum=300
     )
@@ -454,6 +459,7 @@ class Base(Configuration):
                     "fighthealthinsurance.context_processors.form_persistence_context",
                     "fighthealthinsurance.context_processors.canonical_url_context",
                     "fighthealthinsurance.context_processors.site_banner_context",
+                    "fighthealthinsurance.context_processors.advanced_ocr_context",
                 ],
             },
         },
@@ -842,6 +848,7 @@ class Test(Dev):
     TYPESAFE_API_KEY = None
     TYPESAFE_API_URL = "https://typesafe.invalid/v1/systemone"
     TYPESAFE_LETTER_RANKING_ENABLED = False
+    ADVANCED_OCR_OFFERED = False
     TYPESAFE_DENIAL_TRIAGE_ENABLED = False
 
     # Barrier no-ops in tests: mock denials have no DB row, so any positive
@@ -907,6 +914,7 @@ class TestSync(Dev):
     TYPESAFE_API_KEY = None
     TYPESAFE_API_URL = "https://typesafe.invalid/v1/systemone"
     TYPESAFE_LETTER_RANKING_ENABLED = False
+    ADVANCED_OCR_OFFERED = False
     TYPESAFE_DENIAL_TRIAGE_ENABLED = False
 
     DEBUG = True
@@ -948,6 +956,7 @@ class TestActor(Dev):
     TYPESAFE_API_KEY = None
     TYPESAFE_API_URL = "https://typesafe.invalid/v1/systemone"
     TYPESAFE_LETTER_RANKING_ENABLED = False
+    ADVANCED_OCR_OFFERED = False
     TYPESAFE_DENIAL_TRIAGE_ENABLED = False
 
     DEBUG = True

--- a/fighthealthinsurance/templates/scrub.html
+++ b/fighthealthinsurance/templates/scrub.html
@@ -87,17 +87,17 @@ Upload your Health Insurance Denial
 	  </div>
 	</div>
 	{% if upload_more %}
+	{% if advanced_ocr_offered %}
 	<div class="form-check mt-2 mb-2" id="advanced_ocr_section">
 	    <input type="checkbox" id="advanced_ocr_enabled" class="form-check-input">
 	    <label for="advanced_ocr_enabled" class="form-check-label">
-		<b>Enable advanced OCR</b> – uses a WebGPU-accelerated AI model to improve text extraction accuracy.
-		<small class="text-muted d-block">Off by default, and not working in this release: the model fails to
-		load, so standard OCR is used either way. Turning it on today still fetches about 20 MB of model
-		files from huggingface.co before that failure. Once it works, the full model is about 684 MB,
-		downloaded the first time and run on your own device. Standard OCR downloads a much smaller
-		language file the first time.</small>
+		<b>Better text recognition for photos and scans</b> <span class="text-muted">(experimental)</span>
+		<small class="text-muted d-block">Downloads a large model to your device the first time, about 700 MB,
+		and runs there; your file stays on your device. Standard recognition starts faster and works well
+		for clear scans.</small>
 	    </label>
 	</div>
+	{% endif %}
 	<div id="image_select_magic" style="visibility:visible">
 	    <label class="custom-file-label" for="uploader">
 			<b>Upload Insurance Denial</b>

--- a/tests/async-unit/test_advanced_ocr_default_off.py
+++ b/tests/async-unit/test_advanced_ocr_default_off.py
@@ -345,42 +345,47 @@ def test_no_hardcoded_onnxruntime_version_pin():
     ), "a hardcoded onnxruntime-web version is back in qwen_webgpu_ocr.ts"
 
 
-def test_label_states_the_download_cost_truthfully():
-    """Off-by-default is only honest if the label tells the truth in both directions.
+def test_the_option_is_offered_only_behind_the_setting():
+    """A person uploading a letter must not be offered a broken option.
 
-    While the engine is broken the label must say so, and must disclose that
-    turning it on still fetches model files (the tokenizer alone is ~19 MB)
-    before the load fails. It must state the eventual size in MB with the unit.
-    It must not claim standard OCR needs no download or no model: tesseract
-    fetches English trained data, an LSTM model, from a CDN on first use.
-
-    When the engine works, drop the "not working" assertion together with the
-    label sentence it pins; keep the rest.
+    The whole section sits behind ADVANCED_OCR_OFFERED, which defaults to
+    off; when the engine works again the environment flips it, and the
+    checkbox still starts unchecked (the test above).
     """
     html = _scrub_template()
     start = html.index('id="advanced_ocr_section"')
-    # Rendered text: a line wrap inside a phrase, or an &nbsp; used to stop
-    # one, is the same text to a browser and must be the same text to this
-    # test (review). Entities are decoded, then whitespace normalized.
+    gate = html.rfind("{% if advanced_ocr_offered %}", 0, start)
+    assert gate != -1, "the advanced OCR section is no longer gated by advanced_ocr_offered"
+    assert "{% endif %}" in html[start : html.index("</div>", html.index("</label>", start)) + 60]
+    settings_src = (REPO / "settings.py").read_text()
+    assert re.search(
+        r'ADVANCED_OCR_OFFERED\s*=\s*os\.getenv\("ADVANCED_OCR_OFFERED",\s*"false"\)',
+        settings_src,
+    ), "ADVANCED_OCR_OFFERED no longer defaults to off"
+    assert "fighthealthinsurance.context_processors.advanced_ocr_context" in settings_src, (
+        "the context processor that exposes advanced_ocr_offered is not registered"
+    )
+
+
+def test_the_label_speaks_to_a_person():
+    """When the option is shown, the label says what a person needs and
+    nothing a reviewer needs: what it is, that it is experimental, the
+    download size with its unit, that the file stays on the device, and
+    what standard recognition is like. No hosting site, no failure
+    narrative, no partial-download figure, no engine names.
+    """
+    html = _scrub_template()
+    start = html.index('id="advanced_ocr_section"')
     label = html_lib.unescape(html[start : html.index("</label>", start)])
     label = re.sub(r"\s+", " ", label)
-    assert re.search(r"not working|does not work|fails to load", label, re.I), (
-        "the label no longer says the engine is broken, but it still is"
-    )
-    assert re.search(r"\b(19|20)\s*MB\b", label), (
-        "the label no longer discloses the ~20 MB fetched before the load fails"
-    )
-    assert re.search(r"\b684\s*MB\b", label), (
-        "the advanced OCR label no longer states the eventual download size in MB"
-    )
-    assert (
-        "huggingface.co" in label
-    ), "the advanced OCR label no longer says where the model is downloaded from"
+    assert "experimental" in label.lower()
+    assert re.search(r"\babout \d{3} MB\b", label), "the label no longer states the download size in MB"
+    assert "stays on your device" in label
+    assert "Standard recognition" in label
+    for leak in ("huggingface", "not working", "fails to load", "20 MB", "19 MB", "WebGPU", "wasm", "Qwen", "model files"):
+        assert leak.lower() not in label.lower(), f"the label still says {leak!r}"
     assert not re.search(r"needs\s+no\s+download", label, re.I), (
         "the label claims standard OCR needs no download; tesseract downloads "
-        "its language file from a CDN on first use"
+        "a language file on first use"
     )
-    assert not re.search(r"\bno\s+model\b", label, re.I), (
-        "the label claims standard OCR uses no model; tesseract's trained data "
-        "is an LSTM model"
-    )
+

--- a/tests/sync/test_advanced_ocr_offered.py
+++ b/tests/sync/test_advanced_ocr_offered.py
@@ -1,0 +1,30 @@
+"""The upload page offers the on-device advanced OCR option only when
+ADVANCED_OCR_OFFERED is on; the option is hidden, not disabled, while the
+engine is broken."""
+
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+
+class AdvancedOcrOfferedTest(TestCase):
+    @override_settings(ADVANCED_OCR_OFFERED=False)
+    def test_the_option_is_absent_when_not_offered(self):
+        # Explicit, so an ADVANCED_OCR_OFFERED in the caller's environment
+        # cannot fail this; the default itself is pinned in the async-unit
+        # source test (review).
+        response = self.client.get(reverse("scan"))
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'id="advanced_ocr_enabled"')
+        self.assertNotContains(response, "advanced_ocr_section")
+
+    @override_settings(ADVANCED_OCR_OFFERED=True)
+    def test_the_option_appears_unchecked_when_offered(self):
+        response = self.client.get(reverse("scan"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'id="advanced_ocr_enabled"')
+        html = response.content.decode()
+        tag = html[html.index('<input type="checkbox" id="advanced_ocr_enabled"') :]
+        tag = tag[: tag.index(">") + 1]
+        self.assertNotIn("checked", tag)
+        self.assertContains(response, "Better text recognition for photos and scans")
+        self.assertNotContains(response, "huggingface")


### PR DESCRIPTION
After the deploy Melanie read the advanced OCR checkbox's help text as a user would: "Off by default, and not working in this release: the model fails to load ... still fetches about 20 MB of model files from huggingface.co before that failure ... the full model is about 684 MB ...". That is a note for a reviewer. A person uploading a denial letter should not be offered a broken option at all, and does not need megabyte counts or a hosting site's name.

**What changes**

- The checkbox section renders only when `ADVANCED_OCR_OFFERED` is on. It is read from the environment, defaults to off, and reaches templates through a small context processor, so while the engine is broken the page shows nothing. Flip the variable when the engine loads again; the checkbox itself still starts unchecked, and the scripts already treat an absent checkbox as off.
- When shown, the label speaks to a person: "Better text recognition for photos and scans (experimental). Downloads a large model to your device the first time, about 700 MB, and runs there; your file stays on your device. Standard recognition starts faster and works well for clear scans."

**Tests.** The section is gated by the setting and the setting defaults to off; the rendered scan page has no checkbox when the option is not offered and an unchecked one when it is; the label names the size with its unit, says the file stays on the device, and never mentions a hosting site, a failure, or the partial download. The three test configurations pin the setting off. A sabotage removing the gate was confirmed failing. Full sync and async-unit suites, black and mypy are green.

**Review.** Codex (gpt-6-astra, read-only sandbox), two rounds. Round 1: a formatting claim the pinned black disproves, and a fair point that an exported `ADVANCED_OCR_OFFERED` could fail the default-off render test, now pinned in the test configurations and overridden explicitly. Round 2: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYruQVRyBbFzUxy9YGcHTb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable advanced OCR option for the upload page.
  * The option is shown only when enabled and lets users improve recognition for photos and scans with an experimental, on-device model.
  * Updated messaging to explain the approximate 700 MB download and device storage requirements.

* **Bug Fixes**
  * Prevented the advanced OCR option from appearing when unavailable.

* **Tests**
  * Added coverage for enabled and disabled configurations and user-facing wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->