### PR TITLE
Fax: stop refusing toll-free numbers whose middle digits look like N11

### DIFF
--- a/fighthealthinsurance/fax_utils.py
+++ b/fighthealthinsurance/fax_utils.py
@@ -24,8 +24,17 @@ FROM_VOICE = os.getenv("FROM_VOICE", "2029383266")
 class FaxSenderBase(object):
     base_cost = 0
     cost_per_page = 0
-    # Avoid calling 211/etc.
+    # Avoid calling 211/etc.: the N11 service codes (211, 311, ..., 911),
+    # either dialed bare or sitting where a geographic number's exchange
+    # would be. N11 is never an assignable central-office code inside a
+    # geographic area code, so "415-211-xxxx" can only be a typo or a trap.
     special_naps = re.compile(r"^1?(\d11|\d\d\d\d11)")
+    # Toll-free numbers are handed out as flat 7-digit blocks, and their
+    # middle three digits routinely look like a service code: 855-211-3699
+    # is a real insurer fax line (fax 658, 2026-09-11, refused by both
+    # backends and never dialed). The exchange half of the rule above does
+    # not apply to them.
+    toll_free_area_codes = ("800", "833", "844", "855", "866", "877", "888")
     professional = False
 
     def estimate_cost(self, destination: str, pages: int) -> int:
@@ -44,9 +53,13 @@ class FaxSenderBase(object):
             raise Exception("No trying to call 911 this is for faxes.")
         if number_str.startswith("10"):
             raise Exception("No trying to call the operator")
-        if self.special_naps.match(number_str):
+        if self.special_naps.match(number_str) and not self._is_toll_free(number_str):
             raise Exception("No calling special svc numbers")
         return number_str
+
+    def _is_toll_free(self, number_str: str) -> bool:
+        """True for a normalized 1NPANXXXXXX number whose area code is toll-free."""
+        return len(number_str) == 11 and number_str[1:4] in self.toll_free_area_codes
 
     async def send_fax(
         self,

--- a/tests/async/test_faxes.py
+++ b/tests/async/test_faxes.py
@@ -12,8 +12,29 @@ from tests.conftest import skip_if_no_pandoc
 class FaxSendBaseTest(unittest.TestCase):
     def test_parse_phone_number(self):
         f = FaxSenderBase()
-        bad_numbers = ["911", "211", "+0", "+0123", "+1911", "+19002335555"]
-        ok_numbers = ["14255555555", "4255555555", "+1-425-555-5555", "+1 425 555 5555"]
+        bad_numbers = [
+            "911",
+            "211",
+            "+0",
+            "+0123",
+            "+1911",
+            "+19002335555",
+            # N11 is not an assignable exchange in a geographic area code.
+            "4152113699",
+            "+1 (415) 911-3699",
+        ]
+        ok_numbers = [
+            "14255555555",
+            "4255555555",
+            "+1-425-555-5555",
+            "+1 425 555 5555",
+            # Toll-free blocks legitimately carry N11-shaped middle digits
+            # (fax 658, 2026-09-11: an insurer's 855-211 line was refused).
+            "(855) 211-3699",
+            "8552113699",
+            "1-800-411-1234",
+            "+1 888 911 0000",
+        ]
         for number in bad_numbers:
             with pytest.raises(Exception):
                 f.parse_phone_number(number)


### PR DESCRIPTION
FaxSenderBase.parse_phone_number refuses "special service" numbers with the regex ^1?(\d11|\d\d\d\d11): bare N11 codes (211, 411, 911...) and geographic numbers whose exchange is N11, which is never assignable in a geographic area code. Toll-free numbers are handed out as flat 7-digit blocks and routinely have N11-shaped middle digits. Fax 658 (2026-09-11) went to an insurer's 855-211-xxxx line: both backends raised "No calling special svc numbers" on every attempt and nothing was ever dialed.

The refusal now applies only when the normalized number is not toll-free (800/833/844/855/866/877/888). Bare N11, 1900, operator and geographic N11-exchange numbers are still refused; tests cover both sides.


Claude-Session: https://claude.ai/code/session_019SPqa4FZ43ahAjoD53Uj81

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Toll-free phone numbers are now accepted even when their exchange resembles a restricted N11 service code.
  - Invalid geographic phone numbers with non-assignable N11 patterns continue to be rejected.
  - Phone-number parsing now supports additional common formatting styles, including spaces, hyphens, parentheses, and international prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->