### PR TITLE
Bump to v0.23.10a for the worker SIGTERM fix and the status counters

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -82,7 +82,7 @@ else
 fi
 
 # BUILDKIT_NO_CLIENT_TOKEN=true
-FHI_VERSION=v0.23.9a
+FHI_VERSION=v0.23.10a
 
 
 MYORG=${MYORG:-totallylegitco}


### PR DESCRIPTION
Ships #1016 (the fax worker exits on SIGTERM instead of polling the queue until SIGKILL, which ended the 31-minute mixed-version window on every deploy) and #1017 (the reworked fax queue panel and the all-time counters, with additive migration 0208).


Claude-Session: https://claude.ai/code/session_019SPqa4FZ43ahAjoD53Uj81

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application release version to **v0.23.10a** for deployment artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->