### PR TITLE
Staff status: honest fax queue, fax panels together, lifetime totals …

### DIFF
--- a/fighthealthinsurance/apps.py
+++ b/fighthealthinsurance/apps.py
@@ -9,6 +9,9 @@ class FightHealthInsuranceConfig(AppConfig):
         # /metrics endpoint. Emits sample-less families unless pooling is
         # enabled (Prod's PG_USE_POOL), so it is safe in every
         # configuration.
+        # Registers the post_save receiver that keeps the lifetime counters.
+        import fighthealthinsurance.lifetime_counters  # noqa: F401
+
         from fighthealthinsurance.db_pool_metrics import register_pool_stats_collector
 
         register_pool_stats_collector()

--- a/fighthealthinsurance/fax_send_core.py
+++ b/fighthealthinsurance/fax_send_core.py
@@ -265,7 +265,18 @@ def finalize_fax(
     # support on every retry.)
     fax.sent = True
     fax.fax_success = fax_success
-    fax.save()
+    # UPDATE only, never save(): with the pk set, save() falls back to an
+    # INSERT when the UPDATE matches no row, which would re-create a fax
+    # that a delete-my-data request removed while this send was in flight,
+    # appeal text and email included (review). Zero rows means the person
+    # is gone: stop here, and send no notifications about their fax.
+    from fighthealthinsurance.models import FaxesToSend
+
+    if not FaxesToSend.objects.filter(pk=fax.pk).update(
+        sent=True, fax_success=fax_success
+    ):
+        logger.info(f"Fax uuid={fax.uuid} no longer exists at finalize; stopping")
+        return True
     if fax.professional:
         appeal = fax.for_appeal
         if appeal is not None:

--- a/fighthealthinsurance/fax_send_core.py
+++ b/fighthealthinsurance/fax_send_core.py
@@ -270,11 +270,32 @@ def finalize_fax(
     # that a delete-my-data request removed while this send was in flight,
     # appeal text and email included (review). Zero rows means the person
     # is gone: stop here, and send no notifications about their fax.
+    # The lifetime sent/delivered counters move inside this same
+    # transaction, keyed on two once-only markers on the row: finalize runs
+    # under an unlimited retry policy, and a resend resets sent/fax_success,
+    # so neither a retry nor a resend may count the same fax again (review).
+    from django.db import transaction
+
     from fighthealthinsurance.models import FaxesToSend
 
-    if not FaxesToSend.objects.filter(pk=fax.pk).update(
-        sent=True, fax_success=fax_success
-    ):
+    with transaction.atomic():
+        rows = FaxesToSend.objects.filter(pk=fax.pk)
+        # sent / fax_success describe the latest attempt, as they always
+        # have (a resend resets them). The lifetime counters key off two
+        # once-only markers instead, so a resend after a failure, or a
+        # failure after a delivery, cannot count the same fax twice.
+        present = bool(rows.update(sent=True, fax_success=fax_success))
+        if present:
+            newly_sent = bool(
+                rows.filter(attempt_counted=False).update(attempt_counted=True)
+            )
+            newly_delivered = fax_success and bool(
+                rows.filter(delivery_counted=False).update(delivery_counted=True)
+            )
+            from fighthealthinsurance.lifetime_counters import note_fax_events
+
+            note_fax_events(newly_sent=newly_sent, newly_delivered=newly_delivered)
+    if not present:
         logger.info(f"Fax uuid={fax.uuid} no longer exists at finalize; stopping")
         return True
     if fax.professional:

--- a/fighthealthinsurance/helpers/data_helpers.py
+++ b/fighthealthinsurance/helpers/data_helpers.py
@@ -26,86 +26,32 @@ class RemoveDataHelper:
     """Helper class for removing user data for privacy compliance."""
 
     @classmethod
-    def _record_removal(cls, email: str, hashed_email: str) -> None:
-        """Add what is about to be removed to the running totals.
+    def _record_removal(cls, hashed_email: str) -> None:
+        """Count this request and the denials it takes, in the running totals.
 
         Runs inside the deletion's transaction (see remove_data_for_email)
-        so the counts and the deletion commit or roll back together: a
-        deletion that fails halfway and is retried is counted once. The
-        totals row is locked for the rest of that transaction, which
-        serializes two overlapping requests for the same person. Best
-        effort by design: everything sits in its own savepoint, so a
-        bookkeeping failure (the table missing mid-rollout, a database
-        error) rolls back only the bookkeeping and never blocks or poisons
-        the deletion, which is an obligation (review).
+        so the count and the deletion commit or roll back together, and the
+        totals row is locked so overlapping requests serialize. Best effort
+        by design: its own savepoint, so a bookkeeping failure rolls back
+        only itself and never blocks a deletion, which is an obligation.
+        The lifetime numbers themselves are NOT touched here: they are
+        counters that only go up (lifetime_counters.py), which is what makes
+        them deletion-proof.
         """
         try:
             with transaction.atomic():
-                from django.db.models import F, Q, Value
+                from django.db.models import F, Value
                 from django.db.models.functions import Coalesce
 
-                from fighthealthinsurance.models import (
-                    DataRemovalTotals,
-                    FaxesToSend,
-                    ProposedAppeal,
-                )
+                from fighthealthinsurance.models import DataRemovalTotals
 
-                DataRemovalTotals.objects.get_or_create(
-                    pk=DataRemovalTotals.SINGLETON_ID
-                )
-                DataRemovalTotals.objects.select_for_update().get(
-                    pk=DataRemovalTotals.SINGLETON_ID
-                )
-                # The person's denials and EVERY draft on them (speculative
-                # included), locked for the rest of the transaction: the
-                # generator promotes a speculative draft to a real one with
-                # a plain UPDATE, and a promotion landing between this count
-                # and the cascade delete would lose the person from the
-                # lifetime total for good; FOR UPDATE makes that promotion
-                # wait until the rows are gone (no-op on sqlite) (review).
-                denial_ids = list(
-                    Denial.objects.select_for_update(of=("self",))
-                    .filter(hashed_email=hashed_email)
-                    .values_list("denial_id", flat=True)
-                )
-                draft_is_speculative = list(
-                    ProposedAppeal.objects.select_for_update(of=("self",))
-                    .filter(for_denial_id__in=denial_ids)
-                    .values_list("speculative", flat=True)
-                )
-                real_drafts = sum(1 for spec in draft_is_speculative if not spec)
-                # Everything the deletes below take: rows keyed by this
-                # person's hash or email, AND rows that go by cascade
-                # through their denial -- a professional's fax staged for a
-                # patient's denial carries the professional's email (review).
-                # Locked, all of them, not just the delivered ones: the fax
-                # worker commits fax_success=True on its own connection, and
-                # a delivery landing between this count and the delete
-                # would be gone from the lifetime total for good. FOR UPDATE
-                # makes that finalize wait for this transaction (no-op on
-                # sqlite). ``of=("self",)``: the OR reaches the denial through
-                # a nullable FK, an outer join, and Postgres refuses to lock
-                # the nullable side of an outer join; lock only the fax rows
-                # (review).
-                candidates = list(
-                    FaxesToSend.objects.select_for_update(of=("self",))
-                    .filter(
-                        Q(hashed_email=hashed_email)
-                        | Q(email__iexact=email)
-                        | Q(denial_id__hashed_email=hashed_email)
-                    )
-                    .values_list("fax_success", flat=True)
-                )
-                delivered_count = sum(1 for ok in candidates if ok)
-                DataRemovalTotals.objects.filter(
-                    pk=DataRemovalTotals.SINGLETON_ID
-                ).update(
+                pk = DataRemovalTotals.SINGLETON_ID
+                DataRemovalTotals.objects.get_or_create(pk=pk)
+                DataRemovalTotals.objects.select_for_update().get(pk=pk)
+                DataRemovalTotals.objects.filter(pk=pk).update(
                     requests=F("requests") + 1,
-                    denials=F("denials") + len(denial_ids),
-                    drafts=F("drafts") + real_drafts,
-                    faxes_delivered=F("faxes_delivered") + delivered_count,
-                    people_with_draft=F("people_with_draft")
-                    + (1 if real_drafts else 0),
+                    denials=F("denials")
+                    + Denial.objects.filter(hashed_email=hashed_email).count(),
                     since=Coalesce(F("since"), Value(timezone.now())),
                 )
         except Exception:
@@ -126,12 +72,13 @@ class RemoveDataHelper:
         email = email.strip().lower()
         hashed_email: str = Denial.get_hashed_email(email)
         with transaction.atomic():
-            cls._record_removal(email, hashed_email)
+            cls._record_removal(hashed_email)
             cls._delete_rows(email, hashed_email)
 
     @classmethod
     def _delete_rows(cls, email: str, hashed_email: str) -> None:
-        # Core denial/appeal data
+        # Core denial/appeal data (the person_counted flag goes with the
+        # denials; the lifetime counter it fed stays, which is the point).
         Denial.objects.filter(hashed_email=hashed_email).delete()
         Appeal.objects.filter(hashed_email=hashed_email).delete()
         # Follow-up related — use __iexact for plaintext email fields so

--- a/fighthealthinsurance/helpers/data_helpers.py
+++ b/fighthealthinsurance/helpers/data_helpers.py
@@ -26,12 +26,15 @@ class RemoveDataHelper:
     """Helper class for removing user data for privacy compliance."""
 
     @classmethod
-    def _record_removal(cls, hashed_email: str) -> None:
-        """Count this request and the denials it takes, in the running totals.
+    def _record_removal(cls, hashed_email: str, denials_removed: int) -> None:
+        """Count this request and the denials it took, in the running totals.
 
         Runs inside the deletion's transaction (see remove_data_for_email)
         so the count and the deletion commit or roll back together, and the
-        totals row is locked so overlapping requests serialize. Best effort
+        totals row is locked so overlapping requests serialize. The number
+        recorded is what the delete actually removed, not a count taken
+        before it: a denial created in between would otherwise be deleted
+        and never counted (review). Best effort
         by design: its own savepoint, so a bookkeeping failure rolls back
         only itself and never blocks a deletion, which is an obligation.
         The lifetime numbers themselves are NOT touched here: they are
@@ -50,8 +53,7 @@ class RemoveDataHelper:
                 DataRemovalTotals.objects.select_for_update().get(pk=pk)
                 DataRemovalTotals.objects.filter(pk=pk).update(
                     requests=F("requests") + 1,
-                    denials=F("denials")
-                    + Denial.objects.filter(hashed_email=hashed_email).count(),
+                    denials=F("denials") + denials_removed,
                     since=Coalesce(F("since"), Value(timezone.now())),
                 )
         except Exception:
@@ -69,17 +71,30 @@ class RemoveDataHelper:
         Args:
             email: Email address to remove data for
         """
+        from fighthealthinsurance.lifetime_counters import person_lock
+
         email = email.strip().lower()
         hashed_email: str = Denial.get_hashed_email(email)
         with transaction.atomic():
-            cls._record_removal(hashed_email)
-            cls._delete_rows(email, hashed_email)
+            # Take this person's lock before touching any of their rows,
+            # the order every writer of person_counted uses
+            # (lifetime_counters.person_lock). Deleting a denial locks rows
+            # one at a time as the cascade walks them, including the
+            # SET_NULL back-references; a first-draft count locking the
+            # same person's rows in the other order would deadlock, and
+            # PostgreSQL would abort one of them -- possibly this deletion
+            # (review).
+            person_lock(hashed_email)
+            denials_removed = cls._delete_rows(email, hashed_email)
+            cls._record_removal(hashed_email, denials_removed)
 
     @classmethod
-    def _delete_rows(cls, email: str, hashed_email: str) -> None:
+    def _delete_rows(cls, email: str, hashed_email: str) -> int:
+        """Delete everything for this person; return how many denials went."""
         # Core denial/appeal data (the person_counted flag goes with the
         # denials; the lifetime counter it fed stays, which is the point).
-        Denial.objects.filter(hashed_email=hashed_email).delete()
+        _total, per_model = Denial.objects.filter(hashed_email=hashed_email).delete()
+        denials_removed = per_model.get(Denial._meta.label, 0)
         Appeal.objects.filter(hashed_email=hashed_email).delete()
         # Follow-up related — use __iexact for plaintext email fields so
         # mixed-case stored addresses are reliably matched
@@ -96,3 +111,4 @@ class RemoveDataHelper:
         # Mailing list and demo requests
         MailingListSubscriber.objects.filter(email__iexact=email).delete()
         DemoRequests.objects.filter(email__iexact=email).delete()
+        return denials_removed

--- a/fighthealthinsurance/helpers/data_helpers.py
+++ b/fighthealthinsurance/helpers/data_helpers.py
@@ -4,6 +4,10 @@ Data management helpers for Fight Health Insurance.
 Provides utilities for data removal and privacy compliance.
 """
 
+from django.db import transaction
+from django.utils import timezone
+from loguru import logger
+
 from fighthealthinsurance.models import (
     Appeal,
     ChatLeads,
@@ -22,6 +26,94 @@ class RemoveDataHelper:
     """Helper class for removing user data for privacy compliance."""
 
     @classmethod
+    def _record_removal(cls, email: str, hashed_email: str) -> None:
+        """Add what is about to be removed to the running totals.
+
+        Runs inside the deletion's transaction (see remove_data_for_email)
+        so the counts and the deletion commit or roll back together: a
+        deletion that fails halfway and is retried is counted once. The
+        totals row is locked for the rest of that transaction, which
+        serializes two overlapping requests for the same person. Best
+        effort by design: everything sits in its own savepoint, so a
+        bookkeeping failure (the table missing mid-rollout, a database
+        error) rolls back only the bookkeeping and never blocks or poisons
+        the deletion, which is an obligation (review).
+        """
+        try:
+            with transaction.atomic():
+                from django.db.models import F, Q, Value
+                from django.db.models.functions import Coalesce
+
+                from fighthealthinsurance.models import (
+                    DataRemovalTotals,
+                    FaxesToSend,
+                    ProposedAppeal,
+                )
+
+                DataRemovalTotals.objects.get_or_create(
+                    pk=DataRemovalTotals.SINGLETON_ID
+                )
+                DataRemovalTotals.objects.select_for_update().get(
+                    pk=DataRemovalTotals.SINGLETON_ID
+                )
+                # The person's denials and EVERY draft on them (speculative
+                # included), locked for the rest of the transaction: the
+                # generator promotes a speculative draft to a real one with
+                # a plain UPDATE, and a promotion landing between this count
+                # and the cascade delete would lose the person from the
+                # lifetime total for good; FOR UPDATE makes that promotion
+                # wait until the rows are gone (no-op on sqlite) (review).
+                denial_ids = list(
+                    Denial.objects.select_for_update(of=("self",))
+                    .filter(hashed_email=hashed_email)
+                    .values_list("denial_id", flat=True)
+                )
+                draft_is_speculative = list(
+                    ProposedAppeal.objects.select_for_update(of=("self",))
+                    .filter(for_denial_id__in=denial_ids)
+                    .values_list("speculative", flat=True)
+                )
+                real_drafts = sum(1 for spec in draft_is_speculative if not spec)
+                # Everything the deletes below take: rows keyed by this
+                # person's hash or email, AND rows that go by cascade
+                # through their denial -- a professional's fax staged for a
+                # patient's denial carries the professional's email (review).
+                # Locked, all of them, not just the delivered ones: the fax
+                # worker commits fax_success=True on its own connection, and
+                # a delivery landing between this count and the delete
+                # would be gone from the lifetime total for good. FOR UPDATE
+                # makes that finalize wait for this transaction (no-op on
+                # sqlite). ``of=("self",)``: the OR reaches the denial through
+                # a nullable FK, an outer join, and Postgres refuses to lock
+                # the nullable side of an outer join; lock only the fax rows
+                # (review).
+                candidates = list(
+                    FaxesToSend.objects.select_for_update(of=("self",))
+                    .filter(
+                        Q(hashed_email=hashed_email)
+                        | Q(email__iexact=email)
+                        | Q(denial_id__hashed_email=hashed_email)
+                    )
+                    .values_list("fax_success", flat=True)
+                )
+                delivered_count = sum(1 for ok in candidates if ok)
+                DataRemovalTotals.objects.filter(
+                    pk=DataRemovalTotals.SINGLETON_ID
+                ).update(
+                    requests=F("requests") + 1,
+                    denials=F("denials") + len(denial_ids),
+                    drafts=F("drafts") + real_drafts,
+                    faxes_delivered=F("faxes_delivered") + delivered_count,
+                    people_with_draft=F("people_with_draft")
+                    + (1 if real_drafts else 0),
+                    since=Coalesce(F("since"), Value(timezone.now())),
+                )
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Could not record data-removal totals; deleting anyway"
+            )
+
+    @classmethod
     def remove_data_for_email(cls, email: str) -> None:
         """
         Remove all data associated with an email address.
@@ -33,6 +125,12 @@ class RemoveDataHelper:
         """
         email = email.strip().lower()
         hashed_email: str = Denial.get_hashed_email(email)
+        with transaction.atomic():
+            cls._record_removal(email, hashed_email)
+            cls._delete_rows(email, hashed_email)
+
+    @classmethod
+    def _delete_rows(cls, email: str, hashed_email: str) -> None:
         # Core denial/appeal data
         Denial.objects.filter(hashed_email=hashed_email).delete()
         Appeal.objects.filter(hashed_email=hashed_email).delete()

--- a/fighthealthinsurance/lifetime_counters.py
+++ b/fighthealthinsurance/lifetime_counters.py
@@ -11,17 +11,21 @@ back. So:
   does not count).
 * ``people_with_draft`` moves when a person's first generated draft is
   counted, which sets ``person_counted`` on every Denial row of theirs.
-  The decision is made under the person's lock (``person_lock``: a
-  per-hash advisory lock on PostgreSQL, plus FOR UPDATE on the rows), so
-  two racing first drafts serialize and exactly one counts. The hash is
-  the person: a denial created later, or one whose hash changes, adopts
-  the counted state of the person it belongs to under the same lock
-  (Denial.save), and any row that is still unflagged is flagged on the
-  person's next draft, so the flag never depends on one particular denial
+  The person is the hash the denial carries in the database at the time,
+  read under the person's lock (``person_lock``: a per-hash advisory lock
+  on PostgreSQL, taken before any row lock by every writer of the flag,
+  plus FOR UPDATE on the rows), so two racing first drafts serialize and
+  exactly one counts. A denial created later, or one whose hash changes,
+  adopts the counted state of the person it belongs to under the same
+  lock (Denial.save, deciding against the locked row, never against a
+  cached hash), and any row still unflagged is flagged on the person's
+  next draft, so the flag never depends on one particular denial
   surviving. It lives on rows that already carry the hash, survives draft
   churn (the precompute's rows are deleted on a text change), and leaves
   with the person's data on deletion, so nothing is retained beyond what
-  the denials already are.
+  the denials already are. The one ordering caveat: an outer transaction
+  that writes denials of two different people holds both people's locks
+  until it commits; no caller does that today.
 * ``faxes_sent`` moves in finalize_fax the first time a row is finalized
   (an attempt was made, whatever its result), and ``faxes_delivered`` the
   first time it is finalized as delivered; each once per fax, recorded by
@@ -96,30 +100,43 @@ def person_lock(hashed_email: str) -> None:
         )
 
 
-def _mark_person(hashed_email: str) -> bool:
+def _mark_person(denial_id: int) -> bool:
     """True exactly once per person, however many writers race.
 
-    Locks the person's denial rows and flips ``person_counted`` on every one
-    that lacks it; the person counts only if none had it. A second writer
-    waits on the lock and sees the flag. A denial that slipped in unflagged
-    is flagged here too, so the flag never depends on one particular row
-    surviving. If the rows are gone (the person was deleted between the
-    draft insert and this call), nothing is created and nothing is counted.
+    The person is the hash the draft's denial carries IN THE DATABASE, not
+    whatever instance the writer held: a precompute can hold a denial whose
+    email was changed by another request meanwhile (review). Takes the
+    person's lock, then FOR UPDATE on their denial rows, and flips
+    ``person_counted`` on every one that lacks it; the person counts only
+    if none had it. If the denial is not among the locked rows it was
+    re-keyed between the read and the lock: read again and go round with
+    the new hash. If the row is gone (the person was deleted between the
+    draft insert and this call) or has no hash, nothing is counted.
     """
     from fighthealthinsurance.models import Denial
 
-    person_lock(hashed_email)
-    flags = list(
-        Denial.objects.select_for_update(of=("self",))
-        .filter(hashed_email=hashed_email)
-        .values_list("person_counted", flat=True)
-    )
-    if not flags:
-        return False
-    Denial.objects.filter(hashed_email=hashed_email, person_counted=False).update(
-        person_counted=True
-    )
-    return not any(flags)
+    for _attempt in range(3):
+        hashed = (
+            Denial.objects.filter(pk=denial_id)
+            .values_list("hashed_email", flat=True)
+            .first()
+        )
+        if not hashed:
+            return False
+        person_lock(hashed)
+        rows = list(
+            Denial.objects.select_for_update(of=("self",))
+            .filter(hashed_email=hashed)
+            .values_list("pk", "person_counted")
+        )
+        if denial_id not in {pk for pk, _flag in rows}:
+            continue
+        Denial.objects.filter(hashed_email=hashed, person_counted=False).update(
+            person_counted=True
+        )
+        return not any(flag for _pk, flag in rows)
+    logger.warning("Lifetime counters: denial re-keyed repeatedly; not counted")
+    return False
 
 
 @receiver(
@@ -130,10 +147,9 @@ def _mark_person(hashed_email: str) -> bool:
 def _on_draft_saved(sender, instance, created, raw=False, **kwargs) -> None:
     if not created or raw or instance.chosen:
         return
-    hashed = getattr(instance.for_denial, "hashed_email", "") or ""
     try:
         with transaction.atomic():
-            first = _mark_person(hashed) if hashed else False
+            first = _mark_person(instance.for_denial_id)
             _add(appeals_generated=1, people_with_draft=1 if first else 0)
     except Exception:
         logger.opt(exception=True).warning("Lifetime counters: draft bump failed")

--- a/fighthealthinsurance/lifetime_counters.py
+++ b/fighthealthinsurance/lifetime_counters.py
@@ -23,9 +23,11 @@ back. So:
   surviving. It lives on rows that already carry the hash, survives draft
   churn (the precompute's rows are deleted on a text change), and leaves
   with the person's data on deletion, so nothing is retained beyond what
-  the denials already are. The one ordering caveat: an outer transaction
-  that writes denials of two different people holds both people's locks
-  until it commits; no caller does that today.
+  the denials already are. Deleting a person's data takes the same lock
+  first, because a cascade locks their denial rows one at a time and the
+  opposite order would deadlock against a count. The one ordering caveat:
+  an outer transaction that writes denials of two different people would
+  hold both people's locks until it commits; no caller does that today.
 * ``faxes_sent`` moves in finalize_fax the first time a row is finalized
   (an attempt was made, whatever its result), and ``faxes_delivered`` the
   first time it is finalized as delivered; each once per fax, recorded by
@@ -146,9 +148,10 @@ def _mark_person(denial_id: int) -> bool:
     the new person's lock with the try variant and gives up rather than
     waiting. Waiting there, while possibly still holding the previous
     person's advisory lock, is exactly the cycle a re-key going the other
-    way completes (review); only the first attempt, which holds nothing,
-    may block. If the row is gone (the person was deleted between the
-    draft insert and this call) or has no hash, nothing is counted.
+    way completes (review); only the first attempt, which holds no other
+    person's lock, may block. If the row is gone (the person was deleted
+    between the draft insert and this call) or has no hash, nothing is
+    counted.
     """
     from fighthealthinsurance.models import Denial
 

--- a/fighthealthinsurance/lifetime_counters.py
+++ b/fighthealthinsurance/lifetime_counters.py
@@ -11,14 +11,17 @@ back. So:
   does not count).
 * ``people_with_draft`` moves when a person's first generated draft is
   counted, which sets ``person_counted`` on every Denial row of theirs.
-  The decision is made under a row lock on those denials, so two racing
-  first drafts serialize and exactly one counts; a denial created later
-  inherits the flag (Denial.save, same lock) and any unflagged row is
-  flagged on the person's next draft, so the flag never depends on one
-  particular denial surviving. The flag lives on rows that already carry
-  the hash, survives draft churn (the precompute's rows are deleted on a
-  text change), and leaves with the person's data on deletion, so nothing
-  is retained beyond what the denials already are.
+  The decision is made under the person's lock (``person_lock``: a
+  per-hash advisory lock on PostgreSQL, plus FOR UPDATE on the rows), so
+  two racing first drafts serialize and exactly one counts. The hash is
+  the person: a denial created later, or one whose hash changes, adopts
+  the counted state of the person it belongs to under the same lock
+  (Denial.save), and any row that is still unflagged is flagged on the
+  person's next draft, so the flag never depends on one particular denial
+  surviving. It lives on rows that already carry the hash, survives draft
+  churn (the precompute's rows are deleted on a text change), and leaves
+  with the person's data on deletion, so nothing is retained beyond what
+  the denials already are.
 * ``faxes_sent`` moves in finalize_fax the first time a row is finalized
   (an attempt was made, whatever its result), and ``faxes_delivered`` the
   first time it is finalized as delivered; each once per fax, recorded by
@@ -46,9 +49,10 @@ the seed are unrecoverable, and a person who deletes and returns is counted
 again (their new denials start unflagged).
 """
 
+import hashlib
 from typing import Any, Dict
 
-from django.db import transaction
+from django.db import connection, transaction
 from django.db.models import F, Value
 from django.db.models.functions import Coalesce
 from django.db.models.signals import post_save
@@ -68,6 +72,30 @@ def _add(**deltas: int) -> None:
     LifetimeCounters.objects.filter(pk=pk).update(**changes)
 
 
+def _advisory_key(hashed_email: str) -> int:
+    """Stable signed 64-bit key for pg_advisory_xact_lock."""
+    digest = hashlib.blake2b(hashed_email.encode("utf-8"), digest_size=8).digest()
+    return int.from_bytes(digest, "big", signed=True)
+
+
+def person_lock(hashed_email: str) -> None:
+    """Serialize every writer of ``person_counted`` for one person.
+
+    On PostgreSQL this is a transaction-scoped advisory lock keyed on the
+    hash, released at commit or rollback, so a first-draft count, a denial
+    created for the same person and a denial moving to that person cannot
+    interleave, even while the person has no rows yet to lock. Other
+    backends (sqlite in tests) have no equivalent and run single-writer
+    here. Call it inside transaction.atomic(), before touching the rows.
+    """
+    if not hashed_email or connection.vendor != "postgresql":
+        return
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT pg_advisory_xact_lock(%s)", [_advisory_key(hashed_email)]
+        )
+
+
 def _mark_person(hashed_email: str) -> bool:
     """True exactly once per person, however many writers race.
 
@@ -80,6 +108,7 @@ def _mark_person(hashed_email: str) -> bool:
     """
     from fighthealthinsurance.models import Denial
 
+    person_lock(hashed_email)
     flags = list(
         Denial.objects.select_for_update(of=("self",))
         .filter(hashed_email=hashed_email)

--- a/fighthealthinsurance/lifetime_counters.py
+++ b/fighthealthinsurance/lifetime_counters.py
@@ -12,10 +12,13 @@ back. So:
 * ``people_with_draft`` moves when a person's first generated draft is
   counted, which sets ``person_counted`` on every Denial row of theirs.
   The decision is made under a row lock on those denials, so two racing
-  first drafts serialize and exactly one counts; the flag lives on rows
-  that already carry the hash, survives draft churn (the precompute's rows
-  are deleted on a text change), and leaves with the person's data on
-  deletion, so nothing is retained beyond what the denials already are.
+  first drafts serialize and exactly one counts; a denial created later
+  inherits the flag (Denial.save, same lock) and any unflagged row is
+  flagged on the person's next draft, so the flag never depends on one
+  particular denial surviving. The flag lives on rows that already carry
+  the hash, survives draft churn (the precompute's rows are deleted on a
+  text change), and leaves with the person's data on deletion, so nothing
+  is retained beyond what the denials already are.
 * ``faxes_sent`` moves in finalize_fax the first time a row is finalized
   (an attempt was made, whatever its result), and ``faxes_delivered`` the
   first time it is finalized as delivered; each once per fax, recorded by
@@ -68,10 +71,12 @@ def _add(**deltas: int) -> None:
 def _mark_person(hashed_email: str) -> bool:
     """True exactly once per person, however many writers race.
 
-    Locks the person's denial rows, then flips ``person_counted`` on all of
-    them if none was set. A second writer waits on the lock and sees the
-    flag. If the rows are gone (the person was deleted between the draft
-    insert and this call), nothing is created and nothing is counted.
+    Locks the person's denial rows and flips ``person_counted`` on every one
+    that lacks it; the person counts only if none had it. A second writer
+    waits on the lock and sees the flag. A denial that slipped in unflagged
+    is flagged here too, so the flag never depends on one particular row
+    surviving. If the rows are gone (the person was deleted between the
+    draft insert and this call), nothing is created and nothing is counted.
     """
     from fighthealthinsurance.models import Denial
 
@@ -80,10 +85,12 @@ def _mark_person(hashed_email: str) -> bool:
         .filter(hashed_email=hashed_email)
         .values_list("person_counted", flat=True)
     )
-    if not flags or any(flags):
+    if not flags:
         return False
-    Denial.objects.filter(hashed_email=hashed_email).update(person_counted=True)
-    return True
+    Denial.objects.filter(hashed_email=hashed_email, person_counted=False).update(
+        person_counted=True
+    )
+    return not any(flags)
 
 
 @receiver(

--- a/fighthealthinsurance/lifetime_counters.py
+++ b/fighthealthinsurance/lifetime_counters.py
@@ -1,0 +1,154 @@
+"""Lifetime counters that only ever go up.
+
+Melanie (2026-09-11): the lifetime numbers on the staff status page must be
+counters that deletion cannot change, not live counts with something added
+back. So:
+
+* ``appeals_generated`` moves at the moment a generated draft row is saved
+  (post_save on ProposedAppeal: the streaming generator and the speculative
+  precompute both create rows through ``save()``; a user's chosen/edited
+  copy is created ``chosen=True`` and is a pick, not a generation, so it
+  does not count).
+* ``people_with_draft`` moves when a person's first generated draft is
+  counted, which sets ``person_counted`` on every Denial row of theirs.
+  The decision is made under a row lock on those denials, so two racing
+  first drafts serialize and exactly one counts; the flag lives on rows
+  that already carry the hash, survives draft churn (the precompute's rows
+  are deleted on a text change), and leaves with the person's data on
+  deletion, so nothing is retained beyond what the denials already are.
+* ``faxes_sent`` moves in finalize_fax the first time a row is finalized
+  (an attempt was made, whatever its result), and ``faxes_delivered`` the
+  first time it is finalized as delivered; each once per fax, recorded by
+  once-only markers on the row (``attempt_counted``, ``delivery_counted``)
+  that a resend never resets, unlike ``sent``/``fax_success`` which
+  describe the latest attempt. Fax rows "ever created" is the id
+  sequence: a row exists from the moment a fax is staged, before the user
+  confirms and before any dial.
+
+Every bump runs in its own savepoint, so a counter failure never breaks the
+write that triggered it; the increments are single atomic UPDATEs and no
+lock is taken on the hot path. The row is seeded once, at migration time,
+from the rows present then.
+
+Known limitation, deliberately not repaired: during a rolling deploy, pods
+still on the previous image create drafts and finalize faxes without this
+code until the rollout replaces them (minutes for the web pods; the fax
+worker exits on SIGTERM as of the same release). Events in that window are
+not counted, ever. A later repair from surviving rows was built and
+withdrawn: it can only double-count an event whose receiver has not yet
+committed, resurrect the hash of a person who was deleted meanwhile, or
+mask a surviving uncounted event behind earlier deletions (review). A
+bounded, documented gap is better than a repair that lies. Deletions before
+the seed are unrecoverable, and a person who deletes and returns is counted
+again (their new denials start unflagged).
+"""
+
+from typing import Any, Dict
+
+from django.db import transaction
+from django.db.models import F, Value
+from django.db.models.functions import Coalesce
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from django.utils import timezone
+from loguru import logger
+
+
+def _add(**deltas: int) -> None:
+    """One atomic UPDATE per bump; creates the singleton if needed."""
+    from fighthealthinsurance.models import LifetimeCounters
+
+    pk = LifetimeCounters.SINGLETON_ID
+    LifetimeCounters.objects.get_or_create(pk=pk)
+    changes: Dict[str, Any] = {k: F(k) + v for k, v in deltas.items() if v}
+    changes["since"] = Coalesce(F("since"), Value(timezone.now()))
+    LifetimeCounters.objects.filter(pk=pk).update(**changes)
+
+
+def _mark_person(hashed_email: str) -> bool:
+    """True exactly once per person, however many writers race.
+
+    Locks the person's denial rows, then flips ``person_counted`` on all of
+    them if none was set. A second writer waits on the lock and sees the
+    flag. If the rows are gone (the person was deleted between the draft
+    insert and this call), nothing is created and nothing is counted.
+    """
+    from fighthealthinsurance.models import Denial
+
+    flags = list(
+        Denial.objects.select_for_update(of=("self",))
+        .filter(hashed_email=hashed_email)
+        .values_list("person_counted", flat=True)
+    )
+    if not flags or any(flags):
+        return False
+    Denial.objects.filter(hashed_email=hashed_email).update(person_counted=True)
+    return True
+
+
+@receiver(
+    post_save,
+    sender="fighthealthinsurance.ProposedAppeal",
+    dispatch_uid="lifetime_counters_draft_saved",
+)
+def _on_draft_saved(sender, instance, created, raw=False, **kwargs) -> None:
+    if not created or raw or instance.chosen:
+        return
+    hashed = getattr(instance.for_denial, "hashed_email", "") or ""
+    try:
+        with transaction.atomic():
+            first = _mark_person(hashed) if hashed else False
+            _add(appeals_generated=1, people_with_draft=1 if first else 0)
+    except Exception:
+        logger.opt(exception=True).warning("Lifetime counters: draft bump failed")
+
+
+def note_fax_events(*, newly_sent: bool, newly_delivered: bool) -> None:
+    """Called by finalize_fax inside the transaction that flips the row, and
+    only for the transitions that actually matched (once per fax each)."""
+    if not (newly_sent or newly_delivered):
+        return
+    try:
+        with transaction.atomic():
+            _add(
+                faxes_sent=1 if newly_sent else 0,
+                faxes_delivered=1 if newly_delivered else 0,
+            )
+    except Exception:
+        logger.opt(exception=True).warning("Lifetime counters: fax bump failed")
+
+
+def _present_people(Denial):
+    return (
+        Denial.objects.filter(proposedappeal__chosen=False)
+        .exclude(hashed_email="")
+        .values_list("hashed_email", flat=True)
+        .distinct()
+    )
+
+
+def seed_from_present_rows(apps, schema_editor) -> None:
+    """Migration seed: start the counters from the rows present today, and
+    flag every present person's denials as counted. Reversible as a no-op."""
+    LifetimeCounters = apps.get_model("fighthealthinsurance", "LifetimeCounters")
+    ProposedAppeal = apps.get_model("fighthealthinsurance", "ProposedAppeal")
+    Denial = apps.get_model("fighthealthinsurance", "Denial")
+    FaxesToSend = apps.get_model("fighthealthinsurance", "FaxesToSend")
+    if LifetimeCounters.objects.exists():
+        return
+    people = list(_present_people(Denial))
+    Denial.objects.filter(hashed_email__in=people).update(person_counted=True)
+    # Present faxes that were attempted / delivered are counted now and
+    # marked, so a later resend of one of them cannot count it again.
+    faxes_sent = FaxesToSend.objects.filter(sent=True).update(attempt_counted=True)
+    faxes_delivered = FaxesToSend.objects.filter(fax_success=True).update(
+        delivery_counted=True
+    )
+    LifetimeCounters.objects.create(
+        pk=1,
+        appeals_generated=ProposedAppeal.objects.filter(chosen=False).count(),
+        people_with_draft=len(people),
+        faxes_sent=faxes_sent,
+        faxes_delivered=faxes_delivered,
+        since=timezone.now(),
+    )

--- a/fighthealthinsurance/lifetime_counters.py
+++ b/fighthealthinsurance/lifetime_counters.py
@@ -24,10 +24,14 @@ back. So:
   churn (the precompute's rows are deleted on a text change), and leaves
   with the person's data on deletion, so nothing is retained beyond what
   the denials already are. Deleting a person's data takes the same lock
-  first, because a cascade locks their denial rows one at a time and the
-  opposite order would deadlock against a count. The one ordering caveat:
-  an outer transaction that writes denials of two different people would
-  hold both people's locks until it commits; no caller does that today.
+  first, because a cascade locks their denial rows one at a time, and it
+  is the only caller allowed to WAIT for the lock: it takes it as the
+  first statement of its transaction, so it holds nothing that another
+  holder could be waiting for. Every other writer takes the lock with the
+  try variant and carries on without it, because each of them runs inside
+  a transaction that may already hold a row the holder wants. That is the
+  whole deadlock argument: a cycle needs two waiters, and only lock-free
+  transactions ever wait here.
 * ``faxes_sent`` moves in finalize_fax the first time a row is finalized
   (an attempt was made, whatever its result), and ``faxes_delivered`` the
   first time it is finalized as delivered; each once per fax, recorded by
@@ -96,9 +100,18 @@ def person_lock(hashed_email: str, *, blocking: bool = True) -> bool:
     so every writer acquires locks in the same order.
 
     Returns whether the lock is held. ``blocking=False`` uses the try
-    variant and returns False rather than waiting: a caller that already
-    holds another person's locks must never wait, or a re-key going the
-    other way completes a deadlock cycle (review).
+    variant and returns False rather than waiting.
+
+    THE RULE, and the whole reason no writer here can deadlock: **only a
+    transaction that holds no locks yet may wait for this lock.** Exactly
+    one caller qualifies, delete-my-data, which takes it as the first
+    statement of its transaction and must not lose a coin flip. Every
+    other caller may already hold something the lock's holder will want --
+    a generation lease row, a KEY SHARE from an inserted child row, the
+    previous person's rows in a re-key retry -- so they pass
+    ``blocking=False`` and degrade: a counter is a staff number, and a
+    missed one is cheaper than a deadlock that aborts somebody's real
+    work (review).
     """
     if not hashed_email or connection.vendor != "postgresql":
         return True
@@ -142,28 +155,31 @@ def _mark_person(denial_id: int) -> bool:
     ``person_counted`` on every one that lacks it; the person counts only
     if none had it.
 
+    The lock is always taken with the try variant, never waited for: this
+    runs inside whatever transaction saved the draft, which may already
+    hold the generation lease row that a delete-my-data cascade is about
+    to delete, and waiting there would let the two abort each other
+    (review). A busy lock means another writer is working on this person
+    right now -- most often the one counting them -- so the draft is
+    counted and the person is left to whoever holds it.
+
     If the denial is not among the locked rows it was re-keyed between the
     read and the lock. That attempt's savepoint is rolled back, releasing
-    its row locks, and the next attempt reads the new hash -- but it takes
-    the new person's lock with the try variant and gives up rather than
-    waiting. Waiting there, while possibly still holding the previous
-    person's advisory lock, is exactly the cycle a re-key going the other
-    way completes (review); only the first attempt, which holds no other
-    person's lock, may block. If the row is gone (the person was deleted
-    between the draft insert and this call) or has no hash, nothing is
-    counted.
+    its row locks, and the next attempt reads the new hash. If the row is
+    gone (the person was deleted between the draft insert and this call)
+    or has no hash, nothing is counted.
     """
     from fighthealthinsurance.models import Denial
 
-    for attempt in range(3):
+    for _attempt in range(3):
         hashed = _persisted_hash(denial_id)
         if not hashed:
             return False
         try:
             with transaction.atomic():  # savepoint: row locks go on rollback
-                if not person_lock(hashed, blocking=attempt == 0):
+                if not person_lock(hashed, blocking=False):
                     logger.warning(
-                        "Lifetime counters: person lock busy after a re-key; "
+                        "Lifetime counters: person busy elsewhere; "
                         "draft counted, person not"
                     )
                     return False
@@ -226,7 +242,16 @@ def _present_people(Denial):
 
 def seed_from_present_rows(apps, schema_editor) -> None:
     """Migration seed: start the counters from the rows present today, and
-    flag every present person's denials as counted. Reversible as a no-op."""
+    flag every present person's denials as counted. Reversible as a no-op.
+
+    This runs inside the migration's transaction, so the lock the AddFields
+    took on the denial and fax tables is held until the seed finishes.
+    That is seconds at this data size, which Melanie judged not worth
+    splitting up (2026-09-12). If those tables ever grow enough for the
+    pause to be felt during a deploy, move this into its own
+    ``atomic = False`` migration that walks the rows in bounded batches and
+    writes the counters row last.
+    """
     LifetimeCounters = apps.get_model("fighthealthinsurance", "LifetimeCounters")
     ProposedAppeal = apps.get_model("fighthealthinsurance", "ProposedAppeal")
     Denial = apps.get_model("fighthealthinsurance", "Denial")

--- a/fighthealthinsurance/lifetime_counters.py
+++ b/fighthealthinsurance/lifetime_counters.py
@@ -82,7 +82,7 @@ def _advisory_key(hashed_email: str) -> int:
     return int.from_bytes(digest, "big", signed=True)
 
 
-def person_lock(hashed_email: str) -> None:
+def person_lock(hashed_email: str, *, blocking: bool = True) -> bool:
     """Serialize every writer of ``person_counted`` for one person.
 
     On PostgreSQL this is a transaction-scoped advisory lock keyed on the
@@ -90,14 +90,44 @@ def person_lock(hashed_email: str) -> None:
     created for the same person and a denial moving to that person cannot
     interleave, even while the person has no rows yet to lock. Other
     backends (sqlite in tests) have no equivalent and run single-writer
-    here. Call it inside transaction.atomic(), before touching the rows.
+    here. Call it inside transaction.atomic(), before taking any row lock,
+    so every writer acquires locks in the same order.
+
+    Returns whether the lock is held. ``blocking=False`` uses the try
+    variant and returns False rather than waiting: a caller that already
+    holds another person's locks must never wait, or a re-key going the
+    other way completes a deadlock cycle (review).
     """
     if not hashed_email or connection.vendor != "postgresql":
-        return
+        return True
+    key = _advisory_key(hashed_email)
     with connection.cursor() as cursor:
-        cursor.execute(
-            "SELECT pg_advisory_xact_lock(%s)", [_advisory_key(hashed_email)]
-        )
+        if blocking:
+            cursor.execute("SELECT pg_advisory_xact_lock(%s)", [key])
+            return True
+        cursor.execute("SELECT pg_try_advisory_xact_lock(%s)", [key])
+        row = cursor.fetchone()
+        return bool(row and row[0])
+
+
+def _persisted_hash(denial_id: int) -> str:
+    """The hash the denial carries in the database right now.
+
+    Blank when the denial is gone or has no email: either way there is no
+    person to count.
+    """
+    from fighthealthinsurance.models import Denial
+
+    return (
+        Denial.objects.filter(pk=denial_id)
+        .values_list("hashed_email", flat=True)
+        .first()
+        or ""
+    )
+
+
+class _ReKeyed(Exception):
+    """The denial left the locked person between the read and the lock."""
 
 
 def _mark_person(denial_id: int) -> bool:
@@ -108,33 +138,45 @@ def _mark_person(denial_id: int) -> bool:
     email was changed by another request meanwhile (review). Takes the
     person's lock, then FOR UPDATE on their denial rows, and flips
     ``person_counted`` on every one that lacks it; the person counts only
-    if none had it. If the denial is not among the locked rows it was
-    re-keyed between the read and the lock: read again and go round with
-    the new hash. If the row is gone (the person was deleted between the
+    if none had it.
+
+    If the denial is not among the locked rows it was re-keyed between the
+    read and the lock. That attempt's savepoint is rolled back, releasing
+    its row locks, and the next attempt reads the new hash -- but it takes
+    the new person's lock with the try variant and gives up rather than
+    waiting. Waiting there, while possibly still holding the previous
+    person's advisory lock, is exactly the cycle a re-key going the other
+    way completes (review); only the first attempt, which holds nothing,
+    may block. If the row is gone (the person was deleted between the
     draft insert and this call) or has no hash, nothing is counted.
     """
     from fighthealthinsurance.models import Denial
 
-    for _attempt in range(3):
-        hashed = (
-            Denial.objects.filter(pk=denial_id)
-            .values_list("hashed_email", flat=True)
-            .first()
-        )
+    for attempt in range(3):
+        hashed = _persisted_hash(denial_id)
         if not hashed:
             return False
-        person_lock(hashed)
-        rows = list(
-            Denial.objects.select_for_update(of=("self",))
-            .filter(hashed_email=hashed)
-            .values_list("pk", "person_counted")
-        )
-        if denial_id not in {pk for pk, _flag in rows}:
+        try:
+            with transaction.atomic():  # savepoint: row locks go on rollback
+                if not person_lock(hashed, blocking=attempt == 0):
+                    logger.warning(
+                        "Lifetime counters: person lock busy after a re-key; "
+                        "draft counted, person not"
+                    )
+                    return False
+                rows = list(
+                    Denial.objects.select_for_update(of=("self",))
+                    .filter(hashed_email=hashed)
+                    .values_list("pk", "person_counted")
+                )
+                if denial_id not in {pk for pk, _flag in rows}:
+                    raise _ReKeyed
+                Denial.objects.filter(hashed_email=hashed, person_counted=False).update(
+                    person_counted=True
+                )
+                return not any(flag for _pk, flag in rows)
+        except _ReKeyed:
             continue
-        Denial.objects.filter(hashed_email=hashed, person_counted=False).update(
-            person_counted=True
-        )
-        return not any(flag for _pk, flag in rows)
     logger.warning("Lifetime counters: denial re-keyed repeatedly; not counted")
     return False
 

--- a/fighthealthinsurance/migrations/0208_dataremovaltotals.py
+++ b/fighthealthinsurance/migrations/0208_dataremovaltotals.py
@@ -1,0 +1,40 @@
+# Running totals of what delete-my-data requests removed
+# (models.DataRemovalTotals): one row, counts only, no identifiers and no
+# per-request timestamps. Updated by RemoveDataHelper inside the deletion's
+# transaction, read by the staff status page so lifetime totals survive
+# deletion. The single row is created lazily by the helper.
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        (
+            "fighthealthinsurance",
+            "0207_merge_0206_denial_triage_0206_externalservicehealth",
+        ),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="DataRemovalTotals",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("requests", models.PositiveIntegerField(default=0)),
+                ("denials", models.PositiveIntegerField(default=0)),
+                ("drafts", models.PositiveIntegerField(default=0)),
+                ("faxes_delivered", models.PositiveIntegerField(default=0)),
+                ("people_with_draft", models.PositiveIntegerField(default=0)),
+                ("since", models.DateTimeField(blank=True, null=True)),
+            ],
+        ),
+    ]

--- a/fighthealthinsurance/migrations/0208_dataremovaltotals.py
+++ b/fighthealthinsurance/migrations/0208_dataremovaltotals.py
@@ -1,10 +1,12 @@
-# Running totals of what delete-my-data requests removed
-# (models.DataRemovalTotals): one row, counts only, no identifiers and no
-# per-request timestamps. Updated by RemoveDataHelper inside the deletion's
-# transaction, read by the staff status page so lifetime totals survive
-# deletion. The single row is created lazily by the helper.
+# Two single-row counter tables for the staff status page's lifetime numbers
+# (models.LifetimeCounters, models.DataRemovalTotals) -- counters that only go
+# up and that deleting a person's data cannot change -- plus a flag on Denial
+# marking people already counted. No new identifiers. The lifetime row and
+# the flags are seeded from the rows present when this migration runs.
 
 from django.db import migrations, models
+
+from fighthealthinsurance.lifetime_counters import seed_from_present_rows
 
 
 class Migration(migrations.Migration):
@@ -17,6 +19,25 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.CreateModel(
+            name="LifetimeCounters",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("appeals_generated", models.PositiveIntegerField(default=0)),
+                ("people_with_draft", models.PositiveIntegerField(default=0)),
+                ("faxes_sent", models.PositiveIntegerField(default=0)),
+                ("faxes_delivered", models.PositiveIntegerField(default=0)),
+                ("since", models.DateTimeField(blank=True, null=True)),
+            ],
+        ),
         migrations.CreateModel(
             name="DataRemovalTotals",
             fields=[
@@ -31,10 +52,25 @@ class Migration(migrations.Migration):
                 ),
                 ("requests", models.PositiveIntegerField(default=0)),
                 ("denials", models.PositiveIntegerField(default=0)),
-                ("drafts", models.PositiveIntegerField(default=0)),
-                ("faxes_delivered", models.PositiveIntegerField(default=0)),
-                ("people_with_draft", models.PositiveIntegerField(default=0)),
                 ("since", models.DateTimeField(blank=True, null=True)),
             ],
         ),
+        migrations.AddField(
+            model_name="denial",
+            name="person_counted",
+            # db_default too: pods still on the previous image keep inserting
+            # denials without this column until the rollout replaces them.
+            field=models.BooleanField(db_default=False, default=False),
+        ),
+        migrations.AddField(
+            model_name="faxestosend",
+            name="attempt_counted",
+            field=models.BooleanField(db_default=False, default=False),
+        ),
+        migrations.AddField(
+            model_name="faxestosend",
+            name="delivery_counted",
+            field=models.BooleanField(db_default=False, default=False),
+        ),
+        migrations.RunPython(seed_from_present_rows, migrations.RunPython.noop),
     ]

--- a/fighthealthinsurance/migrations/0208_dataremovaltotals.py
+++ b/fighthealthinsurance/migrations/0208_dataremovaltotals.py
@@ -60,17 +60,17 @@ class Migration(migrations.Migration):
             name="person_counted",
             # db_default too: pods still on the previous image keep inserting
             # denials without this column until the rollout replaces them.
-            field=models.BooleanField(db_default=False, default=False),
+            field=models.BooleanField(db_default=False, default=False, editable=False),
         ),
         migrations.AddField(
             model_name="faxestosend",
             name="attempt_counted",
-            field=models.BooleanField(db_default=False, default=False),
+            field=models.BooleanField(db_default=False, default=False, editable=False),
         ),
         migrations.AddField(
             model_name="faxestosend",
             name="delivery_counted",
-            field=models.BooleanField(db_default=False, default=False),
+            field=models.BooleanField(db_default=False, default=False, editable=False),
         ),
         migrations.RunPython(seed_from_present_rows, migrations.RunPython.noop),
     ]

--- a/fighthealthinsurance/models.py
+++ b/fighthealthinsurance/models.py
@@ -2554,35 +2554,44 @@ class Denial(ExportModelOperationsMixin("Denial"), models.Model):  # type: ignor
             models.Index(fields=["created"], name="denial_created_idx"),
         ]
 
+    # The hash this instance was loaded with (from_db), so a save can tell
+    # whether the row is moving to another person. _UNLOADED = deferred or
+    # built in memory: the old value is fetched when it matters.
+    _UNLOADED: typing.Any = object()
+    _loaded_hashed_email: typing.Any = _UNLOADED
+
+    @classmethod
+    def from_db(
+        cls,
+        db: typing.Optional[str],
+        field_names: typing.Collection[str],
+        values: typing.Collection[typing.Any],
+        **kwargs: typing.Any,  # newer Django adds fetch_mode
+    ) -> typing.Self:
+        instance = super().from_db(db, field_names, values, **kwargs)
+        instance._loaded_hashed_email = instance.__dict__.get(
+            "hashed_email", cls._UNLOADED
+        )
+        return instance
+
+    def _hash_changed(self) -> bool:
+        loaded = self._loaded_hashed_email
+        if loaded is self._UNLOADED:
+            loaded = (
+                Denial.objects.filter(pk=self.pk)
+                .values_list("hashed_email", flat=True)
+                .first()
+            )
+        return bool(loaded != self.hashed_email)
+
     def save(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         # Defensive guard: latest_ucr_lookup must point at a UCRLookup whose
         # own denial FK matches this row. Without this, a bad assignment could
         # surface another denial's snapshot/context to UCREnrichmentHelper.
         # Skip the lookup query when this field isn't being touched.
         update_fields = kwargs.get("update_fields")
-        if self._state.adding and self.hashed_email and not self.person_counted:
-            # A person counted in LifetimeCounters.people_with_draft carries
-            # person_counted on every denial of theirs. A denial created later
-            # inherits it, under the same row lock lifetime_counters takes to
-            # count, so the two serialize: whichever commits first, the new
-            # row ends up flagged and the person cannot be counted again once
-            # the older denials are gone (review).
-            with transaction.atomic():
-                siblings = (
-                    Denial.objects.select_for_update(of=("self",))
-                    .filter(hashed_email=self.hashed_email)
-                    .values_list("person_counted", flat=True)
-                )
-                if any(siblings):
-                    self.person_counted = True
-                super().save(*args, **kwargs)
-            return
-        if (
-            update_fields is None
-            and self.pk is not None
-            and not self._state.adding
-            and not kwargs.get("force_insert")
-        ):
+        inserting = self._state.adding or bool(kwargs.get("force_insert"))
+        if update_fields is None and self.pk is not None and not inserting:
             # person_counted is owned by lifetime_counters and flipped with a
             # direct UPDATE: a full save of an instance loaded before that
             # flip must not write the stale False back (review). Existing
@@ -2611,7 +2620,34 @@ class Denial(ExportModelOperationsMixin("Denial"), models.Model):  # type: ignor
                         owner_denial_id, self.denial_id
                     )
                 )
-        super().save(*args, **kwargs)
+        # person_counted bookkeeping (lifetime_counters): the hash is the
+        # person, so a new row, or a row whose hash changed, adopts the
+        # counted state of the person it now belongs to. Decided under that
+        # person's lock, so it serializes with the first-draft count and with
+        # another creation for the same hash, even one that has no rows yet
+        # (review). Every other save leaves the flag alone.
+        if inserting:
+            adopt = bool(self.hashed_email)
+        else:
+            adopt = "hashed_email" in (update_fields or ()) and self._hash_changed()
+        if not adopt:
+            super().save(*args, **kwargs)
+            self._loaded_hashed_email = self.hashed_email
+            return
+        from fighthealthinsurance.lifetime_counters import person_lock
+
+        with transaction.atomic():
+            person_lock(self.hashed_email)
+            counted = Denial.objects.filter(
+                hashed_email=self.hashed_email, person_counted=True
+            )
+            if self.pk is not None:
+                counted = counted.exclude(pk=self.pk)
+            self.person_counted = bool(self.hashed_email) and counted.exists()
+            if update_fields is not None and "person_counted" not in update_fields:
+                kwargs["update_fields"] = [*update_fields, "person_counted"]
+            super().save(*args, **kwargs)
+        self._loaded_hashed_email = self.hashed_email
 
     @classmethod
     def filter_to_allowed_denials(cls, current_user: User):

--- a/fighthealthinsurance/models.py
+++ b/fighthealthinsurance/models.py
@@ -4053,6 +4053,40 @@ class ModelHealthAlertState(models.Model):
         return f"ModelHealthAlertState<{self.key}@{self.last_alert_sent}>"
 
 
+class DataRemovalTotals(models.Model):
+    """Running totals of what delete-my-data requests removed, as counts.
+
+    The delete flow removes a person's denials, drafts and faxes outright,
+    which silently lowers every lifetime total on the staff status page.
+    Ids come from sequences, so "ever created" survives deletion on its
+    own; what does not survive is whether a deleted fax had been delivered
+    and whether a deleted person had ever received a real draft. Those two
+    facts are added to this ONE row at deletion time and added back by the
+    status page.
+
+    One row, not one per request: a per-request row carried a timestamp
+    that a database reader could line up with UsedDeleteToken.used_at and
+    so tie the counts to a hashed email (review). ``since`` is set once,
+    for the whole counter. The row is updated inside the deletion's own
+    transaction and locked for its duration, so counts and deletion commit
+    together and two overlapping requests for one person cannot count the
+    same rows twice. A person who deletes and later returns is counted
+    again; nothing here says who they were.
+    """
+
+    SINGLETON_ID = 1
+
+    requests = models.PositiveIntegerField(default=0)
+    denials = models.PositiveIntegerField(default=0)
+    drafts = models.PositiveIntegerField(default=0)
+    faxes_delivered = models.PositiveIntegerField(default=0)
+    people_with_draft = models.PositiveIntegerField(default=0)
+    since = models.DateTimeField(null=True, blank=True)
+
+    def __str__(self) -> str:
+        return f"DataRemovalTotals<{self.requests} requests>"
+
+
 class ExternalServiceHealth(models.Model):
     """Last outcome of calls to one external service, shared across pods.
 

--- a/fighthealthinsurance/models.py
+++ b/fighthealthinsurance/models.py
@@ -2554,36 +2554,6 @@ class Denial(ExportModelOperationsMixin("Denial"), models.Model):  # type: ignor
             models.Index(fields=["created"], name="denial_created_idx"),
         ]
 
-    # The hash this instance was loaded with (from_db), so a save can tell
-    # whether the row is moving to another person. _UNLOADED = deferred or
-    # built in memory: the old value is fetched when it matters.
-    _UNLOADED: typing.Any = object()
-    _loaded_hashed_email: typing.Any = _UNLOADED
-
-    @classmethod
-    def from_db(
-        cls,
-        db: typing.Optional[str],
-        field_names: typing.Collection[str],
-        values: typing.Collection[typing.Any],
-        **kwargs: typing.Any,  # newer Django adds fetch_mode
-    ) -> typing.Self:
-        instance = super().from_db(db, field_names, values, **kwargs)
-        instance._loaded_hashed_email = instance.__dict__.get(
-            "hashed_email", cls._UNLOADED
-        )
-        return instance
-
-    def _hash_changed(self) -> bool:
-        loaded = self._loaded_hashed_email
-        if loaded is self._UNLOADED:
-            loaded = (
-                Denial.objects.filter(pk=self.pk)
-                .values_list("hashed_email", flat=True)
-                .first()
-            )
-        return bool(loaded != self.hashed_email)
-
     def save(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         # Defensive guard: latest_ucr_lookup must point at a UCRLookup whose
         # own denial FK matches this row. Without this, a bad assignment could
@@ -2620,34 +2590,42 @@ class Denial(ExportModelOperationsMixin("Denial"), models.Model):  # type: ignor
                         owner_denial_id, self.denial_id
                     )
                 )
-        # person_counted bookkeeping (lifetime_counters): the hash is the
-        # person, so a new row, or a row whose hash changed, adopts the
-        # counted state of the person it now belongs to. Decided under that
-        # person's lock, so it serializes with the first-draft count and with
-        # another creation for the same hash, even one that has no rows yet
-        # (review). Every other save leaves the flag alone.
-        if inserting:
-            adopt = bool(self.hashed_email)
-        else:
-            adopt = "hashed_email" in (update_fields or ()) and self._hash_changed()
-        if not adopt:
+        if not (inserting or "hashed_email" in (update_fields or ())):
             super().save(*args, **kwargs)
-            self._loaded_hashed_email = self.hashed_email
             return
+        # person_counted bookkeeping (lifetime_counters): the hash is the
+        # person, so a new row, or a row whose hash changes, adopts the
+        # counted state of the person it now belongs to. Whether the hash
+        # changes is decided against the ROW, locked, never against what
+        # this instance remembers: a stale instance re-saving a move that
+        # already happened is not a move (review). The person's lock comes
+        # first, before any row lock, the same order the first-draft count
+        # uses, so the writers for one person serialize without a cycle.
         from fighthealthinsurance.lifetime_counters import person_lock
 
         with transaction.atomic():
-            person_lock(self.hashed_email)
-            counted = Denial.objects.filter(
-                hashed_email=self.hashed_email, person_counted=True
-            )
-            if self.pk is not None:
-                counted = counted.exclude(pk=self.pk)
-            self.person_counted = bool(self.hashed_email) and counted.exists()
-            if update_fields is not None and "person_counted" not in update_fields:
-                kwargs["update_fields"] = [*update_fields, "person_counted"]
+            if self.hashed_email:  # no person, nothing to serialize with
+                person_lock(self.hashed_email)
+            if inserting:
+                moved = True
+            else:
+                persisted = (
+                    Denial.objects.select_for_update(of=("self",))
+                    .filter(pk=self.pk)
+                    .values_list("hashed_email", flat=True)
+                    .first()
+                )
+                moved = persisted is not None and persisted != self.hashed_email
+            if moved:
+                counted = Denial.objects.filter(
+                    hashed_email=self.hashed_email, person_counted=True
+                )
+                if self.pk is not None:
+                    counted = counted.exclude(pk=self.pk)
+                self.person_counted = bool(self.hashed_email) and counted.exists()
+                if update_fields is not None and "person_counted" not in update_fields:
+                    kwargs["update_fields"] = [*update_fields, "person_counted"]
             super().save(*args, **kwargs)
-        self._loaded_hashed_email = self.hashed_email
 
     @classmethod
     def filter_to_allowed_denials(cls, current_user: User):

--- a/fighthealthinsurance/models.py
+++ b/fighthealthinsurance/models.py
@@ -1871,6 +1871,12 @@ class FaxesToSend(ExportModelOperationsMixin("FaxesToSend"), models.Model):  # t
     # Idempotency guard so a retried send (e.g. Temporal's at-least-once activity
     # execution) never faxes the recipient twice.
     vendor_send_completed = models.BooleanField(default=False)
+    # Set once, ever, by finalize_fax when the lifetime counters count this
+    # row's first attempt and first confirmed delivery (lifetime_counters.py).
+    # `sent` and `fax_success` describe the LATEST attempt and are reset by a
+    # resend; these two are never reset, so a resend cannot count again.
+    attempt_counted = models.BooleanField(default=False, db_default=False)
+    delivery_counted = models.BooleanField(default=False, db_default=False)
     # Professional we may use different backends.
     professional = models.BooleanField(default=False)
     for_appeal = models.ForeignKey(
@@ -2293,6 +2299,12 @@ class Denial(ExportModelOperationsMixin("Denial"), models.Model):  # type: ignor
     denial_id = models.AutoField(primary_key=True, null=False)
     uuid = models.CharField(max_length=300, default=uuid.uuid4, editable=False)
     hashed_email = models.CharField(max_length=300, primary_key=False)
+    # Set on every denial of a person the moment their first generated draft
+    # is counted in LifetimeCounters.people_with_draft (lifetime_counters.py).
+    # Lives on rows that already carry the hash and go with them on deletion,
+    # so no separate identifier is retained; a person who deletes and returns
+    # starts unflagged and is counted again.
+    person_counted = models.BooleanField(default=False, db_default=False)
     denial_text = models.TextField(primary_key=False)
     date_of_service_text = models.TextField(primary_key=False, null=True, blank=True)
     denial_type_text = models.TextField(max_length=200, null=True, blank=True)
@@ -2516,6 +2528,26 @@ class Denial(ExportModelOperationsMixin("Denial"), models.Model):  # type: ignor
         # surface another denial's snapshot/context to UCREnrichmentHelper.
         # Skip the lookup query when this field isn't being touched.
         update_fields = kwargs.get("update_fields")
+        if (
+            update_fields is None
+            and self.pk is not None
+            and not self._state.adding
+            and not kwargs.get("force_insert")
+        ):
+            # person_counted is owned by lifetime_counters and flipped with a
+            # direct UPDATE: a full save of an instance loaded before that
+            # flip must not write the stale False back (review). Existing
+            # rows saved without update_fields get one that excludes it, and
+            # excludes deferred fields the way Django itself would.
+            deferred = self.get_deferred_fields()
+            kwargs["update_fields"] = [
+                f.name
+                for f in self._meta.concrete_fields
+                if not f.primary_key
+                and f.name != "person_counted"
+                and f.attname not in deferred  # deferred names are attnames
+            ]
+            update_fields = kwargs["update_fields"]
         check_lookup = update_fields is None or "latest_ucr_lookup" in update_fields
         if check_lookup and self.latest_ucr_lookup_id:
             owner_denial_id = (
@@ -4053,34 +4085,41 @@ class ModelHealthAlertState(models.Model):
         return f"ModelHealthAlertState<{self.key}@{self.last_alert_sent}>"
 
 
+class LifetimeCounters(models.Model):
+    """Lifetime totals that only ever go up (see lifetime_counters.py).
+
+    One row, no identifiers. ``appeals_generated`` and ``people_with_draft``
+    are bumped when a generated draft row is saved, ``faxes_delivered`` when
+    a fax send succeeds. Deleting a person's data changes none of them:
+    that is the point. Seeded once, at migration time, from the rows
+    present then (``since``).
+    """
+
+    SINGLETON_ID = 1
+
+    appeals_generated = models.PositiveIntegerField(default=0)
+    people_with_draft = models.PositiveIntegerField(default=0)
+    faxes_sent = models.PositiveIntegerField(default=0)
+    faxes_delivered = models.PositiveIntegerField(default=0)
+    since = models.DateTimeField(null=True, blank=True)
+
+    def __str__(self) -> str:
+        return f"LifetimeCounters<{self.appeals_generated} drafts>"
+
+
 class DataRemovalTotals(models.Model):
-    """Running totals of what delete-my-data requests removed, as counts.
+    """Running count of delete-my-data requests, and the denials they took.
 
-    The delete flow removes a person's denials, drafts and faxes outright,
-    which silently lowers every lifetime total on the staff status page.
-    Ids come from sequences, so "ever created" survives deletion on its
-    own; what does not survive is whether a deleted fax had been delivered
-    and whether a deleted person had ever received a real draft. Those two
-    facts are added to this ONE row at deletion time and added back by the
-    status page.
-
-    One row, not one per request: a per-request row carried a timestamp
-    that a database reader could line up with UsedDeleteToken.used_at and
-    so tie the counts to a hashed email (review). ``since`` is set once,
-    for the whole counter. The row is updated inside the deletion's own
-    transaction and locked for its duration, so counts and deletion commit
-    together and two overlapping requests for one person cannot count the
-    same rows twice. A person who deletes and later returns is counted
-    again; nothing here says who they were.
+    One row, counts only, no per-request timestamps (a timestamped row per
+    request could be lined up with UsedDeleteToken.used_at and tied to a
+    hashed email). Updated inside the deletion's own transaction so the
+    count and the deletion commit or roll back together.
     """
 
     SINGLETON_ID = 1
 
     requests = models.PositiveIntegerField(default=0)
     denials = models.PositiveIntegerField(default=0)
-    drafts = models.PositiveIntegerField(default=0)
-    faxes_delivered = models.PositiveIntegerField(default=0)
-    people_with_draft = models.PositiveIntegerField(default=0)
     since = models.DateTimeField(null=True, blank=True)
 
     def __str__(self) -> str:

--- a/fighthealthinsurance/models.py
+++ b/fighthealthinsurance/models.py
@@ -1875,8 +1875,13 @@ class FaxesToSend(ExportModelOperationsMixin("FaxesToSend"), models.Model):  # t
     # row's first attempt and first confirmed delivery (lifetime_counters.py).
     # `sent` and `fax_success` describe the LATEST attempt and are reset by a
     # resend; these two are never reset, so a resend cannot count again.
-    attempt_counted = models.BooleanField(default=False, db_default=False)
-    delivery_counted = models.BooleanField(default=False, db_default=False)
+    # editable=False keeps them off every ModelForm, the admin included.
+    attempt_counted = models.BooleanField(
+        default=False, db_default=False, editable=False
+    )
+    delivery_counted = models.BooleanField(
+        default=False, db_default=False, editable=False
+    )
     # Professional we may use different backends.
     professional = models.BooleanField(default=False)
     for_appeal = models.ForeignKey(
@@ -2263,6 +2268,31 @@ class FaxesToSend(ExportModelOperationsMixin("FaxesToSend"), models.Model):  # t
     def __str__(self):
         return f"{self.fax_id} -- {self.email} -- {self.paid} -- {self.fax_success} -- {self.name}"
 
+    LIFETIME_MARKERS = ("attempt_counted", "delivery_counted")
+
+    def save(self, *args: typing.Any, **kwargs: typing.Any) -> None:
+        # attempt_counted / delivery_counted are owned by finalize_fax and
+        # set with direct UPDATEs. A full save of an instance loaded before
+        # that (resend, precheck, remote_send_fax, admin) must not write the
+        # stale False back, or the next finalize counts the fax again
+        # (review). Existing rows saved without update_fields get one that
+        # excludes the markers and deferred fields, as Denial.save does.
+        if (
+            kwargs.get("update_fields") is None
+            and self.pk is not None
+            and not self._state.adding
+            and not kwargs.get("force_insert")
+        ):
+            deferred = self.get_deferred_fields()
+            kwargs["update_fields"] = [
+                f.name
+                for f in self._meta.concrete_fields
+                if not f.primary_key
+                and f.name not in self.LIFETIME_MARKERS
+                and f.attname not in deferred
+            ]
+        super().save(*args, **kwargs)
+
 
 class DenialTypesRelation(models.Model):
     """Many-to-many through table linking denials to their denial types with source tracking."""
@@ -2304,7 +2334,9 @@ class Denial(ExportModelOperationsMixin("Denial"), models.Model):  # type: ignor
     # Lives on rows that already carry the hash and go with them on deletion,
     # so no separate identifier is retained; a person who deletes and returns
     # starts unflagged and is counted again.
-    person_counted = models.BooleanField(default=False, db_default=False)
+    person_counted = models.BooleanField(
+        default=False, db_default=False, editable=False
+    )
     denial_text = models.TextField(primary_key=False)
     date_of_service_text = models.TextField(primary_key=False, null=True, blank=True)
     denial_type_text = models.TextField(max_length=200, null=True, blank=True)

--- a/fighthealthinsurance/models.py
+++ b/fighthealthinsurance/models.py
@@ -2560,6 +2560,23 @@ class Denial(ExportModelOperationsMixin("Denial"), models.Model):  # type: ignor
         # surface another denial's snapshot/context to UCREnrichmentHelper.
         # Skip the lookup query when this field isn't being touched.
         update_fields = kwargs.get("update_fields")
+        if self._state.adding and self.hashed_email and not self.person_counted:
+            # A person counted in LifetimeCounters.people_with_draft carries
+            # person_counted on every denial of theirs. A denial created later
+            # inherits it, under the same row lock lifetime_counters takes to
+            # count, so the two serialize: whichever commits first, the new
+            # row ends up flagged and the person cannot be counted again once
+            # the older denials are gone (review).
+            with transaction.atomic():
+                siblings = (
+                    Denial.objects.select_for_update(of=("self",))
+                    .filter(hashed_email=self.hashed_email)
+                    .values_list("person_counted", flat=True)
+                )
+                if any(siblings):
+                    self.person_counted = True
+                super().save(*args, **kwargs)
+            return
         if (
             update_fields is None
             and self.pk is not None

--- a/fighthealthinsurance/rest_serializers.py
+++ b/fighthealthinsurance/rest_serializers.py
@@ -264,7 +264,8 @@ class DenialModelSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Denial
-        exclude: list[str] = []
+        # Staff-page bookkeeping (lifetime_counters), not denial data.
+        exclude: list[str] = ["person_counted"]
 
 
 class AppealDetailSerializer(serializers.ModelSerializer):

--- a/fighthealthinsurance/staff_views.py
+++ b/fighthealthinsurance/staff_views.py
@@ -384,7 +384,16 @@ class AdminStatusView(generic.TemplateView):
                 stale_attempts=Count("fax_id", filter=unsent & stale_attempt),
                 failures_recent=Count(
                     "fax_id",
-                    filter=Q(sent=True, fax_success=False, date__gte=week_ago),
+                    # Recent by ATTEMPT, falling back to creation for rows
+                    # never stamped: the same window the Fax delivery panel
+                    # uses, so the two cards cannot disagree. Keyed on
+                    # creation alone, a resend of an old fax that failed
+                    # again could never appear here (review).
+                    filter=Q(sent=True, fax_success=False)
+                    & (
+                        Q(attempting_to_send_as_of__gte=week_ago)
+                        | Q(date__gte=week_ago)
+                    ),
                 ),
             )
             out.update(counts)

--- a/fighthealthinsurance/staff_views.py
+++ b/fighthealthinsurance/staff_views.py
@@ -6,7 +6,9 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from django.core.exceptions import ValidationError
 from django.db import transaction
-from django.db.models import Avg, Count, F, Max, QuerySet
+from django.db import connection
+from django.db.models import Avg, Count, F, Max, Min, QuerySet
+from django.utils.dateparse import parse_datetime
 from django.db.models.functions import Lower
 from django.http import HttpResponse, HttpResponseBase, StreamingHttpResponse
 from django.shortcuts import redirect, render
@@ -138,6 +140,87 @@ class StaffDashboardView(generic.TemplateView):
     template_name = "staff_dashboard.html"
 
 
+def _lifetime_snapshot() -> Dict[str, Any]:
+    """The lifetime figures that must agree with each other, in ONE statement.
+
+    Live delivered faxes, the oldest such row's creation date, live distinct
+    people with a real draft, and the running totals removed by delete-my-
+    data requests. One statement is one snapshot on Postgres, so a deletion
+    committing mid-page cannot be counted both as live and as removed
+    (review). Plain SQL that sqlite (tests) and Postgres (prod) both accept.
+    """
+    from fighthealthinsurance.models import (
+        DataRemovalTotals,
+        Denial,
+        FaxesToSend,
+        ProposedAppeal,
+    )
+
+    fax = FaxesToSend._meta.db_table
+    denial = Denial._meta.db_table
+    draft = ProposedAppeal._meta.db_table
+    totals = DataRemovalTotals._meta.db_table
+    sql = f"""
+        SELECT
+          (SELECT COUNT(*) FROM {fax} WHERE fax_success) AS live_delivered,
+          (SELECT MIN(date) FROM {fax} WHERE fax_success) AS oldest_delivered_created,
+          (SELECT COUNT(DISTINCT d.hashed_email) FROM {denial} d
+             WHERE d.hashed_email <> ''
+               AND EXISTS (SELECT 1 FROM {draft} p
+                           WHERE p.for_denial_id = d.denial_id AND NOT p.speculative)
+          ) AS live_people,
+          (SELECT COALESCE(SUM(t.faxes_delivered), 0) FROM {totals} t) AS removed_delivered,
+          (SELECT COALESCE(SUM(t.people_with_draft), 0) FROM {totals} t) AS removed_people,
+          (SELECT COALESCE(SUM(t.requests), 0) FROM {totals} t) AS removal_requests,
+          (SELECT MIN(t.since) FROM {totals} t) AS removals_since
+    """
+    with connection.cursor() as cursor:
+        cursor.execute(sql)
+        row = cursor.fetchone()
+    keys = (
+        "live_delivered",
+        "oldest_delivered_created",
+        "live_people",
+        "removed_delivered",
+        "removed_people",
+        "removal_requests",
+        "removals_since",
+    )
+    out = dict(zip(keys, row))
+    for key in ("oldest_delivered_created", "removals_since"):
+        # sqlite hands datetimes back as strings; Postgres as datetimes.
+        val = out[key]
+        if isinstance(val, str):
+            out[key] = parse_datetime(val)
+    out["delivered_all_time"] = out["live_delivered"] + out["removed_delivered"]
+    out["people_with_draft_lifetime"] = out["live_people"] + out["removed_people"]
+    return out
+
+
+def _sequence_value(model, column: str) -> Optional[int]:
+    """The id sequence's current value: how many rows were EVER created,
+    which deletion cannot lower (Melanie, 2026-09-11). Not Max(id) of the
+    remaining rows, which drops the moment the newest row is deleted
+    (review). Postgres and sqlite both keep such a counter; anything else
+    gets None and the page says so. A rolled-back insert consumes an id, so
+    this is a ceiling by a hair."""
+    table = model._meta.db_table
+    with connection.cursor() as cursor:
+        if connection.vendor == "postgresql":
+            cursor.execute("SELECT pg_get_serial_sequence(%s, %s)", [table, column])
+            seq = cursor.fetchone()[0]
+            if not seq:
+                return None
+            cursor.execute(f"SELECT last_value, is_called FROM {seq}")
+            last_value, is_called = cursor.fetchone()
+            return int(last_value) if is_called else 0
+        if connection.vendor == "sqlite":
+            cursor.execute("SELECT seq FROM sqlite_sequence WHERE name = %s", [table])
+            row = cursor.fetchone()
+            return int(row[0]) if row else 0
+    return None
+
+
 class AdminStatusView(generic.TemplateView):
     """Staff system-status dashboard.
 
@@ -171,7 +254,11 @@ class AdminStatusView(generic.TemplateView):
         ctx["fax"] = self._fax_backend_status()
         ctx["fax_queue"] = self._fax_queue_status()
         ctx["temporal"] = self._temporal_status()
-        ctx["fax_outcomes"] = self._fax_outcome_status()
+        # One lifetime snapshot (one statement) feeds both panels so they can
+        # never disagree within a page load (review).
+        snapshot = self._lifetime()
+        ctx["fax_outcomes"] = self._fax_outcome_status(snapshot)
+        ctx["all_time"] = self._all_time_status(snapshot)
         ctx["intake_funnel"] = self._intake_funnel_status()
         ctx["letter_scoring"] = self._letter_scoring_status()
         ctx["storage"] = self._storage_status()
@@ -258,10 +345,43 @@ class AdminStatusView(generic.TemplateView):
 
     @staticmethod
     def _fax_queue_status() -> Dict[str, Any]:
-        """Counts of queued / pending / failed faxes from FaxesToSend.
+        """Counts of queued / stuck / abandoned / failed faxes from FaxesToSend.
 
-        Mirrors what the fax actor acts on: it sends faxes that are
-        ``should_send=True, sent=False`` and at least an hour old.
+        The buckets staff act on:
+
+        * ``ready_queued``: confirmed by the user (``should_send=True``) and
+          not yet sent. The sender picks these up.
+        * ``due_now``: the subset older than an hour. A non-zero value here is
+          a STUCK fax -- the sender should already have taken it.
+        * ``awaiting_confirmation``: consumer rows never confirmed and never
+          attempted. Mostly drafts whose user never clicked send in the
+          confirmation email (they accumulate for months), but the consumer
+          appeal-staging path also creates paid rows before dispatching, so
+          a dispatch that fails there lands here too; the label does not
+          call this bucket "not actionable" (review). Telling those two apart
+          needs a send-intent flag on the row: follow-up, not this change.
+        * ``in_flight``: an attempt started in the last two hours that has not
+          finished. Unbounded, this counter showed rows from January whose
+          ``attempting_to_send_as_of`` was never cleared (2026-09-11).
+        * ``stale_attempts``: an attempt started MORE than two hours ago that
+          never finished: a worker died mid-send, or a row that nothing will
+          ever clear. These are the actionable leftovers, kept visible on
+          purpose (review): the professional path dispatches without
+          ``should_send``, so a stranded send there is not "queued" either.
+        * ``failures_recent``: sent in the last week and not delivered.
+
+        * ``requested_unpicked``: a professional's fax. That path dispatches
+          without ``should_send`` (fax_helpers.stage_appeal_as_fax), so a
+          requested, paid send that never reached precheck would otherwise
+          sit in the "never confirmed" bucket and be called not actionable
+          (review). Non-zero here is a stranded send.
+
+        ``due_now`` counts only rows the sender never touched (no attempt
+        timestamp): an attempted leftover is a stale attempt, not "not
+        taken", so one fax never lights two red cards. ``awaiting_confirmation``
+        excludes anything ever attempted and anything professional. All the
+        buckets come from ONE aggregate query so a row that moves bucket
+        mid-refresh cannot be counted in two (review).
         """
         out: Dict[str, Any] = {"ok": True, "error": None}
         try:
@@ -269,21 +389,42 @@ class AdminStatusView(generic.TemplateView):
 
             now = timezone.now()
             one_hour_ago = now - datetime.timedelta(hours=1)
+            two_hours_ago = now - datetime.timedelta(hours=2)
             week_ago = now - datetime.timedelta(days=7)
 
-            unsent = FaxesToSend.objects.filter(sent=False)
-            out["unsent_total"] = unsent.count()
-            out["ready_queued"] = unsent.filter(should_send=True).count()
-            out["due_now"] = unsent.filter(
-                should_send=True, date__lt=one_hour_ago
-            ).count()
-            out["awaiting_confirmation"] = unsent.filter(should_send=False).count()
-            out["in_flight"] = unsent.filter(
-                attempting_to_send_as_of__isnull=False
-            ).count()
-            out["failures_recent"] = FaxesToSend.objects.filter(
-                sent=True, fax_success=False, date__gte=week_ago
-            ).count()
+            unsent = Q(sent=False)
+            never_attempted = Q(attempting_to_send_as_of__isnull=True)
+            live_attempt = Q(attempting_to_send_as_of__gte=two_hours_ago)
+            stale_attempt = Q(attempting_to_send_as_of__lt=two_hours_ago)
+            counts = FaxesToSend.objects.aggregate(
+                unsent_total=Count("fax_id", filter=unsent),
+                ready_queued=Count("fax_id", filter=unsent & Q(should_send=True)),
+                due_now=Count(
+                    "fax_id",
+                    filter=unsent
+                    & never_attempted
+                    & Q(should_send=True, date__lt=one_hour_ago),
+                ),
+                awaiting_confirmation=Count(
+                    "fax_id",
+                    filter=unsent
+                    & never_attempted
+                    & Q(should_send=False, professional=False),
+                ),
+                requested_unpicked=Count(
+                    "fax_id",
+                    filter=unsent
+                    & never_attempted
+                    & Q(should_send=False, professional=True),
+                ),
+                in_flight=Count("fax_id", filter=unsent & live_attempt),
+                stale_attempts=Count("fax_id", filter=unsent & stale_attempt),
+                failures_recent=Count(
+                    "fax_id",
+                    filter=Q(sent=True, fax_success=False, date__gte=week_ago),
+                ),
+            )
+            out.update(counts)
         except Exception as e:
             logger.opt(exception=True).error("Error computing fax queue status")
             out["ok"] = False
@@ -291,7 +432,75 @@ class AdminStatusView(generic.TemplateView):
         return out
 
     @staticmethod
-    def _fax_outcome_status() -> Dict[str, Any]:
+    def _lifetime() -> Optional[Dict[str, Any]]:
+        """None when the snapshot failed: the panels then say "unavailable"
+        rather than render a fabricated zero, and neither retries on its own
+        (a retry would reopen the two-panels-disagree problem) (review)."""
+        try:
+            return _lifetime_snapshot()
+        except Exception:
+            logger.opt(exception=True).error("Error computing the lifetime snapshot")
+            return None
+
+    @staticmethod
+    def _all_time_status(snapshot: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        """Lifetime totals (Melanie, 2026-09-11).
+
+        "Ever created" comes from the id sequences and survives deletion.
+        People who got a real draft and faxes delivered are the two facts a
+        sequence cannot give; they are live counts plus what delete-my-data
+        requests removed (DataRemovalTotals), from the day that counter
+        shipped onwards. "Got a draft" excludes speculative precomputes
+        held in reserve (matches the intake funnel) and blank email hashes.
+        """
+        out: Dict[str, Any] = {"ok": True, "error": None}
+        try:
+            from fighthealthinsurance.models import Denial, FaxesToSend, ProposedAppeal
+
+            live = Denial.objects.aggregate(
+                denials=Count("denial_id"), first=Min("date")
+            )
+            out["denials"] = live["denials"]
+            out["first_denial"] = live["first"]
+            out["drafts"] = ProposedAppeal.objects.count()
+            out["denials_with_draft"] = (
+                Denial.objects.filter(proposedappeal__speculative=False)
+                .values("pk")
+                .distinct()
+                .count()
+            )
+            out["denials_ever"] = _sequence_value(Denial, "denial_id")
+            out["drafts_ever"] = _sequence_value(ProposedAppeal, "id")
+            out["faxes_ever"] = _sequence_value(FaxesToSend, "fax_id")
+            if snapshot is None:
+                for key in (
+                    "people_with_draft",
+                    "faxes_delivered",
+                    "people_with_draft_lifetime",
+                    "faxes_delivered_lifetime",
+                    "removal_requests",
+                    "removals_since",
+                ):
+                    out[key] = None
+            else:
+                out["people_with_draft"] = snapshot["live_people"]
+                out["faxes_delivered"] = snapshot["live_delivered"]
+                out["people_with_draft_lifetime"] = snapshot[
+                    "people_with_draft_lifetime"
+                ]
+                out["faxes_delivered_lifetime"] = snapshot["delivered_all_time"]
+                out["removal_requests"] = snapshot["removal_requests"]
+                out["removals_since"] = snapshot["removals_since"]
+        except Exception as e:
+            logger.opt(exception=True).error("Error computing all-time status")
+            out["ok"] = False
+            out["error"] = str(e)
+        return out
+
+    @staticmethod
+    def _fax_outcome_status(
+        snapshot: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
         """Fax delivery outcomes (last 7 days) from the database.
 
         The Temporal panel above shows workflow *status*, where "Completed"
@@ -328,6 +537,18 @@ class AdminStatusView(generic.TemplateView):
             return {
                 "sent": recent.count(),
                 "delivered": recent.filter(fax_success=True).count(),
+                # Melanie (2026-09-11): the number that matters over time. One
+                # aggregate, so the count and the date come from one snapshot
+                # (review). `date` is the row's creation time; nothing records
+                # the delivery time, so the label says "oldest ... created".
+                # Lifetime delivered = rows present + removed by deletion
+                # requests, from the one-statement snapshot (review).
+                "delivered_all_time": (
+                    None if snapshot is None else snapshot["delivered_all_time"]
+                ),
+                "oldest_delivered_created": (
+                    None if snapshot is None else snapshot["oldest_delivered_created"]
+                ),
                 "failed": failed_qs.count(),
                 "stuck_claims": failed_qs.filter(vendor_send_completed=True).count(),
                 "recent_failures": failed,

--- a/fighthealthinsurance/staff_views.py
+++ b/fighthealthinsurance/staff_views.py
@@ -8,7 +8,6 @@ from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.db import connection
 from django.db.models import Avg, Count, F, Max, Min, QuerySet
-from django.utils.dateparse import parse_datetime
 from django.db.models.functions import Lower
 from django.http import HttpResponse, HttpResponseBase, StreamingHttpResponse
 from django.shortcuts import redirect, render
@@ -140,61 +139,26 @@ class StaffDashboardView(generic.TemplateView):
     template_name = "staff_dashboard.html"
 
 
-def _lifetime_snapshot() -> Dict[str, Any]:
-    """The lifetime figures that must agree with each other, in ONE statement.
+def _lifetime_counters() -> Dict[str, Any]:
+    """The lifetime numbers: counters that only go up (lifetime_counters.py)
+    plus the running deletion count. Raises on failure; the caller renders
+    "unavailable" rather than a fabricated zero."""
+    from fighthealthinsurance.models import DataRemovalTotals, LifetimeCounters
 
-    Live delivered faxes, the oldest such row's creation date, live distinct
-    people with a real draft, and the running totals removed by delete-my-
-    data requests. One statement is one snapshot on Postgres, so a deletion
-    committing mid-page cannot be counted both as live and as removed
-    (review). Plain SQL that sqlite (tests) and Postgres (prod) both accept.
-    """
-    from fighthealthinsurance.models import (
-        DataRemovalTotals,
-        Denial,
-        FaxesToSend,
-        ProposedAppeal,
-    )
-
-    fax = FaxesToSend._meta.db_table
-    denial = Denial._meta.db_table
-    draft = ProposedAppeal._meta.db_table
-    totals = DataRemovalTotals._meta.db_table
-    sql = f"""
-        SELECT
-          (SELECT COUNT(*) FROM {fax} WHERE fax_success) AS live_delivered,
-          (SELECT MIN(date) FROM {fax} WHERE fax_success) AS oldest_delivered_created,
-          (SELECT COUNT(DISTINCT d.hashed_email) FROM {denial} d
-             WHERE d.hashed_email <> ''
-               AND EXISTS (SELECT 1 FROM {draft} p
-                           WHERE p.for_denial_id = d.denial_id AND NOT p.speculative)
-          ) AS live_people,
-          (SELECT COALESCE(SUM(t.faxes_delivered), 0) FROM {totals} t) AS removed_delivered,
-          (SELECT COALESCE(SUM(t.people_with_draft), 0) FROM {totals} t) AS removed_people,
-          (SELECT COALESCE(SUM(t.requests), 0) FROM {totals} t) AS removal_requests,
-          (SELECT MIN(t.since) FROM {totals} t) AS removals_since
-    """
-    with connection.cursor() as cursor:
-        cursor.execute(sql)
-        row = cursor.fetchone()
-    keys = (
-        "live_delivered",
-        "oldest_delivered_created",
-        "live_people",
-        "removed_delivered",
-        "removed_people",
-        "removal_requests",
-        "removals_since",
-    )
-    out = dict(zip(keys, row))
-    for key in ("oldest_delivered_created", "removals_since"):
-        # sqlite hands datetimes back as strings; Postgres as datetimes.
-        val = out[key]
-        if isinstance(val, str):
-            out[key] = parse_datetime(val)
-    out["delivered_all_time"] = out["live_delivered"] + out["removed_delivered"]
-    out["people_with_draft_lifetime"] = out["live_people"] + out["removed_people"]
-    return out
+    counters = LifetimeCounters.objects.filter(pk=LifetimeCounters.SINGLETON_ID).first()
+    removals = DataRemovalTotals.objects.filter(
+        pk=DataRemovalTotals.SINGLETON_ID
+    ).first()
+    return {
+        "appeals_generated": counters.appeals_generated if counters else 0,
+        "people_with_draft_lifetime": counters.people_with_draft if counters else 0,
+        "faxes_sent_lifetime": counters.faxes_sent if counters else 0,
+        "faxes_delivered_lifetime": counters.faxes_delivered if counters else 0,
+        "counting_since": counters.since if counters else None,
+        "removal_requests": removals.requests if removals else 0,
+        "removed_denials": removals.denials if removals else 0,
+        "removals_since": removals.since if removals else None,
+    }
 
 
 def _sequence_value(model, column: str) -> Optional[int]:
@@ -254,11 +218,10 @@ class AdminStatusView(generic.TemplateView):
         ctx["fax"] = self._fax_backend_status()
         ctx["fax_queue"] = self._fax_queue_status()
         ctx["temporal"] = self._temporal_status()
-        # One lifetime snapshot (one statement) feeds both panels so they can
-        # never disagree within a page load (review).
-        snapshot = self._lifetime()
-        ctx["fax_outcomes"] = self._fax_outcome_status(snapshot)
-        ctx["all_time"] = self._all_time_status(snapshot)
+        # The lifetime counters are read once and feed both panels.
+        counters = self._lifetime()
+        ctx["fax_outcomes"] = self._fax_outcome_status(counters)
+        ctx["all_time"] = self._all_time_status(counters)
         ctx["intake_funnel"] = self._intake_funnel_status()
         ctx["letter_scoring"] = self._letter_scoring_status()
         ctx["storage"] = self._storage_status()
@@ -433,25 +396,21 @@ class AdminStatusView(generic.TemplateView):
 
     @staticmethod
     def _lifetime() -> Optional[Dict[str, Any]]:
-        """None when the snapshot failed: the panels then say "unavailable"
-        rather than render a fabricated zero, and neither retries on its own
-        (a retry would reopen the two-panels-disagree problem) (review)."""
+        """None when the counters could not be read: the panels then say
+        "unavailable" rather than render a fabricated zero."""
         try:
-            return _lifetime_snapshot()
+            return _lifetime_counters()
         except Exception:
-            logger.opt(exception=True).error("Error computing the lifetime snapshot")
+            logger.opt(exception=True).error("Error reading the lifetime counters")
             return None
 
     @staticmethod
-    def _all_time_status(snapshot: Optional[Dict[str, Any]]) -> Dict[str, Any]:
-        """Lifetime totals (Melanie, 2026-09-11).
-
-        "Ever created" comes from the id sequences and survives deletion.
-        People who got a real draft and faxes delivered are the two facts a
-        sequence cannot give; they are live counts plus what delete-my-data
-        requests removed (DataRemovalTotals), from the day that counter
-        shipped onwards. "Got a draft" excludes speculative precomputes
-        held in reserve (matches the intake funnel) and blank email hashes.
+    def _all_time_status(counters: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        """Lifetime totals (Melanie, 2026-09-11): counters that only go up
+        (appeals generated, people with a generated draft, faxes delivered,
+        deletion requests), which deleting a person's data cannot change;
+        "ever created" from the id sequences as a cross-check; and what is
+        still present today.
         """
         out: Dict[str, Any] = {"ok": True, "error": None}
         try:
@@ -462,35 +421,39 @@ class AdminStatusView(generic.TemplateView):
             )
             out["denials"] = live["denials"]
             out["first_denial"] = live["first"]
-            out["drafts"] = ProposedAppeal.objects.count()
+            out["drafts"] = ProposedAppeal.objects.filter(chosen=False).count()
             out["denials_with_draft"] = (
-                Denial.objects.filter(proposedappeal__speculative=False)
+                Denial.objects.filter(proposedappeal__chosen=False)
                 .values("pk")
                 .distinct()
                 .count()
             )
+            out["people_with_draft"] = (
+                Denial.objects.filter(proposedappeal__chosen=False)
+                .exclude(hashed_email="")
+                .values("hashed_email")
+                .distinct()
+                .count()
+            )
+            out["faxes_sent"] = FaxesToSend.objects.filter(sent=True).count()
+            out["faxes_delivered"] = FaxesToSend.objects.filter(
+                fax_success=True
+            ).count()
             out["denials_ever"] = _sequence_value(Denial, "denial_id")
             out["drafts_ever"] = _sequence_value(ProposedAppeal, "id")
             out["faxes_ever"] = _sequence_value(FaxesToSend, "fax_id")
-            if snapshot is None:
-                for key in (
-                    "people_with_draft",
-                    "faxes_delivered",
-                    "people_with_draft_lifetime",
-                    "faxes_delivered_lifetime",
-                    "removal_requests",
-                    "removals_since",
-                ):
-                    out[key] = None
-            else:
-                out["people_with_draft"] = snapshot["live_people"]
-                out["faxes_delivered"] = snapshot["live_delivered"]
-                out["people_with_draft_lifetime"] = snapshot[
-                    "people_with_draft_lifetime"
-                ]
-                out["faxes_delivered_lifetime"] = snapshot["delivered_all_time"]
-                out["removal_requests"] = snapshot["removal_requests"]
-                out["removals_since"] = snapshot["removals_since"]
+            keys = (
+                "appeals_generated",
+                "people_with_draft_lifetime",
+                "faxes_sent_lifetime",
+                "faxes_delivered_lifetime",
+                "counting_since",
+                "removal_requests",
+                "removed_denials",
+                "removals_since",
+            )
+            for key in keys:
+                out[key] = None if counters is None else counters[key]
         except Exception as e:
             logger.opt(exception=True).error("Error computing all-time status")
             out["ok"] = False
@@ -499,7 +462,7 @@ class AdminStatusView(generic.TemplateView):
 
     @staticmethod
     def _fax_outcome_status(
-        snapshot: Optional[Dict[str, Any]] = None,
+        counters: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Fax delivery outcomes (last 7 days) from the database.
 
@@ -541,13 +504,10 @@ class AdminStatusView(generic.TemplateView):
                 # aggregate, so the count and the date come from one snapshot
                 # (review). `date` is the row's creation time; nothing records
                 # the delivery time, so the label says "oldest ... created".
-                # Lifetime delivered = rows present + removed by deletion
-                # requests, from the one-statement snapshot (review).
+                # Lifetime delivered: a counter bumped at each successful
+                # finalize, untouched by deletion (lifetime_counters.py).
                 "delivered_all_time": (
-                    None if snapshot is None else snapshot["delivered_all_time"]
-                ),
-                "oldest_delivered_created": (
-                    None if snapshot is None else snapshot["oldest_delivered_created"]
+                    None if counters is None else counters["faxes_delivered_lifetime"]
                 ),
                 "failed": failed_qs.count(),
                 "stuck_claims": failed_qs.filter(vendor_send_completed=True).count(),

--- a/fighthealthinsurance/templates/admin_status.html
+++ b/fighthealthinsurance/templates/admin_status.html
@@ -360,7 +360,7 @@
           <div class="label">Denials ever created (id sequence; includes rolled-back inserts)</div>
         </div>
       </div>
-      <p class="summary-line">Still present today: {{ all_time.denials|default:0 }} denials{% if all_time.first_denial %} (oldest from {{ all_time.first_denial|date:"Y-m-d" }}){% endif %}, {{ all_time.drafts|default:0 }} generated drafts on {{ all_time.denials_with_draft|default:0 }} denials for {{ all_time.people_with_draft|default:0 }} people, {{ all_time.faxes_sent|default:0 }} sent faxes of which {{ all_time.faxes_delivered|default:0 }} confirmed delivered. Draft ids ever issued: {{ all_time.drafts_ever|default:"n/a" }}.</p>
+      <p class="summary-line">Still present today: {{ all_time.denials|default:0 }} denials{% if all_time.first_denial %} (oldest from {{ all_time.first_denial|date:"Y-m-d" }}){% endif %}, {{ all_time.drafts|default:0 }} generated drafts on {{ all_time.denials_with_draft|default:0 }} denials for {{ all_time.people_with_draft|default:0 }} people, {{ all_time.faxes_sent|default:0 }} faxes whose latest attempt went out and {{ all_time.faxes_delivered|default:0 }} whose latest attempt was confirmed delivered. Draft ids ever issued: {{ all_time.drafts_ever|default:"n/a" }}.</p>
     {% endif %}
   </div>
 

--- a/fighthealthinsurance/templates/admin_status.html
+++ b/fighthealthinsurance/templates/admin_status.html
@@ -281,7 +281,7 @@
         </div>
         <div class="stat-card {% if fax_outcomes.delivered_all_time is None %}alert{% endif %}">
           <div class="value">{% if fax_outcomes.delivered_all_time is None %}<span class="badge bad">unavailable</span>{% else %}{{ fax_outcomes.delivered_all_time }}{% endif %}</div>
-          <div class="label">Delivered, all time (present plus removed){% if fax_outcomes.oldest_delivered_created %}; oldest present was created {{ fax_outcomes.oldest_delivered_created|date:"Y-m-d" }}{% endif %}</div>
+          <div class="label">Delivered, all time (counter; deletions do not lower it)</div>
         </div>
         <div class="stat-card {% if fax_outcomes.failed %}alert{% endif %}">
           <div class="value">{{ fax_outcomes.failed|default:0 }}</div>
@@ -329,30 +329,38 @@
     {% if all_time.error %}
       <p class="summary-line"><span class="badge bad">ERROR</span> <span class="error-text">{{ all_time.error }}</span></p>
     {% else %}
-      <p class="summary-line">Ever created comes from the id sequences and survives deletion. People and delivered faxes add back what delete-my-data requests removed{% if all_time.removal_requests is None %} (removal totals unavailable right now){% elif all_time.removals_since %}, recorded since {{ all_time.removals_since|date:"Y-m-d" }} ({{ all_time.removal_requests }} request{{ all_time.removal_requests|pluralize }}){% else %} (none recorded yet){% endif %}; deletions before that are not recoverable.</p>
+      <p class="summary-line">Counters that only go up: a generated draft, a person's first generated draft and a delivered fax each add one at the moment they happen, and deleting someone's data changes none of them. {% if all_time.counting_since %}Counting since {{ all_time.counting_since|date:"Y-m-d" }}, seeded from the rows present that day; deletions before then are not recoverable.{% elif all_time.appeals_generated is None %}<span class="badge bad">counters unavailable right now</span>{% else %}Not seeded yet.{% endif %}</p>
       <div class="stat-grid">
-        <div class="stat-card">
-          <div class="value">{% if all_time.denials_ever is None %}<span class="badge unknown">n/a</span>{% else %}{{ all_time.denials_ever }}{% endif %}</div>
-          <div class="label">Denials ever created{% if all_time.first_denial %} (oldest present from {{ all_time.first_denial|date:"Y-m-d" }}){% endif %}</div>
+        <div class="stat-card {% if all_time.appeals_generated is None %}alert{% endif %}">
+          <div class="value">{% if all_time.appeals_generated is None %}<span class="badge bad">unavailable</span>{% else %}{{ all_time.appeals_generated }}{% endif %}</div>
+          <div class="label">Appeal drafts generated</div>
         </div>
-        <div class="stat-card">
-          <div class="value">{% if all_time.drafts_ever is None %}<span class="badge unknown">n/a</span>{% else %}{{ all_time.drafts_ever }}{% endif %}</div>
-          <div class="label">Appeal drafts ever created</div>
+        <div class="stat-card {% if all_time.people_with_draft_lifetime is None %}alert{% endif %}">
+          <div class="value">{% if all_time.people_with_draft_lifetime is None %}<span class="badge bad">unavailable</span>{% else %}{{ all_time.people_with_draft_lifetime }}{% endif %}</div>
+          <div class="label">People with a generated draft (distinct email hashes)</div>
         </div>
         <div class="stat-card">
           <div class="value">{% if all_time.faxes_ever is None %}<span class="badge unknown">n/a</span>{% else %}{{ all_time.faxes_ever }}{% endif %}</div>
-          <div class="label">Faxes ever created</div>
+          <div class="label">Fax requests (rows ever created; a row exists before the user confirms)</div>
         </div>
-        <div class="stat-card">
-          <div class="value">{% if all_time.people_with_draft_lifetime is None %}<span class="badge bad">unavailable</span>{% else %}{{ all_time.people_with_draft_lifetime }}{% endif %}</div>
-          <div class="label">People who got a draft (distinct email hashes, plus removed)</div>
+        <div class="stat-card {% if all_time.faxes_sent_lifetime is None %}alert{% endif %}">
+          <div class="value">{% if all_time.faxes_sent_lifetime is None %}<span class="badge bad">unavailable</span>{% else %}{{ all_time.faxes_sent_lifetime }}{% endif %}</div>
+          <div class="label">Faxes sent (an attempt was made)</div>
         </div>
         <div class="stat-card {% if all_time.faxes_delivered_lifetime is None %}alert{% endif %}">
           <div class="value">{% if all_time.faxes_delivered_lifetime is None %}<span class="badge bad">unavailable</span>{% else %}{{ all_time.faxes_delivered_lifetime }}{% endif %}</div>
-          <div class="label">Faxes delivered (present, plus removed)</div>
+          <div class="label">Faxes confirmed delivered</div>
+        </div>
+        <div class="stat-card {% if all_time.removal_requests is None %}alert{% endif %}">
+          <div class="value">{% if all_time.removal_requests is None %}<span class="badge bad">unavailable</span>{% else %}{{ all_time.removal_requests }}{% endif %}</div>
+          <div class="label">Delete-my-data requests{% if all_time.removals_since %} (since {{ all_time.removals_since|date:"Y-m-d" }}, {{ all_time.removed_denials }} denial{{ all_time.removed_denials|pluralize }} removed){% endif %}</div>
+        </div>
+        <div class="stat-card">
+          <div class="value">{% if all_time.denials_ever is None %}<span class="badge unknown">n/a</span>{% else %}{{ all_time.denials_ever }}{% endif %}</div>
+          <div class="label">Denials ever created (id sequence; includes rolled-back inserts)</div>
         </div>
       </div>
-      <p class="summary-line">Still present: {{ all_time.denials|default:0 }} denials, {{ all_time.drafts|default:0 }} drafts, {{ all_time.denials_with_draft|default:0 }} denials with a draft, {% if all_time.people_with_draft is None %}an unavailable number of{% else %}{{ all_time.people_with_draft }}{% endif %} people with a draft.</p>
+      <p class="summary-line">Still present today: {{ all_time.denials|default:0 }} denials{% if all_time.first_denial %} (oldest from {{ all_time.first_denial|date:"Y-m-d" }}){% endif %}, {{ all_time.drafts|default:0 }} generated drafts on {{ all_time.denials_with_draft|default:0 }} denials for {{ all_time.people_with_draft|default:0 }} people, {{ all_time.faxes_sent|default:0 }} sent faxes of which {{ all_time.faxes_delivered|default:0 }} confirmed delivered. Draft ids ever issued: {{ all_time.drafts_ever|default:"n/a" }}.</p>
     {% endif %}
   </div>
 

--- a/fighthealthinsurance/templates/admin_status.html
+++ b/fighthealthinsurance/templates/admin_status.html
@@ -165,24 +165,28 @@
     {% else %}
       <div class="stat-grid">
         <div class="stat-card">
-          <div class="value">{{ fax_queue.unsent_total }}</div>
-          <div class="label">Unsent (total)</div>
-        </div>
-        <div class="stat-card">
           <div class="value">{{ fax_queue.ready_queued }}</div>
-          <div class="label">Queued (should send)</div>
+          <div class="label">Queued (user confirmed, not yet sent)</div>
         </div>
-        <div class="stat-card">
+        <div class="stat-card {% if fax_queue.due_now %}alert{% endif %}">
           <div class="value">{{ fax_queue.due_now }}</div>
-          <div class="label">Due now (&gt;1h old)</div>
+          <div class="label">Stuck (queued &gt;1h, never picked up)</div>
         </div>
-        <div class="stat-card">
-          <div class="value">{{ fax_queue.awaiting_confirmation }}</div>
-          <div class="label">Awaiting confirmation</div>
+        <div class="stat-card {% if fax_queue.requested_unpicked %}alert{% endif %}">
+          <div class="value">{{ fax_queue.requested_unpicked }}</div>
+          <div class="label">Professional send never picked up</div>
         </div>
         <div class="stat-card {% if fax_queue.in_flight %}alert{% endif %}">
           <div class="value">{{ fax_queue.in_flight }}</div>
-          <div class="label">In-flight / attempting</div>
+          <div class="label">Attempting now (started &lt;2h ago)</div>
+        </div>
+        <div class="stat-card {% if fax_queue.stale_attempts %}alert{% endif %}">
+          <div class="value">{{ fax_queue.stale_attempts }}</div>
+          <div class="label">Stale attempt (started &gt;2h ago, never finished)</div>
+        </div>
+        <div class="stat-card">
+          <div class="value">{{ fax_queue.awaiting_confirmation }}</div>
+          <div class="label">Never confirmed by the user</div>
         </div>
         <div class="stat-card {% if fax_queue.failures_recent %}alert{% endif %}">
           <div class="value">{{ fax_queue.failures_recent }}</div>
@@ -259,34 +263,6 @@
     {% endif %}
   </div>
 
-  {# ---------------- Intake funnel ---------------- #}
-  <div class="status-section">
-    <h2>&#128203; Intake funnel (last 7 days)</h2>
-    {% if intake_funnel.error %}
-      <p class="summary-line"><span class="badge bad">ERROR</span> <span class="error-text">{{ intake_funnel.error }}</span></p>
-    {% else %}
-      <p class="summary-line"><span class="pill">Stage tallies only; where do people stop between starting a submission and holding drafts?</span></p>
-      <div class="stat-grid">
-        <div class="stat-card">
-          <div class="value">{{ intake_funnel.started|default:0 }}</div>
-          <div class="label">Started a denial</div>
-        </div>
-        <div class="stat-card">
-          <div class="value">{{ intake_funnel.attempted_generation|default:0 }}</div>
-          <div class="label">Reached generation</div>
-        </div>
-        <div class="stat-card">
-          <div class="value">{{ intake_funnel.with_drafts|default:0 }}</div>
-          <div class="label">Have drafts</div>
-        </div>
-        <div class="stat-card">
-          <div class="value">{{ intake_funnel.chose_appeal|default:0 }}</div>
-          <div class="label">Chose an appeal</div>
-        </div>
-      </div>
-    {% endif %}
-  </div>
-
   {# ---------------- Fax delivery outcomes ---------------- #}
   <div class="status-section">
     <h2>📠 Fax delivery (last 7 days)</h2>
@@ -302,6 +278,10 @@
         <div class="stat-card">
           <div class="value">{{ fax_outcomes.delivered|default:0 }}</div>
           <div class="label">Delivered</div>
+        </div>
+        <div class="stat-card {% if fax_outcomes.delivered_all_time is None %}alert{% endif %}">
+          <div class="value">{% if fax_outcomes.delivered_all_time is None %}<span class="badge bad">unavailable</span>{% else %}{{ fax_outcomes.delivered_all_time }}{% endif %}</div>
+          <div class="label">Delivered, all time (present plus removed){% if fax_outcomes.oldest_delivered_created %}; oldest present was created {{ fax_outcomes.oldest_delivered_created|date:"Y-m-d" }}{% endif %}</div>
         </div>
         <div class="stat-card {% if fax_outcomes.failed %}alert{% endif %}">
           <div class="value">{{ fax_outcomes.failed|default:0 }}</div>
@@ -340,6 +320,67 @@
         </tbody>
       </table>
       {% endif %}
+    {% endif %}
+  </div>
+
+  {# ---------------- All time ---------------- #}
+  <div class="status-section">
+    <h2>&#127942; All time</h2>
+    {% if all_time.error %}
+      <p class="summary-line"><span class="badge bad">ERROR</span> <span class="error-text">{{ all_time.error }}</span></p>
+    {% else %}
+      <p class="summary-line">Ever created comes from the id sequences and survives deletion. People and delivered faxes add back what delete-my-data requests removed{% if all_time.removal_requests is None %} (removal totals unavailable right now){% elif all_time.removals_since %}, recorded since {{ all_time.removals_since|date:"Y-m-d" }} ({{ all_time.removal_requests }} request{{ all_time.removal_requests|pluralize }}){% else %} (none recorded yet){% endif %}; deletions before that are not recoverable.</p>
+      <div class="stat-grid">
+        <div class="stat-card">
+          <div class="value">{% if all_time.denials_ever is None %}<span class="badge unknown">n/a</span>{% else %}{{ all_time.denials_ever }}{% endif %}</div>
+          <div class="label">Denials ever created{% if all_time.first_denial %} (oldest present from {{ all_time.first_denial|date:"Y-m-d" }}){% endif %}</div>
+        </div>
+        <div class="stat-card">
+          <div class="value">{% if all_time.drafts_ever is None %}<span class="badge unknown">n/a</span>{% else %}{{ all_time.drafts_ever }}{% endif %}</div>
+          <div class="label">Appeal drafts ever created</div>
+        </div>
+        <div class="stat-card">
+          <div class="value">{% if all_time.faxes_ever is None %}<span class="badge unknown">n/a</span>{% else %}{{ all_time.faxes_ever }}{% endif %}</div>
+          <div class="label">Faxes ever created</div>
+        </div>
+        <div class="stat-card">
+          <div class="value">{% if all_time.people_with_draft_lifetime is None %}<span class="badge bad">unavailable</span>{% else %}{{ all_time.people_with_draft_lifetime }}{% endif %}</div>
+          <div class="label">People who got a draft (distinct email hashes, plus removed)</div>
+        </div>
+        <div class="stat-card {% if all_time.faxes_delivered_lifetime is None %}alert{% endif %}">
+          <div class="value">{% if all_time.faxes_delivered_lifetime is None %}<span class="badge bad">unavailable</span>{% else %}{{ all_time.faxes_delivered_lifetime }}{% endif %}</div>
+          <div class="label">Faxes delivered (present, plus removed)</div>
+        </div>
+      </div>
+      <p class="summary-line">Still present: {{ all_time.denials|default:0 }} denials, {{ all_time.drafts|default:0 }} drafts, {{ all_time.denials_with_draft|default:0 }} denials with a draft, {% if all_time.people_with_draft is None %}an unavailable number of{% else %}{{ all_time.people_with_draft }}{% endif %} people with a draft.</p>
+    {% endif %}
+  </div>
+
+  {# ---------------- Intake funnel ---------------- #}
+  <div class="status-section">
+    <h2>&#128203; Intake funnel (last 7 days)</h2>
+    {% if intake_funnel.error %}
+      <p class="summary-line"><span class="badge bad">ERROR</span> <span class="error-text">{{ intake_funnel.error }}</span></p>
+    {% else %}
+      <p class="summary-line"><span class="pill">Stage tallies only; where do people stop between starting a submission and holding drafts?</span></p>
+      <div class="stat-grid">
+        <div class="stat-card">
+          <div class="value">{{ intake_funnel.started|default:0 }}</div>
+          <div class="label">Started a denial</div>
+        </div>
+        <div class="stat-card">
+          <div class="value">{{ intake_funnel.attempted_generation|default:0 }}</div>
+          <div class="label">Reached generation</div>
+        </div>
+        <div class="stat-card">
+          <div class="value">{{ intake_funnel.with_drafts|default:0 }}</div>
+          <div class="label">Have drafts</div>
+        </div>
+        <div class="stat-card">
+          <div class="value">{{ intake_funnel.chose_appeal|default:0 }}</div>
+          <div class="label">Chose an appeal</div>
+        </div>
+      </div>
     {% endif %}
   </div>
 

--- a/tests/async-unit/test_common_view_logic.py
+++ b/tests/async-unit/test_common_view_logic.py
@@ -141,7 +141,12 @@ class TestCommonViewLogic(TestCase):
     @patch("fighthealthinsurance.common_view_logic.Denial.objects")
     def test_remove_data_for_email(self, mock_denial_objects):
         mock_denial = Mock()
-        mock_denial_objects.filter.return_value.delete.return_value = 1
+        # delete() returns (total, {label: count}); the removal totals read
+        # the denial count out of it, so the mock has to be that shape.
+        mock_denial_objects.filter.return_value.delete.return_value = (
+            1,
+            {"fighthealthinsurance.Denial": 1},
+        )
         RemoveDataHelper.remove_data_for_email("test@example.com")
         mock_denial_objects.filter.assert_called()
         mock_denial_objects.filter.return_value.delete.assert_called()

--- a/tests/async-unit/test_fax_send_core.py
+++ b/tests/async-unit/test_fax_send_core.py
@@ -133,6 +133,20 @@ class TestVendorSendAtomicClaim:
         assert fax.vendor_send_completed is False
 
 
+class _Both:
+    def __init__(self, *cms):
+        self._cms = cms
+
+    def __enter__(self):
+        return [cm.__enter__() for cm in self._cms]
+
+    def __exit__(self, *exc):
+        for cm in reversed(self._cms):
+            cm.__exit__(*exc)
+        return False
+
+
+@pytest.mark.django_db
 class TestFinalizeOrdering:
     """finalize must persist durable state before any notification, so an
     unlimited retry on a failing appeal.save() can't re-flood support."""
@@ -147,13 +161,24 @@ class TestFinalizeOrdering:
         return fax
 
     @staticmethod
-    def _row_present():
-        """finalize now marks the fax with a filtered UPDATE (never save(),
-        which could re-create a deleted row); one matching row means the
-        fax still exists and finalize proceeds to the appeal write."""
+    def _rows(transition: int, present: int):
+        """finalize marks the fax with filtered UPDATEs (never save(), which
+        could re-create a deleted row): the latest-attempt write
+        (``filter(pk).update``, whose row count says whether the fax still
+        exists), then the once-only counted markers
+        (``filter(pk).filter(..._counted=False).update``). Model both, and
+        keep the lifetime counter out of these ordering tests."""
         manager = MagicMock()
-        manager.filter.return_value.update.return_value = 1
-        return patch("fighthealthinsurance.models.FaxesToSend.objects", manager)
+        manager.filter.return_value.filter.return_value.update.return_value = transition
+        manager.filter.return_value.update.return_value = present
+        return (
+            patch("fighthealthinsurance.models.FaxesToSend.objects", manager),
+            patch("fighthealthinsurance.lifetime_counters.note_fax_events"),
+        )
+
+    def _row_present(self):
+        rows, counter = self._rows(transition=1, present=1)
+        return _Both(rows, counter)
 
     def test_appeal_persisted_before_notification(self):
         fax = self._pro_fax()
@@ -182,14 +207,23 @@ class TestFinalizeOrdering:
 
     def test_gone_row_skips_the_appeal_write_and_notifications(self):
         fax = self._pro_fax()
-        manager = MagicMock()
-        manager.filter.return_value.update.return_value = 0
-        with patch("fighthealthinsurance.models.FaxesToSend.objects", manager), patch(
+        rows, counter = self._rows(transition=0, present=0)
+        with rows, counter as bump, patch(
             "fighthealthinsurance.fax_send_core.send_fax_status_notification"
         ) as notify:
             fax_send_core.finalize_fax(fax, True, False)
         fax.for_appeal.save.assert_not_called()
         notify.assert_not_called()
+        bump.assert_not_called()
+
+    def test_already_delivered_row_is_not_counted_again(self):
+        fax = self._pro_fax()
+        rows, counter = self._rows(transition=0, present=1)
+        with rows, counter as bump, patch(
+            "fighthealthinsurance.fax_send_core.send_fax_status_notification"
+        ):
+            fax_send_core.finalize_fax(fax, True, False)
+        bump.assert_called_once_with(newly_sent=False, newly_delivered=False)
 
 
 @pytest.mark.django_db

--- a/tests/async-unit/test_fax_send_core.py
+++ b/tests/async-unit/test_fax_send_core.py
@@ -116,8 +116,7 @@ class TestVendorSendAtomicClaim:
             racer, "get_temporary_document_path", return_value="/tmp/does-not-exist.pdf"
         ):
             assert (
-                fax_send_core.send_fax_via_vendor(racer)
-                == fax_send_core.SEND_NOT_OWNER
+                fax_send_core.send_fax_via_vendor(racer) == fax_send_core.SEND_NOT_OWNER
             )
         assert mock_send.call_count == 1
 
@@ -140,17 +139,27 @@ class TestFinalizeOrdering:
 
     def _pro_fax(self):
         fax = Mock()
+        fax.pk = 1
         fax.professional = True
         fax.email = "pro@example.com"
         fax.uuid = "u"
         fax.for_appeal = Mock()
         return fax
 
+    @staticmethod
+    def _row_present():
+        """finalize now marks the fax with a filtered UPDATE (never save(),
+        which could re-create a deleted row); one matching row means the
+        fax still exists and finalize proceeds to the appeal write."""
+        manager = MagicMock()
+        manager.filter.return_value.update.return_value = 1
+        return patch("fighthealthinsurance.models.FaxesToSend.objects", manager)
+
     def test_appeal_persisted_before_notification(self):
         fax = self._pro_fax()
         order: list = []
         fax.for_appeal.save.side_effect = lambda: order.append("appeal_save")
-        with patch(
+        with self._row_present(), patch(
             "fighthealthinsurance.fax_send_core.send_fax_status_notification",
             side_effect=lambda *a, **k: order.append("notify"),
         ):
@@ -159,14 +168,27 @@ class TestFinalizeOrdering:
 
     def test_no_notification_when_appeal_save_fails(self):
         fax = self._pro_fax()
-        fax.for_appeal.save.side_effect = Exception("locked appeal row")
-        with patch(
+        fax.for_appeal.save.side_effect = RuntimeError("locked appeal row")
+        with self._row_present(), patch(
             "fighthealthinsurance.fax_send_core.send_fax_status_notification"
         ) as notify:
-            with pytest.raises(Exception):
+            with pytest.raises(RuntimeError, match="locked appeal row"):
                 fax_send_core.finalize_fax(fax, True, False)
-        # Notification comes after the durable writes, so a failed appeal.save()
-        # (which the workflow will retry) never re-sends the support email.
+        # The appeal write was attempted and it is what failed; notification
+        # comes after the durable writes, so a failed appeal.save() (which
+        # the workflow will retry) never re-sends the support email.
+        fax.for_appeal.save.assert_called_once()
+        notify.assert_not_called()
+
+    def test_gone_row_skips_the_appeal_write_and_notifications(self):
+        fax = self._pro_fax()
+        manager = MagicMock()
+        manager.filter.return_value.update.return_value = 0
+        with patch("fighthealthinsurance.models.FaxesToSend.objects", manager), patch(
+            "fighthealthinsurance.fax_send_core.send_fax_status_notification"
+        ) as notify:
+            fax_send_core.finalize_fax(fax, True, False)
+        fax.for_appeal.save.assert_not_called()
         notify.assert_not_called()
 
 

--- a/tests/sync/test_admin_status.py
+++ b/tests/sync/test_admin_status.py
@@ -202,14 +202,18 @@ class AdminStatusFaxQueueTest(TestCase):
         self.assertNotContains(response, "not actionable")
         # The all-time delivered count lives in the delivery panel: F only.
         outcomes = response.context["fax_outcomes"]
-        self.assertEqual(outcomes["delivered_all_time"], 1)
-        self.assertIsNotNone(outcomes["oldest_delivered_created"])
-        self.assertContains(response, "Delivered, all time (present plus removed)")
-        # Lifetime panel: only faxes exist in this fixture; the denial-side
-        # numbers are zero here and covered below.
+        # Lifetime delivered is a counter bumped at finalize, not a row count:
+        # fixture rows created with fax_success=True never went through
+        # finalize, so it is 0 here and untouched by them.
+        self.assertEqual(outcomes["delivered_all_time"], 0)
+        self.assertContains(response, "Delivered, all time (counter")
         all_time = response.context["all_time"]
         self.assertTrue(all_time["ok"])
-        self.assertEqual(all_time["faxes_delivered"], 1)
+        self.assertEqual(all_time["faxes_delivered"], 1)  # present rows
+        self.assertEqual(all_time["faxes_delivered_lifetime"], 0)  # counter
+        self.assertEqual(all_time["faxes_sent_lifetime"], 0)  # counter
+        self.assertEqual(all_time["faxes_sent"], 2)  # present rows: E, F
+        self.assertContains(response, "Faxes sent (an attempt was made)")
         self.assertContains(response, "All time")
 
     @mock.patch(_FAX)
@@ -247,13 +251,13 @@ class AdminStatusFaxQueueTest(TestCase):
         t = response.context["all_time"]
         self.assertEqual(t["denials"], 6)
         self.assertEqual(t["drafts"], 6)
-        self.assertEqual(t["denials_with_draft"], 4)  # a1, a2, b1, blank
-        self.assertEqual(t["people_with_draft"], 2)  # a, b
+        self.assertEqual(t["denials_with_draft"], 5)  # a1, a2, b1, blank, spec
+        self.assertEqual(t["people_with_draft"], 3)  # a, b, d; blank is not a person
         self.assertIsNotNone(t["first_denial"])
-        # Both panels read the same delivered aggregate, computed once.
-        self.assertEqual(
-            t["faxes_delivered"], response.context["fax_outcomes"]["delivered_all_time"]
-        )
+        # The counters moved with each generated draft: six drafts, three
+        # people (a counted once across two denials, blank excluded).
+        self.assertEqual(t["appeals_generated"], 6)
+        self.assertEqual(t["people_with_draft_lifetime"], 3)
         # Ever-created comes from the id sequences: never below the live
         # count, and it does not drop when the NEWEST rows are deleted.
         self.assertGreaterEqual(t["denials_ever"], t["denials"])
@@ -265,40 +269,17 @@ class AdminStatusFaxQueueTest(TestCase):
         t2 = self.client.get(reverse("admin_status")).context["all_time"]
         self.assertEqual((t2["denials_ever"], t2["drafts_ever"]), ever_before)
         self.assertEqual(t2["denials"], t["denials"] - 1)
+        # And the counters did not move on deletion.
+        self.assertEqual(t2["appeals_generated"], 6)
+        self.assertEqual(t2["people_with_draft_lifetime"], 3)
 
     @mock.patch(_FAX)
     @mock.patch(_ACTORS)
     @mock.patch(_MODELS)
-    def test_delivered_aggregate_is_computed_once_per_page(
+    def test_unreadable_counters_are_unavailable_not_zero(
         self, mock_models, mock_actors, mock_fax
     ):
-        mock_models.return_value = []
-        mock_actors.return_value = {"alive_actors": 0, "total_actors": 0, "details": []}
-        mock_fax.return_value = _ok_fax_backends()
-        from fighthealthinsurance import staff_views
-
-        real = staff_views._lifetime_snapshot
-        with mock.patch.object(
-            staff_views, "_lifetime_snapshot", side_effect=real
-        ) as agg:
-            self.client.get(reverse("admin_status"))
-        self.assertEqual(agg.call_count, 1)
-        # And that one call is ONE SQL statement: one snapshot (review).
-        from django.db import connection
-        from django.test.utils import CaptureQueriesContext
-
-        with CaptureQueriesContext(connection) as queries:
-            real()
-        self.assertEqual(len(queries), 1, [q["sql"] for q in queries])
-
-    @mock.patch(_FAX)
-    @mock.patch(_ACTORS)
-    @mock.patch(_MODELS)
-    def test_failed_delivered_aggregate_is_unavailable_not_zero(
-        self, mock_models, mock_actors, mock_fax
-    ):
-        """A statement timeout on the lifetime aggregate must not render as
-        "0 delivered" in either panel (review)."""
+        """A failed read of the counters must not render as zero anywhere."""
         mock_models.return_value = []
         mock_actors.return_value = {"alive_actors": 0, "total_actors": 0, "details": []}
         mock_fax.return_value = _ok_fax_backends()
@@ -306,16 +287,25 @@ class AdminStatusFaxQueueTest(TestCase):
         from fighthealthinsurance import staff_views
 
         with mock.patch.object(
-            staff_views, "_lifetime_snapshot", side_effect=RuntimeError("timeout")
+            staff_views, "_lifetime_counters", side_effect=RuntimeError("timeout")
         ):
             response = self.client.get(reverse("admin_status"))
         self.assertEqual(response.status_code, 200)
         self.assertIsNone(response.context["fax_outcomes"]["delivered_all_time"])
-        self.assertIsNone(response.context["all_time"]["faxes_delivered_lifetime"])
-        self.assertContains(response, "unavailable")
-        self.assertContains(response, "removal totals unavailable")
-        self.assertContains(response, "an unavailable number of people")
-        self.assertNotContains(response, "none recorded yet")
+        t = response.context["all_time"]
+        for key in (
+            "appeals_generated",
+            "people_with_draft_lifetime",
+            "faxes_sent_lifetime",
+            "faxes_delivered_lifetime",
+            "removal_requests",
+        ):
+            self.assertIsNone(t[key], key)
+        self.assertContains(response, "counters unavailable right now")
+        self.assertNotContains(response, "Not seeded yet")
+        # one badge per counter-backed card (appeals, people, faxes sent,
+        # faxes delivered, removals, removed denials) plus the summary line
+        self.assertEqual(response.content.decode().count("unavailable"), 7)
 
     def _person_with_data(self, email, delivered=True, professional_fax_for=None):
         from fighthealthinsurance.models import Denial, ProposedAppeal
@@ -349,16 +339,16 @@ class AdminStatusFaxQueueTest(TestCase):
     @mock.patch(_FAX)
     @mock.patch(_ACTORS)
     @mock.patch(_MODELS)
-    def test_deletion_totals_keep_lifetime_numbers(
+    def test_deletion_changes_no_lifetime_counter(
         self, mock_models, mock_actors, mock_fax
     ):
-        """delete-my-data removes the rows; the totals updated in that same
-        transaction keep the person and the delivered faxes in the lifetime
-        figures, including a fax removed by cascade through the denial."""
+        """delete-my-data removes the rows and counts itself; the lifetime
+        counters, which moved when the drafts were generated, do not move."""
         from fighthealthinsurance.helpers.data_helpers import RemoveDataHelper
         from fighthealthinsurance.models import (
             DataRemovalTotals,
             Denial,
+            LifetimeCounters,
             ProposedAppeal,
         )
 
@@ -371,32 +361,30 @@ class AdminStatusFaxQueueTest(TestCase):
         )
         staying = Denial.objects.create(semi_sekret="s", hashed_email="stays")
         ProposedAppeal.objects.create(for_denial=staying, appeal_text="stays too")
-        before = self.client.get(reverse("admin_status")).context["all_time"]
-        self.assertEqual(before["people_with_draft_lifetime"], 2)
-        self.assertEqual(before["faxes_delivered_lifetime"], 2)
+        before = LifetimeCounters.objects.get(pk=LifetimeCounters.SINGLETON_ID)
+        self.assertEqual((before.appeals_generated, before.people_with_draft), (3, 2))
 
         RemoveDataHelper.remove_data_for_email(email)
 
         self.assertFalse(Denial.objects.filter(hashed_email=hashed).exists())
-        totals = DataRemovalTotals.objects.get(pk=DataRemovalTotals.SINGLETON_ID)
+        after = LifetimeCounters.objects.get(pk=LifetimeCounters.SINGLETON_ID)
         self.assertEqual(
+            (after.appeals_generated, after.people_with_draft, after.faxes_delivered),
             (
-                totals.requests,
-                totals.denials,
-                totals.drafts,
-                totals.faxes_delivered,
-                totals.people_with_draft,
+                before.appeals_generated,
+                before.people_with_draft,
+                before.faxes_delivered,
             ),
-            (1, 2, 1, 2, 1),
         )
+        totals = DataRemovalTotals.objects.get(pk=DataRemovalTotals.SINGLETON_ID)
+        self.assertEqual((totals.requests, totals.denials), (1, 2))
         self.assertIsNotNone(totals.since)
         t = self.client.get(reverse("admin_status")).context["all_time"]
-        self.assertEqual(t["people_with_draft"], 1)  # only "stays" is present
-        self.assertEqual(t["people_with_draft_lifetime"], 2)  # plus the removed person
-        self.assertEqual(t["faxes_delivered"], 0)
-        self.assertEqual(t["faxes_delivered_lifetime"], 2)  # both delivered faxes
-        self.assertEqual(t["denials_ever"], before["denials_ever"])  # sequence survives
+        self.assertEqual(t["people_with_draft"], 1)  # present: only "stays"
+        self.assertEqual(t["people_with_draft_lifetime"], 2)  # counter: unchanged
+        self.assertEqual(t["appeals_generated"], 3)
         self.assertEqual(t["removal_requests"], 1)
+        self.assertEqual(t["removed_denials"], 2)
 
     def test_failed_deletion_rolls_the_totals_back_and_a_retry_counts_once(self):
         from django.db import DatabaseError
@@ -419,10 +407,7 @@ class AdminStatusFaxQueueTest(TestCase):
         self.assertFalse(DataRemovalTotals.objects.exists())
         RemoveDataHelper.remove_data_for_email(email)
         totals = DataRemovalTotals.objects.get()
-        self.assertEqual(
-            (totals.requests, totals.people_with_draft, totals.faxes_delivered),
-            (1, 1, 1),
-        )
+        self.assertEqual((totals.requests, totals.denials), (1, 2))
 
     def test_totals_failure_never_blocks_deletion(self):
         """A database error while counting (e.g. the totals table missing

--- a/tests/sync/test_admin_status.py
+++ b/tests/sync/test_admin_status.py
@@ -151,17 +151,326 @@ class AdminStatusFaxQueueTest(TestCase):
         self._make_fax(should_send=True, sent=True, fax_success=False)
         # F: a success (must be ignored everywhere).
         self._make_fax(should_send=True, sent=True, fax_success=True)
+        # G: an attempt from days ago that was never cleared. Not in flight
+        # (bounded to two hours), not an abandoned draft either: it is a
+        # stale attempt, the one bucket staff must still see (review).
+        self._make_fax(
+            should_send=False,
+            sent=False,
+            attempting_to_send_as_of=now - datetime.timedelta(days=3),
+        )
+        # H: queued two hours ago and picked up five minutes ago. Attempting,
+        # and therefore NOT stuck, even though it is older than an hour.
+        self._make_fax(
+            should_send=True,
+            sent=False,
+            date=two_hours_ago,
+            attempting_to_send_as_of=now - datetime.timedelta(minutes=5),
+        )
+        # I: confirmed yesterday, attempted three hours ago, worker died. One
+        # stale attempt; NOT also "stuck", which is for rows never picked up.
+        self._make_fax(
+            should_send=True,
+            sent=False,
+            date=now - datetime.timedelta(days=1),
+            attempting_to_send_as_of=now - datetime.timedelta(hours=3),
+        )
+        # J: a professional's fax. That path dispatches without should_send;
+        # unattempted, it is a stranded request, not an abandoned draft.
+        self._make_fax(should_send=False, sent=False, professional=True)
 
         response = self.client.get(reverse("admin_status"))
         self.assertEqual(response.status_code, 200)
         q = response.context["fax_queue"]
         self.assertTrue(q["ok"])
-        self.assertEqual(q["unsent_total"], 4)  # A, B, C, D
-        self.assertEqual(q["ready_queued"], 3)  # A, B, D
-        self.assertEqual(q["due_now"], 1)  # A only
-        self.assertEqual(q["awaiting_confirmation"], 1)  # C
-        self.assertEqual(q["in_flight"], 1)  # D
+        self.assertEqual(q["unsent_total"], 8)  # A, B, C, D, G, H, I, J
+        self.assertEqual(q["ready_queued"], 5)  # A, B, D, H, I
+        self.assertEqual(q["due_now"], 1)  # A only: H and I were picked up
+        self.assertEqual(
+            q["awaiting_confirmation"], 1
+        )  # C only: G attempted, J professional
+        self.assertEqual(q["requested_unpicked"], 1)  # J
+        self.assertEqual(q["in_flight"], 2)  # D, H; G and I are hours old
+        self.assertEqual(q["stale_attempts"], 2)  # G, I
         self.assertEqual(q["failures_recent"], 1)  # E
+        # The page headlines what is actionable, not the unsent total.
+        self.assertNotContains(response, "Unsent (total)")
+        self.assertContains(response, "Stuck (queued")
+        self.assertContains(response, "Attempting now")
+        self.assertContains(response, "Stale attempt")
+        self.assertContains(response, "Professional send never picked up")
+        self.assertNotContains(response, "not actionable")
+        # The all-time delivered count lives in the delivery panel: F only.
+        outcomes = response.context["fax_outcomes"]
+        self.assertEqual(outcomes["delivered_all_time"], 1)
+        self.assertIsNotNone(outcomes["oldest_delivered_created"])
+        self.assertContains(response, "Delivered, all time (present plus removed)")
+        # Lifetime panel: only faxes exist in this fixture; the denial-side
+        # numbers are zero here and covered below.
+        all_time = response.context["all_time"]
+        self.assertTrue(all_time["ok"])
+        self.assertEqual(all_time["faxes_delivered"], 1)
+        self.assertContains(response, "All time")
+
+    @mock.patch(_FAX)
+    @mock.patch(_ACTORS)
+    @mock.patch(_MODELS)
+    def test_all_time_counts_denials_drafts_and_people(
+        self, mock_models, mock_actors, mock_fax
+    ):
+        from fighthealthinsurance.models import Denial, ProposedAppeal
+
+        mock_models.return_value = []
+        mock_actors.return_value = {"alive_actors": 0, "total_actors": 0, "details": []}
+        mock_fax.return_value = _ok_fax_backends()
+        # Person a: two denials, both drafted (one of them twice) -- one
+        # person, two denials. Person b: one drafted denial. Person c: never
+        # drafted. A blank email hash with a draft: a denial, not a person.
+        # A speculative-only denial: precompute held in reserve, never
+        # served, so not "got a draft" (review).
+        a1 = Denial.objects.create(semi_sekret="s", hashed_email="person-a")
+        a2 = Denial.objects.create(semi_sekret="s", hashed_email="person-a")
+        b1 = Denial.objects.create(semi_sekret="s", hashed_email="person-b")
+        Denial.objects.create(semi_sekret="s", hashed_email="person-c")
+        blank = Denial.objects.create(semi_sekret="s", hashed_email="")
+        spec = Denial.objects.create(semi_sekret="s", hashed_email="person-d")
+        ProposedAppeal.objects.create(for_denial=a1, appeal_text="draft one for a1")
+        ProposedAppeal.objects.create(for_denial=a1, appeal_text="draft two for a1")
+        ProposedAppeal.objects.create(for_denial=a2, appeal_text="draft one for a2")
+        ProposedAppeal.objects.create(for_denial=b1, appeal_text="draft one for b1")
+        ProposedAppeal.objects.create(for_denial=blank, appeal_text="draft, no hash")
+        ProposedAppeal.objects.create(
+            for_denial=spec, appeal_text="speculative only", speculative=True
+        )
+        response = self.client.get(reverse("admin_status"))
+        self.assertEqual(response.status_code, 200)
+        t = response.context["all_time"]
+        self.assertEqual(t["denials"], 6)
+        self.assertEqual(t["drafts"], 6)
+        self.assertEqual(t["denials_with_draft"], 4)  # a1, a2, b1, blank
+        self.assertEqual(t["people_with_draft"], 2)  # a, b
+        self.assertIsNotNone(t["first_denial"])
+        # Both panels read the same delivered aggregate, computed once.
+        self.assertEqual(
+            t["faxes_delivered"], response.context["fax_outcomes"]["delivered_all_time"]
+        )
+        # Ever-created comes from the id sequences: never below the live
+        # count, and it does not drop when the NEWEST rows are deleted.
+        self.assertGreaterEqual(t["denials_ever"], t["denials"])
+        newest_denial = Denial.objects.latest("denial_id")
+        newest_draft = ProposedAppeal.objects.latest("id")
+        ever_before = (t["denials_ever"], t["drafts_ever"])
+        newest_draft.delete()
+        newest_denial.delete()
+        t2 = self.client.get(reverse("admin_status")).context["all_time"]
+        self.assertEqual((t2["denials_ever"], t2["drafts_ever"]), ever_before)
+        self.assertEqual(t2["denials"], t["denials"] - 1)
+
+    @mock.patch(_FAX)
+    @mock.patch(_ACTORS)
+    @mock.patch(_MODELS)
+    def test_delivered_aggregate_is_computed_once_per_page(
+        self, mock_models, mock_actors, mock_fax
+    ):
+        mock_models.return_value = []
+        mock_actors.return_value = {"alive_actors": 0, "total_actors": 0, "details": []}
+        mock_fax.return_value = _ok_fax_backends()
+        from fighthealthinsurance import staff_views
+
+        real = staff_views._lifetime_snapshot
+        with mock.patch.object(
+            staff_views, "_lifetime_snapshot", side_effect=real
+        ) as agg:
+            self.client.get(reverse("admin_status"))
+        self.assertEqual(agg.call_count, 1)
+        # And that one call is ONE SQL statement: one snapshot (review).
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        with CaptureQueriesContext(connection) as queries:
+            real()
+        self.assertEqual(len(queries), 1, [q["sql"] for q in queries])
+
+    @mock.patch(_FAX)
+    @mock.patch(_ACTORS)
+    @mock.patch(_MODELS)
+    def test_failed_delivered_aggregate_is_unavailable_not_zero(
+        self, mock_models, mock_actors, mock_fax
+    ):
+        """A statement timeout on the lifetime aggregate must not render as
+        "0 delivered" in either panel (review)."""
+        mock_models.return_value = []
+        mock_actors.return_value = {"alive_actors": 0, "total_actors": 0, "details": []}
+        mock_fax.return_value = _ok_fax_backends()
+        self._make_fax(should_send=True, sent=True, fax_success=True)
+        from fighthealthinsurance import staff_views
+
+        with mock.patch.object(
+            staff_views, "_lifetime_snapshot", side_effect=RuntimeError("timeout")
+        ):
+            response = self.client.get(reverse("admin_status"))
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.context["fax_outcomes"]["delivered_all_time"])
+        self.assertIsNone(response.context["all_time"]["faxes_delivered_lifetime"])
+        self.assertContains(response, "unavailable")
+        self.assertContains(response, "removal totals unavailable")
+        self.assertContains(response, "an unavailable number of people")
+        self.assertNotContains(response, "none recorded yet")
+
+    def _person_with_data(self, email, delivered=True, professional_fax_for=None):
+        from fighthealthinsurance.models import Denial, ProposedAppeal
+
+        hashed = Denial.get_hashed_email(email)
+        d1 = Denial.objects.create(semi_sekret="s", hashed_email=hashed)
+        d2 = Denial.objects.create(semi_sekret="s", hashed_email=hashed)
+        ProposedAppeal.objects.create(for_denial=d1, appeal_text=f"real draft {email}")
+        ProposedAppeal.objects.create(
+            for_denial=d2, appeal_text=f"reserve {email}", speculative=True
+        )
+        if delivered:
+            self._make_fax(
+                hashed_email=hashed, email=email, sent=True, fax_success=True
+            )
+        self._make_fax(hashed_email=hashed, email=email, sent=True, fax_success=False)
+        if professional_fax_for is not None:
+            # A professional's fax staged for THIS person's denial: keyed by
+            # the professional's email and hash, removed by cascade through
+            # the denial (review).
+            self._make_fax(
+                hashed_email=Denial.get_hashed_email(professional_fax_for),
+                email=professional_fax_for,
+                denial_id=d1,
+                professional=True,
+                sent=True,
+                fax_success=True,
+            )
+        return hashed
+
+    @mock.patch(_FAX)
+    @mock.patch(_ACTORS)
+    @mock.patch(_MODELS)
+    def test_deletion_totals_keep_lifetime_numbers(
+        self, mock_models, mock_actors, mock_fax
+    ):
+        """delete-my-data removes the rows; the totals updated in that same
+        transaction keep the person and the delivered faxes in the lifetime
+        figures, including a fax removed by cascade through the denial."""
+        from fighthealthinsurance.helpers.data_helpers import RemoveDataHelper
+        from fighthealthinsurance.models import (
+            DataRemovalTotals,
+            Denial,
+            ProposedAppeal,
+        )
+
+        mock_models.return_value = []
+        mock_actors.return_value = {"alive_actors": 0, "total_actors": 0, "details": []}
+        mock_fax.return_value = _ok_fax_backends()
+        email = "leaving@example.com"
+        hashed = self._person_with_data(
+            email, professional_fax_for="pro@clinic.example"
+        )
+        staying = Denial.objects.create(semi_sekret="s", hashed_email="stays")
+        ProposedAppeal.objects.create(for_denial=staying, appeal_text="stays too")
+        before = self.client.get(reverse("admin_status")).context["all_time"]
+        self.assertEqual(before["people_with_draft_lifetime"], 2)
+        self.assertEqual(before["faxes_delivered_lifetime"], 2)
+
+        RemoveDataHelper.remove_data_for_email(email)
+
+        self.assertFalse(Denial.objects.filter(hashed_email=hashed).exists())
+        totals = DataRemovalTotals.objects.get(pk=DataRemovalTotals.SINGLETON_ID)
+        self.assertEqual(
+            (
+                totals.requests,
+                totals.denials,
+                totals.drafts,
+                totals.faxes_delivered,
+                totals.people_with_draft,
+            ),
+            (1, 2, 1, 2, 1),
+        )
+        self.assertIsNotNone(totals.since)
+        t = self.client.get(reverse("admin_status")).context["all_time"]
+        self.assertEqual(t["people_with_draft"], 1)  # only "stays" is present
+        self.assertEqual(t["people_with_draft_lifetime"], 2)  # plus the removed person
+        self.assertEqual(t["faxes_delivered"], 0)
+        self.assertEqual(t["faxes_delivered_lifetime"], 2)  # both delivered faxes
+        self.assertEqual(t["denials_ever"], before["denials_ever"])  # sequence survives
+        self.assertEqual(t["removal_requests"], 1)
+
+    def test_failed_deletion_rolls_the_totals_back_and_a_retry_counts_once(self):
+        from django.db import DatabaseError
+
+        from fighthealthinsurance.helpers.data_helpers import RemoveDataHelper
+        from fighthealthinsurance.models import DataRemovalTotals, Denial
+
+        email = "retry@example.com"
+        hashed = self._person_with_data(email)
+        # Fail AFTER the Denial delete has executed inside the transaction:
+        # the FollowUp delete comes later in _delete_rows.
+        with mock.patch(
+            "fighthealthinsurance.helpers.data_helpers.FollowUp.objects.filter",
+            side_effect=DatabaseError("halfway"),
+        ):
+            with self.assertRaises(DatabaseError):
+                RemoveDataHelper.remove_data_for_email(email)
+        # Nothing committed: the denials are back, nothing counted.
+        self.assertTrue(Denial.objects.filter(hashed_email=hashed).exists())
+        self.assertFalse(DataRemovalTotals.objects.exists())
+        RemoveDataHelper.remove_data_for_email(email)
+        totals = DataRemovalTotals.objects.get()
+        self.assertEqual(
+            (totals.requests, totals.people_with_draft, totals.faxes_delivered),
+            (1, 1, 1),
+        )
+
+    def test_totals_failure_never_blocks_deletion(self):
+        """A database error while counting (e.g. the totals table missing
+        mid-rollout) rolls back only its savepoint; the deletion proceeds."""
+        from django.db import DatabaseError
+
+        from fighthealthinsurance.helpers.data_helpers import RemoveDataHelper
+        from fighthealthinsurance.models import DataRemovalTotals, Denial
+
+        from django.db import connection
+
+        email = "blocked@example.com"
+        hashed = self._person_with_data(email)
+
+        def real_db_error(*args, **kwargs):
+            # A statement that actually fails at the database, inside the
+            # bookkeeping savepoint (on Postgres this would poison the
+            # enclosing transaction without the savepoint; sqlite forgives
+            # it, so this pins the code path, not the Postgres semantics).
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT 1 FROM table_that_does_not_exist")
+
+        with mock.patch.object(
+            DataRemovalTotals.objects, "get_or_create", side_effect=real_db_error
+        ):
+            RemoveDataHelper.remove_data_for_email(email)
+        self.assertFalse(Denial.objects.filter(hashed_email=hashed).exists())
+        self.assertFalse(DataRemovalTotals.objects.exists())
+
+    @mock.patch(_FAX)
+    @mock.patch(_ACTORS)
+    @mock.patch(_MODELS)
+    def test_fax_sections_sit_together(self, mock_models, mock_actors, mock_fax):
+        """Fax backends, queue, Temporal (fax workflows) and delivery are one
+        story; the intake funnel must not split them."""
+        mock_models.return_value = []
+        mock_actors.return_value = {"alive_actors": 0, "total_actors": 0, "details": []}
+        mock_fax.return_value = _ok_fax_backends()
+        response = self.client.get(reverse("admin_status"))
+        body = response.content.decode()
+        order = [
+            body.index("Fax Backends"),
+            body.index("Fax Queue"),
+            body.index("Temporal (fax workflows)"),
+            body.index("Fax delivery (last 7 days)"),
+            body.index("Intake funnel"),
+        ]
+        self.assertEqual(order, sorted(order), "fax sections are not contiguous")
 
 
 class FaxOutcomeStatusOrderingTest(TestCase):
@@ -483,7 +792,9 @@ class AdminStatusLetterScoringTest(TestCase):
     _drafts_made = 0
 
     @classmethod
-    def _draft(cls, denial, *, minutes_ago=5, speculative=False, scored=False, now=None):
+    def _draft(
+        cls, denial, *, minutes_ago=5, speculative=False, scored=False, now=None
+    ):
         # Distinct text per row: (denial, text fingerprint) is unique.
         cls._drafts_made += 1
         row = ProposedAppeal.objects.create(
@@ -517,7 +828,9 @@ class AdminStatusLetterScoringTest(TestCase):
         self.assertFalse(status["flag_on"])
 
     def test_a_key_without_the_flag_is_off_and_says_which_half_is_missing(self):
-        with override_settings(TYPESAFE_API_KEY="k", TYPESAFE_LETTER_RANKING_ENABLED=False):
+        with override_settings(
+            TYPESAFE_API_KEY="k", TYPESAFE_LETTER_RANKING_ENABLED=False
+        ):
             status = self._status()
         self.assertEqual(status["level"], "off")
         self.assertTrue(status["key_present"])
@@ -655,9 +968,13 @@ class AdminStatusLetterScoringTest(TestCase):
         )
         User.objects.create_user(username="staff", password="pw123", is_staff=True)
         self.client.login(username="staff", password="pw123")
-        with override_settings(**_SCORING_ON), mock.patch(_MODELS, return_value=[]), mock.patch(
+        with override_settings(**_SCORING_ON), mock.patch(
+            _MODELS, return_value=[]
+        ), mock.patch(
             _ACTORS, return_value={"alive_actors": 0, "total_actors": 0, "details": []}
-        ), mock.patch(_FAX, return_value=_ok_fax_backends()):
+        ), mock.patch(
+            _FAX, return_value=_ok_fax_backends()
+        ):
             response = self.client.get(reverse("admin_status"))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "FAILING")
@@ -670,12 +987,18 @@ class AdminStatusLetterScoringTest(TestCase):
         self._draft(self._denial(), minutes_ago=5)
         User.objects.create_user(username="staff", password="pw123", is_staff=True)
         self.client.login(username="staff", password="pw123")
-        with override_settings(**_SCORING_ON), mock.patch(_MODELS, return_value=[]), mock.patch(
+        with override_settings(**_SCORING_ON), mock.patch(
+            _MODELS, return_value=[]
+        ), mock.patch(
             _ACTORS, return_value={"alive_actors": 0, "total_actors": 0, "details": []}
-        ), mock.patch(_FAX, return_value=_ok_fax_backends()):
+        ), mock.patch(
+            _FAX, return_value=_ok_fax_backends()
+        ):
             response = self.client.get(reverse("admin_status"))
         self.assertContains(response, "NOT SCORING")
-        self.assertContains(response, "1 eligible draft since the last score, none scored")
+        self.assertContains(
+            response, "1 eligible draft since the last score, none scored"
+        )
 
 
 class ComputeModelHealthDetailsTest(TestCase):

--- a/tests/sync/test_admin_status.py
+++ b/tests/sync/test_admin_status.py
@@ -149,6 +149,16 @@ class AdminStatusFaxQueueTest(TestCase):
         self._make_fax(should_send=True, sent=False, attempting_to_send_as_of=now)
         # E: a recent failure.
         self._make_fax(should_send=True, sent=True, fax_success=False)
+        # K: staged long ago, resent from the status page this week, failed
+        # again. Recent by attempt, not by creation: the queue card and the
+        # delivery panel must agree about it (review).
+        self._make_fax(
+            date=now - datetime.timedelta(days=30),
+            should_send=True,
+            sent=True,
+            fax_success=False,
+            attempting_to_send_as_of=now - datetime.timedelta(days=1),
+        )
         # F: a success (must be ignored everywhere).
         self._make_fax(should_send=True, sent=True, fax_success=True)
         # G: an attempt from days ago that was never cleared. Not in flight
@@ -192,7 +202,7 @@ class AdminStatusFaxQueueTest(TestCase):
         self.assertEqual(q["requested_unpicked"], 1)  # J
         self.assertEqual(q["in_flight"], 2)  # D, H; G and I are hours old
         self.assertEqual(q["stale_attempts"], 2)  # G, I
-        self.assertEqual(q["failures_recent"], 1)  # E
+        self.assertEqual(q["failures_recent"], 2)  # E, K
         # The page headlines what is actionable, not the unsent total.
         self.assertNotContains(response, "Unsent (total)")
         self.assertContains(response, "Stuck (queued")
@@ -212,7 +222,7 @@ class AdminStatusFaxQueueTest(TestCase):
         self.assertEqual(all_time["faxes_delivered"], 1)  # present rows
         self.assertEqual(all_time["faxes_delivered_lifetime"], 0)  # counter
         self.assertEqual(all_time["faxes_sent_lifetime"], 0)  # counter
-        self.assertEqual(all_time["faxes_sent"], 2)  # present rows: E, F
+        self.assertEqual(all_time["faxes_sent"], 3)  # present rows: E, F, K
         self.assertContains(response, "Faxes sent (an attempt was made)")
         self.assertContains(response, "All time")
 

--- a/tests/sync/test_finalize_fax_deleted_row.py
+++ b/tests/sync/test_finalize_fax_deleted_row.py
@@ -1,0 +1,46 @@
+"""finalize_fax must never re-create a fax row that was deleted while the
+send was in flight (a delete-my-data request racing the fax worker)."""
+
+from unittest import mock
+
+from django.test import TestCase
+
+from fighthealthinsurance import fax_send_core
+from fighthealthinsurance.models import FaxesToSend
+
+
+class FinalizeFaxDeletedRowTest(TestCase):
+    def _fax(self):
+        return FaxesToSend.objects.create(
+            hashed_email="h",
+            paid=True,
+            email="a@b.com",
+            appeal_text="x",
+            name="Test",
+            destination="(555) 555-0100",
+        )
+
+    @mock.patch("fighthealthinsurance.fax_send_core.send_fax_status_notification")
+    @mock.patch("fighthealthinsurance.fax_send_core.EmailMultiAlternatives")
+    def test_deleted_row_is_not_resurrected_and_nobody_is_notified(
+        self, mock_email, mock_notify
+    ):
+        fax = self._fax()
+        pk = fax.pk
+        FaxesToSend.objects.filter(pk=pk).delete()  # the person asked to be forgotten
+        fax_send_core.finalize_fax(fax, True, False)
+        self.assertFalse(
+            FaxesToSend.objects.filter(pk=pk).exists()
+        )  # save() would INSERT
+        mock_notify.assert_not_called()
+        mock_email.assert_not_called()
+
+    @mock.patch("fighthealthinsurance.fax_send_core.send_fax_status_notification")
+    @mock.patch("fighthealthinsurance.fax_send_core.EmailMultiAlternatives")
+    def test_present_row_is_marked_sent(self, mock_email, mock_notify):
+        fax = self._fax()
+        fax_send_core.finalize_fax(fax, True, False)
+        fax.refresh_from_db()
+        self.assertTrue(fax.sent)
+        self.assertTrue(fax.fax_success)
+        mock_notify.assert_called_once()

--- a/tests/sync/test_lifetime_counters.py
+++ b/tests/sync/test_lifetime_counters.py
@@ -217,7 +217,9 @@ class DraftCounterTest(TestCase):
         ), mock.patch.object(
             lifetime_counters, "person_lock", side_effect=[True, False]
         ):
-            self.assertFalse(lifetime_counters._mark_person(x.pk))
+            ProposedAppeal.objects.create(for_denial=x, appeal_text="draft")
+        # The draft still counts; only the person is given up on, logged.
+        self.assertEqual(_counters()[:2], (1, 0))
         self.assertFalse(Denial.objects.get(pk=x.pk).person_counted)
 
     def test_deferred_load_still_detects_a_hash_change(self):
@@ -528,6 +530,85 @@ class FaxCounterTest(TestCase):
             fax_send_core.finalize_fax(fax, True, False)
         fax.refresh_from_db()
         self.assertTrue(fax.sent and fax.fax_success)
+
+
+class DeletionTotalsTest(TestCase):
+    """RemoveDataHelper's own bookkeeping, which is not a lifetime counter:
+    it counts what deletion took, and must never block a deletion."""
+
+    EMAIL = "person@example.com"
+
+    def _denial(self):
+        return Denial.objects.create(
+            semi_sekret="s", hashed_email=Denial.get_hashed_email(self.EMAIL)
+        )
+
+    def _totals(self):
+        from fighthealthinsurance.models import DataRemovalTotals
+
+        row = DataRemovalTotals.objects.filter(
+            pk=DataRemovalTotals.SINGLETON_ID
+        ).first()
+        return (row.requests, row.denials) if row else (0, 0)
+
+    def test_totals_count_the_denials_the_delete_actually_removed(self):
+        """A denial created after a pre-delete count would be deleted and
+        never counted; the number comes from the delete itself (review)."""
+        from fighthealthinsurance.helpers.data_helpers import RemoveDataHelper
+
+        self._denial()
+        late = None
+
+        real_delete = RemoveDataHelper._delete_rows.__func__
+
+        def delete_rows(cls, email, hashed_email):
+            nonlocal late
+            late = Denial.objects.create(  # lands after any pre-count
+                semi_sekret="s", hashed_email=hashed_email
+            )
+            return real_delete(cls, email, hashed_email)
+
+        with mock.patch.object(
+            RemoveDataHelper, "_delete_rows", classmethod(delete_rows)
+        ):
+            RemoveDataHelper.remove_data_for_email(self.EMAIL)
+        self.assertIsNotNone(late)
+        self.assertEqual(self._totals(), (1, 2))
+        self.assertFalse(Denial.objects.exists())
+
+    def test_deletion_locks_the_person_before_touching_their_rows(self):
+        """The cascade locks denial rows one at a time; taking the person's
+        lock first is what keeps it from deadlocking a count (review)."""
+        from fighthealthinsurance.helpers.data_helpers import RemoveDataHelper
+
+        d = self._denial()
+        order = []
+        with mock.patch.object(
+            lifetime_counters,
+            "person_lock",
+            side_effect=lambda h, **kw: order.append(("lock", h)) or True,
+        ), mock.patch.object(
+            RemoveDataHelper,
+            "_delete_rows",
+            classmethod(
+                lambda cls, email, hashed: order.append(("delete", hashed)) or 0
+            ),
+        ):
+            RemoveDataHelper.remove_data_for_email(self.EMAIL)
+        self.assertEqual(order, [("lock", d.hashed_email), ("delete", d.hashed_email)])
+
+    def test_bookkeeping_failure_never_blocks_a_deletion(self):
+        from fighthealthinsurance.helpers.data_helpers import RemoveDataHelper
+        from fighthealthinsurance.models import DataRemovalTotals
+
+        self._denial()
+        with mock.patch.object(
+            DataRemovalTotals.objects,
+            "get_or_create",
+            side_effect=DatabaseError("no table"),
+        ):
+            RemoveDataHelper.remove_data_for_email(self.EMAIL)
+        self.assertFalse(Denial.objects.exists())
 
 
 class SeedTest(TestCase):

--- a/tests/sync/test_lifetime_counters.py
+++ b/tests/sync/test_lifetime_counters.py
@@ -164,6 +164,62 @@ class DraftCounterTest(TestCase):
         ProposedAppeal.objects.create(for_denial=mover, appeal_text="b again")
         self.assertEqual(_counters()[:2], (2, 1))
 
+    def _stale_then_real(self, stale):
+        """_persisted_hash that lies once, the way a read can be overtaken
+        by another request's re-key before this writer takes the lock."""
+        real = lifetime_counters._persisted_hash
+        reads = []
+
+        def read(denial_id):
+            reads.append(denial_id)
+            return stale if len(reads) == 1 else real(denial_id)
+
+        return reads, read
+
+    def test_rekey_between_read_and_lock_goes_round_to_the_new_person(self):
+        x = self._denial()
+        sibling = self._denial()  # stays with person-a, gets locked first
+        Denial.objects.filter(pk=x.pk).update(hashed_email="person-b")
+        reads, read = self._stale_then_real("person-a")
+        with mock.patch.object(lifetime_counters, "_persisted_hash", new=read):
+            self.assertTrue(lifetime_counters._mark_person(x.pk))
+        self.assertEqual(len(reads), 2)  # read again after the mismatch
+        self.assertTrue(Denial.objects.get(pk=x.pk).person_counted)
+        # person-a was locked but never flagged: the denial had left them
+        self.assertFalse(Denial.objects.get(pk=sibling.pk).person_counted)
+
+    def test_retry_never_waits_for_the_new_persons_lock(self):
+        """The retry holds the previous person's locks, so it must take the
+        new person's lock with the try variant and give up if it is busy;
+        waiting there deadlocks against a re-key going the other way."""
+        x = self._denial()
+        Denial.objects.filter(pk=x.pk).update(hashed_email="person-b")
+        reads, read = self._stale_then_real("person-a")
+        blocking = []
+        real_lock = lifetime_counters.person_lock
+
+        def lock(hashed, *, blocking_flag=None, **kwargs):
+            blocking.append(kwargs.get("blocking", True))
+            return real_lock(hashed, **kwargs)
+
+        with mock.patch.object(
+            lifetime_counters, "_persisted_hash", new=read
+        ), mock.patch.object(lifetime_counters, "person_lock", new=lock):
+            self.assertTrue(lifetime_counters._mark_person(x.pk))
+        self.assertEqual(blocking, [True, False])  # first blocks, retry does not
+
+    def test_busy_lock_after_a_rekey_counts_the_draft_but_not_the_person(self):
+        x = self._denial()
+        Denial.objects.filter(pk=x.pk).update(hashed_email="person-b")
+        reads, read = self._stale_then_real("person-a")
+        with mock.patch.object(
+            lifetime_counters, "_persisted_hash", new=read
+        ), mock.patch.object(
+            lifetime_counters, "person_lock", side_effect=[True, False]
+        ):
+            self.assertFalse(lifetime_counters._mark_person(x.pk))
+        self.assertFalse(Denial.objects.get(pk=x.pk).person_counted)
+
     def test_deferred_load_still_detects_a_hash_change(self):
         a = self._denial()
         ProposedAppeal.objects.create(for_denial=a, appeal_text="first")
@@ -173,25 +229,31 @@ class DraftCounterTest(TestCase):
         self.assertFalse(Denial.objects.get(pk=a.pk).person_counted)
 
     def test_every_flag_writer_takes_the_person_lock(self):
-        with mock.patch.object(lifetime_counters, "person_lock") as lock:
+        def locked(lock):
+            return [call.args[0] for call in lock.call_args_list]
+
+        with mock.patch.object(
+            lifetime_counters, "person_lock", return_value=True
+        ) as lock:
             d = self._denial()
-            lock.assert_called_once_with("person-a")
+            self.assertEqual(locked(lock), ["person-a"])
             lock.reset_mock()
             self._denial("")  # no person, nothing to serialize
             lock.assert_not_called()
             ProposedAppeal.objects.create(for_denial=d, appeal_text="draft")
-            lock.assert_called_once_with("person-a")
+            self.assertEqual(locked(lock), ["person-a"])
+            self.assertEqual(lock.call_args.kwargs, {"blocking": True})
             lock.reset_mock()
             d = Denial.objects.get(pk=d.pk)
             d.denial_text = "edited"
             d.save()  # a full save writes the hash: same lock, flag untouched
-            lock.assert_called_once_with("person-a")
+            self.assertEqual(locked(lock), ["person-a"])
             lock.reset_mock()
             d.save(update_fields=["denial_text"])  # hash not written: no lock
             lock.assert_not_called()
             d.hashed_email = "person-q"
             d.save()
-            lock.assert_called_once_with("person-q")
+            self.assertEqual(locked(lock), ["person-q"])
 
     def test_person_lock_is_a_postgres_advisory_lock(self):
         key = lifetime_counters._advisory_key("person-a")

--- a/tests/sync/test_lifetime_counters.py
+++ b/tests/sync/test_lifetime_counters.py
@@ -45,6 +45,34 @@ class DraftCounterTest(TestCase):
         )
         self.assertEqual(_counters()[:3], (4, 2, 0))
 
+    def test_later_denial_inherits_the_flag_so_deleting_the_first_is_safe(self):
+        """A denial created after the person was counted must carry the
+        flag: otherwise deleting the older denial by hand (admin) leaves the
+        person present but unflagged, and their next draft counts them
+        again (review)."""
+        a = self._denial()
+        ProposedAppeal.objects.create(for_denial=a, appeal_text="first")
+        self.assertEqual(_counters()[:2], (1, 1))
+        b = self._denial()  # same person, created after the count
+        self.assertTrue(Denial.objects.get(pk=b.pk).person_counted)
+        Denial.objects.filter(pk=a.pk).delete()
+        ProposedAppeal.objects.create(for_denial=b, appeal_text="later")
+        self.assertEqual(_counters()[:2], (2, 1))
+
+    def test_unflagged_sibling_is_flagged_on_the_next_draft(self):
+        """The race the row lock serializes can still leave one row
+        unflagged if the two commits interleave the other way; the next
+        draft repairs it without counting the person again."""
+        a = self._denial()
+        b = self._denial()
+        Denial.objects.filter(pk=a.pk).update(person_counted=True)  # as if raced
+        ProposedAppeal.objects.create(for_denial=b, appeal_text="draft")
+        self.assertEqual(_counters()[:2], (1, 0))
+        self.assertTrue(Denial.objects.get(pk=b.pk).person_counted)
+        Denial.objects.filter(pk=a.pk).delete()
+        ProposedAppeal.objects.create(for_denial=b, appeal_text="again")
+        self.assertEqual(_counters()[:2], (2, 0))
+
     def test_speculative_precompute_counts_as_generated(self):
         ProposedAppeal.objects.create(
             for_denial=self._denial(), appeal_text="held back", speculative=True

--- a/tests/sync/test_lifetime_counters.py
+++ b/tests/sync/test_lifetime_counters.py
@@ -12,6 +12,9 @@ from fighthealthinsurance.models import (
     FaxesToSend,
     LifetimeCounters,
     ProposedAppeal,
+    UCRAreaKind,
+    UCRGeographicArea,
+    UCRLookup,
 )
 
 
@@ -72,6 +75,85 @@ class DraftCounterTest(TestCase):
         Denial.objects.filter(pk=a.pk).delete()
         ProposedAppeal.objects.create(for_denial=b, appeal_text="again")
         self.assertEqual(_counters()[:2], (2, 0))
+
+    def test_row_moving_to_another_hash_adopts_that_persons_state(self):
+        """The hash is the person. A flagged row re-keyed to an uncounted
+        person must not suppress that person's first count, and an
+        unflagged row re-keyed into a counted person must be flagged, or
+        deleting that person's older denial lets them count again (review)."""
+        a = self._denial()
+        ProposedAppeal.objects.create(for_denial=a, appeal_text="first")
+        self.assertEqual(_counters()[:2], (1, 1))
+        a = Denial.objects.get(pk=a.pk)
+        a.hashed_email = "person-q"  # the edit form can change the email
+        a.save()
+        self.assertFalse(Denial.objects.get(pk=a.pk).person_counted)
+        ProposedAppeal.objects.create(for_denial=a, appeal_text="q first")
+        self.assertEqual(_counters()[:2], (2, 2))
+        stray = self._denial("person-r")  # unflagged, no draft yet
+        stray = Denial.objects.get(pk=stray.pk)
+        stray.hashed_email = "person-q"
+        stray.save()
+        self.assertTrue(Denial.objects.get(pk=stray.pk).person_counted)
+        Denial.objects.filter(pk=a.pk).delete()
+        ProposedAppeal.objects.create(for_denial=stray, appeal_text="q again")
+        self.assertEqual(_counters()[:2], (3, 2))
+        stray.hashed_email = ""
+        stray.save(update_fields=["hashed_email"])
+        self.assertFalse(Denial.objects.get(pk=stray.pk).person_counted)
+
+    def test_deferred_load_still_detects_a_hash_change(self):
+        a = self._denial()
+        ProposedAppeal.objects.create(for_denial=a, appeal_text="first")
+        thin = Denial.objects.only("denial_text").get(pk=a.pk)
+        thin.hashed_email = "person-q"
+        thin.save()
+        self.assertFalse(Denial.objects.get(pk=a.pk).person_counted)
+
+    def test_every_flag_writer_takes_the_person_lock(self):
+        with mock.patch.object(lifetime_counters, "person_lock") as lock:
+            d = self._denial()
+            lock.assert_called_once_with("person-a")
+            lock.reset_mock()
+            self._denial("")  # no person, nothing to serialize
+            lock.assert_not_called()
+            ProposedAppeal.objects.create(for_denial=d, appeal_text="draft")
+            lock.assert_called_once_with("person-a")
+            lock.reset_mock()
+            d = Denial.objects.get(pk=d.pk)
+            d.denial_text = "edited"
+            d.save()  # hash unchanged: no lock, flag untouched
+            lock.assert_not_called()
+            d.hashed_email = "person-q"
+            d.save()
+            lock.assert_called_once_with("person-q")
+
+    def test_person_lock_is_a_postgres_advisory_lock(self):
+        key = lifetime_counters._advisory_key("person-a")
+        self.assertEqual(key, lifetime_counters._advisory_key("person-a"))
+        self.assertNotEqual(key, lifetime_counters._advisory_key("person-b"))
+        self.assertTrue(-(2**63) <= key < 2**63)
+        conn = mock.MagicMock(vendor="postgresql")
+        cursor = conn.cursor.return_value.__enter__.return_value
+        with mock.patch.object(lifetime_counters, "connection", conn):
+            lifetime_counters.person_lock("person-a")
+        cursor.execute.assert_called_once_with(
+            "SELECT pg_advisory_xact_lock(%s)", [key]
+        )
+        with mock.patch.object(lifetime_counters, "connection", conn):
+            lifetime_counters.person_lock("")
+        cursor.execute.assert_called_once()  # blank hash: no lock
+
+    def test_creation_still_enforces_the_ucr_owner_guard(self):
+        owner = self._denial()
+        area = UCRGeographicArea.objects.create(kind=UCRAreaKind.ZIP3, code="941")
+        lookup = UCRLookup.objects.create(
+            denial=owner, procedure_code="99213", matched_area=area, rates_snapshot=[]
+        )
+        with self.assertRaises(ValueError):
+            Denial(
+                semi_sekret="s", hashed_email="person-a", latest_ucr_lookup=lookup
+            ).save()
 
     def test_speculative_precompute_counts_as_generated(self):
         ProposedAppeal.objects.create(

--- a/tests/sync/test_lifetime_counters.py
+++ b/tests/sync/test_lifetime_counters.py
@@ -210,6 +210,42 @@ class FaxCounterTest(TestCase):
 
     @mock.patch("fighthealthinsurance.fax_send_core.send_fax_status_notification")
     @mock.patch("fighthealthinsurance.fax_send_core.EmailMultiAlternatives")
+    def test_stale_full_save_keeps_the_markers(self, *_):
+        """resend/precheck/remote_send_fax load the row, then save() it in
+        full. If that save interleaves with a finalize on another worker
+        the stale False markers must not be written back (review)."""
+        fax = self._fax()
+        stale = FaxesToSend.objects.get(pk=fax.pk)  # loaded before finalize
+        self._finalize(fax, True)
+        self.assertEqual(_counters()[2:], (1, 1))
+        stale.destination = "(555) 555-0102"
+        stale.sent = False  # what SendFaxHelper.resend writes
+        stale.save()
+        fresh = FaxesToSend.objects.get(pk=fax.pk)
+        self.assertEqual(fresh.destination, "(555) 555-0102")
+        self.assertFalse(fresh.sent)
+        self.assertTrue(fresh.attempt_counted and fresh.delivery_counted)
+        self._finalize(fresh, True)
+        self.assertEqual(_counters()[2:], (1, 1))
+
+    def test_markers_are_not_on_the_admin_form(self):
+        from django.contrib import admin
+        from django.test import RequestFactory
+
+        from django.contrib.auth import get_user_model
+
+        request = RequestFactory().get("/")
+        request.user = get_user_model().objects.create_superuser(
+            "staff", "s@example.com", "pw"
+        )
+        fax_form = admin.site._registry[FaxesToSend].get_form(request)
+        for name in FaxesToSend.LIFETIME_MARKERS:
+            self.assertNotIn(name, fax_form.base_fields)
+        denial_form = admin.site._registry[Denial].get_form(request)
+        self.assertNotIn("person_counted", denial_form.base_fields)
+
+    @mock.patch("fighthealthinsurance.fax_send_core.send_fax_status_notification")
+    @mock.patch("fighthealthinsurance.fax_send_core.EmailMultiAlternatives")
     def test_failure_after_delivery_cannot_count_delivery_again(self, *_):
         fax = self._finalize(self._fax(), True)
         self.assertEqual(_counters()[2:], (1, 1))
@@ -294,4 +330,13 @@ class SeedTest(TestCase):
         )
         self.assertEqual(list(flagged), ["p"])
         lifetime_counters.seed_from_present_rows(apps, None)  # idempotent
+        self.assertEqual(_counters(), (2, 1, 1, 1))
+        # The seed marked the present fax as it counted it, so a resend of
+        # that fax after the migration counts nothing again.
+        seeded = FaxesToSend.objects.get(hashed_email="p")
+        self.assertTrue(seeded.attempt_counted and seeded.delivery_counted)
+        with mock.patch(
+            "fighthealthinsurance.fax_send_core.send_fax_status_notification"
+        ), mock.patch("fighthealthinsurance.fax_send_core.EmailMultiAlternatives"):
+            fax_send_core.finalize_fax(seeded, True, False)
         self.assertEqual(_counters(), (2, 1, 1, 1))

--- a/tests/sync/test_lifetime_counters.py
+++ b/tests/sync/test_lifetime_counters.py
@@ -1,0 +1,297 @@
+"""The lifetime counters only ever go up, and move exactly when a draft is
+generated, a person gets their first generated draft, or a fax is delivered."""
+
+from unittest import mock
+
+from django.db import DatabaseError
+from django.test import TestCase
+
+from fighthealthinsurance import fax_send_core, lifetime_counters
+from fighthealthinsurance.models import (
+    Denial,
+    FaxesToSend,
+    LifetimeCounters,
+    ProposedAppeal,
+)
+
+
+def _counters():
+    row = LifetimeCounters.objects.filter(pk=LifetimeCounters.SINGLETON_ID).first()
+    if row is None:
+        return (0, 0, 0, 0)
+    return (
+        row.appeals_generated,
+        row.people_with_draft,
+        row.faxes_delivered,
+        row.faxes_sent,
+    )
+
+
+class DraftCounterTest(TestCase):
+    def _denial(self, hashed="person-a"):
+        return Denial.objects.create(semi_sekret="s", hashed_email=hashed)
+
+    def test_generated_drafts_and_first_person_count(self):
+        d1 = self._denial()
+        ProposedAppeal.objects.create(for_denial=d1, appeal_text="first draft")
+        self.assertEqual(_counters()[:3], (1, 1, 0))
+        ProposedAppeal.objects.create(for_denial=d1, appeal_text="second draft")
+        self.assertEqual(_counters()[:3], (2, 1, 0))  # same person, once
+        d2 = self._denial()  # same person, another denial
+        ProposedAppeal.objects.create(for_denial=d2, appeal_text="third draft")
+        self.assertEqual(_counters()[:3], (3, 1, 0))
+        ProposedAppeal.objects.create(
+            for_denial=self._denial("person-b"), appeal_text="b draft"
+        )
+        self.assertEqual(_counters()[:3], (4, 2, 0))
+
+    def test_speculative_precompute_counts_as_generated(self):
+        ProposedAppeal.objects.create(
+            for_denial=self._denial(), appeal_text="held back", speculative=True
+        )
+        self.assertEqual(_counters()[:3], (1, 1, 0))
+
+    def test_chosen_copy_is_a_pick_not_a_generation(self):
+        d = self._denial()
+        ProposedAppeal.objects.create(for_denial=d, appeal_text="draft")
+        ProposedAppeal.objects.create(for_denial=d, appeal_text="draft", chosen=True)
+        self.assertEqual(_counters()[:3], (1, 1, 0))
+
+    def test_blank_hash_is_a_draft_but_not_a_person(self):
+        ProposedAppeal.objects.create(for_denial=self._denial(""), appeal_text="x")
+        self.assertEqual(_counters()[:3], (1, 0, 0))
+
+    def test_update_does_not_count_again(self):
+        row = ProposedAppeal.objects.create(for_denial=self._denial(), appeal_text="x")
+        row.appeal_text = "edited"
+        row.save()
+        ProposedAppeal.objects.filter(pk=row.pk).update(speculative=False)
+        self.assertEqual(_counters()[:3], (1, 1, 0))
+
+    def test_counter_failure_never_blocks_the_draft_save(self):
+        with mock.patch.object(
+            lifetime_counters, "_add", side_effect=DatabaseError("no table")
+        ):
+            row = ProposedAppeal.objects.create(
+                for_denial=self._denial(), appeal_text="still saved"
+            )
+        self.assertTrue(ProposedAppeal.objects.filter(pk=row.pk).exists())
+        self.assertEqual(_counters()[:3], (0, 0, 0))
+
+    def test_chosen_only_history_does_not_hide_a_first_generation(self):
+        """Someone who only ever submitted their own text (a chosen copy via
+        the share flow) and later gets their first generated draft is a new
+        person for the counter (review)."""
+        d = self._denial()
+        ProposedAppeal.objects.create(for_denial=d, appeal_text="own text", chosen=True)
+        self.assertEqual(_counters()[:3], (0, 0, 0))
+        ProposedAppeal.objects.create(
+            for_denial=self._denial(), appeal_text="generated"
+        )
+        self.assertEqual(_counters()[:3], (1, 1, 0))
+
+    def test_deleting_the_person_leaves_the_counters(self):
+        d = self._denial()
+        ProposedAppeal.objects.create(for_denial=d, appeal_text="x")
+        d.delete()
+        self.assertEqual(_counters()[:3], (1, 1, 0))
+
+    def test_text_change_dropping_speculative_drafts_does_not_recount(self):
+        """Replacing the denial text deletes the precompute's drafts; the
+        next generation for that person must not count them again (review)."""
+        d = self._denial()
+        ProposedAppeal.objects.create(
+            for_denial=d, appeal_text="reserve", speculative=True
+        )
+        self.assertEqual(_counters()[:3], (1, 1, 0))
+        ProposedAppeal.objects.filter(for_denial=d, speculative=True).delete()
+        ProposedAppeal.objects.create(for_denial=d, appeal_text="fresh draft")
+        self.assertEqual(_counters()[:3], (2, 1, 0))
+
+    def test_flag_survives_draft_churn_but_leaves_with_the_data(self):
+        from fighthealthinsurance.helpers.data_helpers import RemoveDataHelper
+
+        email = "back@example.com"
+        hashed = Denial.get_hashed_email(email)
+        d1 = self._denial(hashed)
+        d2 = self._denial(hashed)
+        ProposedAppeal.objects.create(for_denial=d1, appeal_text="first")
+        flags = Denial.objects.filter(hashed_email=hashed).values_list(
+            "person_counted", flat=True
+        )
+        self.assertEqual(list(flags), [True, True])
+        ProposedAppeal.objects.filter(for_denial=d1).delete()  # churn
+        ProposedAppeal.objects.create(for_denial=d2, appeal_text="again")
+        self.assertEqual(_counters()[:2], (2, 1))
+        RemoveDataHelper.remove_data_for_email(email)
+        self.assertFalse(Denial.objects.filter(hashed_email=hashed).exists())
+        self.assertEqual(_counters()[:2], (2, 1))  # the counter keeps them
+        # A person who returns after deletion starts unflagged: counted again,
+        # documented.
+        ProposedAppeal.objects.create(
+            for_denial=self._denial(hashed), appeal_text="new"
+        )
+        self.assertEqual(_counters()[:2], (3, 2))
+
+    def test_stale_full_save_does_not_clear_the_flag(self):
+        """An instance loaded before the flag flipped, then saved in full
+        (edit paths do this), must not write the stale False back (review)."""
+        d = self._denial()
+        stale = Denial.objects.get(pk=d.pk)
+        ProposedAppeal.objects.create(for_denial=d, appeal_text="first")
+        self.assertTrue(Denial.objects.get(pk=d.pk).person_counted)
+        stale.denial_text = "edited later"
+        stale.save()
+        fresh = Denial.objects.get(pk=d.pk)
+        self.assertTrue(fresh.person_counted)
+        self.assertEqual(fresh.denial_text, "edited later")
+        ProposedAppeal.objects.create(for_denial=d, appeal_text="second")
+        self.assertEqual(_counters()[:2], (2, 1))
+
+    def test_receiver_after_deletion_creates_nothing(self):
+        """A draft insert committed just before the person's deletion, with
+        the receiver running after it: no denial rows remain to flag, so no
+        identifier reappears and no person is counted (review)."""
+        from django.db.models.signals import post_save
+
+        d = self._denial("gone")
+        draft = ProposedAppeal(for_denial=d, appeal_text="late")
+        post_save.disconnect(
+            sender=ProposedAppeal, dispatch_uid="lifetime_counters_draft_saved"
+        )
+        try:
+            draft.save()
+        finally:
+            post_save.connect(
+                lifetime_counters._on_draft_saved,
+                sender=ProposedAppeal,
+                dispatch_uid="lifetime_counters_draft_saved",
+            )
+        self.assertEqual(_counters()[:2], (0, 0))  # the receiver did not run yet
+        Denial.objects.filter(pk=d.pk).delete()
+        with mock.patch.object(lifetime_counters, "_add") as add:
+            lifetime_counters._on_draft_saved(ProposedAppeal, draft, created=True)
+        add.assert_called_once_with(appeals_generated=1, people_with_draft=0)
+        self.assertFalse(Denial.objects.filter(hashed_email="gone").exists())
+
+
+class FaxCounterTest(TestCase):
+    def _fax(self):
+        return FaxesToSend.objects.create(
+            hashed_email="h",
+            paid=True,
+            email="a@b.com",
+            appeal_text="x",
+            name="Test",
+            destination="(555) 555-0100",
+        )
+
+    def _finalize(self, fax, success):
+        fax_send_core.finalize_fax(fax, success, False)
+        fax.refresh_from_db()
+        return fax
+
+    @mock.patch("fighthealthinsurance.fax_send_core.send_fax_status_notification")
+    @mock.patch("fighthealthinsurance.fax_send_core.EmailMultiAlternatives")
+    @mock.patch("fighthealthinsurance.helpers.fax_helpers._dispatch_or_ray_fax")
+    def test_real_resend_after_failure_does_not_count_sent_twice(self, *_):
+        """SendFaxHelper.resend resets sent=False on the row; the lifetime
+        "sent" must still count that fax once (review)."""
+        from fighthealthinsurance.helpers.fax_helpers import SendFaxHelper
+
+        fax = self._finalize(self._fax(), False)
+        self.assertEqual(_counters()[2:], (0, 1))  # delivered, sent
+        SendFaxHelper.resend("(555) 555-0101", str(fax.uuid), fax.hashed_email)
+        fax.refresh_from_db()
+        self.assertFalse(fax.sent)  # the row's latest-attempt flag was reset
+        self.assertTrue(fax.attempt_counted)  # the once-only marker was not
+        self._finalize(fax, True)
+        self.assertEqual(_counters()[2:], (1, 1))
+
+    @mock.patch("fighthealthinsurance.fax_send_core.send_fax_status_notification")
+    @mock.patch("fighthealthinsurance.fax_send_core.EmailMultiAlternatives")
+    def test_failure_after_delivery_cannot_count_delivery_again(self, *_):
+        fax = self._finalize(self._fax(), True)
+        self.assertEqual(_counters()[2:], (1, 1))
+        fax = self._finalize(fax, False)  # e.g. resent to another number, failed
+        self.assertFalse(fax.fax_success)  # latest outcome
+        self.assertTrue(fax.delivery_counted)  # counted once, for life
+        self._finalize(fax, True)
+        self.assertEqual(_counters()[2:], (1, 1))
+
+    @mock.patch("fighthealthinsurance.fax_send_core.send_fax_status_notification")
+    @mock.patch("fighthealthinsurance.fax_send_core.EmailMultiAlternatives")
+    def test_delivered_fax_counts_once_and_failed_send_does_not(self, *_):
+        fax = self._fax()
+        fax_send_core.finalize_fax(fax, True, False)
+        self.assertEqual(_counters()[2:], (1, 1))  # delivered, sent
+        # finalize runs under an unlimited retry policy: a retry on the same
+        # delivered fax must not count it again (review).
+        fax_send_core.finalize_fax(fax, True, False)
+        self.assertEqual(_counters()[2:], (1, 1))
+        failed = self._fax()
+        fax_send_core.finalize_fax(failed, False, False)
+        self.assertEqual(_counters()[2:], (1, 2))  # sent, not delivered
+        # A later resend of that failed fax that succeeds: delivered once,
+        # not sent again (the attempt transition already happened).
+        fax_send_core.finalize_fax(failed, True, False)
+        self.assertEqual(_counters()[2:], (2, 2))
+
+    @mock.patch("fighthealthinsurance.fax_send_core.send_fax_status_notification")
+    @mock.patch("fighthealthinsurance.fax_send_core.EmailMultiAlternatives")
+    def test_gone_row_does_not_count(self, *_):
+        fax = self._fax()
+        FaxesToSend.objects.filter(pk=fax.pk).delete()
+        fax_send_core.finalize_fax(fax, True, False)
+        self.assertEqual(_counters()[2:], (0, 0))
+
+    @mock.patch("fighthealthinsurance.fax_send_core.send_fax_status_notification")
+    @mock.patch("fighthealthinsurance.fax_send_core.EmailMultiAlternatives")
+    def test_counter_failure_never_blocks_finalize(self, *_):
+        fax = self._fax()
+        with mock.patch.object(
+            lifetime_counters, "_add", side_effect=DatabaseError("no table")
+        ):
+            fax_send_core.finalize_fax(fax, True, False)
+        fax.refresh_from_db()
+        self.assertTrue(fax.sent and fax.fax_success)
+
+
+class SeedTest(TestCase):
+    def test_seed_from_present_rows_once(self):
+        from django.apps import apps
+
+        d = Denial.objects.create(semi_sekret="s", hashed_email="p")
+        # Rows that predate the counters: neither the add nor the marker ran.
+        with mock.patch.object(lifetime_counters, "_add"), mock.patch.object(
+            lifetime_counters, "_mark_person", return_value=False
+        ):
+            ProposedAppeal.objects.create(for_denial=d, appeal_text="a")
+            ProposedAppeal.objects.create(for_denial=d, appeal_text="b", chosen=True)
+            ProposedAppeal.objects.create(
+                for_denial=Denial.objects.create(semi_sekret="s", hashed_email=""),
+                appeal_text="c",
+            )
+        FaxesToSend.objects.create(
+            hashed_email="p",
+            paid=True,
+            email="a@b.com",
+            appeal_text="x",
+            name="T",
+            sent=True,
+            fax_success=True,
+        )
+        # The migration seeds the row when the test database is built from
+        # empty (all zeros); clear it so this test exercises the seed itself.
+        LifetimeCounters.objects.all().delete()
+        Denial.objects.update(person_counted=False)
+        lifetime_counters.seed_from_present_rows(apps, None)
+        # chosen copy excluded, blank hash no person; one fax present, sent
+        # and delivered.
+        self.assertEqual(_counters(), (2, 1, 1, 1))
+        flagged = Denial.objects.filter(person_counted=True).values_list(
+            "hashed_email", flat=True
+        )
+        self.assertEqual(list(flagged), ["p"])
+        lifetime_counters.seed_from_present_rows(apps, None)  # idempotent
+        self.assertEqual(_counters(), (2, 1, 1, 1))

--- a/tests/sync/test_lifetime_counters.py
+++ b/tests/sync/test_lifetime_counters.py
@@ -188,10 +188,11 @@ class DraftCounterTest(TestCase):
         # person-a was locked but never flagged: the denial had left them
         self.assertFalse(Denial.objects.get(pk=sibling.pk).person_counted)
 
-    def test_retry_never_waits_for_the_new_persons_lock(self):
-        """The retry holds the previous person's locks, so it must take the
-        new person's lock with the try variant and give up if it is busy;
-        waiting there deadlocks against a re-key going the other way."""
+    def test_counting_never_waits_for_a_persons_lock(self):
+        """Counting runs inside somebody else's transaction, which may hold
+        a row a delete-my-data cascade is about to take, so it takes the
+        lock with the try variant on every attempt and gives up if busy;
+        waiting there is what lets the two abort each other (review)."""
         x = self._denial()
         Denial.objects.filter(pk=x.pk).update(hashed_email="person-b")
         reads, read = self._stale_then_real("person-a")
@@ -206,7 +207,7 @@ class DraftCounterTest(TestCase):
             lifetime_counters, "_persisted_hash", new=read
         ), mock.patch.object(lifetime_counters, "person_lock", new=lock):
             self.assertTrue(lifetime_counters._mark_person(x.pk))
-        self.assertEqual(blocking, [True, False])  # first blocks, retry does not
+        self.assertEqual(blocking, [False, False])  # neither attempt waits
 
     def test_busy_lock_after_a_rekey_counts_the_draft_but_not_the_person(self):
         x = self._denial()
@@ -244,7 +245,9 @@ class DraftCounterTest(TestCase):
             lock.assert_not_called()
             ProposedAppeal.objects.create(for_denial=d, appeal_text="draft")
             self.assertEqual(locked(lock), ["person-a"])
-            self.assertEqual(lock.call_args.kwargs, {"blocking": True})
+            # Counting runs inside whatever transaction saved the draft, so
+            # it never waits for the lock (review).
+            self.assertEqual(lock.call_args.kwargs, {"blocking": False})
             lock.reset_mock()
             d = Denial.objects.get(pk=d.pk)
             d.denial_text = "edited"
@@ -308,14 +311,19 @@ class DraftCounterTest(TestCase):
         self.assertEqual(_counters()[:3], (1, 1, 0))
 
     def test_counter_failure_never_blocks_the_draft_save(self):
+        d = self._denial()
         with mock.patch.object(
             lifetime_counters, "_add", side_effect=DatabaseError("no table")
         ):
-            row = ProposedAppeal.objects.create(
-                for_denial=self._denial(), appeal_text="still saved"
-            )
+            row = ProposedAppeal.objects.create(for_denial=d, appeal_text="still saved")
         self.assertTrue(ProposedAppeal.objects.filter(pk=row.pk).exists())
         self.assertEqual(_counters()[:3], (0, 0, 0))
+        # The flag and the count move together or not at all: the savepoint
+        # took the flag back with the failed bump, so the person is counted
+        # on their next draft instead of being lost for good (review).
+        self.assertFalse(Denial.objects.get(pk=d.pk).person_counted)
+        ProposedAppeal.objects.create(for_denial=d, appeal_text="second")
+        self.assertEqual(_counters()[:2], (1, 1))
 
     def test_chosen_only_history_does_not_hide_a_first_generation(self):
         """Someone who only ever submitted their own text (a chosen copy via
@@ -586,7 +594,7 @@ class DeletionTotalsTest(TestCase):
         with mock.patch.object(
             lifetime_counters,
             "person_lock",
-            side_effect=lambda h, **kw: order.append(("lock", h)) or True,
+            side_effect=lambda h, **kw: order.append(("lock", h, kw)) or True,
         ), mock.patch.object(
             RemoveDataHelper,
             "_delete_rows",
@@ -595,7 +603,13 @@ class DeletionTotalsTest(TestCase):
             ),
         ):
             RemoveDataHelper.remove_data_for_email(self.EMAIL)
-        self.assertEqual(order, [("lock", d.hashed_email), ("delete", d.hashed_email)])
+        # Deletion is the one caller that WAITS for the lock: it takes it as
+        # the first statement of its transaction, holding nothing, and it
+        # must not lose a coin flip to a staff counter (review).
+        self.assertEqual(
+            order,
+            [("lock", d.hashed_email, {}), ("delete", d.hashed_email)],
+        )
 
     def test_bookkeeping_failure_never_blocks_a_deletion(self):
         from fighthealthinsurance.helpers.data_helpers import RemoveDataHelper

--- a/tests/sync/test_lifetime_counters.py
+++ b/tests/sync/test_lifetime_counters.py
@@ -102,6 +102,68 @@ class DraftCounterTest(TestCase):
         stray.save(update_fields=["hashed_email"])
         self.assertFalse(Denial.objects.get(pk=stray.pk).person_counted)
 
+    def test_second_stale_rekey_keeps_the_counted_flag(self):
+        """Two instances hold the same denial under A. The first moves it
+        to B and B is counted. The second then saves its own A->B edit:
+        the row already belongs to B, so that is not a move and B's flag
+        must survive, or B's next draft counts B again (review)."""
+        first = self._denial()
+        second = Denial.objects.get(pk=first.pk)
+        first.hashed_email = "person-b"
+        first.save()
+        ProposedAppeal.objects.create(for_denial=first, appeal_text="b first")
+        self.assertEqual(_counters()[:2], (1, 1))
+        second.hashed_email = "person-b"
+        second.save()
+        self.assertTrue(Denial.objects.get(pk=first.pk).person_counted)
+        ProposedAppeal.objects.create(for_denial=first, appeal_text="b again")
+        self.assertEqual(_counters()[:2], (2, 1))
+
+    def test_partial_save_does_not_move_the_baseline(self):
+        """Assigning a new hash and saving other fields first must not make
+        the later hash save look like a no-op (review)."""
+        a = self._denial()
+        ProposedAppeal.objects.create(for_denial=a, appeal_text="first")
+        a = Denial.objects.get(pk=a.pk)
+        a.hashed_email = "person-b"
+        a.denial_text = "edited"
+        a.save(update_fields=["denial_text"])
+        row = Denial.objects.get(pk=a.pk)
+        self.assertEqual((row.hashed_email, row.person_counted), ("person-a", True))
+        a.save(update_fields=["hashed_email"])
+        row = Denial.objects.get(pk=a.pk)
+        self.assertEqual((row.hashed_email, row.person_counted), ("person-b", False))
+        ProposedAppeal.objects.create(for_denial=a, appeal_text="b first")
+        self.assertEqual(_counters()[:2], (2, 2))
+
+    def test_refreshed_instance_does_not_undo_a_move(self):
+        original = self._denial()
+        mover = Denial.objects.get(pk=original.pk)
+        mover.hashed_email = "person-b"
+        mover.save()
+        ProposedAppeal.objects.create(for_denial=mover, appeal_text="b first")
+        original.refresh_from_db()
+        self.assertEqual(original.hashed_email, "person-b")
+        original.denial_text = "edited later"
+        original.save()  # persisted hash == instance hash: not a move
+        self.assertTrue(Denial.objects.get(pk=original.pk).person_counted)
+        ProposedAppeal.objects.create(for_denial=original, appeal_text="b again")
+        self.assertEqual(_counters()[:2], (2, 1))
+
+    def test_draft_counts_the_denials_persisted_person_not_a_cached_one(self):
+        """The speculative precompute holds a denial instance; if another
+        request changed its email meanwhile, the draft belongs to the new
+        person and must count them, not the old hash (review)."""
+        cached = self._denial()
+        mover = Denial.objects.get(pk=cached.pk)
+        mover.hashed_email = "person-b"
+        mover.save()
+        ProposedAppeal.objects.create(for_denial=cached, appeal_text="from cache")
+        self.assertEqual(_counters()[:2], (1, 1))
+        self.assertTrue(Denial.objects.get(pk=cached.pk).person_counted)
+        ProposedAppeal.objects.create(for_denial=mover, appeal_text="b again")
+        self.assertEqual(_counters()[:2], (2, 1))
+
     def test_deferred_load_still_detects_a_hash_change(self):
         a = self._denial()
         ProposedAppeal.objects.create(for_denial=a, appeal_text="first")
@@ -122,7 +184,10 @@ class DraftCounterTest(TestCase):
             lock.reset_mock()
             d = Denial.objects.get(pk=d.pk)
             d.denial_text = "edited"
-            d.save()  # hash unchanged: no lock, flag untouched
+            d.save()  # a full save writes the hash: same lock, flag untouched
+            lock.assert_called_once_with("person-a")
+            lock.reset_mock()
+            d.save(update_fields=["denial_text"])  # hash not written: no lock
             lock.assert_not_called()
             d.hashed_email = "person-q"
             d.save()


### PR DESCRIPTION
…that survive deletion

Fax queue panel: the "Unsent (total)" card is gone (it equalled the pile of drafts nobody ever confirmed); "Stuck" now means queued for over an hour and never picked up, and is highlighted; attempts are bounded to the last two hours, with attempts older than that on their own "Stale attempt" card instead of vanishing; a professional's send that was never picked up gets its own card; all eight counts come from one aggregate query so a row moving bucket mid-refresh is never counted twice. The Fax delivery section moves next to Fax backends, Fax queue and Temporal.

Lifetime totals (new "All time" section): "ever created" for denials, drafts and faxes comes from the id sequences themselves, which deletion cannot lower. The two facts a sequence cannot give -- delivered faxes and people who received a real draft -- are kept durable by DataRemovalTotals (migration 0208): one row of running counters, no per-request rows or timestamps (those would be linkable to UsedDeleteToken.used_at), updated by RemoveDataHelper inside the deletion's own transaction so counts and deletion commit or roll back together, in a savepoint so bookkeeping can never block a deletion, with the totals row, the person's denials, drafts and faxes locked FOR UPDATE for the duration so a promotion or a delivery landing mid-deletion cannot be lost, and cascade-removed faxes counted. The page reads the whole lifetime picture in one statement; a failed read renders "unavailable", never a fabricated zero.

finalize_fax now marks the fax with a filtered UPDATE instead of save(): with the pk set, save() falls back to INSERT when the row is gone, which could re-create a fax a delete-my-data request had just removed. Zero rows means the person is gone; nobody is notified.

Documented limitations: deletions before this shipped are unrecoverable; a person who deletes and returns is counted twice; sqlite (tests) cannot exercise FOR UPDATE or Postgres transaction-abort semantics. Twelve Codex review rounds.


Claude-Session: https://claude.ai/code/session_019SPqa4FZ43ahAjoD53Uj81

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added lifetime statistics to the staff dashboard for generated drafts, people with drafts, fax attempts, confirmed deliveries, data-removal requests, and denials.
  - Added detailed fax queue categories, including unpicked requests, active attempts, stale attempts, and unconfirmed items.
  - Added clear handling for unavailable lifetime statistics.

- **Bug Fixes**
  - Prevented deleted fax records from being recreated after an in-progress send.
  - Ensured fax attempts and deliveries are counted only once, including resends.
  - Improved data-removal totals so they remain accurate after records are deleted.
  - Removed oldest-delivery date information from delivery reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->