### PR TITLE
Name the current AI providers where the person consents

### DIFF
--- a/fighthealthinsurance/templates/scrub.html
+++ b/fighthealthinsurance/templates/scrub.html
@@ -174,7 +174,7 @@ Upload your Health Insurance Denial
 			<div class="form-check">
 			<input type="checkbox" id="use_external_models" name="use_external_models" value="checked" checked class="form-check-input">
 				<label for="use_external_models" class="form-check-label">
-					Increase the number of possible appeals and use external models. <b>This is not required and involves sharing your data with 3rd parties</b> subject to their own terms of service potentially including OctoAI, Perplexity, TogetherAI, etc.
+					Increase the number of possible appeals and use external models. <b>This is not required and involves sharing your data with 3rd parties</b> subject to their own terms of service including Anthropic, Microsoft Azure, DeepInfra, Perplexity, and TypeSafe.
 				</label>
 			</div>
 			<div class="form-check">

--- a/fighthealthinsurance/templates/scrub.html
+++ b/fighthealthinsurance/templates/scrub.html
@@ -174,7 +174,7 @@ Upload your Health Insurance Denial
 			<div class="form-check">
 			<input type="checkbox" id="use_external_models" name="use_external_models" value="checked" checked class="form-check-input">
 				<label for="use_external_models" class="form-check-label">
-					Increase the number of possible appeals and use external models. <b>This is not required and involves sharing your data with 3rd parties</b> subject to their own terms of service including Anthropic, Microsoft Azure, DeepInfra, Perplexity, TypeSafe, etc.
+					Increase the number of possible appeals and use external models. <b>This is not required and involves sharing your data with third parties</b>, including Anthropic, Microsoft Azure, DeepInfra, Perplexity, TypeSafe, etc., subject to their own terms of service.
 				</label>
 			</div>
 			<div class="form-check">

--- a/fighthealthinsurance/templates/scrub.html
+++ b/fighthealthinsurance/templates/scrub.html
@@ -174,7 +174,7 @@ Upload your Health Insurance Denial
 			<div class="form-check">
 			<input type="checkbox" id="use_external_models" name="use_external_models" value="checked" checked class="form-check-input">
 				<label for="use_external_models" class="form-check-label">
-					Increase the number of possible appeals and use external models. <b>This is not required and involves sharing your data with 3rd parties</b> subject to their own terms of service including Anthropic, Microsoft Azure, DeepInfra, Perplexity, and TypeSafe.
+					Increase the number of possible appeals and use external models. <b>This is not required and involves sharing your data with 3rd parties</b> subject to their own terms of service including Anthropic, Microsoft Azure, DeepInfra, Perplexity, TypeSafe, etc.
 				</label>
 			</div>
 			<div class="form-check">

--- a/tests/sync/test_consent_copy_names_the_policy_providers.py
+++ b/tests/sync/test_consent_copy_names_the_policy_providers.py
@@ -1,0 +1,30 @@
+"""The consent line on the upload page names the same AI providers as the
+privacy policy. The policy moved to the current list in #999; the consent
+line, where the person actually agrees, still named two providers the site
+stopped using. Both lists are read from the templates so they cannot drift
+apart again without this failing."""
+
+import pathlib
+import re
+
+from django.test import TestCase
+
+TEMPLATES = pathlib.Path(__file__).resolve().parents[2] / "fighthealthinsurance" / "templates"
+
+
+def _ai_providers(text: str) -> list[str]:
+    """The comma list that follows "such as" or "including" and starts with
+    the first provider in the policy's own sentence."""
+    m = re.search(r"(?:such as|including) (Anthropic[^.<]*?)\.", text)
+    assert m, "no AI provider sentence found"
+    return [p.strip() for p in re.split(r",\s*(?:and\s+)?|\s+and\s+", m.group(1)) if p.strip()]
+
+
+class ConsentCopyTest(TestCase):
+    def test_upload_consent_names_the_policy_providers(self):
+        policy = (TEMPLATES / "privacy_policy.html").read_text()
+        scrub = (TEMPLATES / "scrub.html").read_text()
+        self.assertEqual(_ai_providers(scrub), _ai_providers(policy))
+        self.assertEqual(len(_ai_providers(policy)), 5)
+        for gone in ("OctoAI", "TogetherAI"):
+            self.assertNotIn(gone, scrub)

--- a/tests/sync/test_consent_copy_names_the_policy_providers.py
+++ b/tests/sync/test_consent_copy_names_the_policy_providers.py
@@ -17,7 +17,9 @@ def _ai_providers(text: str) -> list[str]:
     the first provider in the policy's own sentence."""
     m = re.search(r"(?:such as|including) (Anthropic[^.<]*?)\.", text)
     assert m, "no AI provider sentence found"
-    return [p.strip() for p in re.split(r",\s*(?:and\s+)?|\s+and\s+", m.group(1)) if p.strip()]
+    # The consent line ends its list with "etc." so the sentence stays open;
+    # that is not a provider.
+    return [p.strip() for p in re.split(r",\s*(?:and\s+)?|\s+and\s+", m.group(1)) if p.strip() and p.strip().lower() != "etc"]
 
 
 class ConsentCopyTest(TestCase):
@@ -28,3 +30,9 @@ class ConsentCopyTest(TestCase):
         self.assertEqual(len(_ai_providers(policy)), 5)
         for gone in ("OctoAI", "TogetherAI"):
             self.assertNotIn(gone, scrub)
+
+    def test_upload_consent_stays_open_ended(self):
+        # The named providers are the ones in use today; "etc." keeps the
+        # consent honest if another is added before the copy is (Melanie).
+        scrub = (TEMPLATES / "scrub.html").read_text()
+        self.assertIn("Perplexity, TypeSafe, etc.", scrub)


### PR DESCRIPTION
The privacy policy has named Anthropic, Microsoft Azure, DeepInfra, Perplexity and TypeSafe since #999. The consent line on the upload page, which is where a person actually agrees to sharing with outside models, still said "potentially including OctoAI, Perplexity, TogetherAI, etc." The two disagreed on the page that matters most.

The line now names the same providers as the policy, and a test reads both templates and fails if they ever differ again.

Found while reviewing the intake pages screen by screen; no other user-facing copy names the old providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYruQVRyBbFzUxy9YGcHTb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Updates**
  - Clarified the upload-page disclosure that named AI providers are third parties and operate under their own terms of service.
  - Kept the provider list open-ended, including “Perplexity, TypeSafe, etc.”
  - Aligned the upload-page disclosure with the provider list in the privacy policy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->