### PR TITLE
Letter-shape check: case-insensitive, and a bracketed letterhead line counts

### DIFF
--- a/tests/sync/test_rest_api.py
+++ b/tests/sync/test_rest_api.py
@@ -59,11 +59,14 @@ def assert_letter_like(content: str) -> None:
     salutation / "Re:" line near the top, instead of pinning the exact
     first word of live LLM output.
     """
+    # Case-insensitive, and tolerant of a bracketed placeholder: models write
+    # "RE:" in capitals and "[Appeals Department Address]" as a letterhead
+    # line, both perfectly good letters that a case-sensitive prefix match
+    # failed on.
     stripped = content.lstrip()
-    head_lines = [line.strip().lstrip("*_# ") for line in stripped.splitlines()[:15]]
-    assert stripped.startswith("Dear") or any(
-        line.startswith(("Dear", "Re:", "Appeals Department"))
-        for line in head_lines
+    head_lines = [line.strip().lstrip("*_# [").casefold() for line in stripped.splitlines()[:15]]
+    assert stripped.casefold().startswith("dear") or any(
+        line.startswith(("dear", "re:", "appeals department")) for line in head_lines
     ), f"Appeal should open like a letter (salutation or letterhead): {stripped[:200]!r}"
 
 


### PR DESCRIPTION
The live-model tests in `tests/sync/test_rest_api.py` accept a letter that opens with a salutation or carries a letterhead line near the top. The check was case sensitive and stopped at a bracket, so a model writing `RE:` in capitals or `[Appeals Department Address]` as a letterhead line failed the test on perfectly good output. The suite has been red on main for that reason.

The match is now case-insensitive and strips a leading bracket. Checked the predicate on the shapes that matter (salutation first, `RE:` line, bracketed letterhead, markdown-bold `Re:`, plain prose that should still fail); the tests themselves need live backends so they were not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYruQVRyBbFzUxy9YGcHTb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved appeal-letter validation to accept letterhead lines regardless of capitalization.
  * Added support for letterhead lines that include brackets or Markdown-style prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->