### PR TITLE
Print and fax the letter the person actually edited

### DIFF
--- a/fighthealthinsurance/static/js/appeal.ts
+++ b/fighthealthinsurance/static/js/appeal.ts
@@ -60,10 +60,7 @@ function noteCompletedLetterEdit(): void {
 // `force` is the rebuild button and the panel edits the person just made:
 // an explicit ask. Everything else leaves a hand-edited letter alone.
 function descrub(force = false) {
-  const completed = document.getElementById(
-    "id_completed_appeal_text",
-  ) as HTMLTextAreaElement | null;
-  if (completedLetterEdited && !force && completed && completed.value.trim() !== "") {
+  if (completedLetterEdited && !force) {
     return;
   }
   const appeal_text = document.getElementById("scrubbed_appeal_text");
@@ -277,8 +274,11 @@ function checkForUnfilledPlaceholders(text: string): string[] {
     found.push(singleMatch[0]);
   }
 
-  // Dollar-prefixed template variables like $diagnosis, $DATE, $CASEID
-  const dollarMatches = text.match(/\$[A-Za-z0-9_]+/g);
+  // Dollar-prefixed template variables like $diagnosis, $DATE, $CASEID.
+  // A leading letter or underscore is required so an ordinary amount ("the
+  // treatment costs $500") is not reported as an unfilled placeholder and
+  // does not send a finished letter into the warning (review).
+  const dollarMatches = text.match(/\$[A-Za-z_][A-Za-z0-9_]*/g);
   if (dollarMatches) {
     found.push(...dollarMatches);
   }
@@ -378,18 +378,23 @@ function setupAppeal() {
   if (completed_text != null) {
     completed_text.addEventListener("input", noteCompletedLetterEdit);
   }
-  descrub();
+  // On a server rejection the page comes back with the letter the person
+  // submitted already in the box (fax_views puts the posted text in the
+  // context). Rebuilding on load would strip everything they had added
+  // after the details block, so the first build only fills an empty box
+  // (review).
+  const completedOnLoad = (completed_text as HTMLTextAreaElement | null)?.value ?? "";
+  if (completedOnLoad.trim() === "") {
+    descrub();
+  } else {
+    completedLetterEdited = true;
+  }
 
   // Warn before fax submission if PHI placeholders remain unfilled
   const faxButton = document.getElementById("fax_appeal");
   const faxForm = faxButton?.closest("form") as HTMLFormElement | null;
   if (faxForm) {
-    let skipCheck = false;
     faxForm.addEventListener("submit", (e) => {
-      if (skipCheck) {
-        skipCheck = false;
-        return;
-      }
       // Pick up the details panel for a letter the person has not touched,
       // and leave a hand-edited letter exactly as they left it: this runs
       // one line before the text is read and posted.
@@ -397,9 +402,14 @@ function setupAppeal() {
       const appealText =
         (document.getElementById("id_completed_appeal_text") as HTMLTextAreaElement)
           ?.value || "";
+      if (appealText.trim() === "") {
+        // An empty letter would go out as an empty fax.
+        e.preventDefault();
+        alert("There is no letter to send. Write or rebuild your letter first.");
+        return;
+      }
       const placeholders = checkForUnfilledPlaceholders(appealText);
       if (placeholders.length > 0) {
-        e.preventDefault();
         const listing = placeholders.join(", ");
         const proceed = confirm(
           "Your appeal still contains placeholder text that should be replaced with your personal information:\n\n" +
@@ -407,12 +417,14 @@ function setupAppeal() {
           "\n\nYou may need to fill in your PII/PHI manually — please double-check the letter before submission.\n\n" +
           "Press OK to send the fax anyway, or Cancel to go back and fill in your information first."
         );
-        if (proceed) {
-          skipCheck = true;
-          // Use requestSubmit() so other submit handlers (e.g. pwyw tracking)
-          // still fire and HTML5 constraint validation runs. skipCheck prevents
-          // this handler from re-triggering the placeholder check.
-          faxForm.requestSubmit();
+        // Decided before the submit is stopped: confirming lets this very
+        // submission through, so every other submit handler and the
+        // browser's own validation still run. Calling requestSubmit() from
+        // inside the submit event did nothing at all, so pressing OK
+        // silently sent no fax, and the skip flag it set then waved the
+        // next attempt past this check (review).
+        if (!proceed) {
+          e.preventDefault();
         }
       }
     });

--- a/fighthealthinsurance/static/js/appeal.ts
+++ b/fighthealthinsurance/static/js/appeal.ts
@@ -44,7 +44,28 @@ function getPiiValue(inputId: string, storageKey: string, defaultVal: string): s
 // Sentinel that marks the start of the appended PII block so we can strip & re-add
 const PII_BLOCK_MARKER = "\n\n---\nPatient Information:";
 
-function descrub() {
+// True once the person has typed in the finished letter themselves. Their
+// words win from then on: the letter is rebuilt from the draft and the
+// details panel only when they ask for it with the rebuild button, never
+// silently underneath them, and never on the way to the fax.
+let completedLetterEdited = false;
+let rebuildingCompletedLetter = false;
+
+function noteCompletedLetterEdit(): void {
+  if (!rebuildingCompletedLetter) {
+    completedLetterEdited = true;
+  }
+}
+
+// `force` is the rebuild button and the panel edits the person just made:
+// an explicit ask. Everything else leaves a hand-edited letter alone.
+function descrub(force = false) {
+  const completed = document.getElementById(
+    "id_completed_appeal_text",
+  ) as HTMLTextAreaElement | null;
+  if (completedLetterEdited && !force && completed && completed.value.trim() !== "") {
+    return;
+  }
   const appeal_text = document.getElementById("scrubbed_appeal_text");
   const target = document.getElementById(
     "id_completed_appeal_text",
@@ -162,7 +183,15 @@ function descrub() {
   }
 
   if (target) {
-    target.value = text;
+    rebuildingCompletedLetter = true;
+    try {
+      target.value = text;
+    } finally {
+      rebuildingCompletedLetter = false;
+    }
+    // A rebuild is the letter the person asked for, so it is no longer
+    // an edit of theirs waiting to be protected.
+    completedLetterEdited = false;
   } else {
     console.error(
       "Element with id 'id_completed_appeal_text' not found or not html text area",
@@ -178,10 +207,22 @@ function printAppeal() {
       ?.value || "";
 
   if (childWindow) {
-    childWindow.document.open();
-    childWindow.document.write("<html><head></head><body>");
-    childWindow.document.write(completedAppealText.replace(/\n/gi, "<br>"));
-    childWindow.document.write("</body></html>");
+    // The letter is typed by the person and written by a model, so it is
+    // text, not markup: it goes in through textContent, and the only thing
+    // written as HTML is this fixed shell. A pre with wrapping keeps the
+    // line breaks a letter needs while printing in the page's own font.
+    const doc = childWindow.document;
+    doc.open();
+    doc.write(
+      "<!doctype html><html><head><title>Your appeal</title>" +
+        "<style>body{margin:1in;font-family:inherit}" +
+        "pre{white-space:pre-wrap;word-wrap:break-word;font:inherit;margin:0}</style>" +
+        "</head><body></body></html>",
+    );
+    doc.close();
+    const letter = doc.createElement("pre");
+    letter.textContent = completedAppealText;
+    doc.body.appendChild(letter);
     // Wait 1 second for chrome.
     setTimeout(function () {
       console.log("Executed after 1 second");
@@ -296,8 +337,9 @@ function setupPiiPanelListeners() {
     if (!el) continue;
     el.addEventListener("input", () => {
       setLocalStorageItemWithTTL(storageKey, el.value);
-      // Re-run descrub so the completed appeal textarea reflects the new value
-      descrub();
+      // Re-run descrub so the completed appeal textarea reflects the new value.
+      // The person is editing their own details here, so this is an ask.
+      descrub(true);
     });
   }
 }
@@ -323,11 +365,18 @@ function setupAppeal() {
 
   const appeal_text = document.getElementById("scrubbed_appeal_text");
   if (appeal_text != null) {
-    appeal_text.oninput = descrub;
+    // Wrapped, not assigned: as a handler the event object would arrive as
+    // `force` and rebuild the letter on every keystroke in the draft.
+    appeal_text.oninput = () => descrub();
   }
   const descrub_button = document.getElementById("descrub");
   if (descrub_button != null) {
-    descrub_button.onclick = descrub;
+    // The one control whose whole purpose is to rebuild the letter.
+    descrub_button.onclick = () => descrub(true);
+  }
+  const completed_text = document.getElementById("id_completed_appeal_text");
+  if (completed_text != null) {
+    completed_text.addEventListener("input", noteCompletedLetterEdit);
   }
   descrub();
 
@@ -341,7 +390,9 @@ function setupAppeal() {
         skipCheck = false;
         return;
       }
-      // Regenerate appeal text from current PII panel values before checking
+      // Pick up the details panel for a letter the person has not touched,
+      // and leave a hand-edited letter exactly as they left it: this runs
+      // one line before the text is read and posted.
       descrub();
       const appealText =
         (document.getElementById("id_completed_appeal_text") as HTMLTextAreaElement)

--- a/tests/async-unit/test_appeal_sends_what_was_edited.py
+++ b/tests/async-unit/test_appeal_sends_what_was_edited.py
@@ -1,0 +1,103 @@
+"""The letter the person edited is the letter that prints and faxes.
+
+Two defects in the same file, both invisible to a happy-path walk.
+
+The finished letter is a textarea the person can type in, and it is what the
+fax form posts and what Print shows. It is also rebuilt from the draft plus
+the details panel by ``descrub``, which used to run on every keystroke in the
+draft, on every panel change, and once more inside the fax form's own submit
+handler, one line before the text was read and sent. A correction typed into
+the finished letter was therefore discarded on the way to the fax without a
+word.
+
+Print wrote that same text into a popup with ``document.write`` after turning
+newlines into ``<br>``, so anything in the letter that looks like markup was
+interpreted as markup in a window on this origin. A letter is text.
+"""
+
+import pathlib
+import re
+
+JS = pathlib.Path(__file__).resolve().parents[2] / "fighthealthinsurance" / "static" / "js"
+
+
+def _appeal_source() -> str:
+    return (JS / "appeal.ts").read_text()
+
+
+def _function(src: str, name: str) -> str:
+    """The brace-matched body of one function declared at statement position."""
+    occurrences = re.findall(r"\bfunction\s+" + re.escape(name) + r"\b", src)
+    assert len(occurrences) == 1, f"expected exactly one `function {name}`, found {len(occurrences)}"
+    head = re.search(r"\bfunction\s+" + re.escape(name) + r"\s*\(", src)
+    assert head is not None
+    open_at = src.index("{", src.index(")", head.end()))
+    depth = 0
+    for i in range(open_at, len(src)):
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[open_at : i + 1]
+    raise AssertionError("unbalanced braces")
+
+
+def test_print_puts_the_letter_in_as_text_not_as_markup():
+    body = _function(_appeal_source(), "printAppeal")
+    assert "letter.textContent = completedAppealText;" in body, (
+        "the letter no longer reaches the print window as text"
+    )
+    assert 'doc.createElement("pre")' in body, "the line breaks of the letter are no longer preserved by a pre"
+    assert not re.search(r"write\([^)]*completedAppealText", body), (
+        "the letter is written into the print window as HTML again"
+    )
+    assert "<br>" not in body, "newlines are turned into markup again"
+    # The only thing written as HTML is a fixed shell with no letter in it.
+    for written in re.findall(r"doc\.write\(\s*([\s\S]*?)\);", body):
+        assert "completedAppealText" not in written, "the shell write carries the letter"
+    assert "white-space:pre-wrap" in body, "a printed letter would lose its line wrapping"
+
+
+def test_a_hand_edited_letter_is_not_rebuilt_underneath_the_person():
+    src = _appeal_source()
+    assert re.search(
+        r"function noteCompletedLetterEdit\(\): void \{\s*if \(!rebuildingCompletedLetter\) \{\s*completedLetterEdited = true;",
+        src,
+    ), "typing in the finished letter is no longer noticed, or a rebuild counts as typing"
+    assert 'completed_text.addEventListener("input", noteCompletedLetterEdit)' in src, (
+        "nothing listens for the person typing in the finished letter"
+    )
+    body = _function(src, "descrub")
+    assert re.search(
+        r"if \(completedLetterEdited && !force && completed && completed\.value\.trim\(\) !== \"\"\) \{\s*return;",
+        body,
+    ), "descrub no longer leaves a hand-edited letter alone"
+    assert "rebuildingCompletedLetter = true;" in body and "rebuildingCompletedLetter = false;" in body, (
+        "descrub's own write would be counted as the person typing"
+    )
+
+
+def test_only_the_rebuild_button_and_the_details_panel_force_a_rebuild():
+    src = _appeal_source()
+    # The draft's own keystrokes must not force: as a bare handler the event
+    # object arrives as `force` and every keystroke would rebuild.
+    assert "appeal_text.oninput = () => descrub();" in src, (
+        "the draft's input handler can force a rebuild through the event object"
+    )
+    assert "descrub_button.onclick = () => descrub(true);" in src, "the rebuild button no longer rebuilds"
+    forced = re.findall(r"descrub\(true\)", src)
+    assert len(forced) == 2, f"exactly two explicit rebuilds are expected, found {len(forced)}"
+
+
+def test_the_fax_reads_the_letter_after_deciding_not_to_rebuild_it():
+    src = _appeal_source()
+    submit = src.index('faxForm.addEventListener("submit"')
+    handler = src[submit : src.index("checkForUnfilledPlaceholders(appealText)", submit)]
+    assert "descrub();" in handler, "the details panel is no longer applied for an untouched letter"
+    assert "descrub(true)" not in handler, (
+        "the fax handler forces a rebuild, which is what discarded the person's corrections"
+    )
+    assert handler.index("descrub();") < handler.index("id_completed_appeal_text"), (
+        "the letter is read before the rebuild decision"
+    )

--- a/tests/async-unit/test_appeal_sends_what_was_edited.py
+++ b/tests/async-unit/test_appeal_sends_what_was_edited.py
@@ -69,10 +69,9 @@ def test_a_hand_edited_letter_is_not_rebuilt_underneath_the_person():
         "nothing listens for the person typing in the finished letter"
     )
     body = _function(src, "descrub")
-    assert re.search(
-        r"if \(completedLetterEdited && !force && completed && completed\.value\.trim\(\) !== \"\"\) \{\s*return;",
-        body,
-    ), "descrub no longer leaves a hand-edited letter alone"
+    assert re.search(r"if \(completedLetterEdited && !force\) \{\s*return;", body), (
+        "descrub no longer leaves a hand-edited letter alone"
+    )
     assert "rebuildingCompletedLetter = true;" in body and "rebuildingCompletedLetter = false;" in body, (
         "descrub's own write would be counted as the person typing"
     )
@@ -90,11 +89,66 @@ def test_only_the_rebuild_button_and_the_details_panel_force_a_rebuild():
     assert len(forced) == 2, f"exactly two explicit rebuilds are expected, found {len(forced)}"
 
 
+def test_the_page_does_not_rebuild_over_a_letter_the_server_sent_back():
+    """A rejected fax re-renders with the submitted letter already in the box.
+
+    Rebuilding on load would strip everything the person added after the
+    details block, so the first build only fills an empty box (review).
+    """
+    setup = _function(_appeal_source(), "setupAppeal")
+    assert 'const completedOnLoad = (completed_text as HTMLTextAreaElement | null)?.value ?? "";' in setup
+    assert re.search(
+        r'if \(completedOnLoad\.trim\(\) === ""\) \{\s*descrub\(\);\s*\} else \{\s*completedLetterEdited = true;',
+        setup,
+    ), "the page rebuilds on load over a letter that came back from the server"
+
+
+def test_the_guard_does_not_lapse_when_the_letter_is_emptied():
+    body = _function(_appeal_source(), "descrub")
+    assert re.search(r"if \(completedLetterEdited && !force\) \{\s*return;", body), (
+        "emptying or blanking the letter lets a rebuild back in"
+    )
+    assert "value.trim() !== \"\"" not in body, "the emptiness escape is back"
+
+
+def test_confirming_the_placeholder_warning_actually_sends_and_the_next_try_is_checked():
+    """requestSubmit() called inside a submit event does nothing, so pressing
+    OK sent no fax at all, and the flag it set waved the next attempt past
+    the check entirely (review)."""
+    src = _appeal_source()
+    assert "skipCheck" not in src, "the skip flag is back; a later click would bypass the check"
+    # The name may appear in the comment that explains why it is gone; what
+    # must not come back is the call.
+    assert "faxForm.requestSubmit(" not in src, "the submit is re-entered from inside its own event again"
+    submit = src.index('faxForm.addEventListener("submit"')
+    handler = src[submit:]
+    assert re.search(r"if \(!proceed\) \{\s*e\.preventDefault\(\);", handler), (
+        "confirming no longer lets this submission through"
+    )
+    # An empty letter is stopped before it becomes an empty fax.
+    assert re.search(r'if \(appealText\.trim\(\) === ""\) \{\s*.*e\.preventDefault\(\);', handler, re.S)
+
+
+def test_an_amount_is_not_reported_as_an_unfilled_placeholder():
+    src = _appeal_source()
+    assert re.search(r"text\.match\(/\\\$\[A-Za-z_\]\[A-Za-z0-9_\]\*/g\)", src) or (
+        "/\\$[A-Za-z_][A-Za-z0-9_]*/g" in src
+    ), "the dollar-placeholder pattern accepts a bare amount again"
+
+
+def test_the_setup_actually_runs():
+    src = _appeal_source()
+    assert re.search(r"^setupAppeal\(\);", src, re.M), (
+        "nothing calls setupAppeal, so none of these handlers would be installed"
+    )
+
+
 def test_the_fax_reads_the_letter_after_deciding_not_to_rebuild_it():
     src = _appeal_source()
     submit = src.index('faxForm.addEventListener("submit"')
     handler = src[submit : src.index("checkForUnfilledPlaceholders(appealText)", submit)]
     assert "descrub();" in handler, "the details panel is no longer applied for an untouched letter"
+    assert handler.count("descrub()") == 1, "the fax handler rebuilds more than once"
     assert "descrub(true)" not in handler, (
         "the fax handler forces a rebuild, which is what discarded the person's corrections"
     )


### PR DESCRIPTION
Two fixes in the appeal page's client code, both about the letter the person actually sends.

**The finished letter is a box the person can type in**, and it is what the fax form posts and what Print shows. It was also rebuilt from the draft and the details panel on every keystroke in the draft, on every panel change, and once more inside the fax form's own submit handler, one line before the text was read and posted. A correction typed into the finished letter was discarded on the way out without a word. A rebuild now happens when the person asks for it, with the rebuild button or by editing their own details; a letter they have typed in is left as they left it. A rejected fax comes back with the submitted letter already in the box, so the page no longer rebuilds on load over text the server sent back.

**Print wrote the letter into a popup as markup**, turning newlines into tags, so anything in a letter that looks like markup was treated as markup. The letter now goes in as text inside a preformatted block that keeps its line breaks, and the only thing written as HTML is a fixed shell.

Three more things the reviewer found in the same handler, all of them live today:

- Pressing OK on the unfilled-placeholder warning did not send that fax. Asking a form to submit again from inside its own submit event does nothing, which I confirmed in a browser: the first click is swallowed and the second one sends. The flag it set then waved that second attempt past the placeholder check entirely. The warning is now decided before the submission is stopped, so OK sends, and every attempt is checked.
- An ordinary amount, "the treatment costs $500", was reported as an unfilled placeholder, which is what sent finished letters into that warning.
- An empty letter is now stopped before it becomes an empty fax.

Nine source-inspection tests, each sabotage-checked: the fix was broken in turn and the matching test failed each time. The related async-unit suites pass. Reviewed by Codex, whose five findings are either applied here or declined in the thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYruQVRyBbFzUxy9YGcHTb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Hand-edited appeal letters are no longer overwritten by automatic rebuilding.
  - Letter rebuilding now occurs only after explicit actions, such as selecting rebuild or submitting a fax.
  - Empty letters are blocked from fax submission.
  - Dollar amounts such as `$500` are no longer incorrectly flagged as unfinished placeholders.
  - Printing preserves letter text safely and accurately.
  - Canceling placeholder warnings no longer causes unintended submission behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->