### PR TITLE
Temporal worker: stop polling on SIGTERM instead of ignoring it until…

### DIFF
--- a/fighthealthinsurance/management/commands/run_temporal_worker.py
+++ b/fighthealthinsurance/management/commands/run_temporal_worker.py
@@ -19,12 +19,16 @@ installs.
 
 import asyncio
 import os
+import signal
+import threading
 from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
 from typing import Any
 
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
+
+from fighthealthinsurance.worker_signals import early_stop
 
 QUEUE_ROLES = ("fax", "appeal", "all")
 
@@ -56,6 +60,67 @@ def metrics_runtime() -> Any:
     )
 
 
+def install_shutdown_handlers(workers, stop, log, tasks=None) -> None:
+    """Make SIGTERM/SIGINT stop polling and drain, instead of being dropped.
+
+    In the container this process is PID 1. A PID 1 with no handler for a
+    signal never gets the kernel's default action, so Kubernetes' SIGTERM at
+    rollout did nothing at all: the old worker kept polling its task queue at
+    full rate for the whole terminationGracePeriodSeconds (verified
+    2026-09-11: both old fax-worker pods were still listed as pollers fifteen
+    minutes after SIGTERM, and a resend of fax 658 ran on the old image after
+    the fix for it had been deployed). SIGINT was never affected, which is why
+    Ctrl-C always looked fine locally.
+
+    ``Worker.shutdown()`` stops polling and lets in-flight activities run
+    for ``graceful_shutdown_timeout`` before asking them to cancel, then
+    waits for them to actually finish. That is a healthy-path bound, not a
+    hard one: a synchronous activity blocked in native or database I/O can
+    ignore the cancellation and hold the process past the pod's grace
+    period, at which point Kubernetes SIGKILLs it as before (review).
+    ``stop`` is set first so the two phases that have no worker to shut
+    down -- the client connect and the idle (no-worker) branch -- exit
+    instead of sleeping through the grace period. Install this BEFORE the
+    connect: ``workers`` is appended to later and is read at signal time.
+    ``tasks`` keeps the shutdown task references alive (a bare
+    ``create_task`` result can be garbage-collected mid-flight).
+
+    Signal-driven shutdown is supported only when the command runs on the
+    main thread of its process, which is how the container runs it (PID 1).
+    Off the main thread neither this nor the bootstrap guard can install a
+    handler; the command then runs, but only a loop cancellation stops it.
+    """
+    loop = asyncio.get_running_loop()
+
+    def _request(signame: str) -> None:
+        if stop.is_set():
+            return
+        stop.set()
+        # Shutdown first, logging second: a log write can fail (BrokenPipe
+        # once stdout's reader is gone) and must not stand between the
+        # signal and the drain; a second signal is a no-op (review).
+        for w in workers:
+            task = loop.create_task(w.shutdown())
+            if tasks is not None:
+                tasks.append(task)
+        try:
+            log(f"{signame} received: stopping polling, draining in-flight activities")
+        except Exception:
+            pass
+
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        if signal.getsignal(sig) is None:
+            # Installed outside Python (embedded interpreter): the loop's
+            # close could only put SIG_DFL back, so leave it alone (review).
+            continue
+        try:
+            loop.add_signal_handler(sig, _request, sig.name)
+        except (NotImplementedError, RuntimeError):
+            # Not a Unix main-thread loop: unsupported for signal-driven
+            # shutdown (see the docstring); leave the default disposition.
+            pass
+
+
 class Command(BaseCommand):
     help = "Run the Temporal worker for FHI workflows and activities."
 
@@ -85,9 +150,50 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args: Any, **options: Any) -> None:
-        asyncio.run(self._run(options))
+        # Belt and braces with manage.py: idempotent, shares the same flag.
+        # The loop in _run replaces BOTH SIGTERM and SIGINT and asyncio puts
+        # back the defaults on close, not what a library caller had, so save
+        # and restore both here (review). Signal ownership is only possible
+        # on the main thread; elsewhere there is nothing to restore.
+        on_main_thread = threading.current_thread() is threading.main_thread()
+        previous = (
+            {sig: signal.getsignal(sig) for sig in (signal.SIGTERM, signal.SIGINT)}
+            if on_main_thread
+            else {}
+        )
+        # The guard is only acquired and released on the main thread: a
+        # guard preinstalled by manage.py must not be released (or fail to
+        # be released, raising) from a worker thread (review).
+        event = early_stop.install() if on_main_thread else early_stop.event
+        try:
+            asyncio.run(self._run(options, early_stop=event))
+        finally:
+            if on_main_thread:
+                # Hands SIGTERM back to whatever preceded the bootstrap guard.
+                early_stop.restore()
+            for sig, handler in previous.items():
+                if handler is None or handler == early_stop._handler:
+                    # None: native, never ours. The guard's own handler: the
+                    # restore() above already released it; reinstalling it
+                    # here would resurrect a guard nobody owns (review).
+                    continue
+                try:
+                    signal.signal(sig, handler)
+                except (ValueError, OSError):
+                    pass
 
-    async def _run(self, options: dict) -> None:
+    async def _run(self, options: dict, early_stop=None) -> None:
+        # Handlers first, before the lazy imports below: a SIGTERM that lands
+        # during those imports would otherwise be discarded (PID 1), and the
+        # process would go on to connect and poll on a stale image.
+        workers: list = []
+        shutdown_tasks: list = []
+        stop = asyncio.Event()
+        install_shutdown_handlers(workers, stop, self.stdout.write, shutdown_tasks)
+        if early_stop is not None and early_stop.is_set():
+            # Caught by the bootstrap-time handler before the loop existed.
+            stop.set()
+
         from temporalio.worker import Worker
 
         from fighthealthinsurance.activities import (
@@ -144,8 +250,19 @@ class Command(BaseCommand):
             settings, "TEMPORAL_APPEAL_JOURNEY_ENABLED", False
         )
 
+        # The connect is raced against stop: a SIGTERM that lands while the
+        # connection is still pending must not be discarded (review), and a
+        # terminating pod must not start polling afterwards.
         runtime = metrics_runtime()
-        client = await get_temporal_client(runtime=runtime)
+        connect = asyncio.ensure_future(get_temporal_client(runtime=runtime))
+        stopped = asyncio.ensure_future(stop.wait())
+        await asyncio.wait({connect, stopped}, return_when=asyncio.FIRST_COMPLETED)
+        if stop.is_set():
+            connect.cancel()
+            self.stdout.write("Stop requested during startup; not hosting a worker.")
+            return
+        stopped.cancel()
+        client = connect.result()
         self.stdout.write(
             f"Connected to Temporal at {settings.TEMPORAL_HOST} "
             f"(namespace={settings.TEMPORAL_NAMESPACE}); role={role}; appeal "
@@ -181,6 +298,7 @@ class Command(BaseCommand):
                     graceful_shutdown_timeout=timedelta(minutes=30),
                 )
                 runs.append(fax_worker.run())
+                workers.append(fax_worker)
                 queues.append(task_queue)
             if role in ("appeal", "all") and journey_enabled:
                 # The journey runs on its OWN task queue and worker: several
@@ -217,6 +335,7 @@ class Command(BaseCommand):
                     graceful_shutdown_timeout=timedelta(seconds=300),
                 )
                 runs.append(appeal_worker.run())
+                workers.append(appeal_worker)
                 queues.append(appeal_queue)
             if not runs:
                 # role=appeal with the journey flags dark. Idle instead of
@@ -229,11 +348,22 @@ class Command(BaseCommand):
                     "TEMPORAL_ENABLED and TEMPORAL_APPEAL_JOURNEY_ENABLED are "
                     "set and the process restarts)."
                 )
-                await asyncio.Event().wait()
+                await stop.wait()
                 return
             self.stdout.write(
                 f"Starting Temporal worker(s) on task queue(s) "
                 f"{', '.join(repr(q) for q in queues)} "
                 f"({max_workers} fax activity threads). Ctrl-C to stop."
             )
+            if stop.is_set():
+                # Signalled at an await between the connect and here: nothing
+                # has polled yet, so exit without starting the run loops. A
+                # signal queued during the synchronous construction above is
+                # delivered inside gather instead; polling may already have
+                # started and accepted work by then (the SDK runs several
+                # pollers), which the graceful drain is sized to finish.
+                self.stdout.write(
+                    "Stop requested during startup; not hosting a worker."
+                )
+                return
             await asyncio.gather(*runs)

--- a/fighthealthinsurance/worker_signals.py
+++ b/fighthealthinsurance/worker_signals.py
@@ -1,0 +1,77 @@
+"""Bootstrap-time SIGTERM guard for the Temporal worker process.
+
+No Django imports on purpose, and it must stay importable before anything
+else in the package: manage.py installs this before it imports the rest of
+the app, because in the container the worker is PID 1 and a PID 1 with no
+handler for a signal never receives the kernel's default action. Without a
+handler, a SIGTERM that lands anywhere between process start and the event
+loop's own handlers (module imports, Django setup and checks, the command's
+lazy imports) is discarded outright, and the pod goes on to poll its task
+queue on a stale image until SIGKILL ends the grace period (seen in prod
+2026-09-11). The command's event loop later installs its own handlers and
+honours the flag set here.
+"""
+
+import signal
+from typing import Optional
+
+
+class Flag:
+    """A set-once boolean with the Event interface, but no lock: a Python
+    signal handler must not touch synchronization primitives, because a
+    second signal re-entering the handler while the first holds the
+    Event's non-reentrant lock deadlocks the main thread (review)."""
+
+    __slots__ = ("value",)
+
+    def __init__(self) -> None:
+        self.value = False
+
+    def set(self) -> None:
+        self.value = True
+
+    def is_set(self) -> bool:
+        return self.value
+
+
+class EarlyStop:
+    """One SIGTERM flag per invocation.
+
+    ``install()`` is idempotent so manage.py and the command's ``handle()``
+    share the same flag; ``restore()`` puts the previous disposition back and
+    hands the next invocation a fresh flag, so an early stop in one
+    invocation cannot silently blank a later one in the same interpreter.
+    """
+
+    def __init__(self) -> None:
+        self.event = Flag()
+        self._previous: Optional[object] = None
+        self._installed = False
+
+    def _handler(self, signum, frame) -> None:
+        self.event.set()
+
+    def install(self) -> Flag:
+        if not self._installed:
+            try:
+                previous = signal.getsignal(signal.SIGTERM)
+                if previous is None:
+                    # Installed outside Python (embedded interpreter): we
+                    # could not hand it back, so do not take it (review).
+                    return self.event
+                signal.signal(signal.SIGTERM, self._handler)
+                self._previous = previous
+                self._installed = True
+            except (ValueError, OSError):
+                # Not the main thread: leave the default disposition.
+                pass
+        return self.event
+
+    def restore(self) -> None:
+        if self._installed:
+            signal.signal(signal.SIGTERM, self._previous)  # type: ignore[arg-type]
+            self._installed = False
+        self.event = Flag()
+
+
+early_stop = EarlyStop()

--- a/manage.py
+++ b/manage.py
@@ -1,7 +1,17 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
+
 import os
 import sys
+
+if sys.argv[1:2] == ["run_temporal_worker"]:
+    # First thing, above every import that pulls Django in: the worker is
+    # PID 1 in its container and drops SIGTERM until a handler exists. See
+    # fighthealthinsurance/worker_signals.py.
+    from fighthealthinsurance.worker_signals import early_stop
+
+    early_stop.install()
+
 from decouple import config, UndefinedValueError
 from fighthealthinsurance.utils import get_env_variable
 

--- a/tests/temporal/test_run_temporal_worker.py
+++ b/tests/temporal/test_run_temporal_worker.py
@@ -14,6 +14,21 @@ from fighthealthinsurance.management.commands.run_temporal_worker import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _preserve_signal_dispositions():
+    """Every test that reaches _run() replaces the SIGTERM and SIGINT loop
+    handlers, and asyncio's loop close resets them to the defaults rather
+    than to what the test runner had. Put both back after each test
+    (review)."""
+    import signal as _signal
+
+    saved = {s: _signal.getsignal(s) for s in (_signal.SIGTERM, _signal.SIGINT)}
+    yield
+    for s, h in saved.items():
+        if h is not None:
+            _signal.signal(s, h)
+
+
 def test_known_roles_are_exactly_fax_appeal_all():
     assert QUEUE_ROLES == ("fax", "appeal", "all")
 
@@ -109,9 +124,7 @@ def test_deploy_script_applies_both_worker_manifests():
     roles = {}
     for name in ("worker.yaml", "appeal-worker.yaml"):
         text = (root / "k8s" / "temporal" / name).read_text()
-        m = re.search(
-            r'name: TEMPORAL_WORKER_QUEUES\s*\n\s*value: "(\w+)"', text
-        )
+        m = re.search(r'name: TEMPORAL_WORKER_QUEUES\s*\n\s*value: "(\w+)"', text)
         assert m, f"{name} must pin TEMPORAL_WORKER_QUEUES"
         roles[name] = m.group(1)
     assert roles == {"worker.yaml": "fax", "appeal-worker.yaml": "appeal"}
@@ -193,10 +206,10 @@ def test_worker_manifests_are_redundant_and_scraped():
         assert replicas >= 2, f"{name} must run >=2 replicas"
         assert "topologySpreadConstraints:" in text, f"{name} needs a spread constraint"
         assert "kubernetes.io/hostname" in text
-        assert re.search(r"name: metrics\s*\n\s*containerPort: 9464", text), (
-            f"{name} must expose the metrics port"
-        )
-        assert 'name: TEMPORAL_METRICS_BIND' in text
+        assert re.search(
+            r"name: metrics\s*\n\s*containerPort: 9464", text
+        ), f"{name} must expose the metrics port"
+        assert "name: TEMPORAL_METRICS_BIND" in text
     pdb = (tdir / "worker-pdb.yaml").read_text()
     assert pdb.count("kind: PodDisruptionBudget") == 2
     for group in (
@@ -285,7 +298,9 @@ def test_alert_rules_use_the_workers_temporal_namespace_and_cover_worker_loss():
         for label_ns in re.findall(r'(?<!kube_)\bnamespace="([^"]+)"', expr):
             if "kube_deployment" in expr:
                 continue  # kube-state label: Kubernetes namespace is correct
-            assert label_ns == ns, f"rule filters on Temporal namespace {label_ns!r}, workers use {ns!r}"
+            assert (
+                label_ns == ns
+            ), f"rule filters on Temporal namespace {label_ns!r}, workers use {ns!r}"
     for needle in (
         "absent(up{",
         "kube_deployment_status_replicas_available",
@@ -294,3 +309,414 @@ def test_alert_rules_use_the_workers_temporal_namespace_and_cover_worker_loss():
         "FhiTemporalAppealWorkerAbsent",
     ):
         assert needle in rules, f"worker-loss/server-side coverage missing: {needle}"
+
+
+def _draining_worker_cls(shutdown_calls):
+    """Worker stub whose run() only returns once shutdown() has been called,
+    like the real one: this is what makes a dropped SIGTERM observable."""
+    from unittest.mock import Mock
+
+    cls = Mock()
+
+    def _make(*args, **kwargs):
+        inst = Mock()
+        done = asyncio.Event()
+
+        async def run():
+            await done.wait()
+
+        async def shutdown():
+            shutdown_calls.append(kwargs.get("task_queue"))
+            done.set()
+
+        inst.run = run
+        inst.shutdown = shutdown
+        return inst
+
+    cls.side_effect = _make
+    return cls
+
+
+def _run_until_signal(role, sig, command=None, **flags):
+    """Start _run, deliver ``sig`` to this process once _run has installed
+    its handlers, and return the task queues whose worker was shut down.
+
+    Two guards keep a real signal safe inside pytest (review): a Python-level
+    fallback handler is installed first, so if _run installs no loop handler
+    the signal is recorded and asserted on instead of terminating the test
+    runner; and the kill waits for an explicit readiness handshake around
+    install_shutdown_handlers rather than a sleep.
+    """
+    import os
+    import signal as _signal
+    from django.test import override_settings
+    from unittest.mock import AsyncMock, Mock
+
+    import fighthealthinsurance.management.commands.run_temporal_worker as cmd
+
+    shutdown_calls: list = []
+    leaked: list = []
+    ready = asyncio.Event()
+    real_install = cmd.install_shutdown_handlers
+
+    def _install_and_signal_ready(*args, **kwargs):
+        real_install(*args, **kwargs)
+        ready.set()
+
+    settings = dict(
+        TEMPORAL_ENABLED=True,
+        TEMPORAL_APPEAL_JOURNEY_ENABLED=True,
+        TEMPORAL_INTAKE_JOURNEY_ENABLED=False,
+        TEMPORAL_TASK_QUEUE="q-fax",
+        TEMPORAL_APPEAL_TASK_QUEUE="q-appeal",
+        TEMPORAL_HOST="test-host",
+        TEMPORAL_NAMESPACE="test-ns",
+    )
+    settings.update(flags)
+
+    async def main():
+        task = asyncio.create_task((command or Command())._run({"queues": role}))
+        await asyncio.wait_for(ready.wait(), timeout=2)
+        await asyncio.sleep(0)  # let _run reach its first await past install
+        os.kill(os.getpid(), sig)
+        await asyncio.wait_for(task, timeout=2)
+
+    _signal.signal(sig, lambda signum, frame: leaked.append(signum))
+    with (
+        patch("temporalio.worker.Worker", _draining_worker_cls(shutdown_calls)),
+        patch(
+            "fighthealthinsurance.temporal_client.get_temporal_client",
+            AsyncMock(return_value=Mock()),
+        ),
+        patch.object(cmd, "install_shutdown_handlers", _install_and_signal_ready),
+        override_settings(**settings),
+    ):
+        asyncio.run(main())
+    assert not leaked, "signal reached the fallback handler: _run installed none"
+    return shutdown_calls
+
+
+def test_sigterm_shuts_workers_down_instead_of_being_dropped():
+    """Regression: as PID 1 in the container the process had no SIGTERM
+    handler, the kernel discarded the signal, and the old worker kept
+    polling until SIGKILL at the end of the grace period."""
+    import signal
+
+    calls = _run_until_signal("all", signal.SIGTERM)
+    assert sorted(calls) == ["q-appeal", "q-fax"]
+
+
+def test_sigint_shuts_workers_down_too():
+    import signal
+
+    calls = _run_until_signal("fax", signal.SIGINT)
+    assert calls == ["q-fax"]
+
+
+def test_idle_appeal_role_exits_on_sigterm():
+    """The dark-journey idle branch must not sleep through the grace period."""
+    import signal
+
+    calls = _run_until_signal(
+        "appeal", signal.SIGTERM, TEMPORAL_APPEAL_JOURNEY_ENABLED=False
+    )
+    assert calls == []  # nothing hosted, but _run returned within the timeout
+
+
+def test_sigterm_during_connect_exits_without_hosting():
+    """A signal while the client connect is still pending must not be lost,
+    and the pod must not start polling afterwards (review)."""
+    import os
+    import signal as _signal
+    from django.test import override_settings
+    from unittest.mock import Mock
+
+    worker_cls = _recording_worker_cls()
+    connect_started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def slow_connect(**kwargs):
+        connect_started.set()
+        await release.wait()
+        return Mock()
+
+    async def main():
+        task = asyncio.create_task(Command()._run({"queues": "fax"}))
+        await asyncio.wait_for(connect_started.wait(), timeout=2)
+        os.kill(os.getpid(), _signal.SIGTERM)
+        await asyncio.wait_for(task, timeout=2)
+        release.set()
+
+    leaked: list = []
+    _signal.signal(_signal.SIGTERM, lambda signum, frame: leaked.append(signum))
+    with (
+        patch("temporalio.worker.Worker", worker_cls),
+        patch(
+            "fighthealthinsurance.temporal_client.get_temporal_client",
+            slow_connect,
+        ),
+        override_settings(
+            TEMPORAL_ENABLED=True,
+            TEMPORAL_TASK_QUEUE="q-fax",
+            TEMPORAL_HOST="test-host",
+            TEMPORAL_NAMESPACE="test-ns",
+        ),
+    ):
+        asyncio.run(main())
+    assert not leaked
+    assert worker_cls.call_args_list == []  # no worker was ever constructed
+
+
+def test_sigterm_caught_before_the_loop_exists_still_stops_startup():
+    """Django bootstrap and the lazy imports run before the asyncio loop; a
+    SIGTERM caught by the early handler in that window must still end the
+    process before it hosts a worker (review)."""
+    import signal as _signal
+    from django.test import override_settings
+    from unittest.mock import AsyncMock, Mock
+
+    from fighthealthinsurance.worker_signals import early_stop
+
+    worker_cls = _recording_worker_cls()
+    before = _signal.getsignal(_signal.SIGTERM)
+    event = early_stop.install()
+    try:
+        assert _signal.getsignal(_signal.SIGTERM) == early_stop._handler
+        early_stop._handler(_signal.SIGTERM, None)  # what the kernel would do
+        assert event.is_set()
+        with (
+            patch("temporalio.worker.Worker", worker_cls),
+            patch(
+                "fighthealthinsurance.temporal_client.get_temporal_client",
+                AsyncMock(return_value=Mock()),
+            ),
+            override_settings(
+                TEMPORAL_ENABLED=True,
+                TEMPORAL_TASK_QUEUE="q-fax",
+                TEMPORAL_HOST="test-host",
+                TEMPORAL_NAMESPACE="test-ns",
+            ),
+        ):
+            asyncio.run(
+                asyncio.wait_for(
+                    Command()._run({"queues": "fax"}, early_stop=event), timeout=2
+                )
+            )
+    finally:
+        early_stop.restore()
+    # restore() hands back the previous disposition and a FRESH flag, so
+    # one early stop cannot blank a later invocation (review).
+    assert _signal.getsignal(_signal.SIGTERM) == before
+    assert early_stop.event is not event and not early_stop.event.is_set()
+    assert worker_cls.call_args_list == []
+
+
+def test_handle_installs_and_restores_the_early_sigterm_handler():
+    import signal as _signal
+
+    from fighthealthinsurance.worker_signals import early_stop
+
+    seen = {}
+
+    async def fake_run(self, options, early_stop=None):
+        seen["handler"] = _signal.getsignal(_signal.SIGTERM)
+        seen["flag"] = early_stop
+
+    before = _signal.getsignal(_signal.SIGTERM)
+    with patch.object(Command, "_run", fake_run):
+        Command().handle(queues="fax")
+    assert seen["handler"] == early_stop._handler
+    assert seen["flag"] is not None and not seen["flag"].is_set()
+    assert _signal.getsignal(_signal.SIGTERM) == before  # restored after
+
+
+def test_manage_py_installs_the_guard_before_django_bootstraps():
+    """The window before handle() -- Django setup and system checks -- is
+    covered only if manage.py installs the guard first (review)."""
+    import pathlib
+
+    root = pathlib.Path(__file__).resolve().parents[2]
+    text = (root / "manage.py").read_text()
+    guard = text.index("early_stop.install()")
+    app_import = text.index("from fighthealthinsurance.utils import")
+    django = text.index("execute_from_command_line(sys.argv)")
+    # Above the app import too: fighthealthinsurance.utils pulls Django mail,
+    # models and templates in at import time (review).
+    assert guard < app_import < django
+    assert "fighthealthinsurance.worker_signals" in text
+
+
+def test_worker_signals_imports_nothing_from_django():
+    import ast
+    import pathlib
+
+    root = pathlib.Path(__file__).resolve().parents[2]
+    tree = ast.parse((root / "fighthealthinsurance" / "worker_signals.py").read_text())
+    modules = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(a.name for a in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+    assert modules <= {"signal", "typing"}, modules
+
+
+def test_early_stop_flag_is_lock_free():
+    from fighthealthinsurance.worker_signals import Flag, early_stop
+
+    flag = Flag()
+    assert not flag.is_set()
+    flag.set()
+    assert flag.is_set()
+    assert not hasattr(flag, "_cond")  # not a threading.Event in disguise
+    assert isinstance(early_stop.event, Flag)
+
+
+def _fake_run_that_replaces_both_signals(raise_after=None):
+    """A stand-in _run that does what the real one does to the process:
+    installs loop handlers for SIGTERM and SIGINT (asyncio resets both to
+    the defaults on loop close), then optionally raises."""
+
+    async def fake_run(self, options, early_stop=None):
+        loop = asyncio.get_running_loop()
+        for sig in (_signal_module().SIGTERM, _signal_module().SIGINT):
+            loop.add_signal_handler(sig, lambda: None)
+        if raise_after is not None:
+            raise raise_after
+
+    return fake_run
+
+
+def _signal_module():
+    import signal as _signal
+
+    return _signal
+
+
+def test_handle_restores_both_signals_after_success_and_after_failure():
+    """Regression for the round-5 review: the earlier test's fake _run never
+    replaced SIGINT, so dropping the restoration would still have passed."""
+    from django.core.management.base import CommandError
+
+    _signal = _signal_module()
+    marker_term = lambda signum, frame: None  # noqa: E731
+    marker_int = lambda signum, frame: None  # noqa: E731
+    for raise_after in (None, CommandError("boom")):
+        _signal.signal(_signal.SIGTERM, marker_term)
+        _signal.signal(_signal.SIGINT, marker_int)
+        with patch.object(
+            Command, "_run", _fake_run_that_replaces_both_signals(raise_after)
+        ):
+            if raise_after is None:
+                Command().handle(queues="fax")
+            else:
+                with pytest.raises(CommandError):
+                    Command().handle(queues="fax")
+        assert _signal.getsignal(_signal.SIGTERM) is marker_term
+        assert _signal.getsignal(_signal.SIGINT) is marker_int
+
+
+def test_handle_does_not_resurrect_a_released_bootstrap_guard():
+    """manage.py installs the guard before handle() runs. handle()'s own
+    snapshot then sees the guard's handler; after restore() releases it,
+    handle() must not put it back (review, round 5)."""
+    from fighthealthinsurance.worker_signals import early_stop
+
+    _signal = _signal_module()
+    before_guard = lambda signum, frame: None  # noqa: E731
+    _signal.signal(_signal.SIGTERM, before_guard)
+    early_stop.install()  # what manage.py does
+    assert _signal.getsignal(_signal.SIGTERM) == early_stop._handler
+    with patch.object(Command, "_run", _fake_run_that_replaces_both_signals()):
+        Command().handle(queues="fax")
+    assert _signal.getsignal(_signal.SIGTERM) is before_guard
+
+
+def test_native_signal_handlers_are_left_alone():
+    """A previous handler of None means it was installed outside Python and
+    could never be handed back, so neither the bootstrap guard nor the loop
+    handlers may take it (review)."""
+    from fighthealthinsurance import worker_signals
+    from fighthealthinsurance.management.commands.run_temporal_worker import (
+        install_shutdown_handlers,
+    )
+
+    _signal = _signal_module()
+    with patch.object(_signal, "getsignal", return_value=None), patch.object(
+        _signal, "signal"
+    ) as set_signal:
+        guard = worker_signals.EarlyStop()
+        guard.install()
+        set_signal.assert_not_called()
+        guard.restore()  # nothing installed: nothing to put back
+        set_signal.assert_not_called()
+
+        async def main():
+            loop = asyncio.get_running_loop()
+            with patch.object(loop, "add_signal_handler") as add:
+                install_shutdown_handlers([], asyncio.Event(), lambda m: None)
+                add.assert_not_called()
+
+        asyncio.run(main())
+
+
+def test_shutdown_is_scheduled_even_when_the_log_write_fails():
+    """stop.set() before a failing log write used to leave the workers
+    polling forever, with every later signal a no-op (review, round 5)."""
+    import signal
+    from unittest.mock import Mock
+
+    def write(text):
+        # Startup lines still print; only the signal's own log line finds the
+        # pipe gone (that is the failure mode: stdout's reader left first).
+        if "received: stopping polling" in text:
+            raise BrokenPipeError
+        return None
+
+    cmd = Command()
+    cmd.stdout = Mock()
+    cmd.stdout.write = Mock(side_effect=write)
+    calls = _run_until_signal("fax", signal.SIGTERM, command=cmd)
+    assert calls == ["q-fax"]
+    assert any(
+        "received: stopping polling" in c.args[0]
+        for c in cmd.stdout.write.call_args_list
+    )
+
+
+def test_handle_off_the_main_thread_leaves_a_preinstalled_guard_alone():
+    """A guard installed by manage.py on the main thread, then handle()
+    invoked from a worker thread (library use): the thread can neither
+    acquire nor release signal handlers, so it must not try, and must not
+    turn a successful run into a ValueError in finally (review, round 6)."""
+    import threading
+
+    from fighthealthinsurance.worker_signals import early_stop
+
+    _signal = _signal_module()
+    early_stop.install()  # main thread, as manage.py would
+    guard = _signal.getsignal(_signal.SIGTERM)
+    assert guard == early_stop._handler
+
+    async def fake_run(self, options, early_stop=None):
+        return None  # no loop signal handlers: not allowed off-main-thread
+
+    outcome = {}
+
+    def run_in_thread():
+        try:
+            with patch.object(Command, "_run", fake_run):
+                Command().handle(queues="fax")
+            outcome["ok"] = True
+        except Exception as e:  # pragma: no cover - the assertion below reports it
+            outcome["error"] = e
+
+    try:
+        th = threading.Thread(target=run_in_thread)
+        th.start()
+        th.join(timeout=5)
+        assert outcome.get("ok"), outcome.get("error")
+        # Still installed: the thread did not release what it never owned.
+        assert _signal.getsignal(_signal.SIGTERM) == early_stop._handler
+    finally:
+        early_stop.restore()


### PR DESCRIPTION
… SIGKILL

In the container the worker process is PID 1, and it installed no SIGTERM handler. A PID 1 with no handler never receives the kernel's default action, so Kubernetes' SIGTERM at rollout did nothing: the old worker kept polling its task queue at full rate for the whole terminationGracePeriodSeconds (1860 s) and only died at SIGKILL. Seen in prod 2026-09-11: both old fax-worker pods were still listed as pollers fifteen minutes after SIGTERM, and a resend of fax 658 ran on the old image after the fix for it had been deployed. Every deploy was a 31-minute mixed-version window for faxes.

Now:
- worker_signals.EarlyStop, a module with no Django imports, is installed by manage.py as its first act (above every import that pulls Django in) when the command is run_temporal_worker; it catches a SIGTERM that lands during bootstrap in a lock-free flag.
- _run() installs event-loop handlers for SIGTERM and SIGINT before its lazy imports, races the client connect against the stop flag, refuses to host a worker once a stop was requested, and on a signal schedules Worker.shutdown() for every hosted worker before it logs anything. shutdown() stops polling; the existing graceful_shutdown_timeout lets in-flight activities finish.
- handle() owns and restores signal dispositions on the main thread only, never resurrects a released bootstrap guard, and leaves native handlers alone.

Tests deliver real signals to the test process behind a fallback handler and a readiness handshake, cover the connect window, the bootstrap window, a failing log write, a threaded caller, restoration after success and failure, and pin manage.py's import order. Eight Codex review rounds.

Documented limitations, not defects: an activity blocked in native or database I/O can still hold the process past the grace period; signal- driven shutdown exists only on the main thread, which is how the container runs it.


Claude-Session: https://claude.ai/code/session_019SPqa4FZ43ahAjoD53Uj81

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Temporal workers now shut down gracefully when receiving SIGTERM or SIGINT.
  * Worker startup can be cancelled safely if a shutdown request arrives early.
  * Idle worker processes respond promptly to shutdown requests.

* **Bug Fixes**
  * Improved handling of worker shutdown when signals arrive during startup or connection.
  * Signal handlers are restored after worker completion or failure.

* **Tests**
  * Added comprehensive coverage for graceful shutdown, startup cancellation, and signal-handler restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->